### PR TITLE
fix removing consecutive custom field filters in baseline

### DIFF
--- a/app/models/journable/historic_active_record_relation.rb
+++ b/app/models/journable/historic_active_record_relation.rb
@@ -232,7 +232,7 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
       # but it has to the journals table. We join it to the journals table instead.
       journal_id = "customizable_journals.journal_id = journals.id"
 
-      predicate.gsub! /#{customized_type}.*AND #{customized_id}/m, journal_id
+      predicate.gsub! /#{customized_type}\s*AND #{customized_id}/m, journal_id
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58600

# What are you trying to accomplish?

Correct a too greedy regular expression that would merge two or more independent filters for custom fields into one. 

# Merge checklist

- [x] Added/updated tests
