### PR TITLE
Allow move hierarchy items to the top and to the bottom

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -70,8 +70,14 @@ module Admin
           add_below_action_item(menu)
           add_sub_item_action_item(menu)
           menu.with_divider
-          move_up_action_item(menu) unless first_item?
-          move_down_action_item(menu) unless last_item?
+          if !first_item?
+            move_to_top_action_item(menu)
+            move_up_action_item(menu)
+          end
+          if !last_item?
+            move_down_action_item(menu)
+            move_to_bottom_action_item(menu)
+          end
           menu.with_divider
           deletion_action_item(menu)
         end
@@ -113,6 +119,18 @@ module Admin
           ) { _1.with_leading_visual_icon(icon: "op-arrow-in") }
         end
 
+        def move_to_top_action_item(menu)
+          form_inputs = [{ name: "new_sort_order", value: 0 }]
+
+          menu.with_item(label: I18n.t(:label_sort_highest),
+                         tag: :button,
+                         href: move_custom_field_item_path(@root.custom_field_id, model),
+                         content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+                         form_arguments: { method: :post, inputs: form_inputs }) do |item|
+            item.with_leading_visual_icon(icon: "move-to-top")
+          end
+        end
+
         def move_up_action_item(menu)
           form_inputs = [{ name: "new_sort_order", value: model.sort_order - 1 }]
 
@@ -134,6 +152,18 @@ module Admin
                          content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
                          form_arguments: { method: :post, inputs: form_inputs }) do |item|
             item.with_leading_visual_icon(icon: "chevron-down")
+          end
+        end
+
+        def move_to_bottom_action_item(menu)
+          form_inputs = [{ name: "new_sort_order", value: model.parent.children.length + 1 }]
+
+          menu.with_item(label: I18n.t(:label_sort_lowest),
+                         tag: :button,
+                         href: move_custom_field_item_path(@root.custom_field_id, model),
+                         content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+                         form_arguments: { method: :post, inputs: form_inputs }) do |item|
+            item.with_leading_visual_icon(icon: "move-to-bottom")
           end
         end
 

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -96,7 +96,7 @@ module Admin
           item_service
             .reorder_item(item: @active_item, new_sort_order: params.require(:new_sort_order))
 
-          redirect_to(custom_field_items_path(@custom_field), status: :see_other)
+          redirect_to(custom_field_item_path(@custom_field, @active_item.parent), status: :see_other)
         end
 
         def destroy


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/59154

# What are you trying to accomplish?
Move to the top and move to the bottom action items

## Screenshots
![image](https://github.com/user-attachments/assets/a4361f50-7a81-423e-afcd-77d0b05c7345)
