### PR TITLE
[55870] The Assignee drop down list in the work packages list can't show long name perfectly

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.html
@@ -9,7 +9,8 @@
     [hideName]="true"
     size="mini"
   ></op-principal>
-  <span [opSearchHighlight]="search">
+  <span [opSearchHighlight]="search"
+        class="op-user-autocompleter--name">
       {{ item.name }}
     </span>
 </ng-template>

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.sass
@@ -1,0 +1,5 @@
+// This is rather ugly. Due to `appendTo=body`, we loose the context information for the dropdown.
+// So in order to know, when the dropdown is part of a user-autocompleter, we look whether there is a specific class inside.
+// The user-autocompleter gets an enforced min-width because the names are often times cut off way too early.
+ng-dropdown-panel:has( .op-user-autocompleter--name)
+  min-width: 300px !important

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -26,23 +26,33 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  forwardRef,
+  Input,
+  OnInit,
+  Output,
+  ViewEncapsulation,
+} from '@angular/core';
 import { Observable } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import {
+  filter,
+  map,
+} from 'rxjs/operators';
+import {
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+} from '@angular/forms';
 import { ID } from '@datorama/akita';
 import { OpInviteUserModalService } from 'core-app/features/invite-user-modal/invite-user-modal.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import {
-  OpAutocompleterComponent,
-} from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
+import { OpAutocompleterComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { addFiltersToPath } from 'core-app/core/apiv3/helpers/add-filters-to-path';
-import {
-  UserAutocompleterTemplateComponent,
-} from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component';
+import { UserAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component';
 import { IUser } from 'core-app/core/state/principals/user.model';
 import { compareByAttribute } from 'core-app/shared/helpers/angular/tracking-functions';
 
@@ -68,6 +78,8 @@ export interface IUserAutocompleteItem {
     // as otherwise the close event will be shared across all instances
     OpInviteUserModalService,
   ],
+  styleUrls: ['./user-autocompleter.component.sass'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class UserAutocompleterComponent extends OpAutocompleterComponent<IUserAutocompleteItem> implements OnInit, ControlValueAccessor {
   @Input() public inviteUserToProject:string|undefined;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/55870/github?query_id=5092

# What are you trying to accomplish?
Enforce a higher min-width for user autocompleters to avoid names being cut off rather early. This problem will become even more prominent, once  we show the email adress there as well.

## Screenshots
The overflowing is discussed and accepted by the product
<img width="532" alt="Bildschirmfoto 2024-10-14 um 09 16 06" src="https://github.com/user-attachments/assets/6f1bd04f-275c-4d7f-831d-63a57b04111f">

# What approach did you choose and why?
Since we append the dropdown to the body, we loose every contextual information of the DOM. We have to do that however, to allow the dropdown to overflow e.g the cells of the WP table. Further, we cannot manipulate the HTML structure of the dropdown panel element directly. So in order to only adress the dropdown of the user-autocompleter, I used the `:has` selector and checked for a class which only appears in the user-autocompleter.


