### PR TITLE
Use absolute path to load `.ruby-version` file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ source "https://rubygems.org"
 # then we can use the new bundler syntax `ruby file: '.ruby-version'`.
 # https://github.com/heroku/heroku-buildpack-ruby/issues/1408#issuecomment-1841596215
 
-ruby File.read(".ruby-version").strip
+ruby File.read(File.expand_path(".ruby-version", __dir__)).strip
 
 gem "actionpack-xml_parser", "~> 2.0.0"
 gem "activemodel-serializers-xml", "~> 1.0.1"


### PR DESCRIPTION
# Ticket

none

# What are you trying to accomplish?

The ruby-lsp extension from VSCode editor sometimes tries to load this `.ruby-version` file while its current working directory is not the root of the repository. The ruby-lsp extension then fails to load.

It happens when I open another workspace from the command line while a workspace is already opened.

By using an absolute path to load the `.ruby-version` file, this issue is avoided.