### PR TITLE
Attempt to fix lost oauth token issue.

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_user_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/oauth_user_token.rb
@@ -77,8 +77,11 @@ module Storages
               return Failures::Builder.call(code: :error, log_message:, data:)
             end
 
-            current_token = OAuthClientToken.find_by(user: @user,
-                                                     oauth_client: storage.oauth_configuration.oauth_client)
+            # Uncached block is used here because in case of concurrent update on the second try we need a fresh token.
+            # Otherwise token ends up in an invalid state which leads to an undesired token deletion.
+            current_token = OAuthClientToken.uncached do
+              OAuthClientToken.find_by(user: @user, oauth_client: storage.oauth_configuration.oauth_client)
+            end
             if current_token.nil?
               Failures::Builder.call(code: :unauthorized,
                                      log_message: "Authorization failed. No user access token found.",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57835
# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

It seems like enabling optimistic locking in https://github.com/opf/openproject/pull/16376 was not enough. After `ActiveRecord::StaleObjectError` is raised the sql request for token is cached. Then there is an attempt to refresh stale token, NC answers with `invalid_request` and we delete the token. Actually, the deletion should not happen, because the object should be stale... Anyways, it is just an attempt to fix this.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

This PR makes sure request for OAuthClientToken is not cached by ActiveRecord query cache..

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
