### PR TITLE
Move check of dropdownPanel into timeout

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/autocompleter.helper.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/autocompleter.helper.ts
@@ -10,12 +10,12 @@ interface NgSelectShim {
 // https://github.com/ng-select/ng-select/issues/1259
 export function repositionDropdownBugfix(component?:unknown) {
   const instance = component as NgSelectShim;
-  if (instance?.appendTo && instance?.dropdownPanel) {
-    setTimeout(() => {
+  setTimeout(() => {
+    if (instance?.appendTo && instance?.dropdownPanel) {
       // eslint-disable-next-line no-underscore-dangle
       instance.dropdownPanel?._updateXPosition();
       // eslint-disable-next-line no-underscore-dangle
       instance.dropdownPanel?._updateYPosition();
-    }, 25);
-  }
+    }
+  }, 25);
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57953

# What are you trying to accomplish?
The reposition fix tried to access `ngSelectInstance.dropdownPanel` which was not defined yet. Instead, move the check inside the timeout.