### PR TITLE
Bug/59082 the comment box in activity requires a second click for keyboard focus

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -426,6 +426,8 @@ export default class IndexController extends Controller {
       // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form
       this.scrollJournalContainer(true);
       this.focusEditor();
+    } else {
+      this.focusEditor();
     }
   }
 

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -540,6 +540,30 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_flag: { primeri
     end
   end
 
+  describe "focus editor" do
+    current_user { admin }
+    let(:work_package) { create(:work_package, project:, author: admin) }
+
+    before do
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "focuses the editor", :aggregate_failures do
+      activity_tab.set_journal_sorting(:desc)
+
+      activity_tab.open_new_comment_editor
+
+      activity_tab.expect_focus_on_editor
+
+      activity_tab.set_journal_sorting(:asc)
+
+      activity_tab.open_new_comment_editor
+
+      activity_tab.expect_focus_on_editor
+    end
+  end
+
   describe "sorting" do
     current_user { admin }
     let(:work_package) { create(:work_package, project:, author: admin) }

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -144,11 +144,21 @@ module Components
         expect(page).not_to have_test_selector("op-work-package-journal-form")
       end
 
+      def open_new_comment_editor
+        page.find_test_selector("op-open-work-package-journal-form-trigger").click
+      end
+
+      def expect_focus_on_editor
+        page.within_test_selector("op-work-package-journal-form-element") do
+          expect(page).to have_css(".ck-content:focus")
+        end
+      end
+
       def add_comment(text: nil, save: true)
         sleep 1 # otherwise the stimulus component is not mounted yet and the click does not work
 
         if page.find_test_selector("op-open-work-package-journal-form-trigger")
-          page.find_test_selector("op-open-work-package-journal-form-trigger").click
+          open_new_comment_editor
         else
           expect(page).to have_test_selector("op-work-package-journal-form-element")
         end

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -155,8 +155,6 @@ module Components
       end
 
       def add_comment(text: nil, save: true)
-        sleep 1 # otherwise the stimulus component is not mounted yet and the click does not work
-
         if page.find_test_selector("op-open-work-package-journal-form-trigger")
           open_new_comment_editor
         else
@@ -192,8 +190,6 @@ module Components
       end
 
       def quote_comment(journal)
-        sleep 1 # otherwise the stimulus component is not mounted yet and the click does not work
-
         within_journal_entry(journal) do
           page.find_test_selector("op-wp-journal-#{journal.id}-action-menu").click
           page.find_test_selector("op-wp-journal-#{journal.id}-quote").click


### PR DESCRIPTION
[Ticket](https://community.openproject.org/projects/communicator-stream/work_packages/59082)