### PR TITLE
Make expandable list button text more specific

### DIFF
--- a/app/components/op_primer/expandable_list_component.html.erb
+++ b/app/components/op_primer/expandable_list_component.html.erb
@@ -2,7 +2,7 @@
   component_wrapper(data: wrapper_data_attributes) do
     if elements.count == 0
       render(Primer::Beta::Text.new(color: :subtle)) { t("label_meeting_no_participants") }
-    elsif elements.count <= @cutoff_limit
+    elsif @cutoff_limit.nil? || elements.count <= @cutoff_limit
       flex_layout do |list|
         elements.each do |item|
           list.with_row(mt: 1) { item.to_s }
@@ -16,20 +16,25 @@
 
         list.with_row do
           flex_layout do |flex|
-            flex.with_row(display: :none, data: { 'expandable-list-target': "hiddenElements" }) do
+            flex.with_row(display: :none, data: { "expandable-list-target": "hiddenElements" }) do
               flex_layout do |hidden_user_list|
                 elements[@cutoff_limit..].each do |item|
                   hidden_user_list.with_row(mt: 1) { item.to_s }
                 end
+                hidden_user_list.with_row(mt: 2) do
+                  render(Primer::Beta::Button.new(
+                           scheme: :link,
+                           data: { action: "expandable-list#hideElements" }
+                         )) { I18n.t("label_hide_n_items", count: elements.count - @cutoff_limit) }
+                end
               end
             end
-            flex.with_row(mt: 1) do
+            flex.with_row(mt: 2) do
               render(Primer::Beta::Button.new(
-                scheme: :link,
-                data: { 'expandable-list-target': "showHideButton",
-                        action: 'click->expandable-list#showhiddenElements keydown.enter->expandable-list#showhiddenElements'
-                }
-              )) { I18n.t('label_show_hide_n_items', count: elements.count - @cutoff_limit) }
+                       scheme: :link,
+                       data: { "expandable-list-target": "showButton",
+                               action: "expandable-list#showElements" }
+                     )) { I18n.t("label_show_n_items", count: elements.count - @cutoff_limit) }
             end
           end
         end

--- a/app/components/op_primer/expandable_list_component.html.erb
+++ b/app/components/op_primer/expandable_list_component.html.erb
@@ -13,30 +13,25 @@
         elements.take(@cutoff_limit).each do |item|
           list.with_row(mt: 1) { item.to_s }
         end
-
-        list.with_row do
-          flex_layout do |flex|
-            flex.with_row(display: :none, data: { "expandable-list-target": "hiddenElements" }) do
-              flex_layout do |hidden_user_list|
-                elements[@cutoff_limit..].each do |item|
-                  hidden_user_list.with_row(mt: 1) { item.to_s }
-                end
-                hidden_user_list.with_row(mt: 2) do
-                  render(Primer::Beta::Button.new(
-                           scheme: :link,
-                           data: { action: "expandable-list#hideElements" }
-                         )) { I18n.t("label_hide_n_items", count: elements.count - @cutoff_limit) }
-                end
-              end
+        list.with_row(display: :none, data: { "expandable-list-target": "hiddenElements" }) do
+          flex_layout do |hidden_user_list|
+            elements[@cutoff_limit..].each do |item|
+              hidden_user_list.with_row(mt: 1) { item.to_s }
             end
-            flex.with_row(mt: 2) do
+            hidden_user_list.with_row(mt: 2) do
               render(Primer::Beta::Button.new(
                        scheme: :link,
-                       data: { "expandable-list-target": "showButton",
-                               action: "expandable-list#showElements" }
-                     )) { I18n.t("label_show_n_items", count: elements.count - @cutoff_limit) }
+                       data: { action: "expandable-list#hideElements" }
+                     )) { I18n.t("label_show_less") }
             end
           end
+        end
+        list.with_row(mt: 2) do
+          render(Primer::Beta::Button.new(
+                   scheme: :link,
+                   data: { "expandable-list-target": "showButton",
+                           action: "expandable-list#showElements" }
+                 )) { I18n.t("label_show_n_more", count: elements.count - @cutoff_limit) }
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2255,6 +2255,9 @@ en:
   label_home: "Home"
   label_subject_or_id: "Subject or ID"
   label_calendar_subscriptions: "Calendar subscriptions"
+  label_hide_n_items:
+    one: "Hide %{count} item"
+    other: "Hide %{count} items"
   label_identifier: "Identifier"
   label_in: "in"
   label_in_less_than: "in less than"
@@ -2276,7 +2279,9 @@ en:
   label_share_project_list: "Share project list"
   label_share_work_package: "Share work package"
   label_show_hide: "Show/hide"
-  label_show_hide_n_items: "Show/hide %{count} items"
+  label_show_n_items:
+    one: "Show %{count} item"
+    other: "Show %{count} items"
   label_show_all_registered_users: "Show all registered users"
   label_journal: "Journal"
   label_journal_diff: "Description Comparison"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2255,9 +2255,6 @@ en:
   label_home: "Home"
   label_subject_or_id: "Subject or ID"
   label_calendar_subscriptions: "Calendar subscriptions"
-  label_hide_n_items:
-    one: "Hide %{count} item"
-    other: "Hide %{count} items"
   label_identifier: "Identifier"
   label_in: "in"
   label_in_less_than: "in less than"
@@ -2278,11 +2275,9 @@ en:
   label_share: "Share"
   label_share_project_list: "Share project list"
   label_share_work_package: "Share work package"
-  label_show_hide: "Show/hide"
-  label_show_n_items:
-    one: "Show %{count} item"
-    other: "Show %{count} items"
   label_show_all_registered_users: "Show all registered users"
+  label_show_n_more: "Show %{count} more"
+  label_show_less: "Show less"
   label_journal: "Journal"
   label_journal_diff: "Description Comparison"
   label_language: "Language"

--- a/frontend/src/stimulus/controllers/dynamic/expandable-list.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/expandable-list.controller.ts
@@ -31,14 +31,17 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class ExxpandableListController extends Controller {
-  static targets = ['showHideButton', 'hiddenElements'];
+  static targets = ['hiddenElements', 'showButton'];
   declare readonly hiddenElementsTarget:HTMLElement;
+  declare readonly showButtonTarget:HTMLElement;
 
-  showhiddenElements():void {
-    if (this.hiddenElementsTarget.classList.contains('d-none')) {
-      this.hiddenElementsTarget.classList.remove('d-none');
-    } else {
-      this.hiddenElementsTarget.classList.add('d-none');
-    }
+  showElements():void {
+    this.hiddenElementsTarget.classList.remove('d-none');
+    this.showButtonTarget.classList.add('d-none');
+  }
+
+  hideElements():void {
+    this.hiddenElementsTarget.classList.add('d-none');
+    this.showButtonTarget.classList.remove('d-none');
   }
 }

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
@@ -2,7 +2,6 @@
   component_wrapper do
     render(Primer::OpenProject::SidePanel::Section.new) do |section|
       section.with_title { Meeting.human_attribute_name(:participants) }
-      section.with_description { I18n.t('meeting.attachments.text') }
       section.with_counter(count: @meeting.invited_or_attended_participants.count)
 
       if @meeting.editable?
@@ -21,12 +20,6 @@
       component_wrapper(data: wrapper_data_attributes) do
         flex_layout do |participants_container|
           participants_container.with_row do
-            flex_layout(align_items: :center, justify_content: :space_between) do |heading|
-
-            end
-          end
-
-          participants_container.with_row(mt: 2) do
             render(OpPrimer::ExpandableListComponent.new(cutoff_limit: 5)) do |list|
               elements.each do |item|
                 list.with_element { render_participant(item) }


### PR DESCRIPTION
# Ticket

No ticket initially, then scope increased with the feedbacks so this ticket was created to track the changes: https://community.openproject.org/projects/meetings-stream/work_packages/57911/activity

# What are you trying to accomplish?

I don't like this label:

![image](https://github.com/user-attachments/assets/408a145b-c0e0-4775-92a5-e932de2f84bb)

"Show/hide 30 items". That does not sound right. And I suppose screen readers do not read that properly either.
I'd like to display "Show 30 items" when it's hidden, and "Hide 30 items" when it's shown.

I was annoyed by that for a long time, and today I stumbled upon it while reading the lookbook, so why not fix it.

Now there are more to it:
* Change the phrasing of "Show 4 items"/"Hide 4 items" at the end of the participant section with:
  * "Show 4 more" (when collapsed)
  * "Show less" (when expanded)
* Increase margin above the Show link from 4px to 8px
* Remove the text ("Attached files are available...") from below the "Participants" heading
  This text seems to have been introduced as a bug in a prior change (regression)

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/d62efe46-74d1-429f-9a54-d207f4e3d49f)

Now:

![image](https://github.com/user-attachments/assets/c37bdf5d-f5fb-4ddc-b5c7-cef4d1316b8a)

![image](https://github.com/user-attachments/assets/ac6bcdf1-a198-43d4-91b4-b2ba46531418)


# What approach did you choose and why?

There are two buttons. One "Show", one "Hide". Only one is displayed at once. Clicking one changes the one being displayed.

Also fixed the action which did not trigger when pressing "enter". By not passing the action name explicitly, stimulus uses the default action, which should always work better, and is less verbose code-wise.

Also support @cuttoff_limit being nil, in which case all items are displayed (because when changing the value in lookbook, it crashed when I cleared the field before setting a new value).

Also increased to margin of the button from 4px to 8px as agreed in [frontend meeting](https://community.openproject.org/projects/gmbh/meetings/3590).

# Merge checklist

- [ ] Added/updated tests
  - nope, that's just a minor refactoring. I'll update existing tests if some fail.
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
