### PR TITLE
[#58889] Line height in activity less then e.g. in description

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
@@ -3,7 +3,7 @@
     if journal.notes.present?
       flex_layout do |journal_container|
         journal_container.with_row do
-          render(Primer::Box.new(mt: 1)) do
+          render(Primer::Box.new(mt: 1, classes: "op-uc-container")) do
             format_text(journal, :notes)
           end
         end


### PR DESCRIPTION
https://community.openproject.org/work_packages/58889

Regression of: https://github.com/opf/openproject/pull/16638

| Before | After |
| ------ | ------ |
| <img width="564" alt="before" src="https://github.com/user-attachments/assets/77c15695-70f7-4f18-b9dc-c4b7873b023f"> | <img width="586" alt="after" src="https://github.com/user-attachments/assets/d46a50a8-6d47-48a2-b33f-fc1ce0ec2bda"> |
