### PR TITLE
Implementation/57516 projects should be removable from list with the help of a menu item

### DIFF
--- a/app/components/admin/custom_fields/custom_field_projects/row_component.rb
+++ b/app/components/admin/custom_fields/custom_field_projects/row_component.rb
@@ -43,7 +43,7 @@ module Admin
         private
 
         def more_menu_detach_project
-          if User.current.admin && project.active?
+          if User.current.allowed_in_project?(:select_custom_fields, project)
             {
               scheme: :default,
               icon: nil,

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
@@ -30,26 +30,13 @@ module Settings
   module ProjectCustomFields
     module ProjectCustomFieldMapping
       class RowComponent < Admin::CustomFields::CustomFieldProjects::RowComponent
-        def more_menu_items
-          @more_menu_items ||= [more_menu_detach_project].compact
-        end
-
         private
 
-        def more_menu_detach_project
-          project = model.first
-          if User.current.admin && project.active?
-            {
-              scheme: :default,
-              icon: nil,
-              label: I18n.t("projects.settings.project_custom_fields.actions.remove_from_project"),
-              href: unlink_admin_settings_project_custom_field_path(
-                id: @table.params[:custom_field].id,
-                project_custom_field_project_mapping: { project_id: project.id }
-              ),
-              data: { turbo_method: :delete }
-            }
-          end
+        def detach_from_project_url
+          url_helpers.unlink_admin_settings_project_custom_field_path(
+            id: @table.params[:custom_field].id,
+            project_custom_field_project_mapping: { project_id: project.id }
+          )
         end
       end
     end

--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -31,6 +31,7 @@
 class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
   include OpTurbo::ComponentStream
   include OpTurbo::DialogStreamHelper
+  include ApplicationComponentStreams
   include FlashMessagesOutputSafetyHelper
 
   layout "admin"

--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -133,8 +133,8 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
   end
 
   def find_custom_field_project_to_destroy
-    @project = Project.find(params.to_unsafe_h[:custom_fields_project][:project_id])
-    @custom_field_project = CustomFieldsProject.find_by!(custom_field: @custom_field, project: @project)
+    @custom_field_project = CustomFieldsProject.find_by!(custom_field: @custom_field,
+                                                         project: params[:custom_fields_project][:project_id])
   rescue ActiveRecord::RecordNotFound
     respond_with_project_not_found_turbo_streams
   end

--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -31,6 +31,7 @@
 class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
   include OpTurbo::ComponentStream
   include OpTurbo::DialogStreamHelper
+  include FlashMessagesOutputSafetyHelper
 
   layout "admin"
 
@@ -39,9 +40,10 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
   before_action :require_admin
   before_action :find_model_object
 
-  before_action :available_custom_fields_projects_query, only: :index
+  before_action :available_custom_fields_projects_query, only: %i[index destroy]
   before_action :initialize_custom_field_project, only: :new
   before_action :find_projects_to_activate_for_custom_field, only: :create
+  before_action :find_custom_field_project_to_destroy, only: :destroy
 
   menu_item :custom_fields
 
@@ -70,6 +72,23 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
     end
 
     respond_to_with_turbo_streams(status: create_service.success? ? :ok : :unprocessable_entity)
+  end
+
+  def destroy
+    delete_service = ::CustomFields::CustomFieldProjects::DeleteService
+                         .new(user: current_user, model: @custom_field_project)
+                         .call
+
+    delete_service.on_success { render_project_list(url_for_action: :index) }
+
+    delete_service.on_failure do
+      update_flash_message_via_turbo_stream(
+        message: join_flash_messages(delete_service.errors.full_messages),
+        full: true, dismiss_scheme: :hide, scheme: :danger
+      )
+    end
+
+    respond_to_with_turbo_streams(status: delete_service.success? ? :ok : :unprocessable_entity)
   end
 
   def default_breadcrumb; end
@@ -112,6 +131,18 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     update_flash_message_via_turbo_stream message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide,
                                           scheme: :danger
+    update_project_list_via_turbo_stream
+
+    respond_with_turbo_streams
+  end
+
+  def find_custom_field_project_to_destroy
+    @project = Project.find(params.to_unsafe_h[:custom_fields_project][:project_id])
+    @custom_field_project = CustomFieldsProject.find_by!(custom_field: @custom_field, project: @project)
+  rescue ActiveRecord::RecordNotFound
+    update_flash_message_via_turbo_stream(
+      message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide, scheme: :danger
+    )
     update_project_list_via_turbo_stream
 
     respond_with_turbo_streams

--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -129,23 +129,14 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
       respond_with_turbo_streams
     end
   rescue ActiveRecord::RecordNotFound
-    update_flash_message_via_turbo_stream message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide,
-                                          scheme: :danger
-    update_project_list_via_turbo_stream
-
-    respond_with_turbo_streams
+    respond_with_project_not_found_turbo_streams
   end
 
   def find_custom_field_project_to_destroy
     @project = Project.find(params.to_unsafe_h[:custom_fields_project][:project_id])
     @custom_field_project = CustomFieldsProject.find_by!(custom_field: @custom_field, project: @project)
   rescue ActiveRecord::RecordNotFound
-    update_flash_message_via_turbo_stream(
-      message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide, scheme: :danger
-    )
-    update_project_list_via_turbo_stream
-
-    respond_with_turbo_streams
+    respond_with_project_not_found_turbo_streams
   end
 
   def update_project_list_via_turbo_stream(url_for_action: action_name)
@@ -172,6 +163,14 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
                         .new(user: current_user, model: CustomFieldsProject.new, contract_class: EmptyContract)
                         .call(custom_field: @custom_field)
                         .result
+  end
+
+  def respond_with_project_not_found_turbo_streams
+    update_flash_message_via_turbo_stream message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide,
+                                          scheme: :danger
+    update_project_list_via_turbo_stream
+
+    respond_with_turbo_streams
   end
 
   def include_sub_projects?

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -181,8 +181,9 @@ module Admin::Settings
     end
 
     def find_unlink_project_custom_field_mapping
-      @project = Project.find(permitted_params.project_custom_field_project_mapping[:project_id])
-      @project_custom_field_mapping = @custom_field.project_custom_field_project_mappings.find_by!(project: @project)
+      @project_custom_field_mapping = @custom_field.project_custom_field_project_mappings.find_by!(
+        project_id: permitted_params.project_custom_field_project_mapping[:project_id]
+      )
     rescue ActiveRecord::RecordNotFound
       update_flash_message_via_turbo_stream(
         message: t(:notice_file_not_found), full: true, dismiss_scheme: :hide, scheme: :danger

--- a/app/services/custom_fields/custom_field_projects/delete_service.rb
+++ b/app/services/custom_fields/custom_field_projects/delete_service.rb
@@ -30,11 +30,18 @@ module CustomFields
   module CustomFieldProjects
     class DeleteService < ::BaseServices::Delete
       def destroy(custom_field_project)
+        delete_result = delete(custom_field_id: custom_field_project.custom_field_id,
+                               project_id: custom_field_project.project_id)
+        ActiveRecord::Type::Boolean.new.cast(delete_result)
+      end
+
+      # `custom_fields_projects` table has no `id` column, hence no primary key. #destroy method would not work
+      # Note: `delete_all` goes straight to the database and does not trigger callbacks
+      #
+      # @return [Integer] number of rows deleted
+      def delete(custom_field_id:, project_id:)
         CustomFieldsProject.transaction do
-          # `custom_fields_projects` table has no `id` column, hence no primary key. #destroy method would not work
-          # Note: `delete_all` does not trigger callbacks
-          CustomFieldsProject.where(custom_field_id: custom_field_project.custom_field_id,
-                                    project_id: custom_field_project.project_id).delete_all
+          CustomFieldsProject.where(custom_field_id:, project_id:).delete_all
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,9 @@ Rails.application.routes.draw do
         resources :projects,
                   controller: "/admin/custom_fields/custom_field_projects",
                   only: %i[index new create]
+        resource :project,
+                 controller: "/admin/custom_fields/custom_field_projects",
+                 only: :destroy
       end
     end
   end

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
     create(:custom_fields_project, custom_field:, project: archived_project)
   end
 
+  let(:custom_field_projects_page) { Pages::Admin::CustomFields::CustomFieldsProjects::CustomFieldProjectsIndex.new }
+
   context "with insufficient permissions" do
     it "is not accessible" do
       login_as(non_admin)
@@ -120,6 +122,27 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
           pagination_links.each do |pagination_link|
             uri = URI.parse(pagination_link["href"])
             expect(uri.path).to eq(custom_field_projects_path(custom_field))
+          end
+        end
+      end
+    end
+
+    it "allows unlinking a project from a custom field" do
+      project = create(:project)
+      create(:custom_fields_project, custom_field:, project:)
+
+      custom_field_projects_page.click_menu_item_of("Remove from project", project)
+
+      expect(page).to have_no_text(project.name)
+
+      aggregate_failures "pagination links maintain the correct url after unlinking is done" do
+        within ".op-pagination" do
+          pagination_links = page.all(".op-pagination--item-link")
+          expect(pagination_links.size).to be_positive
+
+          pagination_links.each do |pagination_link|
+            uri = URI.parse(pagination_link["href"])
+            expect(uri.path).to eq(custom_field_projects(custom_field))
           end
         end
       end

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -131,6 +131,8 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       project = create(:project)
       create(:custom_fields_project, custom_field:, project:)
 
+      visit custom_field_projects_path(custom_field)
+
       custom_field_projects_page.click_menu_item_of("Remove from project", project)
 
       expect(page).to have_no_text(project.name)
@@ -142,7 +144,7 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
 
           pagination_links.each do |pagination_link|
             uri = URI.parse(pagination_link["href"])
-            expect(uri.path).to eq(custom_field_projects(custom_field))
+            expect(uri.path).to eq(custom_field_projects_path(custom_field))
           end
         end
       end

--- a/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
+++ b/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
@@ -26,43 +26,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Admin
-  module CustomFields
-    module CustomFieldProjects
-      class RowComponent < Projects::RowComponent
-        include OpTurbo::Streamable
+require "spec_helper"
+require "services/base_services/behaves_like_delete_service"
 
-        def wrapper_uniq_by
-          "project-#{project.id}"
-        end
+RSpec.describe CustomFields::CustomFieldProjects::DeleteService do
+  it_behaves_like "BaseServices delete service" do
+    let(:factory) { :custom_fields_project }
 
-        def more_menu_items
-          @more_menu_items ||= [more_menu_detach_project].compact
-        end
-
-        private
-
-        def more_menu_detach_project
-          if User.current.admin && project.active?
-            {
-              scheme: :default,
-              icon: nil,
-              label: I18n.t("projects.settings.project_custom_fields.actions.remove_from_project"),
-              href: detach_from_project_url,
-              data: { turbo_method: :delete }
-            }
-          end
-        end
-
-        def detach_from_project_url
-          url_helpers.custom_field_project_path(
-            custom_field_id: @table.params[:custom_field].id,
-            custom_fields_project: { project_id: project.id }
-          )
-        end
-
-        def project = model.first
-      end
+    let(:contract_class) do
+      "#{namespace}::UpdateContract".constantize
     end
   end
 end

--- a/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
+++ b/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
@@ -36,5 +36,20 @@ RSpec.describe CustomFields::CustomFieldProjects::DeleteService do
     let(:contract_class) do
       "#{namespace}::UpdateContract".constantize
     end
+
+    before do
+      allow(CustomFieldsProject).to receive(:where).and_return(instance_double(ActiveRecord::Relation,
+                                                                               delete_all: model_destroy_result))
+    end
+
+    context "with transaction rollback" do
+      before do
+        allow(CustomFieldsProject).to receive(:where).and_raise(ActiveRecord::Rollback)
+      end
+
+      it "is unsuccessful" do
+        expect(subject).to be_failure
+      end
+    end
   end
 end

--- a/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
+++ b/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
@@ -36,20 +36,5 @@ RSpec.describe CustomFields::CustomFieldProjects::DeleteService do
     let(:contract_class) do
       "#{namespace}::UpdateContract".constantize
     end
-
-    before do
-      allow(CustomFieldsProject).to receive(:where).and_return(instance_double(ActiveRecord::Relation,
-                                                                               delete_all: model_destroy_result))
-    end
-
-    context "with transaction rollback" do
-      before do
-        allow(CustomFieldsProject).to receive(:where).and_raise(ActiveRecord::Rollback)
-      end
-
-      it "is unsuccessful" do
-        expect(subject).to be_failure
-      end
-    end
   end
 end

--- a/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
+++ b/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
@@ -26,42 +26,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Admin
-  module CustomFields
-    module CustomFieldProjects
-      class RowComponent < Projects::RowComponent
-        include OpTurbo::Streamable
+require "support/pages/projects/index"
 
-        def wrapper_uniq_by
-          "project-#{project.id}"
-        end
+module Pages
+  module Admin
+    module CustomFields
+      module CustomFieldsProjects
+        class CustomFieldProjectsIndex < ::Pages::Projects::Index
+          def path
+            "/custom_fields/#{custom_field.id}/projects"
+          end
 
-        def more_menu_items
-          @more_menu_items ||= [more_menu_detach_project].compact
-        end
-
-        private
-
-        def more_menu_detach_project
-          if User.current.admin && project.active?
-            {
-              scheme: :default,
-              icon: nil,
-              label: I18n.t("projects.settings.project_custom_fields.actions.remove_from_project"),
-              href: detach_from_project_url,
-              data: { turbo_method: :delete }
-            }
+          def within_row(project)
+            row = page.find("#admin-custom-fields-custom-field-projects-row-component-project-#{project.id}")
+            row.hover
+            within row do
+              yield row
+            end
           end
         end
-
-        def detach_from_project_url
-          url_helpers.custom_field_project_path(
-            custom_field_id: @table.params[:custom_field].id,
-            custom_fields_project: { project_id: project.id }
-          )
-        end
-
-        def project = model.first
       end
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/work_packages/57516

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A project should be removable from a custom field on the project list via a menu action item

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

![Kapture 2024-09-13 at 13 38 48](https://github.com/user-attachments/assets/018eb248-a75a-4fbe-a8d8-716dc9dbe5db)

# What approach did you choose and why?

<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

> [!IMPORTANT]  
> Adding a primary key to an existing table has a seemingly higher opportunity cost compared to the
alternative; composite primary keys which will have the carrying cost of introducing different data structure-
which have a higher chance of introducing conflicts or requiring additional handling (ergo- _carrying cost_
>
> In the migration- defining a PRIMARY KEY via Rails migration ensures an autoincremting column is defined as a BIGSERIAL type and existing records are backfilled automatically
> 