### PR TITLE
Fix white-space display in Journal diff

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,13 +180,13 @@ module ApplicationHelper
 
   def html_safe_gsub(string, *gsub_args, &)
     html_safe = string.html_safe?
-    string.gsub(*gsub_args, &)
+    result = string.gsub(*gsub_args, &)
 
     # We only mark the string as safe if the previous string was already safe
     if html_safe
-      string.html_safe # rubocop:disable Rails/OutputSafety
+      result.html_safe # rubocop:disable Rails/OutputSafety
     else
-      string
+      result
     end
   end
 

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe JournalsController do
       let(:params) { { id: work_package.last_journal.id.to_s, field: :description, format: "js" } }
 
       before do
-        work_package.update_attribute :description, "description"
+        work_package.update_attribute :description, "description\nmore changes"
       end
 
       describe "with a user having :view_work_package permission" do
@@ -62,7 +62,11 @@ RSpec.describe JournalsController do
           expect(response.body.strip).to be_html_eql <<-HTML
             <div class="text-diff">
               <label class="hidden-for-sighted">Begin of the insertion</label>
-              <ins class="diffmod">description</ins>
+              <ins class="diffmod">
+                description
+                <br/>
+                more changes
+              </ins>
               <label class="hidden-for-sighted">End of the insertion</label>
             </div>
           HTML


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58092

The html_safe_gsub was not returned correctly, resulting in the gsub not being applied and newlines not being replaced with `<br/>`. A spec was missing for this use-case in the journal controller.

# Merge checklist

- [x] Added/updated tests
