### PR TITLE
Render work packages menu without using request.referer

### DIFF
--- a/app/controllers/work_packages/menus_controller.rb
+++ b/app/controllers/work_packages/menus_controller.rb
@@ -30,7 +30,7 @@ module WorkPackages
     before_action :load_and_authorize_in_optional_project
 
     def show
-      @sidebar_menu_items = WorkPackages::Menu.new(project: @project, params:, request:).menu_items
+      @sidebar_menu_items = WorkPackages::Menu.new(project: @project, params:).menu_items
       render layout: nil
     end
   end

--- a/app/menus/work_packages/menu.rb
+++ b/app/menus/work_packages/menu.rb
@@ -29,9 +29,8 @@ module WorkPackages
   class Menu < Submenu
     attr_reader :view_type, :project, :params
 
-    def initialize(project: nil, params: nil, request: nil)
+    def initialize(project: nil, params: nil)
       @view_type = "work_packages_table"
-      @request = request
 
       super(view_type:, project:, params:)
     end
@@ -69,7 +68,7 @@ module WorkPackages
 
       if query_params[:work_package_default] &&
         (%i[filters query_props query_id name].none? { |k| params.key? k }) &&
-        @request.referer.include?("work_packages")
+        params[:on_work_package_path] == "true"
         return true
       end
 

--- a/app/views/work_packages/menus/_menu.html.erb
+++ b/app/views/work_packages/menus/_menu.html.erb
@@ -1,5 +1,14 @@
+<%
+  on_work_package_path = request.path.include?('/work_packages')
+  path =
+    if @project
+      menu_project_work_packages_path(@project, **params.permit(:query_props, :query_id, :name), on_work_package_path:)
+    else
+      work_packages_menu_path(**params.permit(:query_props, :query_id, :name), on_work_package_path:)
+    end
+%>
 <%= turbo_frame_tag "work_packages_sidemenu",
-                    src: @project ? menu_project_work_packages_path(@project, params.permit(:query_props, :query_id, :name)) : work_packages_menu_path(params.permit(:query_props, :query_id, :name)),
+                    src: path,
                     target: "_top",
                     data: { turbo: false },
                     loading: :lazy %>


### PR DESCRIPTION
Instead of using the request.referer (which may be nil and cause error), explicitly pass the check if we're on the work packages route

https://community.openproject.org/projects/openproject/work_packages/58327/activity