### PR TITLE
[58237] Unnecessary space to the right on certain view width

### DIFF
--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -47,9 +47,6 @@
     padding-left: 15px
     padding-right: 15px
 
-  #main
-    grid-template-columns: auto
-
   #breadcrumb,
   .hidden-for-mobile
     display: none !important
@@ -66,6 +63,9 @@
     display: none !important
 
 @media screen and (max-width: $breakpoint-lg)
+  #main
+    grid-template-columns: auto
+
   #content:has(#content-bodyRight > *)
     grid-template-columns: 1fr auto
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58237/activity

# What are you trying to accomplish?
A while ago, we decided to increase the breakpoint at which the sidebar collapse. However, we forgot to switch the grid definition for `#main` to the same breakpoint


