### PR TITLE
[57683] Clicking a notification email should open the activity view of the work package

### DIFF
--- a/app/mailers/sharing_mailer.rb
+++ b/app/mailers/sharing_mailer.rb
@@ -15,7 +15,7 @@ class SharingMailer < ApplicationMailer
     @role_rights = derive_role_rights(role)
     @allowed_work_package_actions = derive_allowed_work_package_actions(role)
     @url = optionally_activated_url(work_package_url(@work_package.id), @invitation_token)
-    @notification_url = optionally_activated_url(details_notifications_url(@work_package.id), @invitation_token)
+    @notification_url = optionally_activated_url(details_notifications_url(@work_package.id, tab: :activity), @invitation_token)
 
     set_open_project_headers(@work_package)
     message_id(membership, sharer)

--- a/app/views/mailer/_notification_row.html.erb
+++ b/app/views/mailer/_notification_row.html.erb
@@ -1,5 +1,5 @@
 <a style="text-decoration: none;display: block;"
-   href="<%= local_assigns[:notification_url] || details_notifications_url(work_package.id) %>"
+   href="<%= local_assigns[:notification_url] || details_notifications_url(work_package.id, tab: :activity) %>"
    target="_blank">
   <%= render layout: 'mailer/border_table' do %>
     <tr>
@@ -104,7 +104,7 @@
 </table>
 
 <a style="margin-left: 12px;"
-   href="<%= defined?(open_in_browser_path) ? open_in_browser_path : details_notifications_url(work_package.id) %>"
+   href="<%= defined?(open_in_browser_path) ? open_in_browser_path : details_notifications_url(work_package.id, tab: :activity) %>"
    target="_blank"
    rel="noopener noreferrer">
   <%= I18n.t('mail.work_packages.open_in_browser') %>

--- a/app/views/work_package_mailer/mentioned.html.erb
+++ b/app/views/work_package_mailer/mentioned.html.erb
@@ -11,7 +11,7 @@
       <%= render partial: 'mailer/mailer_header',
                  locals: {
                    summary: I18n.t(:'mail.work_packages.mentioned_by', user: @journal.user),
-                   button_href: details_notifications_url(@work_package.id),
+                   button_href: details_notifications_url(@work_package.id, tab: :activity),
                    button_text: I18n.t(:'mail.notification.see_in_center'),
                    user: @user,
                  } %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57683/activity

# What are you trying to accomplish?
Redirect to Activity tab in the notification emails (like it was before the refactoring of the notification center)
