### PR TITLE
Restore ldap-only warning for mail

### DIFF
--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -74,9 +74,7 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
     <div class="form--field -required">
       <%= f.text_field :mail, required: true, container_class: '-middle', disabled: login_via_ldap %>
-      <% if login_via_provider %>
-        <span class="form--field-instructions"><%= t('user.text_change_disabled_for_provider_login') %></span>
-      <% elsif login_via_ldap %>
+      <% if login_via_ldap %>
         <span class="form--field-instructions"><%= t('user.text_change_disabled_for_ldap_login') %></span>
       <% end %>
     </div>


### PR DESCRIPTION
https://github.com/opf/openproject/pull/16544 introduced checks to not show the same warning twice for SSO and LDAP. It accidentally added the warning for mail for SSO, which is not disabled

https://community.openproject.org/work_packages/57961