### PR TITLE
Make Hierarchy::Item#short unique per level

### DIFF
--- a/app/contracts/custom_fields/hierarchy/insert_item_contract.rb
+++ b/app/contracts/custom_fields/hierarchy/insert_item_contract.rb
@@ -40,13 +40,21 @@ module CustomFields
       end
 
       rule(:parent) do
+        next if schema_error?(:parent)
+
         key.failure("must exist") unless value.persisted?
       end
 
       rule(:label) do
-        if CustomField::Hierarchy::Item.exists?(parent_id: values[:parent], label: value)
-          key.failure(:not_unique)
-        end
+        next if schema_error?(:parent)
+
+        key.failure(:not_unique) if values[:parent].children.exists?(label: value)
+      end
+
+      rule(:short) do
+        next if schema_error?(:parent)
+
+        key.failure(:not_unique) if values[:parent].children.exists?(short: value)
       end
     end
   end

--- a/app/contracts/custom_fields/hierarchy/insert_item_contract.rb
+++ b/app/contracts/custom_fields/hierarchy/insert_item_contract.rb
@@ -53,6 +53,7 @@ module CustomFields
 
       rule(:short) do
         next if schema_error?(:parent)
+        next unless key?
 
         key.failure(:not_unique) if values[:parent].children.exists?(short: value)
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,7 +308,7 @@ en:
       label: "Label"
       short: "Short"
       item: "Item"
-      parent: "Item"
+      parent: "Parent"
 
   global_search:
     placeholder: "Search in %{app_title}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,8 +299,16 @@ en:
         label:
           filled?: "must be filled"
           not_unique: "must be unique within the same hierarchy level"
+        short:
+          not_unique: "must be unique within the same hierarchy level"
+        item:
+          root_item: "cannot be a root item"
+          not_persisted: "must be an already existing item"
     rules:
       label: "Label"
+      short: "Short"
+      item: "Item"
+      parent: "Item"
 
   global_search:
     placeholder: "Search in %{app_title}"

--- a/spec/contracts/custom_fields/hierarchy/insert_item_contract_spec.rb
+++ b/spec/contracts/custom_fields/hierarchy/insert_item_contract_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe CustomFields::Hierarchy::InsertItemContract do
       end
     end
 
+    context "when short is not unique in the same hierarchy level" do
+      let(:params) { { parent:, label: "Valid Label", short: "Repeated Short" } }
+
+      before { create(:hierarchy_item, parent:, label: "Unique Label", short: "Repeated Short") }
+
+      it "is invalid with localized validation errors" do
+        result = subject.call(params)
+        expect(result).to be_failure
+        expect(result.errors.to_h).to include(short: ["must be unique within the same hierarchy level"])
+      end
+    end
+
     context "when short is set and is a string" do
       let(:params) { { parent:, label: "Valid Label", short: "Valid Short" } }
 

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
   let(:invalid_custom_field) { create(:custom_field, field_format: "text", hierarchy_root: nil) }
 
   let!(:root) { service.generate_root(custom_field).value! }
-  let!(:luke) { service.insert_item(parent: root, label: "luke").value! }
+  let!(:luke) { service.insert_item(parent: root, label: "luke", short: "LS").value! }
   let!(:mara) { service.insert_item(parent: luke, label: "mara").value! }
 
   subject(:service) { described_class.new }
@@ -72,6 +72,7 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
     context "with valid parameters" do
       it "inserts an item successfully without short" do
         result = service.insert_item(parent: luke, label:)
+
         expect(result).to be_success
         expect(luke.reload.children.count).to eq(2)
       end
@@ -113,11 +114,12 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
       let!(:leia) { service.insert_item(parent: root, label: "leia").value! }
 
       it "refuses to update the item with new attributes" do
-        result = service.update_item(item: luke, label: "leia", short: "LS")
+        result = service.update_item(item: leia, label: "luke", short: "LS")
         expect(result).to be_failure
 
         errors = result.failure.errors
-        expect(errors.to_h).to eq({ label: ["must be unique at the same hierarchical level"] })
+        expect(errors[:label]).to eq(["must be unique within the same hierarchy level"])
+        expect(errors[:short]).to eq(["must be unique within the same hierarchy level"])
       end
     end
   end


### PR DESCRIPTION
#### Relate WP: [OP#58852](https://community.openproject.org/projects/document-workflows-stream/work_packages/58852)

Gives `#short` the same treatment we have for labels.