### PR TITLE
[#57856] Export modal should not show a scrollbar for default settings

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -8,3 +8,4 @@
 @import "filter/filters_component"
 @import "projects/row_component"
 @import "op_primer/border_box_table_component"
+@import "work_packages/exports/modal_dialog_component"

--- a/app/components/open_project/common/divider_component.rb
+++ b/app/components/open_project/common/divider_component.rb
@@ -33,8 +33,8 @@ module OpenProject
     class DividerComponent < Primer::BaseComponent
       def initialize(**system_arguments)
         system_arguments[:tag] = :hr
-        system_arguments[:mt] = system_arguments.fetch(:mt, 4)
-        system_arguments[:mb] = system_arguments.fetch(:mb, 4)
+        system_arguments[:mt] = system_arguments.fetch(:mt, 3)
+        system_arguments[:mb] = system_arguments.fetch(:mb, 3)
         super(**system_arguments) # rubocop:disable Style/SuperArguments
       end
     end

--- a/app/components/work_packages/exports/modal_dialog_component.sass
+++ b/app/components/work_packages/exports/modal_dialog_component.sass
@@ -1,0 +1,3 @@
+#op-work-packages-export-dialog
+  .op-draggable-autocomplete--selected
+    padding-bottom: 0

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
@@ -8,7 +8,7 @@
     ) %>
   <% end %>
   <% container.with_row do |_columns| %>
-    <%= render OpenProject::Common::DividerComponent.new(mt: 2) %>
+    <%= render OpenProject::Common::DividerComponent.new %>
     <%= helpers.angular_component_tag "opce-draggable-autocompleter",
                                       inputs: {
                                         id: "ltf-select-export-pdf-report",
@@ -27,7 +27,7 @@
     %>
   <% end %>
   <%= container.with_row do |_pdf_report_images| %>
-    <%= render OpenProject::Common::DividerComponent.new(mt: 2) %>
+    <%= render OpenProject::Common::DividerComponent.new %>
     <%= render(Primer::Alpha::CheckBox.new(name: 'show_images',
                                            checked: true,
                                            value: "true",

--- a/app/components/work_packages/exports/xls/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/xls/export_settings_component.html.erb
@@ -7,7 +7,7 @@
     ) %>
   <% end %>
   <%= container.with_row do |_xls_include_relations| %>
-    <%= render OpenProject::Common::DividerComponent.new(mt: 2) %>
+    <%= render OpenProject::Common::DividerComponent.new %>
     <%= render(Primer::Alpha::CheckBox.new(
       id: "show_relations_xls",
       name: "show_relations",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/57856

# What are you trying to accomplish?

Avoid showing a scrollbar for no apparent reason.

## Screenshots

| before | after |
|---|---|
| <img width="974" alt="scrollbar" src="https://github.com/user-attachments/assets/3dfd0838-83a6-4326-93de-3c690d807755"> | <img width="972" alt="noscollbar" src="https://github.com/user-attachments/assets/5f67901a-0235-4f86-b77d-38fae9833ffc">|

# What approach did you choose and why?
1) Reduce the standard padding of the spacer. Solution suggested by Marc.
2) Remove the padding below the Angular drop & drop component. To fix the scrollbar for even more other settings combinations. To avoid breaking other places where this component is used, the padding is only removed for the export modal.

> [!NOTE]
> There will always be a valid reason to show the scrollbar for certain combinations,
> as it depends on: screen size, number of columns and column rows, column name lengths and their translations

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
