### PR TITLE
Enable item editing of hierarchical custom fields

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -29,28 +29,40 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper(data: { test_selector: "op-custom-fields--hierarchy-item" }) do
-    flex_layout(align_items: :center, justify_content: :space_between) do |item_container|
-      item_container.with_column(flex_layout: true) do |item_information|
-        item_information.with_column(mr: 2) do
-          render(Primer::Beta::Text.new(font_weight: :bold)) do
-            @hierarchy_item.label
-          end
-        end
-
-        unless @hierarchy_item.short.nil?
+    if show_edit_form?
+      render Admin::CustomFields::Hierarchy::ItemFormComponent.new(
+        custom_field: @custom_field,
+        hierarchy_item: @hierarchy_item,
+        url: custom_field_item_path(@custom_field, @hierarchy_item),
+        method: :put,
+        label: @edit_item_form_data.fetch(:label, nil),
+        short: @edit_item_form_data.fetch(:short, nil)
+      )
+    else
+      flex_layout(align_items: :center, justify_content: :space_between) do |item_container|
+        item_container.with_column(flex_layout: true) do |item_information|
           item_information.with_column(mr: 2) do
-            render(Primer::Beta::Text.new(color: :subtle)) { short_text }
+            render(Primer::Beta::Text.new(font_weight: :bold)) do
+              @hierarchy_item.label
+            end
           end
-        end
-      end
 
-      # Actions
-      item_container.with_column do
-        render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-hierarchy-item--action-menu" })) do |menu|
-          menu.with_show_button(icon: "kebab-horizontal",
-                                scheme: :invisible,
-                                "aria-label": I18n.t("custom_fields.admin.items.actions"))
-          deletion_action_item(menu)
+          unless @hierarchy_item.short.nil?
+            item_information.with_column(mr: 2) do
+              render(Primer::Beta::Text.new(color: :subtle)) { short_text }
+            end
+          end
+
+          # Actions
+          item_container.with_column do
+            render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-hierarchy-item--action-menu" })) do |menu|
+              menu.with_show_button(icon: "kebab-horizontal",
+                                    scheme: :invisible,
+                                    "aria-label": I18n.t("custom_fields.admin.items.actions"))
+              edit_action_item(menu)
+              deletion_action_item(menu)
+            end
+          end
         end
       end
     end

--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -35,14 +35,23 @@ module Admin
         include OpTurbo::Streamable
         include OpPrimer::ComponentHelpers
 
-        def initialize(custom_field:, hierarchy_item:)
+        def initialize(custom_field:, hierarchy_item:, edit_item_form_data: { show: false })
           super
           @custom_field = custom_field
           @hierarchy_item = hierarchy_item
+          @edit_item_form_data = edit_item_form_data
         end
 
         def short_text
           "(#{@hierarchy_item.short})"
+        end
+
+        def wrapper_uniq_by
+          @hierarchy_item.id
+        end
+
+        def show_edit_form?
+          @edit_item_form_data.fetch(:show, false)
         end
 
         def deletion_action_item(menu)
@@ -53,6 +62,15 @@ module Admin
                                                                       id: @hierarchy_item.id),
                          content_arguments: { data: { controller: "async-dialog" } }) do |item|
             item.with_leading_visual_icon(icon: :trash)
+          end
+        end
+
+        def edit_action_item(menu)
+          menu.with_item(label: I18n.t(:button_edit),
+                         tag: :a,
+                         content_arguments: { data: { turbo_stream: true } },
+                         href: edit_custom_field_item_path(@custom_field, @hierarchy_item)) do |item|
+            item.with_leading_visual_icon(icon: :pencil)
           end
         end
       end

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.html.erb
@@ -28,11 +28,13 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  primer_form_with(
-    url: custom_field_items_path(@custom_field),
-    method: :post,
-    data: { test_selector: "op-custom-fields--new-item-form" }
-  ) do |f|
-    render(CustomFields::Hierarchy::NewItemForm.new(f, custom_field: @custom_field, label: @label, short: @short))
+  primer_form_with(url: @url, method: @method, data: { test_selector: "op-custom-fields--new-item-form" }) do |f|
+    render(CustomFields::Hierarchy::ItemForm.new(
+             f,
+             custom_field: @custom_field,
+             hierarchy_item: @hierarchy_item,
+             label: @label,
+             short: @short
+           ))
   end
 %>

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.rb
@@ -29,14 +29,17 @@
 module Admin
   module CustomFields
     module Hierarchy
-      class NewItemFormComponent < ApplicationComponent
+      class ItemFormComponent < ApplicationComponent
         include OpTurbo::Streamable
 
-        def initialize(custom_field:, label: nil, short: nil)
+        def initialize(custom_field:, hierarchy_item:, url:, method:, label: nil, short: nil)
           super
           @custom_field = custom_field
-          @label = label
-          @short = short
+          @hierarchy_item = hierarchy_item
+          @url = url
+          @method = method
+          @label = label || @hierarchy_item.label
+          @short = short || @hierarchy_item.short
         end
 
         def items_path

--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  component_wrapper(tag: 'turbo-frame') do
+  component_wrapper(tag: "turbo-frame") do
     flex_layout do |container|
       if items.empty? && !show_new_item_form?
         container.with_row(mb: 3) do
@@ -48,16 +48,23 @@ See COPYRIGHT and LICENSE files for more details.
 
             items.each do |item|
               item_box.with_row do
-                render Admin::CustomFields::Hierarchy::ItemComponent.new(custom_field: @custom_field,
-                                                                         hierarchy_item: item)
+                render Admin::CustomFields::Hierarchy::ItemComponent.new(
+                  custom_field: @custom_field,
+                  hierarchy_item: item
+                )
               end
             end
 
             if show_new_item_form?
               item_box.with_footer do
-                render Admin::CustomFields::Hierarchy::NewItemFormComponent.new(custom_field: @custom_field,
-                                                                                label: @new_item_form_data[:label],
-                                                                                short: @new_item_form_data[:short])
+                render Admin::CustomFields::Hierarchy::ItemFormComponent.new(
+                  custom_field: @custom_field,
+                  hierarchy_item: CustomField::Hierarchy::Item.new,
+                  url: custom_field_items_path(@custom_field),
+                  method: :post,
+                  label: @new_item_form_data[:label],
+                  short: @new_item_form_data[:short]
+                )
               end
             end
           end

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -41,7 +41,7 @@ module Admin
 
         before_action :require_admin
         before_action :find_model_object, except: %i[destroy deletion_dialog]
-        before_action :find_custom_field_and_item, only: %i[destroy deletion_dialog]
+        before_action :find_custom_field_and_item, only: %i[destroy deletion_dialog edit update]
 
         menu_item :custom_fields
 
@@ -50,6 +50,18 @@ module Admin
         def new
           update_via_turbo_stream(component: ItemsComponent.new(custom_field: @custom_field,
                                                                 new_item_form_data: { show: true }))
+          respond_with_turbo_streams
+        end
+
+        def edit
+          update_via_turbo_stream(
+            component: ItemComponent.new(
+              custom_field: @custom_field,
+              hierarchy_item: @hierarchy_item,
+              edit_item_form_data: { show: true }
+            )
+          )
+
           respond_with_turbo_streams
         end
 
@@ -62,7 +74,22 @@ module Admin
                 update_via_turbo_stream(component: ItemsComponent.new(custom_field: @custom_field,
                                                                       new_item_form_data: { show: true }))
               end,
-              ->(validation_result) { add_errors_to_form(validation_result) }
+              ->(validation_result) { add_errors_to_new_form(validation_result) }
+            )
+
+          respond_with_turbo_streams
+        end
+
+        def update
+          ::CustomFields::Hierarchy::HierarchicalItemService
+            .new
+            .update_item(item: @hierarchy_item, label: item_input[:label], short: item_input[:short])
+            .either(
+              ->(_) do
+                update_via_turbo_stream(component: ItemComponent.new(custom_field: @custom_field,
+                                                                     hierarchy_item: @hierarchy_item))
+              end,
+              ->(validation_result) { add_errors_to_edit_form(validation_result) }
             )
 
           respond_with_turbo_streams
@@ -94,7 +121,7 @@ module Admin
           input
         end
 
-        def add_errors_to_form(validation_result)
+        def add_errors_to_new_form(validation_result)
           validation_result.errors(full: true).to_h.each do |attribute, errors|
             @custom_field.errors.add(attribute, errors.join(", "))
           end
@@ -102,6 +129,18 @@ module Admin
           new_item_form_data = { show: true, label: validation_result[:label], short: validation_result[:short] }
           update_via_turbo_stream(component: ItemsComponent.new(custom_field: @custom_field, new_item_form_data:),
                                   status: :unprocessable_entity)
+        end
+
+        def add_errors_to_edit_form(validation_result)
+          validation_result.errors(full: true).to_h.each do |attribute, errors|
+            @hierarchy_item.errors.add(attribute, errors.join(", "))
+          end
+
+          edit_item_form_data = { show: true, label: validation_result[:label], short: validation_result[:short] }
+          update_via_turbo_stream(
+            component: ItemComponent.new(custom_field: @custom_field, hierarchy_item: @hierarchy_item, edit_item_form_data:),
+            status: :unprocessable_entity
+          )
         end
 
         def find_model_object(object_id = :custom_field_id)

--- a/app/forms/custom_fields/hierarchy/item_form.rb
+++ b/app/forms/custom_fields/hierarchy/item_form.rb
@@ -28,9 +28,9 @@
 
 module CustomFields
   module Hierarchy
-    class NewItemForm < ApplicationForm
-      form do |new_item_form|
-        new_item_form.group(layout: :horizontal) do |input_group|
+    class ItemForm < ApplicationForm
+      form do |item_form|
+        item_form.group(layout: :horizontal) do |input_group|
           input_group.text_field(
             name: :label,
             label: "Label",
@@ -51,7 +51,7 @@ module CustomFields
           )
         end
 
-        new_item_form.group(layout: :horizontal) do |button_group|
+        item_form.group(layout: :horizontal) do |button_group|
           button_group.button(name: :cancel,
                               tag: :a,
                               label: I18n.t(:button_cancel),
@@ -62,9 +62,10 @@ module CustomFields
         end
       end
 
-      def initialize(custom_field:, label:, short:)
+      def initialize(custom_field:, hierarchy_item:, label:, short:)
         super()
         @custom_field = custom_field
+        @hierarchy_item = hierarchy_item
         @label = label
         @short = short
       end
@@ -72,11 +73,8 @@ module CustomFields
       private
 
       def validation_message_for(attribute)
-        @custom_field
-          .errors
-          .messages_for(attribute)
-          .to_sentence
-          .presence
+        @hierarchy_item.errors.messages_for(attribute).to_sentence.presence ||
+          @custom_field.errors.messages_for(attribute).to_sentence.presence
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,7 +180,7 @@ Rails.application.routes.draw do
                  only: :destroy
         resources :items,
                   controller: "/admin/custom_fields/hierarchy/items",
-                  only: %i[index new create destroy] do
+                  except: %i[show] do
           get :deletion_dialog, on: :member
         end
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/57818

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
A button to enable editting items.
![image](https://github.com/user-attachments/assets/5e6620c2-c03c-407d-ae54-089096a6e03a)

And a form for editting items.
![image](https://github.com/user-attachments/assets/e31b2167-5ffe-438b-8a52-94721f2db2f7)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

I needed to make the Item a component_wrapper so we can update it independently of the rest (and to show validation errors)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
