### PR TITLE
[57927] Primerise the Notification badge in the top header

### DIFF
--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.sass
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.sass
@@ -8,4 +8,4 @@
     position: absolute
     top: 10px
     right: 3px
-    background: darkred
+    background: var(--display-red-bgColor-emphasis)

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -320,7 +320,7 @@ $scrollbar-size: 10px
   padding: 0 0.15rem 0 0.15rem
   font-size: 0.7rem
   font-weight: var(--base-text-weight-bold)
-  background: #00A3FF
+  background: var(--bgColor-accent-emphasis)
   color: white
   flex-shrink: 0
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57927/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Primerise the notification badges.

## Screenshots
Before:
![Screenshot 2024-09-17 at 10 37 20](https://github.com/user-attachments/assets/344252c6-cd51-48b8-b0a2-9ba06c2f4030)

After:
![Screenshot 2024-09-17 at 10 26 04](https://github.com/user-attachments/assets/7f993aa6-9480-416c-bd9c-26d553a69a35)

# What approach did you choose and why?
Use primer CSS variables instead of using our custom color values for bg-color.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
