### PR TITLE
[#58519] enable activating hierarchies

### DIFF
--- a/app/controllers/projects/settings/custom_fields_controller.rb
+++ b/app/controllers/projects/settings/custom_fields_controller.rb
@@ -30,9 +30,7 @@ class Projects::Settings::CustomFieldsController < Projects::SettingsController
   menu_item :settings_custom_fields
 
   def show
-    @wp_custom_fields = WorkPackageCustomField
-                          .order("lower(name)")
-                          .where.not(field_format: "hierarchy") # TODO: Remove after enabling hierarchy fields
+    @wp_custom_fields = WorkPackageCustomField.order("lower(name)")
   end
 
   def update

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -146,9 +146,7 @@ module Type::Attributes
     end
 
     def add_custom_fields_to_form_attributes(attributes)
-      WorkPackageCustomField.includes(:custom_options)
-                            .where.not(field_format: "hierarchy") # TODO: Remove after enabling hierarchy fields
-                            .find_each do |field|
+      WorkPackageCustomField.includes(:custom_options).find_each do |field|
         attributes[field.attribute_name] = {
           required: field.is_required,
           has_default: field.default_value.present?,


### PR DESCRIPTION
# Ticket
[OP#58519](https://community.openproject.org/work_packages/58519)

# What are you trying to accomplish?
- custom fields of type hierarchy must be able to show up on work package forms

# What approach did you choose and why?
- activation on project settings -> custom fields enabled
- activation in admin -> work package types -> form configuration
  enabled
- amended schema representer to render correct hierarchy schema entries

