### PR TITLE
No need breadcrumbs in HomeScreen.

### DIFF
--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -26,12 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%=
-  render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { I18n.t("label_home") }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name}, I18n.t(:label_home)])
-  end
-%>
 
 <h2 class="headline--application">
   <span><%= organization_icon %></span>


### PR DESCRIPTION
# What are you trying to accomplish?

Original home screen have no breadcrumbs, but after 96129661235d380f32e8ce091714d671d2f0b1d2 it has.

## Screenshots

### Before

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/1dd5b448-9136-419d-b7bb-94c7bf8d30f0">

### After

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/f81b743a-711b-4f5a-9aca-d1150ec80b61">


### Original (OpenProject Community)

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/2803d1a3-3f4f-446c-ae40-e6cd725f1c91">


# What approach did you choose and why?

Just remove no need breadcrumbs

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
