### PR TITLE
Still possible get a WP without project attached when in URL /work_package creating WP directly

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -259,7 +259,7 @@ module API
 
         link :addChild,
              cache_if: -> { add_work_packages_allowed? } do
-          next if represented.milestone? || represented.new_record?
+          next if represented.milestone? || represented.new_record? || represented.project.nil?
 
           {
             href: api_v3_paths.work_packages_by_project(represented.project.identifier),


### PR DESCRIPTION
# What are you trying to accomplish?

An 500 error while running OP in production

## Server log / Screen shot

### nginx log

```log
172.26.112.81 - - [13/Sep/2024:16:01:11 +0800] "POST /api/v3/work_packages/105977/form HTTP/2.0" 500 173 "https://plm.thape.com.cn/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22type%22%2C%22status%22%2C%22assignee%22%2C%22updatedAt%22%2C%22project%22%2C%22author%22%5D%2C%22hi%22%3Afalse%2C%22g%22%3A%22%22%2C%22is%22%3Afalse%2C%22tv%22%3Afalse%2C%22hla%22%3A%5B%22status%22%2C%22priority%22%2C%22dueDate%22%5D%2C%22t%22%3A%22updatedAt%3Adesc%2Cid%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%2C%7B%22n%22%3A%22author%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22me%22%5D%7D%5D%2C%22ts%22%3A%22PT0S%22%2C%22pp%22%3A20%2C%22pa%22%3A1%7D&name=created_by_me" "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.119 Safari/537.36 Language/zh wxwork/4.1.28 (MicroMessenger/6.2) WindowsWechat  MailPlugin_Electron WeMail embeddisk"
```

### puma log

```log
D, [2024-09-13T16:01:11.156334 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89]   WorkPackage Exists? (6.8ms)  WITH "allowed_work_packages" AS (SELECT "work_packages"."id" FROM "members" INNER JOIN "work_packages" ON "members"."entity_id" = "work_packages"."id" INNER JOIN "projects" ON "projects"."active" = TRUE AND "projects"."id" = "work_packages"."project_id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."active" = TRUE INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id" INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id" INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id" AND (FALSE OR "role_permissions"."permission" = 'view_work_packages' AND "enabled_modules"."name" = 'work_package_tracking') WHERE "members"."user_id" = 327 AND "members"."entity_type" = 'WorkPackage'), "allowed_projects" AS (SELECT "projects"."id" FROM "projects" WHERE "projects"."id" IN (( (SELECT "projects"."id" FROM "members" INNER JOIN "projects" ON "projects"."active" = TRUE AND "members"."project_id" = "projects"."id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."active" = TRUE INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id" INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id" INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id" AND (FALSE OR "role_permissions"."permission" = 'view_work_packages' AND "enabled_modules"."name" = 'work_package_tracking') WHERE "members"."user_id" = 327 AND "members"."entity_id" IS NULL AND "members"."entity_type" IS NULL) UNION ALL (SELECT "projects"."id" FROM "projects" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('work_package_tracking') AND "projects"."active" = TRUE INNER JOIN "roles" ON "roles"."builtin" = 1 AND "projects"."active" AND "projects"."public" AND NOT (EXISTS (SELECT 1 FROM "members" WHERE "members"."user_id" = 327 AND "members"."entity_id" IS NULL AND "members"."entity_type" IS NULL AND "members"."project_id" = "projects"."id")) INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id" AND (FALSE OR "role_permissions"."permission" = 'view_work_packages' AND "enabled_modules"."name" = 'work_package_tracking')) ))) SELECT 1 AS one FROM "work_packages" WHERE (work_packages.project_id IN (SELECT id FROM allowed_projects) OR work_packages.id IN (SELECT id FROM allowed_work_packages)) AND "work_packages"."id" = $1 LIMIT $2  [["id", 105977], ["LIMIT", 1]]
D, [2024-09-13T16:01:11.156782 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89]   CACHE Project Load (0.0ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", 1976], ["LIMIT", 1]]
D, [2024-09-13T16:01:11.157163 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89]   CACHE EnabledModule Pluck (0.0ms)  SELECT "enabled_modules"."name" FROM "enabled_modules" WHERE "enabled_modules"."project_id" = $1  [["project_id", 1976]]
D, [2024-09-13T16:01:11.158626 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89]   Type Pluck (0.5ms)  SELECT "types"."id" FROM "types" INNER JOIN "projects_types" ON "types"."id" = "projects_types"."type_id" WHERE "projects_types"."project_id" = $1 ORDER BY position ASC, types.position  [["project_id", 1976]]
D, [2024-09-13T16:01:11.159401 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89]   TimeEntry Load (0.3ms)  SELECT "time_entries".* FROM "time_entries" WHERE "time_entries"."work_package_id" = $1  [["work_package_id", 105977]]
D, [2024-09-13T16:01:11.169235 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89]   Watcher Load (0.5ms)  SELECT "watchers".* FROM "watchers" WHERE "watchers"."watchable_id" = $1 AND "watchers"."watchable_type" = $2  [["watchable_id", 105977], ["watchable_type", "WorkPackage"]]
E, [2024-09-13T16:01:11.173939 #207451] ERROR -- : [885fb62f-00ab-425e-a626-4b3aa9600f89] user=327 undefined method `identifier' for nil: undefined method `identifier' for nil
D, [2024-09-13T16:01:11.174000 #207451] DEBUG -- : [885fb62f-00ab-425e-a626-4b3aa9600f89] [NoMethodError] undefined method `identifier' for nil: lib/api/v3/work_packages/work_package_representer.rb:266:in `block in <class:WorkPackageRepresenter>'; lib/api/caching/cached_representer.rb:156:in `compile_links_for'; lib/api/v3/work_packages/work_package_representer.rb:581:in `to_hash'; lib/api/caching/cached_representer.rb:42:in `to_json'; lib/api/formatter.rb:35:in `call'
I, [2024-09-13T16:01:11.174412 #207451]  INFO -- : [885fb62f-00ab-425e-a626-4b3aa9600f89] duration=69.06 db=27.22 view=41.84 status=500 method=POST path=/api/v3/work_packages/105977/form params={"lockVersion"=>1, "_links"=>{"project"=>{"href"=>nil}}} host=plm.thape.com.cn user=327
```

# What approach did you choose and why?

I found user create a duplicate work package because in `https://plm.thape.com.cn/work_packages` there is no project available, so first create cause 500 error like above.

It's direct fix and I check DB, all work package all having project_id, so I guess the work package object is new in memory.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
