### PR TITLE
Save 2 seconds by clicking redirect link directly in a test

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/job-status-polling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/job-status-polling.controller.ts
@@ -40,14 +40,18 @@ export default class JobStatusPollingController extends Controller<HTMLElement> 
     setTimeout(() => element.click(), 50);
   }
 
-  redirectClick(_:Event) {
-    this.userInteraction = true;
+  redirectClick(event:PointerEvent) {
+    this.followLink(event.target as HTMLLinkElement);
   }
 
   redirectTargetConnected(element:HTMLLinkElement) {
     setTimeout(() => {
-      this.userInteraction = true;
-      window.location.href = element.href;
+      this.followLink(element);
     }, 2000);
+  }
+
+  followLink(element:HTMLLinkElement) {
+    this.userInteraction = true;
+    window.location.href = element.href;
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/job-status-polling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/job-status-polling.controller.ts
@@ -41,6 +41,7 @@ export default class JobStatusPollingController extends Controller<HTMLElement> 
   }
 
   redirectClick(event:PointerEvent) {
+    event.preventDefault();
     this.followLink(event.target as HTMLLinkElement);
   }
 

--- a/modules/job_status/spec/features/job_status_spec.rb
+++ b/modules/job_status/spec/features/job_status_spec.rb
@@ -66,10 +66,27 @@ RSpec.describe "Job status", :js do
       status.update! payload: { redirect: home_url }
     end
 
-    it "does automatically redirect" do
+    it "does automatically redirect after 2 seconds" do
       visit "/job_statuses/#{status.job_id}"
+      sleep 2
 
-      expect(page).to have_current_path(home_path, wait: 10)
+      expect(page).to have_current_path(home_path)
+    end
+
+    context "when job redirect url is /work_package/:id" do
+      let(:work_package) { create(:work_package) }
+
+      before do
+        status.update! payload: { redirect: work_package_url(work_package) }
+      end
+
+      it "redirects to /projects/:identifier/work_packages/:id/activity when clicking the link without any delay" do
+        visit "/job_statuses/#{status.job_id}"
+        click_on I18n.t("job_status_dialog.redirect_link")
+
+        # should happen before the 2 seconds of autoredirect
+        expect(page).to have_current_path(project_work_package_url(work_package.project, work_package, "activity"), wait: 1)
+      end
     end
   end
 

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -114,9 +114,8 @@ RSpec.describe "Moving a work package through Rails view", :js do
           #
           # The following lines wait for this job status dialog to be discarded.
           expect(page).to have_text "Successful update."
-          # Clicking the link directly would save 2 seconds, but there is a bug
-          # which redirects back. Sleep 2 seconds instead until it's fixed
-          sleep 2 # TODO replace with: click_on(I18n.t("job_status_dialog.redirect_link"))
+          # Clicking the link directly to save the 2 seconds of auto-click
+          click_on(I18n.t("job_status_dialog.redirect_link"))
 
           expect(page).to have_current_path "/projects/#{project2.identifier}/work_packages/#{work_package.id}/activity"
           page.find_by_id("projects-menu", text: "Target")


### PR DESCRIPTION
It can be done because this has been fixed in 8fe4a222148.

And fix the redirection not working properly if the link is clicked. Fixed by explicitly setting `window.href`.
