### PR TITLE
Remove deprecated toast methods

### DIFF
--- a/modules/backlogs/spec/features/resolved_status_spec.rb
+++ b/modules/backlogs/spec/features/resolved_status_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Resolved status" do
     check status.name
     click_button "Save"
 
-    settings_page.expect_toast(message: "Successful update")
+    expect_flash(type: :success, message: "Successful update")
 
     expect(page)
       .to have_checked_field(status.name)

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -290,9 +290,5 @@ module Pages
     def story_selector(story)
       "#story_#{story.id}"
     end
-
-    def toast_type
-      :ruby
-    end
   end
 end

--- a/modules/budgets/spec/support/pages/budget_form.rb
+++ b/modules/budgets/spec/support/pages/budget_form.rb
@@ -179,9 +179,5 @@ module Pages
     def labor_rows
       @labor_rows ||= 0
     end
-
-    def toast_type
-      :rails
-    end
   end
 end

--- a/modules/meeting/spec/features/meetings_participants_spec.rb
+++ b/modules/meeting/spec/features/meetings_participants_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe "Meetings participants" do
 
     edit_page.uninvite(viewer_user)
     show_page = edit_page.click_save
-    show_page.expect_toast(message: "Successful update")
+
+    expect_flash(message: "Successful update")
 
     show_page.expect_uninvited(viewer_user)
   end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Structured meetings CRUD",
   end
 
   it "can create a structured meeting and add agenda items" do
-    show_page.expect_toast(message: "Successful creation")
+    expect_flash(type: :success, message: "Successful creation")
 
     # Does not send invitation mails by default
     perform_enqueued_jobs
@@ -248,7 +248,7 @@ RSpec.describe "Structured meetings CRUD",
   end
 
   it "shows an error toast trying to update an outdated item" do
-    show_page.expect_toast(message: "Successful creation")
+    expect_flash(type: :success, message: "Successful creation")
 
     # Can add and edit a single item
     show_page.add_agenda_item do
@@ -271,7 +271,7 @@ RSpec.describe "Structured meetings CRUD",
   end
 
   it "can copy the meeting" do
-    show_page.expect_toast(message: "Successful creation")
+    expect_flash(type: :success, message: "Successful creation")
 
     # Can add and edit a single item
     show_page.add_agenda_item do
@@ -327,7 +327,7 @@ RSpec.describe "Structured meetings CRUD",
 
     context "when starting with empty sections" do
       it "can add, edit and delete sections" do
-        show_page.expect_toast(message: "Successful creation")
+        expect_flash(type: :success, message: "Successful creation")
 
         # create the first section
         show_page.add_section do

--- a/modules/meeting/spec/support/pages/meetings/base.rb
+++ b/modules/meeting/spec/support/pages/meetings/base.rb
@@ -33,9 +33,5 @@ module Pages::Meetings
     def initialize(project)
       self.project = project
     end
-
-    def toast_type
-      :rails
-    end
   end
 end

--- a/spec/features/forums/message_spec.rb
+++ b/spec/features/forums/message_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "messages", :js do
     create_page.set_subject "The message is"
     create_page.click_save
 
-    create_page.expect_toast(type: :error, message: "Content can't be blank")
+    expect_flash(type: :error, message: "Content can't be blank")
     SeleniumHubWaiter.wait
     create_page.add_text "There is no message here"
 

--- a/spec/features/projects/modules_spec.rb
+++ b/spec/features/projects/modules_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Projects module administration" do
     check "Activity"
     click_button "Save"
 
-    settings_page.expect_toast message: I18n.t(:notice_successful_update)
+    expect_flash type: :success, message: I18n.t(:notice_successful_update)
 
     expect(page).to have_checked_field "Activity"
     expect(page).to have_unchecked_field "Calendar"

--- a/spec/support/pages/admin/system_settings/page.rb
+++ b/spec/support/pages/admin/system_settings/page.rb
@@ -32,10 +32,6 @@ require "support/pages/page"
 
 module Pages::Admin::SystemSettings
   class Page < ::Pages::Page
-    def toast_type
-      :rails
-    end
-
     def press_save_button
       scroll_to(:bottom)
       click_button("Save")

--- a/spec/support/pages/messages/base.rb
+++ b/spec/support/pages/messages/base.rb
@@ -30,8 +30,5 @@ require "support/pages/page"
 
 module Pages::Messages
   class Base < ::Pages::Page
-    def toast_type
-      :rails
-    end
   end
 end

--- a/spec/support/pages/my/password_page.rb
+++ b/spec/support/pages/my/password_page.rb
@@ -45,23 +45,17 @@ module Pages
       end
 
       def expect_password_reuse_error_message(count)
-        expect_toast(type: :error,
+        expect_flash(type: :error,
                      message: I18n.t(:"activerecord.errors.models.user.attributes.password.reused", count:))
       end
 
       def expect_password_weak_error_message
-        expect_toast(type: :error,
+        expect_flash(type: :error,
                      message: "Password Must contain characters of the following classes (at least 2 of 3): lowercase (e.g. 'a'), uppercase (e.g. 'A'), numeric (e.g. '1')")
       end
 
       def expect_password_updated_message
         expect_and_dismiss_flash(type: :info, message: I18n.t(:notice_account_password_updated))
-      end
-
-      private
-
-      def toast_type
-        :rails
       end
     end
   end

--- a/spec/support/pages/projects/settings.rb
+++ b/spec/support/pages/projects/settings.rb
@@ -83,10 +83,6 @@ module Pages
 
       private
 
-      def toast_type
-        :rails
-      end
-
       def path
         project_settings_general_path(project)
       end

--- a/spec/support/pages/projects/show.rb
+++ b/spec/support/pages/projects/show.rb
@@ -47,10 +47,6 @@ module Pages
         within("#menu-sidebar", &)
       end
 
-      def toast_type
-        :rails
-      end
-
       def visit_page
         visit path
       end

--- a/spec/support/pages/types/index.rb
+++ b/spec/support/pages/types/index.rb
@@ -82,10 +82,6 @@ module Pages
       def canonical_name(type)
         type.respond_to?(:name) ? type.name : type
       end
-
-      def toast_type
-        :rails
-      end
     end
   end
 end

--- a/spec/support/toasts/expectations.rb
+++ b/spec/support/toasts/expectations.rb
@@ -1,21 +1,7 @@
 module Toasts
   module Expectations
     def expect_toast(message:, type: :success, wait: 20)
-      if toast_type == :angular
-        expect(page).to have_css(".op-toast.-#{type}", text: message, wait:)
-      elsif type == :error
-        ActiveSupport::Deprecation.warn(
-          "Use `expect_flash(type: :error, message: message)` instead of expect_toast with type: :error"
-        )
-        expect_flash(type: :error, message:)
-      elsif type == :success
-        ActiveSupport::Deprecation.warn(
-          "Use `expect_flash(type: :success, message:)` instead of expect_toast with type: :success"
-        )
-        expect_flash(message:)
-      else
-        raise NotImplementedError
-      end
+      expect(page).to have_css(".op-toast.-#{type}", text: message, wait:)
     end
 
     def expect_and_dismiss_toaster(message: nil, type: :success, wait: 20)
@@ -42,10 +28,6 @@ module Toasts
       else
         expect(page).to have_no_css(".op-toast.-#{type}", text: message, wait:)
       end
-    end
-
-    def toast_type
-      :angular
     end
   end
 end


### PR DESCRIPTION
With toasts no longer in use outside of angular, we can remove the `toast_type` and deprecated methods