### PR TITLE
Hierarchy item filter "is any with descendants"

### DIFF
--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -88,6 +88,13 @@ module CustomFields
         Success(item.self_and_ancestors.reverse)
       end
 
+      # Gets all descendant nodes in a tree starting from the item/node.
+      # @param item [CustomField::Hierarchy::Item] the node
+      # @return [Success(Array<CustomField::Hierarchy::Item>)]
+      def get_descendants(item:)
+        Success(item.self_and_descendants)
+      end
+
       # Move an item/node to a new parent item/node
       # @param item [CustomField::Hierarchy::Item] the parent of the node
       # @param new_parent [CustomField::Hierarchy::Item] the new parent of the node

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2398,6 +2398,7 @@ en:
   label_environment: "Environment"
   label_estimates_and_progress: "Estimates and progress"
   label_equals: "is"
+  label_equals_with_descendants: "is any with descendants"
   label_everywhere: "everywhere"
   label_example: "Example"
   label_experimental: "Experimental"

--- a/spec/models/queries/operators/custom_fields/hierarchies/equals_with_descendants_spec.rb
+++ b/spec/models/queries/operators/custom_fields/hierarchies/equals_with_descendants_spec.rb
@@ -1,0 +1,61 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Operators::CustomFields::Hierarchies::EqualsWithDescendants do
+  subject(:sql) { described_class.sql_for_field(values, db_table, db_field) }
+
+  let(:custom_field) { create(:custom_field, field_format: "hierarchy", hierarchy_root: nil) }
+  let!(:root) { service.generate_root(custom_field).value! }
+  let!(:germany) { service.insert_item(parent: root, label: "Germany", short: "DE").value! }
+  let!(:berlin) { service.insert_item(parent: germany, label: "Berlin").value! }
+  let!(:munich) { service.insert_item(parent: germany, label: "Munich").value! }
+  let!(:portugal) { service.insert_item(parent: root, label: "Portugal", short: "PT").value! }
+  let!(:lisbon) { service.insert_item(parent: portugal, label: "Lisboa").value! }
+  let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
+
+  let(:db_table) { "custom_values" }
+  let(:db_field) { "value" }
+
+  context "when generating for a branch" do
+    let(:values) { [germany.id] }
+
+    it "generates the expected SQL" do
+      expect(sql).to eq("custom_values.value IN ('#{germany.id}','#{berlin.id}','#{munich.id}')")
+    end
+  end
+
+  context "when generating for a leaf" do
+    let(:values) { [lisbon.id] }
+
+    it "generates the expected SQL" do
+      expect(sql).to eq("custom_values.value IN ('#{lisbon.id}')")
+    end
+  end
+end

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -165,6 +165,31 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService do
     end
   end
 
+  describe "#get_descendants" do
+    let!(:subitem) { service.insert_item(parent: mara, label: "Sub1").value! }
+    let!(:subitem2) { service.insert_item(parent: mara, label: "sub two").value! }
+    let!(:unrelated_subitem) { service.insert_item(parent: luke, label: "not related").value! }
+
+    context "with a non-root node" do
+      it "returns all the descendants to that item" do
+        result = service.get_descendants(item: mara)
+        expect(result).to be_success
+
+        descendants = result.value!
+        expect(descendants.size).to eq(3)
+        expect(descendants).to contain_exactly(mara, subitem, subitem2)
+      end
+    end
+
+    context "with a leaf node" do
+      it "returns just the leaf node" do
+        result = service.get_descendants(item: subitem2)
+        expect(result).to be_success
+        expect(result.value!).to match_array(subitem2)
+      end
+    end
+  end
+
   describe "#move_item" do
     let(:lando) { service.insert_item(parent: root, label: "lando").value! }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/59071

# What are you trying to accomplish?
Add a new filter

## Screenshots

https://github.com/user-attachments/assets/ae64e523-5433-4f43-bb22-86b878048560



# What approach did you choose and why?
The idea here is to leverage the default Equals filter, but include hierarchy items from the whole branch in the query.

# Merge checklist
- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
