### PR TITLE
[#58865] add enterprise banner to new custom field form

### DIFF
--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -186,10 +186,7 @@ module CustomFieldsHelper
 
   # Return a string used to display a custom value
   def format_value(value, custom_field)
-    custom_value = CustomValue.new(custom_field:,
-                                   value:)
-
-    custom_value.formatted_value
+    CustomValue.new(custom_field:, value:).formatted_value
   end
 
   # Return an array of custom field formats which can be used in select_tag
@@ -208,15 +205,14 @@ module CustomFieldsHelper
   end
 
   def label_for_custom_field_format(format_string)
-    show_enterprise_text = format_string == "hierarchy" && !EnterpriseToken.allows_to?(:custom_field_hierarchies)
-
     format = OpenProject::CustomFieldFormat.find_by(name: format_string)
-    label = if format
-              format.label.is_a?(Proc) ? format.label.call : I18n.t(format.label)
-            end
+    return "" if format.nil?
 
-    label += " (#{I18n.t(:label_enterprise_addon)})" if show_enterprise_text
+    label = format.label.is_a?(Proc) ? format.label.call : I18n.t(format.label)
 
-    label
+    show_enterprise_text = format_string == "hierarchy" && !EnterpriseToken.allows_to?(:custom_field_hierarchies)
+    suffix = show_enterprise_text ? " (#{I18n.t(:label_enterprise_addon)})" : ""
+
+    "#{label}#{suffix}"
   end
 end

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -59,7 +59,7 @@ class CustomValue < ApplicationRecord
   def strategy
     @strategy ||= begin
       format = custom_field&.field_format || "empty"
-      OpenProject::CustomFieldFormat.find_by_name(format).formatter.new(self) # rubocop:disable Rails/DynamicFindBy
+      OpenProject::CustomFieldFormat.find_by(name: format).formatter.new(self) # rubocop:disable Rails/DynamicFindBy
     end
   end
 

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -59,7 +59,7 @@ class CustomValue < ApplicationRecord
   def strategy
     @strategy ||= begin
       format = custom_field&.field_format || "empty"
-      OpenProject::CustomFieldFormat.find_by(name: format).formatter.new(self) # rubocop:disable Rails/DynamicFindBy
+      OpenProject::CustomFieldFormat.find_by(name: format).formatter.new(self)
     end
   end
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -474,7 +474,6 @@ class PermittedParams
           :searchable,
           :admin_only,
           :default_value,
-          :possible_values,
           :multi_value,
           :content_right_to_left,
           :custom_field_section_id,

--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -34,6 +34,7 @@ class Authorization::EnterpriseService
     board_view
     conditional_highlighting
     custom_actions
+    custom_field_hierarchies
     date_alerts
     define_custom_style
     edit_attribute_groups

--- a/app/views/admin/settings/project_custom_fields/new.html.erb
+++ b/app/views/admin/settings/project_custom_fields/new.html.erb
@@ -34,6 +34,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'custom_field' %>
 
+<% content_controller "admin--custom-fields",
+                      dynamic: true,
+                      'admin--custom-fields-format-config-value': OpenProject::CustomFieldFormatDependent.stimulus_config
+%>
+
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                               url: admin_settings_project_custom_fields_path,
                               html: { id: 'custom_field_form' } do |f| %>

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -86,13 +86,17 @@ See COPYRIGHT and LICENSE files for more details.
           >
             <td>
               <span class="dragula-handle icon icon-table icon-drag-handle"></span>
-              <%= co_f.hidden_field :id, class: 'custom-option-id' %>
+              <%= co_f.hidden_field :id,
+                                    disabled:true,
+                                    class: 'custom-option-id' %>
               <%= co_f.text_field :value,
+                                  disabled: true,
                                   container_class: 'custom-option-value',
                                   no_label: true %>
             </td>
             <td>
               <%= co_f.check_box :default_value,
+                                 disabled: true,
                                  container_class: 'custom-option-default-value',
                                  data: {
                                    'admin--custom-fields-target': 'customOptionDefaults',

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -32,9 +32,6 @@ See COPYRIGHT and LICENSE files for more details.
 <section
   class="form--section"
   id="custom_field_form"
-  data-controller="admin--custom-fields"
-  data-application-target="dynamic"
-  data-admin--custom-fields-format-config-value="<%= OpenProject::CustomFieldFormatDependent.stimulus_config %>"
 >
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name,
@@ -62,6 +59,17 @@ See COPYRIGHT and LICENSE files for more details.
                  }
     %>
   </div>
+  <div class="form--field-extra-actions" <%= format_dependent.attributes(:enterpriseBanner) %>>
+    <%= angular_component_tag "opce-enterprise-banner",
+                              inputs: {
+                                collapsible: true,
+                                opReferrer: "custom-field-hierarchy",
+                                textMessage: "PLACEHOLDER - upgrade to Starkiller Base",
+                                moreInfoLink: OpenProject::Static::Links.links[:enterprise_docs][:boards][:href]
+                              }
+    %>
+  </div>
+
   <div class="form--grouping" id="custom_field_length" <%= format_dependent.attributes(:length) %>>
     <div class="form--grouping-label">
       <%= t(:label_min_max_length) %> <br>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -33,6 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'custom_field' %>
 
+<% content_controller "admin--custom-fields", dynamic: true %>
+
 <% if @custom_field.field_format_hierarchy? %>
   <%= render CustomFields::DetailsComponent.new(@custom_field) %>
 <% else %>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -33,7 +33,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'custom_field' %>
 
-<% content_controller "admin--custom-fields", dynamic: true %>
+<% content_controller "admin--custom-fields",
+                      dynamic: true,
+                      'admin--custom-fields-format-config-value': OpenProject::CustomFieldFormatDependent.stimulus_config
+%>
 
 <% if @custom_field.field_format_hierarchy? %>
   <%= render CustomFields::DetailsComponent.new(@custom_field) %>

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -42,10 +42,20 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for 'custom_field' %>
 
+<% content_controller "admin--custom-fields",
+                      dynamic: true,
+                      'admin--custom-fields-format-config-value': OpenProject::CustomFieldFormatDependent.stimulus_config,
+                      'admin--custom-fields-enterprise-edition-value': EnterpriseToken.active?
+%>
+
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                                              url: custom_fields_path,
                                              html: {id: 'custom_field_form', class: "-wide-labels"} do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <%= hidden_field_tag 'type', @custom_field.type %>
-  <%= styled_button_tag t(:button_save), class: '-primary -with-icon icon-checkmark' %>
+  <%= styled_button_tag t(:button_save),
+                        class: '-primary -with-icon icon-checkmark',
+                        data: {
+                          'admin--custom-fields-target': 'submitButton'
+                        } %>
 <% end %>

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% content_controller "admin--custom-fields",
                       dynamic: true,
                       'admin--custom-fields-format-config-value': OpenProject::CustomFieldFormatDependent.stimulus_config,
-                      'admin--custom-fields-enterprise-edition-value': EnterpriseToken.active?
+                      'admin--custom-fields-enterprise-edition-value': EnterpriseToken.allows_to?(:custom_field_hierarchies)
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -80,6 +80,7 @@ OpenProject::CustomFieldFormat.map do |fields|
 
   fields.register OpenProject::CustomFieldFormat.new("hierarchy",
                                                      label: :label_hierarchy,
+                                                     only: %w(WorkPackage),
                                                      order: 12,
                                                      formatter: "CustomValue::HierarchyStrategy")
 end

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -34,6 +34,7 @@ export default class CustomFieldsController extends Controller {
   static targets = [
     'format',
     'dragContainer',
+    'submitButton',
 
     'customOptionDefaults',
     'customOptionRow',
@@ -48,17 +49,22 @@ export default class CustomFieldsController extends Controller {
     'regexp',
     'searchable',
     'textOrientation',
+
+    'enterpriseBanner',
   ];
 
   static values = {
     formatConfig: Array,
+    enterpriseEdition: Boolean,
   };
 
   declare readonly formatConfigValue:[string, string, string[]][];
+  declare readonly enterpriseEditionValue:boolean;
 
   declare readonly formatTarget:HTMLInputElement;
   declare readonly dragContainerTarget:HTMLElement;
   declare readonly hasDragContainerTarget:boolean;
+  declare readonly submitButtonTarget:HTMLButtonElement;
 
   declare readonly customOptionDefaultsTargets:HTMLInputElement[];
   declare readonly customOptionRowTargets:HTMLTableRowElement[];
@@ -73,6 +79,8 @@ export default class CustomFieldsController extends Controller {
   declare readonly regexpTargets:HTMLElement[];
   declare readonly searchableTargets:HTMLInputElement[];
   declare readonly textOrientationTargets:HTMLElement[];
+
+  declare readonly enterpriseBannerTarget:HTMLElement;
 
   connect() {
     if (this.hasDragContainerTarget) {
@@ -242,8 +250,14 @@ export default class CustomFieldsController extends Controller {
   }
 
   private toggleFormat(format:string) {
+    this.submitButtonTarget.disabled = format === 'hierarchy' && !this.enterpriseEditionValue;
+
     this.formatConfigValue.forEach(([targetsName, operator, formats]) => {
-      const active = operator === 'only' ? formats.includes(format) : !formats.includes(format);
+      let active = operator === 'only' ? formats.includes(format) : !formats.includes(format);
+      if (targetsName === 'enterpriseBanner' && this.enterpriseEditionValue) {
+        active = false;
+      }
+
       const targets = this[`${targetsName}Targets` as keyof typeof this] as HTMLElement[];
       if (targets) {
         this.setActive(targets, active);

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -65,6 +65,7 @@ export default class CustomFieldsController extends Controller {
   declare readonly dragContainerTarget:HTMLElement;
   declare readonly hasDragContainerTarget:boolean;
   declare readonly submitButtonTarget:HTMLButtonElement;
+  declare readonly hasSubmitButtonTarget:boolean;
 
   declare readonly customOptionDefaultsTargets:HTMLInputElement[];
   declare readonly customOptionRowTargets:HTMLTableRowElement[];
@@ -250,7 +251,9 @@ export default class CustomFieldsController extends Controller {
   }
 
   private toggleFormat(format:string) {
-    this.submitButtonTarget.disabled = format === 'hierarchy' && !this.enterpriseEditionValue;
+    if (this.hasSubmitButtonTarget) {
+      this.submitButtonTarget.disabled = format === 'hierarchy' && !this.enterpriseEditionValue;
+    }
 
     this.formatConfigValue.forEach(([targetsName, operator, formats]) => {
       let active = operator === 'only' ? formats.includes(format) : !formats.includes(format);

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -64,7 +64,7 @@ class CustomFieldFormBuilder < TabularFormBuilder
                                   name: custom_field_field_name,
                                   id: custom_field_field_id)
 
-    field_format = OpenProject::CustomFieldFormat.find_by_name(custom_field.field_format)
+    field_format = OpenProject::CustomFieldFormat.find_by(name: custom_field.field_format)
 
     case field_format.try(:edit_as)
     when "date"

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -57,6 +57,7 @@ class CustomFieldFormBuilder < TabularFormBuilder
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   def custom_field_input(options = {})
     field = custom_field.attribute_name
 
@@ -79,6 +80,8 @@ class CustomFieldFormBuilder < TabularFormBuilder
       text_field(field, input_options)
     end
   end
+
+  # rubocop:enable Metrics/AbcSize
 
   def custom_field_input_list(field, input_options)
     customized = Array(custom_value).first&.customized

--- a/lib/open_project/custom_field_format.rb
+++ b/lib/open_project/custom_field_format.rb
@@ -63,7 +63,7 @@ module OpenProject
         @@available.keys
       end
 
-      def find_by_name(name)
+      def find_by(name:)
         @@available[name.to_s]
       end
 

--- a/lib/open_project/custom_field_format_dependent.rb
+++ b/lib/open_project/custom_field_format_dependent.rb
@@ -38,7 +38,8 @@ module OpenProject
       possibleValues: [:only, %w[list]],
       regexp: [:except, %w[list bool date user version hierarchy]],
       searchable: [:except, %w[bool date float int user version]],
-      textOrientation: [:only, %w[text]]
+      textOrientation: [:only, %w[text]],
+      enterpriseBanner: [:only, %w[hierarchy]]
     }.freeze
 
     def self.stimulus_config

--- a/spec/features/admin/custom_fields/user_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/user_custom_field_spec.rb
@@ -31,6 +31,7 @@ require "spec_helper"
 RSpec.describe "User custom fields edit", :js, :with_cuprite do
   shared_let(:admin) { create(:admin) }
   let(:cf_page) { Pages::CustomFields::IndexPage.new }
+  let(:new_cf_page) { Pages::CustomFields::NewPage.new }
 
   before do
     login_as(admin)
@@ -39,30 +40,30 @@ RSpec.describe "User custom fields edit", :js, :with_cuprite do
 
   it "can create and edit user custom fields (#48725)" do
     # Create CF
-    click_link "Create a new custom field"
+    click_on "New custom field"
+    new_cf_page.expect_current_path
 
-    wait_for_reload
-
-    fill_in "custom_field_name", with: "My User CF"
-    select "User", from: "custom_field_field_format"
+    fill_in "Name", with: "My User CF"
+    select "User", from: "Format"
 
     expect(page).to have_no_field("custom_field_custom_options_attributes_0_value")
 
     click_on "Save"
 
     # Expect field to be created
-    cf = CustomField.last
-    expect(cf.name).to eq("My User CF")
+    cf_page.expect_current_path("tab=WorkPackageCustomField")
+    expect(page).to have_list_item("My User CF")
 
     # Edit again
-    find("a", text: "My User CF").click
+    click_on "My User CF"
 
     expect(page).to have_no_field("custom_field_custom_options_attributes_0_value")
-    fill_in "custom_field_name", with: "My User CF (edited)"
+    fill_in "Name", with: "My User CF (edited)"
 
     click_on "Save"
 
     # Expect field to be saved
+    expect(page).to have_css(".PageHeader-title", text: "My User CF (edited)")
     cf = CustomField.last
     expect(cf.name).to eq("My User CF (edited)")
   end

--- a/spec/features/custom_fields/hierarchy_custom_field_spec.rb
+++ b/spec/features/custom_fields/hierarchy_custom_field_spec.rb
@@ -31,14 +31,18 @@
 require "spec_helper"
 
 RSpec.describe "custom fields of type hierarchy", :js, :with_cuprite do
-  let(:user) { create(:admin) }
+  let(:admin) { create(:admin) }
   let(:custom_field_index_page) { Pages::CustomFields::IndexPage.new }
   let(:new_custom_field_page) { Pages::CustomFields::NewPage.new }
   let(:hierarchy_page) { Pages::CustomFields::HierarchyPage.new }
 
+  before do
+    allow(EnterpriseToken).to receive(:allows_to?).and_return(true)
+  end
+
   it "lets you create, update and delete a custom field of type hierarchy",
      with_flag: { custom_field_of_type_hierarchy: true } do
-    login_as user
+    login_as admin
 
     # region CustomField creation
 


### PR DESCRIPTION
# Ticket
[OP#58865](https://community.openproject.org/work_packages/58865)

# What are you trying to accomplish?
- do not allow creation of hierarchy custom fields if no enterprise token is active

# What approach did you choose and why?
- show banner below form field selection, if
  - hierarchy is selected AND
  - enterprise token is not active
- disable submit button, if the enterprise banner is shown
