### PR TITLE
Remove focusout submits the field

### DIFF
--- a/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment-field-handler.ts
+++ b/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment-field-handler.ts
@@ -1,7 +1,5 @@
 import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
-import {
-  ElementRef, Injector, OnInit, Directive,
-} from '@angular/core';
+import { Directive, ElementRef, Injector, OnInit } from '@angular/core';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { Subject } from 'rxjs';
 import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
@@ -84,9 +82,6 @@ export abstract class WorkPackageCommentFieldHandler extends EditFieldHandler im
   focus():void {
     const trigger = this.elementRef.nativeElement.querySelector('.inplace-editing--trigger-container');
     trigger && trigger.focus();
-  }
-
-  onFocusOut():void {
   }
 
   handleUserKeydown(event:JQuery.TriggeredEvent, onlyCancel?:boolean):void {

--- a/frontend/src/app/shared/components/fields/edit/editing-portal/edit-field-handler.ts
+++ b/frontend/src/app/shared/components/fields/edit/editing-portal/edit-field-handler.ts
@@ -144,11 +144,6 @@ export abstract class EditFieldHandler extends UntilDestroyedMixin {
    */
   public abstract isChanged():boolean;
 
-  /**
-   * Handle focus loss
-   */
-  public abstract onFocusOut():void;
-
   public abstract setErrors(newErrors:string[]):void;
 
   public previewContext(resource:HalResource):string|undefined {

--- a/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler.ts
@@ -107,14 +107,6 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
     }
   }
 
-  public async onFocusOut() {
-    // In case of inline create or erroneous forms: do not save on focus loss
-    // const specialField = this.resource.shouldCloseOnFocusOut(this.fieldName);
-    if (this.resource.subject && this.withErrors && this.withErrors.length === 0) {
-      await this.handleUserSubmit();
-    }
-  }
-
   public setErrors(newErrors:string[]) {
     this.errors = newErrors;
     this.element.classList.toggle('-error', this.isErrorenous);

--- a/frontend/src/app/shared/components/fields/edit/field-types/float-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/float-edit-field.component.ts
@@ -38,7 +38,6 @@ import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-
            [disabled]="inFlight"
            [(ngModel)]="value"
            (keydown)="handler.handleUserKeydown($event)"
-           (focusout)="handler.onFocusOut()"
            [attr.lang]="locale"
            [id]="handler.htmlId" />
   `,

--- a/frontend/src/app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.component.ts
@@ -38,7 +38,6 @@ import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-
            [attr.lang]="locale"
            [(ngModel)]="value"
            (keydown)="handler.handleUserKeydown($event)"
-           (focusout)="handler.onFocusOut()"
            [id]="handler.htmlId" />
   `,
 })

--- a/frontend/src/app/shared/components/fields/edit/field-types/text-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/text-edit-field.component.html
@@ -7,6 +7,5 @@
   [disabled]="inFlight"
   [(ngModel)]="value"
   (keydown)="handler.handleUserKeydown($event)"
-  (focusout)="handler.onFocusOut()"
   [id]="handler.htmlId"
 />

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
@@ -27,10 +27,6 @@ export class CustomTextEditFieldService extends EditFieldHandler {
     super();
   }
 
-  onFocusOut():void {
-    // interface
-  }
-
   public initialize(value:GridWidgetResource) {
     this.initializeChangeset(value);
     this.valueChanged$ = new BehaviorSubject(value.options.text as string);

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -255,12 +255,11 @@ RSpec.describe "edit work package", :js do
       subject_field.expect_state_text "My new subject!"
     end
 
-    it "submits the edit mode when changing the focus" do
+    it "does not close the edit mode when changing the focus" do
       page.find("body").click
 
-      wp_page.expect_toast(message: "Successful update")
-      subject_field.expect_inactive!
-      subject_field.expect_state_text "My new subject!"
+      subject_field.expect_active!
+      wp_page.expect_no_toaster(type: :success, message: "Successful update", wait: 1)
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58286

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
The subject would auto submit if you focus out. However, if you edit and open another field, it would result in a race condition between submitting and opening the other field. We can instead simply rely on the user explicitly saving with enter.
