### PR TITLE
[#57814] add detail page for hierarchy custom fields

### DIFF
--- a/app/components/custom_fields/details_component.html.erb
+++ b/app/components/custom_fields/details_component.html.erb
@@ -1,0 +1,21 @@
+<%=
+  component_wrapper do
+    flex_layout do |content|
+      content.with_row(mb: 3) do
+        render Primer::Alpha::Banner.new(scheme: :default, icon: :info, dismiss_scheme: :hide) do
+          I18n.t("custom_fields.admin.notice.remember_items_and_projects")
+        end
+      end
+
+      content.with_row do
+        primer_form_with(
+          model:,
+          scope: :custom_field,
+          id: "custom_field_form",
+          url: custom_field_path(model),
+          method: :put
+        ) { |form| render CustomFields::DetailsForm.new(form) }
+      end
+    end
+  end
+%>

--- a/app/components/custom_fields/details_component.rb
+++ b/app/components/custom_fields/details_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+module CustomFields
+  class DetailsComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+  end
+end

--- a/app/controllers/projects/settings/custom_fields_controller.rb
+++ b/app/controllers/projects/settings/custom_fields_controller.rb
@@ -30,7 +30,9 @@ class Projects::Settings::CustomFieldsController < Projects::SettingsController
   menu_item :settings_custom_fields
 
   def show
-    @wp_custom_fields = WorkPackageCustomField.order("lower(name)")
+    @wp_custom_fields = WorkPackageCustomField
+                          .order("lower(name)")
+                          .where.not(field_format: "hierarchy") # TODO: Remove after enabling hierarchy fields
   end
 
   def update

--- a/app/forms/custom_fields/details_form.rb
+++ b/app/forms/custom_fields/details_form.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomFields
+  class DetailsForm < ApplicationForm
+    form do |details_form|
+      details_form.text_field(
+        name: :name,
+        label: I18n.t(:label_name),
+        required: true
+      )
+
+      details_form.check_box(
+        name: :multi_value,
+        label: I18n.t("activerecord.attributes.custom_field.multi_value")
+      )
+
+      details_form.check_box(
+        name: :required,
+        label: I18n.t("activerecord.attributes.custom_field.is_required"),
+        caption: I18n.t("custom_fields.instructions.is_required")
+      )
+
+      details_form.check_box(
+        name: :is_for_all,
+        label: I18n.t("activerecord.attributes.custom_field.is_for_all"),
+        caption: I18n.t("custom_fields.instructions.is_for_all")
+      )
+
+      details_form.check_box(
+        name: :is_filter,
+        label: I18n.t("activerecord.attributes.custom_field.is_filter"),
+        caption: I18n.t("custom_fields.instructions.is_filter")
+      )
+
+      details_form.check_box(
+        name: :searchable,
+        label: I18n.t("activerecord.attributes.custom_field.searchable"),
+        caption: I18n.t("custom_fields.instructions.searchable")
+      )
+
+      details_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :default)
+    end
+  end
+end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -293,6 +293,10 @@ class CustomField < ApplicationRecord
     version? || user? || list?
   end
 
+  def field_format_hierarchy?
+    field_format == "hierarchy"
+  end
+
   def allow_non_open_versions_possible?
     version?
   end

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -146,7 +146,9 @@ module Type::Attributes
     end
 
     def add_custom_fields_to_form_attributes(attributes)
-      WorkPackageCustomField.includes(:custom_options).all.find_each do |field|
+      WorkPackageCustomField.includes(:custom_options)
+                            .where.not(field_format: "hierarchy") # TODO: Remove after enabling hierarchy fields
+                            .find_each do |field|
         attributes[field.attribute_name] = {
           required: field.is_required,
           has_default: field.default_value.present?,

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -56,7 +56,7 @@ module CustomFields
 
       if cf.is_a?(ProjectCustomField)
         add_cf_to_visible_columns(cf)
-      elsif cf.field_format == "hierarchy"
+      elsif cf.field_format_hierarchy?
         # TODO: Use persistence service
         CustomField::Hierarchy::Item.create(custom_field: cf,
                                             label: nil,

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'custom_field' %>
 
-<% if @custom_field.field_format == "hierarchy" %>
+<% if @custom_field.field_format_hierarchy? %>
   <%= render CustomFields::DetailsComponent.new(@custom_field) %>
 <% else %>
   <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -33,9 +33,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'custom_field' %>
 
-<%= labelled_tabular_form_for @custom_field, as: :custom_field,
-                              url: custom_field_path(@custom_field),
-                              html: {method: :put, id: 'custom_field_form'} do |f| %>
-  <%= render partial: 'form', locals: { f: f } %>
-  <%= styled_button_tag t(:button_save), class: '-primary -with-icon icon-checkmark' %>
+<% if @custom_field.field_format == "hierarchy" %>
+  <%= render CustomFields::DetailsComponent.new(@custom_field) %>
+<% else %>
+  <%= labelled_tabular_form_for @custom_field, as: :custom_field,
+                                url: custom_field_path(@custom_field),
+                                html: { method: :put, id: 'custom_field_form' } do |f| %>
+    <%= render partial: 'form', locals: { f: f } %>
+    <%= styled_button_tag t(:button_save), class: '-primary -with-icon icon-checkmark' %>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,8 @@ en:
         is_for_all_blank_slate:
           heading: For all projects
           description: This custom field is enabled in all projects since the "For all projects" option is checked. It cannot be deactivated for individual projects.
+      notice:
+        remember_items_and_projects: "Remember to set items and projects in the respective tabs for this custom field."
 
     text_add_new_custom_field: >
       To add new custom fields to a project you first need to create them before
@@ -702,6 +704,7 @@ en:
         editable: "Editable"
         field_format: "Format"
         is_filter: "Used as a filter"
+        is_for_all: "For all projects"
         is_required: "Required"
         max_length: "Maximum length"
         min_length: "Minimum length"


### PR DESCRIPTION
# Ticket
[OP#57814](https://community.openproject.org/work_packages/57814)

# What are you trying to accomplish?
- editing of details of custom field of type hierarchy is possible
- form is written with primer components
  - spacing is off, but this is known for primer forms 
- existing custom fields of type hierarchy are not usable yet

# Screenshots

![image](https://github.com/user-attachments/assets/efc3ac1e-4f55-4f0c-ae4d-eeb6374e6f21)

