### PR TITLE
Fix: undefined method serialized for nil in ldap tls option migration

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -335,12 +335,14 @@ class Setting < ApplicationRecord
   def self.deserialize(name, value)
     definition = Settings::Definition[name]
 
-    if definition.serialized? && value.is_a?(String)
+    if definition.nil?
+      nil
+    elsif definition.serialized? && value.is_a?(String)
       deserialize_hash(value)
     elsif value != "".freeze && !value.nil?
       read_formatted_setting(value, definition.format)
-    else
-      definition.format == :string ? value : nil
+    elsif definition.format == :string
+      value
     end
   end
 

--- a/db/migrate/20221115082403_add_ldap_tls_options.rb
+++ b/db/migrate/20221115082403_add_ldap_tls_options.rb
@@ -42,7 +42,7 @@ class AddLdapTlsOptions < ActiveRecord::Migration[7.0]
         # Current LDAP library default is to not verify the certificate
         MigratingAuthSource.reset_column_information
 
-        ldap_settings = Setting.find_by(name: "ldap_tls_options")&.value
+        ldap_settings = Setting.where(name: "ldap_tls_options").pick :value
         migrate_ldap_settings(ldap_settings)
       end
     end


### PR DESCRIPTION
This fix addresses a problem when migrating from OpenProject 12 to 14 or later. 

Yet another example for why you should try to avoid model code in migrations. 