### PR TITLE
[58129] Make Status % Complete a required field

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -41,7 +41,7 @@ class Status < ApplicationRecord
             uniqueness: { case_sensitive: false },
             length: { maximum: 256 }
 
-  validates :default_done_ratio, inclusion: { in: 0..100, allow_nil: true }
+  validates :default_done_ratio, inclusion: { in: 0..100, allow_nil: false }
 
   validate :default_status_must_not_be_readonly
 

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <section class="form--section">
   <div class="form--field -required"><%= f.text_field "name", required: true, container_class: "-middle" %></div>
-  <div class="form--field"><%= f.number_field "default_done_ratio", min: 0, max: 100, container_class: "-xslim" %></div>
+  <div class="form--field -required"><%= f.number_field "default_done_ratio", required: true, min: 0, max: 100, container_class: "-xslim" %></div>
   <div class="form--field"><%= f.check_box "is_closed" %></div>
   <% unless @status.is_default? %>
     <div class="form--field"><%= f.check_box "is_default" %></div>

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Statuses", :skip_csrf, type: :rails_request do
+  shared_let(:admin) { create(:admin) }
+
+  current_user { admin }
+
+  describe "POST /statuses" do
+    it "creates a new status" do
+      post statuses_path, params: { status: { name: "New Status" } }
+
+      expect(Status.find_by(name: "New Status")).not_to be_nil
+      expect(response).to redirect_to(statuses_path)
+    end
+
+    context "with empty % Complete" do
+      it "displays an error" do
+        post statuses_path, params: { status: { name: "New status", default_done_ratio: "" } }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("new")
+        expect(response.body).to include("% Complete must be between 0 and 100.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58129


# What are you trying to accomplish?

A 500 error would occur when creating or updating a status with empty % Complete value.
So:
* mark the field as required (asterisk on the label and required attribute on the input field)
* display a nice error when trying to create or update with an empty % complete value

# What approach did you choose and why?

Model validation, disallow `nil` values.
Add required indicators on the form.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
