### PR TITLE
[58393] Meetings modules is not showing the sidebar selection in the PageHeader

### DIFF
--- a/app/menus/submenu.rb
+++ b/app/menus/submenu.rb
@@ -56,6 +56,8 @@ class Submenu
         return item if item.selected
       end
     end
+
+    nil
   end
 
   def starred_queries

--- a/modules/meeting/app/components/meetings/index_page_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.html.erb
@@ -1,4 +1,4 @@
 <%= render(Primer::OpenProject::PageHeader.new) do |header|
   header.with_title { page_title }
-  header.with_breadcrumbs(breadcrumb_items)
+  header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: section_present? ? :normal : :bold)
 end %>

--- a/modules/meeting/app/components/meetings/index_page_header_component.rb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.rb
@@ -38,12 +38,18 @@ module Meetings
     end
 
     def page_title
-      I18n.t(:label_meeting_plural)
+      if current_item.present?
+        current_item.title
+      else
+        I18n.t(:label_meeting_plural)
+      end
     end
 
     def breadcrumb_items
       [parent_element,
-       page_title]
+       { href: url_for({ controller: "meetings", action: :index, project_id: @project }),
+         text: I18n.t(:label_meeting_plural) },
+       current_breadcrumb_element]
     end
 
     def parent_element
@@ -52,6 +58,34 @@ module Meetings
       else
         { href: home_path, text: helpers.organization_name }
       end
+    end
+
+    def current_breadcrumb_element
+      if section_present?
+        I18n.t("menus.breadcrumb.nested_element", section_header: current_section.header, title: page_title).html_safe
+      else
+        page_title
+      end
+    end
+
+    def section_present?
+      current_section && current_section.header.present?
+    end
+
+    def current_section
+      return @current_section if defined?(@current_section)
+
+      @current_section = Meetings::Menu
+                           .new(project: @project, params:)
+                           .selected_menu_group
+    end
+
+    def current_item
+      return @current_item if defined?(@current_item)
+
+      @current_item = Meetings::Menu
+                        .new(project: @project, params:)
+                        .selected_menu_item
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/58393/activity


# What are you trying to accomplish?
Show selection of the left-hand sidebar in the PageHeader for Meetings

## Screenshots
**Before**
<img width="674" alt="Bildschirmfoto 2024-10-14 um 14 44 11" src="https://github.com/user-attachments/assets/abf3bb47-5850-4647-9482-b56bb664df8f">

**After**
<img width="755" alt="Bildschirmfoto 2024-10-14 um 14 43 55" src="https://github.com/user-attachments/assets/62e3f55a-6d64-4d58-a26e-1ff23180d98b">
