### PR TITLE
[59828] Work package create button doesn't work on mWeb

### DIFF
--- a/frontend/src/app/features/work-packages/routing/split-view-routes.template.ts
+++ b/frontend/src/app/features/work-packages/routing/split-view-routes.template.ts
@@ -117,7 +117,7 @@ export function makeSplitViewRoutes(baseRoute:string,
         // Remember the base route so we can route back to it anywhere
         baseRoute,
         parent: baseRoute,
-        mobileAlternative: showMobileAlternative ? 'work-packages.show' : undefined,
+        mobileAlternative: showMobileAlternative ? 'work-packages.new' : undefined,
       },
       views: {
         // Retarget and by that override the grandparent views


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/59828/activity

# What are you trying to accomplish?
On mobile, redirect to the full create route instead of the show page
