### PR TITLE
[#59765] disable hierarchy cfs from custom actions

### DIFF
--- a/app/models/custom_actions/actions/custom_field.rb
+++ b/app/models/custom_actions/actions/custom_field.rb
@@ -49,6 +49,7 @@ class CustomActions::Actions::CustomField < CustomActions::Actions::Base
 
   def self.all
     WorkPackageCustomField
+      .where.not(field_format: %w(hierarchy))
       .order(:name)
       .map do |cf|
         create_subclass(cf)

--- a/app/models/custom_actions/actions/custom_field.rb
+++ b/app/models/custom_actions/actions/custom_field.rb
@@ -49,8 +49,7 @@ class CustomActions::Actions::CustomField < CustomActions::Actions::Base
 
   def self.all
     WorkPackageCustomField
-      .where.not(field_format: %w(hierarchy))
-      .order(:name)
+      .usable_as_custom_action
       .map do |cf|
         create_subclass(cf)
       end

--- a/app/models/work_package_custom_field.rb
+++ b/app/models/work_package_custom_field.rb
@@ -49,6 +49,11 @@ class WorkPackageCustomField < CustomField
     end
   }
 
+  scope :usable_as_custom_action, -> {
+    where.not(field_format: %w[hierarchy])
+    order(:name)
+  }
+
   def self.summable
     where(field_format: %w[int float])
   end

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe CustomActions::Actions::CustomField do
   describe ".all" do
     before do
       allow(WorkPackageCustomField)
-        .to receive(:order)
+        .to receive(:usable_as_custom_action)
         .and_return(custom_fields)
     end
 


### PR DESCRIPTION
# Ticket
[OP#59354](https://community.openproject.org/work_packages/59354)

# What are you trying to accomplish?
- custom actions should not break

# What approach did you choose and why?
- exclude custom fields of type hierarchy from being listed as available custom actions
- this disables setting custom fields of type hierarchy as a custom action, as all the options have to be preloaded. This can make the form very slow for big hierarchies.

