### PR TITLE
move creation of angular boostrap __ng2-bootstrap-has-run mark, so it is set after turbo:load too

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -414,6 +414,8 @@ export class OpenProjectModule implements DoBootstrap {
     if (root) {
       appRef.bootstrap(ApplicationBaseComponent, root);
     }
+
+    document.body.classList.add('__ng2-bootstrap-has-run');
   }
 
   private registerCustomElements(injector:Injector) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -44,10 +44,6 @@ void initializeLocale()
       initializeGlobalListeners();
 
       // Due to the behaviour of the Edge browser we need to wait for 'DOM ready'
-      void platformBrowserDynamic()
-        .bootstrapModule(OpenProjectModule)
-        .then(() => {
-          jQuery('body').addClass('__ng2-bootstrap-has-run');
-        });
+      void platformBrowserDynamic().bootstrapModule(OpenProjectModule);
     });
   });


### PR DESCRIPTION
# What are you trying to accomplish?
The `__ng2-bootstrap-has-run` class gets lost when turbo replaces body, so it should be set after `turbo:load` too. Without it `expect_angular_frontend_initialized` will randomly fail depending on timing, so whether it manages the presence of the class check before turbo replaced body or not.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
