### PR TITLE
[59159] Removed watchexec-cli from Dockerfile for development

### DIFF
--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -34,17 +34,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
 RUN apt-get update
 RUN apt-get install -y nodejs
 
-# Install watchexec for continuous test execution.
-# Usage:
-# - Add the following line to your ~/.bashrc ("dcrw" stands for "Docker Compose Rspec Watch"):
-# dcrw() { docker compose exec backend-test watchexec --exts rb,erb -- bin/rspec --order defined --format documentation --fail-fast $1; }
-# - and then use it like this:
-# dcrw <path-to-your-spec-file>
-RUN curl -fsSL https://apt.cli.rs/pubkey.asc | tee -a /usr/share/keyrings/rust-tools.asc
-RUN curl -fsSL https://apt.cli.rs/rust-tools.list | tee /etc/apt/sources.list.d/rust-tools.list
-RUN apt update
-RUN apt install watchexec-cli
-
 COPY ./docker/dev/backend/scripts/setup /usr/sbin/setup
 COPY ./docker/dev/backend/scripts/setup-bim /usr/sbin/setup-bim
 COPY ./docker/dev/backend/scripts/run-app /usr/sbin/run-app


### PR DESCRIPTION
Reason: Package mirror TLS problems

# Ticket
https://community.openproject.org/projects/docker/work_packages/59159/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Enable building development Docker image again.

# What approach did you choose and why?
I removed `watchexec-cli` installation from the development Dockerfile
