### PR TITLE
[58130] Primer button press remains green despite oclo

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -16,6 +16,7 @@
     --controlKnob-borderColor-checked: var(--control-checked-color) !important;
     --button-primary-fgColor-rest: var(--button--primary-font-color) !important;
     --button-primary-bgColor-rest: var(--button--primary-background-color) !important;
+    --button-primary-bgColor-active: var(--button--primary-background-active-color) !important;
     --button-primary-bgColor-hover: var(--button--primary-background-hover-color) !important;
     --button-primary-bgColor-disabled: var(--button--primary-background-disabled-color) !important;
     --button-primary-borderColor-disabled: var(--button--primary-border-disabled-color) !important;

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -112,6 +112,7 @@
   --button--active-border-color: #cacaca;
   --button--primary-background-color: var(--primary-button-color);
   --button--primary-background-hover-color: var(--primary-button-color--major1);
+  --button--primary-background-active-color: var(--primary-button-color--major1);
   --button--primary-background-disabled-color: var(--primary-button-color--minor2);
   --button--primary-border-color: var(--button--primary-background-color);
   --button--primary-border-disabled-color: var(--primary-button-color--minor2);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58130/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When there is primary button color set, we should show correct color when the button is in active state.

## Screenshots
Primary button with  bg-color set:
![Screenshot 2024-09-27 at 12 36 17](https://github.com/user-attachments/assets/9b46f59f-4228-41a2-95a3-ebc0ab5f26b6)

Primary button in active state:

Before:
![Screenshot 2024-09-27 at 12 37 03](https://github.com/user-attachments/assets/06942109-6149-45a8-9ad1-6d4139e39871)

After:
![Screenshot 2024-09-27 at 12 36 33](https://github.com/user-attachments/assets/8bb26976-8a7d-40ed-b831-69d431e7af96)


# What approach did you choose and why?
Map the primer variable color for primary active button to our custom variable. 

# Merge checklist

- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
