### PR TITLE
[58689] Eager load relations on work_packages api

### DIFF
--- a/lib/api/v3/work_packages/eager_loading/principals.rb
+++ b/lib/api/v3/work_packages/eager_loading/principals.rb
@@ -1,0 +1,64 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module WorkPackages
+      module EagerLoading
+        class Principals < Base
+          def apply(work_package)
+            work_package.author = principal_for(work_package.author_id)
+            work_package.assigned_to = principal_for(work_package.assigned_to_id)
+            work_package.responsible = principal_for(work_package.responsible_id)
+          end
+
+          private
+
+          def principal_for(principal_id)
+            principals_by_id[principal_id]
+          end
+
+          def principals_by_id
+            @principals_by_id ||= ::Principal
+                .where(id: principal_ids)
+                .to_a
+                .index_by(&:id)
+          end
+
+          def principal_ids
+            work_packages
+              .pluck(:author_id, :assigned_to_id, :responsible_id)
+              .flatten
+              .uniq
+              .compact
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -75,6 +75,7 @@ module API
               ::API::V3::WorkPackages::EagerLoading::Hierarchy,
               ::API::V3::WorkPackages::EagerLoading::Ancestor,
               ::API::V3::WorkPackages::EagerLoading::Project,
+              ::API::V3::WorkPackages::EagerLoading::Principals,
               ::API::V3::WorkPackages::EagerLoading::Checksum,
               ::API::V3::WorkPackages::EagerLoading::CustomValue,
               ::API::V3::WorkPackages::EagerLoading::CustomAction,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -683,6 +683,7 @@ module API
 
         # Attachments need to be eager loaded for the description
         self.to_eager_load = %i[parent
+                                priority
                                 type
                                 watchers
                                 attachments

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -125,6 +125,11 @@ module OpenProject::Bim
     patch_with_namespace :DemoData, :WorkPackageSeeder
     patch_with_namespace :DemoData, :WorkPackageBoardSeeder
 
+    config.to_prepare do
+      # needed for `#bcf_issue?` calls in the work package representer
+      ::API::V3::WorkPackages::WorkPackageRepresenter.to_eager_load << :bcf_issue
+    end
+
     extend_api_response(:v3, :work_packages, :work_package) do
       include API::Bim::Utilities::PathHelper
 

--- a/spec/lib/api/v3/work_packages/eager_loading/principals_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/principals_integration_spec.rb
@@ -1,0 +1,113 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++require 'rspec'
+
+require "spec_helper"
+require_relative "eager_loading_mock_wrapper"
+
+RSpec.describe API::V3::WorkPackages::EagerLoading::Principals do
+  shared_let(:author) { create(:user, firstname: "Arthur", lastname: "Author") }
+
+  describe ".apply" do
+    def create_and_unload_associations(*args)
+      create(*args).reload
+    end
+
+    def user_associations(work_package)
+      %i[author assigned_to responsible].map { |association| work_package.association(association) }
+    end
+
+    context "when work package references users" do
+      shared_let(:astor) { create(:user, firstname: "Astor", lastname: "Assigned to") }
+      shared_let(:robert) { create(:user, firstname: "Robert", lastname: "Responsible") }
+
+      let(:work_package) do
+        create_and_unload_associations(:work_package, author:,
+                                                      assigned_to: astor,
+                                                      responsible: robert)
+      end
+
+      it "preloads them" do
+        expect do
+          EagerLoadingMockWrapper.wrap(described_class, [work_package])
+        end.to change { user_associations(work_package).map(&:loaded?) }
+          .from([false, false, false])
+          .to([true, true, true])
+
+        expect(work_package.author).to eq author
+        expect(work_package.assigned_to).to eq astor
+        expect(work_package.responsible).to eq robert
+      end
+    end
+
+    context "when work package references groups" do
+      let(:group1) { create(:group, firstname: "Group 1") }
+      let(:group2) { create(:group, firstname: "Group 2") }
+
+      let(:work_package) do
+        create_and_unload_associations(:work_package, author:,
+                                                      assigned_to: group1,
+                                                      responsible: group2)
+      end
+
+      it "preloads them" do
+        expect do
+          EagerLoadingMockWrapper.wrap(described_class, [work_package])
+        end.to change { user_associations(work_package).map(&:loaded?) }
+          .from([false, false, false])
+          .to([true, true, true])
+
+        expect(work_package.author).to eq author
+        expect(work_package.assigned_to).to eq group1
+        expect(work_package.responsible).to eq group2
+      end
+    end
+
+    context "when work package references placeholder users" do
+      let(:placeholder_user1) { create(:placeholder_user, firstname: "Placeholder user 1") }
+      let(:placeholder_user2) { create(:placeholder_user, firstname: "Placeholder user 2") }
+
+      let(:work_package) do
+        create_and_unload_associations(:work_package, author:,
+                                                      assigned_to: placeholder_user1,
+                                                      responsible: placeholder_user2)
+      end
+
+      it "preloads them" do
+        expect do
+          EagerLoadingMockWrapper.wrap(described_class, [work_package])
+        end.to change { user_associations(work_package).map(&:loaded?) }
+          .from([false, false, false])
+          .to([true, true, true])
+
+        expect(work_package.author).to eq author
+        expect(work_package.assigned_to).to eq placeholder_user1
+        expect(work_package.responsible).to eq placeholder_user2
+      end
+    end
+  end
+end


### PR DESCRIPTION

# Ticket

https://community.openproject.org/wp/58689

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Make `/api/v3/work_packages` endpoint faster.



# What approach did you choose and why?

Eager loaded relations are users (`author`, `assigned_to`, `responsible`), `priority`, and `bcf_issue`. 
- Users have a new `API::V3::WorkPackages::EagerLoading::Users`.
- `priority` and `bcf_issue` have been added in the `includes` of `API::V3::WorkPackages::WorkPackagesEagerLoadingWrapper. 

On my tests, it reduces the overall request duration by 30%. Not as much as one could hope, but still better.

Most of the time is spent rendering the JSON. That's where the N+1 was.
Still there is time consumed to render all URL, and also to sanitize the description of each work package. Not sure how to reduce that time though.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
