### PR TITLE
[58420] Notification screen does not show submenu headers in the breadcrumb

### DIFF
--- a/app/components/notifications/index_page_header_component.html.erb
+++ b/app/components/notifications/index_page_header_component.html.erb
@@ -1,6 +1,6 @@
 <%= render(Primer::OpenProject::PageHeader.new) do |header|
   header.with_title { page_title }
-  header.with_breadcrumbs(breadcrumb_items)
+  header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: current_breadcrumb_element == page_title ? :bold : :normal)
 
   header.with_action_button(tag: :a,
                             mobile_icon: :gear,

--- a/app/components/notifications/index_page_header_component.rb
+++ b/app/components/notifications/index_page_header_component.rb
@@ -38,16 +38,41 @@ module Notifications
     end
 
     def page_title
-      I18n.t("js.notifications.title")
+      if current_item.present?
+        current_item.title
+      else
+        I18n.t("notifications.menu.inbox")
+      end
     end
 
     def breadcrumb_items
-      [parent_element,
-       page_title]
+      [{ href: home_path, text: helpers.organization_name },
+       { href: notifications_path, text: I18n.t("js.notifications.title") },
+       current_breadcrumb_element]
     end
 
-    def parent_element
-      { href: home_path, text: helpers.organization_name }
+    def current_breadcrumb_element
+      if current_section && current_section.header.present?
+        I18n.t("menus.breadcrumb.nested_element", section_header: current_section.header, title: page_title).html_safe
+      else
+        page_title
+      end
+    end
+
+    def current_section
+      return @current_section if defined?(@current_section)
+
+      @current_section = Notifications::Menu
+                           .new(params:, current_user: User.current)
+                           .selected_menu_group
+    end
+
+    def current_item
+      return @current_item if defined?(@current_item)
+
+      @current_item = Notifications::Menu
+                        .new(params:, current_user: User.current)
+                        .selected_menu_item
     end
   end
 end

--- a/app/menus/notifications/menu.rb
+++ b/app/menus/notifications/menu.rb
@@ -108,7 +108,7 @@ module Notifications
     end
 
     def selected?(query_params)
-      params[:filter] == query_params[:filter] && params[:name] == query_params[:name].to_s
+      params[:filter] == query_params[:filter] && params[:name] == (query_params[:name] ? query_params[:name].to_s : nil)
     end
 
     def query_path(query_params)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58420/activity

# What are you trying to accomplish?
Reveal sidemenu structure in the breadcrumb of the notification center

## Screenshots
**Before**
<img width="400" alt="Bildschirmfoto 2024-10-21 um 13 26 22" src="https://github.com/user-attachments/assets/b85a4e9a-52d3-4eb2-8b56-13f1d2f79729">
<img width="400" alt="Bildschirmfoto 2024-10-21 um 13 26 12" src="https://github.com/user-attachments/assets/b2232f0f-c7bc-400c-a8e8-bb61fa127bfa">


**After**
<img width="400" alt="Bildschirmfoto 2024-10-21 um 13 22 14" src="https://github.com/user-attachments/assets/1abeb5bf-e903-473e-b8f9-4f88c57cdfc4">

<img width="400" alt="Bildschirmfoto 2024-10-21 um 13 22 27" src="https://github.com/user-attachments/assets/5bbf19d6-f037-446a-a705-7ff3229e14ff">


# What approach did you choose and why?
Follow the same structure as in the other modules

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
