### PR TITLE
Try another hack to reposition CKEditor toolbar

### DIFF
--- a/frontend/src/turbo/dialog-stream-action.ts
+++ b/frontend/src/turbo/dialog-stream-action.ts
@@ -4,8 +4,6 @@ export function registerDialogStreamAction() {
   StreamActions.dialog = function dialogStreamAction(this:StreamElement) {
     const content = this.templateElement.content;
     const dialog = content.querySelector('dialog') as HTMLDialogElement;
-    // Set a temporary width so the dialog reflows after opening
-    dialog.style.width = '0px';
 
     document.body.append(content);
 
@@ -21,8 +19,11 @@ export function registerDialogStreamAction() {
       }
     });
 
+    // Hack to fix the width calculation of nested elements
+    // such as the CKEditor toolbar.
     setTimeout(() => {
-      dialog.style.removeProperty('width');
-    }, 10);
+      const width = dialog.offsetWidth;
+      dialog.style.width = `${width + 1}px`;
+    }, 50);
   };
 }


### PR DESCRIPTION
This might reduce flickering and correctly open the toolbar
