### PR TITLE
Overwrite version of fetched journal entries for the activity tab

### DIFF
--- a/app/components/work_packages/activities_tab/journals/index_component.rb
+++ b/app/components/work_packages/activities_tab/journals/index_component.rb
@@ -64,7 +64,11 @@ module WorkPackages
         end
 
         def journals
-          work_package.journals.includes(:user, :notifications).reorder(version: journal_sorting)
+          work_package
+            .journals
+            .includes(:user, :notifications)
+            .reorder(version: journal_sorting)
+            .with_sequence_version
         end
 
         def journal_with_notes

--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -4,7 +4,7 @@
       if show_comment_container?
         journal_container.with_row do
           render(border_box_container(
-                  id: "activity-anchor-#{journal.version}",
+                  id: "activity-anchor-#{journal.sequence_version}",
                   padding: :condensed,
                   "aria-label": I18n.t("activities.work_packages.activity_tab.commented")
                 )) do |border_box_component|
@@ -52,10 +52,10 @@
                             data: {
                               turbo: false,
                               action: "click->work-packages--activities-tab--index#setAnchor:prevent",
-                              "work-packages--activities-tab--index-id-param": journal.version
+                              "work-packages--activities-tab--index-id-param": journal.sequence_version
                             }
                           )) do
-                      "##{journal.version}"
+                      "##{journal.sequence_version}"
                     end
                   end
                   header_end_container.with_column(ml: 1,

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -73,7 +73,7 @@ module WorkPackages
         end
 
         def activity_anchor
-          "#activity-#{journal.version}"
+          "#activity-#{journal.sequence_version}"
         end
 
         def updated?

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -58,7 +58,7 @@ module WorkPackages
             flex_layout: true,
             justify_content: :space_between,
             classes: "work-packages-activities-tab-journals-item-component-details--journal-details-header-container",
-            id: "activity-anchor-#{journal.version}"
+            id: "activity-anchor-#{journal.sequence_version}"
           ) do |header_container|
             render_header_start(header_container)
             render_header_end(header_container)
@@ -192,9 +192,9 @@ module WorkPackages
                      underline: false,
                      font_size: :small,
                      data: { turbo: false, action: "click->work-packages--activities-tab--index#setAnchor:prevent",
-                             "work-packages--activities-tab--index-id-param": journal.version }
+                             "work-packages--activities-tab--index-id-param": journal.sequence_version }
                    )) do
-              "##{journal.version}"
+              "##{journal.sequence_version}"
             end
           end
         end

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -213,7 +213,9 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def find_journal
-    @journal = Journal.find(params[:id])
+    @journal = Journal
+      .with_sequence_version
+      .find(params[:id])
   rescue ActiveRecord::RecordNotFound
     respond_with_error(I18n.t("label_not_found"))
   end
@@ -309,7 +311,9 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def generate_time_based_update_streams(last_update_timestamp)
-    journals = @work_package.journals
+    journals = @work_package
+                 .journals
+                 .with_sequence_version
 
     if @filter == :only_comments
       journals = journals.where.not(notes: "")

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -102,6 +102,10 @@ class Journal < ApplicationRecord
 
   has_many :notifications, dependent: :destroy
 
+  include ::Scopes::Scoped
+
+  scopes :with_sequence_version
+
   # Scopes to all journals excluding the initial journal - useful for change
   # logs like the history on issue#show
   scope :changing, -> { where(["version > 1"]) }

--- a/app/models/journals/scopes/with_sequence_version.rb
+++ b/app/models/journals/scopes/with_sequence_version.rb
@@ -1,0 +1,55 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Journals::Scopes
+  module WithSequenceVersion
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def with_sequence_version
+        joins(
+          <<~SQL.squish
+            JOIN LATERAL (
+              SELECT
+                journals_rank.id,
+                ROW_NUMBER() OVER (ORDER BY version ASC) sequence_version
+              FROM
+                journals journals_rank
+              WHERE
+                journals_rank.journable_id = journals.journable_id
+              AND
+                journals_rank.journable_type = journals.journable_type
+              ) ranked
+              ON ranked.id = journals.id
+          SQL
+        )
+          .select("*")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58513

# What are you trying to accomplish?

Before changing the algorithm, journals were aggregated by creating a new one and removing the predecessor. That however lead to the version numbers having gaps. 

Overwriting the `version` by a custom select based on a window function ensures the version to increased with a fixed increment of 1. 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
