### PR TITLE
Fix CostType redirect to index after deletion.

### DIFF
--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -152,7 +152,7 @@ class CostReportsController < ApplicationController
     else
       raise ActiveRecord::RecordNotFound
     end
-    redirect_to action: "index", default: 1
+    redirect_to action: "index", default: 1, id: nil
   end
 
   ##

--- a/modules/reporting/spec/controllers/cost_reports_controller_spec.rb
+++ b/modules/reporting/spec/controllers/cost_reports_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CostReportsController do
       end
 
       it "redirected" do
-        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(cost_reports_url(default: 1))
       end
     end
 


### PR DESCRIPTION
# What are you trying to accomplish?
Fix report deletion redirect.

1. Go to /cost_reports
2. Select report or save new one. Browser is located to /cost_reports/:id
3. Delete report.
4. Browser is still located /cost_reports/:id
5. Click on Update button leads to 500 error as `@query` is not populated
  
# What approach did you choose and why?
Nullify ID after destroy.  Actually, i'm not sure if it correct way to fix it as I still don't get the way controller works completely :)

# Work Package

https://community.openproject.org/wp/58441