### PR TITLE
Set accept-lang in cuprite

### DIFF
--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -84,6 +84,7 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       "disable-gpu": nil,
       "disable-popup-blocking": nil,
       lang: language,
+      "accept-lang": language,
       "no-sandbox": nil,
       "disable-smooth-scrolling": true
     }


### PR DESCRIPTION
Without accept-lang, the browser locale will follow the system's locale on my local machine.