### PR TITLE
Bug[Op#57989]: unlinking a project within a multi-activation page does not retain the current page

### DIFF
--- a/app/components/admin/custom_fields/custom_field_projects/row_component.rb
+++ b/app/components/admin/custom_fields/custom_field_projects/row_component.rb
@@ -57,11 +57,10 @@ module Admin
         def detach_from_project_url
           url_helpers.custom_field_project_path(
             custom_field_id: @table.params[:custom_field].id,
-            custom_fields_project: { project_id: project.id }
+            custom_fields_project: { project_id: project.id },
+            page: current_page
           )
         end
-
-        def project = model.first
       end
     end
   end

--- a/app/components/admin/custom_fields/custom_field_projects/table_component.rb
+++ b/app/components/admin/custom_fields/custom_field_projects/table_component.rb
@@ -30,8 +30,6 @@ module Admin
   module CustomFields
     module CustomFieldProjects
       class TableComponent < Projects::TableComponent
-        include OpTurbo::Streamable
-
         def columns
           @columns ||= query.selects.reject { |select| select.is_a?(Queries::Selects::NotExistingSelect) }
         end

--- a/app/components/admin/custom_fields/custom_field_projects/table_component.rb
+++ b/app/components/admin/custom_fields/custom_field_projects/table_component.rb
@@ -52,9 +52,10 @@ module Admin
         # the controller action that link_to should use.
         #
         def optional_pagination_options
-          return super unless params[:url_for_action]
-
-          super.merge(params: { action: params[:url_for_action] })
+          super.tap do |options|
+            options[:params] = { action: params[:url_for_action] } if params[:url_for_action]
+            options[:turbo_action] = "advance"
+          end
         end
       end
     end

--- a/app/components/projects/concerns/table_component/streamable_pagination_links_constraints.rb
+++ b/app/components/projects/concerns/table_component/streamable_pagination_links_constraints.rb
@@ -26,18 +26,28 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Admin
-  module CustomFields
-    module CustomFieldProjects
-      class TableComponent < Projects::TableComponent
-        include ::Projects::Concerns::TableComponent::StreamablePaginationLinksConstraints
-
-        def columns
-          @columns ||= query.selects.reject { |select| select.is_a?(Queries::Selects::NotExistingSelect) }
-        end
-
-        def sortable?
-          false
+module Projects
+  module Concerns
+    module TableComponent
+      module StreamablePaginationLinksConstraints
+        # @override optional_pagination_options are passed to the pagination_options
+        # which are passed to #pagination_links_full in pagination_helper.rb
+        #
+        # In Turbo streamable components, we need to be able to specify the url_for(action:) so that links are
+        # generated in the context of the component index action, instead of any turbo stream actions performing
+        # partial updates on the page.
+        #
+        # params[:url_for_action] is passed to the pagination_options making it's way down to any pagination links
+        # that are generated via link_to which calls url_for which uses the params[:url_for_action] to specify
+        # the controller action that link_to should use.
+        #
+        # data-turbo-action="advance" is added to the pagination links ensure links pushState to the browser
+        #
+        def optional_pagination_options
+          super.tap do |options|
+            options[:params] = { action: params[:url_for_action] } if params[:url_for_action]
+            options[:turbo_action] = "advance"
+          end
         end
       end
     end

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -373,5 +373,9 @@ module Projects
     def custom_field_column?(column)
       column.is_a?(::Queries::Projects::Selects::CustomField)
     end
+
+    def current_page
+      table.model.current_page.to_s
+    end
   end
 end

--- a/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
+++ b/app/components/settings/project_custom_fields/project_custom_field_mapping/row_component.rb
@@ -35,7 +35,8 @@ module Settings
         def detach_from_project_url
           url_helpers.unlink_admin_settings_project_custom_field_path(
             id: @table.params[:custom_field].id,
-            project_custom_field_project_mapping: { project_id: project.id }
+            project_custom_field_project_mapping: { project_id: project.id },
+            page: current_page
           )
         end
       end

--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -103,7 +103,7 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
     update_via_turbo_stream(
       component: Admin::CustomFields::CustomFieldProjects::TableComponent.new(
         query: available_custom_fields_projects_query,
-        params: { custom_field: @custom_field, url_for_action: }
+        params: params.merge({ custom_field: @custom_field, url_for_action: })
       )
     )
   end

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -158,7 +158,7 @@ module Admin::Settings
       update_via_turbo_stream(
         component: Settings::ProjectCustomFields::ProjectCustomFieldMapping::TableComponent.new(
           query: project_custom_field_mappings_query,
-          params: { custom_field: @custom_field, url_for_action: }
+          params: params.merge({ custom_field: @custom_field, url_for_action: })
         )
       )
     end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -215,6 +215,12 @@ module PaginationHelper
     #  "advance" - push a new entry onto the history stack.
     #  "replace" - replace the current history entry.
     # See: https://turbo.hotwired.dev/reference/attributes
+    #
+    # Example: Promoting a Frame Navigation to a Page Visit
+    #   By default navigation within a turbo frame does not change the rest of the browser's state,
+    #   but you can promote a frame navigation a "Visit" by setting the turbo-action attribute to "advance".
+    #   See: https://turbo.hotwired.dev/handbook/frames#promoting-a-frame-navigation-to-a-page-visit
+    #
     def turbo_action
       @options[:turbo_action] # rubocop:disable Rails/HelperInstanceVariable
     end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -202,12 +202,21 @@ module PaginationHelper
     def link(text, target, attributes)
       new_attributes = attributes.dup
       new_attributes["data-turbo-stream"] = true if turbo?
+      new_attributes["data-turbo-action"] = turbo_action if turbo_action.present?
 
       super(text, target, new_attributes)
     end
 
     def allowed_params
       @options[:allowed_params] # rubocop:disable Rails/HelperInstanceVariable
+    end
+
+    # Customize the Turbo visit action for pagination links. Can be set to "advance" or "replace".
+    #  "advance" - push a new entry onto the history stack.
+    #  "replace" - replace the current history entry.
+    # See: https://turbo.hotwired.dev/reference/attributes
+    def turbo_action
+      @options[:turbo_action] # rubocop:disable Rails/HelperInstanceVariable
     end
 
     def turbo?

--- a/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
+++ b/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   component_wrapper do
     primer_form_with(
       model: @project_storage,
-      url: admin_settings_storage_project_storage_path(id: @project_storage),
+      url: admin_settings_storage_project_storage_path(id: @project_storage, page: current_page),
       data: {
         turbo: true,
         controller: 'disable-when-checked',

--- a/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.rb
+++ b/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.rb
@@ -32,11 +32,12 @@ module Storages::ProjectStorages
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(storage:, project_storage:)
+    def initialize(storage:, project_storage:, params:)
       super
 
       @storage = storage
       @project_storage = project_storage
+      @params = params
     end
 
     def id
@@ -54,6 +55,10 @@ module Storages::ProjectStorages
         text << I18n.t("project_storages.remove_project.dialog.automatically_managed_appendix")
       end
       text
+    end
+
+    def current_page
+      @params[:page]
     end
 
     def confirmation_text

--- a/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.rb
+++ b/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.rb
@@ -32,7 +32,7 @@ module Storages::ProjectStorages
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(storage:, project_storage:, params:)
+    def initialize(storage:, project_storage:, params: {})
       super
 
       @storage = storage

--- a/modules/storages/app/components/storages/project_storages/projects/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/row_component.rb
@@ -68,7 +68,8 @@ module Storages::ProjectStorages::Projects
         icon: :trash,
         label: I18n.t("project_storages.remove_project.label"),
         href: destroy_confirmation_dialog_admin_settings_storage_project_storage_path(
-          id: project_storage.id
+          id: project_storage.id,
+          page: current_page
         ),
         data: {
           controller: "async-dialog"

--- a/modules/storages/app/components/storages/project_storages/projects/table_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/table_component.rb
@@ -32,8 +32,6 @@
 # for every "column" defined below.
 module Storages::ProjectStorages::Projects
   class TableComponent < Projects::TableComponent
-    include OpTurbo::Streamable
-
     options :storage
 
     def columns

--- a/modules/storages/app/components/storages/project_storages/projects/table_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/table_component.rb
@@ -32,6 +32,8 @@
 # for every "column" defined below.
 module Storages::ProjectStorages::Projects
   class TableComponent < Projects::TableComponent
+    include ::Projects::Concerns::TableComponent::StreamablePaginationLinksConstraints
+
     options :storage
 
     def columns

--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -117,7 +117,8 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   def destroy_confirmation_dialog
     respond_with_dialog Storages::ProjectStorages::DestroyConfirmationDialogComponent.new(
       storage: @storage,
-      project_storage: @project_storage
+      project_storage: @project_storage,
+      params:
     )
   end
 
@@ -186,7 +187,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
       component: Storages::ProjectStorages::Projects::TableComponent.new(
         query: storage_projects_query,
         storage: @storage,
-        params: { url_for_action: }
+        params: params.merge({ url_for_action: })
       )
     )
   end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -371,8 +371,15 @@ RSpec.describe "Admin lists project mappings for a storage",
         expect(page).to have_text(project.name)
       end
 
-      it "is possible to remove the project after checking the confirmation checkbox in the dialog" do
-        expect(page).to have_text(project.name)
+      it "is possible to remove the project after checking the confirmation checkbox in the dialog",
+         with_settings: { per_page_options: "2,5" } do
+        projects = create_list(:project, 4)
+        projects.each { |project| create(:project_storage, storage:, project:) }
+
+        current_page = 3
+        visit admin_settings_storage_project_storages_path(storage, page: current_page)
+
+        project = project_storages_index_page.project_in_first_row(column_text_separator: "\t")
         project_storages_index_page.click_menu_item_of("Remove project", project)
 
         # The original DeleteService would try to remove actual files from actual storages,
@@ -398,7 +405,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         expect(page).to have_no_text(project.name)
 
         aggregate_failures "pagination links maintain the correct url" do
-          project_storages_index_page.expect_correct_pagination_links(model: storage)
+          project_storages_index_page.expect_correct_pagination_links(model: storage, current_page:)
         end
       end
     end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe "Admin lists project mappings for a storage",
           expect(page).to have_text(subproject.name)
 
           aggregate_failures "pagination links maintain the correct url" do
-            project_storages_index_page.expect_correct_pagination_options(model: storage)
+            project_storages_index_page.expect_page_sizes(model: storage)
           end
         end
 
@@ -303,7 +303,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         end
 
         aggregate_failures "pagination links maintain the correct url" do
-          project_storages_index_page.expect_correct_pagination_options(model: storage)
+          project_storages_index_page.expect_page_sizes(model: storage)
         end
       end
 
@@ -405,7 +405,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         expect(page).to have_no_text(project.name)
 
         aggregate_failures "pagination links maintain the correct url" do
-          project_storages_index_page.expect_correct_pagination_links(model: storage, current_page:)
+          project_storages_index_page.expect_page_links(model: storage, current_page:)
         end
       end
     end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -228,6 +228,10 @@ RSpec.describe "Admin lists project mappings for a storage",
 
           expect(page).to have_text(project.name)
           expect(page).to have_text(subproject.name)
+
+          aggregate_failures "pagination links maintain the correct url" do
+            project_storages_index_page.expect_correct_pagination_links(model: storage)
+          end
         end
 
         context "when the user does not select a folder" do
@@ -296,6 +300,10 @@ RSpec.describe "Admin lists project mappings for a storage",
 
         project_storages_index_page.within_the_table_row_containing(project.name) do
           expect(page).to have_text("No specific folder")
+        end
+
+        aggregate_failures "pagination links maintain the correct url" do
+          project_storages_index_page.expect_correct_pagination_links(model: storage)
         end
       end
 
@@ -388,6 +396,10 @@ RSpec.describe "Admin lists project mappings for a storage",
         expect(page).to have_no_selector("dialog")
         expect(page).to have_text("Successful deletion.")
         expect(page).to have_no_text(project.name)
+
+        aggregate_failures "pagination links maintain the correct url" do
+          project_storages_index_page.expect_correct_pagination_links(model: storage)
+        end
       end
     end
   end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe "Admin lists project mappings for a storage",
           expect(page).to have_text(subproject.name)
 
           aggregate_failures "pagination links maintain the correct url" do
-            project_storages_index_page.expect_correct_pagination_links(model: storage)
+            project_storages_index_page.expect_correct_pagination_options(model: storage)
           end
         end
 
@@ -303,7 +303,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         end
 
         aggregate_failures "pagination links maintain the correct url" do
-          project_storages_index_page.expect_correct_pagination_links(model: storage)
+          project_storages_index_page.expect_correct_pagination_options(model: storage)
         end
       end
 

--- a/modules/storages/spec/support/pages/admin/storages/project_storages/project_storages_index.rb
+++ b/modules/storages/spec/support/pages/admin/storages/project_storages/project_storages_index.rb
@@ -33,7 +33,7 @@ module Pages
     module Storages
       module ProjectStorages
         class Index < ::Pages::Projects::Index
-          def path
+          def path(storage)
             "/admin/settings/storages/#{storage.id}/project_storages"
           end
 

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -119,18 +119,21 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       end
     end
 
-    it "allows unlinking a project from a custom field" do
-      project = create(:project)
-      create(:custom_fields_project, custom_field:, project:)
+    it "allows unlinking a project from a custom field", with_settings: { per_page_options: "2,5" } do
+      projects = create_list(:project, 4)
+      projects.each { |project| create(:custom_fields_project, custom_field:, project:) }
 
-      visit custom_field_projects_path(custom_field)
+      current_page = 3
+      visit custom_field_projects_path(custom_field, page: current_page)
 
+      project = custom_field_projects_page.project_in_first_row
       custom_field_projects_page.click_menu_item_of("Remove from project", project)
 
       expect(page).to have_no_text(project.name)
 
       aggregate_failures "pagination links maintain the correct url after unlinking is done" do
-        custom_field_projects_page.expect_correct_pagination_links(model: custom_field)
+        custom_field_projects_page.expect_correct_pagination_links(model: custom_field, current_page:)
+        custom_field_projects_page.expect_current_page_number(current_page)
       end
     end
 

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -115,15 +115,7 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       expect(page).to have_text(subproject.name)
 
       aggregate_failures "pagination links maintain the correct url" do
-        within ".op-pagination" do
-          pagination_links = page.all(".op-pagination--item-link")
-          expect(pagination_links.size).to be_positive
-
-          pagination_links.each do |pagination_link|
-            uri = URI.parse(pagination_link["href"])
-            expect(uri.path).to eq(custom_field_projects_path(custom_field))
-          end
-        end
+        custom_field_projects_page.expect_correct_pagination_links(model: custom_field)
       end
     end
 
@@ -138,15 +130,7 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       expect(page).to have_no_text(project.name)
 
       aggregate_failures "pagination links maintain the correct url after unlinking is done" do
-        within ".op-pagination" do
-          pagination_links = page.all(".op-pagination--item-link")
-          expect(pagination_links.size).to be_positive
-
-          pagination_links.each do |pagination_link|
-            uri = URI.parse(pagination_link["href"])
-            expect(uri.path).to eq(custom_field_projects_path(custom_field))
-          end
-        end
+        custom_field_projects_page.expect_correct_pagination_links(model: custom_field)
       end
     end
 

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       expect(page).to have_text(subproject.name)
 
       aggregate_failures "pagination links maintain the correct url" do
-        custom_field_projects_page.expect_correct_pagination_links(model: custom_field)
+        custom_field_projects_page.expect_correct_pagination_options(model: custom_field)
       end
     end
 

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       expect(page).to have_text(subproject.name)
 
       aggregate_failures "pagination links maintain the correct url" do
-        custom_field_projects_page.expect_correct_pagination_options(model: custom_field)
+        custom_field_projects_page.expect_page_sizes(model: custom_field)
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe "Custom Fields Multi-Project Activation", :js do
       expect(page).to have_no_text(project.name)
 
       aggregate_failures "pagination links maintain the correct url after unlinking is done" do
-        custom_field_projects_page.expect_correct_pagination_links(model: custom_field, current_page:)
+        custom_field_projects_page.expect_page_links(model: custom_field, current_page:)
         custom_field_projects_page.expect_current_page_number(current_page)
       end
     end

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
       expect(page).to have_text(subproject.name)
 
       aggregate_failures "pagination links maintain the correct url" do
-        project_custom_field_mappings_page.expect_correct_pagination_links(model: project_custom_field)
+        project_custom_field_mappings_page.expect_correct_pagination_options(model: project_custom_field)
       end
     end
 

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -123,18 +123,21 @@ RSpec.describe "Project Custom Field Mappings", :js do
       end
     end
 
-    it "allows unlinking a project from a custom field" do
-      project = create(:project)
-      create(:project_custom_field_project_mapping, project_custom_field:, project:)
+    it "allows unlinking a project from a custom field", with_settings: { per_page_options: "2,5" } do
+      projects = create_list(:project, 4)
+      projects.each { |project| create(:project_custom_field_project_mapping, project_custom_field:, project:) }
 
-      visit project_mappings_admin_settings_project_custom_field_path(project_custom_field)
+      current_page = 3
+      visit project_mappings_admin_settings_project_custom_field_path(project_custom_field, page: current_page)
 
+      project = project_custom_field_mappings_page.project_in_first_row
       project_custom_field_mappings_page.click_menu_item_of("Remove from project", project)
 
       expect(page).to have_no_text(project.name)
 
       aggregate_failures "pagination links maintain the correct url after unlinking is done" do
-        project_custom_field_mappings_page.expect_correct_pagination_links(model: project_custom_field)
+        project_custom_field_mappings_page.expect_correct_pagination_links(model: project_custom_field, current_page:)
+        project_custom_field_mappings_page.expect_current_page_number(current_page)
       end
     end
 

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -119,15 +119,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
       expect(page).to have_text(subproject.name)
 
       aggregate_failures "pagination links maintain the correct url" do
-        within ".op-pagination" do
-          pagination_links = page.all(".op-pagination--item-link")
-          expect(pagination_links.size).to be_positive
-
-          pagination_links.each do |pagination_link|
-            uri = URI.parse(pagination_link["href"])
-            expect(uri.path).to eq(project_mappings_admin_settings_project_custom_field_path(project_custom_field))
-          end
-        end
+        project_custom_field_mappings_page.expect_correct_pagination_links(model: project_custom_field)
       end
     end
 
@@ -142,15 +134,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
       expect(page).to have_no_text(project.name)
 
       aggregate_failures "pagination links maintain the correct url after unlinking is done" do
-        within ".op-pagination" do
-          pagination_links = page.all(".op-pagination--item-link")
-          expect(pagination_links.size).to be_positive
-
-          pagination_links.each do |pagination_link|
-            uri = URI.parse(pagination_link["href"])
-            expect(uri.path).to eq(project_mappings_admin_settings_project_custom_field_path(project_custom_field))
-          end
-        end
+        project_custom_field_mappings_page.expect_correct_pagination_links(model: project_custom_field)
       end
     end
 

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
       expect(page).to have_text(subproject.name)
 
       aggregate_failures "pagination links maintain the correct url" do
-        project_custom_field_mappings_page.expect_correct_pagination_options(model: project_custom_field)
+        project_custom_field_mappings_page.expect_page_sizes(model: project_custom_field)
       end
     end
 
@@ -136,7 +136,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
       expect(page).to have_no_text(project.name)
 
       aggregate_failures "pagination links maintain the correct url after unlinking is done" do
-        project_custom_field_mappings_page.expect_correct_pagination_links(model: project_custom_field, current_page:)
+        project_custom_field_mappings_page.expect_page_links(model: project_custom_field, current_page:)
         project_custom_field_mappings_page.expect_current_page_number(current_page)
       end
     end

--- a/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
+++ b/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
@@ -33,17 +33,32 @@ module Pages
     module CustomFields
       module CustomFieldsProjects
         class CustomFieldProjectsIndex < ::Pages::Projects::Index
-          def path
+          def path(custom_field)
             "/custom_fields/#{custom_field.id}/projects"
           end
 
           def within_row(project)
-            row = page.find("#admin-custom-fields-custom-field-projects-row-component-project-#{project.id}")
+            row = page.find("#{row_id_prefix}-#{project.id}")
             row.hover
             within row do
               yield row
             end
           end
+
+          def expect_correct_pagination_links(model:)
+            within ".op-pagination" do
+              pagination_links = page.all(".op-pagination--item-link")
+              expect(pagination_links.size).to be_positive
+
+              pagination_links.each.with_index(1) do |pagination_link, page_number|
+                uri = URI.parse(pagination_link["href"])
+                expect(uri.path).to eq(path(model))
+                expect(uri.query).to include("page=#{page_number}")
+              end
+            end
+          end
+
+          def row_id_prefix = "#admin-custom-fields-custom-field-projects-row-component-project"
         end
       end
     end

--- a/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
+++ b/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
@@ -45,19 +45,6 @@ module Pages
             end
           end
 
-          def expect_correct_pagination_links(model:)
-            within ".op-pagination" do
-              pagination_links = page.all(".op-pagination--item-link")
-              expect(pagination_links.size).to be_positive
-
-              pagination_links.each.with_index(1) do |pagination_link, page_number|
-                uri = URI.parse(pagination_link["href"])
-                expect(uri.path).to eq(path(model))
-                expect(uri.query).to include("page=#{page_number}")
-              end
-            end
-          end
-
           def row_id_prefix = "#admin-custom-fields-custom-field-projects-row-component-project"
         end
       end

--- a/spec/support/pages/admin/settings/project_custom_fields/project_custom_field_mappings_index.rb
+++ b/spec/support/pages/admin/settings/project_custom_fields/project_custom_field_mappings_index.rb
@@ -32,18 +32,12 @@ module Pages
   module Admin
     module Settings
       module ProjectCustomFields
-        class ProjectCustomFieldMappingsIndex < ::Pages::Projects::Index
-          def path
+        class ProjectCustomFieldMappingsIndex < ::Pages::Admin::CustomFields::CustomFieldsProjects::CustomFieldProjectsIndex
+          def path(project_custom_field)
             "/admin/settings/project_custom_fields/#{project_custom_field.id}/project_mappings"
           end
 
-          def within_row(project)
-            row = page.find("#settings-project-custom-fields-project-custom-field-mapping-row-component-project-#{project.id}")
-            row.hover
-            within row do
-              yield row
-            end
-          end
+          def row_id_prefix = "#settings-project-custom-fields-project-custom-field-mapping-row-component-project"
         end
       end
     end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -147,6 +147,18 @@ module Pages
         end
       end
 
+      def expect_correct_pagination_options(model:)
+        within ".op-pagination--options" do
+          pagination_links = page.all(".op-pagination--item-link")
+          expect(pagination_links.size).to be_positive
+
+          pagination_links.each do |pagination_link|
+            uri = URI.parse(pagination_link["href"])
+            expect(uri.path).to eq(path(model))
+          end
+        end
+      end
+
       def expect_filters_container_toggled
         expect(page).to have_css(".op-filters-form")
       end

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -33,7 +33,7 @@ module Pages
     class Index < ::Pages::Page
       include ::Components::Autocompleter::NgSelectAutocompleteHelpers
 
-      def path
+      def path(*)
         "/projects"
       end
 
@@ -124,6 +124,19 @@ module Pages
       def expect_page_link(text)
         within ".op-pagination--pages" do
           expect(page).to have_css("a.op-pagination--item-link", text:)
+        end
+      end
+
+      def expect_correct_pagination_links(model:)
+        within ".op-pagination" do
+          pagination_links = page.all(".op-pagination--item-link")
+          expect(pagination_links.size).to be_positive
+
+          pagination_links.each.with_index(1) do |pagination_link, page_number|
+            uri = URI.parse(pagination_link["href"])
+            expect(uri.path).to eq(path(model))
+            expect(uri.query).to include("page=#{page_number}")
+          end
         end
       end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -551,9 +551,9 @@ module Pages
         within "#project-table", &
       end
 
-      def project_in_first_row
+      def project_in_first_row(column_text_separator: "\n")
         first_row = within("#projects-table") { find(".op-project-row-component", match: :first) }
-        Project.find_by!(name: first_row.text.split("\n").first)
+        Project.find_by!(name: first_row.text.split(column_text_separator).first)
       end
 
       def within_row(project)

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -127,7 +127,7 @@ module Pages
         end
       end
 
-      def expect_correct_pagination_links(model:, current_page: 1)
+      def expect_page_links(model:, current_page: 1)
         within ".op-pagination--pages" do
           pagination_links = page.all(".op-pagination--item-link")
           expect(pagination_links.size).to be_positive
@@ -147,10 +147,11 @@ module Pages
         end
       end
 
-      def expect_correct_pagination_options(model:)
+      def expect_page_sizes(model:)
         within ".op-pagination--options" do
           pagination_links = page.all(".op-pagination--item-link")
           expect(pagination_links.size).to be_positive
+          expect(page).to have_css(".op-pagination--item_current")
 
           pagination_links.each do |pagination_link|
             uri = URI.parse(pagination_link["href"])


### PR DESCRIPTION
#### Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/57989

#### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Unlinking a project from a custom field, project attribute or storage (aka Multi-project activation) should retain the current page. Right now, after removal the project list re-renders on the first page which is not desired behaviour.

Further, clicking on the pagination links did not update the browser URL with `?page` param

##### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_Before_

https://github.com/user-attachments/assets/9245cac3-dc35-45dc-937b-eb1c0c4940a1

_After_

### Custom Fields

https://github.com/user-attachments/assets/eae3f051-a5d6-40e5-ad4b-11b81ea0420d

### Project Attributes

https://github.com/user-attachments/assets/148a533a-72b8-44b2-82e3-c4c79f701cf4

### File Storages

https://github.com/user-attachments/assets/ca067ad2-6332-47a7-8f37-a911c50459d0

#### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- [x] Specify [turbo application visit to "advance" ](https://turbo.hotwired.dev/handbook/frames#promoting-a-frame-navigation-to-a-page-visit)within the project list turbo frame such that clicking pagination links (ex. <url>?page=1) also updates the history state, and the URL updates accordingly. This allows for any further actions to retain the current page.

    _*Navigating within a frame can be configured as either [an application visit ("advance" or "replace") or as a _restoration_ visit](https://turbo.hotwired.dev/handbook/drive#page-navigation-basics)_

- [x] Set the `page` param in the destroy links so that responses render in the current page

Set the turbo action to "advance" within the project list turbo frame such that clicking pagination links (ex. <url>?page=1) also updates the history state, and the URL updates accordingly. This allows for any further actions to retain the current page.

#### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
