### PR TITLE
[#58010] fixed input data for upload query

### DIFF
--- a/modules/storages/app/common/storages/peripherals/storage_interaction/inputs/upload_data.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/inputs/upload_data.rb
@@ -36,9 +36,9 @@ module Storages
           private_class_method :new
 
           def self.build(folder_id:, file_name:, contract: UploadDataContract.new)
-            contract.call(folder_id:, file_name:).to_monad.fmap do |result|
-              new(file_name: result[:file_name], folder_id: ParentFolder.new(result[:folder_id]))
-            end
+            contract.call(folder_id:, file_name:)
+                    .to_monad
+                    .fmap { |result| new(file_name: result[:file_name], folder_id: result[:folder_id]) }
           end
         end
       end

--- a/modules/storages/app/services/storages/upload_link_service.rb
+++ b/modules/storages/app/services/storages/upload_link_service.rb
@@ -56,10 +56,9 @@ module Storages
     private
 
     def request_upload_link(auth_strategy, upload_data)
-      Peripherals::Registry
-        .resolve("#{@storage.short_provider_type}.queries.upload_link")
-        .call(storage: @storage, auth_strategy:, upload_data:)
-        .on_failure do |error|
+      Peripherals::Registry.resolve("#{@storage.short_provider_type}.queries.upload_link")
+                           .call(storage: @storage, auth_strategy:, upload_data:)
+                           .on_failure do |error|
         add_error(:base, error.errors, options: { storage_name: @storage.name, folder: upload_data.folder_id })
         log_storage_error(error.errors)
         @result.success = false

--- a/modules/storages/lib/api/v3/storage_files/storage_files_api.rb
+++ b/modules/storages/lib/api/v3/storage_files/storage_files_api.rb
@@ -52,7 +52,6 @@ module API::V3::StorageFiles
 
       def fetch_upload_link
         lambda do |upload_data|
-          Rails.logger.error "UploadLink #{upload_data.inspect}"
           Storages::UploadLinkService.call(storage: @storage, upload_data:, user: current_user)
         end
       end

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/inputs/upload_data_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/inputs/upload_data_spec.rb
@@ -39,17 +39,17 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Inputs::UploadData do
   end
 
   it "returns a Success(UploadData)" do
-    result = input.build(folder_id: "/Folder/Subfolder", file_name: "i_am_file_with_a_name.txt")
+    result = input.build(folder_id: "1337", file_name: "i_am_file_with_a_name.txt")
 
     expect(result).to be_success
     upload_data = result.value!
-    expect(upload_data.folder_id).to eq(Storages::Peripherals::ParentFolder.new("/Folder/Subfolder"))
+    expect(upload_data.folder_id).to eq("1337")
     expect(upload_data.file_name).to eq("i_am_file_with_a_name.txt")
   end
 
   context "when invalid" do
     context "with a nil file name" do
-      let(:kwargs) { { folder_id: "/folder", file_name: nil } }
+      let(:kwargs) { { folder_id: "42", file_name: nil } }
 
       it "returns a failure" do
         result = input.build(**kwargs)
@@ -63,7 +63,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Inputs::UploadData do
     end
 
     context "with a empty file name" do
-      let(:kwargs) { { folder_id: "/folder", file_name: "" } }
+      let(:kwargs) { { folder_id: "42", file_name: "" } }
 
       it "returns a failure" do
         result = input.build(**kwargs)


### PR DESCRIPTION
# Ticket
[OP#58010](https://community.openproject.org/work_packages/58010)

# What approach did you choose and why?
- changed input data for file upload to be blank id, and not parent folder object
- the id as a value is very specific, while the parent folder object was merely used as a wrapping object for safe handling and validation. validation alas is now done in the contract, so we can use the same approach as in `set_permission` input data
