### PR TITLE
[58467] Changed add hierarchical item behavior

### DIFF
--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -58,7 +58,10 @@ module Admin
             .new
             .insert_item(**item_input)
             .either(
-              ->(_) { update_via_turbo_stream(component: ItemsComponent.new(custom_field: @custom_field)) },
+              ->(_) do
+                update_via_turbo_stream(component: ItemsComponent.new(custom_field: @custom_field,
+                                                                      new_item_form_data: { show: true }))
+              end,
               ->(validation_result) { add_errors_to_form(validation_result) }
             )
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/document-workflows-stream/work_packages/58467/github

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When adding a new item in the hierarchy the item form will stay open for the next entry.

# What approach did you choose and why?
I added the additional rendering of the item form for the turbo stream response to `admin/custom_fields/hierarchy/items#create`.

