### PR TITLE
[#56917] Increase contrast of skip button in onboarding tour

### DIFF
--- a/frontend/src/app/core/setup/globals/onboarding/tours/homescreen_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/homescreen_tour.ts
@@ -4,7 +4,7 @@ export function homescreenOnboardingTourSteps():OnboardingStep[] {
   return [
     {
       'next .op-app-header': I18n.t('js.onboarding.steps.welcome'),
-      skipButton: { className: 'enjoyhint_btn-transparent', text: I18n.t('js.onboarding.buttons.skip') },
+      skipButton: { className: 'enjoyhint_btn-secondary', text: I18n.t('js.onboarding.buttons.skip') },
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-hidden-arrow',
       bottom: 7,

--- a/frontend/src/global_styles/vendor/_enjoyhint.sass
+++ b/frontend/src/global_styles/vendor/_enjoyhint.sass
@@ -134,12 +134,12 @@
   letter-spacing: 1px
   @include onboarding-button-styles
 
-.enjoyhint_btn-transparent
-  background: transparent
+.enjoyhint_btn-secondary
+  background: var(--button--primary-font-color)
   color: var(--primary-button-color)
-  &:hover
-    color: var(--button--primary-font-color)
-  &:active
+
+  &:hover,&:active
+    background: var(--button--primary-background-hover-color)
     color: var(--button--primary-font-color)
 
 #kinetic_container, .enjoyhint_canvas


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/56917

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Increase the contrast of the skip button against its background

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/5c120068-697e-44b7-bd10-b028d68caf83)

### After (light-mode)
![image](https://github.com/user-attachments/assets/3082d354-5e96-470f-9c9f-239e5549c2c8)

### After (dark-mode)
![image](https://github.com/user-attachments/assets/ba077192-f55b-474d-a9d2-2dc2cdb7a045)


# What approach did you choose and why?
Renamed the `btn-trasparent` class for `enjoyhint` buttons to `btn-secondary` and added some background and foreground combinations that pass a 3:1 contrast ratio check.

# Merge checklist
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
