### PR TITLE
[chore] fix hierarchy item depth representation

### DIFF
--- a/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
@@ -30,44 +30,19 @@ module API
   module V3
     module CustomFields
       module Hierarchy
-        class HierarchyItemRepresenter < ::API::Decorators::Single
-          def _type
-            "HierarchyItem"
+        class HierarchicalItemAggregate
+          attr_accessor :depth
+
+          delegate :id, :label, :short, :parent, :children, :root?, to: :item
+
+          def initialize(item:, depth:)
+            @item = item
+            @depth = depth
           end
 
-          self_link path: :custom_field_item,
-                    title_getter: ->(*) { represented.label }
+          private
 
-          property :id
-
-          property :label, render_nil: true
-
-          property :short, render_nil: true
-
-          property :depth,
-                   render_nil: true,
-                   exec_context: :decorator,
-                   getter: ->(*) { represented.depth < 0 ? nil : represented.depth }
-
-          link :parent do
-            next if represented.root?
-
-            parent = represented.parent
-
-            {
-              href: api_v3_paths.custom_field_item(parent.id),
-              title: parent.label
-            }
-          end
-
-          links :children do
-            represented.children.map do |child|
-              {
-                href: api_v3_paths.custom_field_item(child.id),
-                title: child.label
-              }
-            end
-          end
+          attr_accessor :item
         end
       end
     end

--- a/lib/api/v3/custom_fields/hierarchy/item_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/item_api.rb
@@ -42,7 +42,9 @@ module API
               get &::API::V3::Utilities::Endpoints::Show
                      .new(model: CustomField::Hierarchy::Item,
                           render_representer: HierarchyItemRepresenter,
-                          instance_generator: ->(*) { @custom_field_item })
+                          instance_generator: ->(*) do
+                            HierarchicalItemAggregate.new(item: @custom_field_item, depth: @custom_field_item.depth - 1)
+                          end)
                      .mount
 
               mount ItemBranchAPI

--- a/lib/api/v3/custom_fields/hierarchy/item_branch_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/item_branch_api.rb
@@ -40,6 +40,7 @@ module API
               ::CustomFields::Hierarchy::HierarchicalItemService
                 .new
                 .get_branch(item: @custom_field_item)
+                .fmap { |items| items.map { |item| HierarchicalItemAggregate.new(item:, depth: item.depth - 1) } }
                 .either(
                   ->(items) do
                     self_link = api_v3_paths.custom_field_item(@custom_field_item.id)

--- a/lib/api/v3/custom_fields/hierarchy/items_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/items_api.rb
@@ -30,28 +30,13 @@ module API
   module V3
     module CustomFields
       module Hierarchy
-        class HierarchicalItemAggregate
-          attr_accessor :depth
-
-          delegate :id, :label, :short, :parent, :children, :root?, to: :item
-
-          def initialize(item:, depth:)
-            @item = item
-            @depth = depth
-          end
-
-          private
-
-          attr_accessor :item
-        end
-
         class ItemsAPI < ::API::OpenProjectAPI
           include Dry::Monads[:result]
 
           helpers do
             def flatten_tree_hash(hash)
               flat_list = []
-              queue = [hash.merge({ depth: 0 })]
+              queue = [hash.merge({ depth: -1 })]
 
               # From the service we get a hashed tree like this:
               # {:a => {:b => {:c1 => {:d1 => {}}, :c2 => {:d2 => {}}}, :b2 => {}}}


### PR DESCRIPTION
# What are you trying to accomplish?
- all items of first level in a hierarchy are represented in API as depth 0
- (invisible) root has no depth
