### PR TITLE
[22360] Edit lag to follow-precedes-relations

### DIFF
--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -66,8 +66,7 @@ flex_layout do |flex|
         end
         dates_row.with_column(mr: 3) do
           render(Primer::Beta::Text.new) do
-            "#{I18n.t("work_package_relations_tab.lag.title")}: #{I18n.t('datetime.distance_in_words.x_days',
-                                                                         count: relation.lag)}"
+            lag_as_text(relation.lag)
           end
         end
       end
@@ -95,8 +94,7 @@ flex_layout do |flex|
         end
         dates_row.with_column(mr: 1) do
           render(Primer::Beta::Text.new) do
-            "#{I18n.t("work_package_relations_tab.lag.title")}: #{I18n.t('datetime.distance_in_words.x_days',
-                                                                         count: relation.lag)}"
+            lag_as_text(relation.lag)
           end
         end
       end

--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -58,20 +58,46 @@ flex_layout do |flex|
     end
   end
 
-  if should_display_start_and_end_dates?
-    flex.with_row(flex_layout: true, align_items: :center, mb: 2) do |start_and_end_dates_row|
-      start_and_end_dates_row.with_column(mr: 1) do
-        icon = if follows?
-                 :calendar
-               elsif precedes?
-                 :pin
-               end
-
-        render(Primer::Beta::Octicon.new(icon:, color: :muted))
+  if should_display_dates_row?
+    flex.with_row(flex_layout: true, align_items: :center, color: :muted, mb: 2) do |dates_row|
+      if precedes? && lag_present?
+        dates_row.with_column(mr: 1) do
+          render(Primer::Beta::Octicon.new(icon: "arrow-both"))
+        end
+        dates_row.with_column(mr: 3) do
+          render(Primer::Beta::Text.new) do
+            "#{I18n.t("work_package_relations_tab.lag.title")}: #{I18n.t('datetime.distance_in_words.x_days',
+                                                                         count: relation.lag)}"
+          end
+        end
       end
-      start_and_end_dates_row.with_column do
-        render(Primer::Beta::Text.new(color: :muted)) do
-          "#{format_date(related_work_package.start_date)} - #{format_date(related_work_package.due_date)}"
+
+      if related_work_package.start_date.present? || related_work_package.due_date.present?
+        dates_row.with_column(mr: 1) do
+          icon = if follows?
+                   :calendar
+                 elsif precedes?
+                   :pin
+                 end
+
+          render(Primer::Beta::Octicon.new(icon:))
+        end
+        dates_row.with_column do
+          render(Primer::Beta::Text.new) do
+            "#{format_date(related_work_package.start_date)} - #{format_date(related_work_package.due_date)}"
+          end
+        end
+      end
+
+      if follows? && lag_present?
+        dates_row.with_column(ml: 3, mr: 1) do
+          render(Primer::Beta::Octicon.new(icon: "arrow-both"))
+        end
+        dates_row.with_column(mr: 1) do
+          render(Primer::Beta::Text.new) do
+            "#{I18n.t("work_package_relations_tab.lag.title")}: #{I18n.t('datetime.distance_in_words.x_days',
+                                                                         count: relation.lag)}"
+          end
         end
       end
     end

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -95,6 +95,10 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
     end
   end
 
+  def lag_as_text(lag)
+    "#{I18n.t('work_package_relations_tab.lag.subject')}: #{I18n.t('datetime.distance_in_words.x_days', count: lag)}"
+  end
+
   def action_menu_test_selector
     "op-relation-row-#{underlying_resource_id}-action-menu"
   end

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -61,7 +61,11 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
     relation.description.present?
   end
 
-  def should_display_start_and_end_dates?
+  def lag_present?
+    relation.lag.present?
+  end
+
+  def should_display_dates_row?
     return false if parent_child_relationship?
 
     relation.follows? || relation.precedes?

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -62,7 +62,7 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   end
 
   def lag_present?
-    relation.lag.present?
+    relation.lag.present? && relation.lag != 0
   end
 
   def should_display_dates_row?

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -63,7 +63,8 @@
             if lag_shown
               my_form.text_field(
                 name: :lag,
-                label: Relation.human_attribute_name(:lag),
+                type: :number,
+                label: I18n.t("work_package_relations_tab.lag.title"),
                 caption: I18n.t("work_package_relations_tab.lag.caption"),
                 input_width: :small,
               )

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -64,6 +64,7 @@
               my_form.text_field(
                 name: :lag,
                 type: :number,
+                min: 0,
                 label: I18n.t("work_package_relations_tab.lag.title"),
                 caption: I18n.t("work_package_relations_tab.lag.caption"),
                 input_width: :small,

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -19,6 +19,7 @@
           # These are not available inside the render_inline_form block
           # so we need to re-define them here. Figure out solution for this.
           relation = @relation
+          lag_shown = show_lag?
           to_id_field_value = relation.to.present? ? "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}" : nil
           url = ::API::V3::Utilities::PathHelper::ApiV3Path.work_package_available_relation_candidates(@work_package.id, type: relation.relation_type_for(@work_package))
           render_inline_form(f) do |my_form|
@@ -58,6 +59,15 @@
               label: Relation.human_attribute_name(:description),
               autofocus: relation.persisted?
             )
+
+            if lag_shown
+              my_form.text_field(
+                name: :lag,
+                label: Relation.human_attribute_name(:lag),
+                caption: I18n.t("work_package_relations_tab.lag.caption"),
+                input_width: :small,
+              )
+            end
           end
         end
       end %>

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.rb
@@ -64,4 +64,8 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
         url: work_package_relations_path(@work_package) }
     end
   end
+
+  def show_lag?
+    @relation.relation_type == Relation::TYPE_PRECEDES || @relation.relation_type == Relation::TYPE_FOLLOWS
+  end
 end

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -121,12 +121,12 @@ class WorkPackageRelationsController < ApplicationController
 
   def create_relation_params
     params.require(:relation)
-          .permit(:relation_type, :to_id, :description)
+          .permit(:relation_type, :to_id, :description, :lag)
           .merge(from_id: @work_package.id)
   end
 
   def update_relation_params
     params.require(:relation)
-          .permit(:description)
+          .permit(:description, :lag)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -716,6 +716,9 @@ en:
     label_add_x: "Add %{x}"
     label_edit_x: "Edit %{x}"
     label_add_description: "Add description"
+    lag:
+      title: "Lag"
+      caption: "The gap in number of working days in between the two work packages"
     relations:
       label_relates_singular: "related to"
       label_relates_plural: "related to"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,7 +717,8 @@ en:
     label_edit_x: "Edit %{x}"
     label_add_description: "Add description"
     lag:
-      title: "Lag"
+      subject: "Lag"
+      title: "Lag (in days)"
       caption: "The gap in number of working days in between the two work packages"
     relations:
       label_relates_singular: "related to"

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -142,10 +142,13 @@ RSpec.describe "Primerized work package relations tab",
 
       relation_row = relations_tab.expect_relation(relation_follows)
 
-      relations_tab.add_description_to_relation(relation_follows, "Discovered relations have descriptions!")
+      relations_tab.edit_relation_description(relation_follows, "Discovered relations have descriptions!")
 
-      # Reflects new description
+      relations_tab.edit_lag_of_relation(relation_follows, 5)
+
+      # Reflects new description and lag
       expect(relation_row).to have_text("Discovered relations have descriptions!")
+      expect(relation_row).to have_text("5 days")
 
       # Unchanged
       tabs.expect_counter("relations", 4)
@@ -168,6 +171,17 @@ RSpec.describe "Primerized work package relations tab",
       within(child_row) do
         page.find("[data-test-selector='op-relation-row-#{child_wp.id}-action-menu']").click
         expect(page).to have_no_css("[data-test-selector='op-relation-row-#{child_wp.id}-edit-button']")
+      end
+    end
+
+    it "does not show the lag field for all relation types" do
+      scroll_to_element relations_panel
+
+      relations_tab.open_relation_dialog(relation_relates)
+
+      within "##{WorkPackageRelationsTab::WorkPackageRelationDialogComponent::DIALOG_ID}" do
+        expect(page).to have_field("Work package", readonly: true)
+        expect(page).to have_no_field("Lag")
       end
     end
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -168,7 +168,7 @@ module Components
         find_row(target_wp)
       end
 
-      def add_description_to_relation(relatable, description)
+      def edit_relation_description(relatable, description)
         open_relation_dialog(relatable)
 
         within "##{WorkPackageRelationsTab::WorkPackageRelationDialogComponent::DIALOG_ID}" do
@@ -183,14 +183,14 @@ module Components
         end
       end
 
-      def edit_relation_description(relatable, description)
+      def edit_lag_of_relation(relatable, lag)
         open_relation_dialog(relatable)
 
         within "##{WorkPackageRelationsTab::WorkPackageRelationDialogComponent::DIALOG_ID}" do
           expect(page).to have_field("Work package", readonly: true)
-          expect(page).to have_field("Description")
+          expect(page).to have_field("Lag")
 
-          fill_in "Description", with: description
+          fill_in "Lag", with: lag
 
           click_link_or_button "Save"
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/22360/activity

# What are you trying to accomplish?
Show and edit the `Lag` for follows/precedes relationships.

## ToDo

**Dialog**
- [x] Add a text field "Lag" to the Dialogs for follows and precedes relationships
- [ ] ~~The text field should show a unit when not focused. On focus, the unit is hidden~~
- [x] Update the Lag when saving the Dialog 

**Relations tab**

- [x] If a Lag exists, it is shown:
  - [x]  before the date for successors
  - [x] after the date for predecessors 

## Screenshots
<img width="500" alt="Bildschirmfoto 2024-11-28 um 11 04 35" src="https://github.com/user-attachments/assets/01403cf4-854f-4017-991d-c622ae754955">

<img width="500" alt="Bildschirmfoto 2024-11-29 um 12 49 36" src="https://github.com/user-attachments/assets/80f245a8-f33c-4ed4-b72f-936a80cbb384">




# Merge checklist

- [x] Added/updated tests
