### PR TITLE
Disable sorting on custom actions table

### DIFF
--- a/app/components/custom_actions/table_component.rb
+++ b/app/components/custom_actions/table_component.rb
@@ -30,9 +30,7 @@
 
 module CustomActions
   class TableComponent < ::TableComponent
-    columns :name,
-            :description,
-            :sort
+    columns :name, :description, :sort
 
     def headers
       [
@@ -40,6 +38,10 @@ module CustomActions
         ["description", { caption: CustomAction.human_attribute_name(:description) }],
         ["sort", { caption: I18n.t(:label_sort) }]
       ]
+    end
+
+    def sortable?
+      false
     end
 
     def inline_create_link


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58361

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The custom actions are sorted manually by position. The table allows sorting, which introduces a false sense of order.
