### PR TITLE
[#57642] (Comment) Text editor does not take spacing in account

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.html
@@ -72,9 +72,9 @@
         ></edit-form-portal>
       </div>
     </div>
-    <div class="message"
-         *ngIf="!active && (isComment || isBcfComment)"
-         [innerHtml]="postedComment"></div>
+    <div class="message" *ngIf="!active && (isComment || isBcfComment)">
+      <div class="op-uc-container" [innerHtml]="postedComment"></div>
+    </div>
     <ul class="work-package-details-activities-messages" *ngIf="!isInitial">
       <li *ngFor="let detail of details">
         <span class="message" [innerHtml]="detail"></span>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/57642

Cause
```
<div class="message">
  <p class="op-uc-p">...</p>
  <p class="op-uc-p">...</p>
  <p class="op-uc-p">...</p>
</div>
```

# What are you trying to accomplish?

Fix a spacing bug

## Screenshots

| Before | After |
| ------ | ------ |
| <img width="564" alt="before" src="https://github.com/user-attachments/assets/e4df5a15-1849-4751-b019-df55749292fe"> | <img width="586" alt="after" src="https://github.com/user-attachments/assets/3aea66d0-4bd8-4b3b-af68-a094a3edadde"> |

# What approach did you choose and why?

Restore the previous structure, so css rules apply again

Fix
```
<div class="message">
  <div class="op-uc-container">
    <p class="op-uc-p">...</p>
    <p class="op-uc-p">...</p>
    <p class="op-uc-p">...</p>
  </div>
</div>
```

# Merge checklist

- [X] Added/updated tests (this sections [rework](https://community.openproject.org/projects/communicator-stream/work_packages/54733/activity) is already in development, so I did not add one)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
