### PR TITLE
Use the static query strategy for the implicitly created widgets

### DIFF
--- a/modules/my_page/lib/my_page/grid_registration.rb
+++ b/modules/my_page/lib/my_page/grid_registration.rb
@@ -55,7 +55,7 @@ module MyPage
         column_count: 2,
         widgets: [
           {
-            identifier: "work_packages_table",
+            identifier: "work_packages_assigned",
             start_row: 1,
             end_row: 2,
             start_column: 1,
@@ -70,7 +70,7 @@ module MyPage
             }
           },
           {
-            identifier: "work_packages_table",
+            identifier: "work_packages_created",
             start_row: 1,
             end_row: 2,
             start_column: 2,

--- a/modules/my_page/spec/factories/grid_factory.rb
+++ b/modules/my_page/spec/factories/grid_factory.rb
@@ -21,5 +21,11 @@ FactoryBot.define do
         )
       ]
     end
+
+    trait :empty do
+      widgets { [] }
+      row_count { 1 }
+      column_count { 1 }
+    end
   end
 end

--- a/modules/my_page/spec/features/my/custom_text_spec.rb
+++ b/modules/my_page/spec/features/my/custom_text_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe "Custom text widget on my page", :js do
   let(:other_user) do
     create(:user, member_with_permissions: { project => permissions })
   end
+
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   let(:my_page) do
     Pages::My::Page.new
   end

--- a/modules/my_page/spec/features/my/documents_spec.rb
+++ b/modules/my_page/spec/features/my/documents_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe "My page documents widget", :js do
     Pages::My::Page.new
   end
 
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   before do
     login_as user
 

--- a/modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb
+++ b/modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe "My spent time widget with a negative time zone", :js,
   let!(:week_days) { week_with_saturday_and_sunday_as_weekend }
   let!(:non_working_day) { create(:non_working_day, date: tuesday) }
 
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   before do
     login_as user
     my_page.visit!

--- a/modules/my_page/spec/features/my/news_spec.rb
+++ b/modules/my_page/spec/features/my/news_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe "My page news widget spec", :js do
     Pages::My::Page.new
   end
 
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   before do
     login_as user
 

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe "My page time entries current user widget spec", :js do
     create(:user,
            member_with_permissions: { project => %i[view_time_entries edit_time_entries view_work_packages log_own_time] })
   end
+
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   let(:my_page) do
     Pages::My::Page.new
   end

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -161,6 +161,10 @@ RSpec.describe "Arbitrary WorkPackage query table widget on my page", :js do
   context "without the permission to save queries" do
     let(:permissions) { %i[view_work_packages add_work_packages] }
 
+    let!(:my_page_grid) do
+      create(:my_page, :empty, user:)
+    end
+
     it "cannot add the widget" do
       my_page.expect_unable_to_add_widget(1, 1, :within, "Work packages table")
     end

--- a/modules/my_page/spec/features/my/work_package_watcher_widget_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_watcher_widget_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe "Work package watched widget on My page", :js do
     Pages::My::Page.new
   end
 
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   before do
     login_as user
     work_package.add_watcher(user)

--- a/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "POST /api/v3/grids/form", content_type: :json do
           widgets: [
             {
               _type: "GridWidget",
-              identifier: "work_packages_table",
+              identifier: "work_packages_assigned",
               options: {
                 name: "Work packages assigned to me",
                 queryProps: {
@@ -99,7 +99,7 @@ RSpec.describe "POST /api/v3/grids/form", content_type: :json do
             },
             {
               _type: "GridWidget",
-              identifier: "work_packages_table",
+              identifier: "work_packages_created",
               options: {
                 name: "Work packages created by me",
                 queryProps: {

--- a/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "POST /api/v3/grids/form", content_type: :json do
         }
       end
 
-      it "contains default data in the payload" do
+      it "contains default data in the payload" do # rubocop:disable RSpec/ExampleLength
         expected = {
           rowCount: 1,
           columnCount: 2,

--- a/spec/features/projects/favorite_spec.rb
+++ b/spec/features/projects/favorite_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe "Favorite projects", :js do
   end
   let(:projects_page) { Pages::Projects::Index.new }
   let(:top_menu) { Components::Projects::TopMenu.new }
+
+  let!(:my_page_grid) do
+    create(:my_page, :empty, user:)
+  end
+
   let(:my_page) do
     Pages::My::Page.new
   end


### PR DESCRIPTION
Without it, the allowed checks do not allow saving the widget in all constellations of users and their permissions.