### PR TITLE
[58358] Time&Costs module does not show submenu headers in the breadcrumb

### DIFF
--- a/modules/reporting/app/components/cost_reports/index_page_header_component.html.erb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.html.erb
@@ -1,0 +1,21 @@
+<%=
+  render Primer::OpenProject::PageHeader.new do |header|
+    header.with_title { render_widget Widget::Controls::QueryName, @query }
+    header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: :normal)
+
+    if show_export_button?
+      header.with_action_button(scheme: :default,
+                                aria: { label: t(:export_to_excel)},
+                                title: t(:export_to_excel),
+                                mobile_icon: "op-file-xls-descriptions",
+                                mobile_label: t(:export_to_excel),
+                                tag: :a,
+                                href: url_for({ controller: "cost_reports" , action: :index, format: 'xls', project_id: @project })
+      ) do |button|
+        button.with_leading_visual_icon(icon: "op-file-xls-descriptions")
+        t(:export_to_excel)
+      end
+      call_hook(:view_cost_report_toolbar)
+    end
+  end
+%>

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.rb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module CostReports
+  class IndexPageHeaderComponent < ApplicationComponent
+    include ApplicationHelper
+
+    def initialize(query:, project: nil)
+      super
+      @query = query
+      @project = project
+      @user =  User.current
+    end
+
+    def page_title
+      I18n.t(:label_meeting_plural)
+    end
+
+    def breadcrumb_items
+      [parent_element,
+       { href: url_for({ controller: "cost_reports", action: :index, project_id: @project }),
+         text: I18n.t(:cost_reports_title) },
+       current_breadcrumb_element]
+    end
+
+    def parent_element
+      if @project.present?
+        { href: project_overview_path(@project.id), text: @project.name }
+      else
+        { href: home_path, text: helpers.organization_name }
+      end
+    end
+
+    def current_breadcrumb_element
+      return I18n.t(:label_new_report) unless @query.persisted?
+
+      if current_section && current_section.header.present?
+        I18n.t("menus.breadcrumb.nested_element", section_header: current_section.header, title: @query.name).html_safe
+      else
+        I18n.t(:label_new_report)
+      end
+    end
+
+    def current_section
+      return @current_section if defined?(@current_section)
+
+      @current_section = CostReports::Menu
+                           .new(project: @project, params:)
+                           .selected_menu_group
+    end
+
+    def show_export_button?
+      @user.allowed_in_any_work_package?(:export_work_packages, in_project: @project)
+    end
+  end
+end

--- a/modules/reporting/app/views/cost_reports/index.html.erb
+++ b/modules/reporting/app/views/cost_reports/index.html.erb
@@ -35,30 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title (@query.persisted? ? "#{t(:label_cost_report)}: #{@query.name}" : t(:label_new_report)) %>
 
-<%=
-  render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { render_widget Widget::Controls::QueryName, @query, :can_rename => allowed_in_report?(:rename, @query, current_user) }
-    header.with_breadcrumbs([*([ href: home_path, text: organization_name ] unless @project),
-                             *([ href: project_overview_path(@project.id), text: @project.name ] if @project),
-                             { href: url_for({ controller: "cost_reports" , action: :index, project_id: @project }), text: I18n.t(:cost_reports_title)},
-                             (@query.persisted? ? "#{@query.name}" : t(:label_new_report))])
-
-    if User.current.allowed_in_any_work_package?(:export_work_packages, in_project: @project)
-      header.with_action_button(scheme: :default,
-                                aria: { label: t(:export_to_excel)},
-                                title: t(:export_to_excel),
-                                mobile_icon: "op-file-xls-descriptions",
-                                mobile_label: t(:export_to_excel),
-                                tag: :a,
-                                href: url_for({ controller: "cost_reports" , action: :index, format: 'xls', project_id: @project })
-      ) do |button|
-        button.with_leading_visual_icon(icon: "op-file-xls-descriptions")
-        t(:export_to_excel)
-      end
-      call_hook(:view_cost_report_toolbar)
-    end
-  end
-%>
+<%= render CostReports::IndexPageHeaderComponent.new(query: @query, project: @project) %>
 
 <%= render_widget Widget::Settings, @query, :cost_types => @cost_types, :selected_type_id => @unit_id %>
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58358/activity

# What are you trying to accomplish?
Extract PageHeader for Time&Costs into a separate component and show section header in the breadcrumb

## Screenshots

**Before**
<img width="500" alt="Bildschirmfoto 2024-10-14 um 13 41 09" src="https://github.com/user-attachments/assets/ab7869e5-03f6-4b57-802e-7a1c04644081">

**After**
<img width="500" alt="Bildschirmfoto 2024-10-14 um 13 40 30" src="https://github.com/user-attachments/assets/46c2fe0c-7592-462a-a888-e90843c116b7">

