### PR TITLE
[58429] Invite user modal doesn't work on Project overview page

### DIFF
--- a/frontend/src/app/features/invite-user-modal/principal/principal.component.ts
+++ b/frontend/src/app/features/invite-user-modal/principal/principal.component.ts
@@ -244,7 +244,7 @@ export class PrincipalComponent implements OnInit {
         const fieldSchema = fieldsSchema[fieldKey];
         let fieldValue = this.customFields[fieldKey];
 
-        if (fieldSchema.location === '_links') {
+        if (fieldSchema.location === '_links' && !!fieldValue) {
           fieldValue = Array.isArray(fieldValue)
             ? fieldValue.map((opt:any) => (opt._links ? opt._links.self : opt))
             : (fieldValue._links ? fieldValue._links.self : fieldValue);

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -160,6 +160,27 @@ RSpec.describe "Invite user modal", :js, :with_cuprite do
             let(:mail_membership_recipients) { [principal] }
           end
         end
+
+        context "with a required list user CF (regression #58429)" do
+          let(:current_user) { create(:admin) }
+          let(:list_cf) do
+            create(:user_custom_field,
+                   :list,
+                   name: "List",
+                   is_required: true,
+                   editable: false,
+                   default_option: "A")
+          end
+
+          before do
+            list_cf
+          end
+
+          it_behaves_like "invites the principal to the project" do
+            let(:added_principal) { principal }
+            let(:mail_membership_recipients) { [principal] }
+          end
+        end
       end
 
       context "with a user to be invited" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58429/github?query_id=5092

# What are you trying to accomplish?
This covers an edge case where a required userCF with default values prevented the user invite.

# Merge checklist

- [x] Added/updated tests