### PR TITLE
[57412] Text barely readable because of hover effect when row is highlighted by status

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -71,7 +71,8 @@ body[class*="router--"]
   div.row-hovered
     // Use important to override the background styles from __hl classes
     // That also have to be important (cf. 30863)
-    background: var(--bgColor-neutral-muted) !important
+    background: var(--codeMirror-selection-bgColor) !important
+    color: var(--body-font-color) !important
 
     &.-checked
       background-color: hsl(from var(--codeMirror-selection-bgColor) h calc(s - 30) l) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57412/activity

# What are you trying to accomplish?
Use default font color when hovering a WP table row so ensure it is always readable 

## Screenshots
**Before**
<img width="1486" alt="Bildschirmfoto 2024-10-14 um 14 09 29" src="https://github.com/user-attachments/assets/2752a2e1-00c7-4b9c-b634-900e455b82fe">


**After**
<img width="1587" alt="Bildschirmfoto 2024-10-14 um 14 08 56" src="https://github.com/user-attachments/assets/b99ebc06-5352-4092-ac46-128f24bdec3a">

