### PR TITLE
[#58522] add drop down selection to hierarchy cfs

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.html
@@ -20,12 +20,13 @@
            (keydown)="keyPressed($event)"
            bindLabel="name">
   <ng-template ng-tag-tmp let-search="searchTerm">
-    <b [textContent]="text.add_new_action"></b>: {{search}}
+    <b [textContent]="text.add_new_action"></b>: {{ search }}
   </ng-template>
 
   <ng-template ng-option-tmp let-item="item" let-search="searchTerm">
     <span [ngOptionHighlight]="search"
           [textContent]="item.name"
+          [ngStyle]="{'padding-left.px': item.depth * 16}"
           class="ng-option-label ellipsis">
     </span>
   </ng-template>

--- a/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
@@ -105,11 +105,13 @@ export function initializeCoreEditFields(editFieldService:EditFieldService, sele
         'TimeEntriesActivity',
         'Category',
         'CustomOption',
+        'CustomField::Hierarchy::Item',
       ])
       .addFieldType(MultiSelectEditFieldComponent, 'multi-select', [
         '[]CustomOption',
         '[]User',
         '[]Version',
+        '[]CustomField::Hierarchy::Item',
       ])
       .addFieldType(FloatEditFieldComponent, 'float', ['Float'])
       .addFieldType(WorkPackageEditFieldComponent, 'workPackage', ['WorkPackage'])

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.html
@@ -18,6 +18,13 @@
            [appendTo]="appendTo"
            [dropdownPosition]="'top'"
            [hideSelected]="true">
+  <ng-template ng-option-tmp let-item="item">
+    <span
+      class="ng-option-label ellipsis"
+      [textContent]="item.name"
+      [ngStyle]="{'padding-left.px': item.depth * 16}"
+    ></span>
+  </ng-template>
   <ng-template ng-footer-tmp *ngIf="showAddNewUserButton">
     <op-invite-user-button
         [projectId]="resource.project?.id"

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -173,7 +173,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
       });
     }
 
-    this.availableOptions = availableValues || [];
+    this.availableOptions = this.filterInvalidValues(availableValues || []);
     this._selectedOption = this.buildSelectedOption();
     this.checkCurrentValueValidity();
 
@@ -205,6 +205,10 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
       this.setValues([]);
     }
     return Promise.resolve();
+  }
+
+  private filterInvalidValues(availableValues:HalResource[]) {
+    return availableValues.filter((value) => !!value.name);
   }
 
   private checkCurrentValueValidity() {

--- a/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
@@ -26,19 +26,20 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, InjectFlags, OnInit, } from '@angular/core';
+import { ChangeDetectionStrategy, Component, InjectFlags, OnInit } from '@angular/core';
+import { StateService, UIRouterGlobals } from '@uirouter/core';
+import { from, Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import {
-  SelectAutocompleterRegisterService
-} from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-autocompleter-register.service';
-import { from, Observable, } from 'rxjs';
-import { map, tap, } from 'rxjs/operators';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import {
-  CreateAutocompleterComponent
+  SelectAutocompleterRegisterService,
+} from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-autocompleter-register.service';
+import {
+  CreateAutocompleterComponent,
 } from 'core-app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
-import { StateService, UIRouterGlobals } from '@uirouter/core';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { HalResourceSortingService } from 'core-app/features/hal/services/hal-resource-sorting.service';
@@ -52,6 +53,7 @@ export interface ValueOption {
 
 @Component({
   templateUrl: './select-edit-field.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectEditFieldComponent extends EditFieldComponent implements OnInit {
   @InjectField() selectAutocompleterRegister:SelectAutocompleterRegisterService;
@@ -151,7 +153,8 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   private setValues(availableValues:HalResource[]) {
-    this.availableOptions = this.sortValues(availableValues);
+    const sortedValues = this.sortValues(availableValues);
+    this.availableOptions = this.filterInvalidValues(sortedValues);
     this.addEmptyOption();
   }
 
@@ -283,6 +286,10 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
 
   protected sortValues(availableValues:HalResource[]) {
     return this.halSorting.sort(availableValues);
+  }
+
+  private filterInvalidValues(availableValues:HalResource[]) {
+    return availableValues.filter((value) => !!value.name);
   }
 
   // Subclasses shall be able to override the filters with which the

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -51,7 +51,7 @@ module API
           "user" => ["users", "groups", "placeholder_users"],
           "version" => "versions",
           "list" => "custom_options",
-          "hierarchy" => "hierarchical_items"
+          "hierarchy" => "custom_field_items"
         }.freeze
 
         REPRESENTER_MAP = {

--- a/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
+++ b/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
@@ -85,6 +85,8 @@ module API
                 derive_principal_path_method(custom_value)
               when "list"
                 :custom_option
+              when "hierarchy"
+                :custom_field_item
               else
                 custom_field.field_format
               end


### PR DESCRIPTION
# Ticket
[OP#58522](https://community.openproject.org/work_packages/58522)

# What are you trying to accomplish?
- the user should see a dropdown for custom fields of type hierarchy

# What approach did you choose and why?
- amend hierarchy namespaces, routes and strategies
- amend select-edit-field and multi-select-edit-field to be able to react on depth of options

#### Hint
- The indention of the options is still 1 level too big. The reason for this will get fixed in [OP#58868](https://community.openproject.org/work_packages/58868)

