### PR TITLE
[#58479] bug: adjust label "Enabled in projects" to "Projects"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2501,7 +2501,7 @@ en:
   label_project_latest: "Latest projects"
   label_project_default_type: "Allow empty type"
   label_project_hierarchy: "Project hierarchy"
-  label_project_mappings: "Enabled in projects"
+  label_project_mappings: "Projects"
   label_project_new: "New project"
   label_project_plural: "Projects"
   label_project_list_plural: "Project lists"

--- a/docs/system-admin-guide/projects/project-attributes/README.md
+++ b/docs/system-admin-guide/projects/project-attributes/README.md
@@ -88,7 +88,7 @@ The *Details* tab will allow you to edit the name, section and visibility.
 
 ![OpenProject project attribute details editing](open_project_system_admin_guide_project_attributes_details.png)
 
-The *Enabled in projects* tab will show a list of all the projects this project attributes was activated in. 
+The *Projects* tab will show a list of all the projects this project attributes was activated in. 
 
 ![Project attributes enabled in projects list in OpenProject administration](open_project_system_admin_guide_project_attributes_enabled_in_projects.png)
 

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Admin lists project mappings for a storage",
       aggregate_failures "shows tab navigation" do
         within_test_selector("storage_detail_header") do
           expect(page).to have_link("Details")
-          expect(page).to have_link("Enabled in projects")
+          expect(page).to have_link("Projects")
         end
       end
 

--- a/spec/features/admin/project_custom_fields/edit_spec.rb
+++ b/spec/features/admin/project_custom_fields/edit_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Edit project custom fields", :js do
     it "shows tab navigation" do
       within_test_selector("project_attribute_detail_header") do
         expect(page).to have_link("Details")
-        expect(page).to have_link("Enabled in projects")
+        expect(page).to have_link("Projects")
       end
     end
 

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
       aggregate_failures "shows tab navigation" do
         within_test_selector("project_attribute_detail_header") do
           expect(page).to have_link("Details")
-          expect(page).to have_link("Enabled in projects")
+          expect(page).to have_link("Projects")
         end
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58479

# What are you trying to accomplish?
Renaming a label

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
