### PR TITLE
set correct color for normal and expanded states in global search box

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -90,9 +90,8 @@ $search-input-height: 30px
       width: $search-input-width-expanded
       background: var(--overlay-bgColor)
       border-radius: 4px
-      .ng-input input.global-search--input
+      .ng-input input.global-search--input, .ng-clear-wrapper
         color: var(--body-font-color) !important
-
     .ng-dropdown-header
       border-bottom: none
       color: var(--fgColor-muted)

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -26,6 +26,8 @@ $search-input-height: 30px
     font-size: var(--header-item-font-size)
     color: var(--header-item-font-color)
 
+    &.-input-focused
+      color: var(--body-font-color) !important
     &:hover
       text-decoration: none
 
@@ -48,6 +50,8 @@ $search-input-height: 30px
     font-size: 0.9rem
     -webkit-transition: width 0.2s ease-in-out
     transition: width 0.2s ease-in-out
+    .ng-input input.global-search--input
+      color: var(--header-item-font-color) !important
     &::-ms-clear
       margin-right: 5px
       width: 20px
@@ -75,10 +79,6 @@ $search-input-height: 30px
         // We should probably remove the default theme altogether at some point
         top: 0 !important
 
-      input
-        height: $search-input-height
-        cursor: text
-
     .ng-placeholder
       // The ng-select default theme is overly specific
       // We might want to replace it with our own BEM theme definition
@@ -90,6 +90,8 @@ $search-input-height: 30px
       width: $search-input-width-expanded
       background: var(--overlay-bgColor)
       border-radius: 4px
+      .ng-input input.global-search--input
+        color: var(--body-font-color) !important
 
     .ng-dropdown-header
       border-bottom: none


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/57950/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix text color in global search box.

## Screenshots
Before:
![Screenshot 2024-10-28 at 14 09 18](https://github.com/user-attachments/assets/17202d53-38ec-4e9e-b0bd-9c3d66cd71af)

After:
![Screenshot 2024-10-28 at 14 08 53](https://github.com/user-attachments/assets/b562e6d8-ac68-4457-bb6a-531842044967)

# What approach did you choose and why?
Set the correct color for font-color in expanded and normal modes.

# Merge checklist

- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
