### PR TITLE
[57092] Right side of the instance upper banner looks misaligned

### DIFF
--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
@@ -3,7 +3,7 @@
   data-test-selector="op-ian-bell"
   [href]="notificationsPath()"
 >
-  <op-icon icon-classes="icon-bell"></op-icon>
+  <svg bell-fill-icon  size="small"></svg>
   <ng-container *ngIf="(unreadCount$ | async) as unreadCount">
     <span
       *ngIf="unreadCount !== 0"

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
@@ -3,7 +3,7 @@
   data-test-selector="op-ian-bell"
   [href]="notificationsPath()"
 >
-  <svg bell-fill-icon  size="small"></svg>
+  <svg bell-fill-icon size="small"></svg>
   <ng-container *ngIf="(unreadCount$ | async) as unreadCount">
     <span
       *ngIf="unreadCount !== 0"

--- a/frontend/src/app/shared/components/icon/icon.module.ts
+++ b/frontend/src/app/shared/components/icon/icon.module.ts
@@ -29,6 +29,7 @@ import {
   StarFillIconComponent,
   StarIconComponent,
   XIconComponent,
+  BellFillIconComponent,
   OpGitlabIssueClosedIconComponent,
   OpGitlabLabelsIconComponent,
   OpGitlabIssueOpenIconComponent,
@@ -81,6 +82,7 @@ import {
     StarFillIconComponent,
     StarIconComponent,
     XIconComponent,
+    BellFillIconComponent,
 
     OpGitlabIssueClosedIconComponent,
     OpGitlabLabelsIconComponent,
@@ -136,6 +138,7 @@ import {
     StarFillIconComponent,
     StarIconComponent,
     XIconComponent,
+    BellFillIconComponent,
 
     OpGitlabIssueOpenIconComponent,
     OpGitlabIssueClosedIconComponent,

--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -31,7 +31,6 @@
     justify-content: center
     align-items: center
     height: var(--header-height)
-    line-height: var(--header-height)
     zoom: 1
     color: var(--header-item-font-color)
     font-size: var(--header-item-font-size)

--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -9,7 +9,9 @@
     display: flex
     position: relative
     height: 100%
-    min-width: 0px
+    padding: 0 15px
+    justify-content: center
+    align-items: center
 
   &--item-dropdown-indicator
     display: inline-flex
@@ -35,8 +37,7 @@
     color: var(--header-item-font-color)
     font-size: var(--header-item-font-size)
     text-decoration: none
-    min-width: 0px
-    padding: 0 15px
+    min-width: 36px
 
     @media screen and (max-width: $breakpoint-sm)
       padding: 0 8px

--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -9,9 +9,7 @@
     display: flex
     position: relative
     height: 100%
-    padding: 0 15px
-    justify-content: center
-    align-items: center
+    min-width: 0px
 
   &--item-dropdown-indicator
     display: inline-flex
@@ -37,7 +35,8 @@
     color: var(--header-item-font-color)
     font-size: var(--header-item-font-size)
     text-decoration: none
-    min-width: 36px
+    min-width: 0px
+    padding: 0 15px
 
     @media screen and (max-width: $breakpoint-sm)
       padding: 0 8px

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -86,6 +86,7 @@ sub-header,
 .Button.op-app-header--primer-button,
 .Button.op-app-header--primer-button .Button-visual
   color: var(--header-item-font-color)
+  width: auto
 
   &:hover
     background: var(--header-item-bg-hover-color)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57092/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Align the header buttons.

## Screenshots
Before:
![Screenshot 2024-09-17 at 06 45 21](https://github.com/user-attachments/assets/55edfeda-c974-4614-a196-79b00bc5b646)

After:

![Screenshot 2024-09-17 at 06 44 33](https://github.com/user-attachments/assets/ceddf3ad-f174-4e86-bb28-371f3d992f91)


# What approach did you choose and why?
Replace op-icon with octicon for bell icon. And override the width of op-app-header--primer-button to auto, because it has ''Button--iconOnly classwith 2rem width.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
