### PR TITLE
Fix appsignal deprecation warning

### DIFF
--- a/lib/api/appsignal_api.rb
+++ b/lib/api/appsignal_api.rb
@@ -30,8 +30,8 @@ module API
     def self.included(base)
       base.class_eval do
         if OpenProject::Appsignal.enabled?
-          require "appsignal/integrations/grape"
-          insert_before Grape::Middleware::Error, Appsignal::Grape::Middleware
+          require "appsignal/rack/grape_middleware"
+          insert_before Grape::Middleware::Error, Appsignal::Rack::GrapeMiddleware
         end
       end
     end


### PR DESCRIPTION
Message was:
> [2024-09-09T08:51:01 (process) #9][WARN] appsignal: The constant
> Appsignal::Grape::Middleware has been deprecated. Please update the
> constant name to Appsignal::Rack::GrapeMiddleware in the following
> file to remove this message.
