### PR TITLE
Allow setting dev asset proxy to false

### DIFF
--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -35,7 +35,10 @@ module FrontendAssetHelper
   CLI_PROXY = ENV.fetch("OPENPROJECT_CLI_PROXY", CLI_DEFAULT_PROXY)
 
   def self.assets_proxied?
-    ENV["OPENPROJECT_DISABLE_DEV_ASSET_PROXY"].blank? && !Rails.env.production? && cli_proxy.present?
+    override = ENV.fetch("OPENPROJECT_DISABLE_DEV_ASSET_PROXY", nil)
+    return !ActiveModel::Type::Boolean.new.cast(override) unless override.nil?
+
+    !Rails.env.production? && cli_proxy.present?
   end
 
   def self.cli_proxy

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -3,6 +3,13 @@
 # Deletes bundled javascript assets and rebuilds them.
 # Useful for when your frontend doesn't work (jQuery not defined etc.) for seemingly no reason at all.
 
+NPM_COMMAND="ci"
+
+# allow to speed-up boot by using npm install instead of npm ci
+if [ "$1" = "fast" ]; then
+  NPM_COMMAND="install"
+fi
+
 yell() { echo -e "$0: $*" >&2; }
 die() { yell "$*"; exit 1; }
 try() { eval "$@" || die "\n\nFailed to run '$*', check log/setup_dev.log for more information."; }
@@ -18,7 +25,7 @@ echo "Removing public assets"
 try 'rm -rf public/assets >> log/setup_dev.log'
 
 echo "Installing node_modules ... "
-try '(cd frontend && npm ci) >> log/setup_dev.log'
+try "(cd frontend && npm $NPM_COMMAND) >> log/setup_dev.log"
 
 echo "Linking plugin modules"
 try 'bundle exec rake openproject:plugins:register_frontend >> log/setup_dev.log'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -118,6 +118,8 @@ Rails.application.configure do
   if ENV["OPENPROJECT_DEV_EXTRA_HOSTS"].present?
     config.hosts.push(*ENV["OPENPROJECT_DEV_EXTRA_HOSTS"].split(","))
   end
+
+  config.hosts.push /\A\w+\.openproject-dev\.com\z/
 end
 
 ActiveRecord::Base.logger = ActiveSupport::Logger.new($stdout) unless String(ENV.fetch("SILENCE_SQL_LOGS", nil)).to_bool

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -39,7 +39,7 @@ Rails.application.config.after_initialize do
     end
 
     # Add proxy configuration for Angular CLI to csp
-    if FrontendAssetHelper.assets_proxied?
+    if FrontendAssetHelper.assets_proxied? && FrontendAssetHelper.cli_proxy.present?
       proxied = ["ws://#{Setting.host_name}", "http://#{Setting.host_name}",
                  FrontendAssetHelper.cli_proxy.sub("http", "ws"), FrontendAssetHelper.cli_proxy]
       connect_src += proxied

--- a/spec/helpers/frontend_asset_helper_spec.rb
+++ b/spec/helpers/frontend_asset_helper_spec.rb
@@ -31,7 +31,7 @@ require "spec_helper"
 RSpec.describe FrontendAssetHelper do
   describe "#include_frontend_assets" do
     context "when in development or test",
-            with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => "" } do
+            with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => nil } do
       before do
         allow(Rails.env).to receive(:production?).and_return(false)
       end

--- a/spec/helpers/frontend_asset_helper_spec.rb
+++ b/spec/helpers/frontend_asset_helper_spec.rb
@@ -30,11 +30,12 @@ require "spec_helper"
 
 RSpec.describe FrontendAssetHelper do
   describe "#include_frontend_assets" do
-    context "when in development or test",
-            with_env: { "OPENPROJECT_DISABLE_DEV_ASSET_PROXY" => nil } do
-      before do
-        allow(Rails.env).to receive(:production?).and_return(false)
-      end
+    before do
+      allow(FrontendAssetHelper).to receive(:assets_proxied?).and_return(proxied)
+    end
+
+    context "when proxied" do
+      let(:proxied) { true }
 
       it "returns the proxied frontend server" do
         expect(helper.include_frontend_assets).to match(%r{script src="http://(frontend-test|localhost):4200/assets/frontend/main(.*).js"})
@@ -51,10 +52,8 @@ RSpec.describe FrontendAssetHelper do
       end
     end
 
-    context "when in production" do
-      before do
-        allow(Rails.env).to receive(:production?).and_return(true)
-      end
+    context "when not proxied" do
+      let(:proxied) { false }
 
       it "returns the path to the asset" do
         expect(helper.include_frontend_assets).to match(%r{script src="/assets/frontend/main(.*).js"})

--- a/spec/helpers/frontend_asset_helper_spec.rb
+++ b/spec/helpers/frontend_asset_helper_spec.rb
@@ -31,7 +31,7 @@ require "spec_helper"
 RSpec.describe FrontendAssetHelper do
   describe "#include_frontend_assets" do
     before do
-      allow(FrontendAssetHelper).to receive(:assets_proxied?).and_return(proxied)
+      allow(described_class).to receive(:assets_proxied?).and_return(proxied)
     end
 
     context "when proxied" do


### PR DESCRIPTION
Allow explicitly setting OPENPROJECT_DISABLE_DEV_ASSET_PROXY=false.
We want to be able to proxy assets through caddy, not through a different host. So we want asset proxying to be enabled, but no host to be used.