### PR TITLE
make watcher spec less flaky

### DIFF
--- a/app/models/custom_actions/conditions/role.rb
+++ b/app/models/custom_actions/conditions/role.rb
@@ -39,8 +39,11 @@ class CustomActions::Conditions::Role < CustomActions::Conditions::Base
 
     def roles_in_project(work_packages, user)
       with_request_store(projects_of(work_packages)) do |projects|
-        projects.map do |project|
-          user.roles_for_project(project)
+        projects.filter_map do |project|
+          # In some cases and most probably due to side-effects, #roles_for_project returns a falsy value sometimes.
+          # We filter these out here and can thus return a proper Array of roles.
+          roles = user.roles_for_project(project) || []
+          roles unless roles.empty?
         end.flatten
       end
     end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -114,12 +114,18 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
     end
 
     context "when auto completing users" do
-      let!(:other_user) { create(:user, firstname: "Other", member_with_roles: { project => role }) }
+      let(:other_user) { create(:user, firstname: "Other", member_with_roles: { project => role }) }
+
+      before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+        # Fully reset database for this test group
+        ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
+      end
 
       before do
         project
         role
         user
+        other_user
 
         login_as(user)
       end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -116,16 +116,13 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
     context "when auto completing users" do
       let(:other_user) { create(:user, firstname: "Other", member_with_roles: { project => role }) }
 
-      before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-        # Fully reset database for this test group
-        ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
-      end
-
       before do
         project
         role
-        user
-        other_user
+
+        # We must reload the users so that all permission checks are reset and the specs work as expected
+        user.reload
+        other_user.reload
 
         login_as(user)
       end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
   let(:work_package) { create(:work_package, project:) }
   let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
   let(:role) { create(:project_role, permissions:) }
-  let(:user) { create(:user, member_with_roles: { project => role }) }
+  let!(:user) { create(:user, member_with_roles: { project => role }) }
   let(:permissions) do
     %i(view_work_packages
        view_work_package_watchers

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -120,6 +120,8 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
         project
         role
         user
+
+        login_as(user)
       end
 
       it "shows only the email address of the current user by default" do

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
       let!(:other_user) { create(:user, firstname: "Other", member_with_roles: { project => role }) }
 
       it "shows only the email address of the current user by default" do
+        expect(User.find_by_id(other_user.id)).to be_present
+
         autocomplete = find(".wp-watcher--autocomplete ng-select")
         target_dropdown = search_autocomplete autocomplete,
                                               query: "",
@@ -136,6 +138,8 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
         let!(:standard_global_role) { create(:standard_global_role) }
 
         it "shows the email address of all users" do
+          expect(User.find_by_id(other_user.id)).to be_present
+
           autocomplete = find(".wp-watcher--autocomplete ng-select")
           target_dropdown = search_autocomplete autocomplete,
                                                 query: "",

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
   let(:work_package) { create(:work_package, project:) }
   let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
   let(:role) { create(:project_role, permissions:) }
-  let!(:user) { create(:user, member_with_roles: { project => role }) }
+  let(:user) { create(:user, member_with_roles: { project => role }) }
   let(:permissions) do
     %i(view_work_packages
        view_work_package_watchers

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -120,7 +120,8 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
         autocomplete = find(".wp-watcher--autocomplete ng-select")
         target_dropdown = search_autocomplete autocomplete,
                                               query: "",
-                                              results_selector: "body"
+                                              results_selector: "body",
+                                              wait_for_fetched_options: true
 
         # Your own mail address is visible
         expect(target_dropdown).to have_css(".ng-option", text: user.name)
@@ -138,7 +139,8 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
           autocomplete = find(".wp-watcher--autocomplete ng-select")
           target_dropdown = search_autocomplete autocomplete,
                                                 query: "",
-                                                results_selector: "body"
+                                                results_selector: "body",
+                                                wait_for_fetched_options: true
 
           # Your own mail address is visible
           expect(target_dropdown).to have_css(".ng-option", text: user.name)

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -116,6 +116,12 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
     context "when auto completing users" do
       let!(:other_user) { create(:user, firstname: "Other", member_with_roles: { project => role }) }
 
+      before do
+        project
+        role
+        user
+      end
+
       it "shows only the email address of the current user by default" do
         expect(User.find_by_id(other_user.id)).to be_present
 


### PR DESCRIPTION
The watcher spec is sometimes red on dev.

```
❯ script/github_pr_errors --display-rerun-info https://github.com/opf/openproject/actions/runs/11553087641/job/32153513118
Looking for the workflow run with id 11553087641
  Branch: dev
  Commit SHA: 5412c5b16ba398451441c4f15c19f22094d9a116
  Commit message: Merge pull request #17044 from opf/feature/46309-custom-field-no-longer-added-to-all-projects-when-added-to-a-type
  Run started at: 2024-10-28 14:34:55 +0300
  ✗ Test suite: failure  https://github.com/opf/openproject/actions/runs/11553087641
    ✗ Units + Features: failure  https://github.com/opf/openproject/actions/runs/11553087641/job/32153513118
Failures explanation:

  1) Watcher tab within a full screen behaves like watchers tab when auto completing users with view_user_email permissions shows the email address of all users
     Failure/Error: expect(target_dropdown).to have_css(".ng-option", text: other_user.name)
       expected to find visible css ".ng-option" with text "Other Bobbit" within #<Capybara::Node::Element tag="ng-dropdown-panel" path="//HTML[1]/BODY[1]/NG-DROPDOWN-PANEL[1]"> but there were no matches. Also found "BB\n Bob Bobbit bobmail47.bobbit@bob.com", which matched the selector but not all filters.
     Shared Example Group: "watchers tab" called from ./spec/features/work_packages/tabs/watcher_tab_spec.rb:172
     # ./spec/features/work_packages/tabs/watcher_tab_spec.rb:148:in `block (5 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:204:in `block (2 levels) in <top (required)>'
     # ./spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:126:in `block (2 levels) in <top (required)>'

Finished in 9 minutes 51 seconds (files took 57.33 seconds to load)
2358 examples, 1 failure, 2 pending, 1 error occurred outside of examples

To be with the exact same source files as CI, use this command:
  git checkout 5412c5b16ba398451441c4f15c19f22094d9a116

Tests group #28
'./spec/features/work_packages/tabs/watcher_tab_spec.rb:137'
    ↳ html: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2024-10-28-11-43-14.645.html
    ↳ screenshot: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2024-10-28-11-43-14.645.png
To run the tests group in the same order as CI, use this command:
CI=true bundle exec rspec --seed 54165 modules/bim/spec/features/card_view/bulk_actions_spec.rb modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb modules/budgets/spec/features/budgets/delete_budget_spec.rb modules/calendar/spec/features/calendars_spec.rb modules/team_planner/spec/features/team_planner_dates_spec.rb modules/two_factor_authentication/spec/features/backup_codes/generate_backup_codes_spec.rb modules/two_factor_authentication/spec/features/backup_codes/login_with_backup_code_spec.rb spec/features/auth/logout_spec.rb spec/features/custom_fields/create_date_spec.rb spec/features/projects/modules_spec.rb spec/features/users/my_spec.rb spec/features/versions/graph_spec.rb spec/features/versions/project_settings_index_spec.rb spec/features/work_packages/bulk/update_work_package_spec.rb spec/features/work_packages/new/work_package_default_description_spec.rb spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb spec/features/work_packages/tabs/watcher_tab_spec.rb
```

Attempting to fix it.