### PR TITLE
Bug/58787 notification banner is showing up on all pages

### DIFF
--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, HostListener } from '@angular/core';
 import { combineLatest, merge, Observable, timer } from 'rxjs';
 import { filter, map, shareReplay, switchMap, throttleTime } from 'rxjs/operators';
 import { ActiveWindowService } from 'core-app/core/active-window/active-window.service';
@@ -31,6 +31,15 @@ export class InAppNotificationBellComponent implements OnInit {
     readonly pathHelper:PathHelperService,
   ) {
     populateInputsFromDataset(this);
+  }
+
+  // enable other parts of the application to trigger an immediate update
+  // e.g. a stimulus controller
+  // currently used by the new activities tab which does it's own polling
+  // and receives updates from the backend earlier than the polling in the bell component
+  @HostListener('document:ian-update-immediate')
+  triggerImmediateUpdate() {
+    this.storeService.fetchUnread().subscribe();
   }
 
   ngOnInit() {

--- a/frontend/src/app/features/plugins/plugin-context.ts
+++ b/frontend/src/app/features/plugins/plugin-context.ts
@@ -33,7 +33,6 @@ import { AttachmentsResourceService } from 'core-app/core/state/attachments/atta
 import { HttpClient } from '@angular/common/http';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { IanCenterService } from 'core-app/features/in-app-notifications/center/state/ian-center.service';
 /**
  * Plugin context bridge for plugins outside the CLI compiler context
  * in order to access services and parts of the core application
@@ -69,7 +68,6 @@ export class OpenProjectPluginContext {
     attachmentsResourceService: this.injector.get(AttachmentsResourceService),
     http: this.injector.get(HttpClient),
     turboRequests: this.injector.get(TurboRequestsService),
-    ianCenter: this.injector.get(IanCenterService),
   };
 
   public readonly helpers = {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -4,7 +4,6 @@ import {
 } from 'core-app/shared/components/editor/components/ckeditor/ckeditor.types';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { IanCenterService } from 'core-app/features/in-app-notifications/center/state/ian-center.service';
 
 interface CustomEventWithIdParam extends Event {
   params:{
@@ -56,13 +55,11 @@ export default class IndexController extends Controller {
   private turboRequests:TurboRequestsService;
 
   private apiV3Service:ApiV3Service;
-  private ianCenterService:IanCenterService;
 
   async connect() {
     const context = await window.OpenProject.getPluginContext();
     this.turboRequests = context.services.turboRequests;
     this.apiV3Service = context.services.apiV3Service;
-    this.ianCenterService = context.services.ianCenter;
 
     this.setLocalStorageKey();
     this.setLastUpdateTimestamp();
@@ -224,7 +221,7 @@ export default class IndexController extends Controller {
   }
 
   private updateNotificationCenter() {
-    this.ianCenterService.updateImmediate();
+    document.dispatchEvent(new Event('ian-update-immediate'));
   }
 
   private performAutoScrolling(html:string, journalsContainerAtBottom:boolean) {


### PR DESCRIPTION
[Ticket](https://community.openproject.org/projects/communicator-stream/work_packages/58787)

The reason for this bug was the global instantiation of the ian center/store/bell state, which was used to let the new activity tab stimulus controller trigger immediate ian center/store/bell state updates. 

Why this was required: The activity tab usually receives workpackage-specific notifications faster than the ian center/store/bell - thus the capability of the immediate update helps to keep the UI in sync.

The approach is now switched to a simple client-side event mechanism instead of calling the ian store method directly. This fixes the reported bug while still enable the immediate update from the new activity tab controller.
