### PR TITLE
[#57648] Replace "Add assignee" button in Team Planner with + icon

### DIFF
--- a/docs/user-guide/team-planner/README.md
+++ b/docs/user-guide/team-planner/README.md
@@ -50,7 +50,7 @@ A team planner has a number of features numbered 1 to 8 in the above screenshot:
 
 1. Click on the name of your team planner (*Marketing Team* in the example above) to edit it. Unless it's a new team planner, this change has to be confirmed by pressing the floppy disk icon that appears next to the name after you change it.
 2. Use the **+ Add existing** button to add an existing work package  to the team planner. You do this by searching for work package and dragging its card to an assignee, at a certain time. This will then update the *assignee*, *start date* and *finish date* attributes of that work package.
-3. Add a new team member to the assignee column by Clicking on the **Add assignee** button.
+3. Add a new team member to the assignee column by Clicking on the **+ Assignee** button.
 4. By default, the team planner will only show assigned work packages belonging to the current project. However, it is possible to also add assigned work packages belonging to other projects. You can make these work packages from other projects visible by using **Include projects** feature and selecting additional projects to be included in this view.
 5. Use the **Filter** feature (same as in the [work packages](../work-packages/work-package-table-configuration/#filter-work-packages) module) to display only work packages that meet certain filter criteria. You could, for example, filter such that only work packages of certain types, certain status or certain custom field values are visible.
 6. The **Fullscreen** button lets you view the team planner in fullscreen mode.

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -135,8 +135,12 @@
           class="op-team-planner--empty-state-button button -primary"
           data-test-selector="op-team-planner--empty-state-button"
           (click)="showAssigneeAddRow()"
-          [textContent]="text.add_assignee"
         >
+          <op-icon icon-classes="icon-add button--icon"></op-icon>
+          <span
+            class="button--text"
+            [textContent]="text.add_assignee">
+          </span>
         </button>
       </div>
     </ng-container>
@@ -153,8 +157,11 @@
           data-test-selector="tp-assignee-add-button"
           data-tour-selector="tp-assignee-add-button"
         >
-          <span class="spot-icon spot-icon_user-plus"></span>
-          <span [textContent]="text.add_assignee"></span>
+          <op-icon icon-classes="icon-add button--icon"></op-icon>
+          <span
+            class="button--text"
+            [textContent]="text.add_assignee">
+          </span>
         </button>
       </div>
       <ng-container *ngIf="(dropzone$ | async) as dropzone">

--- a/modules/team_planner/config/locales/js-en.yml
+++ b/modules/team_planner/config/locales/js-en.yml
@@ -8,7 +8,7 @@ en:
       create_title: 'Create new team planner'
       unsaved_title: 'Unnamed team planner'
       no_data: 'Add assignees to set up your team planner.'
-      add_assignee: 'Add assignee'
+      add_assignee: 'Assignee'
       remove_assignee: 'Remove assignee'
       two_weeks: '2-week'
       one_week: '1-week'


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57648

# What are you trying to accomplish?

The "Add assignee" buttons in the team planner should be be changed to "+ Assignee" buttons. See screenshots for befor/after.

## Screenshots

### Before
![Screenshot 2024-09-23 at 08 50 57](https://github.com/user-attachments/assets/a2761990-af16-46ae-b9f2-c69dc47313d8)

![Screenshot 2024-09-23 at 08 59 04](https://github.com/user-attachments/assets/b76e6db1-09be-47f6-a035-f441d18ae85e)

### After

![Screenshot 2024-09-23 at 09 22 18](https://github.com/user-attachments/assets/639bd962-567c-41ca-8f59-ca6ffacd11e4)

![Screenshot 2024-09-23 at 09 22 02](https://github.com/user-attachments/assets/9f08a018-ceb5-4d8b-9ac6-127ecd71d827)

# What approach did you choose and why?


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
