### PR TITLE
[59163] Auto focus label field of new hierarchy item

### DIFF
--- a/app/forms/custom_fields/hierarchy/item_form.rb
+++ b/app/forms/custom_fields/hierarchy/item_form.rb
@@ -39,6 +39,7 @@ module CustomFields
             value: @target_item.label,
             visually_hide_label: true,
             required: true,
+            autofocus: true,
             placeholder: I18n.t("custom_fields.admin.items.placeholder.label"),
             validation_message: validation_message_for(:label)
           )


### PR DESCRIPTION
# Ticket
[59163](https://community.openproject.org/projects/openproject/work_packages/59163)

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Automatically set focus to the `label` input field when the form is opened for adding a new hierarchy item for a custom field of type hierarchy.

# What approach did you choose and why?
I added `autofocus: true` to the input.
