### PR TITLE
Bump secure_headers version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,7 @@ gem "rack-protection", "~> 3.2.0"
 gem "rack-attack", "~> 6.7.0"
 
 # CSP headers
-gem "secure_headers", "~> 6.5.0"
+gem "secure_headers", "~> 6.7.0"
 
 # Browser detection for incompatibility checks
 gem "browser", "~> 6.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1057,7 +1057,7 @@ GEM
     sanitize (6.1.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    secure_headers (6.5.0)
+    secure_headers (6.7.0)
     selenium-devtools (0.129.0)
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.25.0)
@@ -1365,7 +1365,7 @@ DEPENDENCIES
   ruby-progressbar (~> 1.13.0)
   rubytree (~> 2.1.0)
   sanitize (~> 6.1.0)
-  secure_headers (~> 6.5.0)
+  secure_headers (~> 6.7.0)
   selenium-devtools
   selenium-webdriver (~> 4.20)
   semantic (~> 1.6.1)

--- a/spec/support/shared/with_direct_uploads.rb
+++ b/spec/support/shared/with_direct_uploads.rb
@@ -65,17 +65,17 @@ class WithDirectUploads
 
     csp_config = SecureHeaders::Configuration.instance_variable_get(:@default_config).csp
 
-    connect_src = csp_config.connect_src.dup
-    form_action = csp_config.form_action.dup
+    connect_src = csp_config[:connect_src].dup
+    form_action = csp_config[:form_action].dup
 
     begin
-      csp_config.connect_src << "test-bucket.s3.amazonaws.com"
-      csp_config.form_action << "test-bucket.s3.amazonaws.com"
+      csp_config[:connect_src] << "test-bucket.s3.amazonaws.com"
+      csp_config[:form_action] << "test-bucket.s3.amazonaws.com"
 
       example.run
     ensure
-      csp_config.connect_src = connect_src
-      csp_config.form_action = form_action
+      csp_config[:connect_src] = connect_src
+      csp_config[:form_action] = form_action
     end
   end
 


### PR DESCRIPTION
# What are you trying to accomplish?

I want to using newest version of [secure_headers](https://github.com/github/secure_headers/releases)

# What approach did you choose and why?

After check [changeset](https://my.diffend.io/gems/secure_headers/6.5.0/6.7.0), just bump it, notice I didn't find the [changelog](https://github.com/github/secure_headers/blob/main/CHANGELOG.md) being updated.



# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
