### PR TITLE
Do not keep settings radio button state when navigating

### DIFF
--- a/app/forms/settings_form_decorator.rb
+++ b/app/forms/settings_form_decorator.rb
@@ -121,6 +121,7 @@ class SettingsFormDecorator
           **button_options.reverse_merge(
             value:,
             checked: setting_value(name) == value,
+            autocomplete: "off",
             label: setting_label(name, value),
             caption: setting_caption(name, value)
           )


### PR DESCRIPTION
# Ticket

None

# What are you trying to accomplish?

I discovered today that radio button accept a `autocomplete="off"` parameter to avoid the browser keeping their state.
As that state being kept on the progress tracking page is something that always annoyed me as this could lead to unintended changes.

I wanted to fix it: when the browser shows the page again, the selected radio button should always be the one that was selected on the initial render of the page, and not the choice made by the user. 

# What approach did you choose and why?

Add `autocomplete="off"` for all radio buttons of primerized settings forms.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
