### PR TITLE
Exclude non project members from user filter

### DIFF
--- a/modules/reporting/app/models/cost_query/filter/user_id.rb
+++ b/modules/reporting/app/models/cost_query/filter/user_id.rb
@@ -52,7 +52,7 @@ class CostQuery::Filter::UserId < Report::Filter::Base
   def self.available_values(*)
     # All users which are members in projects the user can see.
     # Excludes the anonymous user
-    users = User.visible
+    users = User.in_visible_project
                 .human
                 .ordered_by_name
                 .select(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s) << :id)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59827

# What are you trying to accomplish?

For admin users and users having `manage_members` (or `manage_placeholder_users`) permission, using the `visible` scope will return all users. On instances like community, that will return more users that some of the browsers can cope with once the users are turned into options for drop down elements. Before #17156, which attempted to only fix the order, only members of projects visible to the user using the filter were returned. This behaviour is (almost) restored but a scope is used. A few more users could not be returned but it is far from returning all users unless all users are members in projects the current user can see.

This is not a proper fix as e.g. for admins, there is still a large likelihood of running into the problem. A proper fix would be using an autocompleter not loading all values to the frontend.

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
