### PR TITLE
[58127] Subtitle in activity page is centerlized

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -32,14 +32,10 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { (@author.nil? ? t(:label_activity) : t(:label_user_activity, value: link_to_user(@author))).html_safe }
+    header.with_description { t(:label_date_from_to, start: format_date(@date_to - @days), end: format_date(@date_to-1)) }
     header.with_breadcrumbs([{ href: home_path, text: organization_name},
                              *([href: project_overview_path(@project.id), text: @project.name] if @project),
                              t(:label_activity)])
-  end
-%>
-<%=
-  render(Primer::OpenProject::SubHeader.new) do |subheader|
-    subheader.with_text {t(:label_date_from_to, start: format_date(@date_to - @days), end: format_date(@date_to-1))}
   end
 %>
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/gmbh/work_packages/58127/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show time period as a description of page header

## Screenshots
Before:

![Screenshot 2024-09-27 at 10 18 37](https://github.com/user-attachments/assets/5ca52f9d-9b50-442f-9c57-a6736d1723f2)

After:
<img width="280" alt="Screenshot 2024-09-27 at 10 18 57" src="https://github.com/user-attachments/assets/1ca12e47-35eb-4c5a-af18-a2c273dd2c28">
