### PR TITLE
Remove `hostDirective` that already exist in parent class

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-relation-query-configuration.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-relation-query-configuration.component.ts
@@ -6,13 +6,9 @@ import { RestrictedWpTableConfigurationService } from 'core-app/features/work-pa
 import { WpTableConfigurationRelationSelectorComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration-relation-selector';
 import { WpTableConfigurationModalPrependToken } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal';
 import { ExternalQueryConfigurationComponent } from 'core-app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.component';
-import {
-  WorkPackageIsolatedQuerySpaceDirective,
-} from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 
 @Component({
   templateUrl: './external-query-configuration.template.html',
-  hostDirectives: [WorkPackageIsolatedQuerySpaceDirective],
   providers: [
     [
       { provide: WpTableConfigurationService, useClass: RestrictedWpTableConfigurationService },


### PR DESCRIPTION
# Ticket

No ticket

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Some tests from `spec/features/types/form_configuration_query_spec.rb` are not passing locally, but work on CI.

While trying to fix them, I discovered that when adding a "table of related work packages" in a type form configuration, the query configuration modal was not be displayed. That's why the test fails. It correctly signaled that something was going wrong.


## Screenshots

Before, the query configuration modal does not show up and an error is shown is the console:

[query configuration modal not working.webm](https://github.com/user-attachments/assets/27d7584e-2982-408d-9d1e-11dd12d661d2)

After, the query configuration modal is displayed automatically without any issues:

[query configuration modal working.webm](https://github.com/user-attachments/assets/c86778c5-4174-4252-98e4-b5e3d9655e79)


# What approach did you choose and why?

The console error is "Uncaught RuntimeError: NG0309: Directive WorkPackageIsolatedQuerySpaceDirective matches multiple times on the same element. Directives can only match an element once.".

Indeed, the same `hostDirective` was defined in both `ExternalRelationQueryConfigurationComponent` and its parent class `ExternalQueryConfigurationComponent`. Removing it from the child class fixed the error.

Still, what is strange is that it seemed to be working properly in CI and in production: the modal could be displayed despite the hostDirective being probably duplicated there too.


# Merge checklist

- [ ] Added/updated tests
  - none added, but fixed the existing ones which were not passing locally (but pass on CI)
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
