### PR TITLE
Bug/58656 undesired auto scroll to latest emoji reaction

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
@@ -12,7 +12,11 @@
                     test_selector: "reaction-#{reaction}",
                     tag: :a,
                     href: href(reaction:),
-                    data: { turbo_stream: true, turbo_method: :put },
+                    data: { 
+                      turbo_stream: true, 
+                      turbo_method: :put,
+                      "work-packages--activities-tab--index-target": "reactionButton", 
+                    },
                     aria: { label: aria_label_text(reaction, data[:users]) },
                     disabled: current_user_cannot_react?,
                     classes: "op-reactions-button"

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -23,12 +23,13 @@ export default class IndexController extends Controller {
     notificationCenterPathName: String,
   };
 
-  static targets = ['journalsContainer', 'buttonRow', 'formRow', 'form'];
+  static targets = ['journalsContainer', 'buttonRow', 'formRow', 'form', 'reactionButton'];
 
   declare readonly journalsContainerTarget:HTMLElement;
   declare readonly buttonRowTarget:HTMLInputElement;
   declare readonly formRowTarget:HTMLElement;
   declare readonly formTarget:HTMLFormElement;
+  declare readonly reactionButtonTargets:HTMLElement[];
 
   declare updateStreamsUrlValue:string;
   declare sortingValue:string;
@@ -160,6 +161,10 @@ export default class IndexController extends Controller {
 
     this.updateInProgress = true;
 
+    // Unfocus any reaction buttons that may have been focused
+    // otherwise the browser will perform an auto scroll to the before focused button after the stream update was applied
+    this.unfocusReactionButtons();
+
     const journalsContainerAtBottom = this.isJournalsContainerScrolledToBottom(this.journalsContainerTarget);
 
     void this.performUpdateStreamsRequest(this.prepareUpdateStreamsUrl())
@@ -170,6 +175,10 @@ export default class IndexController extends Controller {
     }).finally(() => {
       this.updateInProgress = false;
     });
+  }
+
+  private unfocusReactionButtons() {
+    this.reactionButtonTargets.forEach((button) => button.blur());
   }
 
   private prepareUpdateStreamsUrl():string {


### PR DESCRIPTION
[58656](https://community.openproject.org/work_packages/58656)

The describe issue occurs because the browser performs a browser-native auto-scroll to the reaction button, which was in focus after the update stream gets applied. The reaction button is in focus whenever a user uses the overlay to select an emoji. This seems to be the default behavior of Primer.

My solution was to defocus all reaction buttons before performing the update stream request.