### PR TITLE
[#58651] Add reactions button should not be hidden when user has exhausted all reactions

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
@@ -1,34 +1,39 @@
 <%=
   component_wrapper do
-    if journal.available_emoji_reactions.any?
-      render(Primer::Alpha::Overlay.new(
-              title: I18n.t("reactions.action_title"),
-              padding: :condensed,
-              anchor_side: :outside_top,
-              visually_hide_title: true
-            )) do |overlay|
-        overlay.with_show_button(
-          icon: "smiley",
-          "aria-label": I18n.t("reactions.add_reaction"),
-          title: I18n.t("reactions.add_reaction"),
-          mr: 2,
-          test_selector: "add-reactions-button"
-        )
+    render(Primer::Alpha::Overlay.new(
+            title: I18n.t("reactions.action_title"),
+            padding: :condensed,
+            anchor_side: :outside_top,
+            visually_hide_title: true
+          )) do |overlay|
+      overlay.with_show_button(
+        icon: "smiley",
+        "aria-label": I18n.t("reactions.add_reaction"),
+        title: I18n.t("reactions.add_reaction"),
+        mr: 2,
+        test_selector: "add-reactions-button"
+      )
 
-        overlay.with_body(pt: 2) do
-          flex_layout do |add_reactions_container|
-            journal.available_emoji_reactions.each do |emoji, reaction|
-              add_reactions_container.with_column(mr: 2) do
-                render(Primer::Beta::Button.new(
-                        scheme: :invisible,
-                        id: "#{journal.id}-#{reaction}",
-                        tag: :a,
-                        href: toggle_reaction_work_package_activity_path(journal.journable.id, id: journal.id, reaction:),
-                        data: { "turbo-stream": true, "turbo-method": :put },
-                        "aria-label": I18n.t("reactions.react_with", reaction: reaction.to_s.humanize(capitalize: false))
-                      )) do
-                  emoji
-                end
+      overlay.with_body(pt: 2) do
+        flex_layout do |add_reactions_container|
+          EmojiReaction.available_emoji_reactions.each do |emoji, reaction|
+            add_reactions_container.with_column(mr: 2) do
+              render(Primer::Beta::Button.new(
+                      scheme: button_scheme(reaction),
+                      color: :default,
+                      bg: counter_color(reaction),
+                      id: "overlay-#{journal.id}-#{reaction}",
+                      test_selector: "overlay-reaction-#{reaction}",
+                      tag: :a,
+                      href: href(reaction:),
+                      data: {
+                        turbo_stream: true,
+                        turbo_method: :put,
+                        "work-packages--activities-tab--index-target": "reactionButton",
+                      },
+                      aria: { label: I18n.t("reactions.react_with", reaction: reaction.to_s.humanize(capitalize: false)) }
+                    )) do
+                emoji
               end
             end
           end

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
@@ -14,7 +14,7 @@
         test_selector: "add-reactions-button"
       )
 
-      overlay.with_body(pt: 2) do
+      overlay.with_body(pt: 2, test_selector: "emoji-reactions-overlay") do
         flex_layout do |add_reactions_container|
           EmojiReaction.available_emoji_reactions.each do |emoji, reaction|
             add_reactions_container.with_column(mr: 2) do

--- a/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
@@ -9,7 +9,7 @@
         end
         journal_container.with_row(mt: 3, flex_layout: true) do |reactions_container|
           reactions_container.with_column do
-            render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(journal:))
+            render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(journal:, grouped_emoji_reactions:))
           end
           reactions_container.with_column do
             render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(journal:, grouped_emoji_reactions:))

--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -94,10 +94,4 @@ module Reactable
       end
     end
   end
-
-  def available_emoji_reactions
-    (EmojiReaction.reactions.values - emoji_reactions.pluck(:reaction).uniq).index_by do |reaction|
-      EmojiReaction.emoji(reaction)
-    end.sort
-  end
 end

--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -39,8 +39,6 @@ class EmojiReaction < ApplicationRecord
     eyes: "\u{1F440}"
   }.freeze
 
-  AVAILABLE_EMOJIS = EMOJI_MAP.values.freeze
-
   belongs_to :user
   belongs_to :reactable, polymorphic: true
 
@@ -48,8 +46,8 @@ class EmojiReaction < ApplicationRecord
 
   enum :reaction, EMOJI_MAP.each_with_object({}) { |(k, _v), h| h[k] = k.to_s }
 
-  def self.available_emojis
-    AVAILABLE_EMOJIS
+  def self.available_emoji_reactions
+    EMOJI_MAP.invert.sort
   end
 
   def self.emoji(reaction)

--- a/spec/features/activities/work_package/emoji_reactions_spec.rb
+++ b/spec/features/activities/work_package/emoji_reactions_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Emoji reactions on work package activity", :js, :with_cuprite,
     end
 
     before do
-      first_comment
+      first_comment.emoji_reactions.destroy_all
 
       create(:emoji_reaction, user: admin, reactable: first_comment, reaction: :thumbs_down)
 
@@ -68,6 +68,18 @@ RSpec.describe "Emoji reactions on work package activity", :js, :with_cuprite,
 
       activity_tab.remove_emoji_reaction_for_journal(first_comment, "👎")
       activity_tab.expect_emoji_reactions_for_journal(first_comment, "👍" => 1, "👎" => 1)
+    end
+
+    it "can add or remove emoji reactions from overlay" do
+      activity_tab.add_emoji_reaction_in_overlay(first_comment, "🚀")
+      activity_tab.expect_emoji_reactions_for_journal(first_comment, "👎" => 1, "🚀" => 1)
+      activity_tab.expect_emoji_reactions_highlited_in_overlay(first_comment, "🚀") do
+        thumbs_down = page.find_test_selector("overlay-reaction-thumbs_down")
+        expect(thumbs_down).to have_no_css(".color-bg-accent")
+      end
+
+      activity_tab.within_emoji_reactions_overlay { click_on "🚀" }
+      activity_tab.expect_emoji_reactions_for_journal(first_comment, "👎" => 1)
     end
   end
 

--- a/spec/models/emoji_reaction_spec.rb
+++ b/spec/models/emoji_reaction_spec.rb
@@ -63,9 +63,18 @@ RSpec.describe EmojiReaction do
     end
   end
 
-  describe ".available_emojis" do
-    it "returns the available emojis as HTML codes" do
-      expect(described_class.available_emojis).to eq(["👍", "👎", "😄", "😕", "❤️", "🎉", "🚀", "👀"])
+  describe ".available_emoji_reactions" do
+    it "returns a sorted list of available emoji reactions" do
+      expect(described_class.available_emoji_reactions).to eq(
+        [["❤️", :heart],
+         ["🎉", :party_popper],
+         ["👀", :eyes],
+         ["👍", :thumbs_up],
+         ["👎", :thumbs_down],
+         ["😄", :grinning_face_with_smiling_eyes],
+         ["😕", :confused_face],
+         ["🚀", :rocket]]
+      )
     end
   end
 

--- a/spec/support/components/work_packages/emoji_reactions.rb
+++ b/spec/support/components/work_packages/emoji_reactions.rb
@@ -80,12 +80,36 @@ module Components
         end
       end
 
-      def expect_add_reactions_button
-        expect(page).to have_test_selector("add-reactions-button")
-      end
-
       def expect_no_add_reactions_button
         expect(page).not_to have_test_selector("add-reactions-button")
+      end
+
+      def add_emoji_reaction_in_overlay(journal, emoji)
+        open_emoji_reactions_overlay_for_journal(journal) do
+          click_on emoji
+        end
+      end
+
+      def open_emoji_reactions_overlay_for_journal(journal, &block)
+        within_journal_entry(journal) do
+          click_on "Add reaction"
+          wait_for { page }.to have_test_selector("emoji-reactions-overlay")
+          within_emoji_reactions_overlay(&block)
+        end
+      end
+
+      def expect_emoji_reactions_highlited_in_overlay(journal, *emojis)
+        open_emoji_reactions_overlay_for_journal(journal) do
+          emojis.each do |emoji|
+            expect(page).to have_css(".color-bg-accent", text: emoji)
+          end
+
+          yield if block_given?
+        end
+      end
+
+      def within_emoji_reactions_overlay(&)
+        page.within_test_selector("emoji-reactions-overlay", &)
       end
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/58651

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The current pattern hides the "add reactions" button based on whether there are existing reactions or not. This is an inconsistent pattern and can be confusing to the user.

E.g. See Gif below- when "😕" is clicked the "add reactions" banner doesn't display because the logic resolves that there is a button there for the user to click. It only renders back when no reaction exists.

![image](https://github.com/user-attachments/assets/1639c7db-8e71-4e4f-b81b-744e645e0342)


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


![Kapture 2024-10-29 at 18 34 25](https://github.com/user-attachments/assets/1fedf12b-bbf4-41ea-a8a1-5e111dca2a7c)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Available reactions are never hidden, rather highlighted when active and act as toggle buttons. This pattern is similar to GitHub's emoji reactions

![image](https://github.com/user-attachments/assets/d5055ae9-1f0d-44a9-aeee-38a0832f3299)


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
