### PR TITLE
[#58143] Add the new role and apply defaults

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -118,6 +118,10 @@ class MembersController < ApplicationController
     current_user.allowed_in_project?({ controller:, action: }, @project)
   end
 
+  def user_allowed_to_view_emails?
+    current_user.allowed_globally?(:view_user_email)
+  end
+
   def build_members
     paths = API::V3::Utilities::PathHelper::ApiV3Path
     principals = @principals.map do |principal|
@@ -126,7 +130,7 @@ class MembersController < ApplicationController
         name: principal.name,
         href: paths.send(principal.type.underscore, principal.id)
       }
-      member[:email] = principal.mail if current_user.allowed_globally?(:view_user_email)
+      member[:email] = principal.mail if user_allowed_to_view_emails?
       member
     end
 
@@ -197,7 +201,7 @@ class MembersController < ApplicationController
   def possible_members(criteria, limit)
     Principal
       .possible_member(@project)
-      .like(criteria)
+      .like(criteria, email: user_allowed_to_view_emails?)
       .limit(limit)
   end
 

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -121,11 +121,13 @@ class MembersController < ApplicationController
   def build_members
     paths = API::V3::Utilities::PathHelper::ApiV3Path
     principals = @principals.map do |principal|
-      {
+      member = {
         id: principal.id,
         name: principal.name,
         href: paths.send(principal.type.underscore, principal.id)
       }
+      member[:email] = principal.mail if current_user.allowed_globally?(:view_user_email)
+      member
     end
 
     if @email

--- a/app/models/global_role.rb
+++ b/app/models/global_role.rb
@@ -31,4 +31,15 @@ class GlobalRole < Role
     super
       .where(type: "GlobalRole")
   end
+
+  def self.standard
+    standard_global_role = where(builtin: BUILTIN_STANDARD_GLOBAL).first
+    if standard_global_role.nil?
+      standard_global_role = create(name: "Standard global role", position: 0) do |role|
+        role.builtin = BUILTIN_STANDARD_GLOBAL
+      end
+      raise "Unable to create the standard global role." if standard_global_role.new_record?
+    end
+    standard_global_role
+  end
 end

--- a/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
+++ b/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
@@ -43,21 +43,23 @@ module Queries::Filters::Shared::AnyUserNameAttributeFilter
        Queries::Operators::NotContains]
     end
 
+    def email_field_allowed?
+      true
+    end
+
     private
 
     def sql_concat_name
-      <<-SQL.squish
-        LOWER(
-          CONCAT(
-            users.firstname, ' ', users.lastname,
-            ' ',
-            users.lastname, ' ', users.firstname,
-            ' ',
-            users.login,
-            ' ',
-            users.mail
-          )
-        )
+      fields = [
+        "users.firstname", "users.lastname",
+        "users.lastname", "users.firstname",
+        "users.login"
+      ]
+
+      fields << "users.mail" if email_field_allowed?
+
+      <<~SQL.squish
+        LOWER(CONCAT_WS(#{fields.join(',')}))
       SQL
     end
   end

--- a/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
+++ b/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
@@ -50,16 +50,18 @@ module Queries::Filters::Shared::AnyUserNameAttributeFilter
     private
 
     def sql_concat_name
-      fields = [
-        "users.firstname", "users.lastname",
-        "users.lastname", "users.firstname",
-        "users.login"
-      ]
+      fields = <<~SQL.squish
+        users.firstname, ' ', users.lastname,
+        ' ',
+        users.lastname, ' ', users.firstname,
+        ' ',
+        users.login
+      SQL
 
-      fields << "users.mail" if email_field_allowed?
+      fields << ", ' ',users.mail" if email_field_allowed?
 
       <<~SQL.squish
-        LOWER(CONCAT_WS(#{fields.join(',')}))
+        LOWER(CONCAT(#{fields}))
       SQL
     end
   end

--- a/app/models/queries/principals/filters/typeahead_filter.rb
+++ b/app/models/queries/principals/filters/typeahead_filter.rb
@@ -35,6 +35,10 @@ class Queries::Principals::Filters::TypeaheadFilter < Queries::Principals::Filte
     :search
   end
 
+  def email_field_allowed?
+    User.current.allowed_globally?(:view_user_email)
+  end
+
   def human_name
     I18n.t("label_search")
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -36,6 +36,7 @@ class Role < ApplicationRecord
   BUILTIN_WORK_PACKAGE_EDITOR = 5
   BUILTIN_PROJECT_QUERY_VIEW = 6
   BUILTIN_PROJECT_QUERY_EDIT = 7
+  BUILTIN_STANDARD_GLOBAL = 8
 
   HIDDEN_ROLE_TYPES = [
     "WorkPackageRole",
@@ -93,7 +94,8 @@ class Role < ApplicationRecord
           Role::BUILTIN_WORK_PACKAGE_COMMENTER,
           Role::BUILTIN_WORK_PACKAGE_EDITOR,
           Role::BUILTIN_PROJECT_QUERY_VIEW,
-          Role::BUILTIN_PROJECT_QUERY_EDIT
+          Role::BUILTIN_PROJECT_QUERY_EDIT,
+          Role::BUILTIN_STANDARD_GLOBAL
         ]
       )
       .order(Arel.sql("position"))

--- a/app/seeders/basic_data/base_role_seeder.rb
+++ b/app/seeders/basic_data/base_role_seeder.rb
@@ -49,6 +49,7 @@ module BasicData
       case value
       when :non_member then Role::BUILTIN_NON_MEMBER
       when :anonymous then Role::BUILTIN_ANONYMOUS
+      when :standard_global then Role::BUILTIN_STANDARD_GLOBAL
       when :work_package_editor then Role::BUILTIN_WORK_PACKAGE_EDITOR
       when :work_package_commenter then Role::BUILTIN_WORK_PACKAGE_COMMENTER
       when :work_package_viewer then Role::BUILTIN_WORK_PACKAGE_VIEWER

--- a/app/seeders/common.yml
+++ b/app/seeders/common.yml
@@ -398,3 +398,9 @@ global_roles:
       - :create_user
       - :manage_user
       - :manage_placeholder_user
+  - reference: :default_role_standard_global
+    t_name: Standard global role
+    position: 7
+    builtin: :standard_global
+    permissions:
+      - :view_user_email

--- a/app/services/authorization/user_global_roles_query.rb
+++ b/app/services/authorization/user_global_roles_query.rb
@@ -35,7 +35,8 @@ class Authorization::UserGlobalRolesQuery < Authorization::UserRolesQuery
                      Role::BUILTIN_ANONYMOUS
                    end
 
-    builtin_role_condition = roles_table[:builtin].eq(builtin_role)
+    builtin_roles = [builtin_role, Role::BUILTIN_STANDARD_GLOBAL]
+    builtin_role_condition = roles_table[:builtin].in(builtin_roles)
 
     statement.or(builtin_role_condition)
   end

--- a/app/views/principals/_available_global_roles.html.erb
+++ b/app/views/principals/_available_global_roles.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% available_roles = GlobalRole.all - (global_member&.roles || []) %>
+<% available_roles = GlobalRole.givable - (global_member&.roles || []) %>
 
 <div class="grid-content" id="available_principal_roles">
   <fieldset class="form--fieldset">

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -81,6 +81,11 @@ Rails.application.reloader.to_prepare do
                      require: :loggedin,
                      contract_actions: { placeholder_users: %i[create read update] }
 
+      map.permission :view_user_email,
+                     {},
+                     permissible_on: :global,
+                     require: :loggedin
+
       map.permission :view_project,
                      { projects: [:show] },
                      permissible_on: :project,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3045,6 +3045,7 @@ en:
   permission_view_shared_work_packages: "View work package shares"
   permission_view_time_entries: "View spent time"
   permission_view_timelines: "View timelines"
+  permission_view_user_email: "View users' mail addresses"
   permission_view_wiki_edits: "View wiki history"
   permission_view_wiki_pages: "View wiki"
   permission_work_package_assigned: "Become assignee/responsible"

--- a/db/migrate/20241001205821_add_standard_global_role.rb
+++ b/db/migrate/20241001205821_add_standard_global_role.rb
@@ -1,0 +1,12 @@
+class AddStandardGlobalRole < ActiveRecord::Migration[7.1]
+  def change
+    standard_global_role ||= GlobalRole.find_or_initialize_by(builtin: Role::BUILTIN_STANDARD_GLOBAL)
+
+    standard_global_role.update!(
+      name: I18n.t("seeds.common.global_roles.item_1.name", default: "Standard global role"),
+      permissions: %i[
+        view_user_email
+      ]
+    )
+  end
+end

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -143,7 +143,7 @@ module API
                  getter: ->(*) { represented.mail },
                  setter: ->(fragment:, represented:, **) { represented.mail = fragment },
                  exec_context: :decorator,
-                 cache_if: -> { represented.pref.can_expose_mail? || represented.new_record? || current_user_can_manage? }
+                 cache_if: -> { current_user_can_view_user_email? || represented.new_record? || current_user_can_manage? }
 
         property :avatar,
                  exec_context: :decorator,
@@ -233,6 +233,10 @@ module API
             current_user.allowed_globally?(:create_user) ||
             current_user_is_self?
           )
+        end
+
+        def current_user_can_view_user_email?
+          current_user&.allowed_globally?(:view_user_email)
         end
 
         private

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -33,6 +33,7 @@ require_relative "../support/pages/team_planner"
 require_relative "../../../../spec/features/views/shared_examples"
 
 RSpec.describe "Team planner query handling", :js, :with_cuprite, with_ee: %i[team_planner_view] do
+  shared_let(:standard) { create(:standard_global_role) }
   shared_let(:type_task) { create(:type_task) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do

--- a/modules/team_planner/spec/features/shared_context.rb
+++ b/modules/team_planner/spec/features/shared_context.rb
@@ -30,6 +30,7 @@ require "spec_helper"
 require_relative "../support/pages/team_planner"
 
 RSpec.shared_context "with team planner full access" do
+  shared_let(:standard) { create(:standard_global_role) }
   shared_let(:project) do
     create(:project)
   end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe MembersController do
   end
 
   describe "#autocomplete_for_member" do
-    let(:params) { { "project_id" => project.identifier.to_s } }
+    let(:params) { { "project_id" => project.identifier.to_s, "q" => query } }
+    let(:query) { "" }
     let(:json_response) { response.parsed_body }
     let(:global_permissions) { [] }
     let(:project_permissions) { [] }
@@ -134,6 +135,15 @@ RSpec.describe MembersController do
             }
           )
         end
+
+        context "when searching email addresses" do
+          let(:query) { admin.mail }
+
+          it "does not return matches from emails" do
+            subject
+            expect(json_response).to be_empty
+          end
+        end
       end
 
       context "when the user is authorized to see email addresses" do
@@ -150,6 +160,22 @@ RSpec.describe MembersController do
               "href" => "/api/v3/users/#{admin.id}"
             }
           )
+        end
+
+        context "when searching email addresses" do
+          let(:query) { admin.mail }
+
+          it "returns matches from emails" do
+            subject
+            expect(json_response).to include(
+              {
+                "id" => admin.id,
+                "name" => admin.name,
+                "email" => admin.mail,
+                "href" => "/api/v3/users/#{admin.id}"
+              }
+            )
+          end
         end
       end
     end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -99,24 +99,64 @@ RSpec.describe MembersController do
 
   describe "#autocomplete_for_member" do
     let(:params) { { "project_id" => project.identifier.to_s } }
+    let(:json_response) { response.parsed_body }
+    let(:global_permissions) { [] }
+    let(:project_permissions) { [] }
 
-    before { login_as(user) }
+    subject { post(:autocomplete_for_member, xhr: true, params:) }
 
-    describe "WHEN the user is authorized WHEN a project is provided" do
-      before do
-        role.add_permission! :manage_members
-        member
+    before do
+      mock_permissions_for(user) do |mock|
+        mock.allow_globally(*global_permissions)
+        mock.allow_in_project(*project_permissions, project:)
       end
 
+      login_as(user)
+    end
+
+    describe "WHEN the user is authorized WHEN a project is provided" do
+      let(:project_permissions) { [:manage_members] }
+
       it "is success" do
-        post(:autocomplete_for_member, xhr: true, params:)
+        subject
         expect(response).to be_successful
+      end
+
+      context "when the user is not authorized to see email addresses" do
+        it "returns id, name and href" do
+          subject
+          expect(json_response).to be_an(Array)
+          expect(json_response).to include(
+            {
+              "id" => admin.id,
+              "name" => admin.name,
+              "href" => "/api/v3/users/#{admin.id}"
+            }
+          )
+        end
+      end
+
+      context "when the user is authorized to see email addresses" do
+        let(:global_permissions) { [:view_user_email] }
+
+        it "returns id, name, email and href" do
+          subject
+          expect(json_response).to be_an(Array)
+          expect(json_response).to include(
+            {
+              "id" => admin.id,
+              "name" => admin.name,
+              "email" => admin.mail,
+              "href" => "/api/v3/users/#{admin.id}"
+            }
+          )
+        end
       end
     end
 
     describe "WHEN the user is not authorized" do
       it "is forbidden" do
-        post(:autocomplete_for_member, xhr: true, params:)
+        subject
         expect(response.response_code).to eq(403)
       end
     end

--- a/spec/factories/global_role_factory.rb
+++ b/spec/factories/global_role_factory.rb
@@ -29,5 +29,11 @@
 FactoryBot.define do
   factory :global_role do
     sequence(:name) { |n| "Global Role #{n}" }
+
+    factory :standard_global_role do
+      name { "Standard global role" }
+      builtin { Role::BUILTIN_STANDARD_GLOBAL }
+      initialize_with { GlobalRole.where(builtin: Role::BUILTIN_STANDARD_GLOBAL).first_or_initialize }
+    end
   end
 end

--- a/spec/factories/global_role_factory.rb
+++ b/spec/factories/global_role_factory.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
       name { "Standard global role" }
       builtin { Role::BUILTIN_STANDARD_GLOBAL }
       initialize_with { GlobalRole.where(builtin: Role::BUILTIN_STANDARD_GLOBAL).first_or_initialize }
+      permissions { [:view_user_email] }
     end
   end
 end

--- a/spec/features/global_roles/global_role_assignment_spec.rb
+++ b/spec/features/global_roles/global_role_assignment_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Global role: Global role assignment", :js, :with_cuprite do
 
     let!(:global_role1) { create(:global_role, name: "global_role1", permissions: %i[global1]) }
     let!(:global_role2) { create(:global_role, name: "global_role2", permissions: %i[global2]) }
-
+    let!(:standard_global_role) { create(:standard_global_role) }
     let!(:user) { create(:user) }
     let!(:global_member) do
       create(:global_member,
@@ -57,9 +57,12 @@ RSpec.describe "Global role: Global role assignment", :js, :with_cuprite do
       page.within("#table_principal_roles") do
         expect(page).to have_text "global_role1"
       end
+
+      # And I should not see "Standard global role" within "#available_principal_roles"
       # And I should not see "global_role1" within "#available_principal_roles"
       # And I should see "global_role2" within "#available_principal_roles"
       page.within("#available_principal_roles") do
+        expect(page).to have_no_text "Standard global role"
         expect(page).to have_no_text "global_role1"
         expect(page).to have_text "global_role2"
       end
@@ -78,9 +81,11 @@ RSpec.describe "Global role: Global role assignment", :js, :with_cuprite do
         expect(page).to have_text "global_role2"
       end
 
+      # And I should not see "Standard global role" within "#available_principal_roles"
       # And I should not see "global_role1" within "#available_principal_roles"
       # And I should not see "global_role2" within "#available_principal_roles"
       page.within("#available_principal_roles") do
+        expect(page).to have_no_text "Standard global role"
         expect(page).to have_no_text "global_role1"
         expect(page).to have_no_text "global_role2"
       end
@@ -92,9 +97,11 @@ RSpec.describe "Global role: Global role assignment", :js, :with_cuprite do
 
       wait_for_network_idle
 
+      # And I should not see "Standard global role" within "#available_principal_roles"
       # Then I should see "global_role1" within "#available_principal_roles"
       # And I should not see "global_role2" within "#available_principal_roles"
       page.within("#available_principal_roles") do
+        expect(page).to have_no_text "Standard global role"
         expect(page).to have_text "global_role1"
         expect(page).to have_no_text "global_role2"
       end

--- a/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
@@ -34,6 +34,7 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
   let!(:second_version) { create(:version, name: "Version 2", project:) }
   let!(:third_version) { create(:version, name: "Version 3", project:) }
 
+  shared_let(:standard) { create(:standard_global_role) }
   shared_let(:reader_role_without_project_attributes) do
     create(:project_role, permissions: %i[view_work_packages])
   end

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -29,6 +29,7 @@
 require "spec_helper"
 
 RSpec.describe "Invite user modal", :js, :with_cuprite do
+  shared_let(:standard) { create(:standard_global_role) }
   shared_let(:project) { create(:project) }
   shared_let(:work_package) { create(:work_package, project:) }
 

--- a/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
+++ b/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
@@ -29,6 +29,7 @@
 require "spec_helper"
 
 RSpec.describe "Inviting user in project the current user is lacking permission in", :js, :with_cuprite do
+  shared_let(:standard) { create(:standard_global_role) }
   let(:modal) do
     Components::Users::InviteUserModal.new project: invite_project,
                                            principal: other_user,

--- a/spec/features/users/invite_user_modal/subproject_invite_spec.rb
+++ b/spec/features/users/invite_user_modal/subproject_invite_spec.rb
@@ -29,6 +29,7 @@
 require "spec_helper"
 
 RSpec.describe "Invite user modal subprojects", :js, :with_cuprite do
+  shared_let(:standard) { create(:standard_global_role) }
   shared_let(:project) { create(:project, name: "Parent project") }
   shared_let(:subproject) { create(:project, name: "Subproject", parent: project) }
   shared_let(:work_package) { create(:work_package, project: subproject) }

--- a/spec/models/principals/scopes/like_spec.rb
+++ b/spec/models/principals/scopes/like_spec.rb
@@ -74,5 +74,10 @@ RSpec.describe Principals::Scopes::Like do
       expect(Principal.like("mail"))
         .to contain_exactly(mail, mail2)
     end
+
+    it "does not finds by mail when mail disabled" do
+      expect(Principal.like("mail", email: false))
+        .to be_empty
+    end
   end
 end

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe "API v3 Principals resource" do
     end
 
     it "succeeds" do
-      expect(response.status)
-        .to eq(200)
+      expect(response)
+        .to have_http_status(200)
     end
 
     it_behaves_like "API V3 collection response", 4, 4 do
@@ -143,6 +143,27 @@ RSpec.describe "API v3 Principals resource" do
       end
 
       it_behaves_like "API V3 collection response", 1, 1, "User"
+    end
+
+    context "with a filter for typeahead" do
+      let(:permissions) { [:view_user_email] }
+      let(:filter) do
+        [{ typeahead: { operator: "**", values: ["aaaa@example.com"] } }]
+      end
+
+      before do
+        mock_permissions_for(current_user) do |mock|
+          mock.allow_globally(*permissions)
+        end
+      end
+
+      it_behaves_like "API V3 collection response", 1, 1, "User"
+
+      context "when user does not have permission to view user emails" do
+        let(:permissions) { [] }
+
+        it_behaves_like "API V3 collection response", 0, 0
+      end
     end
 
     context "with a filter for id" do

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe RootSeeder,
       expect(Query.count).to eq 26
       expect(ProjectRole.count).to eq 5
       expect(WorkPackageRole.count).to eq 3
-      expect(GlobalRole.count).to eq 1
+      expect(GlobalRole.count).to eq 2
       expect(Grids::Overview.count).to eq 2
       expect(Version.count).to eq 4
       expect(VersionSetting.count).to eq 4
@@ -126,7 +126,7 @@ RSpec.describe RootSeeder,
 
     include_examples "it creates records", model: Color, expected_count: 144
     include_examples "it creates records", model: DocumentCategory, expected_count: 3
-    include_examples "it creates records", model: GlobalRole, expected_count: 1
+    include_examples "it creates records", model: GlobalRole, expected_count: 2
     include_examples "it creates records", model: WorkPackageRole, expected_count: 3
     include_examples "it creates records", model: ProjectRole, expected_count: 5
     include_examples "it creates records", model: ProjectQueryRole, expected_count: 2
@@ -166,7 +166,7 @@ RSpec.describe RootSeeder,
         expect(Query.count).to eq 26
         expect(ProjectRole.count).to eq 5
         expect(WorkPackageRole.count).to eq 3
-        expect(GlobalRole.count).to eq 1
+        expect(GlobalRole.count).to eq 2
         expect(Grids::Overview.count).to eq 2
         expect(Version.count).to eq 4
         expect(VersionSetting.count).to eq 4

--- a/spec/services/authorization/user_global_roles_query_spec.rb
+++ b/spec/services/authorization/user_global_roles_query_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
   let(:role2) { build(:project_role) }
   let(:anonymous_role) { build(:anonymous_role) }
   let(:non_member) { build(:non_member) }
+  let(:standard_global) { build(:standard_global_role) }
   let(:member) do
     build(:member, project:,
                    roles: [role],
@@ -69,6 +70,7 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
     before do
       non_member.save!
       anonymous_role.save!
+      standard_global.save!
       user.save!
     end
 
@@ -81,8 +83,8 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         member.save!
       end
 
-      it "is the member and non member role" do
-        expect(described_class.query(user)).to contain_exactly(role, non_member)
+      it "is the member, non member role, and standard global role" do
+        expect(described_class.query(user)).to contain_exactly(role, non_member, standard_global)
       end
     end
 
@@ -92,20 +94,20 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         member2.save!
       end
 
-      it "is both member and the non member role" do
-        expect(described_class.query(user)).to contain_exactly(role, role2, non_member)
+      it "is both member roles, the non member role, and standard global role" do
+        expect(described_class.query(user)).to contain_exactly(role, role2, non_member, standard_global)
       end
     end
 
     context "without the user being a member in a project" do
-      it "is the non member role" do
-        expect(described_class.query(user)).to contain_exactly(non_member)
+      it "is the non member role and standard global role" do
+        expect(described_class.query(user)).to contain_exactly(non_member, standard_global)
       end
     end
 
     context "with the user being anonymous" do
-      it "is the anonymous role" do
-        expect(described_class.query(anonymous)).to contain_exactly(anonymous_role)
+      it "is the anonymous role and the global role" do
+        expect(described_class.query(anonymous)).to contain_exactly(anonymous_role, standard_global)
       end
     end
 
@@ -114,8 +116,8 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         global_member.save!
       end
 
-      it "is the global role and non member role" do
-        expect(described_class.query(user)).to contain_exactly(global_role, non_member)
+      it "is the global role, non member role, and standard global role" do
+        expect(described_class.query(user)).to contain_exactly(global_role, non_member, standard_global)
       end
     end
 
@@ -125,8 +127,8 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         global_member.save!
       end
 
-      it "is the global role, member role and non member role" do
-        expect(described_class.query(user)).to contain_exactly(global_role, role, non_member)
+      it "is the global role, member role, non member role, and standard global role" do
+        expect(described_class.query(user)).to contain_exactly(global_role, role, non_member, standard_global)
       end
     end
 
@@ -137,8 +139,8 @@ RSpec.describe Authorization::UserGlobalRolesQuery do
         work_package_member.save!
       end
 
-      it "is the global role, member role and non member role" do
-        expect(described_class.query(user)).to contain_exactly(global_role, role, non_member)
+      it "is the global role, member role, non member role, and standard global role" do
+        expect(described_class.query(user)).to contain_exactly(global_role, role, non_member, standard_global)
       end
     end
   end


### PR DESCRIPTION
# Ticket
Both tickets are addressed in this PR:
- [Add the new role and apply defaults](https://community.openproject.org/wp/58143)
- [Extend api with the email address for the autocompleters](https://community.openproject.org/wp/58145)

# What are you trying to accomplish?
Add a new global permission "View users' email addresses" and add a new global builtin role "Standard global role" in order to have a place for assigning roles for every user in the system.
Enable the "View users' email addresses" on this new role by default.

Enforce displaying the user's email and allow searching users by email addresses via the API based on the "View users' email addresses" permission.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
