### PR TITLE
Change meeting flash banner width to 80%

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -119,7 +119,7 @@ See COPYRIGHT and LICENSE files for more details.
     <main id="content-wrapper" class="<%= initial_classes %>">
       <%= render_primer_banner_message %>
       <%= render_streameable_primer_banner_message %>
-      <turbo-frame id="flash-messages">
+      <turbo-frame id="flash-messages" class="op-primer-banner">
         <%= render_flash_messages %>
       </turbo-frame>
       <% if show_onboarding_modal? %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -119,7 +119,9 @@ See COPYRIGHT and LICENSE files for more details.
     <main id="content-wrapper" class="<%= initial_classes %>">
       <%= render_primer_banner_message %>
       <%= render_streameable_primer_banner_message %>
-      <turbo-frame id="flash-messages" class="op-primer-banner">
+      <%# Banner messages are being rendered using primer %>
+      <div id="banner-messages" class="op-primer-banner"></div>
+      <turbo-frame id="flash-messages">
         <%= render_flash_messages %>
       </turbo-frame>
       <% if show_onboarding_modal? %>

--- a/frontend/src/global_styles/primer/_banners.sass
+++ b/frontend/src/global_styles/primer/_banners.sass
@@ -1,0 +1,40 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+$op-primer-banner-toaster-width: 80%
+
+.op-primer-banner
+  &--wrapper
+    // Move below sidebar
+    z-index: 599
+    position: absolute
+    max-width: $op-primer-banner-toaster-width
+    margin: 0 auto
+    left: 10%
+    right: 10%
+    top: 1rem

--- a/frontend/src/global_styles/primer/_banners.sass
+++ b/frontend/src/global_styles/primer/_banners.sass
@@ -29,12 +29,18 @@
 $op-primer-banner-toaster-width: 80%
 
 .op-primer-banner
-  &--wrapper
-    // Move below sidebar
-    z-index: 599
-    position: absolute
-    max-width: $op-primer-banner-toaster-width
-    margin: 0 auto
-    left: 10%
-    right: 10%
-    top: 1rem
+  z-index: 599
+  position: absolute
+  max-width: $op-primer-banner-toaster-width
+  margin: 0 auto
+  left: 10%
+  right: 10%
+  top: 1rem
+
+  // Align multiple toasts
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+  &--item
+    word-wrap: break-word

--- a/frontend/src/global_styles/primer/_index.sass
+++ b/frontend/src/global_styles/primer/_index.sass
@@ -1,2 +1,3 @@
 @import icons
 @import overrides
+@import banners

--- a/frontend/src/turbo/flash-stream-action.ts
+++ b/frontend/src/turbo/flash-stream-action.ts
@@ -3,7 +3,8 @@ import { StreamActions, StreamElement } from '@hotwired/turbo';
 export function registerFlashStreamAction() {
   StreamActions.flash = function dialogStreamAction(this:StreamElement) {
     const content = this.templateElement.content;
-    const target = document.getElementById('flash-messages');
-    target?.append(content);
+    const target = document.getElementById('banner-messages') as HTMLElement;
+    target.innerHTML = '';
+    target.append(content);
   };
 }

--- a/frontend/src/turbo/flash-stream-action.ts
+++ b/frontend/src/turbo/flash-stream-action.ts
@@ -3,6 +3,7 @@ import { StreamActions, StreamElement } from '@hotwired/turbo';
 export function registerFlashStreamAction() {
   StreamActions.flash = function dialogStreamAction(this:StreamElement) {
     const content = this.templateElement.content;
-    document.body.append(content);
+    const target = document.getElementById('flash-messages');
+    target?.append(content);
   };
 }

--- a/modules/meeting/app/components/meetings/update_flash_component.html.erb
+++ b/modules/meeting/app/components/meetings/update_flash_component.html.erb
@@ -1,4 +1,4 @@
-<div class="op-primer-banner--wrapper">
+<div class="op-primer-banner--item">
   <%=
     render(Primer::Alpha::Banner.new(
       full: false,

--- a/modules/meeting/app/components/meetings/update_flash_component.html.erb
+++ b/modules/meeting/app/components/meetings/update_flash_component.html.erb
@@ -1,23 +1,19 @@
-<%=
-  component_wrapper do
-    flex_layout do |flex|
-      flex.with_row(classes: "op-toast--wrapper") do
-        render(Primer::Alpha::Banner.new(
-          full: false,
-          icon: 'info',
-          scheme: :default,
-          data: {
-            singleton: true
-          }
-        )) do |component|
-          component.with_action_button(
-              tag: :a,
-              href: meeting_path(@meeting),
-              data: { turbo: false },
-              size: :medium) { I18n.t("label_meeting_reload") }
-          I18n.t("notice_meeting_updated")
-        end
-      end
+<div class="op-primer-banner--wrapper">
+  <%=
+    render(Primer::Alpha::Banner.new(
+      full: false,
+      icon: :info,
+      scheme: :default,
+      data: {
+        singleton: true
+      }
+    )) do |component|
+      component.with_action_button(
+        tag: :a,
+        href: meeting_path(@meeting),
+        data: { turbo: false },
+        size: :medium) { I18n.t("label_meeting_reload") }
+      I18n.t("notice_meeting_updated")
     end
-  end
-%>
+  %>
+</div>

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Structured meetings CRUD",
     end
 
     it do
-      flash_component = ".op-toast--wrapper"
+      flash_component = ".op-primer-banner--item"
 
       ## Add agenda item
       show_page.visit!
@@ -74,7 +74,7 @@ RSpec.describe "Structured meetings CRUD",
         show_page.trigger_change_poll
         expect(page).to have_css(flash_component, wait: 5)
         expect(page).to have_text I18n.t(:notice_meeting_updated)
-        page.within(".flash") { click_on "Reload" }
+        page.within(flash_component) { click_on "Reload" }
       end
 
       # Expect no notification in window2
@@ -103,7 +103,7 @@ RSpec.describe "Structured meetings CRUD",
         expect(page).to have_css(flash_component, wait: 5)
         expect(page).to have_text I18n.t(:notice_meeting_updated)
 
-        page.within(".flash") { click_on "Reload" }
+        page.within(flash_component) { click_on "Reload" }
 
         ## Add section
         show_page.add_section do
@@ -119,7 +119,7 @@ RSpec.describe "Structured meetings CRUD",
         show_page.trigger_change_poll
         expect(page).to have_css(flash_component, wait: 5)
         expect(page).to have_text I18n.t(:notice_meeting_updated)
-        page.within(".flash") { click_on "Reload" }
+        page.within(flash_component) { click_on "Reload" }
       end
 
       # Expect no notification in window2
@@ -147,7 +147,7 @@ RSpec.describe "Structured meetings CRUD",
         show_page.trigger_change_poll
         expect(page).to have_text I18n.t(:notice_meeting_updated)
 
-        page.within(".flash") { click_on "Reload" }
+        page.within(flash_component) { click_on "Reload" }
 
         ## Close meeting
         find_test_selector("close-meeting-button").click
@@ -158,7 +158,7 @@ RSpec.describe "Structured meetings CRUD",
         show_page.trigger_change_poll
         expect(page).to have_css(flash_component, wait: 5)
         expect(page).to have_text I18n.t(:notice_meeting_updated)
-        page.within(".flash") { click_on "Reload" }
+        page.within(flash_component) { click_on "Reload" }
       end
 
       # Expect no notification in window2

--- a/modules/meeting/spec/support/pages/structured_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/structured_meeting/show.rb
@@ -43,8 +43,6 @@ module Pages::StructuredMeeting
 
     def trigger_change_poll
       script = <<~JS
-        // Remove flashes from the page to prevent race conditions
-        document.querySelectorAll('.op-toast--wrapper').forEach((el) => el.remove());
         var target = document.querySelector('[data-test-selector="meeting-page-header"]');
         var controller = window.Stimulus.getControllerForElementAndIdentifier(target, 'poll-for-changes')
         controller.triggerTurboStream();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57925/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
- The banner should be wider (80% of the content)
- It should be overlapped by the sidebar on mobile

## Screenshots

<img width="628" alt="Bildschirmfoto 2024-09-19 um 15 47 28" src="https://github.com/user-attachments/assets/a8371d0d-253f-435d-8b7a-2fa8ed9313dc">
<img width="1728" alt="Bildschirmfoto 2024-09-19 um 15 47 04" src="https://github.com/user-attachments/assets/d4f7c03e-3a1d-409d-be5b-dc3631ed9741">



# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
