### PR TITLE
[56769] Migrate queries with timeline to Gantt module

### DIFF
--- a/db/migrate/20240930122522_change_view_of_queries_with_timeline_to_gantt_again.rb
+++ b/db/migrate/20240930122522_change_view_of_queries_with_timeline_to_gantt_again.rb
@@ -1,0 +1,16 @@
+require_relative "20231201085450_change_view_of_queries_with_timeline_to_gantt"
+
+# Inherit from the original migration `ChangeViewOfQueriesWithTimelineToGantt`
+# to avoid duplicating it.
+#
+# The original migration was fine, but it was applied too early: in OpenProject
+# 13.2.0 the migration would already have been run and it was still possible to
+# create Gantt queries inside the work packages module. Such queries were not
+# migrated.
+#
+# This was registered as bug #56769.
+#
+# This migration runs the original migration again to ensure all queries
+# displayed as Gantt charts are displayed in the right module.
+class ChangeViewOfQueriesWithTimelineToGanttAgain < ChangeViewOfQueriesWithTimelineToGantt
+end


### PR DESCRIPTION

The original migration `ChangeViewOfQueriesWithTimelineToGantt` was fine, but it was applied too early: in OpenProject 13.2.0 the migration would already have been run and it was still possible to create Gantt queries inside the work packages module. Such queries were not migrated.

This commit runs the original migration again to ensure all queries displayed as Gantt charts are displayed in the right module.

# Ticket

https://community.openproject.org/wp/56769

# What are you trying to accomplish?

Put work packages queries showing the timeline (Gantt chart) in the "Gantt charts" module

# What approach did you choose and why?

The original migration `ChangeViewOfQueriesWithTimelineToGantt` was fine, but it was applied too early: in OpenProject 13.2.0 the migration would already have been run and it was still possible to create Gantt queries inside the work packages module. Such queries were not migrated.

This PR runs the original migration again to ensure all queries displayed as Gantt charts are displayed in the right module.

# Merge checklist

- [ ] Added/updated tests
  - nope, original `ChangeViewOfQueriesWithTimelineToGantt` migration is already tested in `modules/gantt/spec/migrations/change_view_of_queries_with_timeline_to_gantt_spec.rb`.
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
