### PR TITLE
[57530] Add percent_complete_on_status_closed setting

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -91,7 +91,7 @@ class StatusesController < ApplicationController
 
   def recompute_progress_values
     attributes_triggering_recomputing = ["excluded_from_totals"]
-    attributes_triggering_recomputing << "default_done_ratio" if WorkPackage.use_status_for_done_ratio?
+    attributes_triggering_recomputing << "default_done_ratio" if WorkPackage.status_based_mode?
     changes = @status.previous_changes.slice(*attributes_triggering_recomputing)
     return if changes.empty?
 

--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -113,7 +113,7 @@ class WorkPackages::ProgressController < ApplicationController
   private
 
   def modal_class
-    if WorkPackage.use_status_for_done_ratio?
+    if WorkPackage.status_based_mode?
       WorkPackages::Progress::StatusBased::ModalBodyComponent
     else
       WorkPackages::Progress::WorkBased::ModalBodyComponent
@@ -153,7 +153,7 @@ class WorkPackages::ProgressController < ApplicationController
   end
 
   def allowed_params
-    if WorkPackage.use_status_for_done_ratio?
+    if WorkPackage.status_based_mode?
       %i[estimated_hours status_id]
     # two next lines to be removed in 15.0 with :percent_complete_edition feature flag removal
     elsif !OpenProject::FeatureDecisions.percent_complete_edition_active?

--- a/app/forms/settings_form_decorator.rb
+++ b/app/forms/settings_form_decorator.rb
@@ -101,14 +101,16 @@ class SettingsFormDecorator
   # @param name [Symbol] The name of the setting
   # @param values [Array] The values for the radio buttons. Default to the
   #   setting's allowed values.
+  # @param disabled [Boolean] Force the radio button group to be disabled when
+  #  true, will be disabled if the setting is not writable when false (default)
   # @param button_options [Hash] Options for individual radio buttons
   # @param options [Hash] Additional options for the radio button group
   # @return [Object] The radio button group
-  def radio_button_group(name:, values: [], button_options: {}, **options)
+  def radio_button_group(name:, values: [], disabled: false, button_options: {}, **options)
     values = values.presence || setting_allowed_values(name)
     radio_group_options = options.reverse_merge(
       label: setting_label(name),
-      disabled: setting_disabled?(name)
+      disabled: disabled || setting_disabled?(name)
     )
     form.radio_button_group(
       name:,

--- a/app/models/custom_actions/actions/done_ratio.rb
+++ b/app/models/custom_actions/actions/done_ratio.rb
@@ -46,7 +46,7 @@ class CustomActions::Actions::DoneRatio < CustomActions::Actions::Base
   end
 
   def self.all
-    if WorkPackage.use_field_for_done_ratio?
+    if WorkPackage.work_based_mode?
       super
     else
       []

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -220,6 +220,10 @@ class WorkPackage < ApplicationRecord
     Setting.work_package_done_ratio == "field"
   end
 
+  def self.complete_on_status_closed?
+    Setting.percent_complete_on_status_closed == "set_100p"
+  end
+
   # Returns true if usr or current user is allowed to view the work_package
   def visible?(usr = User.current)
     usr.allowed_in_work_package?(:view_work_packages, self)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -212,14 +212,6 @@ class WorkPackage < ApplicationRecord
     Setting.work_package_done_ratio == "field"
   end
 
-  def self.use_status_for_done_ratio?
-    Setting.work_package_done_ratio == "status"
-  end
-
-  def self.use_field_for_done_ratio?
-    Setting.work_package_done_ratio == "field"
-  end
-
   def self.complete_on_status_closed?
     Setting.percent_complete_on_status_closed == "set_100p"
   end
@@ -309,7 +301,7 @@ class WorkPackage < ApplicationRecord
   end
 
   def done_ratio
-    if WorkPackage.use_status_for_done_ratio? && status && status.default_done_ratio
+    if WorkPackage.status_based_mode? && status && status.default_done_ratio
       status.default_done_ratio
     else
       read_attribute(:done_ratio)
@@ -384,7 +376,7 @@ class WorkPackage < ApplicationRecord
   # Set the done_ratio using the status if that setting is set.  This will keep the done_ratios
   # even if the user turns off the setting later
   def update_done_ratio_from_status
-    if WorkPackage.use_status_for_done_ratio? && status && status.default_done_ratio
+    if WorkPackage.status_based_mode? && status && status.default_done_ratio
       self.done_ratio = status.default_done_ratio
     end
   end

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -287,7 +287,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   def update_progress_attributes
     derive_progress_values_class =
       if OpenProject::FeatureDecisions.percent_complete_edition_active?
-        WorkPackage.use_status_for_done_ratio? ? DeriveProgressValuesStatusBased : DeriveProgressValuesWorkBased
+        WorkPackage.status_based_mode? ? DeriveProgressValuesStatusBased : DeriveProgressValuesWorkBased
       else
         Pre144DeriveProgressValues
       end

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -58,7 +58,10 @@ class WorkPackages::SetAttributesService
     end
 
     def set_complete_for_closed_status?
-      WorkPackage.complete_on_status_closed? && work_package.status_id_changed? && work_package.closed?
+      WorkPackage.complete_on_status_closed? \
+        && percent_complete_not_provided_by_user? \
+        && work_package.status_id_changed? \
+        && work_package.closed?
     end
 
     def derive_work?

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -39,6 +39,7 @@ class WorkPackages::SetAttributesService
       # by the contract and errors will be set.
       return if invalid_progress_values?
 
+      set_complete if set_complete_for_closed_status?
       update_work if derive_work?
       update_remaining_work if derive_remaining_work?
       update_percent_complete if derive_percent_complete?
@@ -56,6 +57,10 @@ class WorkPackages::SetAttributesService
       percent_complete && !percent_complete.between?(0, 100)
     end
 
+    def set_complete_for_closed_status?
+      WorkPackage.complete_on_status_closed? && work_package.status_id_changed? && work_package.closed?
+    end
+
     def derive_work?
       work_not_provided_by_user? && (remaining_work_changed? || percent_complete_changed?)
     end
@@ -67,6 +72,11 @@ class WorkPackages::SetAttributesService
     def derive_percent_complete?
       percent_complete_not_provided_by_user? && (work_changed? || remaining_work_changed?) \
         && !skip_percent_complete_derivation
+    end
+
+    def set_complete
+      self.percent_complete = 100
+      skip_percent_complete_derivation!
     end
 
     # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity

--- a/app/services/work_packages/set_attributes_service/pre_14_4_derive_progress_values.rb
+++ b/app/services/work_packages/set_attributes_service/pre_14_4_derive_progress_values.rb
@@ -41,7 +41,7 @@ class WorkPackages::SetAttributesService
 
     # From this point, copied over from 109b135b:app/services/work_packages/set_attributes_service.rb#L287-L427
     def update_progress_attributes
-      if WorkPackage.use_status_for_done_ratio?
+      if WorkPackage.status_based_mode?
         update_done_ratio
         update_remaining_hours
       elsif only_percent_complete_initially_set?
@@ -73,7 +73,7 @@ class WorkPackages::SetAttributesService
     # Unless both +remaining_hours+ and +estimated_hours+ are set, +done_ratio+ will be
     # considered nil.
     def update_done_ratio
-      if WorkPackage.use_status_for_done_ratio?
+      if WorkPackage.status_based_mode?
         return unless work_package.status_id_changed?
 
         work_package.done_ratio = work_package.status.default_done_ratio
@@ -133,7 +133,7 @@ class WorkPackages::SetAttributesService
     end
 
     def update_estimated_hours
-      return unless WorkPackage.use_field_for_done_ratio?
+      return unless WorkPackage.work_based_mode?
       return if work_package.estimated_hours_came_from_user?
       return unless work_package.remaining_hours_changed?
 
@@ -151,9 +151,9 @@ class WorkPackages::SetAttributesService
     # unset the remaining hours.
     # rubocop:disable Metrics/PerceivedComplexity
     def update_remaining_hours
-      if WorkPackage.use_status_for_done_ratio?
+      if WorkPackage.status_based_mode?
         update_remaining_hours_from_percent_complete
-      elsif WorkPackage.use_field_for_done_ratio? &&
+      elsif WorkPackage.work_based_mode? &&
         work_package.estimated_hours_changed?
         return if work_package.remaining_hours_came_from_user?
         return if work_package.estimated_hours&.negative?

--- a/app/views/admin/settings/progress_tracking/show.html.erb
+++ b/app/views/admin/settings/progress_tracking/show.html.erb
@@ -52,7 +52,6 @@ primer_form_with(
   render_inline_settings_form(f) do |form|
     form.radio_button_group(
       name: "work_package_done_ratio",
-      values: WorkPackage::DONE_RATIO_OPTIONS,
       button_options: {
         data: { action: "admin--progress-tracking#displayWarning" }
       }
@@ -66,6 +65,9 @@ primer_form_with(
         end
       end
     end
+    form.radio_button_group(
+      name: "percent_complete_on_status_closed"
+    )
     form.submit
   end
 end

--- a/app/views/admin/settings/progress_tracking/show.html.erb
+++ b/app/views/admin/settings/progress_tracking/show.html.erb
@@ -53,7 +53,7 @@ primer_form_with(
     form.radio_button_group(
       name: "work_package_done_ratio",
       button_options: {
-        data: { action: "admin--progress-tracking#displayWarning" }
+        data: { action: "admin--progress-tracking#updateEnabledOptions" }
       }
     )
     form.html_content do
@@ -66,7 +66,9 @@ primer_form_with(
       end
     end
     form.radio_button_group(
-      name: "percent_complete_on_status_closed"
+      name: "percent_complete_on_status_closed",
+      disabled: Setting.work_package_done_ratio == "status",
+      data: { admin__progress_tracking_target: "statusClosedRadioGroup" }
     )
     form.submit
   end

--- a/app/views/admin/settings/progress_tracking/show.html.erb
+++ b/app/views/admin/settings/progress_tracking/show.html.erb
@@ -67,7 +67,7 @@ primer_form_with(
     end
     form.radio_button_group(
       name: "percent_complete_on_status_closed",
-      disabled: Setting.work_package_done_ratio == "status",
+      disabled: WorkPackage.status_based_mode?,
       data: { admin__progress_tracking_target: "statusClosedRadioGroup" }
     )
     form.submit

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -741,6 +741,11 @@ module Settings
       per_page_options: {
         default: "20, 100"
       },
+      percent_complete_on_status_closed: {
+        description: "Describes how % complete should change when setting a work package status to a closed one",
+        default: "no_change",
+        allowed: %w[no_change set_100p]
+      },
       plain_text_mail: {
         default: false
       },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3328,6 +3328,13 @@ en:
   setting_password_min_length: "Minimum length"
   setting_password_min_adhered_rules: "Minimum number of required classes"
   setting_per_page_options: "Objects per page options"
+  setting_percent_complete_on_status_closed: "% Complete when status is closed"
+  setting_percent_complete_on_status_closed_no_change: "No change"
+  setting_percent_complete_on_status_closed_no_change_caption_html: >-
+    The value of <i>% Complete</i> will not change even when a work package is closed.
+  setting_percent_complete_on_status_closed_set_100p: "Automatically set to 100%"
+  setting_percent_complete_on_status_closed_set_100p_caption: >-
+    A closed work package is considered complete.
   setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
   setting_project_gantt_query: "Project portfolio Gantt view"

--- a/frontend/src/stimulus/controllers/dynamic/admin/progress-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/progress-tracking.controller.ts
@@ -40,6 +40,7 @@ export default class ProgressTrackingController extends Controller {
     'progressCalculationModeRadioGroup',
     'warningText',
     'warningToast',
+    'statusClosedRadioGroup',
   ];
 
   declare readonly initialModeValue:string;
@@ -48,18 +49,38 @@ export default class ProgressTrackingController extends Controller {
   declare readonly progressCalculationModeRadioGroupTarget:HTMLElement;
   declare readonly warningTextTarget:HTMLElement;
   declare readonly warningToastTarget:HTMLElement;
+  declare readonly statusClosedRadioGroupTarget:HTMLElement;
 
   connect() {
-    this.displayWarning();
+    this.updateEnabledOptions();
   }
 
-  displayWarning() {
+  updateEnabledOptions() {
+    this.updateWarning();
+    this.updateStatusClosedDisabledState();
+  }
+
+  updateWarning() {
     const warningMessageHtml = this.getWarningMessageHtml();
     if (warningMessageHtml) {
       this.warningTextTarget.innerHTML = warningMessageHtml;
       this.warningToastTarget.hidden = false;
     } else {
       this.warningToastTarget.hidden = true;
+    }
+  }
+
+  updateStatusClosedDisabledState() {
+    if (this.getSelectedMode() === 'status') {
+      this.statusClosedRadioGroupTarget.setAttribute('disabled', 'true');
+      this.statusClosedRadioGroupTarget.querySelectorAll('input').forEach((input) => {
+        input.disabled = true;
+      });
+    } else {
+      this.statusClosedRadioGroupTarget.removeAttribute('disabled');
+      this.statusClosedRadioGroupTarget.querySelectorAll('input').forEach((input) => {
+        input.disabled = false;
+      });
     }
   }
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -410,7 +410,7 @@ module API
                    datetime_formatter.format_duration_from_hours(represented.remaining_hours,
                                                                  allow_nil: true)
                  end,
-                 writable: ->(*) { !WorkPackage.use_status_for_done_ratio? },
+                 writable: ->(*) { !WorkPackage.status_based_mode? },
                  render_nil: false
 
         property :derived_remaining_time,

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -149,7 +149,7 @@ FactoryBot.define do
 
     # force done_ratio in status-based mode if given done_ratio is different from status default
     callback(:after_create) do |work_package, evaluator|
-      next unless WorkPackage.use_status_for_done_ratio?
+      next unless WorkPackage.status_based_mode?
       next unless evaluator.__override_names__.include?(:done_ratio)
 
       if work_package.read_attribute(:done_ratio) != evaluator.done_ratio

--- a/spec/features/admin/progress_tracking_spec.rb
+++ b/spec/features/admin/progress_tracking_spec.rb
@@ -69,4 +69,26 @@ RSpec.describe "Progress tracking admin page", :cuprite, :js,
     expect_and_dismiss_toaster(message: "Successful update.")
     expect(Setting.find_by(name: "work_package_done_ratio").value).to eq("field")
   end
+
+  it "disables the status closed radio button when changing to status-based" do
+    login_as(admin)
+
+    Setting.work_package_done_ratio = "field"
+    visit admin_settings_progress_tracking_path
+    expect(page).to have_field("No change", disabled: false)
+    expect(page).to have_field("Automatically set to 100%", disabled: false)
+
+    find(:radio_button, "Status-based").click
+    expect(page).to have_field("No change", disabled: true)
+    expect(page).to have_field("Automatically set to 100%", disabled: true)
+
+    find(:radio_button, "Work-based").click
+    expect(page).to have_field("No change", disabled: false)
+    expect(page).to have_field("Automatically set to 100%", disabled: false)
+
+    Setting.work_package_done_ratio = "status"
+    visit admin_settings_progress_tracking_path
+    expect(page).to have_field("No change", disabled: true)
+    expect(page).to have_field("Automatically set to 100%", disabled: true)
+  end
 end

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -463,10 +463,10 @@ RSpec.describe WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased
 
       context "when the work package is closed and % complete is set to some value" do
         let(:set_attributes) { { status: status_closed, done_ratio: 90 } }
-        let(:expected_derived_attributes) { { remaining_hours: 0.0, done_ratio: 100 } }
+        let(:expected_derived_attributes) { { remaining_hours: 1.0, done_ratio: 90 } }
         let(:expected_kept_attributes) { %w[estimated_hours] }
 
-        include_examples "update progress values", description: "% complete is set to 100% anyway and remaining work is derived",
+        include_examples "update progress values", description: "uses % complete from the user and remaining work is derived",
                                                    expected_hints: {
                                                      remaining_work: :derived
                                                    }

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe WorkPackages::SetAttributesService,
   shared_let(:status_0_pct_complete) { create(:status, default_done_ratio: 0, name: "0% complete") }
   shared_let(:status_50_pct_complete) { create(:status, default_done_ratio: 50, name: "50% complete") }
   shared_let(:status_70_pct_complete) { create(:status, default_done_ratio: 70, name: "70% complete") }
+  shared_let(:status_99_pct_closed) { create(:closed_status, default_done_ratio: 99, name: "Closed 99% complete") }
 
   let(:today) { Time.zone.today }
   let(:user) { build_stubbed(:user) }
@@ -282,6 +283,67 @@ RSpec.describe WorkPackages::SetAttributesService,
           end
 
           it_behaves_like "service call", description: "remaining work is set to the same value and % complete is set to 0%"
+        end
+      end
+    end
+  end
+
+  describe "updating % complete when closing work package" do
+    before do
+      work_package.status = status_50_pct_complete
+      work_package.estimated_hours = 10.0
+      work_package.remaining_hours = 5.0
+      work_package.done_ratio = 50
+      work_package.clear_changes_information
+    end
+
+    context "in work-based mode",
+            with_settings: { work_package_done_ratio: "field" } do
+      context "when `percent_complete_on_status_closed` is set to `no_change`",
+              with_settings: { percent_complete_on_status_closed: "no_change" } do
+        context "when status is closed" do
+          let(:call_attributes) { { status: status_99_pct_closed } }
+          let(:expected_kept_attributes) { %w[estimated_hours remaining_hours done_ratio] }
+
+          it_behaves_like "service call", description: "does not change % complete"
+        end
+      end
+
+      context "when `percent_complete_on_status_closed` is set to `set_100p`",
+              with_settings: { percent_complete_on_status_closed: "set_100p" } do
+        context "when status is closed" do
+          let(:call_attributes) { { status: status_99_pct_closed } }
+          let(:expected_attributes) { { done_ratio: 100, remaining_hours: 0.0 } }
+          let(:expected_kept_attributes) { %w[estimated_hours] }
+
+          it_behaves_like "service call", description: "change % complete to 100% and derives remaining work accordingly"
+        end
+      end
+    end
+
+    context "in status-based mode",
+            with_settings: { work_package_done_ratio: "status" } do
+      context "when `percent_complete_on_status_closed` is set to `no_change`",
+              with_settings: { percent_complete_on_status_closed: "no_change" } do
+        context "when status is closed" do
+          let(:call_attributes) { { status: status_99_pct_closed } }
+          let(:expected_attributes) { { done_ratio: 99, remaining_hours: 0.1 } }
+          let(:expected_kept_attributes) { %w[estimated_hours] }
+
+          it_behaves_like "service call", description: "changes % complete to the status's default % complete value " \
+                                                       "and derives remaining work accordingly"
+        end
+      end
+
+      context "when `percent_complete_on_status_closed` is set to `set_100p`",
+              with_settings: { percent_complete_on_status_closed: "set_100p" } do
+        context "when status is closed" do
+          let(:call_attributes) { { status: status_99_pct_closed } }
+          let(:expected_attributes) { { done_ratio: 99, remaining_hours: 0.1 } }
+          let(:expected_kept_attributes) { %w[estimated_hours] }
+
+          it_behaves_like "service call", description: "changes % complete to the status's default % complete value " \
+                                                       "and derives remaining work accordingly"
         end
       end
     end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe WorkPackages::SetAttributesService,
           let(:expected_attributes) { { done_ratio: 100, remaining_hours: 0.0 } }
           let(:expected_kept_attributes) { %w[estimated_hours] }
 
-          it_behaves_like "service call", description: "change % complete to 100% and derives remaining work accordingly"
+          it_behaves_like "service call", description: "changes % complete to 100% and derives remaining work accordingly"
         end
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57530

# What are you trying to accomplish?

There is a new setting called "**% Complete when status is closed**" with two options:
* Option 1: **Automatically set to 100%**. Guideline text when selected: "A closed work package is considered complete."
* Option 2: **No change (default)**. Guideline text when selected: "The value of % Complete will not change even when a work package is closed."

When "Status-based" mode is selected, "% Complete when status is closed" options should be disabled.

## Screenshots

Admin:
![localhost_3000_admin_settings_progress_tracking](https://github.com/user-attachments/assets/1d61a913-893e-412c-84a6-78ad1ee0b604)

When the setting  "% Complete when status is closed" is "Automatically set to 100%", here is what happens:

[closing sets complete to 100 percent.webm](https://github.com/user-attachments/assets/ec915c7f-6e8c-4f22-8e05-587288713c37)

# What approach did you choose and why?

Quite straightforward:
- add a setting definition
- add it in Admin UI
  - fiddle with stimulus to disable it when status based is selected
- modify `WorkPackages::SetAttributesService::DeriveProgressValuesWorkBased` to take it into account

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
