### PR TITLE
Reordering by drag and drop

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
       flex_layout(align_items: :center, justify_content: :space_between, test_selector: "op-custom-fields--hierarchy-item") do |item_container|
         item_container.with_column(flex_layout: true) do |item_information|
           item_information.with_column(mr: 2) do
-            render(Primer::OpenProject::DragHandle.new)
+            render(Primer::OpenProject::DragHandle.new(draggable: true))
           end
           item_information.with_column(mr: 2) do
             render(Primer::Beta::Link.new(href: custom_field_item_path(@root.custom_field_id, model), underline: false)) do

--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -27,6 +27,8 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<% helpers.content_controller "admin--hierarchy-item", dynamic: true %>
+
 <%=
   component_wrapper(tag: "turbo-frame", refresh: :morph, data: { turbo_action: :advance }) do
     flex_layout do |container|
@@ -57,7 +59,24 @@ See COPYRIGHT and LICENSE files for more details.
             end
           else
             children.each do |item|
-              box.with_row do
+              drag_controls = if item.persisted?
+                                {
+                                  "data-controller": "admin--hierarchy-item",
+                                  "data-action": "dragstart->admin--hierarchy-item#dragstart
+                                                  dragenter->admin--hierarchy-item#dragenter
+                                                  dragleave->admin--hierarchy-item#dragleave
+                                                  drop->admin--hierarchy-item#drop",
+                                  "data-hierarchy-item-id": item.id,
+                                  "data-sort-order": item.sort_order,
+                                  "data-frame-id": Admin::CustomFields::Hierarchy::ItemsComponent.wrapper_key,
+                                  "data-move-url": move_custom_field_item_url(root.custom_field_id, item),
+                                  "data-index-url": custom_field_items_url(root.custom_field_id)
+                                }
+                              else
+                                {}
+                              end
+
+              box.with_row(**drag_controls) do
                 render Admin::CustomFields::Hierarchy::ItemComponent.new(item: item)
               end
             end

--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -65,12 +65,13 @@ See COPYRIGHT and LICENSE files for more details.
                                   "data-action": "dragstart->admin--hierarchy-item#dragstart
                                                   dragenter->admin--hierarchy-item#dragenter
                                                   dragleave->admin--hierarchy-item#dragleave
+                                                  dragend->admin--hierarchy-item#dragend
                                                   drop->admin--hierarchy-item#drop",
                                   "data-hierarchy-item-id": item.id,
                                   "data-sort-order": item.sort_order,
                                   "data-frame-id": Admin::CustomFields::Hierarchy::ItemsComponent.wrapper_key,
                                   "data-move-url": move_custom_field_item_url(root.custom_field_id, item),
-                                  "data-index-url": custom_field_items_url(root.custom_field_id)
+                                  "data-index-url": custom_field_item_url(root.custom_field_id, item.parent)
                                 }
                               else
                                 {}

--- a/frontend/src/stimulus/controllers/dynamic/admin/hierarchy-item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/hierarchy-item.controller.ts
@@ -32,40 +32,55 @@ import { Controller } from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
 
 export default class HierarchyItemController extends Controller {
+  private currentHover:HTMLElement | null;
+
   connect() {}
 
   dragstart(event:DragEvent) {
     const element = dataNode(event.target);
+    element.style.opacity = '0.4';
 
     if (event.dataTransfer) {
       event.dataTransfer.setDragImage(element, 25, 25);
       event.dataTransfer.effectAllowed = 'move';
-      event.dataTransfer.setData('application/drag-key', element.dataset.hierarchyItemId || '');
+      event.dataTransfer.setData('application/dragkey', element.dataset.hierarchyItemId || '');
     }
   }
 
   dragenter(event:DragEvent) {
-    const target = dataNode(event.target);
-    if (target != null) {
-      target.classList.add('border-dashed');
-      event.preventDefault();
-    }
+    this.currentHover = event.target as HTMLElement;
+    event.preventDefault();
+    event.stopPropagation();
+
+    dataNode(event.target).classList.add('bgColor-accent-muted');
+    return false;
   }
 
   dragleave(event:DragEvent) {
-    const target = dataNode(event.target);
-    if (target != null) {
-      target.classList.remove('border-dashed');
+    if (event.target === this.currentHover) {
+      dataNode(event.target).classList.remove('bgColor-accent-muted');
       event.preventDefault();
+      event.stopPropagation();
     }
+    return false;
+  }
+
+  dragend(event:DragEvent) {
+    if (event.target === this.currentHover) {
+      dataNode(event.target).classList.remove('bgColor-accent-muted');
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    return false;
   }
 
   drop(event:DragEvent) {
     const targetElement = dataNode(event.target);
 
     if (event.dataTransfer) {
-      const origin = event.dataTransfer.getData('application/drag-key');
+      const origin = event.dataTransfer.getData('application/dragkey');
       const originElement = document.querySelector(`[data-hierarchy-item-id='${origin}']`) as HTMLElement;
+      originElement.style.opacity = '1';
 
       if (targetElement.dataset.hierarchyItemId === originElement.dataset.hierarchyItemId) {
         return;

--- a/frontend/src/stimulus/controllers/dynamic/admin/hierarchy-item.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/hierarchy-item.controller.ts
@@ -1,0 +1,110 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import * as Turbo from '@hotwired/turbo';
+
+export default class HierarchyItemController extends Controller {
+  connect() {}
+
+  dragstart(event:DragEvent) {
+    const element = dataNode(event.target);
+
+    if (event.dataTransfer) {
+      event.dataTransfer.setDragImage(element, 25, 25);
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('application/drag-key', element.dataset.hierarchyItemId || '');
+    }
+  }
+
+  dragenter(event:DragEvent) {
+    const target = dataNode(event.target);
+    if (target != null) {
+      target.classList.add('border-dashed');
+      event.preventDefault();
+    }
+  }
+
+  dragleave(event:DragEvent) {
+    const target = dataNode(event.target);
+    if (target != null) {
+      target.classList.remove('border-dashed');
+      event.preventDefault();
+    }
+  }
+
+  drop(event:DragEvent) {
+    const targetElement = dataNode(event.target);
+
+    if (event.dataTransfer) {
+      const origin = event.dataTransfer.getData('application/drag-key');
+      const originElement = document.querySelector(`[data-hierarchy-item-id='${origin}']`) as HTMLElement;
+
+      if (targetElement.dataset.hierarchyItemId === originElement.dataset.hierarchyItemId) {
+        return;
+      }
+
+      let targetSortOrder = Number(targetElement.dataset.sortOrder);
+      if (targetElement.compareDocumentPosition(originElement) === Node.DOCUMENT_POSITION_PRECEDING) {
+        targetSortOrder += 1;
+      }
+
+      updateSortOrder(originElement, targetSortOrder);
+    }
+  }
+}
+
+function updateSortOrder(originElement:HTMLElement, sortOrder:number | string) {
+  const { frameId = '', indexUrl = '', moveUrl = '' } = originElement.dataset;
+
+  fetch(new URL(moveUrl), {
+    body: new URLSearchParams([['new_sort_order', sortOrder.toString()]]),
+    method: 'POST',
+    credentials: 'include',
+    headers: [
+      ['Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8'],
+      ['X-CSRF-Token', getMetaValue('csrf-token')],
+    ],
+    redirect: 'manual',
+  }).then(() => {
+    Turbo.visit(indexUrl, { frame: frameId });
+  }).catch(() => {});
+}
+
+function getMetaValue(name:string) {
+  const element = document.head.querySelector(`meta[name='${name}']`);
+  return element?.getAttribute('content') || '';
+}
+
+function dataNode(node:EventTarget | null):HTMLElement {
+  if (!(node instanceof Element)) throw new Error('Cannot handle drag and drop of non HTML element');
+
+  return node.closest('[data-hierarchy-item-id]')!;
+}


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57822

# What are you trying to accomplish?
Drag and drop reordering of hierarchy items

## Screenshots

https://github.com/user-attachments/assets/69867986-8e7d-4407-9a56-1686e44adb56



# What approach did you choose and why?

We have a few things to mention here:
1. Each row in the list will be draggable (on the drag handle) and will serve as a drop zone
2. Moving and item up will insert above of the highlighted item, and moving down will insert below
3. We are able to use turbo frames thanks to some clever request attributes. We make a `fetch` (POST) submiting a form like request to reorder the item, and when the request responds we trigger a Turbo.visit which reloads the frame beautifully

Building UI is not easy :weary: 

# Merge checklist
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
