### PR TITLE
Fix copying a version column board

### DIFF
--- a/app/services/grids/copy/widgets_dependent_service.rb
+++ b/app/services/grids/copy/widgets_dependent_service.rb
@@ -108,11 +108,11 @@ module Grids::Copy
     end
 
     def map_query_filters(filters, _params)
-      ::Queries::Copy::FiltersMapper
-        .new(state, filters)
-        .map_filters!
+      result = ::Queries::Copy::FiltersMapper
+        .new(state)
+        .map_filters(filters)
 
-      ServiceResult.success result: filters
+      ServiceResult.success(result:)
     end
 
     def duplicate_query(query_id, params)

--- a/app/services/queries/copy/filters_mapper.rb
+++ b/app/services/queries/copy/filters_mapper.rb
@@ -28,26 +28,28 @@
 
 module Queries::Copy
   class FiltersMapper
-    attr_reader :state, :filters, :mappers
+    attr_reader :state, :mappers
 
-    def initialize(state, filters)
+    def initialize(state)
       @state = state
-      @filters = filters
       @mappers = build_filter_mappers
     end
 
     ##
-    # Returns the mapped filter array for either
-    # hash-based APIv3 filters or filter clasess
-    def map_filters!
-      filters.map! do |input|
-        if input.is_a?(Hash)
-          filter = input.dup.with_indifferent_access
-          map_api_filter_hash(filter)
-        else
-          map_filter_class(input)
-          input
-        end
+    # Returns the mapped filter array for
+    # an array of hash-based APIv3 filters
+    def map_filters(filters)
+      filters.map do |input|
+        filter = input.dup.with_indifferent_access
+        map_api_filter_hash(filter)
+      end
+    end
+
+    ##
+    # Maps the given query instance
+    def map_query!(query)
+      query.filters.each do |filter|
+        filter.values = mapped_values(filter.name, filter.values)
       end
     end
 
@@ -65,10 +67,6 @@ module Queries::Copy
       subhash["values"] = mapped_values(ar_name, subhash["values"])
 
       filter
-    end
-
-    def map_filter_class(filter)
-      filter.values = mapped_values(filter.name, filter.values)
     end
 
     def mapped_values(ar_name, values)

--- a/app/services/queries/copy/filters_mapper.rb
+++ b/app/services/queries/copy/filters_mapper.rb
@@ -40,10 +40,10 @@ module Queries::Copy
     # Returns the mapped filter array for either
     # hash-based APIv3 filters or filter clasess
     def map_filters!
-      filters.map do |input|
+      filters.map! do |input|
         if input.is_a?(Hash)
           filter = input.dup.with_indifferent_access
-          filter.tap(&method(:map_api_filter_hash))
+          map_api_filter_hash(filter)
         else
           map_filter_class(input)
           input
@@ -63,6 +63,8 @@ module Queries::Copy
       ar_name = ::API::Utilities::QueryFiltersNameConverter.to_ar_name(name, refer_to_ids: true)
 
       subhash["values"] = mapped_values(ar_name, subhash["values"])
+
+      filter
     end
 
     def map_filter_class(filter)

--- a/app/services/queries/copy_service.rb
+++ b/app/services/queries/copy_service.rb
@@ -42,8 +42,8 @@ module Queries
       new_query.sort_criteria = source.sort_criteria if source.sort_criteria
 
       ::Queries::Copy::FiltersMapper
-        .new(state, new_query.filters)
-        .map_filters!
+        .new(state)
+        .map_query!(new_query)
 
       ServiceResult.new(success: new_query.valid?, result: new_query)
     end

--- a/modules/boards/app/services/boards/copy_service.rb
+++ b/modules/boards/app/services/boards/copy_service.rb
@@ -31,8 +31,23 @@ module Boards
     protected
 
     def set_attributes_params(params)
-      super
-        .merge(project: state.project || model.project)
+      super.deep_symbolize_keys.tap do |hash|
+        hash[:project] = state.project || model.project
+
+        hash[:options] = mapped_options(hash[:options]) if hash.key?(:options)
+      end
+    end
+
+    def mapped_options(options)
+      options[:filters] = mapped_filters(options[:filters]) if options.key?(:filters)
+
+      options
+    end
+
+    def mapped_filters(filters)
+      ::Queries::Copy::FiltersMapper
+        .new(state)
+        .map_filters(filters)
     end
   end
 end

--- a/modules/boards/spec/services/copy_service_integration_spec.rb
+++ b/modules/boards/spec/services/copy_service_integration_spec.rb
@@ -94,9 +94,6 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     let(:current_user) do
       create(:user, member_with_roles: { source => role })
     end
-    let(:expected_error) do
-      "Widget contained in Grid Board 'Subproject board': Only subproject filter has invalid values."
-    end
     let!(:version) { create(:version, project: source) }
     let!(:board_view) do
       create(:version_board, project: source, version_columns: [version])
@@ -131,9 +128,6 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
   describe "for a board filtered by version" do
     let(:current_user) do
       create(:user, member_with_roles: { source => role })
-    end
-    let(:expected_error) do
-      "Widget contained in Grid Board 'Subproject board': Only subproject filter has invalid values."
     end
     let!(:version) { create(:version, project: source) }
     let!(:board_view) do

--- a/modules/boards/spec/services/copy_service_integration_spec.rb
+++ b/modules/boards/spec/services/copy_service_integration_spec.rb
@@ -90,6 +90,44 @@ RSpec.describe Projects::CopyService, "integration", type: :model do
     end
   end
 
+  describe "for a version board" do
+    let(:current_user) do
+      create(:user, member_with_roles: { source => role })
+    end
+    let(:expected_error) do
+      "Widget contained in Grid Board 'Subproject board': Only subproject filter has invalid values."
+    end
+    let!(:version) { create(:version, project: source) }
+    let!(:board_view) do
+      create(:version_board, project: source, version_columns: [version])
+    end
+    let(:only_args) { %w[work_packages boards versions] }
+
+    before do
+      login_as current_user
+    end
+
+    it "succeeds to copy the version column" do
+      expect(subject).to be_success
+      expect(board_copies.count).to eq 1
+
+      expect(board_view.widgets.count).to eq(1)
+      expect(board_copy.widgets.count).to eq(1)
+
+      widget_source = board_view.widgets.first.options
+      widget_copy = board_copy.widgets.first.options
+
+      filter_source = widget_source["filters"].first["version_id"]
+      filter_copy = widget_copy["filters"].first["version_id"]
+
+      expect(widget_source["queryId"]).not_to eq(widget_copy["queryId"])
+      expect(filter_source["values"]).to eq [version.id.to_s]
+
+      copied_version = project_copy.versions.first
+      expect(filter_copy["values"]).to eq [copied_version.id.to_s]
+    end
+  end
+
   describe "for ordered work packages" do
     let!(:board_view) { create(:board_grid_with_query, project: source, name: "My Board") }
     let!(:wp_1) { create(:work_package, project: source, subject: "Second") }

--- a/spec/services/queries/filters_mapper_spec.rb
+++ b/spec/services/queries/filters_mapper_spec.rb
@@ -30,9 +30,8 @@ require "spec_helper"
 
 RSpec.describe Queries::Copy::FiltersMapper do
   let(:state) { Shared::ServiceState.new }
-  let(:instance) { described_class.new(state, filters) }
+  let(:instance) { described_class.new(state) }
 
-  subject { instance.map_filters! }
 
   describe "with a query filters array" do
     let(:query) do
@@ -43,7 +42,8 @@ RSpec.describe Queries::Copy::FiltersMapper do
 
       query
     end
-    let(:filters) { query.filters }
+
+    subject { instance.map_query!(query) }
 
     context "when mapping state exists" do
       before do
@@ -77,6 +77,8 @@ RSpec.describe Queries::Copy::FiltersMapper do
       ]
     end
 
+    subject { instance.map_filters(filters) }
+
     context "when mapping state exists" do
       before do
         state.work_package_id_lookup = { 1 => 11 }
@@ -106,6 +108,8 @@ RSpec.describe Queries::Copy::FiltersMapper do
         { parent: { operator: "=", values: ["1"] } }
       ]
     end
+
+    subject { instance.map_filters(filters) }
 
     context "when mapping state exists" do
       before do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58388
https://community.openproject.org/work_packages/53978

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

https://community.openproject.org/work_packages/58388
In case we passed plain filters to the filters mapper, despite the convention of `map_filters!`, the input filters were not modified, but expected to be. I converted this into the two separate behaviors (overriding a query instance's filter, providing an array of filters) and added a test.

https://community.openproject.org/work_packages/53978
When users filter on the board itself, they get persisted as options on the grid itself. They were never mapped, so the new version was not picked up.



# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
