### PR TITLE
Add `CAPYBARA_PUMA_THREADS` to control puma threads count

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -85,7 +85,11 @@ RSpec.configure do |config|
 end
 
 # silence puma if we're using it
-Capybara.server = :puma, { Silent: true }
+puma_options = { Silent: true }
+# use `CAPYBARA_PUMA_THREADS=1:1` to use only 1 puma thread, which is useful
+# when using irb/pry in server code.
+puma_options[:Threads] = ENV["CAPYBARA_PUMA_THREADS"] if ENV.key?("CAPYBARA_PUMA_THREADS")
+Capybara.server = :puma, puma_options
 
 Rails.application.config do
   config.middleware.use RackSessionAccess::Middleware


### PR DESCRIPTION
When using `binding.irb` in backend code, we can have multiple REPL spawning if multiple requests are made. This makes it hard to use IRB as it will jump from one thread to another each time an expression is evaluated. Barely usable.

This commit adds a new environment variable `CAPYBARA_PUMA_THREADS` to control the number of threads Puma uses in tests. Set it to "1:1" to use only one thread, which is useful when using IRB. Not setting it will continue to use the default number of threads for Puma in test environment.

See https://github.com/puma/puma/blob/master/lib/rack/handler/puma.rb#L7 for available options.
