### PR TITLE
[#57804] Add spacing between heading and captcha form in modal

### DIFF
--- a/modules/recaptcha/app/views/recaptcha/request/perform.html.erb
+++ b/modules/recaptcha/app/views/recaptcha/request/perform.html.erb
@@ -1,8 +1,8 @@
 <% html_title t('recaptcha.label_recaptcha') %>
 <% breadcrumb_paths(t('recaptcha.label_recaptcha')) %>
 <div id="login-form" class="form -bordered">
+  <h2 class="mb-3"><%= t 'recaptcha.verify_account' %></h2>
   <%= styled_form_tag({ action: :verify }, { :autocomplete => "off", :id => 'submit_captcha' }) do %>
-    <h2><%= t 'recaptcha.verify_account' %></h2>
     <% if [OpenProject::Recaptcha::TYPE_V2, OpenProject::Recaptcha::TYPE_HCAPTCHA].include?(recaptcha_settings['recaptcha_type']) %>
       <% input_name = "g-recaptcha-response" %>
       <input type="hidden" name="<%= input_name %>" />


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57804

# What are you trying to accomplish?
Add some spacing between heading and the captcha modal

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
### Before
![image](https://github.com/user-attachments/assets/ce1f1ca7-77bd-41c7-b366-4bf0f12227aa)

### After
![image](https://github.com/user-attachments/assets/c64ca1b6-86c3-4a27-af7c-de1ea7e8c638)

# What approach did you choose and why?
Using the primer utility classes to add some margin below the heading.

# Merge checklist
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
