### PR TITLE
[58280] Improve sidebar item alignment

### DIFF
--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -32,7 +32,7 @@
             <% selected = menu_item.selected ? 'selected' : '' %>
             <a class="op-submenu--item-action <%= selected %>" href="<%= menu_item.href %>" data-test-selector="op-submenu--item-action">
               <% if menu_item.icon %>
-                <%= render Primer::Beta::Octicon.new(icon: menu_item.icon, classes: "op-submenu--item-icon", mr: 2) %>
+                <%= render Primer::Beta::Octicon.new(icon: menu_item.icon, classes: "op-submenu--item-icon") %>
               <% end %>
               <span class="op-submenu--item-title">
                 <%= menu_item.title %>
@@ -72,7 +72,7 @@
               <% selected = child_item.selected ? 'selected' : '' %>
               <a class="op-submenu--item-action <%= selected %>" href="<%= child_item.href %>" data-test-selector="op-submenu--item-action">
                 <% if child_item.icon %>
-                  <%= render Primer::Beta::Octicon.new(icon: child_item.icon, classes: "op-submenu--item-icon", mr: 2) %>
+                  <%= render Primer::Beta::Octicon.new(icon: child_item.icon, classes: "op-submenu--item-icon") %>
                 <% end %>
                 <span class="op-submenu--item-title">
                   <%= child_item.title %>

--- a/app/components/open_project/common/submenu_component.sass
+++ b/app/components/open_project/common/submenu_component.sass
@@ -5,7 +5,7 @@
   overflow: hidden
 
   &--search
-    margin: 12px
+    margin: 12px var(--main-menu-x-spacing)
     color: var(--main-menu-font-color)
     display: flex
     flex-direction: column
@@ -42,7 +42,7 @@
     color: var(--main-menu-fieldset-header-color)
     border: 1px solid transparent
     text-transform: uppercase
-    padding: 8px 12px 8px 24px
+    padding: 8px var(--main-menu-x-spacing) 8px var(--main-menu-x-spacing)
     margin-top: 12px
     font-size: 12px
     cursor: pointer
@@ -80,6 +80,9 @@
 
     &_with_icon
       padding-left: 12px
+
+  &--item-icon
+    margin-right: var(--main-menu-x-spacing)
 
   &--item-title
     flex-grow: 1

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.sass
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.sass
@@ -14,3 +14,6 @@
   &--no-favorites-subtext
     font-size: 0.9rem
     color: var(--fgColor-muted, var(--color-fg-subtle))
+
+  .op-app-menu--item-action
+    padding: 0 8px

--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -36,7 +36,7 @@
     font-size: var(--header-item-font-size)
     text-decoration: none
     min-width: 0px
-    padding: 0 15px
+    padding: 0 var(--main-menu-x-spacing)
 
     @media screen and (max-width: $breakpoint-sm)
       padding: 0 8px

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -99,7 +99,7 @@ $arrow-left-width: 40px
     li a
       // work around due to dom manipulation on document: ready:
       // this isn't scoped to .main-item-wrapper to avoid flickering
-      padding-left: 12px
+      padding-left: var(--main-menu-x-spacing)
 
       &.toggler
         // explicitly reset to zero to avoid selector precedence problems
@@ -107,7 +107,7 @@ $arrow-left-width: 40px
 
     .main-menu--children li a:not(.Button)
       // children have no icon so we need to push them right.
-      padding-left: 24px
+      padding-left: var(--main-menu-x-spacing)
 
   a:not(.Button)
     text-decoration: none
@@ -119,7 +119,7 @@ $arrow-left-width: 40px
     font-weight: normal
     font-size: var(--main-menu-font-size)
     font-style: normal
-    padding: 0 12px
+    padding: 0 var(--main-menu-x-spacing)
 
     &:hover
       text-decoration: none
@@ -188,25 +188,25 @@ $arrow-left-width: 40px
         @include main-menu-hover
 
 .main-menu--children-menu-header
-  padding: 10px 10px 0 10px
+  padding: 10px 10px 0 4px
   height: calc(var(--main-menu-item-height) + 10px)
 
-  .main-menu--arrow-left-to-project
+  .main-menu--arrow-left-to-project:not(.Button)
     display: inline-block
     width: $arrow-left-width
     float: left
     border-radius: 3px
-    padding-left: 14px
-    padding-right: 14px
+    padding-left: var(--main-menu-x-spacing-small)
+    padding-right: var(--main-menu-x-spacing-small)
     border: 1px solid transparent
 
     &:hover, &:focus, &:active
       @include main-menu-hover
 
-a.main-menu--parent-node
+a.main-menu--parent-node:not(.Button)
   border: 1px solid transparent
   display: inline-block
-  padding: 0 11px 0 11px
+  padding: 0 var(--main-menu-x-spacing-small)
   font-size: var(--main-menu-font-size)
   font-weight: var(--base-text-weight-bold)
   width: calc(100% - #{$arrow-left-width})

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -78,6 +78,8 @@
   --header-item-font-hover-color: #FFFFFF;
   --header-item-bg-hover-color: #175A8E;
   --main-menu-width: 230px;
+  --main-menu-x-spacing: 16px;
+  --main-menu-x-spacing-small: 12px;
   --main-menu-folded-width: 0px;
   --main-menu-border-color: #EAEAEA;
   --main-menu-border-width: 0px;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58280/activity

# What are you trying to accomplish?
Improve and harmonize the aligments in the sidebar and its submenu

## Screenshots

| After | Before |
|---|---|
| <img width="200" alt="Bildschirmfoto 2024-10-14 um 13 11 19" src="https://github.com/user-attachments/assets/64703ec2-8e70-4880-a058-72d342e75dc2"> | <img width="200" alt="Bildschirmfoto 2024-10-14 um 13 12 57" src="https://github.com/user-attachments/assets/f0c9785c-f4c5-4731-9940-7840b99ab2b3"> |
| <img width="200" alt="Bildschirmfoto 2024-10-14 um 13 14 53" src="https://github.com/user-attachments/assets/ea47d7a9-2fdd-4f81-810f-3d2788378e8a"> | <img width="200" alt="Bildschirmfoto 2024-10-14 um 13 12 39" src="https://github.com/user-attachments/assets/82a29710-160a-4a27-9f7c-ac2750f92479"> |
| <img width="200" alt="Bildschirmfoto 2024-10-14 um 13 11 29" src="https://github.com/user-attachments/assets/58020b84-0e59-4a69-8a5a-92e866c8f1e5"> | <img width="200" alt="Bildschirmfoto 2024-10-14 um 13 12 20" src="https://github.com/user-attachments/assets/9ae43cc4-1c84-499a-b4f5-53812877c27f"> |
