### PR TITLE
[#57904] meeting reload button will take you to your previous spot on the page

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -116,7 +116,7 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
     <% end %>
     <div class="content-overlay"></div>
-    <main id="content-wrapper" class="<%= initial_classes %>">
+    <%= content_tag :main, id: "content-wrapper", class: initial_classes, data: stimulus_content_data do %>
       <%# Primerized flash messages are being rendered separately  %>
       <div id="primerized-flash-messages" class="op-primer-flash">
         <%= render_primerized_flash %>
@@ -134,8 +134,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
       <%= content_tag :div,
                       id: 'content',
-                      class: "#{initial_classes} #{'content--split' if content_for?(:content_body_right)}",
-                      data: stimulus_content_data do %>
+                      class: "#{initial_classes} #{'content--split' if content_for?(:content_body_right)}" do %>
         <h1 class="hidden-for-sighted accessibility-helper"><%= t(:label_content) %></h1>
         <% if content_for?(:content_header) %>
           <div id="content-header">
@@ -162,7 +161,7 @@ See COPYRIGHT and LICENSE files for more details.
           <%= content_for :content_body_right %>
         <% end %>
       <% end %>
-    </main>
+    <% end %>
   </div>
   <div id="ajax-indicator" style="display:none;"><span><%= t(:label_loading) %></span></div>
 </div>

--- a/docs/development/concepts/stimulus/README.md
+++ b/docs/development/concepts/stimulus/README.md
@@ -44,7 +44,7 @@ You need to take care to prefix all actions, values etc. with the exact same pat
 
 ### Requiring a page controller
 
-If you have a single controller used in a partial, we have added a helper to use in a partial in order to append a controller to the `#content`tag. This is useful if your template doesn't have a single DOM root. For example, to load the dynamic `project-storage-form` controller and provide a custom value to it:
+If you have a single controller used in a partial, we have added a helper to use in a partial in order to append a controller to the `#content-wrapper` tag. This is useful if your template doesn't have a single DOM root. For example, to load the dynamic `project-storage-form` controller and provide a custom value to it:
 
 ```erb
 <% content_controller 'project-storage-form',

--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -39,6 +39,10 @@ export default class PollForChangesController extends ApplicationController {
     autoscrollEnabled: Boolean,
   };
 
+  static targets = ['reloadButton'];
+
+  declare reloadButtonTarget:HTMLLinkElement;
+
   declare referenceValue:string;
   declare urlValue:string;
   declare intervalValue:number;
@@ -56,7 +60,6 @@ export default class PollForChangesController extends ApplicationController {
     }
 
     if (this.autoscrollEnabledValue) {
-      window.addEventListener('beforeunload', this.rememberCurrentScrollPosition.bind(this));
       window.addEventListener('DOMContentLoaded', this.autoscrollToLastKnownPosition.bind(this));
     }
   }
@@ -64,6 +67,10 @@ export default class PollForChangesController extends ApplicationController {
   disconnect() {
     super.disconnect();
     clearInterval(this.interval);
+  }
+
+  reloadButtonTargetConnected() {
+    this.reloadButtonTarget.addEventListener('click', this.rememberCurrentScrollPosition.bind(this));
   }
 
   triggerTurboStream() {
@@ -90,11 +97,6 @@ export default class PollForChangesController extends ApplicationController {
   }
 
   autoscrollToLastKnownPosition() {
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('autoscroll') !== 'true') {
-      return;
-    }
-
     const lastKnownPos = sessionStorage.getItem(this.scrollPositionKey());
     if (lastKnownPos) {
       const content = document.getElementById('content-body');

--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -36,11 +36,13 @@ export default class PollForChangesController extends ApplicationController {
     url: String,
     interval: Number,
     reference: String,
+    autoscrollEnabled: Boolean,
   };
 
   declare referenceValue:string;
   declare urlValue:string;
   declare intervalValue:number;
+  declare autoscrollEnabledValue:boolean;
 
   private interval:number;
 
@@ -53,8 +55,10 @@ export default class PollForChangesController extends ApplicationController {
       }, this.intervalValue || 10_000);
     }
 
-    window.addEventListener('beforeunload', this.rememberCurrentScrollPosition.bind(this));
-    window.addEventListener('DOMContentLoaded', this.autoscrollToLastKnownPosition.bind(this));
+    if (this.autoscrollEnabledValue) {
+      window.addEventListener('beforeunload', this.rememberCurrentScrollPosition.bind(this));
+      window.addEventListener('DOMContentLoaded', this.autoscrollToLastKnownPosition.bind(this));
+    }
   }
 
   disconnect() {

--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -52,6 +52,9 @@ export default class PollForChangesController extends ApplicationController {
         void this.triggerTurboStream();
       }, this.intervalValue || 10_000);
     }
+
+    window.addEventListener('beforeunload', this.rememberCurrentScrollPosition.bind(this));
+    window.addEventListener('DOMContentLoaded', this.autoscrollToLastKnownPosition.bind(this));
   }
 
   disconnect() {
@@ -72,5 +75,35 @@ export default class PollForChangesController extends ApplicationController {
         renderStreamMessage(html);
       }
     });
+  }
+
+  rememberCurrentScrollPosition() {
+    const currentPosition = document.getElementById('content-body')?.scrollTop;
+
+    if (currentPosition !== undefined) {
+      sessionStorage.setItem(this.scrollPositionKey(), currentPosition.toString());
+    }
+  }
+
+  autoscrollToLastKnownPosition() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('autoscroll') !== 'true') {
+      return;
+    }
+
+    const lastKnownPos = sessionStorage.getItem(this.scrollPositionKey());
+    if (lastKnownPos) {
+      const content = document.getElementById('content-body');
+
+      if (content) {
+        content.scrollTop = parseInt(lastKnownPos, 10);
+      }
+    }
+
+    sessionStorage.removeItem(this.scrollPositionKey());
+  }
+
+  private scrollPositionKey():string {
+    return `${this.urlValue}/scrollPosition`;
   }
 }

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,4 +1,4 @@
-<%
+<%=
   helpers.content_controller "poll-for-changes",
                      poll_for_changes_reference_value: @meeting.changed_hash,
                      poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -3,7 +3,8 @@
       controller: "poll-for-changes",
       poll_for_changes_reference_value: @meeting.changed_hash,
       poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
-      poll_for_changes_interval_value: check_for_updates_interval
+      poll_for_changes_interval_value: check_for_updates_interval,
+      poll_for_changes_autoscroll_enabled_value: true
   }
 
   component_wrapper do

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,17 +1,14 @@
-<%=
-  params = {
-      controller: "poll-for-changes",
-      poll_for_changes_reference_value: @meeting.changed_hash,
-      poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
-      poll_for_changes_interval_value: check_for_updates_interval,
-      poll_for_changes_autoscroll_enabled_value: true
-  }
+<%
+  helpers.content_controller "poll-for-changes",
+                     poll_for_changes_reference_value: @meeting.changed_hash,
+                     poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
+                     poll_for_changes_interval_value: check_for_updates_interval,
+                     poll_for_changes_autoscroll_enabled_value: true
 
   component_wrapper do
     render(Primer::OpenProject::PageHeader.new(
       test_selector: "meeting-page-header",
-      state: @state,
-      data: params
+      state: @state
     )) do |header|
       header.with_title do |title|
         title.with_editable_form(model: @meeting,

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -42,7 +42,7 @@ module Meetings
       ) do |banner|
         banner.with_action_button(
           tag: :a,
-          href: helpers.meeting_path(meeting),
+          href: helpers.meeting_path(meeting, autoscroll: true),
           data: { turbo: false },
           size: :medium
         ) { I18n.t("label_meeting_reload") }

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -42,8 +42,8 @@ module Meetings
       ) do |banner|
         banner.with_action_button(
           tag: :a,
-          href: helpers.meeting_path(meeting, autoscroll: true),
-          data: { turbo: false },
+          href: helpers.meeting_path(meeting),
+          data: { turbo: false, poll_for_changes_target: "reloadButton" },
           size: :medium
         ) { I18n.t("label_meeting_reload") }
 

--- a/modules/meeting/spec/support/pages/structured_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/structured_meeting/show.rb
@@ -43,7 +43,7 @@ module Pages::StructuredMeeting
 
     def trigger_change_poll
       script = <<~JS
-        var target = document.querySelector('[data-test-selector="meeting-page-header"]');
+        var target = document.querySelector('#content-wrapper');
         var controller = window.Stimulus.getControllerForElementAndIdentifier(target, 'poll-for-changes')
         controller.triggerTurboStream();
       JS


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57904

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Whenever another user makes changes to a meeting, you will get a flash notification that encourages you to reload in order to see the updated contents of the page.

Until now, your viewport was moved back all the way up to the beginning of the page whenever you clicked on that reload button.

With this feature, clicking the reload button will remember your current position on the page and move you back down again.

Caveat: if you do not use the reload button, but trigger a reload manually, your position will be discarded.

## Screenshots
https://github.com/user-attachments/assets/14a83810-0e59-4329-8296-6ec55ad17db5

# What approach did you choose and why?

Introduced a new boolean value that can be set via Stimulus to enable this feature. If done so, the pollForChangesController will track the last known scroll position before reloading the page.

Restoring the last known position only happens when the reload button is used. This is done so that the last known position on the page is NOT restored when you re-enter a meeting page that you've visited previously.

The scroll position is remembered in the `sessionStorage`. This means it is exclusive to the current tab. Additionally, the current path with the meeting id is used as a key. This avoids positional changes on the wrong page when visiting multiple meeting pages after another.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
