### PR TITLE
Remove typo from the notifications page.

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -11,7 +11,6 @@
 
 <% content_for :content_body do %>
   <%= angular_component_tag "opce-notification-center" %>
-dd
 <% end %>
 
 <% content_for :content_body_right do %>


### PR DESCRIPTION
# What are you trying to accomplish?
Remove the typo left on the notifications page `dd`.

## Screenshots
![typo](https://github.com/user-attachments/assets/6e5a5b1c-7f74-4f7b-a19b-a0ad1b8af8ec)

# Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
