### PR TITLE
[#57985] Meeting details concurrent error message is unclear and badly positioned

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -997,6 +997,8 @@ en:
             name:
               blank: "is mandatory. Please select a name."
               not_unique: "is already in use. Please select another name."
+        meeting:
+          error_conflict: "Unable to save because the meeting was updated by someone else in the meantime. Please reload the page."
         notifications:
           at_least_one_channel: "At least one channel for sending notifications needs to be specified."
           attributes:

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.html.erb
@@ -8,12 +8,12 @@
     ) do |f|
       component_collection do |collection|
         collection.with_component(Primer::Alpha::Dialog::Body.new) do
-          flex_layout(my: 3) do |modal_body|
+          flex_layout(mb: 3) do |modal_body|
             modal_body.with_row do
               render(BaseErrorsComponent.new(@meeting))
             end
 
-            modal_body.with_row do
+            modal_body.with_row(mt: 3) do
               render(Meeting::StartDate.new(f, initial_value: start_date_initial_value))
             end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57985/activity

## Screenshots
### Before:
<img width="522" alt="image" src="https://github.com/user-attachments/assets/99a7cb1e-7803-4b83-9854-f78acca13b4f">

### After:
<img width="522" alt="image" src="https://github.com/user-attachments/assets/4b7c8d46-e5e0-4a4a-a22a-aa225ab2ab9a">

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, ~Edge~, ...)
