### PR TITLE
[42811] Do not display a date picker on non date operators in cost query

### DIFF
--- a/modules/reporting/lib/widget/filters/date.rb
+++ b/modules/reporting/lib/widget/filters/date.rb
@@ -30,20 +30,18 @@ class Widget::Filters::Date < Widget::Filters::Base
   include AngularHelper
 
   def render # rubocop:disable Metrics/AbcSize
-    @calendar_headers_tags_included = true
-
     name = "values[#{filter_class.underscore_name}][]"
     id_prefix = "#{filter_class.underscore_name}_"
 
     write(content_tag(:span, class: "advanced-filters--filter-value -binary") do
       label1 = label_tag "#{id_prefix}arg_1_val",
-                         h(filter_class.label) + " " + I18n.t(:label_filter_value),
+                         value_label,
                          class: "hidden-for-sighted"
 
       arg1 = content_tag :span, id: "#{id_prefix}arg_1" do
         text1 = angular_component_tag "opce-basic-single-date-picker",
                                       inputs: {
-                                        value: filter.values.first.to_s,
+                                        value: filter.operator.forced == :integers ? "" : filter.values.first.to_s,
                                         inputId: "#{id_prefix}arg_1_val",
                                         name:
                                       }
@@ -51,20 +49,39 @@ class Widget::Filters::Date < Widget::Filters::Base
       end
 
       label2 = label_tag "#{id_prefix}arg_2_val",
-                         h(filter_class.label) + " " + I18n.t(:label_filter_value),
+                         value_label,
                          class: "hidden-for-sighted"
 
       arg2 = content_tag :span, id: "#{id_prefix}arg_2", class: "advanced-filters--filter-value2" do
         text2 = angular_component_tag "opce-basic-single-date-picker",
                                       inputs: {
-                                        value: filter.values.second.to_s,
+                                        value: filter.operator.forced == :integers ? "" : filter.values.second.to_s,
                                         inputId: "#{id_prefix}arg_2_val",
                                         name: name.to_s
                                       }
         label2 + text2
       end
 
-      arg1 + arg2
+      arg3 = content_tag :span, id: "#{id_prefix}arg_1_integers", class: "advanced-filters--integer" do
+        label3 = label_tag "#{id_prefix}arg_1_integers_val",
+                           value_label,
+                           class: "hidden-for-sighted"
+
+        label3 + text_field_tag(name,
+                                filter.operator.forced == :integers ? filter.values.first.to_s : "",
+                                type: "number",
+                                min: 0,
+                                steps: 1,
+                                class: "advanced-filters--text-field -slim",
+                                id: "#{id_prefix}arg_1_integers_val",
+                                "data-filter-name": filter_class.underscore_name)
+      end
+
+      arg1 + arg2 + arg3
     end)
+  end
+
+  def value_label
+    "#{filter_class.label} #{I18n.t(:label_filter_value)}"
   end
 end

--- a/modules/reporting/spec/features/date_filter_spec.rb
+++ b/modules/reporting/spec/features/date_filter_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe "Cost report date filter", :js do
+  let(:project) { create(:project) }
+
+  let!(:today_time_entry) { create(:time_entry, project: project, hours: 5) }
+  let!(:five_days_ago_time_entry) { create(:time_entry, project: project, hours: 10, spent_on: 5.days.ago) }
+  let!(:five_days_from_now_time_entry) { create(:time_entry, project: project, hours: 15, spent_on: 5.days.from_now) }
+
+  current_user { create(:admin) }
+
+  before do
+    visit cost_reports_path(project)
+  end
+
+  it "filters the time entries" do
+    # Remove filters not tested here but added by default
+    find_by_id("rm_box_user_id").click
+    find_by_id("rm_box_project_id").click
+
+    # 'Date (spent on)' filter is also selected by default
+    select "today", from: "operators[spent_on]"
+    click_link "Apply"
+
+    expect(page).to have_content(today_time_entry.hours)
+    expect(page).to have_content(today_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_ago_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_from_now_time_entry.work_package.subject)
+
+    select "<=", from: "operators[spent_on]"
+    fill_in "spent_on_arg_1_val", with: 4.days.ago.iso8601
+    click_link "Apply"
+
+    expect(page).to have_content(five_days_ago_time_entry.hours)
+    expect(page).to have_content(five_days_ago_time_entry.work_package.subject)
+    expect(page).to have_no_content(today_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_from_now_time_entry.work_package.subject)
+
+    select "during the last days", from: "operators[spent_on]"
+    fill_in "spent_on_arg_1_integers_val", with: "5"
+    click_link "Apply"
+
+    expect(page).to have_content(five_days_ago_time_entry.hours)
+    expect(page).to have_content(five_days_ago_time_entry.work_package.subject)
+    expect(page).to have_content(today_time_entry.hours)
+    expect(page).to have_content(today_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_from_now_time_entry.work_package.subject)
+
+    select ">=", from: "operators[spent_on]"
+    fill_in "spent_on_arg_1_val", with: 4.days.from_now.iso8601
+    click_link "Apply"
+
+    expect(page).to have_content(five_days_from_now_time_entry.hours)
+    expect(page).to have_content(five_days_from_now_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_ago_time_entry.work_package.subject)
+    expect(page).to have_no_content(today_time_entry.work_package.subject)
+
+    select "between", from: "operators[spent_on]"
+    fill_in "spent_on_arg_1_val", with: 4.days.ago.iso8601
+    fill_in "spent_on_arg_2_val", with: 4.days.from_now.iso8601
+    click_link "Apply"
+
+    expect(page).to have_content(today_time_entry.hours)
+    expect(page).to have_content(today_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_ago_time_entry.work_package.subject)
+    expect(page).to have_no_content(five_days_from_now_time_entry.work_package.subject)
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/42811

# What are you trying to accomplish?

On operators for date related filters but that themselves don't take a date as a value, display a field that is not date picker powered. In the context of the cost queries, the operator in question is the "during the last days" operator.

# What approach did you choose and why?

Render an additional field that gets displayed and activated in case the operator is chosen. This is in line with the current implementation of the filter js which hides/shows values based on the arity of the operator. At the same time, it stretches the implementation to the limit of what it can hold. There is now a mix in here based on arity and type where the type is currently only used for the one operator.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
