### PR TITLE
[chore] render item shorts in value selector

### DIFF
--- a/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
@@ -36,7 +36,13 @@ module API
           end
 
           self_link path: :custom_field_item,
-                    title_getter: ->(*) { represented.label }
+                    title_getter: ->(*) do
+                      if represented.short.nil?
+                        represented.label
+                      else
+                        "#{represented.label} (#{represented.short})"
+                      end
+                    end
 
           property :id
 

--- a/spec/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer_rendering_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
       it_behaves_like "has a titled link" do
         let(:link) { "self" }
         let(:href) { api_v3_paths.custom_field_item(item.id) }
-        let(:title) { item.label }
+        let(:title) { "#{item.label} (#{item.short})" }
       end
 
       it_behaves_like "has a titled link" do
@@ -171,7 +171,7 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
       it_behaves_like "has a titled link" do
         let(:link) { "self" }
         let(:href) { api_v3_paths.custom_field_item(item.id) }
-        let(:title) { item.label }
+        let(:title) { "#{item.label} (#{item.short})" }
       end
 
       it_behaves_like "has a titled link" do


### PR DESCRIPTION
# What are you trying to accomplish?
- the hierarchy item value selector does not render shorts yet, but we want them

## Screenshots
![image](https://github.com/user-attachments/assets/515480da-4767-4c62-b696-31381155e636)

# What approach did you choose and why?
- the select component renders HalResource arrays
- the rendered string is, what a resource answers on `.name`
- the hierarchy items do not have a name, so they fall back to `self_link.title`
- this PR adds the short to the self link title
