### PR TITLE
[Op#57662]: Trigger AMPF Sync Job when folder mode is switched from/to "automatic" mode

### DIFF
--- a/modules/storages/app/services/storages/project_storages/bulk_create_service.rb
+++ b/modules/storages/app/services/storages/project_storages/bulk_create_service.rb
@@ -99,9 +99,10 @@ module Storages::ProjectStorages
     end
 
     def broadcast_project_storages_created(params)
-      OpenProject::Notifications.send(
-        OpenProject::Events::PROJECT_STORAGE_CREATED,
+      ::Storages::ProjectStorages::NotificationsService.broadcast_raw(
+        event: :created,
         project_folder_mode: params[:project_folder_mode],
+        project_folder_mode_previously_was: nil,
         storage: @storage
       )
     end

--- a/modules/storages/app/services/storages/project_storages/create_service.rb
+++ b/modules/storages/app/services/storages/project_storages/create_service.rb
@@ -37,11 +37,7 @@ module Storages::ProjectStorages
       project_storage = service_call.result
       project_folder_mode = project_storage.project_folder_mode.to_sym
       add_historical_data(service_call) if project_folder_mode != :inactive
-      OpenProject::Notifications.send(
-        OpenProject::Events::PROJECT_STORAGE_CREATED,
-        project_folder_mode:,
-        storage: project_storage.storage
-      )
+      ::Storages::ProjectStorages::NotificationsService.broadcast_project_storage_created(project_storage:)
 
       service_call
     end

--- a/modules/storages/app/services/storages/project_storages/delete_service.rb
+++ b/modules/storages/app/services/storages/project_storages/delete_service.rb
@@ -48,10 +48,8 @@ module Storages::ProjectStorages
       super.tap do |deletion_result|
         if deletion_result.success?
           delete_associated_file_links
-          OpenProject::Notifications.send(
-            OpenProject::Events::PROJECT_STORAGE_DESTROYED,
-            project_folder_mode: deletion_result.result.project_folder_mode.to_sym,
-            storage: deletion_result.result.storage
+          ::Storages::ProjectStorages::NotificationsService.broadcast_project_storage_destroyed(
+            project_storage: deletion_result.result
           )
         end
       end

--- a/modules/storages/app/services/storages/project_storages/update_service.rb
+++ b/modules/storages/app/services/storages/project_storages/update_service.rb
@@ -38,11 +38,7 @@ module Storages::ProjectStorages
       project_storage = service_call.result
       project_folder_mode = project_storage.project_folder_mode.to_sym
       add_historical_data(service_call) if project_folder_mode != :inactive
-      OpenProject::Notifications.send(
-        OpenProject::Events::PROJECT_STORAGE_UPDATED,
-        project_folder_mode:,
-        storage: project_storage.storage
-      )
+      ::Storages::ProjectStorages::NotificationsService.broadcast_project_storage_updated(project_storage:)
 
       service_call
     end

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -117,7 +117,7 @@ module OpenProject::Storages
           OpenProject::Events::PROJECT_STORAGE_DESTROYED
         ].each do |event|
           OpenProject::Notifications.subscribe(event) do |payload|
-            if payload[:project_folder_mode]&.to_sym == :automatic
+            if ::Storages::ProjectStorages::NotificationsService.automatic_folder_mode_broadcast?(payload)
               ::Storages::AutomaticallyManagedStorageSyncJob.debounce(payload[:storage])
               ::Storages::ManageStorageIntegrationsJob.disable_cron_job_if_needed
             end

--- a/modules/storages/spec/services/storages/project_storages/bulk_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/bulk_create_service_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
 
         aggregate_failures "broadcasts projects storages created event" do
           expect(OpenProject::Notifications).to have_received(:send)
-            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                                project_folder_mode_previously_was: nil, storage:)
         end
       end
     end
@@ -79,7 +80,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
 
         aggregate_failures "broadcasts projects storages created event" do
           expect(OpenProject::Notifications).to have_received(:send)
-            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                                project_folder_mode_previously_was: nil, storage:)
         end
       end
     end
@@ -101,7 +103,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
 
         aggregate_failures "broadcasts projects storages created event" do
           expect(OpenProject::Notifications).to have_received(:send)
-            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                                project_folder_mode_previously_was: nil, storage:)
         end
       end
     end
@@ -122,7 +125,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
 
         aggregate_failures "broadcasts projects storages created event" do
           expect(OpenProject::Notifications).to have_received(:send)
-            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+            .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                                project_folder_mode_previously_was: nil, storage:)
         end
       end
     end
@@ -153,7 +157,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
 
       aggregate_failures "broadcasts projects storages created event" do
         expect(OpenProject::Notifications).to have_received(:send)
-          .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+          .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                              project_folder_mode_previously_was: nil, storage:)
       end
     end
   end
@@ -174,7 +179,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
       expect { instance.call(project_folder_mode:) }.not_to change(Storages::ProjectStorage, :count)
       expect(instance.call).to be_failure
       expect(OpenProject::Notifications).not_to have_received(:send)
-        .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+        .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                            project_folder_mode_previously_was: nil, storage:)
     end
   end
 
@@ -205,7 +211,8 @@ RSpec.describe Storages::ProjectStorages::BulkCreateService do
 
       aggregate_failures "broadcasts projects storages created event" do
         expect(OpenProject::Notifications).to have_received(:send)
-          .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:, storage:)
+          .with(OpenProject::Events::PROJECT_STORAGE_CREATED, project_folder_mode:,
+                                                              project_folder_mode_previously_was: nil, storage:)
       end
     end
   end

--- a/modules/storages/spec/services/storages/project_storages/notifications_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/notifications_service_spec.rb
@@ -1,0 +1,94 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Storages::ProjectStorages::NotificationsService do
+  let(:storage) { build_stubbed(:nextcloud_storage) }
+  let(:project_storage) { build_stubbed(:project_storage, storage:) }
+
+  before do
+    allow(OpenProject::Notifications).to receive(:send)
+  end
+
+  shared_examples "broadcasts the project storage event" do |event|
+    it "broadcasts the project storage event #{event}" do
+      expect(OpenProject::Notifications).to have_received(:send)
+        .with(event, project_folder_mode: project_storage.project_folder_mode.to_sym,
+                     project_folder_mode_previously_was: project_storage.project_folder_mode_previously_was&.to_sym,
+                     storage: project_storage.storage)
+    end
+  end
+
+  describe ".broadcast_project_storage_created" do
+    before { described_class.broadcast_project_storage_created(project_storage:) }
+
+    it_behaves_like "broadcasts the project storage event", OpenProject::Events::PROJECT_STORAGE_CREATED
+  end
+
+  describe ".broadcast_project_storage_updated" do
+    before { described_class.broadcast_project_storage_updated(project_storage:) }
+
+    it_behaves_like "broadcasts the project storage event", OpenProject::Events::PROJECT_STORAGE_UPDATED
+  end
+
+  describe ".broadcast_project_storage_destroyed" do
+    before { described_class.broadcast_project_storage_destroyed(project_storage:) }
+
+    it_behaves_like "broadcasts the project storage event", OpenProject::Events::PROJECT_STORAGE_DESTROYED
+  end
+
+  describe ".automatic_folder_mode_broadcast?" do
+    subject { described_class.automatic_folder_mode_broadcast?(broadcasted_payload) }
+
+    context "when project_folder_mode is automatic" do
+      let(:broadcasted_payload) { { project_folder_mode: "automatic" } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when project_folder_mode_previously_was is automatic" do
+      let(:broadcasted_payload) { { project_folder_mode_previously_was: "automatic" } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when only one of project_folder_mode and project_folder_mode_previously_was is automatic" do
+      let(:broadcasted_payload) { { project_folder_mode: "inactive", project_folder_mode_previously_was: "automatic" } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when both project_folder_mode and project_folder_mode_previously_was are not automatic" do
+      let(:broadcasted_payload) { { project_folder_mode: "inactive", project_folder_mode_previously_was: "inactive" } }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/57662

### What

When a project folder is changed from "automatic" mode to any other mode and vice versa, ensure the storage AMPF sync jobs are triggered as well so that the correct file permissions are applied after the fact.

### How

Emit the previous folder mode value `project_folder_mode_previously_was` in addition to the current folder mode and schedule the jobs if any of those are "automatic".

Attempt to unify project storage events interface by introducing `Storages::ProjectStorages::NotificationsService`


https://github.com/user-attachments/assets/3f51fe3a-d37e-4222-992e-fb42eae9054b


