### PR TITLE
Ambiguous button_save_as translation fix

### DIFF
--- a/modules/reporting/config/locales/crowdin/af.yml
+++ b/modules/reporting/config/locales/crowdin/af.yml
@@ -23,7 +23,7 @@ af:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Opmerking"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/ar.yml
+++ b/modules/reporting/config/locales/crowdin/ar.yml
@@ -23,7 +23,7 @@ ar:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "حفظ التقرير بشكل..."
+  button_save_report_as: "حفظ التقرير بشكل..."
   comments: "التعليق"
   cost_reports_title: "الوقت والتكاليف"
   label_cost_report: "تقرير التكلفة"

--- a/modules/reporting/config/locales/crowdin/az.yml
+++ b/modules/reporting/config/locales/crowdin/az.yml
@@ -23,7 +23,7 @@ az:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/be.yml
+++ b/modules/reporting/config/locales/crowdin/be.yml
@@ -23,7 +23,7 @@ be:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/bg.yml
+++ b/modules/reporting/config/locales/crowdin/bg.yml
@@ -23,7 +23,7 @@ bg:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Запазване на отчета като..."
+  button_save_report_as: "Запазване на отчета като..."
   comments: "Коментар"
   cost_reports_title: "Време и разходи"
   label_cost_report: "Доклад за разходите"

--- a/modules/reporting/config/locales/crowdin/ca.yml
+++ b/modules/reporting/config/locales/crowdin/ca.yml
@@ -23,7 +23,7 @@ ca:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Desa l'informe com..."
+  button_save_report_as: "Desa l'informe com..."
   comments: "Comentari"
   cost_reports_title: "Temps i costs"
   label_cost_report: "Informe de costs"

--- a/modules/reporting/config/locales/crowdin/ckb-IR.yml
+++ b/modules/reporting/config/locales/crowdin/ckb-IR.yml
@@ -23,7 +23,7 @@ ckb-IR:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/cs.yml
+++ b/modules/reporting/config/locales/crowdin/cs.yml
@@ -23,7 +23,7 @@ cs:
   plugin_openproject_reporting:
     name: "Reportování OpenProject"
     description: "Tento modul umožňuje vytvářet vlastní přehledy nákladů s filtrováním a seskupením vytvořených OpenProject plugin čas & náklady ."
-  button_save_as: "Uložit report jako..."
+  button_save_report_as: "Uložit report jako..."
   comments: "Komentář"
   cost_reports_title: "Čas a náklady"
   label_cost_report: "Výkaz nákladů"

--- a/modules/reporting/config/locales/crowdin/da.yml
+++ b/modules/reporting/config/locales/crowdin/da.yml
@@ -23,7 +23,7 @@ da:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Gem rapport som..."
+  button_save_report_as: "Gem rapport som..."
   comments: "Kommentér"
   cost_reports_title: "Time and costs"
   label_cost_report: "Omkostningsrapport"

--- a/modules/reporting/config/locales/crowdin/de.yml
+++ b/modules/reporting/config/locales/crowdin/de.yml
@@ -23,7 +23,7 @@ de:
   plugin_openproject_reporting:
     name: "OpenProject Berichterstattung"
     description: "Dieses Plugin ermöglicht die Erstellung benutzerdefinierter Kostenberichte mit Filtern und Gruppierungen"
-  button_save_as: "Speichern unter ..."
+  button_save_report_as: "Speichern unter ..."
   comments: "Kommentar"
   cost_reports_title: "Zeit und Kosten"
   label_cost_report: "Report"

--- a/modules/reporting/config/locales/crowdin/el.yml
+++ b/modules/reporting/config/locales/crowdin/el.yml
@@ -23,7 +23,7 @@ el:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Αποθήκευση αναφοράς ως..."
+  button_save_report_as: "Αποθήκευση αναφοράς ως..."
   comments: "Σχόλιο"
   cost_reports_title: "Χρόνος και κόστος"
   label_cost_report: "Αναφορά κόστους"

--- a/modules/reporting/config/locales/crowdin/eo.yml
+++ b/modules/reporting/config/locales/crowdin/eo.yml
@@ -23,7 +23,7 @@ eo:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Komento"
   cost_reports_title: "Tempo kaj kostoj"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/es.yml
+++ b/modules/reporting/config/locales/crowdin/es.yml
@@ -23,7 +23,7 @@ es:
   plugin_openproject_reporting:
     name: "Informes de OpenProject"
     description: "Este plug-in permite crear reportes de costos personalizados con filtrado y agrupación creados por los plug-ins OpenProject Time y costes."
-  button_save_as: "Guardar informe como..."
+  button_save_report_as: "Guardar informe como..."
   comments: "Comentario"
   cost_reports_title: "Tiempo y costos"
   label_cost_report: "Informe costo"

--- a/modules/reporting/config/locales/crowdin/et.yml
+++ b/modules/reporting/config/locales/crowdin/et.yml
@@ -23,7 +23,7 @@ et:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Salvesta aruanne kui..."
+  button_save_report_as: "Salvesta aruanne kui..."
   comments: "Kommentaar"
   cost_reports_title: "Time and costs"
   label_cost_report: "Kulude aruanne"

--- a/modules/reporting/config/locales/crowdin/eu.yml
+++ b/modules/reporting/config/locales/crowdin/eu.yml
@@ -23,7 +23,7 @@ eu:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/fa.yml
+++ b/modules/reporting/config/locales/crowdin/fa.yml
@@ -23,7 +23,7 @@ fa:
   plugin_openproject_reporting:
     name: "گزارش OpenProject"
     description: "این افزونه به شما امکان ایجاد گزارش‌های سفارشی هزینه با فیلتر کردن و گروه‌بندی ایجاد شده توسط افزونه زمان و هزینه اوپن‌پروژه را می‌دهد."
-  button_save_as: "ذخیره گزارش به عنوان..."
+  button_save_report_as: "ذخیره گزارش به عنوان..."
   comments: "نظر"
   cost_reports_title: "زمان و هزینه‌ها"
   label_cost_report: "گزارش هزینه"

--- a/modules/reporting/config/locales/crowdin/fi.yml
+++ b/modules/reporting/config/locales/crowdin/fi.yml
@@ -23,7 +23,7 @@ fi:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Tallenna raportti nimellä..."
+  button_save_report_as: "Tallenna raportti nimellä..."
   comments: "Kommentti"
   cost_reports_title: "Työaika ja kustannukset"
   label_cost_report: "Kustannusraportti"

--- a/modules/reporting/config/locales/crowdin/fil.yml
+++ b/modules/reporting/config/locales/crowdin/fil.yml
@@ -23,7 +23,7 @@ fil:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Komento"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/fr.yml
+++ b/modules/reporting/config/locales/crowdin/fr.yml
@@ -23,7 +23,7 @@ fr:
   plugin_openproject_reporting:
     name: "Rapports OpenProject"
     description: "Ce plugin permet de créer des rapports de coûts personnalisés avec filtrage et regroupement."
-  button_save_as: "Enregistrer le rapport sous…"
+  button_save_report_as: "Enregistrer le rapport sous…"
   comments: "Commentaire"
   cost_reports_title: "Temps et coûts"
   label_cost_report: "Rapport de coût"

--- a/modules/reporting/config/locales/crowdin/he.yml
+++ b/modules/reporting/config/locales/crowdin/he.yml
@@ -23,7 +23,7 @@ he:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "שמור דוח כ..."
+  button_save_report_as: "שמור דוח כ..."
   comments: "הערה"
   cost_reports_title: "עלויות"
   label_cost_report: "דוח עלות"

--- a/modules/reporting/config/locales/crowdin/hi.yml
+++ b/modules/reporting/config/locales/crowdin/hi.yml
@@ -23,7 +23,7 @@ hi:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "टिप्पणी"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/hr.yml
+++ b/modules/reporting/config/locales/crowdin/hr.yml
@@ -23,7 +23,7 @@ hr:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Spremi izvješće kao..."
+  button_save_report_as: "Spremi izvješće kao..."
   comments: "Komentar"
   cost_reports_title: "Time and costs"
   label_cost_report: "Izvješće troška"

--- a/modules/reporting/config/locales/crowdin/hu.yml
+++ b/modules/reporting/config/locales/crowdin/hu.yml
@@ -23,7 +23,7 @@ hu:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Mentés másként..."
+  button_save_report_as: "Mentés másként..."
   comments: "Megjegyzés"
   cost_reports_title: "Idő és költség"
   label_cost_report: "Költség jelentés"

--- a/modules/reporting/config/locales/crowdin/id.yml
+++ b/modules/reporting/config/locales/crowdin/id.yml
@@ -23,7 +23,7 @@ id:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Simpan sebagai..."
+  button_save_report_as: "Simpan sebagai..."
   comments: "Komentar"
   cost_reports_title: "Waktu dan biaya"
   label_cost_report: "Laporan biaya"

--- a/modules/reporting/config/locales/crowdin/it.yml
+++ b/modules/reporting/config/locales/crowdin/it.yml
@@ -23,7 +23,7 @@ it:
   plugin_openproject_reporting:
     name: "Reportistica OpenProject"
     description: "Questo plugin consente di creare report di costo personalizzati con filtraggio e raggruppamento creato dal plugin OpenProject Time and costs."
-  button_save_as: "Salvare il report come..."
+  button_save_report_as: "Salvare il report come..."
   comments: "Commento"
   cost_reports_title: "Tempi e costi"
   label_cost_report: "Relazione sui costi"

--- a/modules/reporting/config/locales/crowdin/ja.yml
+++ b/modules/reporting/config/locales/crowdin/ja.yml
@@ -23,7 +23,7 @@ ja:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "名前を付けてレポートの保存"
+  button_save_report_as: "名前を付けてレポートの保存"
   comments: "コメント"
   cost_reports_title: "時間とコスト"
   label_cost_report: "コストレポート"

--- a/modules/reporting/config/locales/crowdin/ka.yml
+++ b/modules/reporting/config/locales/crowdin/ka.yml
@@ -23,7 +23,7 @@ ka:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "კომენტარი"
   cost_reports_title: "დრო და ღირებულებები"
   label_cost_report: "ფასის ანგარიში"

--- a/modules/reporting/config/locales/crowdin/kk.yml
+++ b/modules/reporting/config/locales/crowdin/kk.yml
@@ -23,7 +23,7 @@ kk:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/ko.yml
+++ b/modules/reporting/config/locales/crowdin/ko.yml
@@ -23,7 +23,7 @@ ko:
   plugin_openproject_reporting:
     name: "OpenProject 보고"
     description: "이 플러그인을 사용하면 OpenProject 시간 및 비용 플러그인에서 생성된 필터링 및 그룹화를 사용하여 사용자 지정 비용 보고서를 생성할 수 있습니다."
-  button_save_as: "다른 이름으로 보고서로 저장..."
+  button_save_report_as: "다른 이름으로 보고서로 저장..."
   comments: "코멘트"
   cost_reports_title: "시간 및 비용"
   label_cost_report: "비용 보고서"

--- a/modules/reporting/config/locales/crowdin/lt.yml
+++ b/modules/reporting/config/locales/crowdin/lt.yml
@@ -23,7 +23,7 @@ lt:
   plugin_openproject_reporting:
     name: "OpenProject ataskaitos"
     description: "Šis priedas leidžia kurti savo kaštų ataskaitas su OpenProject laiko ir kašto priedo sukurtu filtravimu ir grupavimu."
-  button_save_as: "Įrašyti ataskaitą kaip..."
+  button_save_report_as: "Įrašyti ataskaitą kaip..."
   comments: "Komentaras"
   cost_reports_title: "Laikas ir išlaidos"
   label_cost_report: "Kaštų ataskaita"

--- a/modules/reporting/config/locales/crowdin/lv.yml
+++ b/modules/reporting/config/locales/crowdin/lv.yml
@@ -23,7 +23,7 @@ lv:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Komentârs"
   cost_reports_title: "Laiks un izmaksas"
   label_cost_report: "Izmaksu pārskats"

--- a/modules/reporting/config/locales/crowdin/mn.yml
+++ b/modules/reporting/config/locales/crowdin/mn.yml
@@ -23,7 +23,7 @@ mn:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/ms.yml
+++ b/modules/reporting/config/locales/crowdin/ms.yml
@@ -23,7 +23,7 @@ ms:
   plugin_openproject_reporting:
     name: "Pelaporan OpenProject"
     description: "Plugin ini membenarkan untuk mencipta laporan kos tersuai dengan penyaring dan pengumpulan yang dibuat oleh plugin Masa dan kos OpenProject."
-  button_save_as: "Simpan laporan sebagai..."
+  button_save_report_as: "Simpan laporan sebagai..."
   comments: "Komen"
   cost_reports_title: "Masa dan kos"
   label_cost_report: "Laporan kos"

--- a/modules/reporting/config/locales/crowdin/ne.yml
+++ b/modules/reporting/config/locales/crowdin/ne.yml
@@ -23,7 +23,7 @@ ne:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/nl.yml
+++ b/modules/reporting/config/locales/crowdin/nl.yml
@@ -23,7 +23,7 @@ nl:
   plugin_openproject_reporting:
     name: "OpenProject Rapportage"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Rapport opslaan als..."
+  button_save_report_as: "Rapport opslaan als..."
   comments: "Commentaar"
   cost_reports_title: "Tijd en kosten"
   label_cost_report: "Kostenrapport"

--- a/modules/reporting/config/locales/crowdin/no.yml
+++ b/modules/reporting/config/locales/crowdin/no.yml
@@ -23,7 +23,7 @@
   plugin_openproject_reporting:
     name: "OpenProject rapportering"
     description: "Dette programtillegget gjør det mulig å lage egendefinerte kostnadsrapporter med filtrering og gruppering opprettet av OpenProject -utvidelsen Tid og kostnad."
-  button_save_as: "Lagre rapport som..."
+  button_save_report_as: "Lagre rapport som..."
   comments: "Kommentar"
   cost_reports_title: "Tid og kostnader"
   label_cost_report: "Kostnadsrapport"

--- a/modules/reporting/config/locales/crowdin/pl.yml
+++ b/modules/reporting/config/locales/crowdin/pl.yml
@@ -23,7 +23,7 @@ pl:
   plugin_openproject_reporting:
     name: "Raportowanie OpenProject"
     description: "Ta wtyczka umożliwia tworzenie niestandardowych raportów kosztów z filtrowaniem i grupowaniem utworzonym przez wtyczkę OpenProject Czas i koszty."
-  button_save_as: "Zapisz raport jako..."
+  button_save_report_as: "Zapisz raport jako..."
   comments: "Komentarz"
   cost_reports_title: "Czas i koszty"
   label_cost_report: "Raport kosztów"

--- a/modules/reporting/config/locales/crowdin/pt-BR.yml
+++ b/modules/reporting/config/locales/crowdin/pt-BR.yml
@@ -23,7 +23,7 @@ pt-BR:
   plugin_openproject_reporting:
     name: "Relatórios do OpenProject"
     description: "Este plugin permite a criação de relatórios de custos personalizados com filtragem e agrupamento criados pelo plugin OpenProject Time e custos."
-  button_save_as: "Salvar relatório como..."
+  button_save_report_as: "Salvar relatório como..."
   comments: "Comentário"
   cost_reports_title: "Tempo e custos"
   label_cost_report: "Relatório de custos"

--- a/modules/reporting/config/locales/crowdin/pt-PT.yml
+++ b/modules/reporting/config/locales/crowdin/pt-PT.yml
@@ -23,7 +23,7 @@ pt-PT:
   plugin_openproject_reporting:
     name: "Relatórios do OpenProject"
     description: "Este plugin permite criar relatórios de custos personalizados com filtragem e agrupamento criados pelo plugin OpenProject Time e custos."
-  button_save_as: "Guardar relatório como..."
+  button_save_report_as: "Guardar relatório como..."
   comments: "Comentário"
   cost_reports_title: "Tempo e custos"
   label_cost_report: "Relatório de custo"

--- a/modules/reporting/config/locales/crowdin/ro.yml
+++ b/modules/reporting/config/locales/crowdin/ro.yml
@@ -23,7 +23,7 @@ ro:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Salvare raport ca..."
+  button_save_report_as: "Salvare raport ca..."
   comments: "Comentariu"
   cost_reports_title: "Timp și costuri"
   label_cost_report: "Raport de cost"

--- a/modules/reporting/config/locales/crowdin/ru.yml
+++ b/modules/reporting/config/locales/crowdin/ru.yml
@@ -23,7 +23,7 @@ ru:
   plugin_openproject_reporting:
     name: "Отчёт OpenProject"
     description: "Этот плагин позволяет создавать пользовательские отчеты о стоимости с фильтрацией и группировкой, созданной плагином OpenProject Time и затратами."
-  button_save_as: "Сохранить отчет как..."
+  button_save_report_as: "Сохранить отчет как..."
   comments: "Комментарий"
   cost_reports_title: "Время и затраты"
   label_cost_report: "Отчет по расходам"

--- a/modules/reporting/config/locales/crowdin/rw.yml
+++ b/modules/reporting/config/locales/crowdin/rw.yml
@@ -23,7 +23,7 @@ rw:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/si.yml
+++ b/modules/reporting/config/locales/crowdin/si.yml
@@ -23,7 +23,7 @@ si:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "අදහස් දක්වන්න"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/sk.yml
+++ b/modules/reporting/config/locales/crowdin/sk.yml
@@ -23,7 +23,7 @@ sk:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Uložiť prehľad ako..."
+  button_save_report_as: "Uložiť prehľad ako..."
   comments: "Komentár"
   cost_reports_title: "Čas a náklady"
   label_cost_report: "Výkaz nákladov"

--- a/modules/reporting/config/locales/crowdin/sl.yml
+++ b/modules/reporting/config/locales/crowdin/sl.yml
@@ -23,7 +23,7 @@ sl:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Shrani poročilo kot..."
+  button_save_report_as: "Shrani poročilo kot..."
   comments: "Komentar"
   cost_reports_title: "Čas in stroški"
   label_cost_report: "Poročilo o stroških"

--- a/modules/reporting/config/locales/crowdin/sr.yml
+++ b/modules/reporting/config/locales/crowdin/sr.yml
@@ -23,7 +23,7 @@ sr:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/sv.yml
+++ b/modules/reporting/config/locales/crowdin/sv.yml
@@ -23,7 +23,7 @@ sv:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Spara rapporten som..."
+  button_save_report_as: "Spara rapporten som..."
   comments: "Kommentar"
   cost_reports_title: "Tid och kostnader"
   label_cost_report: "Kostnadsrapport"

--- a/modules/reporting/config/locales/crowdin/th.yml
+++ b/modules/reporting/config/locales/crowdin/th.yml
@@ -23,7 +23,7 @@ th:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "ความคิดเห็น"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/tr.yml
+++ b/modules/reporting/config/locales/crowdin/tr.yml
@@ -23,7 +23,7 @@ tr:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Raporu... şeklinde kaydet"
+  button_save_report_as: "Raporu... şeklinde kaydet"
   comments: "Yorum"
   cost_reports_title: "Zaman ve maliyetler"
   label_cost_report: "Maliyet raporu"

--- a/modules/reporting/config/locales/crowdin/uk.yml
+++ b/modules/reporting/config/locales/crowdin/uk.yml
@@ -23,7 +23,7 @@ uk:
   plugin_openproject_reporting:
     name: "Звіти OpenProject"
     description: "Цей плагін дає змогу створювати звіти про витрати з можливостями фільтрування й групування, створеними плагіном «Час і витрати» в OpenProject."
-  button_save_as: "Зберегти звіт до:"
+  button_save_report_as: "Зберегти звіт до:"
   comments: "Коментар"
   cost_reports_title: "Час і витрати"
   label_cost_report: "Звіт про витрати"

--- a/modules/reporting/config/locales/crowdin/uz.yml
+++ b/modules/reporting/config/locales/crowdin/uz.yml
@@ -23,7 +23,7 @@ uz:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
   comments: "Comment"
   cost_reports_title: "Time and costs"
   label_cost_report: "Cost report"

--- a/modules/reporting/config/locales/crowdin/vi.yml
+++ b/modules/reporting/config/locales/crowdin/vi.yml
@@ -23,7 +23,7 @@ vi:
   plugin_openproject_reporting:
     name: "OpenProject Reporting"
     description: "Mô-đun này cho phép tạo các báo cáo chi phí tùy chỉnh với việc lọc và nhóm dữ liệu do mô-đun Thời gian và chi phí của OpenProject tạo ra."
-  button_save_as: "Lưu báo cáo dưới dạng..."
+  button_save_report_as: "Lưu báo cáo dưới dạng..."
   comments: "Nhận xét"
   cost_reports_title: "Thời gian và chi phí"
   label_cost_report: "Báo cáo chi phí"

--- a/modules/reporting/config/locales/crowdin/zh-CN.yml
+++ b/modules/reporting/config/locales/crowdin/zh-CN.yml
@@ -23,7 +23,7 @@ zh-CN:
   plugin_openproject_reporting:
     name: "OpenProject 报告"
     description: "该插件允许使用 OpenProject 工时和成本插件创建自定义成本报告，并具有过滤和分组功能。"
-  button_save_as: "报告另存为..."
+  button_save_report_as: "报告另存为..."
   comments: "注释"
   cost_reports_title: "工时和成本"
   label_cost_report: "成本报告"

--- a/modules/reporting/config/locales/crowdin/zh-TW.yml
+++ b/modules/reporting/config/locales/crowdin/zh-TW.yml
@@ -23,7 +23,7 @@ zh-TW:
   plugin_openproject_reporting:
     name: "OpenProject 報表"
     description: "本外掛允許透過OpenProject 時間及成本外掛，建立具篩選及群組的客製化成本報表"
-  button_save_as: "另存報表..."
+  button_save_report_as: "另存報表..."
   comments: "留言"
   cost_reports_title: "時間與費用"
   label_cost_report: "成本報告"

--- a/modules/reporting/config/locales/en.yml
+++ b/modules/reporting/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
     name: "OpenProject Reporting"
     description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
 
-  button_save_as: "Save report as..."
+  button_save_report_as: "Save report as..."
 
   comments: "Comment"
   cost_reports_title: "Time and costs"

--- a/modules/reporting/lib/widget/controls/save_as.rb
+++ b/modules/reporting/lib/widget/controls/save_as.rb
@@ -32,7 +32,7 @@ class Widget::Controls::SaveAs < Widget::Controls
       if @subject.new_record?
         I18n.t(:button_save)
       else
-        I18n.t(:button_save_as)
+        I18n.t(:button_save_report_as)
       end
     button = link_to(link_name, "#", id: "query-icon-save-as", class: "button icon-context icon-save")
     write(button + render_popup)


### PR DESCRIPTION
# What are you trying to accomplish?
Remove ambiguous translation in Reporting module. This leads us to different translations in production and development modes at least.

## Screenshots
There're two translations of button_save_as menu item. [Here](https://github.com/opf/openproject/blob/dev/config/locales/en.yml#L1456) and [here](https://github.com/opf/openproject/blob/dev/modules/reporting/config/locales/en.yml#L35). 

# What approach did you choose and why?
Use new translation key button_save_report_as inside reporting module leaving global button_save_as untouched.