### PR TITLE
[#57264] change available user callbacks for custom fields

### DIFF
--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -236,8 +236,8 @@ module API
             # Do not embed list or multi values as their links contain all the
             # information needed (title and href) already.
             next if represented.available_custom_fields.exclude?(custom_field) ||
-                    custom_field.list? ||
-                    custom_field.multi_value?
+              custom_field.list? ||
+              custom_field.multi_value?
 
             value = represented.send custom_field.attribute_getter
 
@@ -282,19 +282,31 @@ module API
           }
         end
 
+        # rubocop:disable Metrics/AbcSize
         def allowed_users_href_callback
+          # Careful to not alter the static_filters object here.
+          # It is made available in the closure (which is class level) and would thus
+          # keep the appended filters between requests.
           static_filters = allowed_users_static_filters
           instance_filters = method(:allowed_users_instance_filter)
 
-          ->(*) {
-            # Careful to not alter the static_filters object here.
-            # It is made available in the closure (which is class level) and would thus
-            # keep the appended filters between requests.
-            filters = static_filters + instance_filters.call(represented)
+          represented_is_clazz = lambda do |represented, clazz|
+            represented.respond_to?(:model) && represented.model.is_a?(clazz)
+          end
 
-            api_v3_paths.path_for(:principals, filters:, page_size: -1)
+          ->(*) {
+            if represented_is_clazz.(represented, Project)
+              api_v3_paths.available_assignees_in_project(represented.id)
+            elsif represented_is_clazz.(represented, WorkPackage)
+              api_v3_paths.available_assignees_in_work_package(represented.id)
+            else
+              filters = static_filters + instance_filters.call(represented)
+              api_v3_paths.path_for(:principals, filters:, page_size: -1)
+            end
           }
         end
+
+        # rubocop:enable Metrics/AbcSize
 
         def cf_min_length(custom_field)
           custom_field.min_length if custom_field.min_length.positive?
@@ -352,12 +364,7 @@ module API
         end
 
         def allowed_users_instance_filter(represented)
-          project_id_value =
-            if represented.respond_to?(:model) && represented.model.is_a?(Project)
-              represented.id
-            else
-              represented.project_id.to_s
-            end
+          project_id_value = represented.project_id
 
           if project_id_value.present?
             [{ member: { operator: "=", values: [project_id_value.to_s] } }]
@@ -402,13 +409,14 @@ module API
           def custom_field_class(custom_fields)
             custom_field_sha = OpenProject::Cache::CacheKey.expand(custom_fields.sort_by(&:id))
 
-            cached_custom_field_classes[custom_field_sha] ||= begin
-              injector_class = custom_field_injector_config[:injector_class]
+            cached_custom_field_classes[custom_field_sha] ||=
+              begin
+                injector_class = custom_field_injector_config[:injector_class]
 
-              method_name = :"create_#{custom_field_injector_config[:type]}"
+                method_name = :"create_#{custom_field_injector_config[:type]}"
 
-              injector_class.send(method_name, custom_fields, self)
-            end
+                injector_class.send(method_name, custom_fields, self)
+              end
           end
 
           def cached_custom_field_classes

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -290,14 +290,16 @@ module API
           static_filters = allowed_users_static_filters
           instance_filters = method(:allowed_users_instance_filter)
 
-          represented_is_clazz = lambda do |represented, clazz|
-            represented.respond_to?(:model) && represented.model.is_a?(clazz)
+          represented_is_existent_instance = lambda do |represented, clazz|
+            represented.respond_to?(:model) &&
+              represented.model.is_a?(clazz) &&
+              represented.model.id.present?
           end
 
           ->(*) {
-            if represented_is_clazz.(represented, Project)
+            if represented_is_existent_instance.(represented, Project)
               api_v3_paths.available_assignees_in_project(represented.id)
-            elsif represented_is_clazz.(represented, WorkPackage)
+            elsif represented_is_existent_instance.(represented, WorkPackage)
               api_v3_paths.available_assignees_in_work_package(represented.id)
             else
               filters = static_filters + instance_filters.call(represented)

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -254,6 +254,12 @@ RSpec.describe API::V3::Utilities::CustomFieldInjector do
               is_required: true)
       end
 
+      before do
+        allow(schema)
+          .to receive(:id)
+                .and_return(model.id)
+      end
+
       it_behaves_like "has basic schema properties" do
         let(:path) { cf_path }
         let(:type) { "User" }
@@ -278,17 +284,7 @@ RSpec.describe API::V3::Utilities::CustomFieldInjector do
 
       it_behaves_like "links to allowed values via collection link" do
         let(:path) { cf_path }
-        let(:href) do
-          params = [
-            { status: { operator: "!", values: [Principal.statuses[:locked].to_s] } },
-            { type: { operator: "=", values: %w[User Group PlaceholderUser] } },
-            { member: { operator: "=", values: [schema.project_id.to_s] } }
-          ]
-
-          query = CGI.escape(JSON.dump(params))
-
-          "#{api_v3_paths.principals}?filters=#{query}&pageSize=-1"
-        end
+        let(:href) { api_v3_paths.available_assignees_in_work_package(model.id) }
       end
     end
 
@@ -303,6 +299,12 @@ RSpec.describe API::V3::Utilities::CustomFieldInjector do
         build(:custom_field,
               field_format: "user",
               is_required: true)
+      end
+
+      before do
+        allow(schema)
+          .to receive(:project_id)
+                .and_return(nil)
       end
 
       it_behaves_like "links to allowed values via collection link" do


### PR DESCRIPTION
# Ticket
[OP#57264](https://community.openproject.org/work_packages/57264)

# What are you trying to accomplish?
- custom fields of type user should show the correct list of assignable users
- this was wrong for work package custom fields of type user, i.e. they did not show users with permissions from work package shares

# What approach did you choose and why?
- project and work package custom fields of type user now use the endpoints `available_assignees` to get a list of values
