### PR TITLE
Use more up-to-date gosu release to fix vulnerability

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -96,7 +96,9 @@ FROM base AS all-in-one
 ENV OPENPROJECT_RAILS__CACHE__STORE=memcache
 ENV DATABASE_URL=postgres://openproject:openproject@127.0.0.1/openproject
 ENV PGDATA=/var/openproject/pgdata
-ENV GOSU_VERSION="1.17"
+
+COPY --from=openproject/gosu /go/bin/gosu /usr/local/bin/gosu
+RUN chmod +x /usr/local/bin/gosu && gosu nobody true
 
 RUN ./docker/prod/setup/postinstall-onprem.sh && \
   ln -s /app/docker/prod/setup/.irbrc /root/

--- a/docker/prod/setup/postinstall-onprem.sh
+++ b/docker/prod/setup/postinstall-onprem.sh
@@ -52,11 +52,5 @@ rm -rf /tmp/nulldb
 a2enmod proxy proxy_http
 rm -f /etc/apache2/sites-enabled/000-default.conf
 
-# gosu
-dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"
-chmod +x /usr/local/bin/gosu
-gosu nobody true
-
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 truncate -s 0 /var/log/*log


### PR DESCRIPTION
Use up-to-date build of gosu with latest go version, which should remove vulnerability CVEs from the resulting docker image.

https://community.openproject.org/projects/devops/work_packages/59743/activity

Pushed the resulting image for vulnerability analysis  as `test` tag on Docker Hub, and the 3 critical vulnerabilities due to gosu embedding stdlib 1.18.2 are gone:

![image](https://github.com/user-attachments/assets/2f7feefd-e00a-4dea-85ee-02b71b19ed9e)
