### PR TITLE
[#58144] Show email on the UI for users with permission

### DIFF
--- a/app/components/members/row_component.rb
+++ b/app/components/members/row_component.rb
@@ -50,8 +50,7 @@ module Members
     end
 
     def mail
-      return unless user?
-      return if principal.pref.hide_mail
+      return unless user? && current_user.allowed_globally?(:view_user_email)
 
       link = mail_to(principal.mail)
 

--- a/app/components/members/row_component.rb
+++ b/app/components/members/row_component.rb
@@ -50,7 +50,7 @@ module Members
     end
 
     def mail
-      return unless user? && current_user.allowed_globally?(:view_user_email)
+      return unless user? && user_is_allowed_to_see_email
 
       link = mail_to(principal.mail)
 
@@ -286,6 +286,10 @@ module Members
 
     def user?
       principal.is_a?(User)
+    end
+
+    def user_is_allowed_to_see_email
+      (principal == User.current) || User.current.allowed_globally?(:view_user_email)
     end
   end
 end

--- a/app/components/users/profile/attributes_component.html.erb
+++ b/app/components/users/profile/attributes_component.html.erb
@@ -4,7 +4,7 @@
 
     component_wrapper do
       flex_layout do |details_container|
-        if @user.pref.can_expose_mail?
+        if current_user.allowed_globally?(:view_user_email)
           details_container.with_row(font_weight: :bold) do
             User.human_attribute_name(:mail)
           end

--- a/app/components/users/profile/attributes_component.html.erb
+++ b/app/components/users/profile/attributes_component.html.erb
@@ -4,7 +4,7 @@
 
     component_wrapper do
       flex_layout do |details_container|
-        if current_user.allowed_globally?(:view_user_email)
+        if user_is_allowed_to_see_email
           details_container.with_row(font_weight: :bold) do
             User.human_attribute_name(:mail)
           end

--- a/app/components/users/profile/attributes_component.rb
+++ b/app/components/users/profile/attributes_component.rb
@@ -40,7 +40,7 @@ module Users
       end
 
       def render?
-        @user.pref.can_expose_mail? || @user.visible_custom_field_values.any? { _1.value.present? }
+        current_user.allowed_globally?(:view_user_email) || @user.visible_custom_field_values.any? { _1.value.present? }
       end
 
       def visible_custom_fields

--- a/app/components/users/profile/attributes_component.rb
+++ b/app/components/users/profile/attributes_component.rb
@@ -40,7 +40,7 @@ module Users
       end
 
       def render?
-        current_user.allowed_globally?(:view_user_email) || @user.visible_custom_field_values.any? { _1.value.present? }
+        user_is_allowed_to_see_email || @user.visible_custom_field_values.any? { _1.value.present? }
       end
 
       def visible_custom_fields
@@ -50,6 +50,10 @@ module Users
           .group_by(&:custom_field)
           .keys
           .sort_by(&:name)
+      end
+
+      def user_is_allowed_to_see_email
+        User.current == @user || User.current.allowed_globally?(:view_user_email)
       end
     end
   end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -263,7 +263,7 @@ class PermittedParams
   end
 
   def pref
-    params.fetch(:pref, {}).permit(:hide_mail, :time_zone, :theme,
+    params.fetch(:pref, {}).permit(:time_zone, :theme,
                                    :comments_sorting, :warn_on_leaving_unsaved,
                                    :auto_hide_popups)
   end

--- a/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
+++ b/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
@@ -44,7 +44,7 @@ module Queries::Filters::Shared::AnyUserNameAttributeFilter
     end
 
     def email_field_allowed?
-      true
+      User.current.allowed_globally?(:view_user_email)
     end
 
     private

--- a/app/models/queries/principals/filters/typeahead_filter.rb
+++ b/app/models/queries/principals/filters/typeahead_filter.rb
@@ -35,10 +35,6 @@ class Queries::Principals::Filters::TypeaheadFilter < Queries::Principals::Filte
     :search
   end
 
-  def email_field_allowed?
-    User.current.allowed_globally?(:view_user_email)
-  end
-
   def human_name
     I18n.t("label_search")
   end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -90,14 +90,6 @@ class UserPreference < ApplicationRecord
     settings.fetch(:diff_type, "inline")
   end
 
-  def hide_mail
-    settings.fetch(:hide_mail, true)
-  end
-
-  def can_expose_mail?
-    !hide_mail
-  end
-
   def auto_hide_popups=(value)
     settings[:auto_hide_popups] = to_boolean(value)
   end

--- a/app/services/user_preferences/set_attributes_service.rb
+++ b/app/services/user_preferences/set_attributes_service.rb
@@ -29,8 +29,6 @@
 module UserPreferences
   class SetAttributesService < ::BaseServices::SetAttributes
     def set_attributes(params)
-      set_boolean_value(:hide_mail, params.delete(:hide_mail)) if params.key?(:hide_mail)
-
       params.each do |k, v|
         model[k] = v if model.supported_settings_method?(k)
       end

--- a/app/views/common/feed.atom.builder
+++ b/app/views/common/feed.atom.builder
@@ -61,7 +61,9 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       if author
         xml.author do
           xml.name(author)
-          xml.email(author.mail) if author.is_a?(User) && author.mail.present? && author.pref.can_expose_mail?
+          if author.is_a?(User) && author.mail.present? && User.current.allowed_globally?(:view_user_email)
+            xml.email(author.mail)
+          end
         end
       end
       xml.content "type" => "html" do

--- a/app/views/journals/index.atom.builder
+++ b/app/views/journals/index.atom.builder
@@ -44,7 +44,8 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       xml.updated change.created_at.xmlschema
       xml.author do
         xml.name change.user.name
-        xml.email(change.user.mail) if change.user.is_a?(User) && change.user.mail.present? && change.user.pref.can_expose_mail?
+        if change.user.is_a?(User) && change.user.mail.present? && User.current.allowed_globally?(:view_user_email)
+          xml.email(change.user.mail)
       end
       xml.content "type" => "html" do
         xml.text! "<ul>"

--- a/app/views/journals/index.atom.builder
+++ b/app/views/journals/index.atom.builder
@@ -46,6 +46,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
         xml.name change.user.name
         if change.user.is_a?(User) && change.user.mail.present? && User.current.allowed_globally?(:view_user_email)
           xml.email(change.user.mail)
+        end
       end
       xml.content "type" => "html" do
         xml.text! "<ul>"

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -79,10 +79,6 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     </div>
 
-    <%= fields_for :pref, @user.pref, builder: TabularFormBuilder, lang: current_language do |pref_fields| %>
-      <div class="form--field"><%= pref_fields.check_box :hide_mail %></div>
-    <% end %>
-
     <%= call_hook(:view_my_account, user: @user, form: f) %>
 
     <%= render partial: "customizable/form",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -877,7 +877,6 @@ en:
         consented_at: "Consented at"
       user_preference:
         comments_sorting: "Display comments"
-        hide_mail: "Hide my email address"
         impaired: "Accessibility mode"
         time_zone: "Time zone"
         auto_hide_popups: "Auto-hide success notifications"

--- a/config/schemas/user_preferences.schema.json
+++ b/config/schemas/user_preferences.schema.json
@@ -6,9 +6,6 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "hide_mail": {
-                    "type": "boolean"
-                },
                 "time_zone": {
                     "type": ["string", "null"]
                 },

--- a/db/migrate/20241002151949_remove_hide_mail_from_user_preferences.rb
+++ b/db/migrate/20241002151949_remove_hide_mail_from_user_preferences.rb
@@ -1,0 +1,8 @@
+class RemoveHideMailFromUserPreferences < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE user_preferences
+      SET settings =  settings - 'hide_mail'
+    SQL
+  end
+end

--- a/docs/api/apiv3/components/schemas/user_preferences_model.yml
+++ b/docs/api/apiv3/components/schemas/user_preferences_model.yml
@@ -13,7 +13,6 @@ example:
       method: "patch"
   _type: UserPreferences
   commentSortDescending: true
-  hideMail: false
   timeZone: "Europe/Berlin"
   warnOnLeavingUnsaved: true
   notifications:

--- a/docs/api/apiv3/paths/my_preferences.yml
+++ b/docs/api/apiv3/paths/my_preferences.yml
@@ -19,7 +19,6 @@ get:
                     method: "patch"
                 _type: "UserPreferences"
                 commentSortDescending: true
-                hideMail: false
                 timeZone: "Europe/Berlin"
                 warnOnLeavingUnsaved: true
                 notifications:
@@ -83,7 +82,6 @@ patch:
                     method: "patch"
                 _type: UserPreferences
                 commentSortDescending: true
-                hideMail: false
                 timeZone: Europe/Berlin
                 warnOnLeavingUnsaved: true
                 notifications:

--- a/docs/api/apiv3/tags/userpreferences.yml
+++ b/docs/api/apiv3/tags/userpreferences.yml
@@ -12,7 +12,6 @@ description: |-
   | Property               | Description                                                                     | Type                | Constraints | Supported operations |
   |:----------------------:| -----------------------------------------------------------                     | ----------          | ----------- | -------------------- |
   | autoHidePopups         | Whether to hide popups (e.g. success messages) after 5 seconds                  | Boolean             |             | READ / WRITE         |
-  | hideMail               | Hide mail address from other users                                              | Boolean             |             | READ / WRITE         |
   | notifications          | The settings for the notifications to be received by the user                   | NotificationSetting |             | READ / WRITE         |
   | timeZone               | Current selected time zone                                                      | String              |             | READ / WRITE         |
   | commentSortDescending  | Sort comments in descending order                                               | Boolean             |             | READ / WRITE         |

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
@@ -21,20 +21,16 @@
       class="ng-option-label"
     >
       <!--Selectable option-->
-      <span [ngOptionHighlight]="search">
-        {{ item.principal.name }}
-      </span>
+      <span [ngOptionHighlight]="search">{{ item.principal.name }}</span>
       <span
         class="op-autocompleter__option-principal-email"
         *ngIf="item.principal.email"
-        [ngOptionHighlight]="search"
-      >{{ item.principal.email }}</span>
+        [ngOptionHighlight]="search">{{ item.principal.email }}</span>
 
       <!-- Already a member of the project -->
       <div
         *ngIf="item.disabled"
-        class="ellipsis"
-      >{{ text.alreadyAMember() }}</div>
+        class="ellipsis">{{ text.alreadyAMember() }}</div>
     </div>
   </ng-template>
 

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.html
@@ -21,7 +21,14 @@
       class="ng-option-label"
     >
       <!--Selectable option-->
-      <div [ngOptionHighlight]="search">{{ item.principal.name }}</div>
+      <span [ngOptionHighlight]="search">
+        {{ item.principal.name }}
+      </span>
+      <span
+        class="op-autocompleter__option-principal-email"
+        *ngIf="item.principal.email"
+        [ngOptionHighlight]="search"
+      >{{ item.principal.email }}</span>
 
       <!-- Already a member of the project -->
       <div

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.sass
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.sass
@@ -1,0 +1,13 @@
+@import '../../global_styles/openproject/variables'
+
+.op-autocompleter
+  &__option-principal-email
+    color: var(--fgColor-muted)
+    font-size: var(--font-size-small)
+    margin-left: var(--stack-gap-condensed)
+
+  @media screen and (max-width: $breakpoint-sm)
+    &__option-principal-email
+      display: block
+      margin-left: 0
+      margin-top: var(--control-xsmall-gap)

--- a/frontend/src/app/features/invite-user-modal/principal/principal-search.component.ts
+++ b/frontend/src/app/features/invite-user-modal/principal/principal-search.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   Input,
   EventEmitter,
@@ -39,7 +40,9 @@ interface NgSelectPrincipalOption {
 
 @Component({
   selector: 'op-ium-principal-search',
+  styleUrls: ['./principal-search.component.sass'],
   templateUrl: './principal-search.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnInit {
   @Input() spotFormBinding:UntypedFormControl;

--- a/frontend/src/app/features/user-preferences/state/user-preferences.model.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.model.ts
@@ -16,7 +16,6 @@ export interface ImmediateRemindersSettings {
 export interface IUserPreference {
   autoHidePopups:boolean;
   commentSortDescending:boolean;
-  hideMail:boolean;
   timeZone:string|null;
   warnOnLeavingUnsaved:boolean;
   workdays:number[];

--- a/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
@@ -36,7 +36,6 @@ function createInitialState():IUserPreference {
   return {
     autoHidePopups: true,
     commentSortDescending: false,
-    hideMail: true,
     timeZone: null,
     warnOnLeavingUnsaved: true,
     notifications: [],

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -180,16 +180,18 @@
   </ng-container>
 
   <ng-container *ngSwitchCase="resource ==='users' || resource ==='assignee' || resource === 'principals'">
-    <div class="op-autocompleter--option-principal-wrapper">
-      <op-principal
-        *ngIf="item && item.href"
-        [principal]="item"
-        [hideName]="true"
-        class="op-autocompleter--option-principal-avatar"
-        size="mini"
-      ></op-principal>
-      <span [ngOptionHighlight]="search" class="ellipsis">{{ item.name }}</span>
-    </div>
+    <op-principal
+      *ngIf="item && item.href"
+      [principal]="item"
+      [hideName]="true"
+      class="op-autocompleter--option-principal-avatar"
+      size="mini"
+    ></op-principal>
+    <span [ngOptionHighlight]="search">{{ item.name }}</span>
+    <span
+      class="op-autocompleter__option-principal-email"
+      *ngIf="item.email"
+      [ngOptionHighlight]="search">{{ item.email }}</span>
   </ng-container>
 
   <ng-container

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -195,6 +195,10 @@
   <ng-container
     *ngSwitchCase="resource ==='subproject' || resource ==='version' || resource ==='status' || resource ==='default' || !resource">
     <span [ngOptionHighlight]="search">{{ item.name }}</span>
+    <span
+      class="op-autocompleter__option-principal-email"
+      *ngIf="item.email"
+      [ngOptionHighlight]="search">{{ item.email }}</span>
   </ng-container>
 </ng-template>
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
@@ -1,3 +1,5 @@
+@import '../../global_styles/openproject/variables'
+
 .op-autocompleter
   &--option-wrapper
     padding: 5px 5px
@@ -51,3 +53,14 @@
     &-wrapper
       display: flex
       overflow: hidden
+
+  &__option-principal-email
+    color: var(--fgColor-muted)
+    font-size: var(--font-size-small)
+    margin-left: var(--stack-gap-condensed)
+
+  @media screen and (max-width: $breakpoint-sm)
+    &__option-principal-email
+      display: block
+      margin-left: 0
+      margin-top: var(--control-xsmall-gap)

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
@@ -49,11 +49,6 @@
     white-space: nowrap
     text-overflow: ellipsis
 
-  &--option-principal
-    &-wrapper
-      display: flex
-      overflow: hidden
-
   &__option-principal-email
     color: var(--fgColor-muted)
     font-size: var(--font-size-small)
@@ -64,3 +59,5 @@
       display: block
       margin-left: 0
       margin-top: var(--control-xsmall-gap)
+    &--option-principal-avatar + span + &__option-principal-email
+      margin-left: var(--control-small-size)

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
@@ -9,7 +9,7 @@
     [hideName]="true"
     size="mini"
   ></op-principal>
-  <span [opSearchHighlight]="search" >{{ item.name }}</span>
+  <span [opSearchHighlight]="search">{{ item.name }}</span>
   <span
     class="op-autocompleter__option-principal-email"
     *ngIf="item.email"

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
@@ -9,17 +9,12 @@
     [hideName]="true"
     size="mini"
   ></op-principal>
-  <span class="op-autocompleter__option-principal-details">
-    <span
-      class="op-autocompleter__option-principal-name"
-      [opSearchHighlight]="search"
-    >{{ item.name }}</span>
-    <span
-      class="op-autocompleter__option-principal-email"
-      *ngIf="item.email"
-      [opSearchHighlight]="search"
-    >{{ item.email }}</span>
-  </span>
+  <span [opSearchHighlight]="search" >{{ item.name }}</span>
+  <span
+    class="op-autocompleter__option-principal-email"
+    *ngIf="item.email"
+    [opSearchHighlight]="search"
+  >{{ item.email }}</span>
 </ng-template>
 <ng-template #footerTemplate *ngIf="inviteUserToProject">
   <op-invite-user-button

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
@@ -9,7 +9,10 @@
     [hideName]="true"
     size="mini"
   ></op-principal>
-  <span [opSearchHighlight]="search">{{ item.name }}</span>
+  <span [opSearchHighlight]="search"
+        class="op-user-autocompleter--name">
+      {{ item.name }}
+    </span>
   <span
     class="op-autocompleter__option-principal-email"
     *ngIf="item.email"

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
@@ -9,10 +9,17 @@
     [hideName]="true"
     size="mini"
   ></op-principal>
-  <span [opSearchHighlight]="search"
-        class="op-user-autocompleter--name">
-      {{ item.name }}
-    </span>
+  <span class="op-autocompleter__option-principal-details">
+    <span
+      class="op-autocompleter__option-principal-name"
+      [opSearchHighlight]="search"
+    >{{ item.name }}</span>
+    <span
+      class="op-autocompleter__option-principal-email"
+      *ngIf="item.email"
+      [opSearchHighlight]="search"
+    >{{ item.email }}</span>
+  </span>
 </ng-template>
 <ng-template #footerTemplate *ngIf="inviteUserToProject">
   <op-invite-user-button

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.sass
@@ -1,0 +1,16 @@
+@import '../../global_styles/openproject/variables'
+
+.op-autocompleter
+  &__option-principal-details
+    display: inline-flex
+    align-items: flex-start
+    gap: 8px
+
+  &__option-principal-email
+    color: var(--fgColor-muted)
+    font-size: 0.75rem
+
+  @media screen and (max-width: $breakpoint-sm)
+    &__option-principal-details
+      flex-direction: column
+      gap: 4px

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.sass
@@ -2,15 +2,18 @@
 
 .op-autocompleter
   &__option-principal-details
-    display: inline-flex
-    align-items: flex-start
-    gap: 8px
+    display: inline
 
   &__option-principal-email
     color: var(--fgColor-muted)
-    font-size: 0.75rem
+    font-size: var(--font-size-small)
+    margin-left: var(--stack-gap-condensed)
 
   @media screen and (max-width: $breakpoint-sm)
     &__option-principal-details
+      display: inline-flex
       flex-direction: column
       gap: 4px
+
+    &__option-principal-email
+      margin-left: 0

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.sass
@@ -1,19 +1,13 @@
 @import '../../global_styles/openproject/variables'
 
 .op-autocompleter
-  &__option-principal-details
-    display: inline
-
   &__option-principal-email
     color: var(--fgColor-muted)
     font-size: var(--font-size-small)
     margin-left: var(--stack-gap-condensed)
 
   @media screen and (max-width: $breakpoint-sm)
-    &__option-principal-details
-      display: inline-flex
-      flex-direction: column
-      gap: 4px
-
     &__option-principal-email
-      margin-left: 0
+      display: block
+      margin-left: var(--control-small-size)
+      margin-top: var(--control-xsmall-gap)

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.ts
@@ -37,6 +37,7 @@ import { IAutocompleterTemplateComponent } from 'core-app/shared/components/auto
 
 @Component({
   templateUrl: './user-autocompleter-template.component.html',
+  styleUrls: ['./user-autocompleter-template.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UserAutocompleterTemplateComponent implements IAutocompleterTemplateComponent {

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -26,7 +26,16 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  forwardRef,
+  Input,
+  OnInit,
+  Output,
+  ViewEncapsulation,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 import {
   filter,
@@ -142,7 +151,7 @@ export class UserAutocompleterComponent extends OpAutocompleterComponent<IUserAu
     };
   }
 
-  protected defaultTrackByFunction():(item:{ href:unknown, name:unknown }) => unknown|null {
+  protected defaultTrackByFunction():(item:{ href:unknown, name:unknown }) => unknown {
     return (item) => item.href || item.name;
   }
 

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Component,
-  EventEmitter,
-  forwardRef,
-  Input,
-  OnInit,
-  Output,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
   filter,
@@ -61,6 +53,7 @@ export const usersAutocompleterSelector = 'op-user-autocompleter';
 export interface IUserAutocompleteItem {
   id:ID;
   name:string;
+  email?:string|null;
   href:string|null;
   avatar?:string|null;
 }
@@ -68,6 +61,7 @@ export interface IUserAutocompleteItem {
 @Component({
   templateUrl: '../op-autocompleter/op-autocompleter.component.html',
   selector: usersAutocompleterSelector,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -113,7 +107,7 @@ export class UserAutocompleterComponent extends OpAutocompleterComponent<IUserAu
     const filteredURL = this.buildFilteredURL(searchTerm);
 
     filteredURL.searchParams.set('pageSize', '-1');
-    filteredURL.searchParams.set('select', 'elements/id,elements/name,elements/self,total,count,pageSize');
+    filteredURL.searchParams.set('select', 'elements/id,elements/name,elements/email,elements/self,total,count,pageSize');
 
     return this
       .http
@@ -122,7 +116,7 @@ export class UserAutocompleterComponent extends OpAutocompleterComponent<IUserAu
         map((res) => _.uniqBy(res._embedded.elements, (el) => el._links.self?.href || el.id)),
         map((users) => {
           return users.map((user) => {
-              return { id: user.id, name: user.name, href: user._links.self?.href };
+              return { id: user.id, name: user.name, href: user._links.self?.href, email: user.email };
             });
           }),
       );

--- a/lib/api/v3/groups/group_sql_representer.rb
+++ b/lib/api/v3/groups/group_sql_representer.rb
@@ -42,6 +42,9 @@ module API
 
         property :name,
                  column: :lastname
+
+        property :email,
+                 column: :mail
       end
     end
   end

--- a/lib/api/v3/placeholder_users/placeholder_user_sql_representer.rb
+++ b/lib/api/v3/placeholder_users/placeholder_user_sql_representer.rb
@@ -42,6 +42,9 @@ module API
 
         property :name,
                  column: :lastname
+
+        property :email,
+                 column: :mail
       end
     end
   end

--- a/lib/api/v3/user_preferences/user_preference_representer.rb
+++ b/lib/api/v3/user_preferences/user_preference_representer.rb
@@ -53,7 +53,6 @@ module API
           }
         end
 
-        property :hide_mail
         property :time_zone,
                  render_nil: true
 

--- a/lib/api/v3/users/user_sql_representer.rb
+++ b/lib/api/v3/users/user_sql_representer.rb
@@ -57,6 +57,14 @@ module API
               "id = #{User.current.id}"
             end
           end
+
+          def render_if_view_user_email_or_self(*)
+            if User.current.allowed_globally?(:view_user_email)
+              "TRUE"
+            else
+              "id = #{User.current.id}"
+            end
+          end
         end
 
         link :self,
@@ -73,7 +81,8 @@ module API
                  representation: method(:user_name_projection)
 
         property :email,
-                 column: :mail
+                 column: :mail,
+                 render_if: method(:render_if_view_user_email_or_self)
 
         property :firstname,
                  render_if: method(:render_if_manage_user_or_self)

--- a/lib/api/v3/users/user_sql_representer.rb
+++ b/lib/api/v3/users/user_sql_representer.rb
@@ -72,6 +72,9 @@ module API
         property :name,
                  representation: method(:user_name_projection)
 
+        property :email,
+                 column: :mail
+
         property :firstname,
                  render_if: method(:render_if_manage_user_or_self)
 

--- a/spec/components/users/profile/attributes_component_spec.rb
+++ b/spec/components/users/profile/attributes_component_spec.rb
@@ -31,20 +31,30 @@
 require "rails_helper"
 
 RSpec.describe Users::Profile::AttributesComponent, type: :component do
+  shared_let(:logged_in_user) { create(:user) }
+  let(:user) { build(:user) }
   let(:component) { described_class.new(user:) }
+
+  current_user { logged_in_user }
 
   describe "render?" do
     subject { component.render? }
 
-    context "when user has hide_mail = false in their preferences" do
-      let(:user) { build(:user, preferences: { hide_mail: false }) }
+    context "when user has view_user_email permission" do
+      before do
+        create(:standard_global_role)
+      end
 
       it { is_expected.to be(true) }
     end
 
-    context "when user has hide_mail = true in their preferences" do
-      let(:user) { build(:user, preferences: { hide_mail: true }) }
+    context "when user views its own profile" do
+      current_user { user }
 
+      it { is_expected.to be(true) }
+    end
+
+    context "when user has no view_user_email permission" do
       it { is_expected.to be(false) }
     end
 

--- a/spec/contracts/user_preferences/params_contract_spec.rb
+++ b/spec/contracts/user_preferences/params_contract_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe UserPreferences::ParamsContract do
   end
   let(:params) do
     {
-      hide_mail: true,
       auto_hide_popups: true,
       comments_sorting: "desc",
       daily_reminders: {
@@ -204,7 +203,6 @@ RSpec.describe UserPreferences::ParamsContract do
     context "when notification_settings empty" do
       let(:params) do
         {
-          hide_mail: true,
           auto_hide_popups: true,
           comments_sorting: "desc",
           daily_reminders: {

--- a/spec/contracts/user_preferences/update_contract_spec.rb
+++ b/spec/contracts/user_preferences/update_contract_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe UserPreferences::UpdateContract do
   end
   let(:settings) do
     {
-      hide_mail: true,
       auto_hide_popups: true,
       comments_sorting: "desc",
       daily_reminders: {
@@ -105,16 +104,6 @@ RSpec.describe UserPreferences::UpdateContract do
       end
 
       it_behaves_like "contract is valid"
-    end
-
-    context "with a string for hide_mail" do
-      let(:settings) do
-        {
-          hide_mail: "yes please"
-        }
-      end
-
-      it_behaves_like "contract is invalid", hide_mail: :type_mismatch
     end
 
     context "with a field within the daily_reminders having the wrong type" do
@@ -205,7 +194,6 @@ RSpec.describe UserPreferences::UpdateContract do
     context "without a time_zone" do
       let(:settings) do
         {
-          hide_mail: true,
           auto_hide_popups: true,
           comments_sorting: "desc",
           daily_reminders: {

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -629,7 +629,6 @@ RSpec.describe UsersController do
             force_password_change: true
           },
           pref: {
-            hide_mail: "1",
             comments_sorting: "desc"
           }
         }
@@ -650,7 +649,6 @@ RSpec.describe UsersController do
         expect(some_user_from_db.firstname).to eq("Changed")
         expect(some_user_from_db.login).to eq("changed_login")
         expect(some_user_from_db.force_password_change).to be(true)
-        expect(some_user_from_db.pref[:hide_mail]).to be_truthy
         expect(some_user_from_db.pref[:comments_sorting]).to eq("desc")
       end
 

--- a/spec/factories/global_role_factory.rb
+++ b/spec/factories/global_role_factory.rb
@@ -36,5 +36,12 @@ FactoryBot.define do
       initialize_with { GlobalRole.where(builtin: Role::BUILTIN_STANDARD_GLOBAL).first_or_initialize }
       permissions { [:view_user_email] }
     end
+
+    factory :empty_global_role do
+      name { "Empty global role" }
+      builtin { Role::BUILTIN_STANDARD_GLOBAL }
+      initialize_with { GlobalRole.where(builtin: Role::BUILTIN_STANDARD_GLOBAL).first_or_initialize }
+      permissions { [] }
+    end
   end
 end

--- a/spec/factories/user_preference_factory.rb
+++ b/spec/factories/user_preference_factory.rb
@@ -29,7 +29,6 @@
 FactoryBot.define do
   factory :user_preference do
     user
-    hide_mail { true }
     transient do
       others { {} }
     end

--- a/spec/features/groups/group_memberships_spec.rb
+++ b/spec/features/groups/group_memberships_spec.rb
@@ -29,6 +29,8 @@
 require "spec_helper"
 
 RSpec.describe "group memberships through groups page", :js, :with_cuprite do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
   shared_let(:admin) { create(:admin) }
   let!(:project) do
     create(:project, name: "Project 1", identifier: "project1", members: project_members)
@@ -64,6 +66,25 @@ RSpec.describe "group memberships through groups page", :js, :with_cuprite do
     expect(members_page).to have_group "A-Team", roles: ["Manager"]
     expect(members_page).to have_user "Peter Pan", roles: ["Manager"]
     expect(members_page).to have_user "Hannibal Smith", roles: ["Manager"]
+  end
+
+  context "when using the user auto completer to add a user to the group" do
+    it "lets the admin see the email addresses of all users" do
+      group_page.visit!
+      group_page.open_users_tab!
+      SeleniumHubWaiter.wait
+
+      autocomplete = find(".new-group-members--autocomplete")
+      target_dropdown = search_autocomplete autocomplete,
+                                            query: "",
+                                            results_selector: "body"
+
+      expect(target_dropdown).to have_css(".ng-option", text: admin.firstname)
+      expect(target_dropdown).to have_css(".ng-option", text: admin.mail)
+
+      expect(target_dropdown).to have_css(".ng-option", text: hannibal.firstname)
+      expect(target_dropdown).to have_css(".ng-option", text: hannibal.mail)
+    end
   end
 
   context "when there are only invited users not in the group" do

--- a/spec/features/members/membership_filter_spec.rb
+++ b/spec/features/members/membership_filter_spec.rb
@@ -96,18 +96,19 @@ RSpec.describe "group memberships through groups page", :js do
         expect(page).to have_no_css("td.mail", text: hannibal.mail)
         members_page.find_user "Peter Pan"
         members_page.find_mail peter.mail
-
         members_page.search_for_name "@example"
         # Does not find other users based on their email address
         expect(page).to have_no_css("tr", text: "Pan Hannibal")
         expect(page).to have_no_css("td.mail", text: hannibal.mail)
-        members_page.find_user "Peter Pan"
-        members_page.find_mail peter.mail
+        expect(page).to have_no_css("tr", text: "Peter Pan")
+        expect(page).to have_no_css("td.mail", text: peter.mail)
 
         members_page.search_for_name "@example.org"
-        members_page.find_user "Peter Pan"
-        members_page.find_mail peter.mail
+        # Does not find other users based on their email address
+        expect(page).to have_no_css("tr", text: "Pan Hannibal")
         expect(page).to have_no_css("td.mail", text: hannibal.mail)
+        expect(page).to have_no_css("tr", text: "Peter Pan")
+        expect(page).to have_no_css("td.mail", text: peter.mail)
       end
     end
 

--- a/spec/features/members/membership_filter_spec.rb
+++ b/spec/features/members/membership_filter_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe "group memberships through groups page", :js do
            firstname: "Peter",
            lastname: "Pan",
            mail: "foo@example.org",
-           member_with_roles: { project => role },
-           preferences: { hide_mail: false })
+           member_with_roles: { project => role })
   end
 
   let!(:hannibal) do
@@ -46,36 +45,76 @@ RSpec.describe "group memberships through groups page", :js do
            firstname: "Pan",
            lastname: "Hannibal",
            mail: "foo@example.com",
-           member_with_roles: { project => role },
-           preferences: { hide_mail: true })
+           member_with_roles: { project => role })
   end
-  let(:role) { create(:project_role, permissions: %i(add_work_packages)) }
+  let(:role) { create(:project_role, permissions: %i(add_work_packages view_members)) }
   let(:members_page) { Pages::Members.new project.identifier }
+  let(:user_to_login) { admin }
+  let(:standard_global_role) { nil }
 
   before do
-    login_as(admin)
+    standard_global_role
+    login_as user_to_login
     members_page.visit!
     expect_angular_frontend_initialized
   end
 
-  it "filters users based on some name attribute" do
-    members_page.open_filters!
+  shared_examples "it filters users" do
+    it "filters users based on some name attribute" do
+      members_page.open_filters!
 
-    members_page.search_for_name "pan"
-    members_page.find_user "Pan Hannibal"
-    expect(page).to have_no_css("td.mail", text: hannibal.mail)
-    members_page.find_user "Peter Pan"
-    members_page.find_mail peter.mail
+      members_page.search_for_name "pan"
+      members_page.find_user "Pan Hannibal"
+      expect(page).to have_no_css("td.mail", text: hannibal.mail)
+      members_page.find_user "Peter Pan"
+      members_page.find_mail peter.mail
 
-    members_page.search_for_name "@example"
-    members_page.find_user "Pan Hannibal"
-    expect(page).to have_no_css("td.mail", text: hannibal.mail)
-    members_page.find_user "Peter Pan"
-    members_page.find_mail peter.mail
+      members_page.search_for_name "@example"
+      members_page.find_user "Pan Hannibal"
+      expect(page).to have_no_css("td.mail", text: hannibal.mail)
+      members_page.find_user "Peter Pan"
+      members_page.find_mail peter.mail
 
-    members_page.search_for_name "@example.org"
-    members_page.find_user "Peter Pan"
-    members_page.find_mail peter.mail
-    expect(page).to have_no_css("td.mail", text: hannibal.mail)
+      members_page.search_for_name "@example.org"
+      members_page.find_user "Peter Pan"
+      members_page.find_mail peter.mail
+      expect(page).to have_no_css("td.mail", text: hannibal.mail)
+    end
+  end
+
+  it_behaves_like "it filters users"
+
+  context "with a user" do
+    let(:user_to_login) { peter }
+
+    context "without view_user_email permission" do
+      it "filters users based on some name attribute" do
+        members_page.open_filters!
+
+        members_page.search_for_name "pan"
+        members_page.find_user "Pan Hannibal"
+        expect(page).to have_no_css("td.mail", text: hannibal.mail)
+        members_page.find_user "Peter Pan"
+        members_page.find_mail peter.mail
+
+        members_page.search_for_name "@example"
+        # Does not find other users based on their email address
+        expect(page).to have_no_css("tr", text: "Pan Hannibal")
+        expect(page).to have_no_css("td.mail", text: hannibal.mail)
+        members_page.find_user "Peter Pan"
+        members_page.find_mail peter.mail
+
+        members_page.search_for_name "@example.org"
+        members_page.find_user "Peter Pan"
+        members_page.find_mail peter.mail
+        expect(page).to have_no_css("td.mail", text: hannibal.mail)
+      end
+    end
+
+    context "with view_user_email permission" do
+      let(:standard_global_role) { create :standard_global_role }
+
+      it_behaves_like "it filters users"
+    end
   end
 end

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -37,16 +37,14 @@ RSpec.describe "Administrating memberships via the project settings", :js, :with
            status: User.statuses[:active],
            firstname: "Peter",
            lastname: "Pan",
-           mail: "foo@example.org",
-           preferences: { hide_mail: false })
+           mail: "foo@example.org")
   end
   shared_let(:hannibal) do
     create(:user,
            status: User.statuses[:invited],
            firstname: "Hannibal",
            lastname: "Smith",
-           mail: "boo@bar.org",
-           preferences: { hide_mail: true })
+           mail: "boo@bar.org")
   end
   shared_let(:developer_placeholder) { create(:placeholder_user, name: "Developer 1") }
   shared_let(:group) do
@@ -63,10 +61,12 @@ RSpec.describe "Administrating memberships via the project settings", :js, :with
   let!(:existing_members) { [] }
 
   let(:members_page) { Pages::Members.new project.identifier }
+  let(:standard_global_role) { nil }
 
   current_user { admin }
 
   before do
+    standard_global_role
     members_page.visit!
 
     SeleniumHubWaiter.wait
@@ -87,7 +87,7 @@ RSpec.describe "Administrating memberships via the project settings", :js, :with
       SeleniumHubWaiter.wait
       members_page.sort_by "email"
       members_page.expect_sorted_by "email"
-      expect(members_page.contents("email")).to eq [peter.mail]
+      expect(members_page.contents("email")).to eq [hannibal.mail, peter.mail]
 
       SeleniumHubWaiter.wait
       members_page.sort_by "status"
@@ -136,6 +136,24 @@ RSpec.describe "Administrating memberships via the project settings", :js, :with
       expect(members_page).to have_user "Hannibal Smith"
       expect(members_page).not_to have_user "Peter Pan"
       expect(members_page).not_to have_group group.name
+    end
+
+    context "as a member" do
+      current_user { peter }
+
+      context "without view_user_email permission" do
+        it "does not display other user email addresses" do
+          expect(members_page.contents("email")).to eq([peter.mail])
+        end
+      end
+
+      context "with view_user_email permission" do
+        let(:standard_global_role) { create :standard_global_role }
+
+        it "displays other user email addresses" do
+          expect(members_page.contents("email")).to eq([hannibal.mail, peter.mail])
+        end
+      end
     end
   end
 

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -178,6 +178,44 @@ RSpec.describe "Project list sharing",
           # projects_index_page.expect_toast(message: "The modified list has been saved")
         end
       end
+
+      context "when searching for users to share with" do
+        it "does not show the mail address of other users" do
+          using_session "sharer" do
+            login_as(sharer)
+
+            projects_index_page.visit!
+            projects_index_page.set_sidebar_filter "Member-of list"
+            projects_index_page.open_share_dialog
+
+            share_dialog.expect_open
+            target_dropdown = share_dialog.search_user("")
+
+            expect(target_dropdown).to have_css(".ng-option", text: wildcard_user.firstname)
+            expect(target_dropdown).to have_no_css(".ng-option", text: wildcard_user.mail)
+          end
+        end
+
+        context "with permission to see emails" do
+          let!(:standard) { create(:standard_global_role) }
+
+          it "does show the mail address of other users" do
+            using_session "sharer" do
+              login_as(sharer)
+
+              projects_index_page.visit!
+              projects_index_page.set_sidebar_filter "Member-of list"
+              projects_index_page.open_share_dialog
+
+              share_dialog.expect_open
+              target_dropdown = share_dialog.search_user("")
+
+              expect(target_dropdown).to have_css(".ng-option", text: wildcard_user.firstname)
+              expect(target_dropdown).to have_css(".ng-option", text: wildcard_user.mail)
+            end
+          end
+        end
+      end
     end
 
     context "without the permission to manage public project lists" do

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -458,14 +458,12 @@ RSpec.describe "my", :js, :with_cuprite do
         expect(page).to have_text(I18n.t("user.text_change_disabled_for_ldap_login"), count: 3)
 
         fill_in "Hobbies", with: "Ruby, DCS"
-        uncheck "pref[hide_mail]"
         click_on "Save"
 
         expect(page).to have_content I18n.t(:notice_account_updated)
 
         user.reload
         expect(user.custom_values.find_by(custom_field_id: string_cf).value).to eql "Ruby, DCS"
-        expect(user.pref.hide_mail).to be false
       end
     end
 

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require "features/page_objects/notification"
 
 RSpec.describe "edit work package", :js do
+  let!(:standard_global_role) { create(:empty_global_role) }
   let(:dev_role) do
     create(:project_role,
            permissions: %i[view_work_packages
@@ -319,13 +320,7 @@ RSpec.describe "edit work package", :js do
     end
 
     context "with permission to see emails" do
-      let(:dev_role) do
-        create(:project_role,
-               permissions: %i[view_work_packages
-                               edit_work_packages
-                               view_user_email
-                               work_package_assigned])
-      end
+      let!(:standard_global_role) { create(:standard_global_role) }
 
       context "when assigning people to a work package" do
         include_examples "with permission", "assignee"

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -267,7 +267,9 @@ RSpec.describe "edit work package", :js do
   context "when using the user auto completer" do
     RSpec.shared_examples "without permission" do |field_name|
       it "does not show you the email of other users" do
-        wp_page.open_user_auto_completer(field_name)
+        completer = wp_page.edit_field field_name
+        completer.activate!
+
         options = wp_page.visible_user_auto_completer_options
 
         expected_options = [
@@ -281,7 +283,9 @@ RSpec.describe "edit work package", :js do
 
     RSpec.shared_examples "with permission" do |field_name|
       it "does show you the email of other users" do
-        wp_page.open_user_auto_completer(field_name)
+        completer = wp_page.edit_field field_name
+        completer.activate!
+
         options = wp_page.visible_user_auto_completer_options
 
         expected_options = [

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 require "features/page_objects/notification"
 
-RSpec.describe "edit work package", :js do
+RSpec.describe "edit work package", :js, :with_cuprite do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
   let!(:standard_global_role) { create(:empty_global_role) }
   let(:dev_role) do
     create(:project_role,
@@ -271,7 +273,7 @@ RSpec.describe "edit work package", :js do
         completer = wp_page.edit_field field_name
         completer.activate!
 
-        options = wp_page.visible_user_auto_completer_options
+        options = visible_user_auto_completer_options
 
         expected_options = [
           { name: manager.name, email: nil },  # Manager's email should not be visible
@@ -287,7 +289,7 @@ RSpec.describe "edit work package", :js do
         completer = wp_page.edit_field field_name
         completer.activate!
 
-        options = wp_page.visible_user_auto_completer_options
+        options = visible_user_auto_completer_options
 
         expected_options = [
           # With the right permissions, you can see other users email address

--- a/spec/features/work_packages/share/share_spec.rb
+++ b/spec/features/work_packages/share/share_spec.rb
@@ -384,7 +384,8 @@ RSpec.describe "Work package sharing",
   end
 
   context "when having global invite permission" do
-    let(:global_manager_user) { create(:user, global_permissions: %i[manage_user create_user]) }
+    let(:global_permissions) { %i[manage_user create_user] }
+    let(:global_manager_user) { create(:user, global_permissions:) }
     let(:current_user) { global_manager_user }
     let(:locked_user) { create(:user, mail: "holly@openproject.com", status: :locked) }
 
@@ -451,6 +452,30 @@ RSpec.describe "Work package sharing",
       # The number of shared people has not changed, but an error message is shown
       share_modal.expect_shared_count_of(6)
       share_modal.expect_error_message(I18n.t("sharing.warning_locked_user", user: locked_user.name))
+    end
+
+    describe "filtering and displaying user email addresses" do
+      context "when having view email permissions" do
+        let(:global_permissions) { %i[manage_user create_user view_user_email] }
+
+        it "allows filtering by and displaying user emails" do
+          share_modal.search_user(richard.mail)
+          share_modal.expect_ng_option("", "Richard Hendricks#{richard.mail}", results_selector: "body")
+        end
+      end
+
+      context "when having no view email permissions" do
+        it "does not allow filtering by and displaying user emails" do
+          # does not display any email addresses
+          share_modal.search_user("Richard Hendricks")
+          share_modal.expect_ng_option("", "Richard Hendricks", results_selector: "body")
+          share_modal.expect_no_ng_option("", "Richard Hendricks#{richard.mail}", results_selector: "body")
+
+          # does not allow filtering by email
+          share_modal.search_user(richard.mail)
+          share_modal.expect_no_ng_option("", "Richard Hendricks", results_selector: "body")
+        end
+      end
     end
   end
 

--- a/spec/features/work_packages/share/share_spec.rb
+++ b/spec/features/work_packages/share/share_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe "Work package sharing",
 
         it "allows filtering by and displaying user emails" do
           share_modal.search_user(richard.mail)
-          share_modal.expect_ng_option("", "Richard Hendricks#{richard.mail}", results_selector: "body")
+          share_modal.expect_ng_option("", "Richard Hendricks #{richard.mail}", results_selector: "body")
         end
       end
 
@@ -469,7 +469,7 @@ RSpec.describe "Work package sharing",
           # does not display any email addresses
           share_modal.search_user("Richard Hendricks")
           share_modal.expect_ng_option("", "Richard Hendricks", results_selector: "body")
-          share_modal.expect_no_ng_option("", "Richard Hendricks#{richard.mail}", results_selector: "body")
+          share_modal.expect_no_ng_option("", "Richard Hendricks #{richard.mail}", results_selector: "body")
 
           # does not allow filtering by email
           share_modal.search_user(richard.mail)

--- a/spec/lib/api/v3/groups/group_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/groups/group_sql_representer_rendering_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe API::V3::Groups::GroupSqlRepresenter, "rendering" do
         _type: "Group",
         id: group.id,
         name: group.name,
+        email: "",
         _links: {
           self: {
             href: api_v3_paths.group(group.id),

--- a/spec/lib/api/v3/placeholder_users/placeholder_user_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/placeholder_users/placeholder_user_sql_representer_rendering_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUserSqlRepresenter, "render
         _type: "PlaceholderUser",
         id: placeholder_user.id,
         name: placeholder_user.name,
+        email: "",
         _links: {
           self: {
             href: api_v3_paths.placeholder_user(placeholder_user.id),

--- a/spec/lib/api/v3/principals/principal_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/principals/principal_sql_representer_rendering_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe API::V3::Principals::PrincipalSqlRepresenter, "rendering" do
         _type: "Group",
         id: group.id,
         name: group.name,
+        email: "",
         _links: {
           self: {
             href: api_v3_paths.group(group.id),
@@ -83,6 +84,7 @@ RSpec.describe API::V3::Principals::PrincipalSqlRepresenter, "rendering" do
         _type: "PlaceholderUser",
         id: placeholder_user.id,
         name: placeholder_user.name,
+        email: "",
         _links: {
           self: {
             href: api_v3_paths.placeholder_user(placeholder_user.id),
@@ -108,6 +110,7 @@ RSpec.describe API::V3::Principals::PrincipalSqlRepresenter, "rendering" do
         name: current_user.name,
         firstname: current_user.firstname,
         lastname: current_user.lastname,
+        email: current_user.mail,
         _links: {
           self: {
             href: api_v3_paths.user(current_user.id),

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe API::V3::UserPreferences::UserPreferenceRepresenter,
 
   subject(:generated) { representer.to_json }
 
-  it { expect(subject).to have_json_path("hideMail") }
   it { expect(subject).to have_json_path("timeZone") }
   it { expect(subject).to have_json_path("commentSortDescending") }
   it { expect(subject).to have_json_path("warnOnLeavingUnsaved") }

--- a/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
@@ -187,4 +187,43 @@ RSpec.describe API::V3::Users::UserSqlRepresenter, "rendering" do
       end
     end
   end
+
+  describe "email property" do
+    let(:select) { { "email" => {} } }
+
+    context "when the user is the current user" do
+      it "renders the email" do
+        expect(json)
+          .to be_json_eql(
+            {
+              email: rendered_user.mail
+            }.to_json
+          )
+      end
+    end
+
+    context "when the user has view_user_email permission" do
+      let(:current_user) { create(:user, global_permissions: [:view_user_email]) }
+      let(:rendered_user) { create(:user) }
+
+      it "renders the email" do
+        expect(json)
+          .to be_json_eql(
+            {
+              email: rendered_user.mail
+            }.to_json
+          )
+      end
+    end
+
+    context "when the user has no view_user_email permission" do
+      let(:current_user) { create(:user, global_permissions: []) }
+      let(:rendered_user) { create(:user) }
+
+      it "hides the email" do
+        expect(json)
+          .to be_json_eql({}.to_json)
+      end
+    end
+  end
 end

--- a/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe API::V3::Users::UserSqlRepresenter, "rendering" do
         name: current_user.name,
         firstname: current_user.firstname,
         lastname: current_user.lastname,
+        email: current_user.mail,
         _links: {
           self: {
             href: api_v3_paths.user(current_user.id),

--- a/spec/migrations/remove_hide_mail_from_user_preferences_spec.rb
+++ b/spec/migrations/remove_hide_mail_from_user_preferences_spec.rb
@@ -1,0 +1,61 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20241002151949_remove_hide_mail_from_user_preferences.rb")
+
+RSpec.describe RemoveHideMailFromUserPreferences, type: :model do
+  # Silencing migration logs, since we are not interested in that during testing
+  subject(:run_migration) do
+    perform_enqueued_jobs do
+      ActiveRecord::Migration.suppress_messages { described_class.new.up }
+    end
+  end
+
+  context "when hide_mail user preference exists" do
+    before do
+      create(:user_preference, settings: { hide_mail: true, other: "setting" })
+    end
+
+    it "removes the flag" do
+      run_migration
+      expect(UserPreference.first.settings).to eq({ "other" => "setting" })
+    end
+  end
+
+  context "when hide_mail user preference does not exists" do
+    before do
+      create(:user_preference, settings: { other: "setting" })
+    end
+
+    it "does nothing" do
+      run_migration
+      expect(UserPreference.first.settings).to eq({ "other" => "setting" })
+    end
+  end
+end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe PermittedParams do
     let(:attribute) { :pref }
 
     let(:hash) do
-      acceptable_params = %w(hide_mail time_zone
-                             comments_sorting warn_on_leaving_unsaved)
+      acceptable_params = %w(time_zone comments_sorting
+                             warn_on_leaving_unsaved)
 
       acceptable_params.index_with { |_x| "value" }
     end

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -101,27 +101,6 @@ RSpec.describe UserPreference do
     end
   end
 
-  describe "hide_mail" do
-    it_behaves_like "accepts real and false booleans",
-                    :hide_mail=,
-                    :hide_mail?
-
-    context "when a new pref instance" do
-      subject { described_class.new }
-
-      it "defaults to true" do
-        expect(subject.settings[:hide_mail]).to be_nil
-        expect(subject.hide_mail).to be true
-        expect(subject.hide_mail?).to be true
-
-        subject.hide_mail = false
-        expect(subject.settings[:hide_mail]).to be false
-        expect(subject.hide_mail).to be false
-        expect(subject.hide_mail?).to be false
-      end
-    end
-  end
-
   describe "#diff_type" do
     it "can be set and written" do
       expect(subject.diff_type)

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -418,6 +418,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
                 _type: "Group",
                 id: other_group.id,
                 name: other_group.name,
+                email: "",
                 _links: {
                   self: {
                     href: api_v3_paths.group(other_group.id),
@@ -429,6 +430,7 @@ RSpec.describe "API v3 Group resource", content_type: :json do
                 _type: "Group",
                 id: group.id,
                 name: group.name,
+                email: "",
                 _links: {
                   self: {
                     href: api_v3_paths.group(group.id),

--- a/spec/requests/api/v3/placeholder_users/index_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/index_resource_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUsersAPI,
               _type: "PlaceholderUser",
               id: placeholder2.id,
               name: placeholder2.name,
+              email: "",
               _links: {
                 self: {
                   href: api_v3_paths.placeholder_user(placeholder2.id),
@@ -81,6 +82,7 @@ RSpec.describe API::V3::PlaceholderUsers::PlaceholderUsersAPI,
               _type: "PlaceholderUser",
               id: placeholder1.id,
               name: placeholder1.name,
+              email: "",
               _links: {
                 self: {
                   href: api_v3_paths.placeholder_user(placeholder1.id),

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe "API v3 Principals resource" do
                 _type: "PlaceholderUser",
                 id: placeholder_user.id,
                 name: placeholder_user.name,
+                email: "",
                 _links: {
                   self: {
                     href: api_v3_paths.placeholder_user(placeholder_user.id),
@@ -239,6 +240,7 @@ RSpec.describe "API v3 Principals resource" do
                 _type: "Group",
                 id: group.id,
                 name: group.name,
+                email: "",
                 _links: {
                   self: {
                     href: api_v3_paths.group(group.id),
@@ -250,6 +252,7 @@ RSpec.describe "API v3 Principals resource" do
                 _type: "User",
                 id: other_user.id,
                 name: other_user.name,
+                email: other_user.mail,
                 _links: {
                   self: {
                     href: api_v3_paths.user(other_user.id),
@@ -263,6 +266,7 @@ RSpec.describe "API v3 Principals resource" do
                 name: user.name,
                 firstname: user.firstname,
                 lastname: user.lastname,
+                email: user.mail,
                 _links: {
                   self: {
                     href: api_v3_paths.user(user.id),

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -252,7 +252,6 @@ RSpec.describe "API v3 Principals resource" do
                 _type: "User",
                 id: other_user.id,
                 name: other_user.name,
-                email: other_user.mail,
                 _links: {
                   self: {
                     href: api_v3_paths.user(other_user.id),

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "API v3 Principals resource" do
         [{ any_name_attribute: { operator: "~", values: ["aaaa@example.com"] } }]
       end
 
-      context "when user havs permission to view user emails" do
+      context "when user has permission to view user emails" do
         let(:standard_global_role) { create :standard_global_role }
 
         it_behaves_like "API V3 collection response", 1, 1, "User"

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -305,6 +305,7 @@ RSpec.describe "API v3 Watcher resource", content_type: :json do
                 _type: "User",
                 id: available_watcher.id,
                 name: available_watcher.name,
+                email: available_watcher.mail,
                 _links: {
                   self: {
                     href: api_v3_paths.user(available_watcher.id),
@@ -318,6 +319,7 @@ RSpec.describe "API v3 Watcher resource", content_type: :json do
                 name: current_user.name,
                 firstname: current_user.firstname,
                 lastname: current_user.lastname,
+                email: current_user.mail,
                 _links: {
                   self: {
                     href: api_v3_paths.user(current_user.id),

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -305,7 +305,6 @@ RSpec.describe "API v3 Watcher resource", content_type: :json do
                 _type: "User",
                 id: available_watcher.id,
                 name: available_watcher.name,
-                email: available_watcher.mail,
                 _links: {
                   self: {
                     href: api_v3_paths.user(available_watcher.id),

--- a/spec/services/users/set_attributes_service_integration_spec.rb
+++ b/spec/services/users/set_attributes_service_integration_spec.rb
@@ -40,16 +40,6 @@ RSpec.describe Users::SetAttributesService, "Integration", type: :model do
 
   subject { instance.call(params) }
 
-  context "with a boolean castable preference" do
-    let(:params) do
-      { pref: { hide_mail: "0" } }
-    end
-
-    it "returns an error for that" do
-      expect(subject.errors).to be_empty
-    end
-  end
-
   context "with an invalid parameter" do
     let(:params) do
       { pref: { workdays: "foobar" } }

--- a/spec/services/users/set_attributes_service_integration_spec.rb
+++ b/spec/services/users/set_attributes_service_integration_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe Users::SetAttributesService, "Integration", type: :model do
 
   subject { instance.call(params) }
 
+  context "with a boolean castable preference" do
+    let(:params) do
+      { pref: { warn_on_leaving_unsaved: "0" } }
+    end
+
+    it "returns no error for that" do
+      expect(subject.errors).to be_empty
+    end
+  end
+
   context "with an invalid parameter" do
     let(:params) do
       { pref: { workdays: "foobar" } }

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -132,12 +132,16 @@ module Components::Autocompleter
     #
     # The order of elements in the Array is equal to the visible order on the website.
     def visible_user_auto_completer_options
-      find(".ng-dropdown-panel [role='listbox']").all(".ng-option[role='option']").map do |opt|
+      find(".ng-dropdown-panel [role='listbox']").all(".ng-option[role='option']").filter_map do |opt|
         name = opt.find(".op-user-autocompleter--name").text
         email_element = opt.all(".op-autocompleter__option-principal-email").first
         email = email_element&.text
 
         { name:, email: }
+      rescue Capybara::ElementNotFound
+        # In rare cases, the auto completer result body includes additional elements that do not contain all of the
+        # expected information. For example in the share modal. We will omit these entries.
+        nil
       end
     end
   end

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -118,5 +118,27 @@ module Components::Autocompleter
       # click the element to select it
       target_dropdown.find(".ng-option", text:, match: :first, wait: 15).click
     end
+
+    # Finds the currently visible, expanded user auto completer and returns its dropdown menu options.
+    # A user always has a name, but their email is only visible in certain circumstances, so that value
+    # might be nil.
+    #
+    # The options are returned as an Array of Hashes, like this example with two users:
+    #
+    #   [
+    #     { name: "Bob", email: nil },
+    #     { name: "Alice", email: "alice@example.com" }
+    #   ]
+    #
+    # The order of elements in the Array is equal to the visible order on the website.
+    def visible_user_auto_completer_options
+      find(".ng-dropdown-panel [role='listbox']").all(".ng-option[role='option']").map do |opt|
+        name = opt.find(".op-user-autocompleter--name").text
+        email_element = opt.all(".op-autocompleter__option-principal-email").first
+        email = email_element&.text
+
+        { name:, email: }
+      end
+    end
   end
 end

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -33,10 +33,10 @@ module Components::Autocompleter
       retry_block do
         if results_selector
           results_selector = "#{results_selector} .ng-dropdown-panel" if results_selector == "body"
-          page.find(results_selector)
+          page.find(results_selector, wait: 5)
         else
           within(element) do
-            page.find("ng-select .ng-dropdown-panel")
+            page.find("ng-select .ng-dropdown-panel", wait: 5)
           end
         end
       rescue StandardError => e

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -89,7 +89,7 @@ module Components
       end
 
       def open_select_in_step(selector, query = "")
-        select_field = modal_element.find(selector)
+        select_field = modal_element.find(selector, wait: 5)
 
         search_autocomplete select_field,
                             query:,

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -113,7 +113,7 @@ module Components
 
       def expect_loaded
         SeleniumHubWaiter.wait
-        expect(filter_button).to have_css(".badge", wait: 2, visible: :all)
+        expect(filter_button).to have_css(".badge", wait: 10, visible: :all)
       end
 
       def add_filter(name)

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -33,6 +33,8 @@ module Pages
     attr_reader :project, :work_package
 
     def initialize(work_package, project = nil)
+      super()
+
       @work_package = work_package
       @project = project
     end

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -330,10 +330,6 @@ module Pages
       find('[data-test-selector="mark-notification-read-button"]').click
     end
 
-    def open_user_auto_completer(field = "assignee")
-      find("op-editable-attribute-field[ng-reflect-field-name='#{field}'] [role='button']", wait: 10).click
-    end
-
     # Finds the currently visible, expanded user auto completer and returns its dropdown menu options.
     # A user always has a name, but their email is only visible in certain circumstances, so that value
     # might be nil.

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -332,28 +332,6 @@ module Pages
       find('[data-test-selector="mark-notification-read-button"]').click
     end
 
-    # Finds the currently visible, expanded user auto completer and returns its dropdown menu options.
-    # A user always has a name, but their email is only visible in certain circumstances, so that value
-    # might be nil.
-    #
-    # The options are returned as an Array of Hashes, like this example with two users:
-    #
-    #   [
-    #     { name: "Bob", email: nil },
-    #     { name: "Alice", email: "alice@example.com" }
-    #   ]
-    #
-    # The order of elements in the Array is equal to the visible order on the website.
-    def visible_user_auto_completer_options
-      find(".ng-dropdown-panel [role='listbox']").all(".ng-option[role='option']").map do |opt|
-        name = opt.find(".op-user-autocompleter--name").text
-        email_element = opt.all(".op-autocompleter__option-principal-email").first
-        email = email_element&.text
-
-        { name:, email: }
-      end
-    end
-
     private
 
     def create_page(_args)

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -330,6 +330,32 @@ module Pages
       find('[data-test-selector="mark-notification-read-button"]').click
     end
 
+    def open_user_auto_completer(field = "assignee")
+      find("op-editable-attribute-field[ng-reflect-field-name='#{field}'] [role='button']", wait: 10).click
+    end
+
+    # Finds the currently visible, expanded user auto completer and returns its dropdown menu options.
+    # A user always has a name, but their email is only visible in certain circumstances, so that value
+    # might be nil.
+    #
+    # The options are returned as an Array of Hashes, like this example with two users:
+    #
+    #   [
+    #     { name: "Bob", email: nil },
+    #     { name: "Alice", email: "alice@example.com" }
+    #   ]
+    #
+    # The order of elements in the Array is equal to the visible order on the website.
+    def visible_user_auto_completer_options
+      find(".ng-dropdown-panel [role='listbox']").all(".ng-option[role='option']").map do |opt|
+        name = opt.find(".op-user-autocompleter--name").text
+        email_element = opt.all(".op-autocompleter__option-principal-email").first
+        email = email_element&.text
+
+        { name:, email: }
+      end
+    end
+
     private
 
     def create_page(_args)

--- a/spec/support/pages/work_packages/split_work_package.rb
+++ b/spec/support/pages/work_packages/split_work_package.rb
@@ -74,7 +74,7 @@ module Pages
     end
 
     def create_page(args)
-      args.merge!(project: project || work_package.project)
+      args[:project] = project || work_package.project
       SplitWorkPackageCreate.new(**args)
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58144

# What are you trying to accomplish?
Remove hide_mail flag and replace with :view_user_email permission checks.
Display email addresses in the user autocompleters.

# ToDo
- [x] Remove user hide_mail setting.
- [x] Replace existing user email preferences with a `view_user_email` permission check.
- [x] Update autocompleters to display emails based on the `view_user_email` permission check.
  - [x] Select project members
  - [x] Share work packages
  - [x] Work Package assignee, accountable, watchers
  - [x] Work Package filter user autocompleters
  - [x] Share project lists
  - [x] Select group members
  - [x] Invite user modal (+ button on the top bar)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
