### PR TITLE
Add helm release trigger workflow when a docker release is done

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -308,3 +308,20 @@ jobs:
     with:
       subject: "Docker build failed"
       body: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  trigger_helm_release:
+    needs: [setup, build, merge]
+    permissions:
+      contents: none
+    if: github.repository == 'opf/openproject'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Helm charts release
+        env:
+          TOKEN: ${{ secrets.OPENPROJECT_CI_TOKEN }}
+          REPOSITORY: opf/helm-charts
+          WORKFLOW_ID: core_release.yml
+        run: |
+          curl -i --fail-with-body -H"authorization: Bearer $TOKEN" \
+            -XPOST -H"Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$REPOSITORY/actions/workflows/$WORKFLOW_ID/dispatches \
+            -d '{"ref": "dev", "inputs": { "tag" : "${{ needs.setup.outputs.version }}" }}'


### PR DESCRIPTION
When the docker release are pushed, we want to automate the release (or upgrade) of the helm chart appVersion so they are easily upgradable.

This could be part of the devkit action, but then the tag is not yet ready, and causes the PR to fail. Instead, we can trigger it as the last step of the docker workflow.