### PR TITLE
use format_date to format timestamp instead of parsing date from stringified timestamp

### DIFF
--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -8,7 +8,7 @@
         <%= link_to_project(news.project) + ': ' %>
         <%= link_to h(news.title), news_path(news) %>
       </div>
-      <div class="widget-box--author news-author"><%= authoring_at Date.strptime(news.created_at.to_s), news.author %></div>
+      <div class="widget-box--author news-author"><%= authoring_at format_date(news.created_at), news.author %></div>
       <p class="widget-box--additional-info"><%=  news.summary %></p>
     </li>
   <% end %>


### PR DESCRIPTION
# What are you trying to accomplish?
Replace odd code

# What approach did you choose and why?
Use `format_date` helper on timestamp, which handles converting to date and applying same format as everywhere else

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
