### PR TITLE
Ignore FileLink renames when rendering activities

### DIFF
--- a/spec/lib/journal_formatter/file_link_spec.rb
+++ b/spec/lib/journal_formatter/file_link_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe OpenProject::JournalFormatter::FileLink do
   subject(:instance) { described_class.new(journal) }
 
   describe "#render" do
+    context "having both a predecessor and a current value" do
+      let(:old) do
+        { "link_name" => "this_is_the_old_file_name.jiff", "storage_name" => nil }
+      end
+
+      it "does not render anything" do
+        expect(instance.render(key, [old, changes])).to be_nil
+      end
+    end
+
     context "having the origin_name as nil" do
       let(:changes) { { "link_name" => file_link.origin_name, "storage_name" => nil } }
 


### PR DESCRIPTION
#### Related WP: [OP#53995](https://community.openproject.org/projects/openproject/work_packages/53995)

# What?

Sometimes, any change to a work package would add entries about the addition of file links to the current user.

After trying to pinpoint it for some time, we could finally nail it to file renames on the remote.

# Why?

Some basics first: our `StorableJournal` stores the **storage name** and **file link name**, the reason being that we want to still render the information even if the file link or storage has been removed.

So, the journal rendering was pretty naive: if the current entry is file name nil, this should be a removal, otherwise an file link was added.

On a rename we would land on the *file link added* case. Also, previous mentions would use the new name of the file, due to the way we render the links, so it would basically look like the same file was re-added multiple times.

# And the fix?

We still need to keep track of the most current file name to render the **file link removed** message, so instead of avoid the creation of the Journal entry, we skip the render if both old and new file link names are present.

So we went from this:
![image](https://github.com/user-attachments/assets/b3670fa4-a546-4487-b4c7-7128931f186e)

to this:

![Screenshot from 2024-09-04 17-32-35](https://github.com/user-attachments/assets/528acc55-4006-4cd8-8d7a-0c6666701098)

