### PR TITLE
load storage/activity data only for admins

### DIFF
--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -151,10 +151,20 @@ module Projects
     end
 
     def projects(query)
-      query
-        .results
-        .with_required_storage
-        .with_latest_activity
+      scope = query.results
+
+      # The two columns associated with the
+      # * disk storage
+      # * latest activity
+      # information are only available to admins.
+      # For non admins, the performance penalty of fetching the information therefore needs never be paid.
+      if User.current.admin?
+        scope = scope
+                  .with_required_storage
+                  .with_latest_activity
+      end
+
+      scope
         .includes(:custom_values, :enabled_modules)
         .paginate(page: helpers.page_param(params), per_page: helpers.per_page_param(params))
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59202

# What are you trying to accomplish?

Avoid the performance penalty caused by loading the storage and activity information at least for non admins. 

The problem needs to be fixed for admins independently but at least the bulk of users should be freed from it.