### PR TITLE
[#57037] Migrate UserPreference settings with the "default" theme to "light"

### DIFF
--- a/db/migrate/20240909151818_migrate_legacy_default_theme_to_light_theme.rb
+++ b/db/migrate/20240909151818_migrate_legacy_default_theme_to_light_theme.rb
@@ -29,29 +29,29 @@
 #++
 
 class MigrateLegacyDefaultThemeToLightTheme < ActiveRecord::Migration[7.1]
-  class MigrationUserPreference < ActiveRecord::Base
-    self.table_name = "user_preferences"
-  end
-
   # Migrate legacy `default` theme to `light` theme
   #
   # Moving from:
   # {
   #   "settings": {
-  #     "theme": "default"
+  #     "theme": "default",
+  #     "foo": "bar"
   #   }
   # }
   #
   # To:
   # {
   #   "settings": {
-  #     "theme": "light" # current default theme
+  #     "theme": "light", # current default theme
+  #     "foo": "bar"
   #   }
   # }
   def up
-    MigrationUserPreference
-      .where(settings: { theme: "default" })
-      .update_all(settings: { theme: "light" })
+    execute <<-SQL.squish
+      UPDATE user_preferences
+      SET settings = jsonb_set(settings, '{theme}', '"light"')
+      WHERE settings->>'theme' = 'default';
+    SQL
   end
 
   # no-op

--- a/db/migrate/20240909151818_migrate_legacy_default_theme_to_light_theme.rb
+++ b/db/migrate/20240909151818_migrate_legacy_default_theme_to_light_theme.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class MigrateLegacyDefaultThemeToLightTheme < ActiveRecord::Migration[7.1]
+  class MigrationUserPreference < ActiveRecord::Base
+    self.table_name = "user_preferences"
+  end
+
+  # Migrate legacy `default` theme to `light` theme
+  #
+  # Moving from:
+  # {
+  #   "settings": {
+  #     "theme": "default"
+  #   }
+  # }
+  #
+  # To:
+  # {
+  #   "settings": {
+  #     "theme": "light" # current default theme
+  #   }
+  # }
+  def up
+    MigrationUserPreference
+      .where(settings: { theme: "default" })
+      .update_all(settings: { theme: "light" })
+  end
+
+  # no-op
+  def down; end
+end

--- a/spec/migrations/migrate_legacy_default_theme_to_light_theme_spec.rb
+++ b/spec/migrations/migrate_legacy_default_theme_to_light_theme_spec.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20240909151818_migrate_legacy_default_theme_to_light_theme.rb")
+
+RSpec.describe MigrateLegacyDefaultThemeToLightTheme, type: :model do
+  RSpec::Matchers.define_negated_matcher :not_change, :change
+
+  # Silencing migration logs, since we are not interested in that during testing
+  subject(:run_migration) { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+  shared_let(:user_with_default_theme) { create(:user, preferences: { settings: { theme: "default" } }) }
+  shared_let(:user_with_light_theme) { create(:user, preferences: { settings: { theme: "light" } }) }
+  shared_let(:user_with_light_high_contrast_theme) { create(:user, preferences: { settings: { theme: "light_high_contrast" } }) }
+  shared_let(:user_with_dark_theme) { create(:user, preferences: { settings: { theme: "dark" } }) }
+
+  it "sets the theme to light for users with the 'default' theme" do
+    expect { run_migration }
+      .to change { user_with_default_theme.reload.pref.settings["theme"] }
+      .from("default")
+      .to("light")
+  end
+
+  it "does not change the theme for users with another theme that isn't 'default'" do
+    expect { run_migration }
+      .to not_change { user_with_light_theme.reload.pref.settings["theme"] }
+      .and(not_change { user_with_light_high_contrast_theme.reload.pref.settings["theme"] })
+      .and(not_change { user_with_dark_theme.reload.pref.settings["theme"] })
+  end
+end

--- a/spec/migrations/migrate_legacy_default_theme_to_light_theme_spec.rb
+++ b/spec/migrations/migrate_legacy_default_theme_to_light_theme_spec.rb
@@ -35,10 +35,12 @@ RSpec.describe MigrateLegacyDefaultThemeToLightTheme, type: :model do
   # Silencing migration logs, since we are not interested in that during testing
   subject(:run_migration) { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
 
-  shared_let(:user_with_default_theme) { create(:user, preferences: { settings: { theme: "default" } }) }
-  shared_let(:user_with_light_theme) { create(:user, preferences: { settings: { theme: "light" } }) }
-  shared_let(:user_with_light_high_contrast_theme) { create(:user, preferences: { settings: { theme: "light_high_contrast" } }) }
-  shared_let(:user_with_dark_theme) { create(:user, preferences: { settings: { theme: "dark" } }) }
+  shared_let(:user_with_default_theme) { create(:user, preferences: { settings: { theme: "default", foo: "bar" } }) }
+  shared_let(:user_with_light_theme) { create(:user, preferences: { settings: { theme: "light", foo: "bar" } }) }
+  shared_let(:user_with_light_high_contrast_theme) do
+    create(:user, preferences: { settings: { theme: "light_high_contrast", foo: "bar" } })
+  end
+  shared_let(:user_with_dark_theme) { create(:user, preferences: { settings: { theme: "dark", foo: "bar" } }) }
 
   it "sets the theme to light for users with the 'default' theme" do
     expect { run_migration }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57037

# What are you trying to accomplish?
A lot of areas were broken display-wise when upgrading from 9.x versions. This happened if users still had in their `UserPreference` theme settings the `default` option. I'm bringing these "default" values to "light" which is the current default setting for the theme setting.

## Screenshots
**Before**
<img width="467" alt="Screenshot showing the transparency issue" src="https://github.com/user-attachments/assets/b9a541af-811f-4556-bf2b-0c9ad3e81eed">

**After**
<img width="524" alt="Screenshot showcasing the fixed transparency" src="https://github.com/user-attachments/assets/ea32bd85-730a-4a85-b964-5db050adc089">

# What approach did you choose and why?
This was missed when upgrading OpenProject at some point so this should bring everything back in order for users that still have the "default" theme setting which is no longer supported, and keep the preferences for said users who have since moved to one of the valid options like "light" or "light_high_contrast".

A migration should suffice.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
