### PR TITLE
[#55021] Free choice of columns in exports

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -30,6 +30,7 @@
 module Projects
   class RowComponent < ::RowComponent
     delegate :favored_project_ids, to: :table
+    delegate :identifier, to: :project
 
     def project
       model.first
@@ -108,17 +109,7 @@ module Projects
     end
 
     def id
-      content = "".html_safe
-
-      content << project.id.to_s
-      content
-    end
-
-    def identifier
-      content = "".html_safe
-
-      content << project.identifier
-      content
+      project.id.to_s
     end
 
     def name

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -107,6 +107,20 @@ module Projects
       number_to_human_size(project.required_disk_space, precision: 2)
     end
 
+    def id
+      content = "".html_safe
+
+      content << project.id.to_s
+      content
+    end
+
+    def identifier
+      content = "".html_safe
+
+      content << project.identifier
+      content
+    end
+
     def name
       content = content_tag(:i, "", class: "projects-table--hierarchy-icon")
 

--- a/app/models/projects/exports/query_exporter.rb
+++ b/app/models/projects/exports/query_exporter.rb
@@ -32,7 +32,7 @@ module Projects::Exports
     alias :query :object
 
     def columns
-      @columns ||= (forced_columns + selected_columns)
+      @columns ||= selected_columns
     end
 
     def page
@@ -50,13 +50,6 @@ module Projects::Exports
     end
 
     private
-
-    def forced_columns
-      [
-        { name: :id, caption: Project.human_attribute_name(:id) },
-        { name: :identifier, caption: Project.human_attribute_name(:identifier) }
-      ]
-    end
 
     def selected_columns
       query

--- a/app/models/queries/projects/orders/default_order.rb
+++ b/app/models/queries/projects/orders/default_order.rb
@@ -30,6 +30,6 @@ class Queries::Projects::Orders::DefaultOrder < Queries::Orders::Base
   self.model = Project
 
   def self.key
-    /\A(id|created_at|public|lft)\z/
+    /\A(id|identifier|created_at|public|lft)\z/
   end
 end

--- a/app/models/queries/projects/selects/default.rb
+++ b/app/models/queries/projects/selects/default.rb
@@ -27,7 +27,7 @@
 # ++
 
 class Queries::Projects::Selects::Default < Queries::Selects::Base
-  KEYS = %i[status_explanation hierarchy name public description].freeze
+  KEYS = %i[id identifier status_explanation hierarchy name public description].freeze
 
   def self.key
     Regexp.new(KEYS.join("|"))

--- a/app/models/queries/projects/selects/default.rb
+++ b/app/models/queries/projects/selects/default.rb
@@ -1,4 +1,4 @@
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
 
   it "performs a successful export" do
     expect(rows.count).to eq(1)
-    expect(sheet.row(1)).to eq [project.id.to_s, project.identifier,
-                                project.name, project.description, "Off track", "false"]
+    expect(sheet.row(1)).to eq [project.name, project.description, "Off track", "false"]
   end
 
   context "with project description containing html" do
@@ -38,8 +37,7 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
 
     it "performs a successful export" do
       expect(rows.count).to eq(1)
-      expect(sheet.row(1)).to eq [project.id.to_s, project.identifier, project.name,
-                                  "This is an html description.", "Off track", "false"]
+      expect(sheet.row(1)).to eq [project.name, "This is an html description.", "Off track", "false"]
     end
   end
 
@@ -48,9 +46,18 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
 
     it "performs a successful export" do
       expect(rows.count).to eq(1)
-      expect(sheet.row(1)).to eq [project.id.to_s, project.identifier,
-                                  project.name, project.description,
+      expect(sheet.row(1)).to eq [project.name, project.description,
                                   "Off track", project.status_explanation, "false"]
+    end
+  end
+
+  context "with id and identifier enabled" do
+    let(:query_columns) { %w[name description project_status public id identifier] }
+
+    it "performs a successful export" do
+      expect(rows.count).to eq(1)
+      expect(sheet.row(1)).to eq [project.name, project.description, "Off track",
+                                  "false", project.id.to_s, project.identifier]
     end
   end
 
@@ -66,7 +73,7 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
 
       it "renders all those columns" do
         cf_names = global_project_custom_fields.map(&:name)
-        expect(header).to eq ["ID", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+        expect(header).to eq ["Name", "Description", "Status", "Public", *cf_names]
 
         expect(header).to include not_used_string_cf.name
         expect(header).to include hidden_cf.name
@@ -85,8 +92,7 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
         end
 
         expect(sheet.row(1))
-          .to eq [project.id.to_s, project.identifier, project.name, project.description, "Off track", "false",
-                  *custom_values]
+          .to eq [project.name, project.description, "Off track", "false", *custom_values]
 
         # The column for the project-level-disabled custom field is blank
         expect(sheet.row(1)[header.index(not_used_string_cf.name)]).to be_nil
@@ -97,7 +103,7 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
       it "renders available project custom fields in the header if enabled in any project" do
         cf_names = global_project_custom_fields.map(&:name)
 
-        expect(header).to eq ["ID", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+        expect(header).to eq ["Name", "Description", "Status", "Public", *cf_names]
 
         expect(header).not_to include not_used_string_cf.name
         expect(header).not_to include hidden_cf.name
@@ -116,8 +122,7 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
         end
 
         expect(sheet.row(1))
-          .to eq [project.id.to_s, project.identifier, project.name, project.description, "Off track", "false",
-                  *custom_values]
+          .to eq [project.name, project.description, "Off track", "false", *custom_values]
       end
     end
 
@@ -125,10 +130,10 @@ RSpec.describe XlsExport::Project::Exporter::XLS do
       let(:permissions) { %i(view_projects) }
 
       it "does not render project custom fields in the header" do
-        expect(header).to eq ["ID", "Identifier", "Name", "Description", "Status", "Public"]
+        expect(header).to eq %w[Name Description Status Public]
 
         expect(sheet.row(1))
-          .to eq [project.id.to_s, project.identifier, project.name, project.description, "Off track", "false"]
+          .to eq [project.name, project.description, "Off track", "false"]
       end
     end
   end

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
 
   it "performs a successful export" do
     expect(parsed.size).to eq(2)
-    expect(parsed.last).to eq [project.id.to_s, project.identifier,
-                               project.name, project.description, "Off track", "false"]
+    expect(parsed.last).to eq [project.name, project.description, "Off track", "false"]
   end
 
   context "with status_explanation enabled" do
@@ -52,9 +51,18 @@ RSpec.describe Projects::Exports::CSV, "integration" do
 
     it "performs a successful export" do
       expect(parsed.size).to eq(2)
-      expect(parsed.last).to eq [project.id.to_s, project.identifier,
-                                 project.name, project.description,
+      expect(parsed.last).to eq [project.name, project.description,
                                  "Off track", "some explanation", "false"]
+    end
+  end
+
+  context "with id and identifier selected" do
+    let(:query_columns) { %w[name description id identifier project_status public] }
+
+    it "performs a successful export" do
+      expect(parsed.size).to eq(2)
+      expect(parsed.last).to eq [project.name, project.description, project.id.to_s,
+                                 project.identifier, "Off track", "false"]
     end
   end
 
@@ -74,13 +82,12 @@ RSpec.describe Projects::Exports::CSV, "integration" do
       it "does not render project custom fields in the header" do
         expect(parsed.size).to eq 2
 
-        expect(header).to eq ["\xEF\xBB\xBFid", "Identifier", "Name", "Description", "Status", "Public"]
+        expect(header).to eq ["\xEF\xBB\xBFName", "Description", "Status", "Public"]
       end
 
       it "does not render the custom field values in the rows if enabled for a project" do
         expect(rows.first)
-          .to eq [project.id.to_s, project.identifier, project.name,
-                  project.description, "Off track", "false"]
+          .to eq [project.name, project.description, "Off track", "false"]
       end
     end
 
@@ -93,7 +100,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
         expect(cf_names).not_to include(not_used_string_cf.name)
         expect(cf_names).not_to include(hidden_cf.name)
 
-        expect(header).to eq ["\xEF\xBB\xBFid", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+        expect(header).to eq ["\xEF\xBB\xBFName", "Description", "Status", "Public", *cf_names]
       end
 
       it "renders the custom field values in the rows if enabled for a project" do
@@ -110,8 +117,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
           end
         end
         expect(rows.first)
-          .to eq [project.id.to_s, project.identifier, project.name,
-                  project.description, "Off track", "false", *custom_values]
+          .to eq [project.name, project.description, "Off track", "false", *custom_values]
       end
     end
 
@@ -126,7 +132,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
         expect(cf_names).to include(not_used_string_cf.name)
         expect(cf_names).to include(hidden_cf.name)
 
-        expect(header).to eq ["\xEF\xBB\xBFid", "Identifier", "Name", "Description", "Status", "Public", *cf_names]
+        expect(header).to eq ["\xEF\xBB\xBFName", "Description", "Status", "Public", *cf_names]
       end
 
       it "renders the custom field values in the rows if enabled for a project" do
@@ -145,8 +151,7 @@ RSpec.describe Projects::Exports::CSV, "integration" do
           end
         end
         expect(rows.first)
-          .to eq [project.id.to_s, project.identifier, project.name,
-                  project.description, "Off track", "false", *custom_values]
+          .to eq [project.name, project.description, "Off track", "false", *custom_values]
       end
     end
   end

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe ProjectQuery do
       it "lists registered selects" do
         expect(instance.available_selects.map(&:attribute))
           .to match_array(%i[
+                            id
+                            identifier
                             name
                             favored
                             public
@@ -151,6 +153,8 @@ RSpec.describe ProjectQuery do
       it "includes admin columns" do
         expect(instance.available_selects.map(&:attribute))
           .to match_array(%i[
+                            id
+                            identifier
                             name
                             favored
                             public


### PR DESCRIPTION
# Attention
This is my first real PR for OpenProject. Please be extra thorough when reviewing this. I took care when assembling this PR, but I probably forgot something 😉 

# Ticket
https://community.openproject.org/wp/55021

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
In the project list, you can now select and switch the order of the ID and identifier columns.

Previously, these columns were not visible, but they were **always** part of the CSV and XLS export. Now, those columns are only part of the export when they have been explicitly configured in the view.

In other words: the ID and identifier columns now behave like all other columns.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

![image](https://github.com/user-attachments/assets/01e7b349-cf35-4bef-9531-c55b683d0c5e)
![image](https://github.com/user-attachments/assets/fada5945-30de-42f6-9260-7574aded3d0c)
![image](https://github.com/user-attachments/assets/500d9a9a-edad-4242-a98d-613be081dc0a)

CSV export sample (with id and identifier **not** showing in the view):
```
cat ~/Downloads/OpenProject_Projects_2024-09-1120240911-58047-1ur3j5.csv
Favorite,Name,Status,Public,Created on,Latest activity at,Required disk storage
"",Demo project,On track,true,09/03/2024 11:50 AM,09/03/2024 11:50 AM,0.0
"",Scrum project,On track,true,09/03/2024 11:50 AM,09/03/2024 11:50 AM,0.0
"",[dev] Empty,"",true,09/03/2024 11:50 AM,09/04/2024 10:36 AM,0.0
"",[dev] Work package sharing,"",true,09/03/2024 11:50 AM,09/03/2024 11:50 AM,0.0
"",[dev] Large,"",true,09/03/2024 11:50 AM,09/03/2024 11:50 AM,0.0
"",[dev] Large child,"",true,09/03/2024 11:50 AM,09/03/2024 11:50 AM,0.0
"",[dev] Custom fields,"",true,09/03/2024 11:50 AM,09/03/2024 11:50 AM,0.0
```

# What approach did you choose and why?

I decided to hide the id and identifier columns by default. Since they have not been part of the default project list view until now I figured that they are not important to *most* users. If needed, they can now be configured to show up.

The columns were part of the export by default, but from my understanding, users visit this page more often than they export it. Hence, omitting these columns by default is the best choice. Users relying on the columns being present in an export might run into issues, though ☝🏻 We should include a notice in the release notes.

Please note that some columns are only visible for admins. I did not see a reason to hide id and identifier here, so I added them for everyone to see.

Translations for the "new columns" worked out of the box 👍🏻 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
