### PR TITLE
[#58773] Activity tab emoji line overflow behaviour can introduce horizontal scroll

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
@@ -1,7 +1,7 @@
 <%=
   component_wrapper do
     if grouped_emoji_reactions.present?
-      flex_layout(test_selector: "emoji-reactions") do |reactions_container|
+      flex_layout(test_selector: "emoji-reactions", flex_wrap: :wrap, classes: "op-emoji-reactions--gap") do |reactions_container|
         grouped_emoji_reactions.each do |reaction, data|
           reactions_container.with_column(mr: 2) do
             render(Primer::Beta::Button.new(
@@ -12,10 +12,10 @@
                     test_selector: "reaction-#{reaction}",
                     tag: :a,
                     href: href(reaction:),
-                    data: { 
-                      turbo_stream: true, 
+                    data: {
+                      turbo_stream: true,
                       turbo_method: :put,
-                      "work-packages--activities-tab--index-target": "reactionButton", 
+                      "work-packages--activities-tab--index-target": "reactionButton"
                     },
                     aria: { label: aria_label_text(reaction, data[:users]) },
                     disabled: current_user_cannot_react?,

--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.sass
@@ -1,3 +1,6 @@
+.op-emoji-reactions--gap
+  row-gap: var(--base-size-4, 4px)
+
 .op-reactions-button:disabled
   cursor: default
   background-color: transparent


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

* https://community.openproject.org/wp/58773
* https://community.openproject.org/wp/58824

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

flex wrap emoji reactions list with 4px row gap

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_Before_

![Kapture 2024-11-07 at 02 31 09](https://github.com/user-attachments/assets/46edf112-d516-441b-a03a-d51efeac8a4f)

_After_

![Kapture 2024-11-07 at 02 44 58](https://github.com/user-attachments/assets/fff75365-59e7-41c5-bd5d-eb78daee553f)

<details> <summary> Mobile </summary>

<img width="378" alt="Screenshot 2024-11-07 at 10 55 50 AM" src="https://github.com/user-attachments/assets/8b297be3-8de6-46b6-9a99-87d277bd5d0f">
<img width="417" alt="Screenshot 2024-11-07 at 10 54 59 AM" src="https://github.com/user-attachments/assets/482eed9a-ab4e-431c-90aa-016d4f723a44">


</details>


# What approach did you choose and why?

Add flex wrap and row gap properties

<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
