### PR TITLE
Fix remain hard code color in Invite user dialog.

### DIFF
--- a/frontend/src/app/shared/components/option-list/option-list.sass
+++ b/frontend/src/app/shared/components/option-list/option-list.sass
@@ -10,8 +10,8 @@
   &--item
     padding: 1rem 1rem 0.5rem 0.75rem
     display: flex
-    border: 1px solid #cbd5e0
-    background: #f7fafc
+    border: 1px solid var(--borderColor-muted)
+    background-color: var(--bgColor-muted)
     border-radius: 4px
 
     &:not(:last-child)


### PR DESCRIPTION
# What are you trying to accomplish?

Fix the display issue in dark mode.

## Screenshots

### Before

#### Light

<img width="961" alt="image" src="https://github.com/user-attachments/assets/82256753-0b59-4e70-b7b4-2da6ec637dca">

#### Dark

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/6fb97cf7-4d14-41f2-8b7a-3058a35040f7">


### After

#### Light

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/e2334d2a-4703-458d-857b-13024ec6dbe0">

#### Dark

<img width="986" alt="image" src="https://github.com/user-attachments/assets/bd562b11-cf9b-4365-8799-22a9de2d147a">


# What approach did you choose and why?

Simply using build-in color name similar to #16499 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
