### PR TITLE
OP#59817 Remove activity menu for anonymous users with login required

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -43,6 +43,7 @@ Redmine::MenuManager.map :top_menu do |menu|
   menu.push :activity,
             { controller: "/activities", action: "index" },
             context: :modules,
+            if: Proc.new { User.current.logged? || !Setting.login_required? },
             icon: "history"
 
   menu.push :work_packages,


### PR DESCRIPTION
[OP#59817](https://community.openproject.org/projects/openproject/work_packages/details/59817/overview
)

# What are you trying to accomplish?
Remove top menu Activity item for anonymous users when login is required as it's leads to nowhere(same login page).

# What approach did you choose and why?
Fresh installation shows only Activity item in top menu and leads to the same login page when login is required., so I removed that item when user is anonymous and login is required. 
As we don't have any items in top menu in this case and menu is not rendered, I've removed spec for that.
Returning empty array when there's no items thus we don't need to group them(otherwise we have 500 with heading? access to nil)