### PR TITLE
[57978] Mobile: Scrolling quickly to the top or bottom will not show top or bottom on the first try

### DIFF
--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -49,7 +49,7 @@
   margin: 0 0 0 0
   padding: 0
   // Needed for Safari
-  height: calc(100vh - var(--header-height))
+  height: calc(100dvh - var(--header-height))
   overflow-y: auto
   overflow-x: hidden
   background-color: var(--body-background)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57978/activity

# What are you trying to accomplish?
On mobile browsers there were often two scrollbars causing parts of the application to be hidden. 

# What approach did you choose and why?
The height of the content was previously calculated with `100vh`. On mobile however, the browser adress bar counts into that. Therefore all modern browers support `dvh` which ignores the adress bar. 
This only happened now, because we had special mobile scrolling rules which I removed recently.
