### PR TITLE
[#57704] Resolve pending spec in `direct_ifc_upload_spec.rb`

### DIFF
--- a/modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
+++ b/modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe "direct IFC upload", :js, with_config: { edition: "bim" }, with_d
 
         page.attach_file("file", ifc_fixture.path, visible: :all)
 
+        expected_validation_message = I18n.t("activerecord.errors.messages.file_too_large", count: 1024)
+        expect(page).to have_field(type: "file", validation_message: expected_validation_message)
+
         form_validity = page.evaluate_script <<~JS
           document
             .querySelector('#new_bim_ifc_models_ifc_model')

--- a/modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
+++ b/modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe "direct IFC upload", :js, with_config: { edition: "bim" }, with_d
 
     context "when the file size exceeds the allowed maximum", with_settings: { attachment_max_size: 1 } do
       it "invalidates the form via JavaScript preventing submission" do
-        pending "This test is currently flaky due to an unknown reason"
-
         visit new_bcf_project_ifc_model_path(project_id: project.identifier)
 
         page.attach_file("file", ifc_fixture.path, visible: :all)


### PR DESCRIPTION
The JS form validity was previously flaky but seems resolved now. I can't point out exactly what has changed.

Cheers to @cbliard who caught that it was now passing

https://community.openproject.org/work_packages/57704

----

```bash
❯ docker compose exec backend-test script/bulk_run_rspec modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb
1 tests to run
logs: /home/dev/openproject/tmp/bulk_run/logs
================================================================================
Running modules/bim/spec/features/ifc_models/direct_ifc_upload_spec.rb 5 times
================================================================================
------------------------------------ Run 0 -------------------------------------
ok
------------------------------------ Run 1 -------------------------------------
ok
------------------------------------ Run 2 -------------------------------------
ok
------------------------------------ Run 3 -------------------------------------
ok
------------------------------------ Run 4 -------------------------------------
ok
PASSED
Saving
Done
results in /home/dev/openproject/tmp/bulk_run
```
