### PR TITLE
Implements the ability to add items above or below another

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -29,15 +29,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   component_wrapper(tag: "turbo-frame", refresh: :morph) do
-    if show_edit_form?
-      render Admin::CustomFields::Hierarchy::ItemFormComponent.new(
-        target_item: model,
-        url: custom_field_item_path(@root.custom_field_id, model),
-        method: :put
-      )
+    if show_form?
+      render Admin::CustomFields::Hierarchy::ItemFormComponent.new(model)
     else
       flex_layout(align_items: :center, justify_content: :space_between, test_selector: "op-custom-fields--hierarchy-item") do |item_container|
         item_container.with_column(flex_layout: true) do |item_information|
+          item_information.with_column(mr: 2) do
+            render(Primer::OpenProject::DragHandle.new)
+          end
           item_information.with_column(mr: 2) do
             render(Primer::Beta::Link.new(href: custom_field_item_path(@root.custom_field_id, model), underline: false)) do
               render(Primer::Beta::Text.new(font_weight: :bold)) { model.label }
@@ -62,8 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
             menu.with_show_button(icon: "kebab-horizontal",
                                   scheme: :invisible,
                                   "aria-label": I18n.t("custom_fields.admin.items.actions"))
-            edit_action_item(menu)
-            deletion_action_item(menu)
+            menu_items(menu)
           end
         end
       end

--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -38,7 +38,7 @@ module Admin
         def initialize(item:, show_edit_form: false)
           super(item)
           @show_edit_form = show_edit_form
-          @root = item.root
+          @root = item.root || item.parent.root
         end
 
         def wrapper_uniq_by
@@ -49,11 +49,23 @@ module Admin
           "(#{model.short})"
         end
 
-        def show_edit_form? = @show_edit_form
+        def show_form? = @show_edit_form || model.new_record?
 
         def children_count
           I18n.t("custom_fields.admin.hierarchy.subitems", count: model.children.count)
         end
+
+        def menu_items(menu)
+          edit_action_item(menu)
+          menu.with_divider
+          add_above_action_item(menu)
+          add_below_action_item(menu)
+          add_sub_item_action_item(menu)
+          menu.with_divider
+          deletion_action_item(menu)
+        end
+
+        private
 
         def deletion_action_item(menu)
           menu.with_item(label: I18n.t(:button_delete),
@@ -71,6 +83,33 @@ module Admin
                          href: edit_custom_field_item_path(@root.custom_field_id, model)) do |item|
             item.with_leading_visual_icon(icon: :pencil)
           end
+        end
+
+        def add_above_action_item(menu)
+          menu.with_item(
+            label: I18n.t(:button_add_item_above),
+            tag: :a,
+            content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+            href: new_child_custom_field_item_path(@root.custom_field_id, model.parent, position: model.sort_order)
+          ) { _1.with_leading_visual_icon(icon: "fold-up") }
+        end
+
+        def add_below_action_item(menu)
+          menu.with_item(
+            label: I18n.t(:button_add_item_below),
+            tag: :a,
+            content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+            href: new_child_custom_field_item_path(@root.custom_field_id, model.parent, position: model.sort_order + 1)
+          ) { _1.with_leading_visual_icon(icon: "fold-down") }
+        end
+
+        def add_sub_item_action_item(menu)
+          menu.with_item(
+            label: I18n.t(:button_add_sub_item),
+            tag: :a,
+            content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+            href: new_child_custom_field_item_path(@root.custom_field_id, model)
+          ) { _1.with_leading_visual_icon(icon: "op-arrow-in") }
         end
       end
     end

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  primer_form_with(url: @url, method: @method, test_selector: "op-custom-fields--new-item-form") do |f|
+  primer_form_with(**item_options, test_selector: "op-custom-fields--new-item-form") do |f|
     render(CustomFields::Hierarchy::ItemForm.new(f, target_item: model))
   end
 %>

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  primer_form_with(**item_options, test_selector: "op-custom-fields--new-item-form") do |f|
+  primer_form_with(**item_options) do |f|
     render(CustomFields::Hierarchy::ItemForm.new(f, target_item: model))
   end
 %>

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.rb
@@ -35,8 +35,8 @@ module Admin
         include OpTurbo::Streamable
 
         def item_options
-          options = { url:, method: http_verb }
-          options[:data] = { turbo_frame: ItemsComponent.wrapper_key } if model.new_record?
+          options = { url:, method: http_verb, data: { test_selector: "op-custom-fields--new-item-form" } }
+          options[:data][:turbo_frame] = ItemsComponent.wrapper_key if model.new_record?
 
           options
         end

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.rb
@@ -34,10 +34,29 @@ module Admin
       class ItemFormComponent < ApplicationComponent
         include OpTurbo::Streamable
 
-        def initialize(target_item:, url:, method:)
-          super(target_item)
-          @url = url
-          @method = method
+        def item_options
+          options = { url:, method: http_verb }
+          options[:data] = { turbo_frame: ItemsComponent.wrapper_key } if model.new_record?
+
+          options
+        end
+
+        def http_verb
+          model.new_record? ? :post : :put
+        end
+
+        def url
+          if model.new_record?
+            new_child_custom_field_item_path(root.custom_field_id, model.parent, position: model.sort_order)
+          else
+            custom_field_item_path(root.custom_field_id, model)
+          end
+        end
+
+        private
+
+        def root
+          @root ||= model.new_record? ? model.parent.root : model.root
         end
       end
     end

--- a/app/components/admin/custom_fields/hierarchy/item_form_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.rb
@@ -47,7 +47,7 @@ module Admin
 
         def url
           if model.new_record?
-            new_child_custom_field_item_path(root.custom_field_id, model.parent, position: model.sort_order)
+            new_child_custom_field_item_path(root.custom_field_id, model.parent)
           else
             custom_field_item_path(root.custom_field_id, model)
           end

--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     flex_layout do |container|
       container.with_row do
         render(Primer::OpenProject::SubHeader.new) do |subheader|
-          subheader.with_action_button(tag: :a, scheme: :primary, href: new_item_path)  do |button|
+          subheader.with_action_button(tag: :a, scheme: :primary, href: new_item_path) do |button|
             button.with_leading_visual_icon(icon: :plus)
             I18n.t(:label_item)
           end
@@ -42,28 +42,23 @@ See COPYRIGHT and LICENSE files for more details.
         render(Primer::Beta::BorderBox.new) do |box|
           box.with_header { item_header }
 
-          if children.empty? && !show_new_item_form?
+          if children.empty?
             box.with_row do
               render(Primer::Beta::Blankslate.new(test_selector: "op-custom-fields--hierarchy-items-blankslate")) do |component|
-                component.with_visual_icon(icon: "list-ordered")
-                component.with_heading(tag: :h3).with_content(I18n.t("custom_fields.admin.items.blankslate.title"))
-                component.with_description { I18n.t("custom_fields.admin.items.blankslate.description") }
+                component.with_visual_icon(icon: blank_icon)
+
+                component.with_heading(tag: :h3).with_content(I18n.t(blank_header_text))
+                component.with_description { I18n.t(blank_description_text) }
+                component.with_primary_action(tag: :a, href: new_item_path) do |button|
+                  button.with_leading_visual_icon(icon: :plus)
+                  I18n.t(:label_item)
+                end
               end
             end
           else
             children.each do |item|
               box.with_row do
                 render Admin::CustomFields::Hierarchy::ItemComponent.new(item: item)
-              end
-            end
-
-            if show_new_item_form?
-              box.with_footer(test_selector: "op-custom-fields--new-item-form") do
-                render Admin::CustomFields::Hierarchy::ItemFormComponent.new(
-                  target_item: @new_item,
-                  url: new_child_custom_field_item_path(root.custom_field_id, model),
-                  method: :post
-                )
               end
             end
           end

--- a/app/components/admin/custom_fields/hierarchy/items_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.rb
@@ -45,7 +45,7 @@ module Admin
         end
 
         def new_item_path
-          position = model.children.any? ? children.last.sort_order + 1 : 0
+          position = model.children.any? ? model.children.last.sort_order + 1 : 0
 
           new_child_custom_field_item_path(root.custom_field_id, model, position:)
         end

--- a/app/components/admin/custom_fields/hierarchy/items_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.rb
@@ -35,21 +35,32 @@ module Admin
         include OpTurbo::Streamable
         include OpPrimer::ComponentHelpers
 
-        property :children
-
         def initialize(item:, new_item: nil)
           super(item)
           @new_item = new_item
         end
-
-        def show_new_item_form? = @new_item
 
         def root
           @root ||= model.root? ? model : model.root
         end
 
         def new_item_path
-          new_child_custom_field_item_path(root.custom_field_id, model)
+          position = children.any? ? children.last.sort_order + 1 : 0
+
+          new_child_custom_field_item_path(root.custom_field_id, model, position:)
+        end
+
+        def children
+          list = model.children
+          return list unless @new_item
+
+          position = @new_item.sort_order&.to_i
+
+          if position
+            list[0...position] + [@new_item] + list[position..]
+          else
+            list + [@new_item]
+          end
         end
 
         def item_header
@@ -57,6 +68,26 @@ module Admin
             slices.each do |slice|
               loaf.with_item(href: slice[:href], target: nil) { slice[:label] }
             end
+          end
+        end
+
+        def blank_icon
+          model.root? ? "list-ordered" : "op-arrow-in"
+        end
+
+        def blank_header_text
+          if model.root?
+            "custom_fields.admin.items.blankslate.root.title"
+          else
+            "custom_fields.admin.items.blankslate.item.title"
+          end
+        end
+
+        def blank_description_text
+          if model.root?
+            "custom_fields.admin.items.blankslate.root.description"
+          else
+            "custom_fields.admin.items.blankslate.item.description"
           end
         end
 

--- a/app/components/admin/custom_fields/hierarchy/items_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.rb
@@ -45,7 +45,7 @@ module Admin
         end
 
         def new_item_path
-          position = children.any? ? children.last.sort_order + 1 : 0
+          position = model.children.any? ? children.last.sort_order + 1 : 0
 
           new_child_custom_field_item_path(root.custom_field_id, model, position:)
         end

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -67,7 +67,8 @@ module Admin
             .either(
               lambda do |item|
                 redirect_to(
-                  new_child_custom_field_item_path(@custom_field, @active_item, position: item.sort_order + 1)
+                  new_child_custom_field_item_path(@custom_field, @active_item, position: item.sort_order + 1),
+                  status: :see_other
                 )
               end,
               lambda do |validation_result|
@@ -82,7 +83,7 @@ module Admin
             .update_item(item: @active_item, label: item_input[:label], short: item_input[:short])
             .either(
               lambda do |_|
-                redirect_to(custom_field_item_path(@custom_field, @active_item.parent))
+                redirect_to(custom_field_item_path(@custom_field, @active_item.parent), status: :see_other)
               end,
               lambda do |validation_result|
                 add_errors_to_edit_form(validation_result)

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -56,7 +56,7 @@ module Admin
         end
 
         def new
-          @new_item = ::CustomField::Hierarchy::Item.new(parent: @active_item)
+          @new_item = ::CustomField::Hierarchy::Item.new(parent: @active_item, sort_order: params[:position])
         end
 
         def edit; end
@@ -65,8 +65,12 @@ module Admin
           item_service
             .insert_item(**item_input)
             .either(
-              ->(_) { redirect_to(new_child_custom_field_item_path(@custom_field, @active_item), status: :see_other) },
-              ->(validation_result) do
+              lambda do |item|
+                redirect_to(
+                  new_child_custom_field_item_path(@custom_field, @active_item, position: item.sort_order + 1)
+                )
+              end,
+              lambda do |validation_result|
                 add_errors_to_form(validation_result)
                 render action: :new
               end
@@ -77,10 +81,10 @@ module Admin
           item_service
             .update_item(item: @active_item, label: item_input[:label], short: item_input[:short])
             .either(
-              ->(_) do
-                redirect_to(custom_field_item_path(@custom_field, @active_item.parent), status: :see_other)
+              lambda do |_|
+                redirect_to(custom_field_item_path(@custom_field, @active_item.parent))
               end,
-              ->(validation_result) do
+              lambda do |validation_result|
                 add_errors_to_edit_form(validation_result)
                 render action: :edit
               end
@@ -111,6 +115,7 @@ module Admin
         def item_input
           input = { parent: @active_item, label: params[:label] }
           input[:short] = params[:short] if params[:short].present?
+          input[:sort_order] = params[:sort_order].to_i if params[:sort_order].present?
 
           input
         end

--- a/app/forms/custom_fields/hierarchy/item_form.rb
+++ b/app/forms/custom_fields/hierarchy/item_form.rb
@@ -30,6 +30,8 @@ module CustomFields
   module Hierarchy
     class ItemForm < ApplicationForm
       form do |item_form|
+        item_form.hidden name: :sort_order, value: @target_item.sort_order
+
         item_form.group(layout: :horizontal) do |input_group|
           input_group.text_field(
             name: :label,

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -32,7 +32,7 @@ class CustomField::Hierarchy::Item < ApplicationRecord
   self.table_name = "hierarchical_items"
 
   belongs_to :custom_field
-  has_closure_tree order: "sort_order", numeric_order: true, dependent: :destroy
+  has_closure_tree order: "sort_order", numeric_order: true, dont_order_roots: true, dependent: :destroy
 
   scope :including_children, -> { includes(children: :children) }
 end

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -44,7 +44,7 @@ module CustomFields
           .bind { |validation| create_root_item(validation[:custom_field]) }
       end
 
-      # Insert a new node on the hierarchy tree.
+      # Insert a new node on the hierarchy tree at a desired position or at the end if no sort_order is passed.
       # @param parent [CustomField::Hierarchy::Item] the parent of the node
       # @param label [String] the node label/name that must be unique at the same tree level
       # @param short [String] an alias for the node

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -118,11 +118,14 @@ module CustomFields
         Success(item)
       end
 
-      def create_child_item(validation:, sort_order:)
-        item = validation[:parent].children.create(label: validation[:label], short: validation[:short], sort_order:)
+      def create_child_item(validation:, sort_order: nil)
+        attributes = validation.to_h
+        attributes[:sort_order] = sort_order - 1 if sort_order
+
+        item = validation[:parent].children.create(**attributes)
         return Failure(item.errors) if item.new_record?
 
-        Success(item.reload)
+        Success(item)
       end
 
       def update_item_attributes(item:, attributes:)

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -48,6 +48,7 @@ module CustomFields
       # @param parent [CustomField::Hierarchy::Item] the parent of the node
       # @param label [String] the node label/name that must be unique at the same tree level
       # @param short [String] an alias for the node
+      # @param sort_order [Integer] the position into which insert the item.
       # @return [Success(CustomField::Hierarchy::Item), Failure(Dry::Validation::Result), Failure(ActiveModel::Errors)]
       def insert_item(parent:, label:, short: nil, sort_order: nil)
         CustomFields::Hierarchy::InsertItemContract

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1474,6 +1474,9 @@ en:
   button_actions: "Actions"
   button_add: "Add"
   button_add_comment: "Add comment"
+  button_add_item_above: "Add item above"
+  button_add_item_below: "Add item below"
+  button_add_sub_item: "Add sub-item"
   button_add_member: Add member
   button_add_watcher: "Add watcher"
   button_annotate: "Annotate"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,8 +247,12 @@ en:
       items:
         actions: "Item actions"
         blankslate:
-          title: "Your list of items is empty"
-          description: "Start by adding items to the custom field of type hierarchy. Each item can be used to create a hierarchy bellow it. To navigate and create sub-items inside a hierarchy click on the created item."
+          root:
+            title: "Your list of items is empty"
+            description: "Start by adding items to the custom field of type hierarchy. Each item can be used to create a hierarchy bellow it. To navigate and create sub-items inside a hierarchy click on the created item."
+          item:
+            title: This item doesn't have any hierarchy level below
+            description: Add items to this list to create sub-items inside another one
         placeholder:
           label: "Item label"
           short: "Short name"

--- a/spec/features/custom_fields/hierarchy_custom_field_spec.rb
+++ b/spec/features/custom_fields/hierarchy_custom_field_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "custom fields of type hierarchy", :js, :with_cuprite do
     hierarchy_page.expect_current_path
     expect(page).to have_test_selector("op-custom-fields--hierarchy-items-blankslate")
 
-    click_on "Item"
+    within("sub-header") { click_on "Item" }
     expect(page).not_to have_test_selector("op-custom-fields--hierarchy-items-blankslate")
     fill_in "Label", with: "Stormtroopers"
     fill_in "Short", with: "ST"

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
 
   let!(:root) { service.generate_root(custom_field).value! }
   let!(:luke) { service.insert_item(parent: root, label: "luke").value! }
-  let!(:leia) { service.insert_item(parent: luke, label: "leia").value! }
+  let!(:mara) { service.insert_item(parent: luke, label: "mara").value! }
 
   subject(:service) { described_class.new }
 
@@ -79,6 +79,14 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
       it "inserts an item successfully with short" do
         result = service.insert_item(parent: root, label:, short:)
         expect(result).to be_success
+      end
+
+      it "insert an item into a specific sort_order" do
+        leia = service.insert_item(parent: root, label: "leia").value!
+        expect(root.reload.children).to contain_exactly(luke, leia)
+
+        bob = service.insert_item(parent: root, label: "Bob", sort_order: 1).value!
+        expect(root.reload.children).to contain_exactly(luke, bob, leia)
       end
     end
 
@@ -136,13 +144,13 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
   describe "#get_branch" do
     context "with a non-root node" do
       it "returns all the ancestors to that item" do
-        result = service.get_branch(item: leia)
+        result = service.get_branch(item: mara)
         expect(result).to be_success
 
         ancestors = result.value!
         expect(ancestors.size).to eq(3)
-        expect(ancestors).to contain_exactly(root, luke, leia)
-        expect(ancestors.last).to eq(leia)
+        expect(ancestors).to contain_exactly(root, luke, mara)
+        expect(ancestors.last).to eq(mara)
       end
     end
 
@@ -159,14 +167,14 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
     let(:lando) { service.insert_item(parent: root, label: "lando").value! }
 
     it "move the node to the new parent" do
-      expect { service.move_item(item: leia, new_parent: lando) }.to change { leia.reload.ancestors.first }.to(lando)
+      expect { service.move_item(item: mara, new_parent: lando) }.to change { mara.reload.ancestors.first }.to(lando)
     end
 
     it "all child nodes follow" do
       service.move_item(item: luke, new_parent: lando)
 
       expect(luke.reload.ancestors).to contain_exactly(root, lando)
-      expect(leia.reload.ancestors).to contain_exactly(root, lando, luke)
+      expect(mara.reload.ancestors).to contain_exactly(root, lando, luke)
     end
   end
 


### PR DESCRIPTION
### Related WP: [OP#58760](https://community.openproject.org/projects/document-workflows-stream/work_packages/58760)

## what?

We want the users to be able to add items above or below a certain point in the hierarchy.

## How?

We are now inserting on a specific sort order, that's passed by the form as a hidden field and also a URL parameter to control where the form should be shown.

This PR also makes sure that the appearance of the diverse screens match the figma designs.

## Known issues

1. We are missing some icons
2. We still can't edit and insert at the same time.

![image](https://github.com/user-attachments/assets/efc26e0c-981d-4efa-a2bf-892b6228e072)
![image](https://github.com/user-attachments/assets/6d20d111-58bf-4db4-b1d1-c10cb71f50a4)
![image](https://github.com/user-attachments/assets/b5dde4fb-aca0-4e4b-bb96-6cb78bb32712)

Small video demo:

https://github.com/user-attachments/assets/70019468-6251-4aa6-8e38-7d37e6f1ae85

