### PR TITLE
[58261] Version info shows html tag

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,12 +172,6 @@ module ApplicationHelper
     end.join.html_safe
   end
 
-  def html_hours(text)
-    html_safe_gsub(text,
-                   %r{(\d+)\.(\d+)},
-                   '<span class="hours hours-int">\1</span><span class="hours hours-dec">.\2</span>')
-  end
-
   def html_safe_gsub(string, *gsub_args, &)
     html_safe = string.html_safe?
     result = string.gsub(*gsub_args, &)

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -73,12 +73,12 @@ See COPYRIGHT and LICENSE files for more details.
         <table>
           <tr>
             <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
-            <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours)) %></td>
+            <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours).html_safe) %></td>
           </tr>
           <% if User.current.allowed_in_project?(:view_time_entries, @project) %>
             <tr>
               <td width="130px" align="right"><%= t(:label_spent_time) %></td>
-              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours)) %></td>
+              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours).html_safe) %></td>
             </tr>
           <% end %>
         </table>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -73,12 +73,12 @@ See COPYRIGHT and LICENSE files for more details.
         <table>
           <tr>
             <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
-            <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours).html_safe) %></td>
+            <td width="240px" class="total-hours" align="right"><%= l_hours(@version.estimated_hours) %></td>
           </tr>
           <% if User.current.allowed_in_project?(:view_time_entries, @project) %>
             <tr>
               <td width="130px" align="right"><%= t(:label_spent_time) %></td>
-              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours).html_safe) %></td>
+              <td width="240px" class="total-hours" align="right"><%= l_hours(@version.spent_hours) %></td>
             </tr>
           <% end %>
         </table>

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -55,8 +55,6 @@ table
         font-style: normal
         font-weight: var(--base-text-weight-bold)
         background-color: #EEEEEE
-    .hours-dec
-      font-size: 0.9em
 
 #workflow_form
   .generic-table--results-container
@@ -144,8 +142,6 @@ tr
 td
   &.hours
     font-weight: var(--base-text-weight-bold)
-    .hours-dec
-      font-size: 0.9em
   .date
     .spot-drop-modal
       display: block


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58261/github?query_id=5092

# What are you trying to accomplish?
Avoid html_tags to be shown when looking at a versions details. Mark the hours as html_safe so that they are shown correctly

