### PR TITLE
i18n for `responsible` reason in notification center

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -671,7 +671,9 @@ en:
         mentioned: "Mentioned"
         watched: "Watcher"
         assigned: "Assignee"
-        accountable: "Accountable"
+        # The enum value is named 'responsible' in the database and that is what is transported through the API
+        # up to the frontend.
+        responsible: "Accountable"
         created: "Created"
         scheduled: "Scheduled"
         commented: "Commented"


### PR DESCRIPTION
This reverts 169caaed728fb2b12f0698364b50f2be41e6a22d which introduces the bug in order to fix another bug. But that other bug does not longer exist as commented https://github.com/opf/openproject/pull/16252#pullrequestreview-2218591817

# Ticket

https://community.openproject.org/wp/57997
