### PR TITLE
[58108] Dark mode: "Custom text" widget - table cell editing UI has wrong colors

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -91,5 +91,6 @@
       --ck-color-button-default-active-background: var(--button-default-bgColor-active);
       --ck-color-button-on-hover-background: var(--button-default-bgColor-hover);
       --ck-color-button-on-disabled-background: var(--button-default-bgColor-disabled);
+      --ck-color-labeled-field-label-background: var(--overlay-bgColor);
   }
 </style>

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -92,6 +92,6 @@
       --ck-color-button-on-hover-background: var(--button-default-bgColor-hover);
       --ck-color-button-on-disabled-background: var(--button-default-bgColor-disabled);
       --ck-color-labeled-field-label-background: var(--overlay-bgColor);
-      --ck-color-input-disabled-background: var(--bgColor-disabled)
+      --ck-color-input-disabled-background: var(--bgColor-disabled);
   }
 </style>

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -92,5 +92,6 @@
       --ck-color-button-on-hover-background: var(--button-default-bgColor-hover);
       --ck-color-button-on-disabled-background: var(--button-default-bgColor-disabled);
       --ck-color-labeled-field-label-background: var(--overlay-bgColor);
+      --ck-color-input-disabled-background: var(--bgColor-disabled)
   }
 </style>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58108/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix the text color of label in ck editor

## Screenshots
Before:
![Screenshot 2024-10-21 at 15 47 06](https://github.com/user-attachments/assets/fb8b6a48-4862-432e-a8ca-b82bec80b893)

After:

![Screenshot 2024-10-23 at 07 32 01](https://github.com/user-attachments/assets/34c7a60a-49af-483f-b225-d02b276da32f)

# What approach did you choose and why?
Map ck color variable used for bg-color of label to a primer css variable

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
