### PR TITLE
Chore: do not run non-related Github actions on doc changes

### DIFF
--- a/.github/workflows/codeql-scan-core.yml
+++ b/.github/workflows/codeql-scan-core.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "dev", "release/*", "stable/*" ]
   pull_request:
     branches: [ "dev", "release/*", "stable/*" ]
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: '32 1 * * 2'
 

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -2,6 +2,8 @@ name: rubocop
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   rubocop:


### PR DESCRIPTION
Some actions run if there are changes only on markdown files which is pointless.

This PR add excludes.