### PR TITLE
Store timezones for TimeEntries and finalize how we determine end time

### DIFF
--- a/db/migrate/20241125104347_add_timezone_identifier_to_time_entry.rb
+++ b/db/migrate/20241125104347_add_timezone_identifier_to_time_entry.rb
@@ -1,0 +1,6 @@
+class AddTimezoneIdentifierToTimeEntry < ActiveRecord::Migration[7.1]
+  def change
+    add_column :time_entries, :time_zone, :string
+    add_column :time_entry_journals, :time_zone, :string
+  end
+end

--- a/db/migrate/20241125104347_add_timezone_identifier_to_time_entry.rb
+++ b/db/migrate/20241125104347_add_timezone_identifier_to_time_entry.rb
@@ -1,6 +1,13 @@
 class AddTimezoneIdentifierToTimeEntry < ActiveRecord::Migration[7.1]
   def change
-    add_column :time_entries, :time_zone, :string
-    add_column :time_entry_journals, :time_zone, :string
+    change_table :time_entries, bulk: true do |t|
+      t.string :time_zone, null: true
+      t.remove :end_time, type: :integer
+    end
+
+    change_table :time_entry_journals, bulk: true do |t|
+      t.string :time_zone, null: true
+      t.remove :end_time, type: :integer
+    end
   end
 end

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -116,7 +116,7 @@ class TimeEntry < ApplicationRecord
     return nil if start_time.blank?
     return nil if time_zone.blank?
 
-    ActiveSupport::TimeZone[time_zone].local(spent_on.year, spent_on.month, spent_on.day, start_time / 60, start_time % 60)
+    time_zone_object.local(spent_on.year, spent_on.month, spent_on.day, start_time / 60, start_time % 60)
   end
 
   def end_timestamp
@@ -144,5 +144,9 @@ class TimeEntry < ApplicationRecord
 
   def cost_attribute
     hours
+  end
+
+  def time_zone_object
+    ActiveSupport::TimeZone[time_zone]
   end
 end

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -47,21 +47,12 @@ class TimeEntry < ApplicationRecord
   validates_presence_of :hours, if: -> { !ongoing? }
   validates_numericality_of :hours, allow_nil: true, message: :invalid
 
-  validates :start_time, :end_time,
+  validates :start_time, :hours,
             presence: true,
             if: -> { TimeEntry.must_track_start_and_end_time? }
 
   validates :start_time,
             numericality: { only_integer: true, greater_than_or_equal_to: MIN_TIME, less_than_or_equal_to: MAX_TIME },
-            allow_blank: true
-
-  validates :end_time,
-            numericality: {
-              only_integer: true,
-              greater_than: ->(te) { te.start_time.to_i },
-              less_than_or_equal_to: MAX_TIME
-              # TODO: nice error message
-            },
             allow_blank: true
 
   scope :on_work_packages, ->(work_packages) { where(work_package_id: work_packages) }
@@ -129,10 +120,11 @@ class TimeEntry < ApplicationRecord
   end
 
   def end_timestamp
-    return nil if end_time.blank?
+    return nil if start_time.blank?
     return nil if time_zone.blank?
+    return nil if hours.blank?
 
-    ActiveSupport::TimeZone[time_zone].local(spent_on.year, spent_on.month, spent_on.day, end_time / 60, end_time % 60)
+    start_timestamp + hours.hours
   end
 
   class << self

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -123,12 +123,14 @@ class TimeEntry < ApplicationRecord
 
   def start_timestamp
     return nil if start_time.blank?
+    return nil if time_zone.blank?
 
     ActiveSupport::TimeZone[time_zone].local(spent_on.year, spent_on.month, spent_on.day, start_time / 60, start_time % 60)
   end
 
   def end_timestamp
     return nil if end_time.blank?
+    return nil if time_zone.blank?
 
     ActiveSupport::TimeZone[time_zone].local(spent_on.year, spent_on.month, spent_on.day, end_time / 60, end_time % 60)
   end

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -121,6 +121,18 @@ class TimeEntry < ApplicationRecord
       (user_id == usr.id && usr.allowed_in_project?(:view_own_hourly_rate, project))
   end
 
+  def start_timestamp
+    return nil if start_time.blank?
+
+    ActiveSupport::TimeZone[time_zone].local(spent_on.year, spent_on.month, spent_on.day, start_time / 60, start_time % 60)
+  end
+
+  def end_timestamp
+    return nil if end_time.blank?
+
+    ActiveSupport::TimeZone[time_zone].local(spent_on.year, spent_on.month, spent_on.day, end_time / 60, end_time % 60)
+  end
+
   class << self
     def can_track_start_and_end_time?(_project: nil)
       OpenProject::FeatureDecisions.track_start_and_end_times_for_time_entries_active? &&

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe TimeEntry do
            spent_on: date,
            hours:,
            start_time: start_time,
-           end_time: start_time + (hours * 60).to_i,
            user:,
            time_zone: user.time_zone,
            rate: hourly_one,
@@ -436,57 +435,18 @@ RSpec.describe TimeEntry do
       end
     end
 
-    describe "end_time" do
-      it "allows blank values" do
-        time_entry.end_time = nil
-        expect(time_entry).to be_valid
-      end
-
-      it "allows integer values between 0 and 1439" do
-        time_entry.end_time = 1337
-        expect(time_entry).to be_valid
-      end
-
-      it "does not allow values > 1439" do
-        time_entry.end_time = 1440
-        expect(time_entry).not_to be_valid
-      end
-
-      it "does not allow non integer values" do
-        time_entry.end_time = 1.5
-        expect(time_entry).not_to be_valid
-      end
-
-      it "does not allow negative values" do
-        time_entry.end_time = -42
-        expect(time_entry).not_to be_valid
-      end
-    end
-
     describe "start_time and end_time" do
-      it "does not allow end times smaller than the start time" do
-        time_entry.start_time = 10 * 60
-        time_entry.end_time = 8 * 60
-
-        expect(time_entry).not_to be_valid
-      end
-
-      context "when enforcing start and end times" do
+      context "when enforcing times" do
         before do
           allow(described_class).to receive(:must_track_start_and_end_time?).and_return(true)
         end
 
         it "validates that both values are present" do
           time_entry.start_time = nil
-          time_entry.end_time = nil
 
           expect(time_entry).not_to be_valid
 
           time_entry.start_time = 10 * 60
-
-          expect(time_entry).not_to be_valid
-
-          time_entry.end_time = 12 * 60
 
           expect(time_entry).to be_valid
         end
@@ -515,8 +475,8 @@ RSpec.describe TimeEntry do
   end
 
   describe "#end_timestamp" do
-    it "returns nil if end_time is nil" do
-      time_entry.end_time = nil
+    it "returns nil if start_time is nil" do
+      time_entry.start_time = nil
       expect(time_entry.end_timestamp).to be_nil
     end
 
@@ -526,11 +486,12 @@ RSpec.describe TimeEntry do
     end
 
     it "generates a proper timestamp from the stored information" do
-      time_entry.end_time = 14 * 60
+      time_entry.start_time = 8 * 60
+      time_entry.hours = 2.5
       time_entry.spent_on = Date.new(2024, 12, 24)
       time_entry.time_zone = "America/Los_Angeles"
 
-      expect(time_entry.end_timestamp.iso8601).to eq("2024-12-24T14:00:00-08:00")
+      expect(time_entry.end_timestamp.iso8601).to eq("2024-12-24T10:30:00-08:00")
     end
   end
 

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe TimeEntry do
            start_time: start_time,
            end_time: start_time + (hours * 60).to_i,
            user:,
+           time_zone: user.time_zone,
            rate: hourly_one,
            comments: "lorem")
   end
@@ -490,6 +491,36 @@ RSpec.describe TimeEntry do
           expect(time_entry).to be_valid
         end
       end
+    end
+  end
+
+  describe "#start_timestamp" do
+    it "returns nil if start_time is nil" do
+      time_entry.start_time = nil
+      expect(time_entry.start_timestamp).to be_nil
+    end
+
+    it "generates a proper timestamp from the stored information" do
+      time_entry.start_time = 14 * 60
+      time_entry.spent_on = Date.new(2024, 12, 24)
+      time_entry.time_zone = "America/Los_Angeles"
+
+      expect(time_entry.start_timestamp.iso8601).to eq("2024-12-24T14:00:00-08:00")
+    end
+  end
+
+  describe "#end_timestamp" do
+    it "returns nil if end_time is nil" do
+      time_entry.end_time = nil
+      expect(time_entry.end_timestamp).to be_nil
+    end
+
+    it "generates a proper timestamp from the stored information" do
+      time_entry.end_time = 14 * 60
+      time_entry.spent_on = Date.new(2024, 12, 24)
+      time_entry.time_zone = "America/Los_Angeles"
+
+      expect(time_entry.end_timestamp.iso8601).to eq("2024-12-24T14:00:00-08:00")
     end
   end
 

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -500,6 +500,11 @@ RSpec.describe TimeEntry do
       expect(time_entry.start_timestamp).to be_nil
     end
 
+    it "returns nil if timezone is nil" do
+      time_entry.time_zone = nil
+      expect(time_entry.start_timestamp).to be_nil
+    end
+
     it "generates a proper timestamp from the stored information" do
       time_entry.start_time = 14 * 60
       time_entry.spent_on = Date.new(2024, 12, 24)
@@ -512,6 +517,11 @@ RSpec.describe TimeEntry do
   describe "#end_timestamp" do
     it "returns nil if end_time is nil" do
       time_entry.end_time = nil
+      expect(time_entry.end_timestamp).to be_nil
+    end
+
+    it "returns nil if timezone is nil" do
+      time_entry.time_zone = nil
       expect(time_entry.end_timestamp).to be_nil
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/59466

# What are you trying to accomplish?
During the discussion today we realized that it is important to also persist the timezone of the tracked time entries so that we can properly determine what the time is. We used to anticipate that we could use the user's current timezone from the preferences, but as this might change in the future and would destroy old time entries, we also need to persist the timezone.

We also deducted that we will not need an `end_time` field but it will be implied by `start_time + hours`.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
