### PR TITLE
[#43829] Order cost user filter by name

### DIFF
--- a/modules/reporting/app/models/cost_query/filter/user_id.rb
+++ b/modules/reporting/app/models/cost_query/filter/user_id.rb
@@ -52,11 +52,10 @@ class CostQuery::Filter::UserId < Report::Filter::Base
   def self.available_values(*)
     # All users which are members in projects the user can see.
     # Excludes the anonymous user
-    users = User.joins(members: :project)
-                .merge(Project.visible)
+    users = User.visible
                 .human
+                .ordered_by_name
                 .select(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s) << :id)
-                .distinct
 
     values = users.map { |u| [u.name, u.id] }
     values.unshift [::I18n.t(:label_me), me_value] if User.current.logged?


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/43829

# What are you trying to accomplish?

Have the user filter in cost reports sorted by name so that it is easier to use.