### PR TITLE
fix/58657 use select signaling to speed up request for template projects

### DIFF
--- a/frontend/src/app/features/projects/components/new-project/new-project.component.ts
+++ b/frontend/src/app/features/projects/components/new-project/new-project.component.ts
@@ -51,13 +51,15 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     .add('user_action', '=', ['projects/copy']) // no null values
     .add('templated', '=', true);
 
-  templateOptions$:Observable<ProjectTemplateOption[]> =
-  this
+  templateOptions$:Observable<ProjectTemplateOption[]> = this
     .apiV3Service
     .projects
     .filtered(
       this.copyableTemplateFilter,
-      { pageSize: '-1' },
+      {
+        pageSize: '-1',
+        select: 'elements/id, elements/name, elements/identifier, elements/self, elements/ancestors, total, count, pageSize',
+      },
     )
     .get()
     .pipe(


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58657

# What are you trying to accomplish?

Speed up the API request for project templates on the project creation form by using signaling. This pattern is e.g. also employed in the project selection and all other project dropdowns.

For 200 template projects (an unrealistically high number IMO) with some custom fields active, the response time drops from ~ 2 seconds to 50ms.

