### PR TITLE
Bump IfcConvert version

### DIFF
--- a/docker/dev/backend/scripts/setup-bim
+++ b/docker/dev/backend/scripts/setup-bim
@@ -29,8 +29,8 @@ unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 # IFCconvert
-wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.6.0-517b819-linux64.zip
-unzip -q IfcConvert-v0.6.0-517b819-linux64.zip
+wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
 wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz

--- a/docker/prod/setup/preinstall-common.sh
+++ b/docker/prod/setup/preinstall-common.sh
@@ -77,8 +77,8 @@ if [ ! "$BIM_SUPPORT" = "false" ]; then
 	mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 	# IFCconvert
-	wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.6.0-517b819-linux64.zip
-	unzip -q IfcConvert-v0.6.0-517b819-linux64.zip
+	wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+	unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
 	mv IfcConvert "/usr/local/bin/IfcConvert"
 
 	wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz

--- a/modules/bim/bin/setup_dev.sh
+++ b/modules/bim/bin/setup_dev.sh
@@ -25,8 +25,8 @@ unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 # IFCconvert
-wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.6.0-517b819-linux64.zip
-unzip -q IfcConvert-v0.6.0-517b819-linux64.zip
+wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
 wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz

--- a/packaging/addons/openproject-edition/bin/preinstall
+++ b/packaging/addons/openproject-edition/bin/preinstall
@@ -70,10 +70,10 @@ if [ "$edition" = "bim" ]; then
 	fi
 
 	if ! ${CLI} run which IfcConvert &>/dev/null ||
-	   ! echo "83eed7f2f12079df5f6a55a07f812d27b28620bd  $(${CLI} run which IfcConvert)" | sha1sum -c - ; then
+	   ! echo "2d48d5df36371fc5920a71f0d74b29449b0b166a  $(${CLI} run which IfcConvert)" | sha1sum -c - ; then
 		echo "Fetching and installing IfcConvert..."
-		wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.6.0-517b819-linux64.zip
-		unzip -qq IfcConvert-v0.6.0-517b819-linux64.zip
+		wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+		unzip -qq IfcConvert-v0.7.11-fea8e3a-linux64.zip
 		mv IfcConvert "$APP_HOME/bin/IfcConvert"
 	fi
 


### PR DESCRIPTION
# What are you trying to accomplish?
Bump IfcConvert tool to v0.7.11 

# What approach did you choose and why?
Got some models unable to convert with 0.6. After migration to Debian 12 we can easily switch official builds.
