### PR TITLE
[#55234] Fix text filter width on project list

### DIFF
--- a/app/components/projects/index_sub_header_component.html.erb
+++ b/app/components/projects/index_sub_header_component.html.erb
@@ -8,6 +8,7 @@
                                     icon: :search,
                                     size: :small
                                   },
+                                  input_width: :medium,
                                   show_clear_button: true,
                                   clear_button_id: clear_button_id,
                                   data: filter_input_data_attributes)

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -38,7 +38,7 @@
   label
     margin-bottom: 0
   input
-    border-radius: 6px
+    border-radius: var(--borderRadius-medium)
 
 action-menu
   anchored-position
@@ -80,6 +80,11 @@ sub-header,
     .FormControl-horizontalGroup
       flex-direction: column
       row-gap: 1rem
+
+// Todo: Fix this as soon as possible in the primer repo!
+.SubHeader-leftPane
+  [class*="FormControl-input-width--"]:not(.FormControl-input-width--auto)
+    width: 100vw
 
 .Button.op-app-header--primer-button,
 .Button.op-app-header--primer-button .Button-visual


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/55234

# What are you trying to accomplish?
Add a larger width to the project list search input.

## Screenshots
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/c3549104-154e-44c4-9ddd-0816d7154232">

# What approach did you choose and why?
Added an override for the project list input filter, because the primer provided css was not working.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
