### PR TITLE
Allow word-break on meeting agenda items content

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -10,7 +10,7 @@
       grid.with_area(:content, tag: :span) do
         if @meeting_agenda_item.visible_work_package?
           flex_layout(align_items: :center) do |flex|
-            flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do
+            flex.with_column(mr: 2, flex: 1) do
               render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
                                             test_selector: 'op-meeting-agenda-title',
                                             font_size: :normal, font_weight: :bold, target: "_blank")) do

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -6,6 +6,7 @@ $meeting-agenda-item--presenter-width: 300px
   display: grid
   grid-template-columns: 20px auto 1fr fit-content($meeting-agenda-item--presenter-width) fit-content(40px)
   grid-template-areas: "drag-handle content duration presenter actions" ".notes notes notes notes"
+  align-items: center
 
   &--drag-handle,
   &--duration,
@@ -24,7 +25,7 @@ $meeting-agenda-item--presenter-width: 300px
     white-space: nowrap
 
   &--content
-    @include text-shortener
+    word-break: break-word
 
   @media screen and (max-width: $breakpoint-lg)
     grid-template-columns: 20px auto 1fr calc($meeting-agenda-item--presenter-width - 50px) 50px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57671

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The work package is the most important part of the agenda item. If it needs more space than one row, give it that.

## Screenshots

**Before**
![](https://community.openproject.org/api/v3/attachments/191122/content) 

**After mobile**
<img width="508" alt="Bildschirmfoto 2024-09-09 um 16 13 05" src="https://github.com/user-attachments/assets/ad31e008-f58e-4a27-9327-de6b1f298b14">

**After tablet**
<img width="1136" alt="Bildschirmfoto 2024-09-09 um 16 13 25" src="https://github.com/user-attachments/assets/437de8b9-060c-4722-a1b5-26ff6aecbc38">

**After desktop**
<img width="1568" alt="Bildschirmfoto 2024-09-09 um 16 13 39" src="https://github.com/user-attachments/assets/f8e0250a-c115-4c12-9396-a9233b216c10">

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
