### PR TITLE
[58454] Sidebar menu should be hidden when page width is reduced

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -168,6 +168,12 @@ See COPYRIGHT and LICENSE files for more details.
       $('.can-hide-navigation').addClass('hidden-navigation');
     }
 
+    window.addEventListener('resize', function() {
+      if (window.innerWidth < 1012) {
+        $('.can-hide-navigation').addClass('hidden-navigation');
+      }
+    });
+
     if (mainMenuCollapsed === 'true') {
       savedMainMenuWidth = 0;
     }

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -168,12 +168,6 @@ See COPYRIGHT and LICENSE files for more details.
       $('.can-hide-navigation').addClass('hidden-navigation');
     }
 
-    window.addEventListener('resize', function() {
-      if (window.innerWidth < 1012) {
-        $('.can-hide-navigation').addClass('hidden-navigation');
-      }
-    });
-
     if (mainMenuCollapsed === 'true') {
       savedMainMenuWidth = 0;
     }

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -132,9 +132,14 @@ export class MainMenuToggleService {
     } else {
       this.openMenu();
     }
-
     // Save the collapsed state in localStorage
     window.OpenProject.guardedLocalStorage(this.localStorageStateKey, String(!this.showNavigation));
+    // Set focus on first visible main menu item.
+    // This needs to be called after AngularJS has rendered the menu, which happens some when after(!) we leave this
+    // method here. So we need to set the focus after a timeout.
+    setTimeout(() => {
+      jQuery('#main-menu [class*="-menu-item"]:visible').first().focus();
+    }, 500);
   }
 
   public closeMenu():void {

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -167,6 +167,7 @@ export class MainMenuToggleService {
     this.global.showNavigation = this.showNavigation;
     this.htmlNode.style.setProperty('--main-menu-width', `${this.elementWidth}px`);
 
+    // Send change event when size of menu is changing (menu toggled or resized)
     const changeEvent = jQuery.Event('change');
     this.changeData.next(changeEvent);
   }

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -72,6 +72,8 @@ export class MainMenuToggleService {
     public injector:Injector,
     readonly deviceService:DeviceService,
   ) {
+    // Add resize event listener
+    window.addEventListener('resize', this.onWindowResize.bind(this));
   }
 
   public initializeMenu():void {
@@ -97,6 +99,12 @@ export class MainMenuToggleService {
 
     // small desktop version default: hide menu on initialization
     this.closeWhenOnSmallDesktop();
+  }
+
+  private onWindowResize():void {
+    if (window.innerWidth < 1012) {
+      this.closeMenu();
+    }
   }
 
   // click on arrow or hamburger icon

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector, OnInit } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -34,7 +34,7 @@ import { DeviceService } from 'core-app/core/browser/device.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 
 @Injectable({ providedIn: 'root' })
-export class MainMenuToggleService implements OnInit {
+export class MainMenuToggleService {
   public toggleTitle:string;
 
   private elementWidth:number;
@@ -74,12 +74,9 @@ export class MainMenuToggleService implements OnInit {
     public injector:Injector,
     readonly deviceService:DeviceService,
   ) {
+    this.initializeMenu();
     // Add resize event listener
     window.addEventListener('resize', this.onWindowResize.bind(this));
-  }
-
-  public ngOnInit():void {
-    this.initializeMenu();
   }
 
   public initializeMenu():void {
@@ -147,7 +144,7 @@ export class MainMenuToggleService implements OnInit {
     jQuery('.searchable-menu--search-input').blur();
   }
 
-  public openMenu(): void {
+  public openMenu():void {
     this.setWidth(this.defaultWidth);
     this.wasCollapsedByUser = false;
     window.OpenProject.guardedLocalStorage(this.localStorageStateKey, 'false');

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -98,12 +98,18 @@ export class MainMenuToggleService {
     }
 
     // small desktop version default: hide menu on initialization
-    this.closeWhenOnSmallDesktop();
+    this.adjustMenuVisibility();
   }
 
   private onWindowResize():void {
-    if (window.innerWidth < 1012) {
-      this.closeMenu();
+    this.adjustMenuVisibility();
+  }
+
+  private adjustMenuVisibility():void {
+    if (window.innerWidth >= 1012) {
+      this.setWidth(this.defaultWidth); // Open menu if the screen is wider than 1012px
+    } else {
+      this.closeMenu(); // Close menu if the screen is narrower
     }
   }
 
@@ -141,13 +147,6 @@ export class MainMenuToggleService {
     jQuery('.searchable-menu--search-input').blur();
   }
 
-  public closeWhenOnSmallDesktop():void {
-    if (this.deviceService.isSmallDesktop) {
-      this.closeMenu();
-      window.OpenProject.guardedLocalStorage(this.localStorageStateKey, 'false');
-    }
-  }
-
   public saveWidth(width?:number):void {
     this.setWidth(width);
     window.OpenProject.guardedLocalStorage(this.localStorageKey, String(this.elementWidth));
@@ -158,11 +157,7 @@ export class MainMenuToggleService {
     if (width !== undefined) {
       // Leave a minimum amount of space for space for the content
       const maxMenuWidth = this.deviceService.isSmallDesktop ? window.innerWidth - 120 : window.innerWidth - 520;
-      if (width > maxMenuWidth) {
-        this.elementWidth = maxMenuWidth;
-      } else {
-        this.elementWidth = width as number;
-      }
+      this.elementWidth = Math.min(width as number, maxMenuWidth);
     }
 
     this.snapBack();
@@ -172,7 +167,6 @@ export class MainMenuToggleService {
     this.global.showNavigation = this.showNavigation;
     this.htmlNode.style.setProperty('--main-menu-width', `${this.elementWidth}px`);
 
-    // Send change event when size of menu is changing (menu toggled or resized)
     const changeEvent = jQuery.Event('change');
     this.changeData.next(changeEvent);
   }

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -119,7 +119,7 @@ export class MainMenuToggleService {
     }
   }
 
-  public toggleNavigation(event?:JQuery.TriggeredEvent | Event):void {
+  public toggleNavigation(event?:JQuery.TriggeredEvent|Event):void {
     if (event) {
       event.stopPropagation();
       event.preventDefault();
@@ -167,6 +167,8 @@ export class MainMenuToggleService {
 
     // Check if menu is open or closed and apply CSS class if needed
     this.toggleClassHidden();
+    this.snapBack();
+    this.setToggleTitle();
 
     // Save the width if it's open
     if (this.elementWidth > 0) {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/58454

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
While resizing the window, if the window size is small, hide the menu like when we reload the page.

## Screenshots
Before:
https://github.com/user-attachments/assets/7fae43a9-0505-4f8d-9ef5-bff49760d4f3

After:
https://github.com/user-attachments/assets/7da06ace-4a34-4592-9364-195f07d2f184

# What approach did you choose and why?
Hide the side menu while resizing if the window size is smaller than 1012px.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
