### PR TITLE
Render errors for the `short` field of Hierarchy Items

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_form_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_form_component.rb
@@ -47,7 +47,7 @@ module Admin
 
         def url
           if model.new_record?
-            new_child_custom_field_item_path(root.custom_field_id, model.parent)
+            new_child_custom_field_item_path(root.custom_field_id, model.parent, position: model.sort_order)
           else
             custom_field_item_path(root.custom_field_id, model)
           end

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -73,7 +73,7 @@ module Admin
               end,
               lambda do |validation_result|
                 add_errors_to_form(validation_result)
-                render action: :new
+                render :new
               end
             )
         end
@@ -129,7 +129,7 @@ module Admin
         end
 
         def add_errors_to_form(validation_result)
-          @new_item = ::CustomField::Hierarchy::Item.new(parent: @active_item, **validation_result.to_h)
+          @new_item = ::CustomField::Hierarchy::Item.new(**item_input)
           validation_result.errors(full: true).to_h.each do |attribute, errors|
             @new_item.errors.add(attribute, errors.join(", "))
           end

--- a/app/forms/custom_fields/hierarchy/item_form.rb
+++ b/app/forms/custom_fields/hierarchy/item_form.rb
@@ -50,7 +50,8 @@ module CustomFields
             visually_hide_label: true,
             full_width: false,
             required: false,
-            placeholder: I18n.t("custom_fields.admin.items.placeholder.short")
+            placeholder: I18n.t("custom_fields.admin.items.placeholder.short"),
+            validation_message: validation_message_for(:short)
           )
         end
 


### PR DESCRIPTION
I introduced 2 issues with the #17110 PR:

1. Missing the error message on the FE
2. The form would float back to the bottom of the list on error.

This PR aims to fix it.

#### Related WP: [OP#58852](https://community.openproject.org/projects/document-workflows-stream/work_packages/58852)
