### PR TITLE
Relax expectations for flash messages in tests 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,11 @@ AllCops:
   Exclude:
     - '**/node_modules/**/*'
 
+# This cop is disabled because it is deprecated and will be removed in the next
+# major version update of rubocop-capybara to 3.0
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
+
 FactoryBot/ConsistentParenthesesStyle:
   Enabled: false
 

--- a/spec/support/flash/expectations.rb
+++ b/spec/support/flash/expectations.rb
@@ -1,38 +1,67 @@
 module Flash
   module Expectations
-    def expect_flash(message:, type: :success, wait: 20)
+    # Expect a flash message to be present.
+    #
+    # A type and/or message text can be provided to add constraints on the
+    # expectations.
+    #
+    # @param type [Symbol] the type of flash message. Can be :any, :error,
+    #   :warning, :success or :notice (default: :any)
+    # @param message [String, nil] the expected message text (default: nil)
+    # @param wait [Integer] the maximum wait time for the flash in seconds (default: 20)
+    def expect_flash(type: :any, message: nil, wait: 20)
       expected_css = expected_flash_css(type)
       expect(page).to have_css(expected_css, text: message, wait:)
     end
 
-    def find_flash_element(type:)
+    # Find the flash element.
+    #
+    # @param type [Symbol] the type of flash message. Can be :any, :error,
+    #   :warning, :success or :notice (default: :any)
+    # @return [Capybara::Node::Element] the found flash element
+    def find_flash_element(type: :any)
       expected_css = expected_flash_css(type)
       page.find(expected_css)
     end
 
-    def expect_and_dismiss_flash(message: nil, type: :success, wait: 20)
+    # Expect a flash message to be present and then dismiss it.
+    #
+    # A type and/or message text can be provided to add constraints on the
+    # expectations.
+    #
+    # @param type [Symbol] the type of flash message. Can be :any, :error,
+    #   :warning, :success or :notice (default: :any)
+    # @param message [String, nil] the expected message text (default: nil)
+    # @param wait [Integer] the maximum wait time for the flash in seconds (default: 20)
+    def expect_and_dismiss_flash(type: :any, message: nil, wait: 20)
       expect_flash(type:, message:, wait:)
       dismiss_flash!
       expect_no_flash(type:, message:, wait: 0.1)
     end
 
+    # Dismiss the flash message by clicking its close button.
     def dismiss_flash!
-      page.find(".Banner-close button").click # rubocop:disable Capybara/SpecificActions
+      find_flash_element.find(".Banner-close").click_button
     end
 
-    def expect_no_flash(type: :success, message: nil, wait: 10)
-      if type.nil?
-        expect(page).not_to have_test_selector("op-primer-flash-message")
-      else
-        expected_css = expected_flash_css(type)
-        expect(page).to have_no_css(expected_css, text: message, wait:)
-      end
+    # Expect that no flash message is present.
+    #
+    # A type and/or message text can be provided to add constraints on the
+    # expectations.
+    #
+    # @param type [Symbol] the type of flash message. Can be :any, :error,
+    #   :warning, :success or :notice (default: :any)
+    # @param message [String, nil] the expected message text (default: nil)
+    # @param wait [Integer] the maximum wait time for absence of the flash in seconds (default: 10)
+    def expect_no_flash(type: :any, message: nil, wait: 10)
+      expected_css = expected_flash_css(type)
+      expect(page).to have_no_css(expected_css, text: message, wait:)
     end
 
     def expected_flash_css(type)
       scheme = mapped_flash_type(type)
       case scheme
-      when :default
+      when :any
         %{[data-test-selector="op-primer-flash-message"].Banner}
       else
         %{[data-test-selector="op-primer-flash-message"].Banner--#{scheme}}
@@ -48,7 +77,7 @@ module Flash
       when :success, :notice
         :success
       else
-        :default
+        :any
       end
     end
   end


### PR DESCRIPTION
# Ticket
None

Follow up to #16789 (this [comment](https://github.com/opf/openproject/pull/16789#discussion_r1778626196)) and #16863.
<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Make the test code more intentional when we want to be precise with flash messages, and less verbose when we just want to dismiss them, the flash helpers do not have implicit values for `:type` and `:message` anymore, and do not require them to be present either.

# What approach did you choose and why?

Previously `expect_flash` default value for `type` was `:success`, meaning that code like `expect_flash(message: "An error occurred")` implicitly expected a `:success` flash, which is not obvious by reading the code.

This commit changes the default value for `type` to `:any` for all flash helpers, so that there is no implicit expectations on the flash type anymore. `expect_flash(message: "An error occurred")` would then check the flash message text and only the flash message text, which is a fair expectation.

Additionally, it also relaxes the expectation on the message text so that `expect_and_dismiss_flash` and other helpers can be called without `:type` or `:message` parameters, and it will be done regardless of the flash type and message text.

Finally it also adds documentation to all flash helpers.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
