### PR TITLE
[57687] Mobile: Underline Nav readjusts horizontal scroll unnecessarily even when tab is visible

### DIFF
--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -47,8 +47,10 @@ action-menu
 
 .UnderlineNav
   @include no-visible-scroll-bar
-  scroll-behavior: smooth
   margin-bottom: 12px
+
+  @media screen and (min-width: $breakpoint-sm)
+    scroll-behavior: smooth
 
 /* Remove margin-left: 2rem from Breadcrumbs */
 #breadcrumb,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57687/activity

# What are you trying to accomplish?
Disable smooth scrolling on mobile

