### PR TITLE
Use default formatting of text in agenda items

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -85,7 +85,7 @@
 
       grid.with_area(:notes, tag: :div) do
         if @meeting_agenda_item.notes.present?
-          render(Primer::Box.new(mt: 1)) do
+          render(Primer::Box.new(classes: "op-uc-container", mt: 1)) do
             format_text(@meeting_agenda_item, :notes)
           end
         end


### PR DESCRIPTION


# Ticket
https://community.openproject.org/work_packages/57792

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Consistent styling between edit and show of agenda items

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
We initially agreed to make the edit behave like show, but it's actually simply a missing container class. Achieving the same on edit is not easily doable.
