### PR TITLE
[58508]Remove "Beta" label from Dark mode selection

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,7 +580,7 @@ en:
         excluded_from_totals: "Excluded from totals"
 
   themes:
-    dark: "Dark (Beta)"
+    dark: "Dark"
     light: "Light"
     light_high_contrast: "Light high contrast"
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/58508/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
remove beta from dark mode option in mode selection dropdwon in account settings page.

## Screenshots
Before:
![Screenshot 2024-10-22 at 15 36 15](https://github.com/user-attachments/assets/00fed26e-85d5-448f-bacb-6160b1efe4e7)

After:
![Screenshot 2024-10-22 at 15 30 32](https://github.com/user-attachments/assets/2f2b38be-d3b2-47df-bb33-60d128f97d2a)


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
