### PR TITLE
Fix label check when not changing the label

### DIFF
--- a/app/contracts/custom_fields/hierarchy/update_item_contract.rb
+++ b/app/contracts/custom_fields/hierarchy/update_item_contract.rb
@@ -45,7 +45,12 @@ module CustomFields
       rule(:label) do
         next unless key?
 
-        if CustomField::Hierarchy::Item.exists?(parent_id: values[:item].parent_id, label: value)
+        label_already_exists = CustomField::Hierarchy::Item
+          .where(parent_id: values[:item].parent_id, label: value)
+          .where.not(id: values[:item].id)
+          .exists?
+
+        if label_already_exists
           key.failure("must be unique at the same hierarchical level")
         end
       end

--- a/spec/contracts/custom_fields/hierarchy/update_item_contract_spec.rb
+++ b/spec/contracts/custom_fields/hierarchy/update_item_contract_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe CustomFields::Hierarchy::UpdateItemContract do
         [
           { item: luke, label: "Luke Skywalker", short: "LS" },
           { item: luke, label: "Luke Skywalker" },
+          { item: luke, label: "luke", short: "lu" },
           { item: luke, short: "LS" },
           { item: luke, short: "lo" },
           { item: luke }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57818

# What are you trying to accomplish?
When updating a Hierarchycal Item and not changing the label the record would collide with itself as per contract. I added a condition to ignore the current item id on the query.

# Merge checklist
- [X] Added/updated tests
