### PR TITLE
[59810] Parent WP and existing children can be selected as a child

### DIFF
--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
@@ -18,9 +18,7 @@
         flex.with_row do
           # @workpackage is not available inside the render_inline_form block
           # so we need to re-define them here. Figure out solution for this.
-          ancestors_id = @work_package.ancestors.pluck(:id)
-          children_id = @work_package.children.pluck(:id)
-          non_relatable_wp_ids = [@work_package.id] + ancestors_id + children_id
+          url = ::API::V3::Utilities::PathHelper::ApiV3Path.work_package_available_relation_candidates(@work_package.id, type: Relation::TYPE_CHILD)
           render_inline_form(f) do |my_form|
             my_form.work_package_autocompleter(
               name: :id,
@@ -29,11 +27,12 @@
               autocomplete_options: {
                 resource: 'work_packages',
                 searchKey: 'subjectOrId',
+                url:,
+                relations: true, # Activates relations fetch mode in the autocomplete
                 openDirectly: false,
                 focusDirectly: true,
                 dropdownPosition: 'bottom',
                 appendTo: "##{DIALOG_ID}",
-                filters: [{ name: "id", operator: "!", values:  non_relatable_wp_ids}],
                 data: { test_selector: ID_FIELD_TEST_SELECTOR }
               }
             )

--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
@@ -16,6 +16,11 @@
           end
         end
         flex.with_row do
+          # @workpackage is not available inside the render_inline_form block
+          # so we need to re-define them here. Figure out solution for this.
+          ancestors_id = @work_package.ancestors.pluck(:id)
+          children_id = @work_package.children.pluck(:id)
+          non_relatable_wp_ids = [@work_package.id] + ancestors_id + children_id
           render_inline_form(f) do |my_form|
             my_form.work_package_autocompleter(
               name: :id,
@@ -28,6 +33,7 @@
                 focusDirectly: true,
                 dropdownPosition: 'bottom',
                 appendTo: "##{DIALOG_ID}",
+                filters: [{ name: "id", operator: "!", values:  non_relatable_wp_ids}],
                 data: { test_selector: ID_FIELD_TEST_SELECTOR }
               }
             )

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -216,13 +216,7 @@ RSpec.describe "Primerized work package relations tab",
       # wp_predecessor is already related to work_package as relation_follows
       # in a predecessor relation, so it should not be autocompleteable anymore
       # under the "Predecessor (before)" type
-      scroll_to_element relations_panel
-
-      relations_panel.find("[data-test-selector='new-relation-action-menu']").click
-
-      within page.find_by_id("new-relation-action-menu-list") do # Primer appends "list" to the menu id automatically
-        click_link_or_button "Predecessor (before)"
-      end
+      relations_tab.select_relation_type "Predecessor (before)"
 
       wait_for_reload
 
@@ -254,13 +248,7 @@ RSpec.describe "Primerized work package relations tab",
     end
 
     it "doesn't autocomplete parent, children, and WP itself" do
-      scroll_to_element relations_panel
-
-      relations_panel.find("[data-test-selector='new-relation-action-menu']").click
-
-      within page.find_by_id("new-relation-action-menu-list") do
-        click_link_or_button "Child"
-      end
+      relations_tab.select_relation_type "Child"
 
       wait_for_reload
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -80,6 +80,14 @@ module Components
         expect(page).not_to have_test_selector("op-relation-row-#{actual_relatable.id}")
       end
 
+      def select_relation_type(relation_type)
+        page.find_test_selector("new-relation-action-menu").click
+
+        within page.find_by_id("new-relation-action-menu-list") do
+          click_link_or_button relation_type
+        end
+      end
+
       def remove_relation(relatable)
         actual_relatable = find_relatable(relatable)
         relatable_row = find_row(actual_relatable)
@@ -131,12 +139,10 @@ module Components
         # Open create form
 
         SeleniumHubWaiter.wait
-        page.find_test_selector("new-relation-action-menu").click
 
         label_text_for_relation_type = I18n.t("#{i18n_namespace}.label_#{type}_singular")
-        within page.find_by_id("new-relation-action-menu-list") do # Primer appends "list" to the menu id automatically
-          click_link_or_button label_text_for_relation_type.capitalize
-        end
+
+        select_relation_type label_text_for_relation_type.capitalize
 
         wait_for_reload if using_cuprite?
 
@@ -272,11 +278,7 @@ module Components
         SeleniumHubWaiter.wait
 
         retry_block do
-          page.find_test_selector("new-relation-action-menu").click
-
-          within page.find_by_id("new-relation-action-menu-list") do # Primer appends "list" to the menu id automatically
-            click_link_or_button "Child"
-          end
+          select_relation_type "Child"
         end
 
         within "##{WorkPackageRelationsTab::AddWorkPackageChildFormComponent::DIALOG_ID}" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/59810/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
While creating a child relation for a work package, ancestors and children of the WP and the WP itself should not be rendered.

## Screenshots

https://github.com/user-attachments/assets/2a05b1b7-8574-4dd0-900f-e071f70d2032

# What approach did you choose and why?
Filter the WP autocompleter data

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
