### PR TITLE
[#57671] Improve display of work package and agenda titles in meetings

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -10,21 +10,21 @@
       grid.with_area(:content, tag: :span) do
         if @meeting_agenda_item.visible_work_package?
           flex_layout(align_items: :center) do |flex|
-            flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do
-              render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
-                                            test_selector: 'op-meeting-agenda-title',
-                                            font_size: :normal, font_weight: :bold, target: "_blank")) do
-                @meeting_agenda_item.work_package.subject
-              end
-            end
+            # flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do
+            #   render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
+            #                                 test_selector: 'op-meeting-agenda-title',
+            #                                 font_size: :normal, font_weight: :bold, target: "_blank")) do
+            #     @meeting_agenda_item.work_package.subject
+            #   end
+            # end
 
-            flex.with_column(mr: 2, classes: 'hidden-for-mobile') do
+            flex.with_column(mr: 2) do
               render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
-                "#{@meeting_agenda_item.work_package.type.name} ##{@meeting_agenda_item.work_package.id}"
+                "##{@meeting_agenda_item.work_package.id} #{@meeting_agenda_item.work_package.type.name}"
               end
             end
 
-            flex.with_column(mr: 2, classes: 'hidden-for-mobile') do
+            flex.with_column(mr: 2) do
               render(Primer::Beta::Label.new(font_weight: :bold)) do
                 @meeting_agenda_item.work_package.status.name
               end
@@ -45,8 +45,19 @@
         end
       end
 
+      grid.with_area(:title, tag: :div) do
+        if @meeting_agenda_item.visible_work_package?
+          render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
+                                        test_selector: 'op-meeting-agenda-title',
+                                        font_size: :normal, font_weight: :bold, target: "_blank")) do
+            @meeting_agenda_item.work_package.subject
+          end
+        end
+      end
+
+
       if @meeting_agenda_item.duration_in_minutes.present? && @meeting_agenda_item.duration_in_minutes > 0
-        grid.with_area(:duration, Primer::Beta::Text, color: duration_color_scheme, mr: 1, font_size: :small) do
+        grid.with_area(:duration, Primer::Beta::Text, color: duration_color_scheme, mr: 2, font_size: :small) do
           I18n.t('datetime.distance_in_words.x_minutes_abbreviated', count: @meeting_agenda_item.duration_in_minutes)
         end
       end
@@ -60,6 +71,8 @@
           end
         end
       end
+
+
 
       grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
         if edit_enabled?

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -10,14 +10,6 @@
       grid.with_area(:content, tag: :span, mr: 2) do
         if @meeting_agenda_item.visible_work_package?
           flex_layout(align_items: :center) do |flex|
-            # flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do
-            #   render(Primer::Beta::Link.new(href: work_package_path(@meeting_agenda_item.work_package), underline: false,
-            #                                 test_selector: 'op-meeting-agenda-title',
-            #                                 font_size: :normal, font_weight: :bold, target: "_blank")) do
-            #     @meeting_agenda_item.work_package.subject
-            #   end
-            # end
-
             flex.with_column(mr: 2) do
               render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
                 "##{@meeting_agenda_item.work_package.id} #{@meeting_agenda_item.work_package.type.name}"
@@ -55,7 +47,6 @@
         end
       end
 
-
       if @meeting_agenda_item.duration_in_minutes.present? && @meeting_agenda_item.duration_in_minutes > 0
         grid.with_area(:duration, Primer::Beta::Text, color: duration_color_scheme, mr: 2, font_size: :small) do
           I18n.t('datetime.distance_in_words.x_minutes_abbreviated', count: @meeting_agenda_item.duration_in_minutes)
@@ -71,8 +62,6 @@
           end
         end
       end
-
-
 
       grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
         if edit_enabled?

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -48,15 +48,15 @@
       end
 
       if @meeting_agenda_item.duration_in_minutes.present? && @meeting_agenda_item.duration_in_minutes > 0
-        grid.with_area(:duration, Primer::Beta::Text, color: duration_color_scheme, mr: 2, font_size: :small) do
+        grid.with_area(:duration, Primer::Beta::Text, color: duration_color_scheme, mr: 2) do
           I18n.t('datetime.distance_in_words.x_minutes_abbreviated', count: @meeting_agenda_item.duration_in_minutes)
         end
       end
 
       if @meeting_agenda_item.presenter
         grid.with_area(:presenter, tag: :div, classes: 'ellipsis') do
-          flex_layout do |flex|
-            flex.with_column(classes: 'ellipsis') do
+          flex_layout(align_items: :flex_end) do |flex|
+            flex.with_column(classes: 'ellipsis custom-presenter-flex') do
               render(Users::AvatarComponent.new(user: @meeting_agenda_item.presenter, size: 'mini', title:, classes: 'op-principal_flex'))
             end
           end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -7,7 +7,7 @@
         end
       end
 
-      grid.with_area(:content, tag: :span) do
+      grid.with_area(:content, tag: :span, mr: 2) do
         if @meeting_agenda_item.visible_work_package?
           flex_layout(align_items: :center) do |flex|
             # flex.with_column(mr: 2, flex: 1, classes: 'ellipsis') do

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -1,6 +1,7 @@
 @import 'helpers'
 
 $meeting-agenda-item--presenter-width: 300px
+$meeting-agenda-item--presenter-width--mobile: 150px
 
 .op-meeting-agenda-item
   display: grid
@@ -10,7 +11,9 @@ $meeting-agenda-item--presenter-width: 300px
   &--drag-handle,
   &--duration,
   &--content,
-  &--presenter,
+  &--presenter
+    align-self: start
+
   &--title
     align-self: center
 
@@ -33,8 +36,11 @@ $meeting-agenda-item--presenter-width: 300px
     overflow-wrap: anywhere
 
   @media screen and (max-width: $breakpoint-lg)
-    grid-template-columns: 20px auto 1fr calc($meeting-agenda-item--presenter-width - 50px) 50px
+    grid-template-columns: 20px auto 1fr 150px 50px
     grid-template-areas: "drag-handle content content content actions" ". duration . presenter presenter" ". title title title title" ". notes notes notes notes"
 
     &--author
       justify-self: stretch
+
+    &--presenter
+      max-width: $meeting-agenda-item--presenter-width--mobile

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -5,12 +5,13 @@ $meeting-agenda-item--presenter-width: 300px
 .op-meeting-agenda-item
   display: grid
   grid-template-columns: 20px auto 1fr fit-content($meeting-agenda-item--presenter-width) fit-content(40px)
-  grid-template-areas: "drag-handle content duration presenter actions" ".notes notes notes notes"
+  grid-template-areas: "drag-handle content duration presenter actions" ". title title title title" ". notes notes notes notes"
 
   &--drag-handle,
   &--duration,
   &--content,
-  &--presenter
+  &--presenter,
+  &--title
     align-self: center
 
   &--actions
@@ -22,13 +23,18 @@ $meeting-agenda-item--presenter-width: 300px
 
   &--duration
     white-space: nowrap
+    justify-self: end
+
+  &--title
+    overflow-wrap: anywhere
+    margin-bottom: 0
 
   &--content
     @include text-shortener
 
   @media screen and (max-width: $breakpoint-lg)
     grid-template-columns: 20px auto 1fr calc($meeting-agenda-item--presenter-width - 50px) 50px
-    grid-template-areas: "drag-handle content content content actions" ". duration . presenter presenter" ". notes notes notes notes"
+    grid-template-areas: "drag-handle content content content actions" ". duration . presenter presenter" ". title title title title" ". notes notes notes notes"
 
     &--author
       justify-self: stretch

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -30,7 +30,7 @@ $meeting-agenda-item--presenter-width: 300px
     margin-bottom: 0
 
   &--content
-    @include text-shortener
+    overflow-wrap: anywhere
 
   @media screen and (max-width: $breakpoint-lg)
     grid-template-columns: 20px auto 1fr calc($meeting-agenda-item--presenter-width - 50px) 50px

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -1,6 +1,6 @@
 @import 'helpers'
 
-$meeting-agenda-item--presenter-width: 300px
+$meeting-agenda-item--presenter-width: 170px
 $meeting-agenda-item--presenter-width--mobile: 150px
 
 .op-meeting-agenda-item
@@ -11,36 +11,49 @@ $meeting-agenda-item--presenter-width--mobile: 150px
   &--drag-handle,
   &--duration,
   &--content,
-  &--presenter
-    align-self: start
-
-  &--title
-    align-self: center
-
+  &--presenter,
   &--actions
-    justify-self: end
-
-  &--presenter
-    max-width: $meeting-agenda-item--presenter-width
-    justify-self: end
+    align-self: start
 
   &--duration
     white-space: nowrap
     justify-self: end
 
-  &--title
-    overflow-wrap: anywhere
-    margin-bottom: 0
-
   &--content
     overflow-wrap: anywhere
 
+  &--presenter
+    max-width: $meeting-agenda-item--presenter-width
+    justify-self: end
+
+  &--actions
+    justify-self: end
+    margin-top: -5px // Needed because the invisible effect makes the button look misaligned otherwise
+
+  &--title
+    align-self: center
+    overflow-wrap: anywhere
+
+  .custom-presenter-flex
+    margin-left: auto
+
   @media screen and (max-width: $breakpoint-lg)
-    grid-template-columns: 20px auto 1fr 150px 50px
-    grid-template-areas: "drag-handle content content content actions" ". duration . presenter presenter" ". title title title title" ". notes notes notes notes"
+    grid-template-columns: 20px auto 1fr auto 50px
+    grid-template-areas: "drag-handle content content content actions" ". title title title title" ". presenter duration . ."  ". notes notes notes notes"
 
     &--author
       justify-self: stretch
 
     &--presenter
+      width: inherit
       max-width: $meeting-agenda-item--presenter-width--mobile
+      margin-left: 0
+      margin-top: 5px
+
+    &--duration
+      justify-self: start
+      margin-top: 5px
+      margin-left: 8px
+
+    .custom-presenter-flex
+      margin-left: 0

--- a/modules/meeting/app/components/meeting_sections/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/header_component.html.erb
@@ -13,8 +13,8 @@
           end
         end
         if @meeting_section.agenda_items_sum_duration_in_minutes > 0
-          grid.with_area(:duration, Primer::Beta::Text, color: :subtle, mr: 1, font_size: :small) do
-            render(Primer::Beta::Text.new(font_size: :small, font_weight: :normal, color: :subtle)) do
+          grid.with_area(:duration, Primer::Beta::Text, color: :subtle, mr: 1) do
+            render(Primer::Beta::Text.new(font_weight: :normal, color: :subtle)) do
               render(OpenProject::Common::DurationComponent.new(@meeting_section.agenda_items_sum_duration_in_minutes, :minutes, abbreviated: true))
             end
           end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57671

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
This PR is to display the full titles of agenda items and work packages in a meeting, and modify the layout to look better with these full titles as well.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

This PR consists of changes to the grid layout for the individual meeting agenda items to better suit the new layout. The work package type and status are now displayed even in the mobile layout. An older issue with the presenter moving out of the right margin has also been dealt with here.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
