### PR TITLE
[58359] Update-Warning is not readable in dark mode

### DIFF
--- a/frontend/src/global_styles/layout/_warning_bar.sass
+++ b/frontend/src/global_styles/layout/_warning_bar.sass
@@ -5,7 +5,8 @@
   width: 100%
 
 .warning-bar--item
-  background-color: #f4f4aa
+  background-color: var(--bgColor-attention-emphasis)
+  color: var(--fgColor-onEmphasis)
   padding: 10px
   display: flex
   align-items: center


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58359/activity

# What are you trying to accomplish?
Use Primer colors for warning bar

## Screenshots
**Before**
<img width="1255" alt="Bildschirmfoto 2024-10-14 um 14 24 49" src="https://github.com/user-attachments/assets/827fce68-0cd4-4de7-8ce2-6b2bfc60e8c8">

<img width="1277" alt="Bildschirmfoto 2024-10-14 um 14 24 59" src="https://github.com/user-attachments/assets/8ce30374-c954-45a6-aa0e-ab83683f22da">

**After**
<img width="1143" alt="Bildschirmfoto 2024-10-14 um 14 23 46" src="https://github.com/user-attachments/assets/632d6da6-e654-4bc0-b9b3-13dc25680c65">

<img width="1154" alt="Bildschirmfoto 2024-10-14 um 14 23 35" src="https://github.com/user-attachments/assets/ddfbb75a-82fd-4de3-9323-ee64e57c202e">



