### PR TITLE
[57675] Fix Unified diff link when not at the root of a repository

### DIFF
--- a/app/views/repositories/diff.html.erb
+++ b/app/views/repositories/diff.html.erb
@@ -51,10 +51,10 @@ See COPYRIGHT and LICENSE files for more details.
   <% unidiff_link = f.link_to 'Diff', url: permitted_params.repository_diff.to_h, caption: 'Unified diff' %>
   <% if !@path.blank? %>
     <% unidiff_link.gsub!('?', '&amp;') %>
+    <% wrong_url = /\/diff\/.*\.diff/ %>
+    <% good_url = '/diff.diff'.concat('?repo_path=', CGI.escape(without_leading_slash(@path)).gsub('&', '%26')) %>
+    <% unidiff_link.gsub!(wrong_url, good_url) %>
   <% end %>
-  <% wrong_url = CGI::escapeHTML(CGI.escape(with_leading_slash(@path))).concat('.diff') %>
-  <% good_url = '.diff'.concat('?repo_path=', CGI.escape(without_leading_slash(@path)).gsub('&', '%26')) %>
-  <% unidiff_link.gsub!(wrong_url, good_url) %>
   <%= unidiff_link.html_safe %>
 <% end %>
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/57675/activity

# What are you trying to accomplish?

Fixing the URL of the Unified diff link when comparing revisions and not being at the root of a repository.

The wrong URL looks like this: https://_openproject.server_/projects/_a_project_/repository/revisions/_a_revision_/diff/_some_path_.diff&rev_to=_another_revision_.
The good URL is: https://_openproject.server_/projects/_a_project_/repository/revisions/_a_revision_/diff.diff?repo_path=_some_path_&rev_to=_another_revision_.

# What approach did you choose and why?

I modified the pattern of the wrong URL to ensure that the wrong URL is replaced by the good one.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)