### PR TITLE
[#58700] remove left margin for breadcrumbs in border box headers

### DIFF
--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -60,7 +60,8 @@ ul.SegmentedControl
 page-header,
 sub-header,
 .op-work-package-details-tab-component,
-.tabnav
+.tabnav,
+.Box-header
   ol, ul
     margin-left: 0
 


### PR DESCRIPTION
# Ticket
[OP#58700](https://community.openproject.org/work_packages/58700)

# What are you trying to accomplish?
- remove left margin of breadcrumbs in hierarchy items box

# What approach did you choose and why?
- remove left margin of breadcrumbs in all border box headers
