### PR TITLE
Fix showing custom fields in a project webhook

### DIFF
--- a/modules/webhooks/app/workers/attachment_webhook_job.rb
+++ b/modules/webhooks/app/workers/attachment_webhook_job.rb
@@ -38,10 +38,7 @@ class AttachmentWebhookJob < RepresentedWebhookJob
     webhook.enabled_for_project?(project.id)
   end
 
-  def payload_representer
-    User.system.run_given do |user|
-      ::API::V3::Attachments::AttachmentRepresenter
-        .create(resource, current_user: user, embed_links: true)
-    end
+  def payload_representer_class
+    ::API::V3::Attachments::AttachmentRepresenter
   end
 end

--- a/modules/webhooks/app/workers/project_webhook_job.rb
+++ b/modules/webhooks/app/workers/project_webhook_job.rb
@@ -39,10 +39,7 @@ class ProjectWebhookJob < RepresentedWebhookJob
     end
   end
 
-  def payload_representer
-    User.system.run_given do |user|
-      ::API::V3::Projects::ProjectRepresenter
-        .create(resource, current_user: user, embed_links: true)
-    end
+  def payload_representer_class
+    ::API::V3::Projects::ProjectRepresenter
   end
 end

--- a/modules/webhooks/app/workers/represented_webhook_job.rb
+++ b/modules/webhooks/app/workers/represented_webhook_job.rb
@@ -68,14 +68,22 @@ class RepresentedWebhookJob < WebhookJob
     raise NotImplementedError
   end
 
-  def payload_representer
+  def represented_payload
+    User.system.run_given do |user|
+      payload_representer_class
+        .create(resource, current_user: user, embed_links: true)
+        .to_hash # to_hash needs to be called within the system user block
+    end
+  end
+
+  def payload_representer_class
     raise NotImplementedError
   end
 
   def request_body
     {
       :action => event_name,
-      payload_key => payload_representer
+      payload_key => represented_payload
     }.to_json
   end
 end

--- a/modules/webhooks/app/workers/time_entry_webhook_job.rb
+++ b/modules/webhooks/app/workers/time_entry_webhook_job.rb
@@ -31,10 +31,7 @@ class TimeEntryWebhookJob < RepresentedWebhookJob
     :time_entry
   end
 
-  def payload_representer
-    User.system.run_given do |user|
-      ::API::V3::TimeEntries::TimeEntryRepresenter
-        .create(resource, current_user: user, embed_links: true)
-    end
+  def payload_representer_class
+    ::API::V3::TimeEntries::TimeEntryRepresenter
   end
 end

--- a/modules/webhooks/app/workers/work_package_webhook_job.rb
+++ b/modules/webhooks/app/workers/work_package_webhook_job.rb
@@ -31,10 +31,7 @@ class WorkPackageWebhookJob < RepresentedWebhookJob
     :work_package
   end
 
-  def payload_representer
-    User.system.run_given do |user|
-      ::API::V3::WorkPackages::WorkPackageRepresenter
-        .create(resource, current_user: user, embed_links: true)
-    end
+  def payload_representer_class
+    ::API::V3::WorkPackages::WorkPackageRepresenter
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58287

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Ensure custom field values are shown for webhook requests

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
The getter was only called outside the user system block, which caused the custom fields to not be visible

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
