### PR TITLE
chore(deps): bump md-to-pdf to v0.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ gem "structured_warnings", "~> 0.4.0"
 gem "airbrake", "~> 13.0.0", require: false
 
 gem "markly", "~> 0.10" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "32603f09a249999a00e8ca23eb17215b46a26c0f"
+gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "fe05b4f8bae8fd46f4fa93b8e0adee6295ef7388"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 32603f09a249999a00e8ca23eb17215b46a26c0f
-  ref: 32603f09a249999a00e8ca23eb17215b46a26c0f
+  revision: fe05b4f8bae8fd46f4fa93b8e0adee6295ef7388
+  ref: fe05b4f8bae8fd46f4fa93b8e0adee6295ef7388
   specs:
-    md_to_pdf (0.1.1)
+    md_to_pdf (0.1.2)
       color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.3)


### PR DESCRIPTION
Gem update for support of empty lines and paragraphs in html table cells.
Nothing to review, tests are available at https://github.com/opf/md-to-pdf/commit/d9f95d264ef425b319724fb059bf917a514e01be
