### PR TITLE
[57994] Display mode drop down from Design page doesn't change to correct display mode

### DIFF
--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -30,7 +30,7 @@ module OpenProject::CustomStyles
   module ColorThemes
     module_function
 
-    OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME = "OpenProject".freeze
+    OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME = "OpenProject default".freeze
 
     DEPRECATED_ALTERNATIVE_COLOR = "#35C53F".freeze
     DEPRECATED_PRIMARY_COLOR = "#1A67A3".freeze
@@ -61,7 +61,7 @@ module OpenProject::CustomStyles
         }
       },
       {
-        theme: "OpenProject Light",
+        theme: "OpenProject Grey",
         colors: {
           "primary-button-color" => PRIMER_PRIMARY_BUTTON_COLOR,
           "accent-color" => ACCENT_COLOR,
@@ -81,7 +81,7 @@ module OpenProject::CustomStyles
         logo: "logo_openproject.png"
       },
       {
-        theme: "OpenProject Dark",
+        theme: "OpenProject Navy Blue",
         colors: {
           "primary-button-color" => PRIMER_PRIMARY_BUTTON_COLOR,
           "accent-color" => ACCENT_COLOR,

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -30,7 +30,7 @@ module OpenProject::CustomStyles
   module ColorThemes
     module_function
 
-    OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME = "OpenProject default".freeze
+    OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME = "OpenProject (default)".freeze
 
     DEPRECATED_ALTERNATIVE_COLOR = "#35C53F".freeze
     DEPRECATED_PRIMARY_COLOR = "#1A67A3".freeze
@@ -61,7 +61,7 @@ module OpenProject::CustomStyles
         }
       },
       {
-        theme: "OpenProject Grey",
+        theme: "OpenProject Gray",
         colors: {
           "primary-button-color" => PRIMER_PRIMARY_BUTTON_COLOR,
           "accent-color" => ACCENT_COLOR,

--- a/spec/features/custom_styles/tabs_navigation_spec.rb
+++ b/spec/features/custom_styles/tabs_navigation_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
     end
 
     it "selects a color theme and redirect to the interface tab" do
-      select("OpenProject Light", from: "theme")
+      select("OpenProject Gray", from: "theme")
       find("[data-test-selector='color-theme-button']").click
       expect(page).to have_css(".op-toast.-success", text: I18n.t(:notice_successful_update))
       expect(page).to have_current_path custom_style_path(tab: "interface")
@@ -76,7 +76,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       expect(page).to have_current_path custom_style_path(tab: "branding")
 
       # select a color theme and redirect to the branding tab
-      select("OpenProject Dark", from: "theme")
+      select("OpenProject Navy Blue", from: "theme")
       find("[data-test-selector='color-theme-button']").click
       expect(page).to have_css(".op-toast.-success", text: I18n.t(:notice_successful_update))
       expect(page).to have_current_path custom_style_path(tab: "branding")
@@ -92,7 +92,7 @@ RSpec.describe "Tabs navigation and content switching on the admin/design page" 
       expect(page).to have_current_path custom_style_path(tab: "pdf_export_styles")
 
       # select a color theme and redirect to the PDF export styles tab
-      select("OpenProject", from: "theme")
+      select("OpenProject (default)", from: "theme")
       find("[data-test-selector='color-theme-button']").click
       expect(page).to have_css(".op-toast.-success", text: I18n.t(:notice_successful_update))
       expect(page).to have_current_path custom_style_path(tab: "pdf_export_styles")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57994/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Set better names for color theme options in the drop-down.

## Screenshots
Before:
![Screenshot 2024-09-25 at 09 56 02](https://github.com/user-attachments/assets/c3b8ce8b-80f5-47c1-87cf-a4fb8d977d67)
After:
![Screenshot 2024-09-25 at 13 04 33](https://github.com/user-attachments/assets/b98f9ef3-cc73-4041-8626-22dc5106822d)

