### PR TITLE
[58431] Restore images in all-in-one docker container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,6 +90,9 @@ jobs:
           path: public/
           name: public-assets-${{ github.sha }}
           overwrite: true
+          # Since v4.4, hidden files are excluded by default.
+          # We need to include public/assets/.sprockets-manifest-*.json
+          include-hidden-files: true
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
       checkout_ref: ${{ steps.extract_version.outputs.checkout_ref }}


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58431

# What are you trying to accomplish?

Restore asset images on docker all-in-one container.
We can't do much for docker images existing having already this issue (from openproject/openproject:14.5.0 to 14.6.1).

## Screenshots

Images missing:
![image](https://github.com/user-attachments/assets/8dca5b4e-f2ef-45f4-91fe-bfb681dc331d)


# What approach did you choose and why?

Images are precompiled and when they are served, there is a translation from the image name to its actual path. For instance `asset_path("logo_openproject_white_big.png")` =>
`assets/logo_openproject_white_big-2c6d79fa03613154cf6bd67c622dbae5b93ed3199e0e7332d96b6f8ec21f85a1.png`.

Translation is done with the `public/assets/.sprockets-manifest-*.json` file which tracks the mapping between the asset file name and its actual path.

To build the docker images for all architectures, the assets are precompiled once for all architectures, uploaded as a GitHub artifact, and then downloaded for each architecture when building the images.

The files are uploaded with the `actions/upload-artifact` action, but hidden files are excluded by default since v4.4. That's why the file is missing and the images from sprockets pipeline are not correctly served.

This PR restores the images by explicitly adding `public/assets/.sprockets-manifest-*.json` to the assets files artifact.

This issue does not affect flavor builds because the assets are compiled during the docker build (no upload/download excluding hidden files)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
