### PR TITLE
[#58271] Access token refresh results in error message in files tab

### DIFF
--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -188,16 +188,6 @@ export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
       this.attachmentsResourceService.fetchCollection(this.workPackage.$links.attachments.href as string).subscribe();
     }
 
-    if (this.workPackage.$links.fileLinks) {
-      this.fileLinkResourceService
-        .updateCollectionsForWorkPackage(this.workPackage.$links.fileLinks.href as string)
-        .pipe(take(1))
-        .subscribe(
-          () => { /* Do nothing */ },
-          (error:HttpErrorResponse) => { this.toastService.addError(error); },
-        );
-    }
-
     // Listen to tab changes to update the tab label
     this.keepTab.observable
       .pipe(this.untilDestroyed())


### PR DESCRIPTION
# Ticket
[WP#58271](https://community.openproject.org/work_packages/58271)

# What are you trying to accomplish?

The goal is to sequentialize API requests from the OpenProject backend to Nextcloud to minimize the risk of race conditions or invalid OAuth tokens due to concurrent requests. 
This PR aims to achieve this by controlling the sequence of `file_links` and `storage` requests from the frontend code that initiates the requests in the _Work package - Files Tab_.

What I observed:

Original order of requests when the error occurs:

**1. File links**
- URL: https://community.openproject.org/api/v3/work_packages/57909/file_links
- Path: _embedded.elements[0]._links.status
- Error: urn:openproject-org:api:v3:file-links:Error
- Initiated from: [work-package-single-view.base.ts](https://github.com/opf/openproject/pull/17085/files#diff-3a2cb798437a0a2bf88346c0a150fc962a3208bd841936b12cada02254432e12)

**2. Storages**
- URL: https://community.openproject.org/api/v3/storages/34
- Path: _links.authorizationState.href
- Status: urn:openproject-org:api:v3:storages:authorization



# What approach did you choose and why?

It seemed when the `file_links`-request has completed before the `storage`-request, it results in `file-links:Error`.
However, I noticed that the same error persisted in the file_links response payload even when the storages request was omitted.

When I reversed the order, requesting storages first and then file_links, the issue did not reoccur in my local testing environment.

Additionally, I moved the file_links request from [work-package-single-view.base.ts](https://github.com/opf/openproject/pull/17085/files#diff-3a2cb798437a0a2bf88346c0a150fc962a3208bd841936b12cada02254432e12) and transferred the error handling to the storage component.


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
