### PR TITLE
[#58087] disable seeded built-in oauth application

### DIFF
--- a/app/seeders/oauth_applications_seeder.rb
+++ b/app/seeders/oauth_applications_seeder.rb
@@ -52,7 +52,7 @@ class OAuthApplicationsSeeder < Seeder
     OAuth::Applications::CreateService
       .new(user: User.system)
       .call(
-        enabled: true,
+        enabled: false,
         name: "OpenProject Mobile App",
         redirect_uri: "openprojectapp://oauth-callback",
         builtin: true,

--- a/spec/features/admin/oauth/oauth_applications_management_spec.rb
+++ b/spec/features/admin/oauth/oauth_applications_management_spec.rb
@@ -106,15 +106,7 @@ RSpec.describe "OAuth applications management", :js, :with_cuprite do
       within_test_selector("op-admin-oauth--built-in-applications") do
         expect(page).to have_test_selector("op-admin-oauth--application", count: 1)
         expect(page).to have_link(text: "OpenProject Mobile App")
-        expect(page).to have_test_selector("op-admin-oauth--application-enabled-toggle-switch", text: "On")
-
-        find_test_selector("op-admin-oauth--application-enabled-toggle-switch").click
-        expect(page).not_to have_test_selector("op-admin-oauth--application-enabled-toggle-switch", text: "Loading")
         expect(page).to have_test_selector("op-admin-oauth--application-enabled-toggle-switch", text: "Off")
-
-        app.reload
-        expect(app).to be_builtin
-        expect(app).not_to be_enabled
 
         find_test_selector("op-admin-oauth--application-enabled-toggle-switch").click
         expect(page).not_to have_test_selector("op-admin-oauth--application-enabled-toggle-switch", text: "Loading")
@@ -123,6 +115,14 @@ RSpec.describe "OAuth applications management", :js, :with_cuprite do
         app.reload
         expect(app).to be_builtin
         expect(app).to be_enabled
+
+        find_test_selector("op-admin-oauth--application-enabled-toggle-switch").click
+        expect(page).not_to have_test_selector("op-admin-oauth--application-enabled-toggle-switch", text: "Loading")
+        expect(page).to have_test_selector("op-admin-oauth--application-enabled-toggle-switch", text: "Off")
+
+        app.reload
+        expect(app).to be_builtin
+        expect(app).not_to be_enabled
 
         click_on "OpenProject Mobile App"
       end


### PR DESCRIPTION
# Ticket
[OP#58087](https://community.openproject.org/work_packages/58087)

# What are you trying to accomplish?
- have the seeded built-in OAuth application disabled by default
- this is due to the fact, that we seed the app while still being behind a feature flag