### PR TITLE
[59770] When opening relations modal, focus is not on text field

### DIFF
--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
@@ -25,7 +25,7 @@
                 resource: 'work_packages',
                 searchKey: 'subjectOrId',
                 openDirectly: false,
-                focusDirectly: false,
+                focusDirectly: true,
                 dropdownPosition: 'bottom',
                 appendTo: "##{DIALOG_ID}",
                 data: { test_selector: ID_FIELD_TEST_SELECTOR }

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -45,7 +45,7 @@
                   url:,
                   relations: true, # Activates relations fetch mode in the autocomplete
                   openDirectly: false,
-                  focusDirectly: false,
+                  focusDirectly: true,
                   dropdownPosition: 'bottom',
                   appendTo: "##{DIALOG_ID}",
                   data: { test_selector: TO_ID_FIELD_TEST_SELECTOR}
@@ -56,6 +56,7 @@
             my_form.text_field(
               name: :description,
               label: Relation.human_attribute_name(:description),
+              autofocus: relation.persisted?
             )
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/59770/activity

# What are you trying to accomplish?
Automatically focus the input field when opening the relations dialog