### PR TITLE
[47777] Work package date picker: wrong spacing

### DIFF
--- a/frontend/src/app/shared/components/datepicker/styles/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/styles/datepicker.modal.sass
@@ -8,7 +8,7 @@
 
   @media #{$spot-mq-drop-modal-in-context}
     height: unset
-    min-height: 486px
+    min-height: 475px // Avoid jump in height when the calendar has 6 rows to display all weeks
     width: 100vw
     // Basically the width of the two calendars next to each other + spacings
     // will be overwritten on mobile
@@ -52,7 +52,7 @@
     visibility: hidden
 
   &--flatpickr-instance.inline
-    margin: 1rem auto !important
+    margin: 0.5rem auto !important
 
   &--stretch-content
     flex-grow: 1
@@ -63,7 +63,7 @@
     // Of specificity here to overwrite the
     // nested spot-container styles
     &.spot-container
-      margin-top: $spot-spacing-0_5
+      margin-top: 0
 
 @media screen and (max-width: $breakpoint-sm)
   .op-datepicker-modal


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/47777/activity

# What are you trying to accomplish?
Reduce spacings in date picker

## Screenshots

**Before**
<img width="400" alt="Bildschirmfoto 2024-10-28 um 11 28 25" src="https://github.com/user-attachments/assets/4e583231-19af-4072-b86b-edf46d4025f2">


**After**
<img width="400" alt="Bildschirmfoto 2024-10-28 um 11 27 04" src="https://github.com/user-attachments/assets/54434faa-d4ac-4cd0-870f-3c55771bdc15">

