### PR TITLE
fix[Op#57516]: Reset column info and primary key after migration for fresh state

### DIFF
--- a/spec/migrations/add_primary_key_to_custom_fields_projects_spec.rb
+++ b/spec/migrations/add_primary_key_to_custom_fields_projects_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe AddPrimaryKeyToCustomFieldsProjects, type: :model do
 
   it "adds an `id` primary key column with backfilled values" do
     ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) }
+    CustomFieldsProject.reset_column_information
+    CustomFieldsProject.reset_primary_key
 
     create_list(:custom_fields_project, 5)
 


### PR DESCRIPTION
_Follows #16694_ 

ActiveRecord & FactoryBot definitions would have cached column and primary key info. When recreating the previous state, let's reset.

```
 1) AddPrimaryKeyToCustomFieldsProjects adds an `id` primary key column with backfilled values
     Failure/Error: create_list(:custom_fields_project, 5)

     ActiveRecord::StatementInvalid:
       PG::UndefinedColumn: ERROR:  column "id" does not exist
       LINE 1: ...stom_field_id", "project_id") VALUES ($1, $2) RETURNING "id"
```

https://community.openproject.org/wp/57516