### PR TITLE
Extract work package info line into a Primer component

### DIFF
--- a/lookbook/docs/patterns/26-work-package-info-line.md.erb
+++ b/lookbook/docs/patterns/26-work-package-info-line.md.erb
@@ -1,0 +1,29 @@
+The work package info line is a consistent way to display the most commonly-used  set of basic work package attributes.
+
+## Anatomy
+
+The info line consists of three attributes that are displayed together:
+
+- Type
+- ID
+- Status
+
+Only the ID the only interactive element; it is clickable and points the work package. All other interaction has to come from the element using this work component.
+
+## Best practices
+
+It's best to not separate these three elements in different lines. The element can, however, be wrapped in multi-line if needed.
+
+## Used in
+
+- Hovercard
+- Work package relations tab
+- Work package header
+- ...
+
+## Technical notes
+
+
+### Code structure
+
+[CODE EXAMPLE HERE]


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/58734/activity

# What are you trying to accomplish?
Make the work package info line available as a Primer component.

## Screenshots
<img width="476" alt="work-package-info-line" src="https://github.com/user-attachments/assets/b0afd129-1318-493b-9e37-6fdfd5ef3aa6">

# What approach did you choose and why?
This element is already used in the Hovercard and @aaron-contreras also needs to use it in the Primerised Relations tab. So we're extracting it and turning into a Primerised component with docs. 

# Merge checklist

- [ ] Prepare first draft
- [ ] Add code examples
- [ ] Final review
