### PR TITLE
[58294] Move "Powered by CKEditor" to the left side

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
@@ -66,6 +66,11 @@ export class CKEditorSetupService {
       openProject: this.createConfig(context),
       removePlugins: context.removePlugins,
       initialData,
+      ui: {
+        poweredBy: {
+          side: 'left',
+        },
+      },
       language: {
         ui: uiLocale,
         content: contentLanguage,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58294

<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Move "Powered by CKEditor" to the left side of the rich text editor to prevent clicking it accidentally when saving or cancelling

## Screenshots


Before:

![image](https://github.com/user-attachments/assets/e0a48040-2d4f-4b74-b8f0-4db55eb2858e)

After:

![image](https://github.com/user-attachments/assets/538cd112-61e2-40a5-b3ff-51b5b51f7956)


# What approach did you choose and why?

There is an option to move it to the left, documented here: https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/managing-ckeditor-logo.html

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
