### PR TITLE
[#58120] Reload banner gets triggered when a new item is added to a meeting

### DIFF
--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,14 +1,17 @@
 <%=
-  helpers.content_controller "poll-for-changes",
-                     poll_for_changes_reference_value: @meeting.changed_hash,
-                     poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
-                     poll_for_changes_interval_value: check_for_updates_interval,
-                     poll_for_changes_autoscroll_enabled_value: true
+  params = {
+    controller: "poll-for-changes",
+    poll_for_changes_reference_value: @meeting.changed_hash,
+    poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
+    poll_for_changes_interval_value: check_for_updates_interval,
+    poll_for_changes_autoscroll_enabled_value: true
+  }
 
   component_wrapper do
     render(Primer::OpenProject::PageHeader.new(
       test_selector: "meeting-page-header",
-      state: @state
+      state: @state,
+      data: params
     )) do |header|
       header.with_title do |title|
         title.with_editable_form(model: @meeting,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/58120

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
