### PR TITLE
Implement drill up/down the hierarchy field

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/delete_item_dialog_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/delete_item_dialog_component.html.erb
@@ -28,9 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Alpha::Dialog.new(id: DIALOG_ID,
-                                   title: "Delete item",
-                                   data: { test_selector: TEST_SELECTOR })) do |dialog|
+  render(Primer::Alpha::Dialog.new(id: DIALOG_ID, title: "Delete item", test_selector: TEST_SELECTOR)) do |dialog|
     dialog.with_header(variant: :large)
     dialog.with_body do
       "Are you sure you want to delete this item from the current hierarchy level?"
@@ -42,14 +40,12 @@ See COPYRIGHT and LICENSE files for more details.
       end)
 
       concat(primer_form_with(
-               model: @custom_field,
-               url: custom_field_item_path(custom_field_id: @custom_field.id, id: @hierarchy_item.id),
-               method: :delete,
-               data: { turbo: true }
-             ) do
-        render(Primer::ButtonComponent.new(scheme: :danger,
-                                           type: :submit,
-                                           data: { "close-dialog-id": DIALOG_ID })) do
+        model: @custom_field,
+        url: custom_field_item_path(custom_field_id: @custom_field.id, id: @hierarchy_item.id),
+        method: :delete,
+        data: { turbo: true }
+      ) do
+        render(Primer::ButtonComponent.new(scheme: :danger, type: :submit, data: { "close-dialog-id": DIALOG_ID })) do
           I18n.t(:button_delete)
         end
       end)

--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
       flex_layout(align_items: :center, justify_content: :space_between, test_selector: "op-custom-fields--hierarchy-item") do |item_container|
         item_container.with_column(flex_layout: true) do |item_information|
           item_information.with_column(mr: 2) do
-            render(Primer::Beta::Link.new(href: custom_field_item_path(model.root.custom_field_id, model), underline: false)) do
+            render(Primer::Beta::Link.new(href: custom_field_item_path(@root.custom_field_id, model), underline: false)) do
               render(Primer::Beta::Text.new(font_weight: :bold)) { model.label }
             end
           end

--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -42,8 +42,10 @@ See COPYRIGHT and LICENSE files for more details.
       flex_layout(align_items: :center, justify_content: :space_between) do |item_container|
         item_container.with_column(flex_layout: true) do |item_information|
           item_information.with_column(mr: 2) do
-            render(Primer::Beta::Text.new(font_weight: :bold)) do
-              @hierarchy_item.label
+            render(Primer::Beta::Link.new(href: custom_field_item_path(@hierarchy_item.root, @hierarchy_item), underline: false)) do
+              render(Primer::Beta::Text.new(font_weight: :bold)) do
+                @hierarchy_item.label
+              end
             end
           end
 
@@ -52,16 +54,21 @@ See COPYRIGHT and LICENSE files for more details.
               render(Primer::Beta::Text.new(color: :subtle)) { short_text }
             end
           end
+        end
 
-          # Actions
-          item_container.with_column do
-            render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-hierarchy-item--action-menu" })) do |menu|
-              menu.with_show_button(icon: "kebab-horizontal",
-                                    scheme: :invisible,
-                                    "aria-label": I18n.t("custom_fields.admin.items.actions"))
-              edit_action_item(menu)
-              deletion_action_item(menu)
-            end
+        if @hierarchy_item.children.exists?
+          item_information.with_column(mr: 2) do
+            render(Primer::Beta::Text.new) { children_count }
+          end
+        end
+
+        item_container.with_column do
+          render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-hierarchy-item--action-menu" })) do |menu|
+            menu.with_show_button(icon: "kebab-horizontal",
+                                  scheme: :invisible,
+                                  "aria-label": I18n.t("custom_fields.admin.items.actions"))
+            edit_action_item(menu)
+            deletion_action_item(menu)
           end
         end
       end

--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -28,42 +28,37 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  component_wrapper(data: { test_selector: "op-custom-fields--hierarchy-item" }) do
+  component_wrapper(tag: "turbo-frame", refresh: :morph) do
     if show_edit_form?
       render Admin::CustomFields::Hierarchy::ItemFormComponent.new(
-        custom_field: @custom_field,
-        hierarchy_item: @hierarchy_item,
-        url: custom_field_item_path(@custom_field, @hierarchy_item),
-        method: :put,
-        label: @edit_item_form_data.fetch(:label, nil),
-        short: @edit_item_form_data.fetch(:short, nil)
+        target_item: model,
+        url: custom_field_item_path(@root.custom_field_id, model),
+        method: :put
       )
     else
-      flex_layout(align_items: :center, justify_content: :space_between) do |item_container|
+      flex_layout(align_items: :center, justify_content: :space_between, test_selector: "op-custom-fields--hierarchy-item") do |item_container|
         item_container.with_column(flex_layout: true) do |item_information|
           item_information.with_column(mr: 2) do
-            render(Primer::Beta::Link.new(href: custom_field_item_path(@hierarchy_item.root, @hierarchy_item), underline: false)) do
-              render(Primer::Beta::Text.new(font_weight: :bold)) do
-                @hierarchy_item.label
-              end
+            render(Primer::Beta::Link.new(href: custom_field_item_path(model.root.custom_field_id, model), underline: false)) do
+              render(Primer::Beta::Text.new(font_weight: :bold)) { model.label }
             end
           end
 
-          unless @hierarchy_item.short.nil?
+          if model.short.present?
             item_information.with_column(mr: 2) do
               render(Primer::Beta::Text.new(color: :subtle)) { short_text }
             end
           end
-        end
 
-        if @hierarchy_item.children.exists?
-          item_information.with_column(mr: 2) do
-            render(Primer::Beta::Text.new) { children_count }
+          if model.children.any?
+            item_information.with_column(mr: 2) do
+              render(Primer::Beta::Text.new) { children_count }
+            end
           end
         end
 
         item_container.with_column do
-          render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-hierarchy-item--action-menu" })) do |menu|
+          render(Primer::Alpha::ActionMenu.new(test_selector: "op-hierarchy-item--action-menu")) do |menu|
             menu.with_show_button(icon: "kebab-horizontal",
                                   scheme: :invisible,
                                   "aria-label": I18n.t("custom_fields.admin.items.actions"))

--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -35,35 +35,31 @@ module Admin
         include OpTurbo::Streamable
         include OpPrimer::ComponentHelpers
 
-        def initialize(custom_field:, hierarchy_item:, edit_item_form_data: { show: false })
-          super
-          @custom_field = custom_field
-          @hierarchy_item = hierarchy_item
-          @edit_item_form_data = edit_item_form_data
-        end
-
-        def short_text
-          "(#{@hierarchy_item.short})"
+        def initialize(item:, show_edit_form: false)
+          super(item)
+          @show_edit_form = show_edit_form
+          @root = item.root
         end
 
         def wrapper_uniq_by
-          @hierarchy_item.id
+          model.id
         end
 
-        def show_edit_form?
-          @edit_item_form_data.fetch(:show, false)
+        def short_text
+          "(#{model.short})"
         end
+
+        def show_edit_form? = @show_edit_form
 
         def children_count
-          pluralize(@hierarchy_item.children.count, "sub-item")
+          I18n.t("custom_fields.admin.hierarchy.subitems", count: model.children.count)
         end
 
         def deletion_action_item(menu)
           menu.with_item(label: I18n.t(:button_delete),
                          scheme: :danger,
                          tag: :a,
-                         href: deletion_dialog_custom_field_item_path(custom_field_id: @custom_field.id,
-                                                                      id: @hierarchy_item.id),
+                         href: deletion_dialog_custom_field_item_path(custom_field_id: @root.custom_field_id, id: model.id),
                          content_arguments: { data: { controller: "async-dialog" } }) do |item|
             item.with_leading_visual_icon(icon: :trash)
           end
@@ -72,8 +68,7 @@ module Admin
         def edit_action_item(menu)
           menu.with_item(label: I18n.t(:button_edit),
                          tag: :a,
-                         content_arguments: { data: { turbo_stream: true } },
-                         href: edit_custom_field_item_path(@custom_field, @hierarchy_item)) do |item|
+                         href: edit_custom_field_item_path(@root.custom_field_id, model)) do |item|
             item.with_leading_visual_icon(icon: :pencil)
           end
         end

--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -54,6 +54,10 @@ module Admin
           @edit_item_form_data.fetch(:show, false)
         end
 
+        def children_count
+          pluralize(@hierarchy_item.children.count, "sub-item")
+        end
+
         def deletion_action_item(menu)
           menu.with_item(label: I18n.t(:button_delete),
                          scheme: :danger,

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,18 +34,10 @@ module Admin
       class ItemFormComponent < ApplicationComponent
         include OpTurbo::Streamable
 
-        def initialize(custom_field:, hierarchy_item:, url:, method:, label: nil, short: nil)
-          super
-          @custom_field = custom_field
-          @hierarchy_item = hierarchy_item
+        def initialize(target_item:, url:, method:)
+          super(target_item)
           @url = url
           @method = method
-          @label = label || @hierarchy_item.label
-          @short = short || @hierarchy_item.short
-        end
-
-        def items_path
-          custom_field_items_path(@custom_field)
         end
       end
     end

--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -28,42 +28,33 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  component_wrapper(tag: "turbo-frame") do
+  component_wrapper(tag: "turbo-frame", refresh: :morph, data: { turbo_action: :advance }) do
     flex_layout do |container|
-      if items.empty? && !show_new_item_form?
-        container.with_row(mb: 3) do
-          render Primer::Beta::Blankslate.new(
-            border: true,
-            test_selector: "op-custom-fields--hierarchy-items-blankslate"
-          ) do |component|
-            component.with_visual_icon(icon: "list-ordered")
-            component.with_heading(tag: :h3).with_content(I18n.t("custom_fields.admin.items.blankslate.title"))
-            component.with_description { I18n.t("custom_fields.admin.items.blankslate.description") }
-          end
-        end
-      else
-        container.with_row(mb: 3) do
-          render(Primer::Beta::BorderBox.new) do |item_box|
-            item_box.with_header { @custom_field.name }
+      container.with_row(mb: 3) do
+        render(Primer::Beta::BorderBox.new) do |box|
+          box.with_header { item_header }
 
-            items.each do |item|
-              item_box.with_row do
-                render Admin::CustomFields::Hierarchy::ItemComponent.new(
-                  custom_field: @custom_field,
-                  hierarchy_item: item
-                )
+          if children.empty? && !show_new_item_form?
+            box.with_row do
+              render(Primer::Beta::Blankslate.new(test_selector: "op-custom-fields--hierarchy-items-blankslate")) do |component|
+                component.with_visual_icon(icon: "list-ordered")
+                component.with_heading(tag: :h3).with_content(I18n.t("custom_fields.admin.items.blankslate.title"))
+                component.with_description { I18n.t("custom_fields.admin.items.blankslate.description") }
+              end
+            end
+          else
+            children.each do |item|
+              box.with_row do
+                render Admin::CustomFields::Hierarchy::ItemComponent.new(item: item)
               end
             end
 
             if show_new_item_form?
-              item_box.with_footer do
+              box.with_footer(test_selector: "op-custom-fields--new-item-form") do
                 render Admin::CustomFields::Hierarchy::ItemFormComponent.new(
-                  custom_field: @custom_field,
-                  hierarchy_item: CustomField::Hierarchy::Item.new,
-                  url: custom_field_items_path(@custom_field),
-                  method: :post,
-                  label: @new_item_form_data[:label],
-                  short: @new_item_form_data[:short]
+                  target_item: @new_item,
+                  url: new_child_custom_field_item_path(model.root.custom_field_id, model),
+                  method: :post
                 )
               end
             end
@@ -74,8 +65,7 @@ See COPYRIGHT and LICENSE files for more details.
       container.with_row do
         render Primer::Beta::Button.new(scheme: :primary,
                                         tag: :a,
-                                        data: { turbo_stream: true },
-                                        href: new_custom_field_item_path(@custom_field)) do |button|
+                                        href: new_child_custom_field_item_path(model.root.custom_field_id, model)) do |button|
           button.with_leading_visual_icon(icon: :plus)
           I18n.t(:label_item)
         end

--- a/app/components/admin/custom_fields/hierarchy/items_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.rb
@@ -42,7 +42,6 @@ module Admin
           @new_item = new_item
         end
 
-        def branch_root = model
         def show_new_item_form? = @new_item
 
         def root

--- a/app/contracts/custom_fields/hierarchy/update_item_contract.rb
+++ b/app/contracts/custom_fields/hierarchy/update_item_contract.rb
@@ -45,12 +45,7 @@ module CustomFields
       rule(:label) do
         next unless key?
 
-        label_already_exists = CustomField::Hierarchy::Item
-          .where(parent_id: values[:item].parent_id, label: value)
-          .where.not(id: values[:item].id)
-          .exists?
-
-        if label_already_exists
+        if values[:item].siblings.where(label: value).any?
           key.failure("must be unique at the same hierarchical level")
         end
       end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -46,6 +46,8 @@ class CustomField < ApplicationRecord
           dependent: :destroy,
           inverse_of: "custom_field"
 
+  scope :hierarchy_root_and_children, -> { includes(hierarchy_root: { children: :children }) }
+
   acts_as_list scope: [:type]
 
   validates :field_format, presence: true

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -33,4 +33,6 @@ class CustomField::Hierarchy::Item < ApplicationRecord
 
   belongs_to :custom_field
   has_closure_tree order: "sort_order", numeric_order: true, dependent: :destroy
+
+  scope :including_children, -> { includes(children: :children) }
 end

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -84,7 +84,7 @@ module CustomFields
       # @param item [CustomField::Hierarchy::Item] the parent of the node
       # @return [Success(Array<CustomField::Hierarchy::Item>)]
       def get_branch(item:)
-        Success(item.ancestors.reverse)
+        Success(item.self_and_ancestors.reverse)
       end
 
       # Move an item/node to a new parent item/node

--- a/app/views/admin/custom_fields/hierarchy/items/edit.html.erb
+++ b/app/views/admin/custom_fields/hierarchy/items/edit.html.erb
@@ -31,6 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Admin::CustomFields::EditFormHeaderComponent.new(custom_field: @custom_field, selected: :items)) %>
 
-<%= turbo_frame_tag :hierarchy_list, data: { turbo_action: :advance } do %>
-  <%= render(Admin::CustomFields::Hierarchy::ItemsComponent.new(item: @hierarchy_item)) %>
-<% end %>
+<%= render(Admin::CustomFields::Hierarchy::ItemComponent.new(item: @active_item, show_edit_form: true)) %>

--- a/app/views/admin/custom_fields/hierarchy/items/index.html.erb
+++ b/app/views/admin/custom_fields/hierarchy/items/index.html.erb
@@ -31,6 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Admin::CustomFields::EditFormHeaderComponent.new(custom_field: @custom_field, selected: :items)) %>
 
-<%= turbo_frame_tag :hierarchy_list, data: { turbo_action: :advance } do %>
-  <%= render(Admin::CustomFields::Hierarchy::ItemsComponent.new(custom_field: @custom_field)) %>
-<% end %>
+<%= render(Admin::CustomFields::Hierarchy::ItemsComponent.new(item: @active_item)) %>

--- a/app/views/admin/custom_fields/hierarchy/items/new.html.erb
+++ b/app/views/admin/custom_fields/hierarchy/items/new.html.erb
@@ -27,8 +27,8 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%=
-  primer_form_with(url: @url, method: @method, test_selector: "op-custom-fields--new-item-form") do |f|
-    render(CustomFields::Hierarchy::ItemForm.new(f, target_item: model))
-  end
-%>
+<% html_title t(:label_administration), "#{CustomField.model_name.human} #{h @custom_field.name}", t(:label_item_plural) %>
+
+<%= render(Admin::CustomFields::EditFormHeaderComponent.new(custom_field: @custom_field, selected: :items)) %>
+
+<%= render(Admin::CustomFields::Hierarchy::ItemsComponent.new(item: @active_item, new_item: @new_item)) %>

--- a/app/views/admin/custom_fields/hierarchy/items/show.html.erb
+++ b/app/views/admin/custom_fields/hierarchy/items/show.html.erb
@@ -32,5 +32,5 @@ See COPYRIGHT and LICENSE files for more details.
 <%= render(Admin::CustomFields::EditFormHeaderComponent.new(custom_field: @custom_field, selected: :items)) %>
 
 <%= turbo_frame_tag :hierarchy_list, data: { turbo_action: :advance } do %>
-  <%= render(Admin::CustomFields::Hierarchy::ItemsComponent.new(custom_field: @custom_field)) %>
+  <%= render(Admin::CustomFields::Hierarchy::ItemsComponent.new(item: @hierarchy_item)) %>
 <% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -40,7 +40,6 @@ See COPYRIGHT and LICENSE files for more details.
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
   <%# Disable prefetching while we have data-turbo=false on body %>
   <meta name="turbo-prefetch" content="false">
-  <meta name="turbo-refresh-method" content="morph">
 </head>
 <body
   class="<%= body_css_classes %> __overflowing_element_container __overflowing_body"

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -40,6 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
   <%# Disable prefetching while we have data-turbo=false on body %>
   <meta name="turbo-prefetch" content="false">
+  <meta name="turbo-refresh-method" content="morph">
 </head>
 <body
   class="<%= body_css_classes %> __overflowing_element_container __overflowing_body"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,11 @@ en:
           short: "Short name"
       notice:
         remember_items_and_projects: "Remember to set items and projects in the respective tabs for this custom field."
+      hierarchy:
+        subitems:
+          zero: no sub-items
+          one: 1 sub-item
+          other: "%{count} sub-items"
 
     text_add_new_custom_field: >
       To add new custom fields to a project you first need to create them before

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,9 +179,10 @@ Rails.application.routes.draw do
                  controller: "/admin/custom_fields/custom_field_projects",
                  only: :destroy
         resources :items,
-                  controller: "/admin/custom_fields/hierarchy/items",
-                  except: %i[show] do
+                  controller: "/admin/custom_fields/hierarchy/items" do
           get :deletion_dialog, on: :member
+          get :new_child, on: :member, action: :new
+          post :new_child, on: :member, action: :create
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,14 +172,9 @@ Rails.application.routes.draw do
 
     scope module: :admin do
       scope module: :custom_fields do
-        resources :projects,
-                  controller: "/admin/custom_fields/custom_field_projects",
-                  only: %i[index new create]
-        resource :project,
-                 controller: "/admin/custom_fields/custom_field_projects",
-                 only: :destroy
-        resources :items,
-                  controller: "/admin/custom_fields/hierarchy/items" do
+        resources :projects, controller: "/admin/custom_fields/custom_field_projects", only: %i[index new create]
+        resource :project, controller: "/admin/custom_fields/custom_field_projects", only: :destroy
+        resources :items, controller: "/admin/custom_fields/hierarchy/items" do
           get :deletion_dialog, on: :member
           get :new_child, on: :member, action: :new
           post :new_child, on: :member, action: :create

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -140,9 +140,9 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
         expect(result).to be_success
 
         ancestors = result.value!
-        expect(ancestors.size).to eq(2)
-        expect(ancestors).to contain_exactly(root, luke)
-        expect(ancestors.last).to eq(luke)
+        expect(ancestors.size).to eq(3)
+        expect(ancestors).to contain_exactly(root, luke, leia)
+        expect(ancestors.last).to eq(leia)
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
       it "returns a empty list" do
         result = service.get_branch(item: root)
         expect(result).to be_success
-        expect(result.value!).to be_empty
+        expect(result.value!).to match_array(root)
       end
     end
   end


### PR DESCRIPTION
#### ⚠️ Related WP: [OP#57819](https://community.openproject.org/work_packages/57819)

## What?

We want to be able to navigate to (and back to) the different branches of the hierarchy custom field and, of course, do the normal CRUD operations over the branch child nodes.

## How?

This PR makes a lot of changes on the way we normally have been doing this, by going in a more `turbo_frames` first approach.

First it makes the turbo frame use the `morph` refresh mechanism and also the action `advance` so that the browser location and history are updated on every navigation. This required some tweaks as the `Primer::Breadcrumbs` don't allow us to pass extra attributes to its hyperlinks (besides target and href).

The result is a clean approach with a more standard RoR view approach and following the hotwire guidelines.

There's a couple of interesting pieces that I learned around this: for turbo frame responses a specific layout needs to be used. This ensures a minimalist response and focuses on just the frame being acted upon.

## Known issues

While you can have multiple items in edit mode and update them separately, the moment you click on new, the entire state resets. This is due to the way we render the form inside the border-box footer needing the re-render of the entire component.

There's no easy way around it due to the usage of the primer components. We would need to be able to somehow generate just a HTML snipped of a single row of a `BorderBox` so that we could append/prepend/update it.

This will probably become very relevant the moment we try to make the **Insert Above** or **Insert Below** actions.

### Extra Notes
Special thanks for @akabiru that put up with my silly and ranty questions and to @brunopagno that helped me clean this mess. <3