### PR TITLE
[59174] Added group by for hierarchy items

### DIFF
--- a/app/models/custom_field/hierarchy/hierarchy_item_adapter.rb
+++ b/app/models/custom_field/hierarchy/hierarchy_item_adapter.rb
@@ -28,22 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries
-  module Filters
-    module Shared
-      module CustomFields
-        class Hierarchy < Base
-          def ar_object_filter?
-            true
-          end
+class CustomField::Hierarchy::HierarchyItemAdapter
+  attr_reader :name
 
-          def value_objects
-            CustomField::Hierarchy::Item
-              .where(id: @values)
-              .map { |item| CustomField::Hierarchy::HierarchyItemAdapter.new(item:) }
-          end
-        end
-      end
-    end
+  delegate :id, :label, :short, :to_s, to: :item
+
+  def initialize(item:)
+    @item = item
+    @name = item.label
   end
+
+  private
+
+  attr_accessor :item
 end

--- a/app/models/custom_field/hierarchy/hierarchy_item_adapter.rb
+++ b/app/models/custom_field/hierarchy/hierarchy_item_adapter.rb
@@ -29,14 +29,11 @@
 #++
 
 class CustomField::Hierarchy::HierarchyItemAdapter
-  attr_reader :name
-
   delegate :id, :label, :short, :to_s, to: :item
 
-  def initialize(item:)
-    @item = item
-    @name = item.label
-  end
+  def initialize(item:) = @item = item
+
+  def name = @item.label
 
   private
 

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -36,5 +36,5 @@ class CustomField::Hierarchy::Item < ApplicationRecord
 
   scope :including_children, -> { includes(children: :children) }
 
-  def to_s = label
+  def to_s = short.nil? ? label : "#{label} (#{short})"
 end

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -35,4 +35,6 @@ class CustomField::Hierarchy::Item < ApplicationRecord
   has_closure_tree order: "sort_order", numeric_order: true, dont_order_roots: true, dependent: :destroy
 
   scope :including_children, -> { includes(children: :children) }
+
+  def to_s = label
 end

--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -92,7 +92,7 @@ module CustomField::OrderStatements
 
   private
 
-  def can_be_used_for_grouping? = field_format.in?(%w[list date bool int float string link])
+  def can_be_used_for_grouping? = field_format.in?(%w[list date bool int float string link hierarchy])
 
   # Template for all the join statements.
   #

--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -117,8 +117,11 @@ module ::Query::Results::GroupBy
     CustomFields::Hierarchy::HierarchicalItemService
       .new
       .get_descendants(item: custom_field.hierarchy_root, include_self: false)
-      .fmap { |list| list.filter { |item| keys.include?(item.label) } }
-      .fmap { |list| list.index_by(&:label) }
+      .fmap do |list|
+        list.map { |item| CustomField::Hierarchy::HierarchyItemAdapter.new(item:) }
+            .filter { |item| keys.include?(item.label) }
+            .index_by(&:label)
+      end
       .either(
         ->(list) { list },
         ->(error) do
@@ -127,6 +130,7 @@ module ::Query::Results::GroupBy
         end
       )
   end
+
   # rubocop:enable Metrics/AbcSize
 
   def transform_list_custom_field_keys(custom_field, groups)

--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -101,9 +101,7 @@ module ::Query::Results::GroupBy
 
     groups.transform_keys do |key|
       if custom_field.multi_value?
-        (key ? key.split(".") : []).map do |subkey|
-          items[subkey]
-        end
+        Array(key&.split(".")).map { |subkey| items[subkey] }
       else
         items[key] || nil
       end
@@ -118,8 +116,7 @@ module ::Query::Results::GroupBy
       .new
       .get_descendants(item: custom_field.hierarchy_root, include_self: false)
       .fmap do |list|
-        list.map { |item| CustomField::Hierarchy::HierarchyItemAdapter.new(item:) }
-            .filter { |item| keys.include?(item.label) }
+        list.filter_map { |item| CustomField::Hierarchy::HierarchyItemAdapter.new(item:) if keys.include?(item.label) }
             .index_by(&:label)
       end
       .either(
@@ -138,9 +135,7 @@ module ::Query::Results::GroupBy
 
     groups.transform_keys do |key|
       if custom_field.multi_value?
-        (key ? key.split(".") : []).map do |subkey|
-          options[subkey].first
-        end
+        Array(key&.split(".")).map.map { |subkey| options[subkey].first }
       else
         options[key]&.first
       end

--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -89,10 +89,45 @@ module ::Query::Results::GroupBy
 
     if custom_field.list?
       transform_list_custom_field_keys(custom_field, groups)
+    elsif custom_field.field_format_hierarchy?
+      transform_hierarchy_custom_field_keys(custom_field, groups)
     else
       transform_single_custom_field_keys(custom_field, groups)
     end
   end
+
+  def transform_hierarchy_custom_field_keys(custom_field, groups)
+    items = hierarchy_items_for_keys(custom_field, groups)
+
+    groups.transform_keys do |key|
+      if custom_field.multi_value?
+        (key ? key.split(".") : []).map do |subkey|
+          items[subkey]
+        end
+      else
+        items[key] || nil
+      end
+    end
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def hierarchy_items_for_keys(custom_field, groups)
+    keys = groups.keys.map { |k| k ? k.split(".") : [] }.flatten.uniq
+
+    CustomFields::Hierarchy::HierarchicalItemService
+      .new
+      .get_descendants(item: custom_field.hierarchy_root, include_self: false)
+      .fmap { |list| list.filter { |item| keys.include?(item.label) } }
+      .fmap { |list| list.index_by(&:label) }
+      .either(
+        ->(list) { list },
+        ->(error) do
+          msg = "#{I18n.t('api_v3.errors.code_500')} #{error}"
+          raise ::API::Errors::InternalError.new(msg)
+        end
+      )
+  end
+  # rubocop:enable Metrics/AbcSize
 
   def transform_list_custom_field_keys(custom_field, groups)
     options = custom_options_for_keys(custom_field, groups)
@@ -103,7 +138,7 @@ module ::Query::Results::GroupBy
           options[subkey].first
         end
       else
-        options[key] ? options[key].first : nil
+        options[key]&.first
       end
     end
   end
@@ -111,7 +146,7 @@ module ::Query::Results::GroupBy
   def custom_options_for_keys(custom_field, groups)
     keys = groups.keys.map { |k| k ? k.split(".") : [] }
     # Because of multi select cfs we might end up having overlapping groups
-    # (e.g group "1" and group "1.3" and group "3" which represent concatenated ids).
+    # (e.g. group "1" and group "1.3" and group "3" which represent concatenated ids).
     # This can result in us having ids in the keys array multiple times (e.g. ["1", "1", "3", "3"]).
     # If we were to use the keys array with duplicates to find the actual custom options,
     # AR would throw an error as the number of records returned does not match the number

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -33,11 +33,9 @@ module API
         @count = count
         @query = query
 
-        if group_key.is_a?(Array)
-          group_key = set_links!(group_key)
-        end
-
-        @link = ::API::V3::Utilities::ResourceLinkGenerator.make_link(group_key)
+        @link = ::API::V3::Utilities::ResourceLinkGenerator.make_link(
+          group_key.is_a?(Array) ? set_links!(group_key) : group_key
+        )
 
         super(group_key, current_user:)
       end
@@ -86,10 +84,13 @@ module API
       end
 
       def value
-        if represented == true || represented == false
+        case represented
+        when TrueClass, FalseClass
           represented
+        when Array
+          represented.empty? ? nil : represented.map(&:to_s).sort.join(", ")
         else
-          represented ? represented.to_s : nil
+          represented&.to_s
         end
       end
 

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -84,7 +84,6 @@ module API
           def self.resources(name,
                              except: [],
                              only: %i[index show create_form update_form schema])
-
             (Array(only) - Array(except)).each do |method|
               send(method, name)
             end
@@ -209,6 +208,11 @@ module API
 
           def self.custom_field(id)
             "#{root}/custom_fields/#{id}"
+          end
+
+          # Needed as the method is derived from the name of the class for the query API representation.
+          def self.custom_field_hierarchy_item(id)
+            custom_field_item(id)
           end
 
           def self.custom_field_item(id)

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -210,17 +210,12 @@ module API
             "#{root}/custom_fields/#{id}"
           end
 
-          # Needed as the method is derived from the name of the class for the query API representation.
-          def self.custom_field_hierarchy_item(id)
-            custom_field_item(id)
-          end
-
           def self.custom_field_item(id)
             "#{root}/custom_field_items/#{id}"
           end
 
           # API::V3::Queries::Filters::QueryFilterInstanceRepresenter need a path derived from a class name.
-          def self.hierarchy_item_filter_adapter(id)
+          def self.hierarchy_item_adapter(id)
             custom_field_item(id)
           end
 

--- a/lib/api/v3/utilities/resource_link_generator.rb
+++ b/lib/api/v3/utilities/resource_link_generator.rb
@@ -59,6 +59,8 @@ module API
               :activity
             when Changeset
               :revision
+            when ::CustomField::Hierarchy::HierarchyItemAdapter
+              :custom_field_item
             else
               record.class.model_name.singular
             end


### PR DESCRIPTION
# Ticket
[59174](https://community.openproject.org/projects/document-workflows-stream/work_packages/59174)

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Enable `GROUP BY` for hierarchy items.

## Screenshots
![image](https://github.com/user-attachments/assets/c56a1626-3019-4e11-a6e0-69d4fbba216c)

# What approach did you choose and why?
Fixed generating the API response that creates the row keys for dividing the workpackage table into groups.
