### PR TITLE
Feature/57347 add validation connection check unexpected content for nextcloud storages

### DIFF
--- a/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
@@ -161,9 +161,9 @@ module Storages
 
         Rails.logger.error(
           "Connection validation failed with unknown error:\n\t" \
-            "storage: ##{@storage.id} #{@storage.name}\n\t" \
-            "status: #{query.result}\n\t" \
-            "response: #{query.error_payload}"
+          "storage: ##{@storage.id} #{@storage.name}\n\t" \
+          "status: #{query.result}\n\t" \
+          "response: #{query.error_payload}"
         )
 
         Some(ConnectionValidation.new(type: :error,
@@ -184,10 +184,14 @@ module Storages
         unexpected_files = files.result.files.reject { |file| expected_folder_ids.include?(file.id) }
         return None() if unexpected_files.empty?
 
-        Some(ConnectionValidation.new(type: :warning,
-                                      error_code: :wrn_unexpected_content,
-                                      timestamp: Time.current,
-                                      description: I18n.t("storages.health.connection_validation.unexpected_content")))
+        Some(
+          ConnectionValidation.new(
+            type: :warning,
+            error_code: :wrn_unexpected_content,
+            timestamp: Time.current,
+            description: I18n.t("storages.health.connection_validation.unexpected_content.nextcloud")
+          )
+        )
       end
 
       # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/one_drive_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/one_drive_connection_validator.rb
@@ -149,7 +149,7 @@ module Storages
         Some(ConnectionValidation.new(type: :warning,
                                       error_code: :wrn_unexpected_content,
                                       timestamp: Time.current,
-                                      description: I18n.t("storages.health.connection_validation.unexpected_content")))
+                                      description: I18n.t("storages.health.connection_validation.unexpected_content.one_drive")))
       end
 
       # rubocop:enable Metrics/AbcSize

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_query.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/files_query.rb
@@ -42,7 +42,7 @@ module Storages
           end
 
           def call(auth_strategy:, folder:)
-            validate_input_data(auth_strategy, folder).on_failure { return _1 }
+            validate_input_data(folder).on_failure { return _1 }
 
             origin_user = Util.origin_user_id(caller: self.class, storage: @storage, auth_strategy:)
                               .on_failure { return _1 }
@@ -56,12 +56,10 @@ module Storages
 
           private
 
-          def validate_input_data(auth_strategy, folder)
+          def validate_input_data(folder)
             error_data = StorageErrorData.new(source: self.class)
 
-            if auth_strategy.user.nil?
-              Util.error(:error, "Cannot execute query without user context.", error_data)
-            elsif folder.is_a?(ParentFolder)
+            if folder.is_a?(ParentFolder)
               ServiceResult.success
             else
               Util.error(:error, "Folder input is not a ParentFolder object.", error_data)

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -210,8 +210,8 @@ en:
         client_id_wrong: The configured OAuth 2 client id is invalid. Please check the configuration.
         client_secret_wrong: The configured OAuth 2 client secret is invalid. Please check the configuration.
         drive_id_wrong: The configured drive id could not be found. Please check the configuration.
-        group_folder_version_mismatch: The Group Folder version is not supported. Please update your Nextcloud server.
         group_folder_not_found: The group folder could not be found.
+        group_folder_version_mismatch: The Group Folder version is not supported. Please update your Nextcloud server.
         host_not_found: No Nextcloud server found at the configured host url. Please check the configuration.
         missing_dependencies: 'A required dependency is missing on the file storage. Please add the following dependency: %{dependency}.'
         not_configured: The connection could not be validated. Please finish configuration first.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -217,7 +217,9 @@ en:
         placeholder: Check your connection against the server.
         subtitle: Connection validation
         tenant_id_wrong: The configured directory (tenant) id is invalid. Please check the configuration.
-        unexpected_content: Unexpected content found in the drive.
+        unexpected_content:
+          nextcloud: Unexpected content found in the managed folder.
+          one_drive: Unexpected content found in the drive.
         unknown_error: The connection could not be validated. An unknown error occurred. Please check the server logs for further information.
       label_error: Error
       label_healthy: Healthy

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -218,7 +218,7 @@ en:
         subtitle: Connection validation
         tenant_id_wrong: The configured directory (tenant) id is invalid. Please check the configuration.
         unexpected_content:
-          nextcloud: Unexpected content found in the managed folder.
+          nextcloud: Unexpected content found in the managed group folder.
           one_drive: Unexpected content found in the drive.
         unknown_error: The connection could not be validated. An unknown error occurred. Please check the server logs for further information.
       label_error: Error

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
         client_secret_wrong: The configured OAuth 2 client secret is invalid. Please check the configuration.
         drive_id_wrong: The configured drive id could not be found. Please check the configuration.
         group_folder_version_mismatch: The Group Folder version is not supported. Please update your Nextcloud server.
+        group_folder_not_found: The group folder could not be found.
         host_not_found: No Nextcloud server found at the configured host url. Please check the configuration.
         missing_dependencies: 'A required dependency is missing on the file storage. Please add the following dependency: %{dependency}.'
         not_configured: The connection could not be validated. Please finish configuration first.

--- a/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
@@ -164,9 +164,7 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
       before { project_storage }
 
       context "if the request returns not_found" do
-        let(:files_response) do
-          Storages::Peripherals::StorageInteraction::Nextcloud::Util.error(:not_found)
-        end
+        let(:files_response) { build_failure(code: :not_found, payload: nil) }
 
         it "returns a validation failure" do
           expect(subject.type).to eq(:error)
@@ -212,6 +210,7 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
   context "if query returns an unhandled error" do
     let(:storage) { create(:nextcloud_storage_configured) }
     let(:capabilities_response) { build_failure(code: :error, payload: nil) }
+    let(:files_response) { build_failure(code: :error, payload: nil) }
 
     before do
       allow(Rails.logger).to receive(:error)

--- a/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
@@ -163,6 +163,18 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
 
       before { project_storage }
 
+      context "if the request returns not_found" do
+        let(:files_response) do
+          Storages::Peripherals::StorageInteraction::Nextcloud::Util.error(:not_found)
+        end
+
+        it "returns a validation failure" do
+          expect(subject.type).to eq(:error)
+          expect(subject.error_code).to eq(:err_group_folder_not_found)
+          expect(subject.description).to eq("The group folder could not be found.")
+        end
+      end
+
       context "if the request returns an error" do
         let(:files_response) do
           Storages::Peripherals::StorageInteraction::Nextcloud::Util.error(:error)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57347/github

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Adding a validator for the `NextcloudConnectionValidation` that checks for unforseen folder contents inside the group folder on Nextcloud side.


# What approach did you choose and why?
I just programmed it!

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
