### PR TITLE
[#57655] Code maintenance: replace SettingsHelper#system_settings_tabs method

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -33,8 +33,11 @@ module SettingsHelper
   include OpenProject::FormTagHelper
 
   def setting_select(setting, choices, options = {})
-    if blank_text = options.delete(:blank)
-      choices = [[blank_text.is_a?(Symbol) ? I18n.t(blank_text) : blank_text, ""]] + choices
+    blank_text = options.delete(:blank)
+
+    if blank_text
+      translated_blank = blank_text.is_a?(Symbol) ? I18n.t(blank_text) : blank_text
+      choices.unshift([translated_blank, ""])
     end
 
     setting_label(setting, options) +

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -32,31 +32,6 @@ module SettingsHelper
   extend self
   include OpenProject::FormTagHelper
 
-  def system_settings_tabs
-    [
-      {
-        name: "general",
-        controller: "/admin/settings/general_settings",
-        label: :label_general
-      },
-      {
-        name: "languages",
-        controller: "/admin/settings/languages_settings",
-        label: :label_languages
-      },
-      {
-        name: "repositories",
-        controller: "/admin/settings/repositories_settings",
-        label: :label_repository_plural
-      },
-      {
-        name: "experimental",
-        controller: "/admin/settings/experimental_settings",
-        label: :label_experimental
-      }
-    ]
-  end
-
   def setting_select(setting, choices, options = {})
     if blank_text = options.delete(:blank)
       choices = [[blank_text.is_a?(Symbol) ? I18n.t(blank_text) : blank_text, ""]] + choices

--- a/app/views/admin/settings/experimental_settings/show.html.erb
+++ b/app/views/admin/settings/experimental_settings/show.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<%= styled_form_tag(admin_settings_update_experimental_path, method: :patch) do %>
+<%= styled_form_tag(admin_settings_experimental_path, method: :patch) do %>
   <section class="form--section">
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= t('settings.experimental.feature_flags') %></legend>

--- a/app/views/admin/settings/general_settings/show.html.erb
+++ b/app/views/admin/settings/general_settings/show.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 
-<%= styled_form_tag(admin_settings_update_general_path, method: :patch) do %>
+<%= styled_form_tag(admin_settings_general_path, method: :patch) do %>
   <section class="form--section">
     <div class="form--field"><%= setting_text_field :app_title, size: 30, container_class: '-middle' %></div>
     <div class="form--field">

--- a/app/views/admin/settings/languages_settings/show.html.erb
+++ b/app/views/admin/settings/languages_settings/show.html.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<%= styled_form_tag(admin_settings_update_languages_path, method: :patch) do %>
+<%= styled_form_tag(admin_settings_languages_path, method: :patch) do %>
 
   <section class="form--section">
     <div class="form--field" id="setting_available_languages">

--- a/app/views/admin/settings/repositories_settings/show.html.erb
+++ b/app/views/admin/settings/repositories_settings/show.html.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<%= styled_form_tag(admin_settings_update_repositories_path, method: :patch) do %>
+<%= styled_form_tag(admin_settings_repositories_path, method: :patch) do %>
   <section class="form--section">
     <div class="form--field">
       <%= setting_check_box :autofetch_changesets %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -409,13 +409,29 @@ Redmine::MenuManager.map :admin_menu do |menu|
             caption: :label_system_settings,
             icon: "gear"
 
-  SettingsHelper.system_settings_tabs.each do |node|
-    menu.push :"settings_#{node[:name]}",
-              { controller: node[:controller], action: :show },
-              caption: node[:label],
-              if: Proc.new { User.current.admin? && (node[:name] != "experimental" || Rails.env.development?) },
-              parent: :settings
-  end
+  menu.push :settings_general,
+            { controller: "/admin/settings/general_settings", action: :show },
+            if: Proc.new { User.current.admin? },
+            caption: :label_general,
+            parent: :settings
+
+  menu.push :settings_languages,
+            { controller: "/admin/settings/languages_settings", action: :show },
+            if: Proc.new { User.current.admin? },
+            caption: :label_languages,
+            parent: :settings
+
+  menu.push :settings_repositories,
+            { controller: "/admin/settings/repositories_settings", action: :show },
+            if: Proc.new { User.current.admin? },
+            caption: :label_repository_plural,
+            parent: :settings
+
+  menu.push :settings_experimental,
+            { controller: "/admin/settings/experimental_settings", action: :show },
+            if: Proc.new { User.current.admin? && Rails.env.development? },
+            caption: :label_experimental,
+            parent: :settings
 
   menu.push :mail_and_notifications,
             { controller: "/admin/settings/aggregation_settings", action: :show },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -471,10 +471,10 @@ Rails.application.routes.draw do
 
   namespace :admin do
     namespace :settings do
-      SettingsHelper.system_settings_tabs.each do |tab|
-        get tab[:name], controller: tab[:controller], action: :show, as: tab[:name].to_s
-        patch tab[:name], controller: tab[:controller], action: :update, as: "update_#{tab[:name]}"
-      end
+      resource :general, controller: "/admin/settings/general_settings", only: %i[show update]
+      resource :languages, controller: "/admin/settings/languages_settings", only: %i[show update]
+      resource :repositories, controller: "/admin/settings/repositories_settings", only: %i[show update]
+      resource :experimental, controller: "/admin/settings/experimental_settings", only: %i[show update]
 
       resource :authentication, controller: "/admin/settings/authentication_settings", only: %i[show update]
       resource :attachments, controller: "/admin/settings/attachments_settings", only: %i[show update]


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57655

# What are you trying to accomplish?
The submenu entries below Admin -> Settings used to be organized in tabs. The UI changed to render regular submenus, but the code remained in the old tab-style. This PR refactors it to behave like our other submenus.

Since the old tabs had special URLs, I took the freedom to streamline the routes as well.

While browsing through the code, I found a code smell in a neighboring method (`SettingsHelper#setting_select`). I refactored that.

## Screenshots
No changes for the end user.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
