### PR TITLE
[58857] Added specs for hierarchy items API and representer

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,20 +295,20 @@ en:
 
   dry_validation:
     errors:
-      integer?: "must be an integer"
-      filled?: "must be filled"
-      greater_or_equal_zero: "must be greater or equal to 0"
-      not_found: "not found"
+      int?: "must be an integer."
+      filled?: "must be filled."
+      greater_or_equal_zero: "must be greater or equal to 0."
+      not_found: "not found."
       rules:
         item:
-          root_item: "cannot be a root item"
-          not_persisted: "must be an already existing item"
+          root_item: "cannot be a root item."
+          not_persisted: "must be an already existing item."
         label:
-          not_unique: "must be unique within the same hierarchy level"
+          not_unique: "must be unique within the same hierarchy level."
         short:
-          not_unique: "must be unique within the same hierarchy level"
+          not_unique: "must be unique within the same hierarchy level."
         parent:
-          not_descendant: "must be a descendant of the hierarchy root"
+          not_descendant: "must be a descendant of the hierarchy root."
     rules:
       depth: "Depth"
       item: "Item"

--- a/lib/api/v3/custom_fields/hierarchy/get_items_parameter_contract.rb
+++ b/lib/api/v3/custom_fields/hierarchy/get_items_parameter_contract.rb
@@ -35,6 +35,9 @@ module API
         class GetItemsParameterContract < Dry::Validation::Contract
           config.messages.backend = :i18n
 
+          # ToDo: https://community.openproject.org/projects/openproject/work_packages/59238/activity
+          config.messages.load_paths << "config/locales/en.yml"
+
           option :hierarchy_root
 
           params do

--- a/spec/contracts/custom_fields/hierarchy/insert_item_contract_spec.rb
+++ b/spec/contracts/custom_fields/hierarchy/insert_item_contract_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CustomFields::Hierarchy::InsertItemContract do
       it "is invalid" do
         result = subject.call(params)
         expect(result).to be_failure
-        expect(result.errors.to_h).to include(label: ["must be unique within the same hierarchy level"])
+        expect(result.errors.to_h).to include(label: ["must be unique within the same hierarchy level."])
       end
 
       context "if locale is set to 'de'" do
@@ -89,7 +89,7 @@ RSpec.describe CustomFields::Hierarchy::InsertItemContract do
       it "is invalid with localized validation errors" do
         result = subject.call(params)
         expect(result).to be_failure
-        expect(result.errors.to_h).to include(short: ["must be unique within the same hierarchy level"])
+        expect(result.errors.to_h).to include(short: ["must be unique within the same hierarchy level."])
       end
     end
 

--- a/spec/contracts/custom_fields/hierarchy/update_item_contract_spec.rb
+++ b/spec/contracts/custom_fields/hierarchy/update_item_contract_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CustomFields::Hierarchy::UpdateItemContract do
       it("is invalid") do
         result = subject.call(params)
         expect(result).to be_failure
-        expect(result.errors.to_h).to include(item: ["cannot be a root item"])
+        expect(result.errors.to_h).to include(item: ["cannot be a root item."])
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe CustomFields::Hierarchy::UpdateItemContract do
       it "is invalid" do
         result = subject.call(params)
         expect(result).to be_failure
-        expect(result.errors[:item]).to match_array("must be an already existing item")
+        expect(result.errors[:item]).to match_array("must be an already existing item.")
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe CustomFields::Hierarchy::UpdateItemContract do
         result = subject.call(params)
         expect(result).to be_failure
 
-        expect(result.errors[:label]).to match_array("must be unique within the same hierarchy level")
+        expect(result.errors[:label]).to match_array("must be unique within the same hierarchy level.")
       end
     end
 
@@ -105,7 +105,7 @@ RSpec.describe CustomFields::Hierarchy::UpdateItemContract do
 
         p result
 
-        expect(result.errors[:short]).to match_array("must be unique within the same hierarchy level")
+        expect(result.errors[:short]).to match_array("must be unique within the same hierarchy level.")
       end
     end
 

--- a/spec/factories/hierarchy_item_factory.rb
+++ b/spec/factories/hierarchy_item_factory.rb
@@ -1,7 +1,36 @@
 # frozen_string_literal: true
 
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 FactoryBot.define do
   factory :hierarchy_item, class: "CustomField::Hierarchy::Item" do
     sequence(:label) { |n| "Item #{n}" }
+    sequence(:short) { |n| "I #{n}" }
   end
 end

--- a/spec/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer_rendering_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rendering" do
+  include API::V3::Utilities::PathHelper
+
+  let(:custom_field) { create(:custom_field, field_format: "hierarchy", hierarchy_root: nil) }
+  let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
+  let!(:root) { service.generate_root(custom_field).value! }
+  let!(:luke) { service.insert_item(parent: root, label: "Luke", short: "LS").value! }
+  let!(:r2d2) { service.insert_item(parent: luke, label: "R2-D2", short: "R2").value! }
+  let!(:mouse) { service.insert_item(parent: r2d2, label: "Mouse Droid", short: "MD").value! }
+  let!(:c3po) { service.insert_item(parent: luke, label: "C-3PO", short: "3PO").value! }
+  let!(:mara) { service.insert_item(parent: root, label: "Mara", short: "MJ").value! }
+  let(:user) { build_stubbed(:user) }
+  let(:representer) { described_class.new(item, current_user: user) }
+
+  subject(:generated) { representer.to_json }
+
+  context "if item is root" do
+    let(:item) { root }
+
+    describe "_links" do
+      it_behaves_like "has an untitled link" do
+        let(:link) { "self" }
+        let(:href) { api_v3_paths.custom_field_item(item.id) }
+      end
+
+      it_behaves_like "has no link" do
+        let(:link) { "parent" }
+      end
+
+      it_behaves_like "has a link collection" do
+        let(:link) { "children" }
+        let(:hrefs) do
+          [
+            {
+              href: api_v3_paths.custom_field_item(luke.id),
+              title: luke.label
+            },
+            {
+              href: api_v3_paths.custom_field_item(mara.id),
+              title: mara.label
+            }
+          ]
+        end
+      end
+
+      it_behaves_like "has an untitled link" do
+        let(:link) { "branch" }
+        let(:href) { api_v3_paths.custom_field_item_branch(item.id) }
+      end
+    end
+
+    describe "properties" do
+      it_behaves_like "property", :_type do
+        let(:value) { "HierarchyItem" }
+      end
+
+      it_behaves_like "property", :id do
+        let(:value) { item.id }
+      end
+
+      it_behaves_like "property", :label do
+        let(:value) { nil }
+      end
+
+      it_behaves_like "property", :short do
+        let(:value) { nil }
+      end
+
+      it_behaves_like "property", :depth do
+        let(:value) { 0 }
+      end
+    end
+
+    context "and depth is negative" do
+      let(:item) { API::V3::CustomFields::Hierarchy::HierarchicalItemAggregate.new(item: root, depth: -1) }
+
+      describe "properties" do
+        it_behaves_like "property", :depth do
+          let(:value) { nil }
+        end
+      end
+    end
+  end
+
+  context "if item is leave" do
+    let(:item) { mouse }
+
+    describe "_links" do
+      it_behaves_like "has a titled link" do
+        let(:link) { "self" }
+        let(:href) { api_v3_paths.custom_field_item(item.id) }
+        let(:title) { item.label }
+      end
+
+      it_behaves_like "has a titled link" do
+        let(:link) { "parent" }
+        let(:href) { api_v3_paths.custom_field_item(r2d2.id) }
+        let(:title) { r2d2.label }
+      end
+
+      it_behaves_like "has a link collection" do
+        let(:link) { "children" }
+        let(:hrefs) { [] }
+      end
+
+      it_behaves_like "has an untitled link" do
+        let(:link) { "branch" }
+        let(:href) { api_v3_paths.custom_field_item_branch(item.id) }
+      end
+    end
+
+    describe "properties" do
+      it_behaves_like "property", :_type do
+        let(:value) { "HierarchyItem" }
+      end
+
+      it_behaves_like "property", :id do
+        let(:value) { item.id }
+      end
+
+      it_behaves_like "property", :label do
+        let(:value) { item.label }
+      end
+
+      it_behaves_like "property", :short do
+        let(:value) { item.short }
+      end
+
+      it_behaves_like "property", :depth do
+        let(:value) { item.depth }
+      end
+    end
+  end
+
+  context "if item is intermediate" do
+    let(:item) { r2d2 }
+
+    describe "_links" do
+      it_behaves_like "has a titled link" do
+        let(:link) { "self" }
+        let(:href) { api_v3_paths.custom_field_item(item.id) }
+        let(:title) { item.label }
+      end
+
+      it_behaves_like "has a titled link" do
+        let(:link) { "parent" }
+        let(:href) { api_v3_paths.custom_field_item(luke.id) }
+        let(:title) { luke.label }
+      end
+
+      it_behaves_like "has a link collection" do
+        let(:link) { "children" }
+        let(:hrefs) do
+          [
+            {
+              href: api_v3_paths.custom_field_item(mouse.id),
+              title: mouse.label
+            }
+          ]
+        end
+      end
+
+      it_behaves_like "has an untitled link" do
+        let(:link) { "branch" }
+        let(:href) { api_v3_paths.custom_field_item_branch(item.id) }
+      end
+    end
+
+    describe "properties" do
+      it_behaves_like "property", :_type do
+        let(:value) { "HierarchyItem" }
+      end
+
+      it_behaves_like "property", :id do
+        let(:value) { item.id }
+      end
+
+      it_behaves_like "property", :label do
+        let(:value) { item.label }
+      end
+
+      it_behaves_like "property", :short do
+        let(:value) { item.short }
+      end
+
+      it_behaves_like "property", :depth do
+        let(:value) { item.depth }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/custom_fields/hierarchy/item_api_spec.rb
+++ b/spec/requests/api/v3/custom_fields/hierarchy/item_api_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "API v3 custom field items", :webmock, content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  let(:custom_field) { create(:custom_field, field_format: "hierarchy", hierarchy_root: nil) }
+  let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
+  let!(:root) { service.generate_root(custom_field).value! }
+  let!(:luke) { service.insert_item(parent: root, label: "Luke", short: "LS").value! }
+  let!(:r2d2) { service.insert_item(parent: luke, label: "R2-D2", short: "R2").value! }
+  let!(:mouse) { service.insert_item(parent: r2d2, label: "Mouse Droid", short: "MD").value! }
+  let!(:c3po) { service.insert_item(parent: luke, label: "C-3PO", short: "3PO").value! }
+  let!(:mara) { service.insert_item(parent: root, label: "Mara", short: "MJ").value! }
+
+  subject(:last_response) { get path }
+
+  describe "GET /api/v3/custom_field_items/:id" do
+    let(:path) { api_v3_paths.custom_field_item(mouse.id) }
+
+    context "if user is not logged in" do
+      it_behaves_like "unauthenticated access"
+    end
+
+    context "if user is logged in" do
+      before { login_as create(:user) }
+
+      it_behaves_like "successful response"
+
+      it "responds with the correct item" do
+        expect(last_response.body).to be_json_eql("HierarchyItem".to_json).at_path("_type")
+        expect(last_response.body).to be_json_eql(mouse.label.to_json).at_path("label")
+        expect(last_response.body).to be_json_eql((mouse.depth - 1).to_json).at_path("depth")
+      end
+
+      context "if custom field does not exist" do
+        let(:path) { api_v3_paths.custom_field_item(1337) }
+
+        it_behaves_like "not found"
+      end
+    end
+  end
+
+  describe "GET /api/v3/custom_field_items/:id/branch" do
+    let(:path) { api_v3_paths.custom_field_item_branch(mouse.id) }
+
+    context "if user is not logged in" do
+      it_behaves_like "unauthenticated access"
+    end
+
+    context "if user is logged in" do
+      before { login_as create(:user) }
+
+      it_behaves_like "API V3 collection response", 4, 4, "HierarchyItem", "Collection" do
+        let(:elements) { [root, luke, r2d2, mouse] }
+      end
+
+      context "if custom field does not exist" do
+        let(:path) { api_v3_paths.custom_field_items(1337) }
+
+        it_behaves_like "not found"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/custom_fields/hierarchy/items_api_spec.rb
+++ b/spec/requests/api/v3/custom_fields/hierarchy/items_api_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "API v3 custom field hierarchy items", :webmock, content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  describe "GET /api/v3/custom_fields/:id/items" do
+    let(:custom_field) { create(:custom_field, field_format: "hierarchy", hierarchy_root: nil) }
+    let!(:root) { service.generate_root(custom_field).value! }
+    let!(:luke) { service.insert_item(parent: root, label: "Luke", short: "LS").value! }
+    let!(:r2d2) { service.insert_item(parent: luke, label: "R2-D2", short: "R2").value! }
+    let!(:mouse) { service.insert_item(parent: r2d2, label: "Mouse Droid", short: "MD").value! }
+    let!(:c3po) { service.insert_item(parent: luke, label: "C-3PO", short: "3PO").value! }
+    let!(:mara) { service.insert_item(parent: root, label: "Mara", short: "MJ").value! }
+    let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
+
+    let(:path) { api_v3_paths.custom_field_items(custom_field.id) }
+
+    subject(:last_response) { get path }
+
+    context "if user is not logged in" do
+      it_behaves_like "unauthenticated access"
+    end
+
+    context "if user is logged in" do
+      before { login_as create(:user) }
+
+      it_behaves_like "API V3 collection response", 6, 6, "HierarchyItem", "Collection" do
+        let(:elements) { [root, luke, r2d2, mouse, c3po, mara] }
+      end
+
+      context "if custom field does not exist" do
+        let(:path) { api_v3_paths.custom_field_items(1337) }
+
+        it_behaves_like "not found"
+      end
+
+      context "if depth is limited to specific value" do
+        let(:path) { api_v3_paths.custom_field_items(custom_field.id, nil, 1) }
+
+        it_behaves_like "API V3 collection response", 3, 3, "HierarchyItem", "Collection" do
+          let(:elements) { [root, luke, mara] }
+        end
+      end
+
+      context "if parent is set to specific item" do
+        let(:path) { api_v3_paths.custom_field_items(custom_field.id, luke.id, 1) }
+
+        it_behaves_like "API V3 collection response", 3, 3, "HierarchyItem", "Collection" do
+          let(:elements) { [luke, r2d2, c3po] }
+        end
+      end
+
+      context "if parent is set to an undefined value" do
+        let(:path) { api_v3_paths.custom_field_items(custom_field.id, "wrong item") }
+
+        it_behaves_like "error response", 400, "InvalidQuery", "Parent #{I18n.t('dry_validation.errors.int?')}"
+      end
+
+      context "if depth is negative" do
+        let(:path) { api_v3_paths.custom_field_items(custom_field.id, nil, -1) }
+
+        it_behaves_like "error response", 400, "InvalidQuery", "Depth #{I18n.t('dry_validation.errors.greater_or_equal_zero')}"
+      end
+    end
+  end
+end

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
         expect(result).to be_failure
 
         errors = result.failure.errors
-        expect(errors[:label]).to eq(["must be unique within the same hierarchy level"])
-        expect(errors[:short]).to eq(["must be unique within the same hierarchy level"])
+        expect(errors[:label]).to eq(["must be unique within the same hierarchy level."])
+        expect(errors[:short]).to eq(["must be unique within the same hierarchy level."])
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/58857/

- Added request specs for /api/v3/custom_field/{id}/items
- Added request specs for /api/v3/custom_field_items/{id}
- Added request specs for /api/v3/custom_fiels_items/{id}/branch
- Added representer specs for HierarchyItemRepresenter
- Make shift repair of Dry::Validation::Contract english localization