### PR TITLE
Feature/57990 preserve percent complete over remaining work when migrating

### DIFF
--- a/app/workers/work_packages/progress/apply_statuses_change_job.rb
+++ b/app/workers/work_packages/progress/apply_statuses_change_job.rb
@@ -70,12 +70,12 @@ class WorkPackages::Progress::ApplyStatusesChangeJob < WorkPackages::Progress::J
     if WorkPackage.work_based_mode?
       clear_percent_complete_when_0h_work
     elsif WorkPackage.status_based_mode?
-      set_p_complete_from_status
+      set_percent_complete_from_status
       if OpenProject::FeatureDecisions.percent_complete_edition_active?
-        fix_remaining_work_set_with_100p_complete
-        derive_unset_work_from_remaining_work_and_p_complete
+        fix_remaining_work_set_with_100_percent_complete
+        derive_unset_work_from_remaining_work_and_percent_complete
       end
-      derive_remaining_work_from_work_and_p_complete
+      derive_remaining_work_from_work_and_percent_complete
     end
   end
 

--- a/app/workers/work_packages/progress/migrate_values_job.rb
+++ b/app/workers/work_packages/progress/migrate_values_job.rb
@@ -51,19 +51,19 @@ class WorkPackages::Progress::MigrateValuesJob < WorkPackages::Progress::Job
     case current_mode
     when "field"
       unset_all_percent_complete_values if previous_mode == "disabled"
-      fix_remaining_work_set_with_100p_complete
+      fix_remaining_work_set_with_100_percent_complete
       fix_remaining_work_exceeding_work
       fix_only_work_being_set
       fix_only_remaining_work_being_set
-      derive_unset_work_from_remaining_work_and_p_complete
-      derive_unset_p_complete_from_work_and_remaining_work
+      derive_unset_work_from_remaining_work_and_percent_complete
+      derive_unset_percent_complete_from_work_and_remaining_work
       fix_percent_complete_and_remaining_work_when_work_is_0h
-      derive_remaining_work_from_work_and_p_complete
+      derive_remaining_work_from_work_and_percent_complete
     when "status"
-      set_p_complete_from_status
-      fix_remaining_work_set_with_100p_complete
-      derive_unset_work_from_remaining_work_and_p_complete
-      derive_remaining_work_from_work_and_p_complete
+      set_percent_complete_from_status
+      fix_remaining_work_set_with_100_percent_complete
+      derive_unset_work_from_remaining_work_and_percent_complete
+      derive_remaining_work_from_work_and_percent_complete
     else
       raise "Unknown progress calculation mode: #{current_mode}, aborting."
     end
@@ -117,7 +117,7 @@ class WorkPackages::Progress::MigrateValuesJob < WorkPackages::Progress::Job
     SQL
   end
 
-  def derive_unset_p_complete_from_work_and_remaining_work
+  def derive_unset_percent_complete_from_work_and_remaining_work
     execute(<<~SQL.squish)
       UPDATE temp_wp_progress_values
       SET done_ratio = CASE

--- a/app/workers/work_packages/progress/migrate_values_job.rb
+++ b/app/workers/work_packages/progress/migrate_values_job.rb
@@ -50,23 +50,31 @@ class WorkPackages::Progress::MigrateValuesJob < WorkPackages::Progress::Job
   def adjust_progress_values
     case current_mode
     when "field"
-      unset_all_percent_complete_values if previous_mode == "disabled"
-      fix_remaining_work_set_with_100_percent_complete
-      fix_remaining_work_exceeding_work
-      fix_only_work_being_set
-      fix_only_remaining_work_being_set
-      derive_unset_work_from_remaining_work_and_percent_complete
-      derive_unset_percent_complete_from_work_and_remaining_work
-      fix_percent_complete_and_remaining_work_when_work_is_0h
-      derive_remaining_work_from_work_and_percent_complete
+      adjust_progress_values_for_work_based_mode
     when "status"
-      set_percent_complete_from_status
-      fix_remaining_work_set_with_100_percent_complete
-      derive_unset_work_from_remaining_work_and_percent_complete
-      derive_remaining_work_from_work_and_percent_complete
+      adjust_progress_values_for_status_based_mode
     else
       raise "Unknown progress calculation mode: #{current_mode}, aborting."
     end
+  end
+
+  def adjust_progress_values_for_work_based_mode
+    unset_all_percent_complete_values if previous_mode == "disabled"
+    fix_remaining_work_set_with_100_percent_complete
+    fix_remaining_work_exceeding_work
+    fix_only_work_being_set
+    fix_only_remaining_work_being_set
+    derive_unset_work_from_remaining_work_and_percent_complete
+    derive_unset_percent_complete_from_work_and_remaining_work
+    fix_percent_complete_and_remaining_work_when_work_is_0h
+    derive_remaining_work_from_work_and_percent_complete
+  end
+
+  def adjust_progress_values_for_status_based_mode
+    set_percent_complete_from_status
+    fix_remaining_work_set_with_100_percent_complete
+    derive_unset_work_from_remaining_work_and_percent_complete
+    derive_remaining_work_from_work_and_percent_complete
   end
 
   def unset_all_percent_complete_values

--- a/app/workers/work_packages/progress/sql_commands.rb
+++ b/app/workers/work_packages/progress/sql_commands.rb
@@ -60,7 +60,7 @@ module WorkPackages::Progress::SqlCommands
     SQL
   end
 
-  def derive_remaining_work_from_work_and_p_complete
+  def derive_remaining_work_from_work_and_percent_complete
     execute(<<~SQL.squish)
       UPDATE temp_wp_progress_values
       SET remaining_hours =
@@ -74,7 +74,7 @@ module WorkPackages::Progress::SqlCommands
     SQL
   end
 
-  def set_p_complete_from_status
+  def set_percent_complete_from_status
     execute(<<~SQL.squish)
       UPDATE temp_wp_progress_values
       SET done_ratio = statuses.default_done_ratio
@@ -83,7 +83,7 @@ module WorkPackages::Progress::SqlCommands
     SQL
   end
 
-  def fix_remaining_work_set_with_100p_complete
+  def fix_remaining_work_set_with_100_percent_complete
     execute(<<~SQL.squish)
       UPDATE temp_wp_progress_values
       SET estimated_hours = remaining_hours,
@@ -94,7 +94,7 @@ module WorkPackages::Progress::SqlCommands
     SQL
   end
 
-  def derive_unset_work_from_remaining_work_and_p_complete
+  def derive_unset_work_from_remaining_work_and_percent_complete
     execute(<<~SQL.squish)
       UPDATE temp_wp_progress_values
       SET estimated_hours =

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1930,7 +1930,7 @@ en:
       progress_mode_changed_to_status_based: Progress calculation mode set to status-based
       status_excluded_from_totals_set_to_false_message: now included in hierarchy totals
       status_excluded_from_totals_set_to_true_message: now excluded from hierarchy totals
-      status_percent_complete_changed: "% complete changed from %{old_value}% to %{new_value}%"
+      status_percent_complete_changed: "% Complete changed from %{old_value}% to %{new_value}%"
       system_update:
         file_links_journal: >
           From now on, activity related to file links (files stored in external storages) will appear here in the

--- a/spec/lib/journal_formatter/cause_spec.rb
+++ b/spec/lib/journal_formatter/cause_spec.rb
@@ -314,11 +314,11 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
 
     it do
       expect(cause).to render_html_variant("<strong>Status &#39;In progress&#39;</strong> " \
-                                           "% complete changed from 20% to 40%")
+                                           "% Complete changed from 20% to 40%")
     end
 
     it do
-      expect(cause).to render_raw_variant("Status 'In progress' % complete changed from 20% to 40%")
+      expect(cause).to render_raw_variant("Status 'In progress' % Complete changed from 20% to 40%")
     end
 
     it_behaves_like "XSS-proof rendering of status name"
@@ -412,12 +412,12 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
 
     it do
       expect(cause).to render_html_variant("<strong>Status &#39;In progress&#39;</strong> " \
-                                           "% complete changed from 20% to 40% and now excluded from hierarchy totals")
+                                           "% Complete changed from 20% to 40% and now excluded from hierarchy totals")
     end
 
     it do
       expect(cause).to render_raw_variant("Status 'In progress' " \
-                                          "% complete changed from 20% to 40% and now excluded from hierarchy totals")
+                                          "% Complete changed from 20% to 40% and now excluded from hierarchy totals")
     end
 
     it_behaves_like "XSS-proof rendering of status name"

--- a/spec/migrations/update_progress_calculation_spec.rb
+++ b/spec/migrations/update_progress_calculation_spec.rb
@@ -863,14 +863,17 @@ RSpec.describe UpdateProgressCalculation, type: :model do
           .to eql [nil, 50]
       end
 
-      it "creates a journal for the work package transitioning ∑ % complete from 90% to 20%" do
+      it "creates a journal for the work package transitioning ∑ remaining work from 50h to 80h " \
+         "and ∑ % complete from 90% to 20%" do
         expect(wp_wrong.journals.count).to eq(2)
 
         expect(wp_wrong.journals.first.get_changes.keys)
           .not_to include("derived_done_ratio")
 
-        expect(wp_wrong.journals.last.get_changes["derived_done_ratio"])
-          .to eql [nil, 20]
+        expect(wp_wrong.journals.last.get_changes).to include(
+          "derived_remaining_hours" => [50.0, 80.0],
+          "derived_done_ratio" => [nil, 20]
+        )
       end
     end
   end

--- a/spec/migrations/update_progress_calculation_spec.rb
+++ b/spec/migrations/update_progress_calculation_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
             wp both w and pc set      |  10h |                |        60%
             wp only w set 0h          |   0h |                |
           TABLE
+          # % Complete is discarded and derived because of the "disabled" mode
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp only w set             |  10h |            10h |         0%
@@ -213,6 +214,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
             wp both rw and pc set     |      |             4h |        60%
             wp only rw set 0h         |      |             0h |
           TABLE
+          # % Complete is discarded and derived because of the "disabled" mode
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp only rw set            |   4h |             4h |         0%
@@ -233,6 +235,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
             wp all set consistent     |  10h |             4h |        60%
             wp all set inconsistent   |  10h |             1h |        10%
           TABLE
+          # % Complete is discarded and derived because of the "disabled" mode
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp both w and rw set      |  10h |             4h |        60%
@@ -254,6 +257,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
             wp all set inconsistent   |  10h |            10h |        60%
             wp all set inconsistent 0h|   0h |             0h |        60%
           TABLE
+          # % Complete is discarded and derived because of the "disabled" mode
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp both w and rw set      |  10h |            10h |         0%
@@ -273,6 +277,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
             wp both w and big rw set  |  10h |            99h |
             wp all set big wp         |  10h |            99h |        60%
           TABLE
+          # % Complete is discarded and derived because of the "disabled" mode
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp both w and big rw set  |  10h |            10h |         0%
@@ -493,7 +498,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp all set consistent     |  10h |             4h |        60%
-            wp all set inconsistent   |  10h |             1h |        90%
+            wp all set inconsistent   |  10h |             9h |        10%
           TABLE
         )
       end
@@ -511,7 +516,7 @@ RSpec.describe UpdateProgressCalculation, type: :model do
           to: <<~TABLE
             subject                   | work | remaining work | % complete
             wp all set consistent     |  10h |            10h |         0%
-            wp all set inconsistent   |  10h |            10h |         0%
+            wp all set inconsistent   |  10h |             4h |        60%
             wp all set 0h             |   0h |             0h |
           TABLE
         )
@@ -823,14 +828,14 @@ RSpec.describe UpdateProgressCalculation, type: :model do
         run_migration
       end
 
-      it "fixes the total values and sets ∑ % complete to nil (not 0) but keeps % complete (unless wrong)" do
+      it "fixes the total values and sets ∑ % complete to nil (not 0) and keeps % complete (unless wrong)" do
         expect_work_packages(table_work_packages.map(&:reload), <<~TABLE)
           subject            | work  | remaining work | % complete | ∑ work | ∑ remaining work | ∑ % complete |
           wp zero            |       |                |          0 |        |                  |              |
           wp correct         |  100h |            50h |         50 |   100h |              50h |           50 |
             wp correct child |       |                |            |        |                  |              |
-          wp wrong           |       |                |         90 |   100h |              50h |           50 |
-            wp wrong child   |  100h |            50h |         50 |        |                  |              |
+          wp wrong           |       |                |         90 |   100h |              80h |           20 |
+            wp wrong child   |  100h |            80h |         20 |        |                  |              |
         TABLE
       end
 
@@ -858,14 +863,14 @@ RSpec.describe UpdateProgressCalculation, type: :model do
           .to eql [nil, 50]
       end
 
-      it "creates a journal for the work package transitioning ∑ % complete from 90 to 50" do
+      it "creates a journal for the work package transitioning ∑ % complete from 90% to 20%" do
         expect(wp_wrong.journals.count).to eq(2)
 
         expect(wp_wrong.journals.first.get_changes.keys)
           .not_to include("derived_done_ratio")
 
         expect(wp_wrong.journals.last.get_changes["derived_done_ratio"])
-          .to eql [nil, 50]
+          .to eql [nil, 20]
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57990

# What are you trying to accomplish?

In 14.0, when the progress values were made consistent, a data migration was done to transform all progress values of all work packages to make them consistent. To do so there were some general rules: as the % Complete value is always a derived value in 14.0, it makes sense to preserve Work and Remaining work in 14.0, and make % Complete a derived value.

In 14.6, we'll make [% Complete editable again](https://community.openproject.org/projects/openproject/work_packages/52233/activity), and we want to preserve that value more than before. For people not having made the jump to 14.x because they feared losing their % Complete value, we'll update the data migration so that Work and % Complete are preserved, and Remaining work is derived. It better reflect how the application is working now with regards to the progress values.

# What approach did you choose and why?

Update the job to derive % Complete only when it's unset, and alway derive Remaining work from the 2 others as last step.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
