### PR TITLE
[#58524] render hierarchy items path in work package view

### DIFF
--- a/frontend/src/app/shared/components/fields/display/display-field.service.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.service.ts
@@ -27,18 +27,27 @@
 //++
 
 import { Injectable, Injector } from '@angular/core';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { AbstractFieldService, IFieldType } from 'core-app/shared/components/fields/field.service';
-import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
-import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
-import { MultipleLinesCustomOptionsDisplayField } from 'core-app/shared/components/fields/display/field-types/multiple-lines-custom-options-display-field.module';
-import { MultipleLinesUserFieldModule } from 'core-app/shared/components/fields/display/field-types/multiple-lines-user-display-field.module';
-import { ProgressTextDisplayField } from 'core-app/shared/components/fields/display/field-types/progress-text-display-field.module';
-import { DateDisplayField } from 'core-app/shared/components/fields/display/field-types/date-display-field.module';
 
-export interface IDisplayFieldType extends IFieldType<DisplayField> {
-  new(resource:HalResource, attributeType:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField;
-}
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
+import { AbstractFieldService, IFieldType } from 'core-app/shared/components/fields/field.service';
+import {
+  MultipleLinesCustomOptionsDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/multiple-lines-custom-options-display-field.module';
+import {
+  MultipleLinesUserFieldModule,
+} from 'core-app/shared/components/fields/display/field-types/multiple-lines-user-display-field.module';
+import {
+  ProgressTextDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/progress-text-display-field.module';
+import { DateDisplayField } from 'core-app/shared/components/fields/display/field-types/date-display-field.module';
+import {
+  HierarchyItemDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/hierarchy-item-display-field.module';
+import {
+  MultipleLinesHierarchyItemDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module';
 
 export interface DisplayFieldContext {
   /** The injector to use for the context of this field. Relevant for embedded service injection */
@@ -49,6 +58,10 @@ export interface DisplayFieldContext {
 
   /** Options passed to the display field */
   options:{ [key:string]:any };
+}
+
+export interface IDisplayFieldType extends IFieldType<DisplayField> {
+  new(resource:HalResource, attributeType:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -80,6 +93,17 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
     if (context.container === 'single-view' && isCustomMultiLinesField) {
       return new MultipleLinesCustomOptionsDisplayField(fieldName, context) as DisplayField;
     }
+
+    const isHierarchyItemsField = ['CustomField::Hierarchy::Item'].indexOf(schema.type) >= 0;
+    if (context.container === 'single-view' && isHierarchyItemsField) {
+      return new HierarchyItemDisplayField(fieldName, context) as DisplayField;
+    }
+
+    const isMultilineHierarchyItemsField = ['[]CustomField::Hierarchy::Item'].indexOf(schema.type) >= 0;
+    if (context.container === 'single-view' && isMultilineHierarchyItemsField) {
+      return new MultipleLinesHierarchyItemDisplayField(fieldName, context) as DisplayField;
+    }
+
     // Separate class seems not needed (merge with []CustomOption above?)
     const isVersionMultiLinesField = ['[]Version'].indexOf(schema.type) >= 0;
     if (context.container === 'single-view' && isVersionMultiLinesField) {
@@ -104,6 +128,6 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
     const cls = this.getSpecificClassFor(resource._type, fieldName, schema.type);
 
     // eslint-disable-next-line new-cap
-    return new cls(fieldName, context) as DisplayField;
+    return new cls(fieldName, context);
   }
 }

--- a/frontend/src/app/shared/components/fields/display/field-types/hierarchy-item-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/hierarchy-item-display-field.module.ts
@@ -26,36 +26,33 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { cssClassCustomOption } from 'core-app/shared/components/fields/display/display-field.module';
-import { ResourcesDisplayField } from './resources-display-field.module';
+import { from, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
-export class MultipleLinesCustomOptionsDisplayField extends ResourcesDisplayField {
-  public render(element:HTMLElement, displayText:string):void {
-    const values = this.stringValue;
-    element.setAttribute('title', displayText);
-    element.textContent = displayText;
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
+import {
+  ResourceDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/resource-display-field.module';
+import { renderHierarchyItem } from 'core-app/shared/components/fields/display/field-types/render-hierarchy-item';
 
+export class HierarchyItemDisplayField extends ResourceDisplayField {
+  public render(element:HTMLElement, _displayText:string) {
     element.innerHTML = '';
+    element.classList.add('hierarchy-items');
 
-    if (values.length === 0) {
-      this.renderEmpty(element);
-    } else {
-      this.renderValues(values, element);
-    }
-  }
-
-  public get valueString():string {
-    return this.stringValue.join(', ');
-  }
-
-  protected renderValues(values:string[], element:HTMLElement) {
-    values.forEach((value) => {
-      const div = document.createElement('div');
-      div.classList.add(cssClassCustomOption, '-multiple-lines');
-      div.setAttribute('title', value);
-      div.textContent = value;
-
-      element.appendChild(div);
+    this.branch().subscribe((path) => {
+      element.appendChild(path);
     });
+  }
+
+  private branch():Observable<HTMLDivElement> {
+    const attribute = this.attribute as HalResource;
+    const itemLink = attribute.$link as HalLink;
+
+    return from(itemLink.$fetch())
+      .pipe(
+        switchMap((resource:HalResource) => renderHierarchyItem(resource)),
+      );
   }
 }

--- a/frontend/src/app/shared/components/fields/display/field-types/hierarchy-item-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/hierarchy-item-display-field.module.ts
@@ -38,17 +38,22 @@ import { renderHierarchyItem } from 'core-app/shared/components/fields/display/f
 
 export class HierarchyItemDisplayField extends ResourceDisplayField {
   public render(element:HTMLElement, _displayText:string) {
+    const item = this.attribute as HalResource;
+    if (item === null || item.name === this.texts.placeholder) {
+      this.renderEmpty(element);
+      return;
+    }
+
     element.innerHTML = '';
     element.classList.add('hierarchy-items');
 
-    this.branch().subscribe((path) => {
+    this.branch(item).subscribe((path) => {
       element.appendChild(path);
     });
   }
 
-  private branch():Observable<HTMLDivElement> {
-    const attribute = this.attribute as HalResource;
-    const itemLink = attribute.$link as HalLink;
+  private branch(item:HalResource):Observable<HTMLDivElement> {
+    const itemLink = item.$link as HalLink;
 
     return from(itemLink.$fetch())
       .pipe(

--- a/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module.ts
@@ -38,10 +38,15 @@ import { renderHierarchyItem } from 'core-app/shared/components/fields/display/f
 
 export class MultipleLinesHierarchyItemDisplayField extends ResourcesDisplayField {
   public render(element:HTMLElement, _displayText:string) {
+    const items = this.attribute as HalResource[];
+    if (items.length === 0) {
+      this.renderEmpty(element);
+      return;
+    }
+
     element.innerHTML = '';
     element.classList.add('hierarchy-items');
-
-    this.branches().subscribe((elements) => {
+    this.branches(items).subscribe((elements) => {
       elements.forEach((el) => {
         element.appendChild(el);
       });
@@ -52,10 +57,8 @@ export class MultipleLinesHierarchyItemDisplayField extends ResourcesDisplayFiel
     return this.stringValue.join(', ');
   }
 
-  private branches():Observable<HTMLDivElement[]> {
-    const attribute = this.attribute as HalResource[];
-
-    return combineLatest(attribute.map((value:HalResource) => {
+  private branches(items:HalResource[]):Observable<HTMLDivElement[]> {
+    return combineLatest(items.map((value:HalResource) => {
       const itemLink = value.$link as HalLink;
 
       return from(itemLink.$fetch())

--- a/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module.ts
@@ -26,36 +26,42 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { cssClassCustomOption } from 'core-app/shared/components/fields/display/display-field.module';
-import { ResourcesDisplayField } from './resources-display-field.module';
+import { combineLatest, from, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
-export class MultipleLinesCustomOptionsDisplayField extends ResourcesDisplayField {
-  public render(element:HTMLElement, displayText:string):void {
-    const values = this.stringValue;
-    element.setAttribute('title', displayText);
-    element.textContent = displayText;
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
+import {
+  ResourcesDisplayField,
+} from 'core-app/shared/components/fields/display/field-types/resources-display-field.module';
+import { renderHierarchyItem } from 'core-app/shared/components/fields/display/field-types/render-hierarchy-item';
 
+export class MultipleLinesHierarchyItemDisplayField extends ResourcesDisplayField {
+  public render(element:HTMLElement, _displayText:string) {
     element.innerHTML = '';
+    element.classList.add('hierarchy-items');
 
-    if (values.length === 0) {
-      this.renderEmpty(element);
-    } else {
-      this.renderValues(values, element);
-    }
+    this.branches().subscribe((elements) => {
+      elements.forEach((el) => {
+        element.appendChild(el);
+      });
+    });
   }
 
   public get valueString():string {
     return this.stringValue.join(', ');
   }
 
-  protected renderValues(values:string[], element:HTMLElement) {
-    values.forEach((value) => {
-      const div = document.createElement('div');
-      div.classList.add(cssClassCustomOption, '-multiple-lines');
-      div.setAttribute('title', value);
-      div.textContent = value;
+  private branches():Observable<HTMLDivElement[]> {
+    const attribute = this.attribute as HalResource[];
 
-      element.appendChild(div);
-    });
+    return combineLatest(attribute.map((value:HalResource) => {
+      const itemLink = value.$link as HalLink;
+
+      return from(itemLink.$fetch())
+        .pipe(
+          switchMap((resource:HalResource) => renderHierarchyItem(resource)),
+        );
+    }));
   }
 }

--- a/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
@@ -1,0 +1,72 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
+
+export function renderHierarchyItem(item:HalResource):Observable<HTMLDivElement> {
+  const customFieldItemLinks = item.$links as { branch:() => HalResource[] };
+  return from(customFieldItemLinks.branch())
+    .pipe(
+      map((ancestors:CollectionResource) => spansFromAncestors(ancestors)),
+      map((spans) => {
+        const div = document.createElement('div');
+        div.className = 'path';
+        spans.forEach((span) => div.appendChild(span));
+        return div;
+      }),
+    );
+}
+
+function spansFromAncestors(ancestors:CollectionResource):HTMLSpanElement[] {
+  const spans:HTMLSpanElement[] = [];
+
+  ancestors.elements
+    .filter((el) => !!el.label)
+    .forEach((el, idx, all) => {
+      const span = document.createElement('span');
+      span.textContent = el.label as string;
+      spans.push(span);
+
+      if (idx < all.length - 1) {
+        const separator = document.createElement('span');
+        separator.textContent = '/';
+        spans.push(separator);
+      } else if (el.short !== null) {
+        const short = document.createElement('span');
+        short.textContent = `(${el.short})`;
+        short.className = 'color-fg-subtle';
+        spans.push(short);
+      }
+    });
+
+  return spans;
+}

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -79,6 +79,7 @@ display-field
         vertical-align: middle
         // Inherit from Parent, e.g. strikethrough for baseline comparison
         text-decoration: inherit
+
         &:first-of-type
           padding-right: 5px
 
@@ -93,6 +94,7 @@ display-field
     // Table specific styles
     .wp-table--cell-container &
       width: 100%
+
       .-actual-value,
       .-derived-value
         @include wp-table--time-values
@@ -109,6 +111,15 @@ display-field
 
   &.spentTime .time-logging--value
     padding: 0 2px
+
+  &.hierarchy-items
+    .path
+      & > span
+        margin-right: 0.25rem
+
+      & > span:last-child
+        margin-right: 0
+
 
 .wp-table--cell-container
   .inline-edit--display-field.-placeholder,

--- a/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
@@ -65,6 +65,10 @@ module API
               }
             end
           end
+
+          link :branch do
+            { href: api_v3_paths.custom_field_item_branch(represented.id) }
+          end
         end
       end
     end

--- a/lib/api/v3/custom_fields/hierarchy/item_branch_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/item_branch_api.rb
@@ -42,7 +42,7 @@ module API
                 .get_branch(item: @custom_field_item)
                 .either(
                   ->(items) do
-                    self_link = api_v3_paths.custom_field_item(@custom_field_item.id)
+                    self_link = api_v3_paths.custom_field_item_branch(@custom_field_item.id)
                     HierarchyItemCollectionRepresenter.new(items, self_link:, current_user:)
                   end,
                   ->(error) do

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -215,6 +215,10 @@ module API
             "#{root}/custom_field_items/#{id}"
           end
 
+          def self.custom_field_item_branch(id)
+            "#{custom_field_item(id)}/branch"
+          end
+
           def self.custom_field_items(id, parent = nil, depth = nil)
             query = { parent:, depth: }.compact_blank.to_query
 


### PR DESCRIPTION
# Ticket
[OP#58524](https://community.openproject.org/work_packages/58524)

# What are you trying to accomplish?
- show assigned hierarchy items for custom fields of type hierarchy

# What approach did you choose and why?
- write new display field classes for hierarchy items
- amend display field service registry
- fixed text representation of custom fields of type list
- add branch link to hierarchy item representer

