### PR TITLE
[#59572] fixed rendering of hierarchy values in wp table views

### DIFF
--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -48,6 +48,8 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
     item = CustomField::Hierarchy::Item.find_by(id: value.to_s)
     if item.nil?
       "#{value} #{I18n.t(:label_not_found)}"
+    elsif item.short.present?
+      "#{item.label} (#{item.short})"
     else
       item.label
     end

--- a/frontend/src/app/core/state/is-array-of.ts
+++ b/frontend/src/app/core/state/is-array-of.ts
@@ -26,23 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import isArrayOf from 'core-app/core/state/is-array-of';
-
-export class TextDisplayField extends DisplayField {
-  public get valueString():string {
-    // render a text representation for the assigned attribute, independent of the attribute being a resource,
-    // an array of resources or a single text value.
-
-    if (this.value instanceof HalResource) {
-      return this.value.name;
-    }
-
-    if (isArrayOf(this.value, HalResource)) {
-      return this.value.map((r) => r.name).join(', ');
-    }
-
-    return this.value as string;
+export default function isArrayOf<T>(array:unknown, type:new (...args:never[]) => T):array is T[] {
+  if (!Array.isArray(array)) {
+    return false;
   }
+
+  return array.every((item):item is T => item instanceof type);
 }


### PR DESCRIPTION
- 


# Ticket
[OP#59572](https://community.openproject.org/wp/59572)

# What are you trying to accomplish?
- render hierarchy item values correctly in work package table

# What approach did you choose and why?
- use text display field (default) to also handle resources and represent them

