### PR TITLE
[#59176] Activity tab: Too much spacing between comment and Emoji line

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
@@ -7,7 +7,7 @@
             format_text(journal, :notes)
           end
         end
-        journal_container.with_row(mt: 3, flex_layout: true) do |reactions_container|
+        journal_container.with_row(flex_layout: true) do |reactions_container|
           reactions_container.with_column do
             render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(journal:, grouped_emoji_reactions:))
           end


### PR DESCRIPTION
https://community.openproject.org/work_packages/59176

Follows #17135

`.op-uc-container` adds a padding bottom of 1 rem, hence the margin top on the "add reactions" button is no longer needed

_Before_

| Below the comment | Above the comment |
|--------|--------|
| <img width="387" alt="image showing padding bottom" src="https://github.com/user-attachments/assets/194cef99-4427-4b8c-a950-1f0a84c033a9"> | <img width="387" alt="image showing margin top" src="https://github.com/user-attachments/assets/689470ef-2914-4148-abc4-bf23be6f36a3"> |

_After_

<img width="941" alt="Screenshot 2024-11-11 at 4 45 43 PM" src="https://github.com/user-attachments/assets/3e0fabb5-a47f-49f4-8d6e-6f03704fc3b1">
