### PR TITLE
[#58142] Update banners to render overlayed flash with rounded borders

### DIFF
--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -137,15 +137,6 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
     respond_with_project_not_found_turbo_streams
   end
 
-  def update_project_list_via_turbo_stream(url_for_action: action_name)
-    update_via_turbo_stream(
-      component: Admin::CustomFields::CustomFieldProjects::TableComponent.new(
-        query: available_custom_fields_projects_query,
-        params: { custom_field: @custom_field, url_for_action: }
-      )
-    )
-  end
-
   def available_custom_fields_projects_query
     @available_custom_fields_projects_query = ProjectQuery.new(
       name: "custom-fields-projects-#{@custom_field.id}"
@@ -165,7 +156,7 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
 
   def respond_with_project_not_found_turbo_streams
     render_error_flash_message_via_turbo_stream message: t(:notice_project_not_found)
-    update_project_list_via_turbo_stream
+    render_project_list(url_for_action: :index)
 
     respond_with_turbo_streams
   end

--- a/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
+++ b/app/controllers/admin/custom_fields/custom_field_projects_controller.rb
@@ -65,9 +65,8 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
     create_service.on_success { render_project_list(url_for_action: :index) }
 
     create_service.on_failure do
-      update_flash_message_via_turbo_stream(
-        message: join_flash_messages(create_service.errors),
-        full: true, dismiss_scheme: :hide, scheme: :danger
+      render_error_flash_message_via_turbo_stream(
+        message: join_flash_messages(create_service.errors)
       )
     end
 
@@ -82,9 +81,8 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
     delete_service.on_success { render_project_list(url_for_action: :index) }
 
     delete_service.on_failure do
-      update_flash_message_via_turbo_stream(
-        message: join_flash_messages(delete_service.errors.full_messages),
-        full: true, dismiss_scheme: :hide, scheme: :danger
+      render_error_flash_message_via_turbo_stream(
+        message: join_flash_messages(delete_service.errors.full_messages)
       )
     end
 
@@ -166,8 +164,7 @@ class Admin::CustomFields::CustomFieldProjectsController < ApplicationController
   end
 
   def respond_with_project_not_found_turbo_streams
-    update_flash_message_via_turbo_stream message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide,
-                                          scheme: :danger
+    render_error_flash_message_via_turbo_stream message: t(:notice_project_not_found)
     update_project_list_via_turbo_stream
 
     respond_with_turbo_streams

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -89,9 +89,8 @@ module Admin::Settings
       create_service.on_success { render_project_list(url_for_action: :project_mappings) }
 
       create_service.on_failure do
-        update_flash_message_via_turbo_stream(
-          message: join_flash_messages(create_service.errors),
-          full: true, dismiss_scheme: :hide, scheme: :danger
+        render_error_flash_message_via_turbo_stream(
+          message: join_flash_messages(create_service.errors)
         )
       end
 
@@ -106,9 +105,8 @@ module Admin::Settings
       delete_service.on_success { render_project_list(url_for_action: :project_mappings) }
 
       delete_service.on_failure do
-        update_flash_message_via_turbo_stream(
-          message: join_flash_messages(delete_service.errors.full_messages),
-          full: true, dismiss_scheme: :hide, scheme: :danger
+        render_error_flash_message_via_turbo_stream(
+          message: join_flash_messages(delete_service.errors.full_messages)
         )
       end
 
@@ -184,8 +182,8 @@ module Admin::Settings
         project_id: permitted_params.project_custom_field_project_mapping[:project_id]
       )
     rescue ActiveRecord::RecordNotFound
-      update_flash_message_via_turbo_stream(
-        message: t(:notice_file_not_found), full: true, dismiss_scheme: :hide, scheme: :danger
+      render_error_flash_message_via_turbo_stream(
+        message: t(:notice_file_not_found)
       )
       replace_via_turbo_stream(
         component: Settings::ProjectCustomFields::ProjectCustomFieldMapping::TableComponent.new(
@@ -213,8 +211,8 @@ module Admin::Settings
         false
       end
     rescue ActiveRecord::RecordNotFound
-      update_flash_message_via_turbo_stream(
-        message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide, scheme: :danger
+      render_error_flash_message_via_turbo_stream(
+        message: t(:notice_project_not_found)
       )
       render_project_list
 

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -182,15 +182,8 @@ module Admin::Settings
         project_id: permitted_params.project_custom_field_project_mapping[:project_id]
       )
     rescue ActiveRecord::RecordNotFound
-      render_error_flash_message_via_turbo_stream(
-        message: t(:notice_file_not_found)
-      )
-      replace_via_turbo_stream(
-        component: Settings::ProjectCustomFields::ProjectCustomFieldMapping::TableComponent.new(
-          query: project_custom_field_mappings_query,
-          params: { custom_field: @custom_field }
-        )
-      )
+      render_error_flash_message_via_turbo_stream(message: t(:notice_file_not_found))
+      render_project_list(url_for_action: :project_mappings)
 
       respond_with_turbo_streams
     end
@@ -211,10 +204,8 @@ module Admin::Settings
         false
       end
     rescue ActiveRecord::RecordNotFound
-      render_error_flash_message_via_turbo_stream(
-        message: t(:notice_project_not_found)
-      )
-      render_project_list
+      render_error_flash_message_via_turbo_stream(message: t(:notice_project_not_found))
+      render_project_list(url_for_action: :project_mappings)
 
       respond_with_turbo_streams
     end

--- a/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages/project_storages_controller.rb
@@ -129,8 +129,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
 
     delete_service.on_success do
       update_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_successful_delete),
-        full: true, dismiss_scheme: :hide, scheme: :success
+        message: I18n.t(:notice_successful_delete), scheme: :success
       )
       update_project_list_via_turbo_stream(url_for_action: :index)
     end
@@ -138,8 +137,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
     delete_service.on_failure do |failure|
       error = failure.errors.map(&:message).to_sentence
       render_error_flash_message_via_turbo_stream(
-        message: I18n.t("project_storages.remove_project.deletion_failure_flash", error:),
-        full: true, dismiss_scheme: :hide
+        message: I18n.t("project_storages.remove_project.deletion_failure_flash", error:)
       )
     end
 
@@ -151,9 +149,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   def load_project_storage
     @project_storage = Storages::ProjectStorage.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    update_flash_message_via_turbo_stream(
-      message: t(:notice_file_not_found), full: true, dismiss_scheme: :hide, scheme: :danger
-    )
+    render_error_flash_message_via_turbo_stream(message: t(:notice_file_not_found))
     update_project_list_via_turbo_stream
 
     respond_with_turbo_streams
@@ -175,8 +171,7 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
       respond_with_turbo_streams
     end
   rescue ActiveRecord::RecordNotFound
-    update_flash_message_via_turbo_stream message: t(:notice_project_not_found), full: true, dismiss_scheme: :hide,
-                                          scheme: :danger
+    render_error_flash_message_via_turbo_stream(message: t(:notice_project_not_found))
     update_project_list_via_turbo_stream
 
     respond_with_turbo_streams
@@ -214,11 +209,8 @@ class Storages::Admin::Storages::ProjectStoragesController < ApplicationControll
   def ensure_storage_configured!
     return if @storage.configured?
 
-    update_flash_message_via_turbo_stream(
-      message: I18n.t("storages.enabled_in_projects.setup_incomplete_description"),
-      full: true,
-      dismiss_scheme: :hide,
-      scheme: :danger
+    render_error_flash_message_via_turbo_stream(
+      message: I18n.t("storages.enabled_in_projects.setup_incomplete_description")
     )
     respond_with_turbo_streams
     false


### PR DESCRIPTION
https://community.openproject.org/work_packages/58142

https://github.com/opf/openproject/pull/16640 unified the primerized flash message rendering and updated to a default overlayed flash. Hence we should remove `full: true` that is used in full width contexts which is no longer the case.

🚧  _These are mainly style changes, test coverage already exists_

_Before_

![image](https://github.com/user-attachments/assets/cb80a792-56db-4f85-8cf7-4192b943efd6)


_After_

<img width="1778" alt="Screenshot 2024-09-27 at 2 28 26 PM" src="https://github.com/user-attachments/assets/6d64270c-1286-4dd6-a79b-ae5db6cf7afe">
<img width="1773" alt="Screenshot 2024-09-27 at 3 48 27 PM" src="https://github.com/user-attachments/assets/9916b70e-b2df-47a4-b4f1-65081515a101">

<img width="1844" alt="Screenshot 2024-09-27 at 6 32 49 PM" src="https://github.com/user-attachments/assets/9fd1d78a-9d2f-4dbd-b58f-11a837686a37">

