### PR TITLE
Make tests relying on xeokit work locally

### DIFF
--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -16,7 +16,6 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "old", over
     end
 
     options.add_argument("--no-sandbox")
-    options.add_argument("--disable-gpu")
     options.add_argument("--disable-popup-blocking")
     options.add_argument("--lang=#{language}")
     options.add_preference("intl.accept_languages", language)
@@ -24,6 +23,10 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "old", over
     # https://github.com/grosser/parallel_tests/issues/658
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--disable-smooth-scrolling")
+    # Software GPU to avoid the dreaded "[ERROR] [Canvas '__0']: Failed to get a
+    # WebGL context" error for tests using xeokit, adapted from answers of
+    # https://stackoverflow.com/q/70948512/177665 and
+    options.add_argument("--use-gl=angle")
     # Disable "Select your search engine screen"
     options.add_argument("--disable-search-engine-choice-screen")
 


### PR DESCRIPTION
# What are you trying to accomplish?

Tests using xeokit, the 3d visualization kit from BIM edition, did not work locally for me in headless mode. It fails with the following devtools console error: "[ERROR] [Canvas '__0']: Failed to get a WebGL context". They do pass on CI though.

One example test is `./modules/bim/spec/features/model_viewer_spec.rb`.

In an effort to make these tests pass both on CI and locally, I'm trying some flags seen on https://stackoverflow.com/q/70948512/177665 to keep the GPU enabled, but use a software implementation. It works locally. Not sure yet if it works in a docker container and on CI.

# What approach did you choose and why?

Tried various things from https://stackoverflow.com/q/70948512/177665: 
- removed flag `--disable-gpu` and used `--use-angle=swiftshader --use-gl=angle --in-process-gpu --headless=new`, but it did not work.
- tried removing `--use-angle=swiftshader` as suggested in another answer and it worked.
- tried removing `--in-process-gpu` and keeping `--headless=old` and it continued working

So the final solution is: remove `--disable-gpu` and add `--use-gl=angle`.