### PR TITLE
Move the reference value back to the header

### DIFF
--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -39,9 +39,11 @@ export default class PollForChangesController extends ApplicationController {
     autoscrollEnabled: Boolean,
   };
 
-  static targets = ['reloadButton'];
+  static targets = ['reloadButton', 'reference'];
 
   declare reloadButtonTarget:HTMLLinkElement;
+  declare referenceTarget:HTMLElement;
+  declare readonly hasReferenceTarget:boolean;
 
   declare referenceValue:string;
   declare urlValue:string;
@@ -69,12 +71,20 @@ export default class PollForChangesController extends ApplicationController {
     clearInterval(this.interval);
   }
 
+  buildReference():string {
+    if (this.hasReferenceTarget) {
+      return this.referenceTarget.dataset.referenceValue as string;
+    }
+
+    return this.referenceValue;
+  }
+
   reloadButtonTargetConnected() {
     this.reloadButtonTarget.addEventListener('click', this.rememberCurrentScrollPosition.bind(this));
   }
 
   triggerTurboStream() {
-    void fetch(`${this.urlValue}?reference=${this.referenceValue}`, {
+    void fetch(`${this.urlValue}?reference=${this.buildReference()}`, {
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
       },

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,6 +1,5 @@
 <%=
   helpers.content_controller "poll-for-changes",
-                     poll_for_changes_reference_value: @meeting.changed_hash,
                      poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
                      poll_for_changes_interval_value: check_for_updates_interval,
                      poll_for_changes_autoscroll_enabled_value: true
@@ -8,7 +7,11 @@
   component_wrapper do
     render(Primer::OpenProject::PageHeader.new(
       test_selector: "meeting-page-header",
-      state: @state
+      state: @state,
+      data: {
+        poll_for_changes_target: "reference",
+        reference_value: @meeting.changed_hash
+      }
     )) do |header|
       header.with_title do |title|
         title.with_editable_form(model: @meeting,


### PR DESCRIPTION
https://community.openproject.org/work_packages/58120

# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The meeting reference value is being automatically updated by turbo stream. We moved the poll-for-changes to the content controller, as that allows flashes to be `targets` on the controller.

This however breaks the reference updating. For that to work, allow a reference target to be defined instead of taking it from the value.