### PR TITLE
[58728] Loading animation is too big in HoverCard

### DIFF
--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.html
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.html
@@ -8,7 +8,7 @@
     id="op-hover-card-body"
     [src]="turboFrameSrc">
     <op-content-loader
-      viewBox="0 0 180 60"
+      viewBox="0 0 330 60"
     >
       <svg:rect x="10" y="0" width="60%" height="16" rx="1" />
       <svg:rect x="10" y="20" width="80%" height="16" rx="1" />


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58728/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Set a better size for the loading indicator of hovercard

## Screenshots
Before:

![Screenshot 2024-11-11 at 13 12 44](https://github.com/user-attachments/assets/338b03a6-8307-44aa-ae75-b3267b0214e8)


After:

![Screenshot 2024-11-11 at 13 12 05](https://github.com/user-attachments/assets/77e70547-ecb7-4bb3-a622-bcf297b7e929)


# What approach did you choose and why?
Change viewport value

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
