### PR TITLE
[#58337] use correct link attachment upload

### DIFF
--- a/frontend/src/app/core/state/attachments/attachments.service.ts
+++ b/frontend/src/app/core/state/attachments/attachments.service.ts
@@ -175,12 +175,12 @@ export class AttachmentsResourceService extends ResourceStoreService<IAttachment
    */
   private getUploadTarget(resource:HalResource):string {
     return this.getDirectUploadLink(resource)
-      || AttachmentsResourceService.getAttachmentsSelfLink(resource)
+      || AttachmentsResourceService.getAddAttachmentsLink(resource)
       || this.apiV3Service.attachments.path;
   }
 
   private getDirectUploadLink(resource:HalResource):string|null {
-    const links = resource.$links as unknown&{ prepareAttachment:HalLink };
+    const links = resource.$links as { prepareAttachment:HalLink };
 
     if (links.prepareAttachment) {
       return links.prepareAttachment.href as string;
@@ -194,8 +194,13 @@ export class AttachmentsResourceService extends ResourceStoreService<IAttachment
   }
 
   private static getAttachmentsSelfLink(resource:HalResource):string|null {
-    const attachments = resource.attachments as unknown&{ href?:string };
+    const attachments = resource.attachments as { href?:string };
     return attachments?.href || null;
+  }
+
+  private static getAddAttachmentsLink(resource:HalResource):string|null {
+    const link = resource.addAttachment as { href?:string };
+    return link?.href || null;
   }
 
   protected createStore():ResourceStore<IAttachment> {

--- a/frontend/src/app/core/state/attachments/attachments.service.ts
+++ b/frontend/src/app/core/state/attachments/attachments.service.ts
@@ -194,11 +194,19 @@ export class AttachmentsResourceService extends ResourceStoreService<IAttachment
   }
 
   private static getAttachmentsSelfLink(resource:HalResource):string|null {
+    if (isNewResource(resource)) {
+      return null;
+    }
+
     const attachments = resource.attachments as { href?:string };
     return attachments?.href || null;
   }
 
   private static getAddAttachmentsLink(resource:HalResource):string|null {
+    if (isNewResource(resource)) {
+      return null;
+    }
+
     const link = resource.addAttachment as { href?:string };
     return link?.href || null;
   }

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
@@ -20,10 +20,12 @@ export class CustomTextEditFieldService extends EditFieldHandler {
 
   public active:boolean;
 
-  constructor(protected elementRef:ElementRef,
+  constructor(
+    protected elementRef:ElementRef,
     protected injector:Injector,
     protected halResource:HalResourceService,
-    protected schemaCache:SchemaCacheService) {
+    protected schemaCache:SchemaCacheService,
+  ) {
     super();
   }
 
@@ -39,7 +41,7 @@ export class CustomTextEditFieldService extends EditFieldHandler {
   /**
    * Handle saving the text
    */
-  public handleUserSubmit():Promise<any> {
+  public handleUserSubmit():Promise<void> {
     return this.update();
   }
 
@@ -135,6 +137,7 @@ export class CustomTextEditFieldService extends EditFieldHandler {
     const schemaHref = 'customtext-schema';
     const grid:GridResource = value.grid;
     const resourceSource:HalSource = {
+      id: `${grid.id}_custom_text`,
       text: value.options.text,
       getEditorContext: () => ({
         type: 'full',
@@ -142,6 +145,7 @@ export class CustomTextEditFieldService extends EditFieldHandler {
       } as ICKEditorContext),
       canAddAttachments: value.grid.canAddAttachments as boolean,
       _links: {
+        addAttachment: grid.addAttachment as { href?:string },
         attachments: grid.attachments as { href?:string },
         schema: {
           href: schemaHref,

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -901,6 +901,31 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_flag: { primeri
     end
   end
 
+  describe "images in the comment",
+           with_settings: { journal_aggregation_time_minutes: 0, show_work_package_attachments: false } do
+    let(:work_package) { create(:work_package, project:, author: admin) }
+    let(:image_fixture) { UploadedFile.load_from("spec/fixtures/files/image.png") }
+    let(:editor) { Components::WysiwygEditor.new }
+
+    context "if work package attachments are deactivated in project" do
+      it "shows the inline image and have it uploaded to the work package", :aggregate_failures do
+        login_as admin
+
+        wp_page.visit!
+        wp_page.wait_for_activity_tab
+
+        page.find_test_selector("op-open-work-package-journal-form-trigger").click
+        editor.drag_attachment(image_fixture.path, "")
+        editor.wait_until_upload_progress_toaster_cleared
+
+        page.find_test_selector("op-submit-work-package-journal-form").click
+
+        expect(find_test_selector("op-journal-notes-body")).to have_css("img")
+        expect(page).to have_test_selector("op-journal-detail-description", text: "File image.png added as attachment")
+      end
+    end
+  end
+
   describe "retracted journal entries" do
     let(:work_package) { create(:work_package, project:, author: admin) }
     let!(:first_comment_by_admin) do

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -902,6 +902,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_flag: { primeri
   end
 
   describe "images in the comment",
+           with_cuprite: false,
            with_settings: { journal_aggregation_time_minutes: 0, show_work_package_attachments: false } do
     let(:work_package) { create(:work_package, project:, author: admin) }
     let(:image_fixture) { UploadedFile.load_from("spec/fixtures/files/image.png") }
@@ -915,7 +916,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_flag: { primeri
         wp_page.wait_for_activity_tab
 
         page.find_test_selector("op-open-work-package-journal-form-trigger").click
-        editor.drag_attachment(image_fixture.path, "")
+        editor.drag_attachment(image_fixture.path, "", scroll: false)
         editor.wait_until_upload_progress_toaster_cleared
 
         page.find_test_selector("op-submit-work-package-journal-form").click

--- a/spec/support/components/attachments/attachments.rb
+++ b/spec/support/components/attachments/attachments.rb
@@ -7,7 +7,13 @@ module Components
 
     ##
     # Drag and Drop the file loaded from path on to the (native) target element
-    def drag_and_drop_file(target, path, position = :center, stopover = nil, cancel_drop: false, delay_dragleave: false)
+    def drag_and_drop_file(target,
+                           path,
+                           position = :center,
+                           stopover = nil,
+                           cancel_drop: false,
+                           delay_dragleave: false,
+                           scroll: true)
       # Remove any previous input, if any
       page.execute_script <<-JS
         jQuery('#temporary_attachment_files').remove()
@@ -22,7 +28,7 @@ module Components
           target
         else
           # Use the HTML5 file dropper to create a fake drop event
-          scroll_to_element(target)
+          scroll_to_element(target) if scroll
           target.native
         end
 

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -83,7 +83,7 @@ module Components
 
     ##
     # Create an image fixture with the optional caption from inside the ckeditor
-    def drag_attachment(image_fixture, caption = "Some caption")
+    def drag_attachment(image_fixture, caption = "Some caption", scroll: true)
       in_editor do |_container, editable|
         # Click the latest figure, if any
         # Do not wait more than 1 second to check if there is an image
@@ -98,7 +98,7 @@ module Components
 
         editable.base.send_keys(:enter, "some text", :enter, :enter)
 
-        attachments.drag_and_drop_file(editable, image_fixture, :bottom)
+        attachments.drag_and_drop_file(editable, image_fixture, :bottom, scroll:)
 
         expect(page)
             .to have_css('img[src^="/api/v3/attachments/"]', count: images.length + 1, wait: 10)


### PR DESCRIPTION
# Ticket
[OP#58337](https://community.openproject.org/work_packages/58337)

# What are you trying to accomplish?
- if attachments are disabled in files tab, file upload inline in rich text editors should stil work as expected

# What approach did you choose and why?
- use `addAttachment` link as an upload target, if no direct upload is specified - before was `attachments` link, which is conditionally hidden
