### PR TITLE
Update tableless models to not rely on fake schema loading

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -34,8 +34,8 @@ class Action < ApplicationRecord
 
   default_scope { default }
 
-  attribute :id, :text, default: nil
-  attribute :permission, :text, default: nil
-  attribute :global, :boolean, default: false
-  attribute :module, :text, default: false
+  define_attribute :id, ActiveRecord::Type.lookup(:text), default: nil
+  define_attribute :permission, ActiveRecord::Type.lookup(:text), default: nil
+  define_attribute :global, ActiveRecord::Type.lookup(:boolean), default: false
+  define_attribute :module, ActiveRecord::Type.lookup(:text), default: false
 end

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -37,7 +37,7 @@ class Capability < ApplicationRecord
   belongs_to :context, class_name: "Project"
   belongs_to :principal
 
-  attribute :action, :text, default: nil
-  attribute :context_id, :integer, default: nil
-  attribute :principal_id, :integer, default: nil
+  define_attribute :action, ActiveRecord::Type.lookup(:text), default: nil
+  define_attribute :context_id, ActiveRecord::Type.lookup(:integer), default: nil
+  define_attribute :principal_id, ActiveRecord::Type.lookup(:integer), default: nil
 end

--- a/app/models/concerns/tableless.rb
+++ b/app/models/concerns/tableless.rb
@@ -38,24 +38,12 @@ module Tableless
   end
 
   class_methods do
-    def attribute_names
-      @attribute_names ||= attribute_types.keys
+    def load_schema!
+      # noop
     end
 
-    def load_schema!
-      @columns_hash ||= Hash.new
-
-      # From active_record/attributes.rb
-      attributes_to_define_after_schema_loads.each do |name, (type, default)|
-        if type.is_a?(Symbol)
-          type = ActiveRecord::Type.lookup(type, default)
-        end
-
-        define_attribute(name, type, default:)
-
-        # Improve Model#inspect output
-        @columns_hash[name.to_s] = ActiveRecord::ConnectionAdapters::Column.new(name.to_s, default)
-      end
+    def columns_hash
+      @columns_hash ||= {}
     end
   end
 end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -36,9 +36,9 @@ class Day < ApplicationRecord
            primary_key: :date,
            dependent: nil
 
-  attribute :date, :date, default: nil
-  attribute :day_of_week, :integer, default: nil
-  attribute :working, :boolean, default: "t"
+  define_attribute :date, ActiveRecord::Type.lookup(:date), default: nil
+  define_attribute :day_of_week, ActiveRecord::Type.lookup(:integer), default: nil
+  define_attribute :working, ActiveRecord::Type.lookup(:boolean), default: "t"
 
   delegate :name, to: :week_day, allow_nil: true
 


### PR DESCRIPTION
# Ticket
Part of https://community.openproject.org/projects/openproject/work_packages/57304



# What are you trying to accomplish?

In Rails 7.2 the internal `attributes_to_define_after_schema_loads` method [has been removed](https://github.com/rails/rails/issues/52685) and as it was considered internal only, it is not planned to be replaced. We rely on that method to hook into the schema loading of our fake `Tableless` models by manually attaching attributes and overwriting the column cache for it.

We can achieve the same thing, by directly defining the attributes and completely skipping the schema loading by making `load_schema!` a no-op and manually creating a column cache.

It has been extracted from #17228 as there are more things that block the upgrade to Rails 7.2, but we can already do this here to validate with all tests that the tableless models still work as intended.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
