### PR TITLE
[#59346] add log warning to unexpected content

### DIFF
--- a/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
@@ -31,6 +31,7 @@
 module Storages
   module Peripherals
     class NextcloudConnectionValidator
+      include TaggedLogging
       include Dry::Monads[:maybe]
 
       using ServiceResultRefinements
@@ -40,13 +41,15 @@ module Storages
       end
 
       def validate
-        maybe_is_not_configured
-          .or { has_base_configuration_error? }
-          .or { has_ampf_configuration_error? }
-          .value_or(ConnectionValidation.new(type: :healthy,
-                                             error_code: :none,
-                                             timestamp: Time.current,
-                                             description: nil))
+        with_tagged_logger do
+          maybe_is_not_configured
+            .or { has_base_configuration_error? }
+            .or { has_ampf_configuration_error? }
+            .value_or(ConnectionValidation.new(type: :healthy,
+                                               error_code: :none,
+                                               timestamp: Time.current,
+                                               description: nil))
+        end
       end
 
       private
@@ -55,7 +58,7 @@ module Storages
         host_url_not_found
           .or { missing_dependencies }
           .or { version_mismatch }
-          .or { with_unexpected_content }
+          # .or { with_unexpected_content }
           .or { capabilities_request_failed_with_unknown_error }
       end
 
@@ -194,6 +197,11 @@ module Storages
         unexpected_files = files.result.files.reject { |file| expected_folder_ids.include?(file.id) }
         return None() if unexpected_files.empty?
 
+        file_representation = unexpected_files.map do |file|
+          "Name: #{file.name}, ID: #{file.id}, Location: #{file.location}"
+        end
+        warn "Unexpected files/folder found in group folder:\n\t#{file_representation.join("\n\t")}"
+
         Some(
           ConnectionValidation.new(
             type: :warning,
@@ -209,13 +217,11 @@ module Storages
       def capabilities_request_failed_with_unknown_error
         return None() if capabilities.success?
 
-        Rails.logger.error(
-          "Connection validation failed with unknown error:\n\t" \
-          "storage: ##{@storage.id} #{@storage.name}\n\t" \
-          "request: Nextcloud capabilities\n\t" \
-          "status: #{capabilities.result}\n\t" \
-          "response: #{capabilities.error_payload}"
-        )
+        error "Connection validation failed with unknown error:\n\t" \
+              "storage: ##{@storage.id} #{@storage.name}\n\t" \
+              "request: Nextcloud capabilities\n\t" \
+              "status: #{capabilities.result}\n\t" \
+              "response: #{capabilities.error_payload}"
 
         Some(ConnectionValidation.new(type: :error,
                                       error_code: :err_unknown,
@@ -226,13 +232,11 @@ module Storages
       def files_request_failed_with_unknown_error
         return None() if files.success?
 
-        Rails.logger.error(
-          "Connection validation failed with unknown error:\n\t" \
-          "storage: ##{@storage.id} #{@storage.name}\n\t" \
-          "request: Group folder content\n\t" \
-          "status: #{files.result}\n\t" \
-          "response: #{files.error_payload}"
-        )
+        error "Connection validation failed with unknown error:\n\t" \
+              "storage: ##{@storage.id} #{@storage.name}\n\t" \
+              "request: Group folder content\n\t" \
+              "status: #{files.result}\n\t" \
+              "response: #{files.error_payload}"
 
         Some(ConnectionValidation.new(type: :error,
                                       error_code: :err_unknown,

--- a/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
@@ -58,7 +58,7 @@ module Storages
         host_url_not_found
           .or { missing_dependencies }
           .or { version_mismatch }
-          # .or { with_unexpected_content }
+          .or { with_unexpected_content }
           .or { capabilities_request_failed_with_unknown_error }
       end
 

--- a/modules/storages/app/common/storages/tagged_logging.rb
+++ b/modules/storages/app/common/storages/tagged_logging.rb
@@ -30,7 +30,7 @@
 
 module Storages
   module TaggedLogging
-    delegate :info, :error, to: :logger
+    delegate :info, :warn, :error, to: :logger
 
     # @param tag [Class, String, Array<Class, String>] the tag or list of tags to annotate the logs with
     # @yield [Logger]


### PR DESCRIPTION
# Ticket
[OP#59346](https://community.openproject.org/wp/59346)

# What are you trying to accomplish?
- listing unexpected files and folders in log

```
backend-1  | W, [2024-12-02T15:33:06.143101 #8]  WARN -- : [Storages::Peripherals::NextcloudConnectionValidator] Unexpected files/folder found in group folder:
backend-1  | 	Name: another test 2 (38), ID: 2119, Location: /OpenProject/another%20test%202%20(38)
backend-1  | 	Name: Frêches Prỏje¢t mit Sônðerze1cħen & Ümläuten (34), ID: 2182, Location: /OpenProject/Fr%c3%aaches%20Pr%e1%bb%8fje%c2%a2t%20mit%20S%c3%b4n%c3%b0erze1c%c4%a7en%20%26%20%c3%9cml%c3%a4uten%20(34)
backend-1  | 	Name: Stærforge (10), ID: 1979, Location: /OpenProject/St%c3%a6rforge%20(10)
backend-1  | 	Name: test project 3 (39), ID: 2135, Location: /OpenProject/test%20project%203%20(39)
backend-1  | 	Name: test project 3 (40), ID: 2139, Location: /OpenProject/test%20project%203%20(40)
backend-1  | 	Name: test project 3 (42), ID: 2143, Location: /OpenProject/test%20project%203%20(42)
backend-1  | 	Name: test project 3 (43), ID: 2148, Location: /OpenProject/test%20project%203%20(43)
backend-1  | 	Name: test project 3 (44), ID: 2152, Location: /OpenProject/test%20project%203%20(44)
backend-1  | 	Name: test project 3 (45), ID: 2155, Location: /OpenProject/test%20project%203%20(45)
backend-1  | 	Name: test project 3 (46), ID: 2159, Location: /OpenProject/test%20project%203%20(46)
backend-1  | 	Name: test project 3 (47), ID: 2162, Location: /OpenProject/test%20project%203%20(47)
backend-1  | 	Name: test project 3 (48), ID: 2165, Location: /OpenProject/test%20project%203%20(48)
backend-1  | 	Name: test project 3 (49), ID: 2168, Location: /OpenProject/test%20project%203%20(49)
backend-1  | 	Name: test project (35), ID: 1032, Location: /OpenProject/test%20project%20(35)
backend-1  | 	Name: test project 3 (50), ID: 2171, Location: /OpenProject/test%20project%203%20(50)
backend-1  | 	Name: test project 3 (51), ID: 2176, Location: /OpenProject/test%20project%203%20(51)
```

# What approach did you choose and why?
- added tagged logging to nextcloud and onedrive validator
- log file name, file id and location as a warning

# QA
- this must be tested locally by a developer, as QA usually has no access to server logs