### PR TITLE
[57634] Theming for font color is broken in sub-project

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -191,17 +191,17 @@ $arrow-left-width: 40px
   padding: 10px 10px 0 10px
   height: calc(var(--main-menu-item-height) + 10px)
 
-.main-menu--arrow-left-to-project
-  display: inline-block
-  width: $arrow-left-width
-  float: left
-  border-radius: 3px
-  padding-left: 14px
-  padding-right: 14px
-  border: 1px solid transparent
+  .main-menu--arrow-left-to-project
+    display: inline-block
+    width: $arrow-left-width
+    float: left
+    border-radius: 3px
+    padding-left: 14px
+    padding-right: 14px
+    border: 1px solid transparent
 
-  &:hover, &:focus, &:active
-    @include main-menu-hover
+    &:hover, &:focus, &:active
+      @include main-menu-hover
 
 a.main-menu--parent-node
   border: 1px solid transparent


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57634/activity

# What are you trying to accomplish?
When hovering the back arrow of a submenu, it should adapt the font color based on the hover color (either white or black)

## Screenshots
**before**
<img width="208" alt="Bildschirmfoto 2024-10-07 um 08 26 46" src="https://github.com/user-attachments/assets/9c0c68a5-38ec-439c-b380-72ce68a8b790">


**after**
<img width="187" alt="Bildschirmfoto 2024-10-07 um 08 26 28" src="https://github.com/user-attachments/assets/643b848a-0e88-4315-9c3d-20e24120817c">


# What approach did you choose and why?
The code was already there, but the specificity was not high enough.
