### PR TITLE
[53809] Fix issues in PageHeaders & SubHeaders in the (rails) global index pages

### DIFF
--- a/app/components/add_button_component.html.erb
+++ b/app/components/add_button_component.html.erb
@@ -1,9 +1,11 @@
-<a href="<%= dynamic_path %>"
-   id="<%= id %>"
-   title="<%= title %>"
-   arial-label="<%= aria_label %>"
-   class="<%= link_css_class %>">
-  <%= icon %>
-  <%= label %>
-</a>
-
+<%= render(Primer::ButtonComponent.new(scheme: :primary,
+                                       aria: { label: aria_label },
+                                       title:,
+                                       test_selector:,
+                                       tag: :a,
+                                       id:,
+                                       href: dynamic_path) ) do |button|
+  button.with_leading_visual_icon(icon: :plus)
+  label_text
+end
+%>

--- a/app/components/add_button_component.rb
+++ b/app/components/add_button_component.rb
@@ -48,12 +48,6 @@ class AddButtonComponent < ApplicationComponent
     accessibility_label_text
   end
 
-  def label
-    content_tag(:span,
-                label_text,
-                class: "button--text")
-  end
-
   def aria_label
     accessibility_label_text
   end
@@ -64,13 +58,5 @@ class AddButtonComponent < ApplicationComponent
 
   def label_text
     raise "Specify the label text to be used for this component"
-  end
-
-  def link_css_class
-    "button -primary"
-  end
-
-  def icon
-    helpers.op_icon("button--icon icon-add")
   end
 end

--- a/app/components/notifications/index_page_header_component.rb
+++ b/app/components/notifications/index_page_header_component.rb
@@ -47,7 +47,7 @@ module Notifications
     end
 
     def parent_element
-      { href: home_path, text: I18n.t(:label_home) }
+      { href: home_path, text: helpers.organization_name }
     end
   end
 end

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -112,6 +112,7 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
 
   def breadcrumb_items
     [
+      { href: home_path, text: helpers.organization_name },
       { href: projects_path, text: t(:label_project_plural) },
       current_breadcrumb_element
     ]

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -33,8 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { (@author.nil? ? t(:label_activity) : t(:label_user_activity, value: link_to_user(@author))).html_safe }
     header.with_description { t(:label_date_from_to, start: format_date(@date_to - @days), end: format_date(@date_to-1)) }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name},
-                             *([href: project_overview_path(@project.id), text: @project.name] if @project),
+    header.with_breadcrumbs([*([ href: home_path, text: organization_name ] unless @project),
+                             *([ href: project_overview_path(@project.id), text: @project.name ] if @project),
                              t(:label_activity)])
   end
 %>

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -33,11 +33,6 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<h2 class="headline--application">
-  <span><%= organization_icon %></span>
-  <%= organization_name %>
-</h2>
-
 <%= render partial: 'announcements/show' %>
 
 <% if @homescreen[:blocks].any? %>

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -33,9 +33,9 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_news_plural) }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name},
-                               *([href: project_overview_path(@project.id), text: @project.name] if @project),
-                               t(:label_news_plural)])
+    header.with_breadcrumbs([*([ href: home_path, text: organization_name ] unless @project),
+                             *([ href: project_overview_path(@project.id), text: @project.name ] if @project),
+                             t(:label_news_plural)])
   end
 %>
 <% if managable %>

--- a/modules/boards/app/components/boards/add_button_component.rb
+++ b/modules/boards/app/components/boards/add_button_component.rb
@@ -47,6 +47,10 @@ module Boards
       "add-board-button"
     end
 
+    def test_selector
+      "add-board-button"
+    end
+
     def accessibility_label_text
       I18n.t("boards.label_create_new_board")
     end

--- a/modules/boards/app/views/boards/boards/index.html.erb
+++ b/modules/boards/app/views/boards/boards/index.html.erb
@@ -32,8 +32,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t("boards.label_boards") }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name },
-                             *([href: project_overview_path(@project.id), text: @project.name] if @project),
+    header.with_breadcrumbs([*([ href: home_path, text: organization_name ] unless @project),
+                             *([ href: project_overview_path(@project.id), text: @project.name ] if @project),
                              t("boards.label_boards")])
   end
 %>

--- a/modules/boards/app/views/boards/boards/index.html.erb
+++ b/modules/boards/app/views/boards/boards/index.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render Primer::OpenProject::SubHeader.new do |subheader|
-    subheader.with_action_component(data: { "test-selector": "add-board-button"}) do
+    subheader.with_action_component do
        render Boards::AddButtonComponent.new(current_project: @project)
     end
   end

--- a/modules/boards/app/views/boards/boards/index.html.erb
+++ b/modules/boards/app/views/boards/boards/index.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t("boards.label_boards") }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name},
+    header.with_breadcrumbs([{ href: home_path, text: organization_name },
                              *([href: project_overview_path(@project.id), text: @project.name] if @project),
                              t("boards.label_boards")])
   end

--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -59,11 +59,9 @@ module Pages
 
     def create_board(action: "Basic", title: "#{action} Board", expect_empty: false, via_toolbar: true)
       if via_toolbar
-        within '[data-test-selector="add-board-button"]' do
-          click_link "Board"
-        end
+        page.find_test_selector("add-board-button").click
       else
-        find('[data-test-selector="boards--create-button"]').click
+        page.find_test_selector("boards--create-button").click
       end
 
       new_board_page = NewBoard.new

--- a/modules/boards/spec/features/support/board_list_page.rb
+++ b/modules/boards/spec/features/support/board_list_page.rb
@@ -35,15 +35,11 @@ module Pages
     end
 
     def expect_create_button
-      within '[data-test-selector="add-board-button"]' do
-        expect(page).to have_link "Board"
-      end
+      expect(page).to have_test_selector "add-board-button"
     end
 
     def expect_no_create_button
-      within '[data-test-selector="add-board-button"]' do
-        expect(page).to have_no_link "Board"
-      end
+      expect(page).not_to have_test_selector "add-board-button"
     end
 
     def expect_delete_buttons(*boards)

--- a/modules/boards/spec/features/support/board_new_page.rb
+++ b/modules/boards/spec/features/support/board_new_page.rb
@@ -13,9 +13,7 @@ module Pages
     def navigate_by_create_button
       visit work_package_boards_path unless page.current_path == work_package_boards_path
 
-      within '[data-test-selector="add-board-button"]' do
-        click_link "Board"
-      end
+      page.find_test_selector("add-board-button").click
     end
 
     def set_title(title)

--- a/modules/calendar/app/components/calendar/add_button_component.html.erb
+++ b/modules/calendar/app/components/calendar/add_button_component.html.erb
@@ -1,8 +1,0 @@
-<a href="<%= dynamic_path %>"
-   id="<%= id %>"
-   title="<%= title %>"
-   arial-label="<%= aria_label %>"
-   class="<%= link_css_class %>">
-  <%= icon %>
-  <%= label %>
-</a>

--- a/modules/calendar/app/components/calendar/add_button_component.rb
+++ b/modules/calendar/app/components/calendar/add_button_component.rb
@@ -51,6 +51,10 @@ module Calendar
       "add-calendar-button"
     end
 
+    def test_selector
+      "add-calendar-button"
+    end
+
     def accessibility_label_text
       I18n.t("js.calendar.create_new")
     end

--- a/modules/calendar/app/views/calendar/calendars/index.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/index.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render Primer::OpenProject::SubHeader.new do |subheader|
-    subheader.with_action_component(data: { "test-selector": "add-calendar-button"}) do
+    subheader.with_action_component do
       render Calendar::AddButtonComponent.new(current_project: @project)
     end
   end

--- a/modules/calendar/app/views/calendar/calendars/index.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/index.html.erb
@@ -31,8 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_calendar_plural) }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name},
-                             *([href: project_overview_path(@project.id), text: @project.name] if @project),
+    header.with_breadcrumbs([*([ href: home_path, text: organization_name ] unless @project),
+                             *([ href: project_overview_path(@project.id), text: @project.name ] if @project),
                              t(:label_calendar_plural)])
   end
 %>

--- a/modules/calendar/spec/features/calendar_sharing_spec.rb
+++ b/modules/calendar/spec/features/calendar_sharing_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe "Calendar sharing via ical", :js do
       it "shows disabled sharing menu item" do
         visit project_calendars_path(project)
 
-        click_link "Create new calendar"
+        page.find_test_selector("add-calendar-button").click
 
         # wait for settings button to become visible
         expect(page).to have_css("#work-packages-settings-button")

--- a/modules/calendar/spec/support/pages/calendar.rb
+++ b/modules/calendar/spec/support/pages/calendar.rb
@@ -140,9 +140,7 @@ module Pages
     end
 
     def click_on_create_button
-      within '[data-test-selector="add-calendar-button"]' do
-        click_link "Calendar"
-      end
+      page.find_test_selector("add-calendar-button").click
     end
 
     def click_on_cancel_button
@@ -150,19 +148,19 @@ module Pages
     end
 
     def expect_create_button
-      expect(page).to have_css ".button", text: "Calendar"
+      expect(page).to have_test_selector "add-calendar-button"
     end
 
     def expect_no_create_button
-      expect(page).to have_no_css ".button", text: "Calendar"
+      expect(page).not_to have_test_selector "add-calendar-button"
     end
 
     def expect_delete_button(query)
-      expect(page).to have_css "[data-test-selector='calendar-remove-#{query.id}']"
+      expect(page).to have_test_selector "calendar-remove-#{query.id}"
     end
 
     def expect_no_delete_button(query)
-      expect(page).to have_no_css "[data-test-selector='calendar-remove-#{query.id}']"
+      expect(page).not_to have_test_selector "calendar-remove-#{query.id}"
     end
 
     def expect_no_views_visible

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -66,7 +66,7 @@ module Meetings
       if @project.present?
         { href: project_overview_path(@project.id), text: @project.name }
       else
-        { href: home_path, text: I18n.t(:label_home) }
+        { href: home_path, text: helpers.organization_name }
       end
     end
   end

--- a/modules/meeting/app/components/meetings/index_page_header_component.rb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.rb
@@ -50,7 +50,7 @@ module Meetings
       if @project.present?
         { href: project_overview_path(@project.id), text: @project.name }
       else
-        { href: home_path, text: I18n.t(:label_home) }
+        { href: home_path, text: helpers.organization_name }
       end
     end
   end

--- a/modules/meeting/app/views/meetings/new.html.erb
+++ b/modules/meeting/app/views/meetings/new.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { page_title }
     header.with_breadcrumbs([@project.present? ?
                                { href: project_overview_path(@project.id), text: @project.name } :
-                               { href: home_path, text: I18n.t(:label_home) },
+                               { href: home_path, text: organization_name },
                              { href: @project.present? ? project_meetings_path(@project.id) : meetings_path,
                                text: I18n.t(:label_meeting_plural) },
                              breadcrumb_element.html_safe])

--- a/modules/reporting/app/views/cost_reports/index.html.erb
+++ b/modules/reporting/app/views/cost_reports/index.html.erb
@@ -42,24 +42,23 @@ See COPYRIGHT and LICENSE files for more details.
                              *([href: project_overview_path(@project.id), text: @project.name] if @project),
                              { href: url_for({ controller: "cost_reports" , action: :index, project_id: @project }), text: I18n.t(:cost_reports_title)},
                              (@query.persisted? ? "#{@query.name}" : t(:label_new_report))])
-  end
-%>
-<% if User.current.allowed_in_any_work_package?(:export_work_packages, in_project: @project) %>
-  <%=
-    render(Primer::OpenProject::SubHeader.new) do |subheader|
-      subheader.with_action_button(scheme: :default,
-                                   aria: { label: t(:export_to_excel)},
-                                   title: t(:export_to_excel),
-                                   tag: :a,
-                                   href: url_for({ controller: "cost_reports" , action: :index, format: 'xls', project_id: @project })
-                                   ) do |button|
+
+    if User.current.allowed_in_any_work_package?(:export_work_packages, in_project: @project)
+      header.with_action_button(scheme: :default,
+                                aria: { label: t(:export_to_excel)},
+                                title: t(:export_to_excel),
+                                mobile_icon: "op-file-xls-descriptions",
+                                mobile_label: t(:export_to_excel),
+                                tag: :a,
+                                href: url_for({ controller: "cost_reports" , action: :index, format: 'xls', project_id: @project })
+      ) do |button|
         button.with_leading_visual_icon(icon: "op-file-xls-descriptions")
         t(:export_to_excel)
       end
+      call_hook(:view_cost_report_toolbar)
     end
-  %>
-  <%= call_hook(:view_cost_report_toolbar) %>
-<% end %>
+  end
+%>
 
 <%= render_widget Widget::Settings, @query, :cost_types => @cost_types, :selected_type_id => @unit_id %>
 

--- a/modules/reporting/app/views/cost_reports/index.html.erb
+++ b/modules/reporting/app/views/cost_reports/index.html.erb
@@ -40,7 +40,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { render_widget Widget::Controls::QueryName, @query, :can_rename => allowed_in_report?(:rename, @query, current_user) }
     header.with_breadcrumbs([{ href: home_path, text: organization_name},
                              *([href: project_overview_path(@project.id), text: @project.name] if @project),
-                             t(:label_news_plural)])
+                             { href: url_for({ controller: "cost_reports" , action: :index, project_id: @project }), text: I18n.t(:cost_reports_title)},
+                             (@query.persisted? ? "#{@query.name}" : t(:label_new_report))])
   end
 %>
 <% if User.current.allowed_in_any_work_package?(:export_work_packages, in_project: @project) %>

--- a/modules/reporting/app/views/cost_reports/index.html.erb
+++ b/modules/reporting/app/views/cost_reports/index.html.erb
@@ -38,8 +38,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { render_widget Widget::Controls::QueryName, @query, :can_rename => allowed_in_report?(:rename, @query, current_user) }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name},
-                             *([href: project_overview_path(@project.id), text: @project.name] if @project),
+    header.with_breadcrumbs([*([ href: home_path, text: organization_name ] unless @project),
+                             *([ href: project_overview_path(@project.id), text: @project.name ] if @project),
                              { href: url_for({ controller: "cost_reports" , action: :index, project_id: @project }), text: I18n.t(:cost_reports_title)},
                              (@query.persisted? ? "#{@query.name}" : t(:label_new_report))])
 

--- a/modules/team_planner/app/components/team_planner/add_button_component.rb
+++ b/modules/team_planner/app/components/team_planner/add_button_component.rb
@@ -47,6 +47,10 @@ module TeamPlanner
       "add-team-planner-button"
     end
 
+    def test_selector
+      "add-team-planner-button"
+    end
+
     def accessibility_label_text
       I18n.t("team_planner.label_create_new_team_planner")
     end

--- a/modules/team_planner/app/views/team_planner/team_planner/index.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/index.html.erb
@@ -3,8 +3,7 @@
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t('team_planner.label_team_planner_plural') }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name},
-                             { href: project_overview_path(@project.id), text: @project.name },
+    header.with_breadcrumbs([{ href: project_overview_path(@project.id), text: @project.name },
                              t('team_planner.label_team_planner_plural')])
   end
 %>

--- a/modules/team_planner/app/views/team_planner/team_planner/index.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/index.html.erb
@@ -10,7 +10,7 @@
 
 <%=
   render Primer::OpenProject::SubHeader.new do |subheader|
-    subheader.with_action_component(data: { "test-selector": "add-team-planner-button"}) do
+    subheader.with_action_component do
       render ::TeamPlanner::AddButtonComponent.new(current_project: @project)
     end
   end

--- a/modules/team_planner/app/views/team_planner/team_planner/overview.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/overview.html.erb
@@ -9,7 +9,7 @@
 
 <%=
   render Primer::OpenProject::SubHeader.new do |subheader|
-    subheader.with_action_component(data: { "test-selector": "add-team-planner-button"}) do
+    subheader.with_action_component do
       render ::TeamPlanner::AddButtonComponent.new
     end
   end

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Team planner",
     end
 
     expect(page).to have_content "There is currently nothing to display."
-    click_on "Create", match: :first
+    page.find_test_selector("add-team-planner-button").click
 
     team_planner.expect_title
 

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -172,15 +172,11 @@ module Pages
     end
 
     def expect_create_button
-      within '[data-test-selector="add-team-planner-button"]' do
-        expect(page).to have_link text: "Team planner"
-      end
+      expect(page).to have_test_selector "add-team-planner-button"
     end
 
     def expect_no_create_button
-      within '[data-test-selector="add-team-planner-button"]' do
-        expect(page).to have_no_link text: "Team planner"
-      end
+      expect(page).not_to have_test_selector "add-team-planner-button"
     end
 
     def expect_views_listed_in_order(*queries)
@@ -192,9 +188,7 @@ module Pages
     end
 
     def click_on_create_button
-      within '[data-test-selector="add-team-planner-button"]' do
-        click_link "Team planner"
-      end
+      page.find_test_selector("add-team-planner-button").click
     end
 
     def click_on_cancel_button


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/53809/activity

# What are you trying to accomplish?
Fix remaining issues from previous PR (see QA section in the ticket description): 
* Breadcrumbs correction in Home, Meetings, Time and costs pages, 
* Use Primer button for adding a new board, calendar, team planner.

## Screenshots
|  | Before | After |
|---|---|---|
| Home | <img width="315" alt="Bildschirmfoto 2024-10-11 um 09 05 26" src="https://github.com/user-attachments/assets/e760f57b-213a-44a5-a8fb-a04cc013eb0a"> | <img width="303" alt="Bildschirmfoto 2024-10-11 um 09 01 57" src="https://github.com/user-attachments/assets/f20f9981-c0fd-46d7-8d30-eb5c4b46e8ec"> |
| Meetings | <img width="243" alt="Bildschirmfoto 2024-10-11 um 09 05 10" src="https://github.com/user-attachments/assets/f3b856a1-c4d3-423e-9bec-4123cfc3414c"> | <img width="329" alt="Bildschirmfoto 2024-10-11 um 09 02 19" src="https://github.com/user-attachments/assets/0d0819bc-882c-4884-afee-d1cf34e8126f"> |
| Time&Costs | <img width="265" alt="Bildschirmfoto 2024-10-11 um 09 04 39" src="https://github.com/user-attachments/assets/e35b4ff5-fc88-4dd4-a6af-0e835669c3af"> | <img width="416" alt="Bildschirmfoto 2024-10-11 um 09 02 06" src="https://github.com/user-attachments/assets/35b32aba-e206-4ba7-91fc-d9f8e8470c4c"> |
| Create button | <img width="145" alt="Bildschirmfoto 2024-10-11 um 09 04 19" src="https://github.com/user-attachments/assets/22bc631c-b34b-4207-ba25-e81e74a94b5f"> | <img width="145" alt="Bildschirmfoto 2024-10-11 um 09 02 29" src="https://github.com/user-attachments/assets/0c934b86-b800-43ad-82d7-9395dd7550dd"> |


# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
