### PR TITLE
[57614] Meetings: The add button should have a trailing icon to indicate that it's a drop-down

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
@@ -3,6 +3,7 @@
     render(Primer::Alpha::ActionMenu.new(classes: "hide-when-print")) do |component|
       component.with_show_button(scheme: button_scheme, disabled: @disabled) do |button|
         button.with_leading_visual_icon(icon: :plus)
+        button.with_trailing_visual_icon(icon: "triangle-down")
         t("button_add")
       end
       component.with_item(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57614/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add a trailing arrow-down icon to the create a new agenda item button.

## Screenshots
Before:
![Screenshot 2024-09-17 at 08 08 08](https://github.com/user-attachments/assets/2bed210a-f1da-4954-88f1-c428a9d8dd1f)

After:
![Screenshot 2024-09-17 at 08 06 47](https://github.com/user-attachments/assets/7557de51-84ee-444f-a2a8-cd9c8f3d3872)

# What approach did you choose and why?
Use with_trailing_visual_icon for a primer button.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
