### PR TITLE
fix github rate limit issue in deploy targets feature

### DIFF
--- a/modules/github_integration/app/workers/cron/check_deploy_status_job.rb
+++ b/modules/github_integration/app/workers/cron/check_deploy_status_job.rb
@@ -28,6 +28,8 @@
 
 module Cron
   class CheckDeployStatusJob < ApplicationJob
+    class DeployCheckAccessTokenExpired < StandardError; end
+
     include OpenProject::GithubIntegration::NotificationHandler::Helper
 
     priority_number :low
@@ -55,7 +57,19 @@ module Cron
     def pull_requests
       GithubPullRequest
         .closed
+        .where(repository: "opf/openproject")
+        .where(merged: true)
         .where.not(merge_commit_sha: nil)
+        .where("merged_at > ?", look_back_cutoff_date)
+    end
+
+    ##
+    # These PRs have been merged but seemingly not been deployed within a month.
+    # It might be that they were merged into a different branch (not dev or release) via rebase.
+    #
+    # What ever it may be, at this point we're going to give up and not check on those anymore.
+    def look_back_cutoff_date
+      Time.zone.today - 1.month
     end
 
     def check_deploy_status(deploy_target, pull_request, core_sha)
@@ -110,6 +124,13 @@ module Cron
       user_id = plugin_settings[:github_user_id].presence
 
       user_id ? User.find(user_id) : User.system
+    end
+
+    ##
+    # With an access token configured, requests are authenticated which increases the rate limit
+    # from 60 per hour to 5000 per hour.
+    def github_access_token
+      plugin_settings[:github_access_token].presence
     end
 
     def plugin_settings
@@ -183,6 +204,9 @@ module Cron
         OpenProject.logger.error "#{error_prefix}: #{res.error}"
       elsif res.status == 404
         OpenProject.logger.error "#{error_prefix}: not found"
+      elsif res.status == 401
+        # raise so we notice this in AppSignal and can fix it
+        raise DeployCheckAccessTokenExpired, "response: #{res.body}"
       elsif res.status != 200
         OpenProject.logger.error "#{error_prefix}: #{res.body}"
       else
@@ -193,7 +217,17 @@ module Cron
     end
 
     def compare_commits_request(sha_a, sha_b)
-      OpenProject.httpx.get(compare_commits_url(sha_a, sha_b))
+      authenticated_request(OpenProject.httpx).get(compare_commits_url(sha_a, sha_b))
+    end
+
+    def authenticated_request(httpx)
+      return httpx if github_access_token.blank?
+
+      httpx.with(
+        headers: {
+          "Authorization" => "Bearer #{github_access_token}"
+        }
+      )
     end
 
     def compare_commits_url(sha_a, sha_b)

--- a/modules/github_integration/spec/workers/cron/check_deploy_status_job_spec.rb
+++ b/modules/github_integration/spec/workers/cron/check_deploy_status_job_spec.rb
@@ -37,9 +37,129 @@ RSpec.describe Cron::CheckDeployStatusJob, type: :job, with_flag: { deploy_targe
   let(:work_package) { create(:work_package) }
 
   let(:deploy_target) { create(:deploy_target, api_key:) }
-  let(:pull_request) { create(:github_pull_request, work_packages: [work_package], state: :closed, merge_commit_sha:) }
+  let(:pull_request) do
+    create :github_pull_request, pull_request_attributes.merge(pull_request_attribute_override)
+  end
+
+  let(:pull_request_attributes) do
+    {
+      work_packages: [work_package],
+      state: :closed,
+      repository: "opf/openproject",
+      merge_commit_sha:,
+      merged: true,
+      merged_at: Date.yesterday
+    }
+  end
+
+  let(:pull_request_attribute_override) { {} }
 
   let(:job) { described_class.new }
+
+  describe "#pull_requests" do
+    before do
+      pull_request
+    end
+
+    context "with matching PRs" do
+      it "includes them" do
+        expect(job.pull_requests).to include pull_request
+      end
+    end
+
+    context "with not merged PRs" do
+      let(:pull_request_attribute_override) { { merged: false } }
+
+      it "does not include them" do
+        expect(job.pull_requests).not_to include pull_request
+      end
+    end
+
+    context "with PRs from other repositories" do
+      let(:pull_request_attribute_override) { { repository: "opf/website" } }
+
+      it "does not include them" do
+        expect(job.pull_requests).not_to include pull_request
+      end
+    end
+
+    context "with PRs past the use-by date" do
+      let(:pull_request_attribute_override) { { merged_at: Date.today - 2.months } }
+
+      it "does not include them" do
+        expect(job.pull_requests).not_to include pull_request
+      end
+    end
+  end
+
+  describe "#commit_contains?", :webmock do
+    let(:result) { job.commit_contains? core_sha, merge_commit_sha }
+    let(:response) { {} }
+
+    let(:request_url) { "https://api.github.com/repos/opf/openproject/compare/#{core_sha}...#{merge_commit_sha}" }
+    let(:request_headers) do
+      {
+        "Accept" => "*/*",
+        "Accept-Encoding" => "gzip, deflate",
+        "User-Agent" => "httpx.rb/1.3.1"
+      }
+    end
+
+    before do
+      stub_request(:get, request_url)
+        .with(headers: request_headers)
+        .to_return(status: 200, body: response.to_json, headers: {})
+    end
+
+    context "with a response not indicating the commits are related" do
+      it "is false" do
+        expect(result).to eq false
+      end
+    end
+
+    context "with a response indicating the commits are related" do
+      let(:response) do
+        {
+          status: "behind",
+          ahead_by: 0,
+          behind_by: 42
+        }
+      end
+
+      it "is true" do
+        expect(result).to eq true
+      end
+    end
+
+    context(
+      "with a github access token configured",
+      with_settings: {
+        plugin_openproject_github_integration: {
+          github_access_token: "pat_42"
+        }
+      }
+    ) do
+      it "sends an authenticated request" do
+        result
+
+        expect(WebMock)
+          .to have_requested(:get, request_url)
+          .with(headers: { "Authorization" => "Bearer pat_42" })
+      end
+    end
+
+    context "with an invalid access token" do
+      before do
+        stub_request(:get, request_url)
+          .with(headers: request_headers)
+          .to_return(status: 401, body: response.to_json, headers: { message: "invalid token" })
+      end
+
+      it "raises an error" do
+        expect { result }.to raise_error(Cron::CheckDeployStatusJob::DeployCheckAccessTokenExpired)
+      end
+    end
+  end
 
   context "with no prior checks and the same deployed sha" do
     before do


### PR DESCRIPTION
using authentication allows for a higher rate limit (5000 per hour instead of 60)

reducing number of requests to mitigate the issue further

# Ticket
https://community.openproject.org/projects/openproject/work_packages/57657/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

I want to fix the deploy target feature on community.

# What approach did you choose and why?

I added authentication to the GitHub API calls because that fixes the issue.

# Merge checklist

- [x] Added/updated tests
- [x] ~Added/updated documentation in Lookbook (patterns, previews, etc)~ N/A
- [X] ~Tested major browsers (Chrome, Firefox, Edge, ...)~ N/A
