### PR TITLE
Increase spacing between create button and explanation text

### DIFF
--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -1,15 +1,15 @@
 <%= component_wrapper(tag: "turbo-frame") do %>
   <%=
     if should_render_create_button?
-      flex_layout(justify_content: :space_between, mb: 4) do |action_bar|
-        action_bar.with_column do
+      flex_layout(justify_content: :space_between, align_items: :center, mb: 4) do |action_bar|
+        action_bar.with_column(pr: 1) do
           render(Primer::Beta::Text.new(color: :muted)) do
             t("#{I18N_NAMESPACE}.index.action_bar_title")
           end
         end
 
         # Prevent the menu from overflowing on Safari
-        action_bar.with_column(flex_shrink: 0) do
+        action_bar.with_column(flex_shrink: 0, ml: 2) do
           render(Primer::Alpha::ActionMenu.new(test_selector: NEW_RELATION_ACTION_MENU,
                                                menu_id: NEW_RELATION_ACTION_MENU)) do |menu|
             menu.with_show_button do |button|


### PR DESCRIPTION
Increase the space and fix alignment between "create relation" button and the text on the left

See https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/58345/activity#activity-15


**Before**

<img width="591" alt="Bildschirmfoto 2024-11-27 um 08 07 13" src="https://github.com/user-attachments/assets/c6b02de4-d4dd-49b5-856c-4003ed209673">


**After**
<img width="604" alt="Bildschirmfoto 2024-11-27 um 08 06 18" src="https://github.com/user-attachments/assets/88836296-6000-4fe7-b776-15f225da2923">
