### PR TITLE
Sent notifications to users mentioning themselves again

### DIFF
--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -332,7 +332,7 @@ class Notifications::CreateFromModelService
 
   def user_not_mentioned_or_mentioned_indirectly(self_reason)
     self_reason != NotificationSetting::MENTIONED ||
-    (mention_matches[:user_ids].exclude?(user_with_fallback.id) &&
+    (mention_matches[:user_ids].exclude?(user_with_fallback.id.to_s) &&
      mention_matches[:user_login_names].exclude?(user_with_fallback.login))
   end
 

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -991,7 +991,16 @@ RSpec.describe Notifications::CreateFromModelService,
           end
           let(:author) { recipient }
 
-          it_behaves_like "creates no notification"
+          it_behaves_like "creates notification" do
+            let(:notification_channel_reasons) do
+              {
+                read_ian: false,
+                reason: :mentioned,
+                mail_alert_sent: false,
+                mail_reminder_sent: false
+              }
+            end
+          end
         end
 
         context "when there is already a notification for the journal (because it was aggregated)" do


### PR DESCRIPTION
But still prevent sending notification when the user is part of a group they mention.

# Ticket

https://community.openproject.org/wp/58151

# Merge checklist

- [x] Added/updated tests