### PR TITLE
[#57505] Turn project list into favorite without reloading the page

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -54,7 +54,7 @@ module Projects
                tag: :a,
                tooltip_direction: :e,
                href: helpers.build_favorite_path(project, format: :html),
-               data: { method: currently_favored? ? :delete : :post },
+               data: { "turbo-method": currently_favored? ? :delete : :post },
                classes: currently_favored? ? "op-primer--star-icon " : "op-project-row-component--favorite",
                label: currently_favored? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite),
                aria: { label: currently_favored? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite) },
@@ -259,7 +259,7 @@ module Projects
         scheme: :default,
         icon: "star",
         href: helpers.build_favorite_path(project, format: :html),
-        data: { method: :post },
+        data: { "turbo-method": :post },
         label: I18n.t(:button_favorite),
         aria: { label: I18n.t(:button_favorite) }
       }
@@ -273,7 +273,7 @@ module Projects
         icon: "star-fill",
         size: :medium,
         href: helpers.build_favorite_path(project, format: :html),
-        data: { method: :delete },
+        data: { "turbo-method": :delete },
         classes: "op-primer--star-icon",
         label: I18n.t(:button_unfavorite),
         aria: { label: I18n.t(:button_unfavorite) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57505

# What are you trying to accomplish?
Favourite the projects on the project list page without reloading the whole project list.

# Screenshots

<details><summary>Demo</summary>
<p>

![Sep-25-2024 23-31-13](https://github.com/user-attachments/assets/35306dd2-377a-4b3f-8274-a1225c117ebf)


</p>
</details> 

# What approach did you choose and why?
Change the project favourite button request to be executed with turbo. This way, the parent frame will be automatically reloaded instead of reloading the whole page.
# Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
