### PR TITLE
[Op#58763] Double label on "add reactions" button hover

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
@@ -9,6 +9,7 @@
       overlay.with_show_button(
         icon: "smiley",
         "aria-label": I18n.t("reactions.add_reaction"),
+        name: I18n.t("reactions.add_reaction"),
         mr: 2,
         test_selector: "add-reactions-button"
       )

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
@@ -9,7 +9,6 @@
       overlay.with_show_button(
         icon: "smiley",
         "aria-label": I18n.t("reactions.add_reaction"),
-        title: I18n.t("reactions.add_reaction"),
         mr: 2,
         test_selector: "add-reactions-button"
       )


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/work_packages/58763

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Remove duplicate labels on hover

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_Before_

<img width="1191" alt="Screenshot 2024-11-01 at 1 33 42 PM" src="https://github.com/user-attachments/assets/7203d559-2f0b-4707-a53f-81d47b15366c">

_After_

<img width="1328" alt="Screenshot 2024-11-01 at 1 32 09 PM" src="https://github.com/user-attachments/assets/bbed04d3-445b-4466-aa21-e813004679e0">


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Removed duplicate "title" on the overlay show button. Primer mandates the title set as a tooltip on the overlay.

See: https://primer.style/components/overlay/rails/alpha#arguments

# Merge checklist

- [ ] Added/updated tests - No tests relevant
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
