### PR TITLE
[57644] Column ordering broken on project list

### DIFF
--- a/app/components/projects/configure_view_modal_component.html.erb
+++ b/app/components/projects/configure_view_modal_component.html.erb
@@ -26,13 +26,13 @@
                                             selected: selected_columns,
                                             protected: helpers.protected_projects_columns_options,
                                             name: COLUMN_HTML_NAME,
-                                            id: 'columns-select',
+                                            id: COLUMN_HTML_ID,
+                                            dragAreaName: "#{COLUMN_HTML_ID}_dragarea",
+                                            formControlId: "#{COLUMN_HTML_ID}_autocompleter",
                                             inputLabel: I18n.t(:'queries.configure_view.columns.input_label'),
                                             inputPlaceholder: I18n.t(:'queries.configure_view.columns.input_placeholder'),
                                             dragAreaLabel: I18n.t(:'queries.configure_view.columns.drag_area_label'),
-                                            appendToComponent: true,
-                                            dragAreaName: "columns-select_dragarea",
-                                            formControlId: "columns-select_autocompleter"
+                                            appendToComponent: true
                                           }%>
           <% end %>
         <% end %>

--- a/app/components/projects/configure_view_modal_component.html.erb
+++ b/app/components/projects/configure_view_modal_component.html.erb
@@ -30,7 +30,9 @@
                                             inputLabel: I18n.t(:'queries.configure_view.columns.input_label'),
                                             inputPlaceholder: I18n.t(:'queries.configure_view.columns.input_placeholder'),
                                             dragAreaLabel: I18n.t(:'queries.configure_view.columns.drag_area_label'),
-                                            appendToComponent: true
+                                            appendToComponent: true,
+                                            dragAreaName: "columns-select_dragarea",
+                                            formControlId: "columns-select_autocompleter"
                                           }%>
           <% end %>
         <% end %>

--- a/app/components/projects/configure_view_modal_component.rb
+++ b/app/components/projects/configure_view_modal_component.rb
@@ -34,6 +34,7 @@ class Projects::ConfigureViewModalComponent < ApplicationComponent
   MODAL_ID = "op-project-list-configure-dialog"
   QUERY_FORM_ID = "op-project-list-configure-query-form"
   COLUMN_HTML_NAME = "columns"
+  COLUMN_HTML_ID = "columns-select"
 
   options :query
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57644/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix draggable columns inside configure view modal of projects list to work correctly.

## Screenshots
Before:
https://github.com/user-attachments/assets/9f6b767f-bc89-4732-a8ed-3ed00f19d88e

After:
https://github.com/user-attachments/assets/6820fcf7-76d1-4cd3-8a4a-804b0358b6c9

# What approach did you choose and why?
When the component is inside a Primer dialog component and isn't append to the body, it should have `formControlId` and `dragAreaName` inputs' values.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, Safari)
