### PR TITLE
[#57835] Use advisory lock to synchronize token refresh process.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,7 @@ class User < Principal
      inverse_of: :user
   has_one :rss_token, class_name: "::Token::RSS", dependent: :destroy
   has_many :api_tokens, class_name: "::Token::API", dependent: :destroy
+  has_many :oauth_client_tokens, dependent: :destroy
 
   # The user might have one invitation token
   has_one :invitation_token, class_name: "::Token::Invitation", dependent: :destroy


### PR DESCRIPTION
https://community.openproject.org/work_packages/57835

Let's assume we have two OpenProject threads sent request to Nextcloud and received Unauthorized. Then each does the following:
   A. Send refresh token request on Nextcloud side.
   B. Send original request but with new token received in A.
   C. If B is successful then update token in OpenProject DB.

There are problems with above:
1. Before this commit the three operations above are not synchronized which leads to incostistent state when
token has been updated on Nextcloud side, but it is not saved in OpenProject DB.
2. Step B and C logic is wrong. Original request can be unsuccessful even with updated token. That's no reason to skip
updating the token in OpenProject DB.

What has changed in this commit?
The logic has been changed to the following:
   1. Try to acquire a lock. Acquired?
     A. Yes.
       1. Send refresh token request on Nextcloud side.
       2. Update token in OpenProject DB.
       3. Relese the lock.
       4. Send original request but with new token received in 1.
     B. No. Then respond with error.

There are two main points introduced:
1. Advisory lock around refresh token request to Nextcloud and update token data in OpenProject DB.
2. Removal of wrong condition(when updating the token data in OpenProject DB depends on successful repetition of
original request to Nextcloud but with newly received token)