### PR TITLE
Bump @primer/css by add more dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,7 +49,9 @@
         "@openproject/octicons-angular": "^19.18.0",
         "@openproject/primer-view-components": "^0.48.0",
         "@openproject/reactivestates": "^3.0.1",
-        "@primer/css": "^21.3.3",
+        "@primer/css": "^21.5.0",
+        "@primer/primitives": "^9.1.2",
+        "@primer/view-components": "npm:@openproject/primer-view-components@^0.48.0",
         "@types/hotwired__turbo": "^8.0.1",
         "@uirouter/angular": "^13.0.0",
         "@uirouter/core": "^6.1.0",
@@ -4824,6 +4826,7 @@
       "version": "0.48.0",
       "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.48.0.tgz",
       "integrity": "sha512-eR9vv6UTInqr3Oi3nlOLHlFa6hDhy4kdEbTXZEZS8pEa9E4IlcZNGjA+0foRPecBCizg2v+E+TgpS/wk3Vd0FA==",
+      "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -4885,15 +4888,15 @@
       "integrity": "sha512-HWwz+6MrfK5NTWcg9GdKFpMBW/yrAV937oXiw2eDtsd88P3SRwoCt6ZO6QmKp9RP3nDU9cbqmuGZ0xBh0eIFeg=="
     },
     "node_modules/@primer/css": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@primer/css/-/css-21.4.0.tgz",
-      "integrity": "sha512-mBq0F6lvAuPioW30RP1CyvSkW76UpAzZp1HM+5N/cfpwuarYVsCWYkWQlDtJqIsGYNSa1E2GgL17HzzDt4Bofg==",
-      "dependencies": {
-        "@primer/primitives": "^9.0.3",
-        "@primer/view-components": "^0.34.0"
-      },
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/@primer/css/-/css-21.5.0.tgz",
+      "integrity": "sha512-zkvHxWpVcjURujbWaq4YL8R/9g9qkM6275KMXXgNs/T2o8GekUDH6Qx2cpIPVd/AHtwIwDsy4+yjWcNWsuRgkA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@primer/primitives": "^9.0.3"
       }
     },
     "node_modules/@primer/primitives": {
@@ -4910,6 +4913,7 @@
       "version": "0.48.0",
       "resolved": "https://registry.npmjs.org/@openproject/primer-view-components/-/primer-view-components-0.48.0.tgz",
       "integrity": "sha512-eR9vv6UTInqr3Oi3nlOLHlFa6hDhy4kdEbTXZEZS8pEa9E4IlcZNGjA+0foRPecBCizg2v+E+TgpS/wk3Vd0FA==",
+      "license": "MIT",
       "dependencies": {
         "@github/auto-check-element": "^5.2.0",
         "@github/auto-complete-element": "^3.6.2",
@@ -25398,13 +25402,9 @@
       "integrity": "sha512-HWwz+6MrfK5NTWcg9GdKFpMBW/yrAV937oXiw2eDtsd88P3SRwoCt6ZO6QmKp9RP3nDU9cbqmuGZ0xBh0eIFeg=="
     },
     "@primer/css": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@primer/css/-/css-21.4.0.tgz",
-      "integrity": "sha512-mBq0F6lvAuPioW30RP1CyvSkW76UpAzZp1HM+5N/cfpwuarYVsCWYkWQlDtJqIsGYNSa1E2GgL17HzzDt4Bofg==",
-      "requires": {
-        "@primer/primitives": "^9.0.3",
-        "@primer/view-components": "npm:@openproject/primer-view-components@^0.48.0"
-      }
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/@primer/css/-/css-21.5.0.tgz",
+      "integrity": "sha512-zkvHxWpVcjURujbWaq4YL8R/9g9qkM6275KMXXgNs/T2o8GekUDH6Qx2cpIPVd/AHtwIwDsy4+yjWcNWsuRgkA=="
     },
     "@primer/primitives": {
       "version": "9.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,9 @@
     "@openproject/octicons-angular": "^19.18.0",
     "@openproject/primer-view-components": "^0.48.0",
     "@openproject/reactivestates": "^3.0.1",
-    "@primer/css": "^21.3.3",
+    "@primer/css": "^21.5.0",
+    "@primer/primitives": "^9.1.2",
+    "@primer/view-components": "npm:@openproject/primer-view-components@^0.48.0",
     "@types/hotwired__turbo": "^8.0.1",
     "@uirouter/angular": "^13.0.0",
     "@uirouter/core": "^6.1.0",
@@ -176,6 +178,5 @@
     "generate-typings": "tsc -d -p src/tsconfig.app.json"
   },
   "overrides": {
-    "@primer/view-components": "npm:@openproject/primer-view-components@^0.48.0"
   }
 }


### PR DESCRIPTION
# What are you trying to accomplish?

Make sure new @primer/css continue work in OP

# What approach did you choose and why?

Add removed dependency in [`@primer/css`](https://github.com/primer/css/pull/2724) in package.json

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
