### PR TITLE
Fix error pages being styled incorrectly

### DIFF
--- a/app/views/layouts/only_logo.html.erb
+++ b/app/views/layouts/only_logo.html.erb
@@ -34,7 +34,10 @@ See COPYRIGHT and LICENSE files for more details.
 <head>
   <%= render partial: 'layouts/common_head' %>
 </head>
-<body>
+<body
+  class="<%= body_css_classes %>"
+  <%= user_theme_data_attributes %>
+>
   <div id="wrapper">
     <header class="op-app-header<%= ' op-app-header_development' if OpenProject::Configuration.development_highlight_enabled? %>">
       <div class="op-app-header--center op-logo">

--- a/config/application.rb
+++ b/config/application.rb
@@ -113,6 +113,9 @@ module OpenProject
     # http://stackoverflow.com/questions/4590229
     config.middleware.use Rack::TempfileReaper
 
+    # Move secure_headers middleware to after the ShowExceptions
+    config.middleware.move_after ActionDispatch::ShowExceptions, SecureHeaders::Middleware
+
     # Add lookbook preview paths when enabled
     if OpenProject::Configuration.lookbook_enabled?
       config.paths.add Primer::ViewComponents::Engine.root.join("app/components").to_s, eager_load: true


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57658

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Ensure CSP gets inserted in the call stack _after_ ShowException middleware. Without it, SecureHeaders will try to produce a CSP that is based on the original request, not the one from ShowExceptions.

## Screenshots
![image](https://github.com/user-attachments/assets/18e2429f-20ea-4f60-b223-ac5efed2a381)


# What approach did you choose and why?
Move the middleware from SecureHeaders after ShowExceptions
