### PR TITLE
[57990] Make migration work with database from before 14.0 version

### DIFF
--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -170,7 +170,7 @@ module OpenProject
               label: "homescreen.links.blog"
             },
             blog_article_progress_changes: {
-              href: "https://www.openproject.org/blog/changes-progress-work-estimates/",
+              href: "https://www.openproject.org/blog/updates-to-progress-tracking-in-14-4-based-on-user-feedback/",
               label: "Significant changes to progress and work estimates"
             },
             release_notes: {


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57990

# What are you trying to accomplish?

- Fix migration not working for databases before 14.0 version
- Link to the newest blog article about progress values migration

# What approach did you choose and why?

The code to create the temporary table in common between the migration and the job to update status and % complete values. It has recently changed to get the `excluded_from_totals` value from the `statuses` table, but this field has been created in 14.2, and does not exist yet in 14.0 when this migration is run.

This commit adds the previous version of the code to create the temporary table, that does not require the `excluded_from_totals` field. It also avoids creating the depths table which is not necessary in this case.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
