### PR TITLE
Debug turbo events in development

### DIFF
--- a/frontend/src/turbo/constants.ts
+++ b/frontend/src/turbo/constants.ts
@@ -1,0 +1,17 @@
+export const TURBO_EVENTS:string[] = [
+  'turbo:click',
+  'turbo:before-visit',
+  'turbo:visit',
+  'turbo:submit-start',
+  'turbo:before-fetch-request',
+  'turbo:before-fetch-response',
+  'turbo:submit-end',
+  'turbo:before-cache',
+  'turbo:before-render',
+  'turbo:before-stream-render',
+  'turbo:render',
+  'turbo:load',
+  'turbo:frame-render',
+  'turbo:frame-load',
+  'turbo:fetch-request-error',
+];

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -5,11 +5,22 @@ import { registerDialogStreamAction } from './dialog-stream-action';
 import { addTurboEventListeners } from './turbo-event-listeners';
 import { registerFlashStreamAction } from './flash-stream-action';
 import { applyTurboNavigationPatch } from './turbo-navigation-patch';
+import { debugLog, whenDebugging } from 'core-app/shared/helpers/debug_output';
+import { TURBO_EVENTS } from './constants';
 
 // Disable default turbo-drive for now as we don't need it for now AND it breaks angular routing
 Turbo.session.drive = false;
 // Start turbo
 Turbo.start();
+
+// Register logging of events
+whenDebugging(() => {
+  TURBO_EVENTS.forEach((name:string) => {
+    document.addEventListener(name, (event) => {
+      debugLog(`[TURBO EVENT ${name}] %O`, event);
+    });
+  });
+});
 
 // Register our own actions
 addTurboEventListeners();


### PR DESCRIPTION
In development mode, output all turbo events to console so we can observe what happens during navigation