### PR TITLE
[chore] enable contract localization test

### DIFF
--- a/spec/contracts/custom_fields/hierarchy/insert_item_contract_spec.rb
+++ b/spec/contracts/custom_fields/hierarchy/insert_item_contract_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe CustomFields::Hierarchy::InsertItemContract do
         expect(result.errors.to_h).to include(label: ["must be unique within the same hierarchy level"])
       end
 
-      context "if locale is set to 'de'", skip: "Skipped until the german localization is available" do
+      context "if locale is set to 'de'" do
         it "is invalid with localized validation errors" do
           I18n.with_locale(:de) do
             result = subject.call(params)
             expect(result).to be_failure
-            expect(result.errors.to_h).to include(label: ["muss einzigartig innerhalb derselben Hierarchieebene sein"])
+            expect(result.errors.to_h).to include(label: ["muss innerhalb der gleichen Hierarchieebene eindeutig sein"])
           end
         end
       end


### PR DESCRIPTION
# What are you trying to accomplish?
- localisation for non-default locales must work in dry validation contracts
- a test is enabled to test for such a translation