### PR TITLE
[57251] Fix mention notification email sometimes not being sent correctly on update

### DIFF
--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -129,6 +129,7 @@ class Notifications::CreateFromModelService
     Notifications::UpdateService
       .new(model: existing_notification, user:, contract_class: EmptyContract)
       .call(read_ian: strategy.supports_ian?(reason) ? false : nil,
+            mail_alert_sent: existing_notification.mail_alert_sent || (strategy.supports_mail?(reason) ? false : nil),
             reason:)
   end
 

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -997,7 +997,7 @@ RSpec.describe Notifications::CreateFromModelService,
         context "when there is already a notification for the journal (because it was aggregated)" do
           let(:note) { "Hello user:\"#{recipient_login}\"" }
           let!(:existing_notification) do
-            create(:notification, resource:, journal:, recipient:, reason: :mentioned, read_ian: true)
+            create(:notification, resource:, journal:, recipient:, reason: :mentioned, read_ian: true, mail_alert_sent: nil)
           end
 
           it_behaves_like "creates no notification"
@@ -1006,7 +1006,27 @@ RSpec.describe Notifications::CreateFromModelService,
             call
 
             expect(existing_notification.reload.read_ian)
-              .to be_falsey
+              .to be(false)
+          end
+
+          it "changes the mail_alert_sent of the existing notification from nil to false" do
+            call
+
+            expect(existing_notification.reload.mail_alert_sent)
+              .to be(false)
+          end
+
+          context "and the mail alert has already been sent" do
+            before do
+              existing_notification.update(mail_alert_sent: true)
+            end
+
+            it "keeps the mail_alert_sent of the existing notification to true" do
+              call
+
+              expect(existing_notification.reload.mail_alert_sent)
+                .to be(true)
+            end
           end
         end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57251

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When a notification exists for a user for a work package journal for a reason other than :mentioned, then its `mail_alert_sent` value is `nil`.

On a subsequent update of the work package which mentions the user, the existing notification is updated. In this update, the `mail_alert_sent` value must be changed from `nil` to `false` if the reason is :mentioned. Without it, the immediate notification email for the mention would not be sent (which is the buggy behavior).

<!-- Provide a description of the changes. -->

# What approach did you choose and why?

In `Notifications::CreateFromModelService`, there is some logic in place to create a new notification or update the existing one. In the `update_notification` logic, there is already some code to update `read_ian` value so that the in-app notification is visible again.

I added some logic next to it to also update `mail_alert_sent`. The value true is kept so that the email is sent only once.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
