### PR TITLE
Fix script injection vulnerability in version-check workflow 

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write  # to comment on the PR
 
 jobs:
-  check-pr:
+  version-check:
     if: contains(github.event.pull_request.labels.*.name, 'needs review')
     runs-on: ubuntu-latest
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Verify linked version matches core version
         id: version-check
-        run: ./script/ci/version_check.sh "${{ github.event.pull_request.body }}"
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: ./script/ci/version_check.sh "$PR_BODY"
 
       - name: Add comment if versions differ
         if: steps.version-check.outputs.version_mismatch == 'true'
@@ -31,13 +33,13 @@ jobs:
           header: version-mismatch-comment
           message: |
             The provided work package version does not match the core version:
-            
+
              - Work package URL: ${{ steps.version-check.outputs.wp_url }}
              - Work package version: ${{steps.version-check.outputs.wp_version}}
              - Core version: ${{steps.version-check.outputs.core_version}}
-            
+
             Please make sure that:
-            
+
              - The work package version OR your pull request target branch is correct
       - name: Version check passed
         if: steps.version-check.outputs.version_mismatch != 'true'

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -32,7 +32,10 @@ jobs:
         with:
           header: version-mismatch-comment
           message: |
-            The provided work package version does not match the core version:
+            > [!CAUTION]
+            > The provided work package version does not match the core version
+
+            Details:
 
              - Work package URL: ${{ steps.version-check.outputs.wp_url }}
              - Work package version: ${{steps.version-check.outputs.wp_version}}


### PR DESCRIPTION
a"; ls $GITHUB_WORKSPACE; echo "
`ls $GITHUB_WORKSPACE`

# What are you trying to accomplish?

Avoid script injection attacks from using pr_body

See https://github.com/opf/openproject/actions/runs/11050115223/job/30697184030?pr=16820#step:5:15
The PR body has some backticks in it. It results in the commands between being executed:

```
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/62144d9a-6c8e-4fc7-898a-d82f104d9250.sh: line 21: excluded_from_totals: command not found
/home/runner/work/_temp/62144d9a-6c8e-4fc7-898a-d82f104d9[25](https://github.com/opf/openproject/actions/runs/11050115223/job/30697184030?pr=16820#step:4:26)0.sh: line 21: statuses: command not found
/home/runner/work/_temp/62144d9a-6c8e-4fc7-898a-d82f104d9250.sh: line 21: excluded_from_totals: command not found
```

 In this particular example it failed, but a well-crafted injection could work. That's what I'm trying to do with the first lines of this PR body.

# What approach did you choose and why?

Use an intermediate environment variable as recommended in https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable.