### PR TITLE
Overwrite primer activity tab feature flag to always be true

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -45,3 +45,10 @@ OpenProject::FeatureDecisions.add :built_in_oauth_applications,
 
 OpenProject::FeatureDecisions.add :custom_field_of_type_hierarchy,
                                   description: "Allows the use of the custom field type 'Hierarchy'."
+
+# TODO: Remove once the feature flag primerized_work_package_activities is removed altogether
+OpenProject::FeatureDecisions.define_singleton_method(:primerized_work_package_activities_active?) do
+  Rails.env.production? ||
+    (Setting.exists?("feature_primerized_work_package_activities_active") &&
+      Setting.send(:feature_primerized_work_package_activities_active?))
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59040

# What are you trying to accomplish?

Quick fix for having the `OpenProject::FeatureDecisions.primerized_work_package_activities_active?` always return true (at least in production).

The better solution would be to properly remove the feature flag but given that it would require removing code and adapting specs, this quick solution is now chosen for the release of 15.0.
