### PR TITLE
 Feature/46309 Custom field no longer added to all projects when added to a type

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -83,7 +83,7 @@ class TypesController < ApplicationController
       .new(@type, current_user)
       .call(permitted_type_params) do |call|
       call.on_success do
-        redirect_to_type_tab_path(@type, update_success_message)
+        redirect_to_type_tab_path(@type, t(:notice_successful_update))
       end
 
       call.on_failure do |result|
@@ -149,14 +149,6 @@ class TypesController < ApplicationController
 
   def show_local_breadcrumb
     false
-  end
-
-  def update_success_message
-    if params[:tab].in?(%w[form_configuration projects])
-      t(:notice_successful_update_custom_fields_added_to_type)
-    else
-      t(:notice_successful_update)
-    end
   end
 
   def destroy_error_message

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -165,17 +165,12 @@ class BaseTypeService
   # for this type. If a custom field is not in a group, it is removed from the
   # custom_field_ids list.
   def set_active_custom_fields
-    active_cf_ids = []
-
-    type.attribute_groups.each do |group|
-      group.members.each do |attribute|
-        if CustomField.custom_field_attribute? attribute
-          active_cf_ids << attribute.gsub(/^custom_field_/, "").to_i
-        end
-      end
-    end
-
-    type.custom_field_ids = active_cf_ids.uniq
+    type.custom_field_ids = type
+                              .attribute_groups
+                              .flat_map(&:members)
+                              .select { CustomField.custom_field_attribute? _1 }
+                              .map { _1.gsub(/^custom_field_/, "").to_i }
+                              .uniq
   end
 
   def set_active_custom_fields_for_project_ids(project_ids)

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -178,27 +178,17 @@ class BaseTypeService
     type.custom_field_ids = active_cf_ids.uniq
   end
 
-  def active_custom_field_ids
-    @active_custom_field_ids ||= begin
-    end
-  end
+  def set_active_custom_fields_for_project_ids(project_ids)
+    new_project_ids_to_activate_cfs = project_ids.reject(&:empty?).map(&:to_i) - type.project_ids
 
-  def set_active_custom_fields_for_projects(projects, custom_field_ids)
-    values = projects
+    values = Project
+               .where(id: new_project_ids_to_activate_cfs)
                .to_a
-               .product(custom_field_ids)
+               .product(type.custom_field_ids)
                .map { |p, cf_ids| { project_id: p.id, custom_field_id: cf_ids } }
 
     return if values.empty?
 
     CustomFieldsProject.insert_all(values)
-  end
-
-  def set_active_custom_fields_for_project_ids(project_ids)
-    new_project_ids_to_activate_cfs = project_ids.reject(&:empty?).map(&:to_i) - type.project_ids
-    set_active_custom_fields_for_projects(
-      Project.where(id: new_project_ids_to_activate_cfs),
-      type.custom_field_ids
-    )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2960,9 +2960,6 @@ en:
   notice_successful_update_custom_fields_added_to_project: |
     Successful update. The custom fields of the activated types are automatically activated
     on the work package form. <a href="%{url}" target="_blank">See more</a>.
-  notice_successful_update_custom_fields_added_to_type: |
-    Successful update. The active custom fields are automatically activated for
-    the associated projects of this type.
   notice_to_many_principals_to_display: "There are too many results.\nNarrow down the search by typing in the name of the new member (or group)."
   notice_user_missing_authentication_method: User has yet to choose a password or another way to sign in.
   notice_user_invitation_resent: An invitation has been sent to %{email}.

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -305,19 +305,6 @@ RSpec.describe "form configuration", :js do
       context "if inactive in project" do
         it "can be added to the type, but is not shown" do
           add_cf_to_group
-          # Disable in project, should be invisible
-          # This step is necessary, since we auto-activate custom fields
-          # when adding them to the form configuration
-          project_settings_page.visit_tab!("custom_fields")
-
-          expect(page).to have_css(".custom-field-#{custom_field.id} td", text: "MyNumber")
-          expect(page).to have_css(".custom-field-#{custom_field.id} td", text: type.name)
-
-          id_checkbox = find("#project_work_package_custom_field_ids_#{custom_field.id}")
-          expect(id_checkbox).to be_checked
-          id_checkbox.set(false)
-
-          click_button "Save"
 
           # Visit work package with that type
           wp_page.visit!


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/46309

# What are you trying to accomplish?

Adding a custom field to a type no longer adds it to all the projects the type is active in. 

When adding a project to a type, though, will add all custom fields to the project.

# Merge checklist

- [x] Added/updated tests
