### PR TITLE
Bug/57550 custom field with format version are ordered as strings 2

### DIFF
--- a/app/models/queries/versions/orders/name_order.rb
+++ b/app/models/queries/versions/orders/name_order.rb
@@ -36,7 +36,7 @@ class Queries::Versions::Orders::NameOrder < Queries::Orders::Base
   private
 
   def order
-    ordered = Version.order_by_name
+    ordered = Version.order(:name)
 
     if direction == :desc
       ordered = ordered.reverse_order

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -57,8 +57,6 @@ class Version < ApplicationRecord
 
   scope :systemwide, -> { where(sharing: "system") }
 
-  scope :order_by_name, -> { order(Arel.sql("LOWER(#{Version.table_name}.name) ASC")) }
-
   def self.with_status_open
     where(status: "open")
   end

--- a/db/migrate/20240920152544_set_versions_name_collation.rb
+++ b/db/migrate/20240920152544_set_versions_name_collation.rb
@@ -1,7 +1,7 @@
 class SetVersionsNameCollation < ActiveRecord::Migration[7.1]
   def up
     execute <<-SQL.squish
-      CREATE COLLATION IF NOT EXISTS versions_name (provider = icu, locale = 'en-u-kn-true');
+      CREATE COLLATION IF NOT EXISTS versions_name (provider = icu, locale = 'und-u-kn-true');
     SQL
 
     change_column :versions, :name, :string, collation: "versions_name"

--- a/modules/backlogs/app/models/backlog.rb
+++ b/modules/backlogs/app/models/backlog.rb
@@ -32,7 +32,7 @@ class Backlog
   def self.owner_backlogs(project, options = {})
     options.reverse_merge!(limit: nil)
 
-    backlogs = Sprint.apply_to(project).with_status_open.displayed_right(project).order_by_name
+    backlogs = Sprint.apply_to(project).with_status_open.displayed_right(project).order(:name)
 
     stories_by_sprints = Story.backlogs(project.id, backlogs.map(&:id))
 


### PR DESCRIPTION
# Ticket
[OP#57550](https://community.openproject.org/wp/57550)

# What are you trying to accomplish?
Quick followup for #16776 that was merged prematurely, this includes the change to migration to use "universal" `und` instead of `en` collation, removes `order_by_name` scope.

Another PR should handle cleanup of `Queries::Versions::Orders::NameOrder` and `Queries::Versions::Orders::SemverNameOrder`, and remove special null handling for version, start date and due date columns.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
