### PR TITLE
Bug: confirm destroy project page not support turbo navigate yet.

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -354,7 +354,8 @@ module Projects
           scheme: :danger,
           icon: :trash,
           label: I18n.t(:button_delete),
-          href: confirm_destroy_project_path(project)
+          href: confirm_destroy_project_path(project),
+          data: { turbo: false }
         }
       end
     end

--- a/app/views/projects/_toolbar.html.erb
+++ b/app/views/projects/_toolbar.html.erb
@@ -79,7 +79,8 @@ See COPYRIGHT and LICENSE files for more details.
     <li class="toolbar-item">
       <%= link_to confirm_destroy_project_path(@project),
                   class: 'button delete',
-                  title: t(:label_delete_project) do %>
+                  title: t(:label_delete_project),
+                  data: { turbo: false } do %>
         <%= op_icon('button--icon icon-delete') %>
         <span class="button--text"><%= t(:button_delete) %></span>
       <% end %>


### PR DESCRIPTION
# What are you trying to accomplish?

Similar #16531, I found confirm destroy project not working after click, even you type the project name exactly right, the delete button is not en-able.

# What approach did you choose and why?

Simply do a page refresh will fix the problem, so need turbo off this page.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
