### PR TITLE
[52150] Zen mode for project lists page

### DIFF
--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -14,6 +14,7 @@
         page_title
       end
       header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: current_breadcrumb_element == page_title ? :bold : :normal)
+      header.with_action_zen_mode_button(data: {'test-selector': 'projects-lists-zen-mode-button'})
 
       if can_save?
         header_save_action(

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -1091,6 +1091,16 @@ RSpec.describe "Projects index page", :js, :with_cuprite, with_settings: { login
           .to have_no_css("td", text: news.created_at.strftime("%m/%d/%Y"))
       end
     end
+
+    it "can see zen-mode button" do
+      login_as(simple_member)
+      visit projects_path
+
+      projects_page.page.find_test_selector("projects-lists-zen-mode-button").click
+      expect(page).to have_css(".zen-mode")
+      projects_page.page.find_test_selector("projects-lists-zen-mode-button").click
+      expect(page).to have_no_css(".zen-mode")
+    end
   end
 
   describe "order" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/project-portfolio-management-stream/work_packages/52150/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add zen-mode button to projects list page

## Screenshots
![Screenshot 2024-10-29 at 12 09 19](https://github.com/user-attachments/assets/3d8ea5d1-0da5-4db9-8eb7-2ada825cf6a3)

# Merge checklist

- [X] Added/updated tests
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
