### PR TITLE
[59795] Missing space between project selector and "include sub-projects"-checkbox

### DIFF
--- a/app/components/admin/custom_fields/custom_field_projects/new_custom_field_projects_form_modal_component.html.erb
+++ b/app/components/admin/custom_fields/custom_field_projects/new_custom_field_projects_form_modal_component.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
     ) do |form|
       concat(render(Primer::Alpha::Dialog::Body.new(
         id: dialog_body_id, test_selector: dialog_body_id, aria: { label: title },
-        style: "min-height: 300px"
+        classes: "Overlay-body_autocomplete_height"
       )) do
         render(Projects::CustomFields::CustomFieldMappingForm.new(form, project_mapping: @custom_field_project_mapping))
       end)

--- a/app/forms/projects/custom_fields/custom_field_mapping_form.rb
+++ b/app/forms/projects/custom_fields/custom_field_mapping_form.rb
@@ -31,8 +31,7 @@ module Projects::CustomFields
     include OpPrimer::ComponentHelpers
 
     form do |form|
-      form.group(layout: :vertical) do |group|
-        group.project_autocompleter(
+      form.project_autocompleter(
           name: :id,
           label: Project.model_name.human,
           visually_hide_label: true,
@@ -48,13 +47,12 @@ module Projects::CustomFields
           }
         )
 
-        group.check_box(
+      form.check_box(
           name: :include_sub_projects,
           label: I18n.t(:label_include_sub_projects),
           checked: false,
           label_arguments: { class: "no-wrap" }
         )
-      end
     end
 
     def initialize(project_mapping:)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/59795/activity

# What are you trying to accomplish?
Correct form definition to ensure enough space between the elements

## Screenshots
**Before**
<img width="500" alt="Bildschirmfoto 2024-11-29 um 08 10 56" src="https://github.com/user-attachments/assets/cc673003-e7c2-4796-a7de-e9ef70df72c6">


**After**
<img width="500" alt="Bildschirmfoto 2024-11-29 um 08 10 10" src="https://github.com/user-attachments/assets/17a4a7ab-b969-4ace-a4f3-af54e8156e50">
