### PR TITLE
Memoize cfs activated in project to avoid n+1

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -211,9 +211,14 @@ module Type::Attributes
   ##
   # Returns whether the custom field is active in the given project.
   def custom_field_in_project?(attribute, project)
-    project
-      .all_work_package_custom_fields.pluck(:id)
-      .map { |id| "custom_field_#{id}" }
+    custom_fields_in_project = RequestStore.fetch(:"custom_field_in_project_#{project.id}") do
+      project
+        .all_work_package_custom_fields
+        .pluck(:id)
+        .map { |id| "custom_field_#{id}" }
+    end
+
+    custom_fields_in_project
       .include? attribute
   end
 end


### PR DESCRIPTION
# What are you trying to accomplish?

Avoid barrage of similar SQL statements when rendering a work package index page

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/9a9068ca-62ff-4be1-b45e-3e93c2f3af32">

# What approach did you choose and why?

This is a drive by fix and I did not look into whether there are better, less local, options. Using the request store a request is only carried out once.
