### PR TITLE
Allow setting omniauth direct login provider to the new auth providers

### DIFF
--- a/app/models/auth_provider.rb
+++ b/app/models/auth_provider.rb
@@ -36,6 +36,10 @@ class AuthProvider < ApplicationRecord
     raise NotImplementedError
   end
 
+  def human_type
+    raise NotImplementedError
+  end
+
   def auth_url
     root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
     URI.join(root_url, "auth/#{slug}/").to_s

--- a/app/views/admin/settings/authentication_settings/show.html.erb
+++ b/app/views/admin/settings/authentication_settings/show.html.erb
@@ -58,6 +58,27 @@ See COPYRIGHT and LICENSE files for more details.
     </fieldset>
 
     <fieldset class="form--fieldset">
+      <legend class="form--fieldset-legend"><%= I18n.t(:'settings.authentication.single_sign_on') %></legend>
+      <div class="form--field">
+        <% providers = AuthProvider
+          .where(available: true)
+          .order("lower(display_name) ASC")
+          .select(:type, :display_name, :slug)
+          .to_a
+          .map { |p| ["#{p.display_name} (#{p.human_type})", p.slug] }
+        %>
+        <%= setting_select :omniauth_direct_login_provider,
+                           [[t(:label_disabled), ""]] + providers,
+                           container_class: '-middle' %>
+        <span class="form--field-instructions">
+          <%= t("settings.authentication.omniauth_direct_login_hint_html",
+                internal_path: internal_signin_url) %>
+        </span>
+      </div>
+    </fieldset>
+
+
+    <fieldset class="form--fieldset">
       <fieldset id="registration_footer" class="form--fieldset">
         <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>
         <%= render Settings::TextSettingComponent.new(I18n.locale, name: "registration_footer") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3321,7 +3321,9 @@ en:
   setting_default_language: "Default language"
   setting_default_projects_modules: "Default enabled modules for new projects"
   setting_default_projects_public: "New projects are public by default"
+  setting_disable_password_login: "Disable password authentication"
   setting_diff_max_lines_displayed: "Max number of diff lines displayed"
+  setting_omniauth_direct_login_provider: "Direct login SSO provider"
   setting_display_subprojects_work_packages: "Display subprojects work packages on main projects by default"
   setting_duration_format: "Duration format"
   setting_duration_format_hours_only: "Hours only"
@@ -3425,6 +3427,14 @@ en:
   setting_working_days: "Working days"
 
   settings:
+    authentication:
+      single_sign_on: "Single Sign-On"
+      omniauth_direct_login_hint_html: >
+        If this option is active, login requests will redirect to the configured omniauth provider.
+        The login dropdown and sign-in page will be disabled.
+        <br/>
+        <strong>Note:</strong> Unless you also disable password logins, with this option enabled, 
+        users can still log in internally by visiting the <code>%{internal_path}</code> login page.
     attachments:
       whitelist_text_html: >
         Define a list of valid file extensions and/or mime types for uploaded files.

--- a/modules/auth_saml/app/models/saml/provider.rb
+++ b/modules/auth_saml/app/models/saml/provider.rb
@@ -45,6 +45,10 @@ module Saml
 
     def self.slug_fragment = "saml"
 
+    def human_type
+      "SAML"
+    end
+
     def seeded_from_env?
       (Setting.seed_saml_provider || {}).key?(slug)
     end

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -37,6 +37,10 @@ module OpenIDConnect
 
     def self.slug_fragment = "oidc"
 
+    def human_type
+      "OpenID Connect"
+    end
+
     def seeded_from_env?
       (Setting.seed_oidc_provider || {}).key?(slug)
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/58437

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Allow users to also set the omniauth direct login through the authentication settings

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
<img width="966" alt="Bildschirmfoto 2024-10-16 um 16 15 02" src="https://github.com/user-attachments/assets/8c166997-d37b-4e0a-90f4-cce3771d4fcd">
