### PR TITLE
Cleanup filter list controller

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
@@ -47,7 +47,7 @@ export default class FilterListController extends Controller {
   declare readonly clearButtonIdValue:string;
 
   connect():void {
-   document.getElementById(this.clearButtonIdValue)?.addEventListener('click', () => {
+    document.getElementById(this.clearButtonIdValue)?.addEventListener('click', () => {
       this.resetFilterViaClearButton();
     });
   }
@@ -66,7 +66,7 @@ export default class FilterListController extends Controller {
       const text = item.textContent?.toLowerCase();
 
       if (text?.includes(query)) {
-        (item as HTMLElement).classList.remove('d-none');
+        item.classList.remove('d-none');
         showNoResultsText = false;
       } else {
         (item as HTMLElement).classList.add('d-none');

--- a/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
@@ -43,6 +43,7 @@ export default class FilterListController extends Controller {
 
   declare readonly filterTarget:HTMLInputElement;
   declare readonly noResultsTextTarget:HTMLInputElement;
+  declare readonly hasNoResultsTextTarget:boolean;
   declare readonly searchItemTargets:HTMLInputElement[];
   declare readonly clearButtonIdValue:string;
 
@@ -66,23 +67,25 @@ export default class FilterListController extends Controller {
       const text = item.textContent?.toLowerCase();
 
       if (text?.includes(query)) {
-        item.classList.remove('d-none');
+        this.setVisibility(item, true);
         showNoResultsText = false;
       } else {
-        item.classList.add('d-none');
+        this.setVisibility(item, false);
       }
     });
 
-    if (showNoResultsText) {
-      this.noResultsTextTarget?.classList.remove('d-none');
-    } else {
-      this.noResultsTextTarget?.classList.add('d-none');
+    if (this.hasNoResultsTextTarget) {
+      this.setVisibility(this.noResultsTextTarget, showNoResultsText);
     }
   }
 
   resetFilterViaClearButton() {
     this.searchItemTargets.forEach((item) => {
-      item.classList.remove('d-none');
+      this.setVisibility(item, true);
     });
+  }
+
+  setVisibility(element:HTMLElement, visible:boolean) {
+    element.classList.toggle('d-none', !visible);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filter-list.controller.ts
@@ -69,7 +69,7 @@ export default class FilterListController extends Controller {
         item.classList.remove('d-none');
         showNoResultsText = false;
       } else {
-        (item as HTMLElement).classList.add('d-none');
+        item.classList.add('d-none');
       }
     });
 
@@ -82,7 +82,7 @@ export default class FilterListController extends Controller {
 
   resetFilterViaClearButton() {
     this.searchItemTargets.forEach((item) => {
-      (item as HTMLElement).classList.remove('d-none');
+      item.classList.remove('d-none');
     });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/projects/settings/project-custom-fields-mapping-filter.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/projects/settings/project-custom-fields-mapping-filter.controller.ts
@@ -57,13 +57,13 @@ export default class extends FilterListController {
 
   hideBulkActionContainers() {
     this.bulkActionContainerTargets.forEach((item) => {
-      (item as HTMLElement).classList.add('d-none');
+      item.classList.add('d-none');
     });
   }
 
   showBulkActionContainers() {
     this.bulkActionContainerTargets.forEach((item) => {
-      (item as HTMLElement).classList.remove('d-none');
+      item.classList.remove('d-none');
     });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/projects/settings/project-custom-fields-mapping-filter.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/projects/settings/project-custom-fields-mapping-filter.controller.ts
@@ -57,13 +57,13 @@ export default class extends FilterListController {
 
   hideBulkActionContainers() {
     this.bulkActionContainerTargets.forEach((item) => {
-      item.classList.add('d-none');
+      this.setVisibility(item, false);
     });
   }
 
   showBulkActionContainers() {
     this.bulkActionContainerTargets.forEach((item) => {
-      item.classList.remove('d-none');
+      this.setVisibility(item, true);
     });
   }
 }


### PR DESCRIPTION
# What are you trying to accomplish?
A bit of cleanup, mostly remove repetition of `'d-none'`, also use `hasNoResultsTextTarget` so there are no warning about using `resultsTextTarget` when it does not exist.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
