### PR TITLE
Bug/58555 reminder mail not sent in case more than 15 notifications are to be reported about

### DIFF
--- a/app/views/digest_mailer/work_packages.html.erb
+++ b/app/views/digest_mailer/work_packages.html.erb
@@ -60,7 +60,7 @@
                 <table <%= placeholder_table_styles %>>
                   <tr>
                     <td style="background: #D1E5F5; padding: 8px 12px; border: 1px solid #1A67A3; border-radius: 16px; overflow: hidden; text-overflow: ellipsis;">
-                      <a href="<%= notifications_path %>"
+                      <a href="<%= notifications_url %>"
                          target="_blank"
                          style="color: #1A67A3; text-decoration: none; font-size: 14px;white-space: nowrap;">
                         <%= I18n.t(:'mail.work_packages.see_all') %>

--- a/app/workers/mails/reminder_job.rb
+++ b/app/workers/mails/reminder_job.rb
@@ -32,7 +32,11 @@ class Mails::ReminderJob < Mails::DeliverJob
 
   good_job_control_concurrency_with(
     total_limit: 1,
-    key: -> { "#{self.class.name}-#{arguments.last}" }
+    key: -> do
+      id = arguments.last.respond_to?(:id) ? arguments.last.id : arguments.last
+
+      "#{self.class.name}-#{id}"
+    end
   )
 
   private

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe DigestMailer do
         .to have_text(expected_text, normalize_ws: true)
     end
 
+    it "includes a reference to the notification center if there are more than the maximum number of shown work packages" do
+      stub_const("DigestMailer::MAX_SHOWN_WORK_PACKAGES", 0)
+
+      expect(mail_body)
+        .to have_text I18n.t(:"mail.work_packages.more_to_see.one")
+
+      expect(mail_body)
+        .to have_link(I18n.t(:"mail.work_packages.see_all"), href: notifications_url)
+    end
+
     context "with only a deleted work package for the digest" do
       let(:work_package) { nil }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58555

# What are you trying to accomplish?

The notification_path is not defined in the context of the template being rendered. It will thus result in an hard error and this means that the mail is not sent at all. I haven't been able to figure out why the path is not defined but it needs to be the `notifications_url` in any case since the full url needs to be available as the link is followed from the mail client.

A second thing that was changed is the concurrency key although no errors have been reported about that. But with the way it was defined before, only one of multiple users sharing the same name could have a `Mail::ReminderJob` scheduled at the same time. The reason for this is that sometimes the user object is passed in. On it, `to_s` will be called to determine the concurrency_key. If two people share the same name, then adding the job for the second user will be prevented. This is changed by using the id of the user object instead. 

# Merge checklist

- [x] Added/updated tests
