### PR TITLE
Fix date picker being blank and jumpy when appearing

### DIFF
--- a/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
@@ -52,7 +52,6 @@ import { debounce } from 'lodash';
 import {
   SpotDropModalTeleportationService,
 } from 'core-app/spot/components/drop-modal/drop-modal-teleportation.service';
-import { delay } from 'rxjs';
 
 // eslint-disable-next-line change-detection-strategy/on-push
 @Component({
@@ -216,9 +215,6 @@ export class OpModalSingleDatePickerComponent implements ControlValueAccessor, O
   private initializeDatepickerAfterOpen():void {
     this.spotDropModalTeleportationService
       .afterRenderOnce$(true)
-      .pipe(
-        delay(100),
-      )
       .subscribe(() => {
         this.initializeDatepicker();
       });

--- a/frontend/src/app/spot/components/drop-modal/drop-modal-portal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal-portal.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewChecked,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -10,13 +9,12 @@ import {
 import { SpotDropModalTeleportationService, TeleportInstance } from './drop-modal-teleportation.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 
-
 @Component({
   selector: 'opce-spot-drop-modal-portal',
   template: '<ng-container *ngTemplateOutlet="template"></ng-container>',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SpotDropModalPortalComponent extends UntilDestroyedMixin implements OnInit, AfterViewChecked {
+export class SpotDropModalPortalComponent extends UntilDestroyedMixin implements OnInit {
   @HostBinding('class.spot-drop-modal-portal') className = true;
 
   template:TeleportInstance|null = null;
@@ -39,10 +37,7 @@ export class SpotDropModalPortalComponent extends UntilDestroyedMixin implements
       .subscribe((templ) => {
         this.template = templ;
         this.cdRef.detectChanges();
+        this.template$.hasRendered$.next(!!this.elementRef.nativeElement.children.length);
       });
-  }
-
-  ngAfterViewChecked():void {
-    this.template$.hasRendered$.next(!!this.elementRef.nativeElement.children.length);
   }
 }

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -109,15 +109,6 @@ export class SpotDropModalComponent implements OnDestroy {
   open() {
     this._opened = true;
     this.updateAppHeight();
-    this.cdRef.detectChanges();
-
-    /*
-     * If we don't activate the body after one tick, angular will complain because
-     * it already rendered a `null` template, but then gets an update to that
-     * template in the same tick.
-     * To make it happy, we update afterwards
-     */
-    this.teleportationService.activate(this.body);
 
     this.teleportationService
       .hasRenderedFiltered$
@@ -126,6 +117,7 @@ export class SpotDropModalComponent implements OnDestroy {
         take(1),
       )
       .subscribe(() => {
+        this.cdRef.detectChanges();
         const referenceEl = this.elementRef.nativeElement as HTMLElement;
         const floatingEl = this.anchor.nativeElement as HTMLElement;
         this.cleanupFloatingUI = autoUpdate(
@@ -173,10 +165,16 @@ export class SpotDropModalComponent implements OnDestroy {
             // Index 1 because the element at index 0 is the trigger button to open the modal
             (findAllFocusableElementsWithin(document.querySelector('.spot-drop-modal-portal')!)[1])?.focus();
           }
-
-          this.cdRef.detectChanges();
         });
       });
+
+    /*
+     * If we don't activate the body after one tick, angular will complain because
+     * it already rendered a `null` template, but then gets an update to that
+     * template in the same tick.
+     * To make it happy, we update afterwards
+     */
+    this.teleportationService.activate(this.body);
   }
 
   close():void {

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_relative "../support/pages/team_planner"
 require_relative "../../../../spec/features/views/shared_examples"
 
-RSpec.describe "Team planner query handling", :js, with_ee: %i[team_planner_view] do
+RSpec.describe "Team planner query handling", :js, :with_cuprite, with_ee: %i[team_planner_view] do
   shared_let(:type_task) { create(:type_task) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do
@@ -97,7 +97,7 @@ RSpec.describe "Team planner query handling", :js, with_ee: %i[team_planner_view
     filters.open
 
     filters.add_filter_by("Type", "is (OR)", [type_bug.name])
-
+    team_planner.clear_any_toasters
     filters.expect_filter_count("2")
 
     team_planner.within_lane(user) do
@@ -120,6 +120,7 @@ RSpec.describe "Team planner query handling", :js, with_ee: %i[team_planner_view
     # Change filter
     filters.open
     filters.add_filter_by("Type", "is (OR)", [type_bug.name])
+    team_planner.clear_any_toasters
     filters.expect_filter_count("2")
 
     # Save current filters

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -191,6 +191,7 @@ RSpec.describe "Working Days", :js, :with_cuprite do
 
       # Check if a date is correctly highlighted after selecting it in different time zones
       datepicker.select_day 5
+      expect(datepicker).to have_day_selected("5")
 
       # It can cancel and reopen
       within_test_selector("op-datepicker-modal") do

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -187,7 +187,6 @@ RSpec.describe "Working Days", :js, :with_cuprite do
     end
 
     it "can add non-working days" do
-      # Initial loading can sometimes take a while
       datepicker.open_modal!
 
       # Check if a date is correctly highlighted after selecting it in different time zones

--- a/spec/features/views/shared_examples.rb
+++ b/spec/features/views/shared_examples.rb
@@ -37,6 +37,7 @@ RSpec.shared_examples "module specific query view management" do
       # Change the query
       filters.open
       filters.add_filter_by "Subject", "contains", ["Test"]
+      module_page.clear_any_toasters
       filters.expect_filter_count(initial_filter_count + 1)
 
       # Save it
@@ -48,6 +49,7 @@ RSpec.shared_examples "module specific query view management" do
 
       # Change the filter again
       filters.add_filter_by "% Complete", "is", ["25"], "percentageDone"
+      module_page.clear_any_toasters
       filters.expect_filter_count(initial_filter_count + 2)
 
       # Save as another query
@@ -61,8 +63,7 @@ RSpec.shared_examples "module specific query view management" do
       # Rename a query
       settings_menu.open_and_choose "Rename view"
       expect(page).to have_focus_on(".editable-toolbar-title--input")
-      page.driver.browser.switch_to.active_element.send_keys("My second query (renamed)")
-      page.driver.browser.switch_to.active_element.send_keys(:return)
+      find_field("Name of this view").send_keys("My second query (renamed)", :return)
       module_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
 
       query_title.expect_not_changed

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -85,6 +85,11 @@ module Components
           .first(".flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)",
                  text: value)
           .click
+
+        # safeguard
+        unless flatpickr_container.has_css?(".flatpickr-day.selected", text: value, wait: 1)
+          raise "Expected #{value} to be selected"
+        end
       end
     end
 

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -85,11 +85,6 @@ module Components
           .first(".flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)",
                  text: value)
           .click
-
-        # safeguard
-        unless flatpickr_container.has_css?(".flatpickr-day.selected", text: value, wait: 1)
-          raise "Expected #{value} to be selected"
-        end
       end
     end
 

--- a/spec/support/components/datepicker/datepicker_modal.rb
+++ b/spec/support/components/datepicker/datepicker_modal.rb
@@ -12,5 +12,9 @@ module Components
         raise "Expected date to equal #{date}, but got #{input.value}" unless input.value == date.iso8601
       end
     end
+
+    def has_day_selected?(value)
+      flatpickr_container.has_css?(".flatpickr-day.selected", text: value, wait: 1)
+    end
   end
 end

--- a/spec/support/components/datepicker/datepicker_modal.rb
+++ b/spec/support/components/datepicker/datepicker_modal.rb
@@ -1,13 +1,8 @@
 module Components
   class DatepickerModal < Datepicker
     def open_modal!
-      retry_block do
-        click_on "Non-working day", wait: 10
-        unless page.has_css?(".flatpickr-calendar", wait: 10)
-          click_on "Cancel"
-          raise "Flatpickr should render a calendar"
-        end
-      end
+      click_on "Non-working day"
+      expect_visible
     end
 
     def set_date_input(date)
@@ -15,25 +10,6 @@ module Components
         set_date(date)
         input = find_field("date")
         raise "Expected date to equal #{date}, but got #{input.value}" unless input.value == date.iso8601
-      end
-    end
-
-    ##
-    # Select day from datepicker
-    def select_day(value)
-      unless (1..31).cover?(value.to_i)
-        raise ArgumentError, "Invalid value #{value} for day, expected 1-31"
-      end
-
-      expect(flatpickr_container).to have_text(value)
-
-      retry_block do
-        flatpickr_container
-          .first(".flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)",
-                 text: value)
-          .click
-
-        raise "Expected #{value} to be selected" unless flatpickr_container.has_css?(".flatpickr-day.selected", text: value)
       end
     end
   end

--- a/spec/support/toasts/expectations.rb
+++ b/spec/support/toasts/expectations.rb
@@ -23,6 +23,13 @@ module Toasts
       page.find(".op-toast--close").click
     end
 
+    # Clears a toaster if there is one waiting 1 second max, but do not fail if there is none
+    def clear_any_toasters
+      if has_button?(I18n.t("js.close_popup_title"), wait: 1)
+        find_button(I18n.t("js.close_popup_title")).click
+      end
+    end
+
     def expect_no_toaster(type: :success, message: nil, wait: 10)
       if type.nil?
         expect(page).to have_no_css(".op-toast", wait:)


### PR DESCRIPTION
It was in order to fix the flaky spec
`spec/features/admin/working_days_spec.rb:189`. The flakiness can be forced by adding a `sleep 2` at the beginning of the test, just before the `datepicker.open_modal!` call.

Not absolutely sure why so many forced change detection calls are needed, but this way it seems to work. It seems to be related to having a lot of nested templates, outlets and `if`s in templates which each time need a new change detection to be reevaluated. But I'm not an expert in this.

As a bonus there is no delay anymore in the drop modal initialization, which should lead to more stable tests. For instance execution time of `spec/features/admin/working_days_spec.rb:189` dropped from 17 secs to 7 secs.

<details><summary>FWIW, here is how the error looked on the CI</summary>
<p>

It was failing at two places: twice when trying to open the modal (it was opened "blank" without the flatpickr initialized on first try, then closed by clicking "Cancel" button on second try, then 3 times when trying to set the date (because it's closed).

```
-- rspec-retry: failed try 1 of 3 max --
RuntimeError: 'Flatpickr should render a calendar'
occurred on /app/spec/support/components/datepicker/datepicker_modal.rb:8:in `block in open_modal!'
backtrace:
  /app/spec/support/components/datepicker/datepicker_modal.rb:8:in `block in open_modal!'
  /app/spec/support/rspec_retry.rb:79:in `retry_block'
  /app/spec/support/components/datepicker/datepicker_modal.rb:4:in `open_modal!'
  /app/spec/features/admin/working_days_spec.rb:191:in `block (3 levels) in <top (required)>'
  /app/spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
  /app/spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
  /app/spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
  /app/spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
ran 1 try in 11.167048228 seconds, waiting 0.5 seconds until the next try.
--
-- rspec-retry: failed try 2 of 3 max --
Capybara::ElementNotFound: 'Unable to find link or button "Cancel"'
occurred on /app/spec/support/components/datepicker/datepicker_modal.rb:7:in `block in open_modal!'
backtrace:
  /app/spec/support/components/datepicker/datepicker_modal.rb:7:in `block in open_modal!'
  /app/spec/support/rspec_retry.rb:79:in `retry_block'
  /app/spec/support/components/datepicker/datepicker_modal.rb:4:in `open_modal!'
  /app/spec/features/admin/working_days_spec.rb:191:in `block (3 levels) in <top (required)>'
  /app/spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
  /app/spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
  /app/spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
  /app/spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
ran 2 tries in 25.873807058 seconds, waiting 0.75 seconds until the next try.
--
-- rspec-retry: failed try 1 of 3 max --
Capybara::ElementNotFound: 'Unable to find css ".flatpickr-calendar" within #<Capybara::Node::Element tag="body" path="//HTML[1]/BODY[1]">'
occurred on /app/spec/support/components/datepicker/datepicker.rb:36:in `flatpickr_container'
backtrace:
  /app/spec/support/components/datepicker/datepicker.rb:36:in `flatpickr_container'
  /app/spec/support/components/datepicker/datepicker_modal.rb:36:in `block in select_day'
  /app/spec/support/rspec_retry.rb:79:in `retry_block'
  /app/spec/support/components/datepicker/datepicker_modal.rb:30:in `select_day'
  /app/spec/features/admin/working_days_spec.rb:194:in `block (3 levels) in <top (required)>'
  /app/spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
  /app/spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
  /app/spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
  /app/spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
ran 1 try in 4.286365785 seconds, waiting 0.5 seconds until the next try.
--
-- rspec-retry: failed try 2 of 3 max --
Capybara::ElementNotFound: 'Unable to find css ".flatpickr-calendar" within #<Capybara::Node::Element tag="body" path="//HTML[1]/BODY[1]">'
occurred on /app/spec/support/components/datepicker/datepicker.rb:36:in `flatpickr_container'
backtrace:
  /app/spec/support/components/datepicker/datepicker.rb:36:in `flatpickr_container'
  /app/spec/support/components/datepicker/datepicker_modal.rb:31:in `block in select_day'
  /app/spec/support/rspec_retry.rb:79:in `retry_block'
  /app/spec/support/components/datepicker/datepicker_modal.rb:30:in `select_day'
  /app/spec/features/admin/working_days_spec.rb:194:in `block (3 levels) in <top (required)>'
  /app/spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
  /app/spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
  /app/spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
  /app/spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
ran 2 tries in 8.794877994 seconds, waiting 0.75 seconds until the next try.
--
-- rspec-retry: failed try 3 of 3 max --
Capybara::ElementNotFound: 'Unable to find css ".flatpickr-calendar" within #<Capybara::Node::Element tag="body" path="//HTML[1]/BODY[1]">'
occurred on /app/spec/support/components/datepicker/datepicker.rb:36:in `flatpickr_container'
backtrace:
  /app/spec/support/components/datepicker/datepicker.rb:36:in `flatpickr_container'
  /app/spec/support/components/datepicker/datepicker_modal.rb:31:in `block in select_day'
  /app/spec/support/rspec_retry.rb:79:in `retry_block'
  /app/spec/support/components/datepicker/datepicker_modal.rb:30:in `select_day'
  /app/spec/features/admin/working_days_spec.rb:194:in `block (3 levels) in <top (required)>'
  /app/spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
  /app/spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
  /app/spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
  /app/spec/support/cuprite_setup.rb:133:in `block (2 levels) in <top (required)>'
ran 3 tries in 13.592000601 seconds, it was the last try.
--
```

</p>
</details> 