### PR TITLE
Move the selected menu item into submenu component

### DIFF
--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -130,9 +130,9 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
   def current_section
     return @current_section if defined?(@current_section)
 
-    projects_menu = Projects::Menu.new(controller_path:, params:, current_user:)
-
-    @current_section = projects_menu.menu_items.find { |section| section.children.any?(&:selected) }
+    @current_section = Projects::Menu
+      .new(controller_path:, params:, current_user:)
+      .selected_menu_group
   end
 
   def header_save_action(header:, message:, label:, href:, method: nil)

--- a/app/menus/submenu.rb
+++ b/app/menus/submenu.rb
@@ -44,6 +44,20 @@ class Submenu
     ]
   end
 
+  def selected_menu_group
+    menu_items.detect do |group|
+      group.children.detect(&:selected)
+    end
+  end
+
+  def selected_menu_item
+    menu_items.each do |group|
+      group.children.each do |item|
+        return item if item.selected
+      end
+    end
+  end
+
   def starred_queries
     base_query
       .where("starred" => "t")


### PR DESCRIPTION
In case we need a selected menu item name from a page header (or somewhere else), we should be able to get it from the submenu