### PR TITLE
Bug/57526 migration 20230608151123 add validity period to journals is very slow

### DIFF
--- a/db/migrate/20230608151123_add_validity_period_to_journals.rb
+++ b/db/migrate/20230608151123_add_validity_period_to_journals.rb
@@ -17,108 +17,128 @@ class AddValidityPeriodToJournals < ActiveRecord::Migration[7.0]
   end
 
   def fix_all_journal_timestamps
-    max_attempts = attempts = (ENV["MAX_JOURNAL_TIMESTAMPS_ATTEMPTS"].presence && ENV["MAX_JOURNAL_TIMESTAMPS_ATTEMPTS"].to_i) ||
-                              Journal.all.maximum(:version)
+    return unless current_max_journal_version
 
-    invalid_journables = nil
+    say "Fixing potential timestamp inconsistencies on existing journals."
 
-    loop do
-      invalid_journables = fix_journal_timestamps(invalid_journables)
+    say "Creating utility table to improve the performance of subsequent actions."
+    create_successor_journals_utility_table
 
-      break if invalid_journables.empty?
+    current_max_journal_version.downto(1).each do |version|
+      say_with_time "Fixing timestamps for journals with version #{version}." do
+        fixed_journals = fix_journal_timestamps(version)
 
-      if attempts == 0
-        raise <<~MSG.squish
-          There are still journals with timestamps after their successors timestamp.
-          Aborting after #{max_attempts}.
-          Run the migration again with the env variable MAX_JOURNAL_TIMESTAMPS_ATTEMPTS set to a higher value.
-        MSG
-      else
-        say "Journals with timestamps after their successors timestamp remain in the database. Retrying..."
+        say "Fixed timestamps for #{fixed_journals.cmdtuples} journals.", true if fixed_journals.cmdtuples.positive?
       end
-
-      attempts -= 1
     end
 
-    say "All journals' timestamps in the database are correct."
+    say "Done."
+
+    drop_successor_journals_utility_table
   end
 
-  def fix_journal_timestamps(invalid_journables)
-    limit_condition = invalid_journables ? "AND journable_id IN (#{invalid_journables.uniq.join(', ')})" : ""
+  def create_successor_journals_utility_table
+    suppress_messages do
+      create_table :successor_journals, id: false do |t|
+        t.references :predecessor, null: true, index: false
+        t.references :successor, null: true, index: false
+      end
 
-    # Update journals with their timestamps after the timestamp of their successor
-    # (as identified by the journal belonging to the same journable and having the smallest version
-    # larger than the journal's).
-    # If one such is found, the:
-    # * created_at is set to be the minimum of the journal's and the successor's created_at. But of the successor's value some
-    #   small amount needs to be subtracted as later on the validity_period is calculated as a range from the predecessor's
-    #   created_at to the successor's created_at. If the two values would be equal, the range would be empty
-    #   resulting in an error.
-    # * updated_at is only altered if created_at and updated_at are equal, meaning the journal has never been updated.
-    #   A journal might very well be updated after its successor was created, because as a note can be updated
-    #   by the user at anytime.
-    #   This might have the consequence of the updated_at wrongfully being after the created_at of the successor,
-    #   but this will not be invalid.
-
-    updated = select_rows <<~SQL.squish
-      UPDATE journals
-      SET
-        created_at = LEAST(journals.created_at, successors.created_at - interval '1  ms'),
-        updated_at = CASE
-                       WHEN journals.created_at = journals.updated_at
-                       THEN LEAST(journals.created_at, successors.created_at - interval '1  ms')
-                       ELSE journals.updated_at
-                     END
-
-      FROM (
+      execute <<~SQL.squish
+        INSERT INTO
+          successor_journals
         SELECT
-          predecessors.id,
-          successors.created_at
+          predecessors.id predecessor_id,
+          successors.id successor_id
         FROM
           journals predecessors
         LEFT JOIN LATERAL (SELECT DISTINCT ON (journable_type, journable_id) *
-                           FROM journals successors
-                           WHERE successors.version > predecessors.version
-                             AND successors.journable_id = predecessors.journable_id
-                             AND successors.journable_type = predecessors.journable_type
-                             AND successors.created_at <= predecessors.created_at
-                           ORDER BY successors.journable_type ASC,
+                            FROM journals successors
+                            WHERE successors.version > predecessors.version
+                              AND successors.journable_id = predecessors.journable_id
+                              AND successors.journable_type = predecessors.journable_type
+                            ORDER BY successors.journable_type ASC,
                                     successors.journable_id ASC,
                                     successors.version ASC) successors
         ON successors.journable_id = predecessors.journable_id
         AND successors.journable_type = predecessors.journable_type
-      ) successors
-      WHERE successors.id = journals.id
-      AND successors.created_at <= journals.created_at
-      #{limit_condition}
-      RETURNING journals.journable_id
-    SQL
+      SQL
 
-    updated.flatten
+      add_index :successor_journals, :predecessor_id
+      add_index :successor_journals, :successor_id
+    end
+  end
+
+  def drop_successor_journals_utility_table
+    suppress_messages do
+      drop_table :successor_journals
+    end
+  end
+
+  def current_max_journal_version
+    @current_max_journal_version ||= suppress_messages { select_one("SELECT MAX(version) FROM journals")["max"] }
+  end
+
+  # Update journals with their timestamps after the timestamp of their successor
+  # (as identified by the journal belonging to the same journable and having the smallest version
+  # larger than the journal's).
+  # If one such is found, the:
+  # * created_at is set to be the minimum of the journal's and the successor's created_at. But of the successor's value some
+  #   small amount needs to be subtracted as later on the validity_period is calculated as a range from the predecessor's
+  #   created_at to the successor's created_at. If the two values would be equal, the range would be empty
+  #   resulting in an error.
+  # * updated_at is only altered if created_at and updated_at are equal, meaning the journal has never been updated.
+  #   A journal might very well be updated after its successor was created, because as a note can be updated
+  #   by the user at anytime.
+  #   This might have the consequence of the updated_at wrongfully being after the created_at of the successor,
+  #   but this will not be invalid.
+  def fix_journal_timestamps(version)
+    suppress_messages do
+      execute <<~SQL.squish
+        UPDATE journals
+        SET
+          created_at = LEAST(journals.created_at, successors.created_at - INTERVAL '1ms'),
+          updated_at = CASE
+                         WHEN journals.created_at = journals.updated_at
+                         THEN LEAST(journals.created_at, successors.created_at - INTERVAL '1ms')
+                         ELSE journals.updated_at
+                       END
+        FROM successor_journals, journals successors
+        WHERE successor_journals.predecessor_id = journals.id AND successor_journals.successor_id = successors.id
+        AND successors.created_at <= journals.created_at
+        AND journals.version = #{version}
+      SQL
+    end
   end
 
   def write_validity_period
-    execute <<~SQL.squish
-      UPDATE journals
-      SET validity_period = values.validity_period
-      FROM (
-        SELECT
-          predecessors.id,
-          tstzrange(predecessors.created_at, successors.created_at) validity_period
-        FROM
-          journals predecessors
-        LEFT JOIN LATERAL (SELECT DISTINCT ON (journable_type, journable_id) *
-                           FROM journals successors
-                           WHERE successors.version > predecessors.version
-                             AND successors.journable_id = predecessors.journable_id
-                           ORDER BY successors.journable_type ASC,
-                                    successors.journable_id ASC,
-                                    successors.version ASC) successors
-        ON successors.journable_id = predecessors.journable_id
-        AND successors.journable_type = predecessors.journable_type
-      ) values
-      WHERE values.id = journals.id
-    SQL
+    say_with_time "Writing validity periods for journals." do
+      suppress_messages do
+        execute <<~SQL.squish
+          UPDATE journals
+          SET validity_period = values.validity_period
+          FROM (
+            SELECT
+              predecessors.id,
+              tstzrange(predecessors.created_at, successors.created_at) validity_period
+            FROM
+              journals predecessors
+            LEFT JOIN LATERAL (SELECT DISTINCT ON (journable_type, journable_id) *
+                               FROM journals successors
+                               WHERE successors.version > predecessors.version
+                                 AND successors.journable_id = predecessors.journable_id
+                               ORDER BY successors.journable_type ASC,
+                                        successors.journable_id ASC,
+                                        successors.version ASC) successors
+            ON successors.journable_id = predecessors.journable_id
+            AND successors.journable_type = predecessors.journable_type
+          ) values
+          WHERE values.id = journals.id
+        SQL
+      end
+    end
+
+    say "Done."
   end
 
   def add_validity_period_constraint

--- a/spec/migrations/add_validity_period_to_journals_spec.rb
+++ b/spec/migrations/add_validity_period_to_journals_spec.rb
@@ -1,0 +1,184 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20230608151123_add_validity_period_to_journals.rb")
+
+RSpec.describe AddValidityPeriodToJournals, type: :model do
+  # Silencing migration logs, since we are not interested in that during testing
+  subject do
+    ActiveRecord::Migration.suppress_messages do
+      described_class
+        .new
+        .tap { _1.migrate(:down) }
+        .tap { _1.migrate(:up) }
+    end
+  end
+
+  let(:zero_time) { 30.minutes.ago }
+  let(:initial_journal_time) { zero_time }                   # Created with the work package -> No conflicts
+  let(:second_journal_time) { zero_time + 1.minute }         # Created one minute later      -> Conflicts with 3
+  let(:third_journal_time) { zero_time + 1.minute }          # Created one minute later      -> Conflicts with 2
+  let(:fourth_journal_time) { zero_time + 2.minutes }        # Created two minutes later     -> Conflicts with 5, 6 and 7
+  let(:fourth_journal_update_time) { zero_time + 3.minutes } # Updated three minute later    -> Not relevant for this migration
+  let(:fifth_journal_time) { zero_time + 2.minutes }         # Created two minutes later     -> Conflicts with 4, 6 and 7
+  let(:sixth_journal_time) { zero_time + 2.minutes }         # Created two minutes later     -> Conflicts with 5, 5 and 7
+  let(:seventh_journal_time) { zero_time + 2.minutes }       # Created two minutes later     -> Conflicts with 4, 5 and 6
+
+  let(:work_package) do
+    create(:work_package) do
+      Journal.destroy_all
+    end
+  end
+
+  let(:user) { create(:user) }
+
+  let!(:initial_journal) do
+    create(:work_package_journal,
+           version: 1,
+           user:,
+           created_at: initial_journal_time,
+           updated_at: initial_journal_time,
+           validity_period: zero_time...zero_time + 1.minute,
+           journable: work_package).reload
+  end
+  let!(:second_journal) do
+    create(:work_package_journal,
+           version: 2,
+           user:,
+           created_at: second_journal_time,
+           updated_at: second_journal_time,
+           validity_period: zero_time + 2.minutes...zero_time + 3.minutes,
+           journable: work_package).reload
+  end
+  let!(:third_journal) do
+    create(:work_package_journal,
+           version: 3,
+           user:,
+           created_at: third_journal_time,
+           updated_at: third_journal_time,
+           validity_period: zero_time + 4.minutes...zero_time + 5.minutes,
+           journable: work_package).reload
+  end
+  let!(:fourth_journal) do
+    create(:work_package_journal,
+           version: 4,
+           user:,
+           created_at: fourth_journal_time,
+           updated_at: fourth_journal_update_time,
+           validity_period: zero_time + 6.minutes...zero_time + 7.minutes,
+           journable: work_package).reload
+  end
+  let!(:fifth_journal) do
+    create(:work_package_journal,
+           version: 5,
+           user:,
+           created_at: fifth_journal_time,
+           updated_at: fifth_journal_time,
+           validity_period: zero_time + 8.minutes...zero_time + 9.minutes,
+           journable: work_package).reload
+  end
+  let!(:sixth_journal) do
+    create(:work_package_journal,
+           version: 6,
+           user:,
+           created_at: sixth_journal_time,
+           updated_at: sixth_journal_time,
+           validity_period: zero_time + 10.minutes...zero_time + 11.minutes,
+           journable: work_package).reload
+  end
+  let!(:seventh_journal) do
+    create(:work_package_journal,
+           version: 7,
+           user:,
+           created_at: seventh_journal_time,
+           updated_at: seventh_journal_time,
+           validity_period: zero_time + 11.minutes...zero_time + 12.minutes,
+           journable: work_package).reload
+  end
+
+  it "resets the overlapping journals", :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    subject
+
+    initial_journal.reload
+    second_journal.reload
+    third_journal.reload
+    fourth_journal.reload
+    fifth_journal.reload
+    sixth_journal.reload
+    seventh_journal.reload
+
+    expect(initial_journal.created_at).to eql initial_journal_time
+    expect(initial_journal.updated_at).to eql initial_journal_time
+    expect(initial_journal.validity_period.begin).to eql initial_journal_time
+    expect(initial_journal.validity_period.end.strftime("%s%L").to_i).to eql second_journal_time.strftime("%s%L").to_i - 1
+
+    expect(second_journal.created_at.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i - 1
+    expect(second_journal.updated_at.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i - 1
+    expect(second_journal.validity_period.begin.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i - 1
+    expect(second_journal.validity_period.end.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i
+
+    expect(third_journal.created_at.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i
+    expect(third_journal.updated_at.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i
+    expect(third_journal.validity_period.begin.strftime("%s%L").to_i).to eql third_journal_time.strftime("%s%L").to_i
+    # Since the fourth journal had to be moved 3 times (by 3 ms in total) to avoid conflicts with its subsequent 3 journals,
+    # the validity period ends at the old fourth journal time minus 3 ms.
+    expect(third_journal.validity_period.end.strftime("%s%L").to_i).to eql fourth_journal_time.strftime("%s%L").to_i - 3
+
+    # The fourth journal had to be moved 3 times to avoid conflicts with its subsequent 3 journals.
+    # All timestamps had to be moved by 1 ms each time.
+    expect(fourth_journal.created_at.strftime("%s%L").to_i).to eql fourth_journal_time.strftime("%s%L").to_i - 3
+    # This time is not updated at all. It already had a different time than the created_at.
+    # It now overlaps with the fifth, sixth and seventh journal. This can happen and is okay.
+    # It might e.g. be, that the comment on the journal was updated.
+    expect(fourth_journal.updated_at.strftime("%s%L").to_i).to eql fourth_journal_update_time.strftime("%s%L").to_i
+    expect(fourth_journal.validity_period.begin.strftime("%s%L").to_i).to eql fourth_journal_time.strftime("%s%L").to_i - 3
+    expect(fourth_journal.validity_period.end.strftime("%s%L").to_i).to eql fifth_journal_time.strftime("%s%L").to_i - 2
+
+    # The fifth journal had to be moved 2 times to avoid conflicts with its subsequent 2 journals.
+    # All timestamps had to be moved by 1 ms each time.
+    expect(fifth_journal.created_at.strftime("%s%L").to_i).to eql fifth_journal_time.strftime("%s%L").to_i - 2
+    expect(fifth_journal.updated_at.strftime("%s%L").to_i).to eql fifth_journal_time.strftime("%s%L").to_i - 2
+    expect(fifth_journal.validity_period.begin.strftime("%s%L").to_i).to eql fifth_journal_time.strftime("%s%L").to_i - 2
+    expect(fifth_journal.validity_period.end.strftime("%s%L").to_i).to eql sixth_journal_time.strftime("%s%L").to_i - 1
+
+    # The sixth journal had to be moved 1 times to avoid conflicts with its subsequent 1 journals.
+    # All timestamps had to be moved by 1 ms.
+    expect(sixth_journal.created_at.strftime("%s%L").to_i).to eql sixth_journal_time.strftime("%s%L").to_i - 1
+    expect(sixth_journal.updated_at.strftime("%s%L").to_i).to eql sixth_journal_time.strftime("%s%L").to_i - 1
+    expect(sixth_journal.validity_period.begin.strftime("%s%L").to_i).to eql sixth_journal_time.strftime("%s%L").to_i - 1
+    expect(sixth_journal.validity_period.end.strftime("%s%L").to_i).to eql seventh_journal_time.strftime("%s%L").to_i
+
+    # The seventh journal is the last in the list of conflicting journals so it itself had not to be moved.
+    expect(seventh_journal.created_at.strftime("%s%L").to_i).to eql seventh_journal_time.strftime("%s%L").to_i
+    expect(seventh_journal.updated_at.strftime("%s%L").to_i).to eql seventh_journal_time.strftime("%s%L").to_i
+    expect(seventh_journal.validity_period.begin.strftime("%s%L").to_i).to eql seventh_journal_time.strftime("%s%L").to_i
+    # Since it is the currently last journal, it's range is open-ended.
+    expect(seventh_journal.validity_period.end).to be_nil
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57526
https://community.openproject.org/wp/58090

# What are you trying to accomplish?

In cases with very large data sets in the journals table, especially with a lot of versions per journable, the former implementation of the migration would perform poorly. This was the case because a version of the journal was touched multiple times within the same transaction when fixing inconsistent timestamps on journals.

# What approach did you choose and why?

The migration now will now touch each journal only once at the most because it fixes the inconsistencies from the highest version backwards down to the first one. Additionally, a utility table is created that can be used within each step to create the connection between a journal and its succeeding one. That utitilty table is then also used when actually writing the `validity_period`.

A test is added to prevent regressions.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
