### PR TITLE
Mark SAML provider as available if idp_cert_fingerprint is present

### DIFF
--- a/modules/auth_saml/app/models/saml/provider.rb
+++ b/modules/auth_saml/app/models/saml/provider.rb
@@ -97,7 +97,7 @@ module Saml
     end
 
     def idp_certificate_configured?
-      idp_cert.present?
+      idp_cert.present? || idp_cert_fingerprint.present?
     end
 
     def idp_certificate_valid?


### PR DESCRIPTION
If we migrate from older providers, SAML might only have idp_cert_fingerprint configured. It should be marked available

https://community.openproject.org/work_packages/59535