### PR TITLE
Fix empty settings on migration from auth providers

### DIFF
--- a/modules/auth_saml/db/migrate/20240821121856_migrate_saml_settings_to_providers.rb
+++ b/modules/auth_saml/db/migrate/20240821121856_migrate_saml_settings_to_providers.rb
@@ -1,6 +1,9 @@
 class MigrateSamlSettingsToProviders < ActiveRecord::Migration[7.1]
   def up
-    providers = Hash(Setting.plugin_openproject_auth_saml).with_indifferent_access[:providers]
+    settings = Setting.plugin_openproject_auth_saml
+    return if settings.blank?
+
+    providers = Hash(settings).with_indifferent_access[:providers]
     return if providers.blank?
 
     providers.each do |name, options|

--- a/modules/openid_connect/db/migrate/20240829140616_migrate_oidc_settings_to_providers.rb
+++ b/modules/openid_connect/db/migrate/20240829140616_migrate_oidc_settings_to_providers.rb
@@ -30,7 +30,10 @@
 
 class MigrateOidcSettingsToProviders < ActiveRecord::Migration[7.1]
   def up
-    providers = Hash(Setting.plugin_openproject_openid_connect).with_indifferent_access[:providers]
+    settings = Setting.plugin_openproject_openid_connect
+    return if settings.blank?
+
+    providers = Hash(settings).with_indifferent_access[:providers]
     return if providers.blank?
 
     providers.each do |name, configuration|


### PR DESCRIPTION
`Setting.plugin_openproject_openid_connect` is an empty string on some instances.