### PR TITLE
[#57685] Rename "My account" to "Account settings"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2370,7 +2370,7 @@ en:
   label_more: "More"
   label_more_than_ago: "more than days ago"
   label_move_work_package: "Move work package"
-  label_my_account: "My account"
+  label_my_account: "Account settings"
   label_my_activity: "My activity"
   label_my_account_data: "My account data"
   label_my_avatar: "My avatar"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/57685

# What are you trying to accomplish?
Renaming the "My account" menu entries, breadcrumb items and labels to "Account settings"

# What approach did you choose and why?
Simple change in the translation key
