### PR TITLE
docs/user-guide/time-and-costs/progress-tracking/README.md: fix % Com…

### DIFF
--- a/docs/user-guide/time-and-costs/progress-tracking/README.md
+++ b/docs/user-guide/time-and-costs/progress-tracking/README.md
@@ -98,8 +98,8 @@ When you add, edit, or remove a value for *Work*, *Remaining Work*, or *% Comple
 When none of the three fields (% Complete, Work, or Remaining Work) have values set, the field you fill in first will determine how the others are calculated:
 
 - If you enter % Complete only, no other fields will be automatically updated. Work and Remaining Work will remain empty.
-- If you enter Work only, Remaining Work will automatically match the Work value, and % Complete will be set to 100%. You can manually clear these values if needed.
-- If you enter Remaining Work only, Work will automatically match the Remaining Work value, and % Complete will be set to 100%. You can manually clear these values if needed.
+- If you enter Work only, Remaining Work will automatically match the Work value, and % Complete will be set to 0%. You can manually clear these values if needed.
+- If you enter Remaining Work only, Work will automatically match the Remaining Work value, and % Complete will be set to 0%. You can manually clear these values if needed.
 
 **When one field is set**
 


### PR DESCRIPTION
When no field is set and one of Work and Remaining Work is filled,  the % Complete will be 0%, not 100%.

When Work match Remaining Work value, (Work - Remaining Work) / Work should be 0.