### PR TITLE
[#59765] removed searchable configuration for hierarchies

### DIFF
--- a/app/forms/custom_fields/details_form.rb
+++ b/app/forms/custom_fields/details_form.rb
@@ -61,12 +61,6 @@ module CustomFields
         caption: I18n.t("custom_fields.instructions.is_filter")
       )
 
-      details_form.check_box(
-        name: :searchable,
-        label: I18n.t("activerecord.attributes.custom_field.searchable"),
-        caption: I18n.t("custom_fields.instructions.searchable")
-      )
-
       details_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :default)
     end
   end

--- a/lib/open_project/custom_field_format_dependent.rb
+++ b/lib/open_project/custom_field_format_dependent.rb
@@ -37,7 +37,7 @@ module OpenProject
       multiSelect: [:only, %w[list user version hierarchy]],
       possibleValues: [:only, %w[list]],
       regexp: [:except, %w[list bool date user version hierarchy]],
-      searchable: [:except, %w[bool date float int user version]],
+      searchable: [:except, %w[bool date float int user version hierarchy]],
       textOrientation: [:only, %w[text]],
       enterpriseBanner: [:only, %w[hierarchy]]
     }.freeze


### PR DESCRIPTION
# Ticket
[OP#59765](https://community.openproject.org/work_packages/59765)

# What are you trying to accomplish?
- Custom fields of type hierarchy should no longer be configurable as "searchable"

# What approach did you choose and why?
- removed searchable from new form and edit form for hierarchies
