### PR TITLE
[57993] Browser tab is missing breadcrumb

### DIFF
--- a/app/components/admin/design_header_component.html.erb
+++ b/app/components/admin/design_header_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% helpers.html_title t(:label_administration), t(:label_custom_style), @title %>
+<% helpers.html_title t(:label_administration), t(:label_custom_style), selected_tab(@tabs)[:label] %>
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_custom_style) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57993/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show selected tab in the html title.

## Screenshots
Before:
![Screenshot 2024-09-24 at 11 30 50](https://github.com/user-attachments/assets/c766f587-5192-44f5-a633-651ff2f4da1c)

After:
![Screenshot 2024-09-24 at 11 30 27](https://github.com/user-attachments/assets/cd19d060-112d-44f3-8502-d27c319b471f)
