### PR TITLE
[57143] Primer: Action menu is sometimes incorrectly positioned on mobile

### DIFF
--- a/frontend/src/app/core/setup/globals/global-listeners/top-menu-scroll.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/top-menu-scroll.ts
@@ -31,22 +31,26 @@ export function scrollHeaderOnMobile() {
   const headerHeight = 55;
   let prevScrollPos = window.scrollY;
 
-  window.addEventListener('scroll', () => {
-    // Condition needed for safari browser to avoid negative positions
-    const currentScrollPos = window.scrollY < 0 ? 0 : window.scrollY;
-    // Only if sidebar is not opened or search bar is opened
-    if (!(jQuery('#main').hasClass('hidden-navigation'))
+  const scrollableElement = document.getElementById('content-body');
+
+  if (scrollableElement) {
+    scrollableElement.addEventListener('scroll', () => {
+      // Condition needed for safari browser to avoid negative positions
+      const currentScrollPos = scrollableElement.scrollTop < 0 ? 0 : scrollableElement.scrollTop;
+      // Only if sidebar is not opened or search bar is opened
+      if (!(jQuery('#main').hasClass('hidden-navigation'))
         || jQuery('.op-app-header').hasClass('op-app-header_search-open')
         || Math.abs(currentScrollPos - prevScrollPos) <= headerHeight) { // to avoid flickering at the end of the page
-      return;
-    }
+        return;
+      }
 
-    if (prevScrollPos !== undefined && currentScrollPos !== undefined && (prevScrollPos > currentScrollPos)) {
-      // Slide top menu in or out of viewport and change viewport height
-      jQuery('#wrapper').removeClass('_header-scrolled');
-    } else {
-      jQuery('#wrapper').addClass('_header-scrolled');
-    }
-    prevScrollPos = currentScrollPos;
-  });
+      if (prevScrollPos !== undefined && currentScrollPos !== undefined && (prevScrollPos > currentScrollPos)) {
+        // Slide top menu in or out of viewport and change viewport height
+        jQuery('#wrapper').removeClass('_header-scrolled');
+      } else {
+        jQuery('#wrapper').addClass('_header-scrolled');
+      }
+      prevScrollPos = currentScrollPos;
+    });
+  }
 }

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -32,34 +32,15 @@
     -webkit-overflow-scrolling: touch
     height: 100%
 
-  // ------------------- BEGIN CHANGED SCROLL BEHAVIOR
-  // Change scroll behavior on mobile:
-  // Let the window be the one who scrolls.
-  // Thus we make sure, that mobile browsers (like iOS Safari) hide their toolbars on scroll.
-  html
-    overflow: auto
-  body,
-  #main
-    overflow: visible
-
-  #wrapper,
-  #content-wrapper,
-  #content-body,
-  #content-bodyRight
-    overflow: hidden
-
   #main
     margin-top: var(--header-height)
 
-    ._header-scrolled &
+  ._header-scrolled
+    #main
       margin-top: 0
-
-  #content-wrapper
-    height: 100%
-    // Take care that the wrapper has the available screen height at the least
-    // Check for example notification center on mobile before changing that
-    min-height: calc(100vh - var(--header-height))
-  // ------------------- END CHANGED SCROLL BEHAVIOR
+    #main,
+    #content-wrapper
+      height: 100dvh
 
   #content-body,
   #content-header

--- a/frontend/src/global_styles/layout/_main_menu_mobile.sass
+++ b/frontend/src/global_styles/layout/_main_menu_mobile.sass
@@ -61,12 +61,9 @@
     background: #fff
     transition: background .3s
 
-  #main:not(.nosidebar)
-    .content-overlay
-      display: block
-
   #wrapper:not(.hidden-navigation)
     .content-overlay
+      display: block
       position: fixed
       height: 100%
       background: #000


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/gmbh/work_packages/57143/activity

# What are you trying to accomplish?
Position the Primer Action::Menu correctly on mobile even when the page is scrolled.

## Screenshots
<img width="438" alt="Bildschirmfoto 2024-09-13 um 14 08 14" src="https://github.com/user-attachments/assets/1b61657f-c90b-4ba8-ab2f-6c78fe1525c5">


# What approach did you choose and why?
Remove special mobile scrolling behavior that we introduced to collapse the adress bar on iOS Safari. It somehow conflicts with the positioning of the ActionMenu. I honestly still don't fully understand why. 

* iOS needs the body tag to be the overflowing element so that it collapses the adress bar on scroll. 
* For that to work, the elements below (content-wrapper, content, etc) need to span 100%
* For whatever reason, that conflicts with the ActionMenu positioning. I assume, that it has something to do with the Top-Layer that is opened by the ActionMenu. 

⚠️ This PR shows the ActionMenu correctly again, at the cost of the loss of the collapsed address bar on iOS Safari. I still consider this better than before, but we might have to check with the product team

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
