### PR TITLE
[#58824] Emoji reactions overlap on mWeb

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -3,6 +3,7 @@
 @import "work_packages/activities_tab/journals/index_component"
 @import "work_packages/activities_tab/journals/item_component"
 @import "work_packages/activities_tab/journals/item_component/details"
+@import "work_packages/activities_tab/journals/item_component/add_reactions"
 @import "work_packages/activities_tab/journals/item_component/reactions"
 @import "shares/modal_body_component"
 @import "shares/invite_user_form_component"

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
@@ -15,7 +15,7 @@
       )
 
       overlay.with_body(pt: 2, test_selector: "emoji-reactions-overlay") do
-        flex_layout do |add_reactions_container|
+        flex_layout(flex_wrap: :wrap, classes: "op-add-reactions-overlay") do |add_reactions_container|
           EmojiReaction.available_emoji_reactions.each do |emoji, reaction|
             add_reactions_container.with_column(mr: 2) do
               render(Primer::Beta::Button.new(

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.sass
@@ -1,0 +1,4 @@
+.op-add-reactions-overlay
+  row-gap: var(--base-size-4, 4px)
+  @media screen and (max-width: $breakpoint-sm)
+    max-width: 200px


### PR DESCRIPTION
https://community.openproject.org/work_packages/58824

Follows #17132

* Flex wrap the emoji reactions
* Apply a max width of 200px on the overlay on mobile

| Before | After |
|--------|--------|
| <img width="387" alt="Screenshot 2024-11-08 at 5 15 40 PM" src="https://github.com/user-attachments/assets/cfc6e930-e792-4195-9537-435746ea0285"> | <img width="387" alt="Screenshot 2024-11-08 at 5 15 40 PM" src="https://github.com/user-attachments/assets/30460b03-9b9c-435b-a835-22e2eaadbbe5"> |
