### PR TITLE
[59771] Some relations type do not pre-populate the right WP when relation is edited

### DIFF
--- a/app/components/work_package_relations_tab/work_package_relation_form_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.rb
@@ -47,7 +47,12 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
   end
 
   def related_work_package
-    @related_work_package ||= @relation.to
+    @related_work_package ||= begin
+      related = @relation.to
+      # We cannot rely on the related WorkPackage being the "to",
+      # depending on the relation it can also be "from"
+      related.id == @work_package.id ? @relation.from : related
+    end
   end
 
   def submit_url_options

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -170,6 +170,29 @@ RSpec.describe "Primerized work package relations tab",
         expect(page).to have_no_css("[data-test-selector='op-relation-row-#{child_wp.id}-edit-button']")
       end
     end
+
+    context "with the shown WorkPackage being the 'to' relation part" do
+      let(:another_wp) { create(:work_package, type: type2, subject: "related to main") }
+
+      let(:relation_to) do
+        create(:relation,
+               from: another_wp,
+               to: work_package,
+               relation_type: Relation::TYPE_FOLLOWS)
+      end
+
+      it "shows the correct related WorkPackage in the dialog (regression #59771)" do
+        scroll_to_element relations_panel
+
+        relations_tab.open_relation_dialog(relation_to)
+
+        within "##{WorkPackageRelationsTab::WorkPackageRelationDialogComponent::DIALOG_ID}" do
+          expect(page).to have_field("Work package",
+                                     readonly: true,
+                                     with: "#{another_wp.type.name.upcase} ##{another_wp.id} - #{another_wp.subject}")
+        end
+      end
+    end
   end
 
   describe "creating a relation" do

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -169,15 +169,7 @@ module Components
       end
 
       def add_description_to_relation(relatable, description)
-        actual_relatable = find_relatable(relatable)
-        relation_row = find_row(actual_relatable)
-
-        within relation_row do
-          page.find_test_selector("op-relation-row-#{actual_relatable.id}-action-menu").click
-          page.find_test_selector("op-relation-row-#{actual_relatable.id}-edit-button").click
-        end
-
-        wait_for_reload if using_cuprite?
+        open_relation_dialog(relatable)
 
         within "##{WorkPackageRelationsTab::WorkPackageRelationDialogComponent::DIALOG_ID}" do
           expect(page).to have_field("Work package", readonly: true)
@@ -192,15 +184,7 @@ module Components
       end
 
       def edit_relation_description(relatable, description)
-        actual_relatable = find_relatable(relatable)
-        relation_row = find_row(actual_relatable)
-
-        within relation_row do
-          page.find_test_selector("op-relation-row-#{actual_relatable.id}-action-menu").click
-          page.find_test_selector("op-relation-row-#{actual_relatable.id}-edit-button").click
-        end
-
-        wait_for_reload if using_cuprite?
+        open_relation_dialog(relatable)
 
         within "##{WorkPackageRelationsTab::WorkPackageRelationDialogComponent::DIALOG_ID}" do
           expect(page).to have_field("Work package", readonly: true)
@@ -212,6 +196,18 @@ module Components
 
           wait_for_reload if using_cuprite?
         end
+      end
+
+      def open_relation_dialog(relatable)
+        actual_relatable = find_relatable(relatable)
+        relation_row = find_row(actual_relatable)
+
+        within relation_row do
+          page.find_test_selector("op-relation-row-#{actual_relatable.id}-action-menu").click
+          page.find_test_selector("op-relation-row-#{actual_relatable.id}-edit-button").click
+        end
+
+        wait_for_reload if using_cuprite?
       end
 
       def expect_relation(relatable)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/59771/activity

# What are you trying to accomplish?
Show correct related WorkPackage in the relation dialog

# What approach did you choose and why?
The related WP is not necessarily stored as `to`. Depending on the relation type, it can also be the `from` part.
