### PR TITLE
Fix small issues in the anonymize-sql-dump script

### DIFF
--- a/script/anonymize-sql-dump
+++ b/script/anonymize-sql-dump
@@ -173,16 +173,8 @@ echo_header "CREATING ADMIN USER"
 create_admin_rb_file=$(mktemp /tmp/create_admin_rb.XXXXXX)
 
 cat <<RUBY > "$create_admin_rb_file"
-  u = User.new(
-    login: 'admin',
-    mail: 'admin@localhost',
-    firstname: 'admin',
-    lastname: 'lastname',
-    password: 'admin',
-    password_confirmation: 'admin',
-    admin: true
-  )
-  u.save!(validate: false)
+  admin_user = AdminUserSeeder.new.new_admin
+  admin_user.save!(validate: false)
 RUBY
 
 cd "$OPENPROJECT_DEV_DIR"
@@ -194,12 +186,13 @@ rm "$create_admin_rb_file"
 
 
 echo_header "DUMPING ANONYMIZED DATA TO $(pwd)/tmp.dump.sql"
-pg_dump --format=plain tmp > tmp.dump.sql
+pg_dump --no-owner --format=plain tmp > tmp.dump.sql
 
 
 
 echo_header "DONE"
 echo "Anonymized database dump saved to $(pwd)/tmp.dump.sql"
 echo "Copy it to your machine and load it like this:"
+echo "  dropdb --if-exists --force openproject_debug_me"
 echo "  createdb --owner=openproject openproject_debug_me"
 echo "  psql --username=openproject openproject_debug_me < tmp.dump.sql"


### PR DESCRIPTION
- Reuse AdminUserSeeder to create the admin user. Previous code did not set a valid email, which prevented the user from being saved (That's why language could not be set).
- drop the db before creating it, to avoid "database already exists" errors.
- Remove owner from ALTER statements in dump file, avoiding "ERROR: must be able to SET ROLE " errors when loading the sql file.
