### PR TITLE
enable ordering work packages by hierarchy items

### DIFF
--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -31,7 +31,7 @@ module CustomField::OrderStatements
   # value of the custom field.
   def order_statement
     case field_format
-    when "string", "date", "bool", "link", "int", "float", "list", "user", "version"
+    when "string", "date", "bool", "link", "int", "float", "list", "user", "version", "hierarchy"
       "cf_order_#{id}.value"
     end
   end
@@ -52,6 +52,8 @@ module CustomField::OrderStatements
       join_for_order_by_user_sql
     when "version"
       join_for_order_by_version_sql
+    when "hierarchy"
+      join_for_order_by_hierarchy_sql
     end
   end
 
@@ -166,5 +168,10 @@ module CustomField::OrderStatements
       join: "INNER JOIN #{Version.quoted_table_name} versions ON versions.id = cv.value::bigint",
       multi_value:
     )
+  end
+
+  def join_for_order_by_hierarchy_sql
+    table_name = CustomField::Hierarchy::Item.quoted_table_name
+    join_for_order_sql(value: "item.label", join: "INNER JOIN #{table_name} item ON item.id = cv.value::bigint")
   end
 end

--- a/spec/models/custom_field/order_statements_spec.rb
+++ b/spec/models/custom_field/order_statements_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CustomField::OrderStatements do
+  # integration tests at spec/models/query/results_cf_sorting_integration_spec.rb
+  context "when hierarchy" do
+    subject(:custom_field) { create(:hierarchy_wp_custom_field) }
+
+    describe "#order_statement" do
+      it { expect(subject.order_statement).to eq("cf_order_#{custom_field.id}.value") }
+    end
+
+    describe "#order_join_statement" do
+      it do
+        expect(custom_field.order_join_statement).to eq(
+          <<-SQL.squish
+            LEFT OUTER JOIN (
+              SELECT DISTINCT ON (cv.customized_id) cv.customized_id , item.label "value"
+              FROM "custom_values" cv
+              INNER JOIN "hierarchical_items" item ON item.id = cv.value::bigint
+              WHERE cv.customized_type = 'WorkPackage'
+              AND cv.custom_field_id = #{custom_field.id}
+              AND cv.value IS NOT NULL
+              AND cv.value != ''
+              ORDER BY cv.customized_id, cv.id
+            ) cf_order_#{custom_field.id} ON cf_order_#{custom_field.id}.customized_id = "work_packages".id
+          SQL
+        )
+      end
+    end
+  end
+end

--- a/spec/models/query/results_cf_sorting_integration_spec.rb
+++ b/spec/models/query/results_cf_sorting_integration_spec.rb
@@ -343,4 +343,33 @@ RSpec.describe Query::Results, "Sorting by custom field" do
       end
     end
   end
+
+  context "for hierarchy format" do
+    include_examples "it sorts" do
+      let(:custom_field) { create(:hierarchy_wp_custom_field, hierarchy_root: nil) }
+      let(:root) { service.generate_root(custom_field).value! }
+      let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
+
+      let!(:item_first) { service.insert_item(parent: root, label: "aa item").value! }
+      let!(:item_a) { service.insert_item(parent: root, label: "item_a").value! }
+      let!(:item_a1) { service.insert_item(parent: item_a, label: "item_a1").value! }
+      let!(:item_a2) { service.insert_item(parent: item_a, label: "item_a2").value! }
+      let!(:item_c) { service.insert_item(parent: root, label: "item_c").value! }
+      let!(:item_b) { service.insert_item(parent: root, label: "item_b").value! }
+      let!(:item_last) { service.insert_item(parent: root, label: "zz item").value! }
+
+      let(:work_packages) do
+        [
+          wp_without_cf_value,
+          wp_with_cf_value(item_first.id),
+          wp_with_cf_value(item_a.id),
+          wp_with_cf_value(item_a1.id),
+          wp_with_cf_value(item_a2.id),
+          wp_with_cf_value(item_b.id),
+          wp_with_cf_value(item_c.id),
+          wp_with_cf_value(item_last.id)
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/59766

# What are you trying to accomplish?
Enable ordering by custom field hierarchies on work packages

## Screenshots

https://github.com/user-attachments/assets/3fc7c336-3c6f-4e93-8473-e617a2176e39

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
