### PR TITLE
Updates GoodJob to version 3.99

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,7 +126,7 @@ gem "multi_json", "~> 1.15.0"
 gem "oj", "~> 3.16.0"
 
 gem "daemons"
-gem "good_job", "= 3.26.2" # update should be done manually in sync with saas-openproject version.
+gem "good_job", "= 3.99.1" # update should be done manually in sync with saas-openproject version.
 
 gem "rack-protection", "~> 3.2.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -333,8 +333,9 @@ group :development, :test do
   # Output a stack trace anytime, useful when a process is stuck
   gem "rbtrace"
 
-  # REPL with debug commands
-  gem "debug"
+  # REPL with debug commands, Debug changed to byebug due to the issue below
+  # https://github.com/puma/puma/issues/2835#issuecomment-2302133927
+  gem "byebug"
 
   gem "pry-byebug", "~> 3.10.0", platforms: [:mri]
   gem "pry-doc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,9 +453,6 @@ GEM
     date_validator (0.12.0)
       activemodel (>= 3)
       activesupport (>= 3)
-    debug (1.10.0)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
     deckar01-task_list (2.3.4)
       html-pipeline (~> 2.0)
     declarative (0.0.20)
@@ -1225,6 +1222,7 @@ DEPENDENCIES
   brakeman (~> 7.0.0)
   browser (~> 6.2.0)
   budgets!
+  byebug
   capybara (~> 3.40.0)
   capybara-screenshot (~> 1.0.17)
   capybara_accessible_selectors!
@@ -1242,7 +1240,6 @@ DEPENDENCIES
   dalli (~> 3.2.0)
   dashboards!
   date_validator (~> 0.12.0)
-  debug
   deckar01-task_list (~> 2.3.1)
   disposable (~> 0.6.2)
   doorkeeper (~> 5.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -602,7 +602,7 @@ GEM
       i18n (>= 0.7)
       multi_json
       request_store (>= 1.0)
-    good_job (3.26.2)
+    good_job (3.99.1)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)
@@ -1264,7 +1264,7 @@ DEPENDENCIES
   friendly_id (~> 5.5.0)
   fuubar (~> 2.5.0)
   gon (~> 6.4.0)
-  good_job (= 3.26.2)
+  good_job (= 3.99.1)
   google-apis-gmail_v1
   googleauth
   grape (~> 2.2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -243,7 +243,7 @@ module OpenProject
     config.good_job.max_cache = OpenProject::Configuration[:good_job_max_cache]
     config.good_job.enable_cron = OpenProject::Configuration[:good_job_enable_cron]
     config.good_job.shutdown_timeout = 30
-    config.good_job.smaller_number_is_higher_priority = false
+    config.good_job.smaller_number_is_higher_priority = true
 
     config.action_controller.asset_host = OpenProject::Configuration::AssetHost.value
 

--- a/db/migrate/20241202112406_create_good_job_execution_error_backtrace.rb
+++ b/db/migrate/20241202112406_create_good_job_execution_error_backtrace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionErrorBacktrace < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :error_backtrace)
+      end
+    end
+
+    add_column :good_job_executions, :error_backtrace, :text, array: true
+  end
+end

--- a/db/migrate/20241202112407_create_good_job_process_lock_ids.rb
+++ b/db/migrate/20241202112407_create_good_job_process_lock_ids.rb
@@ -10,11 +10,9 @@ class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
       end
     end
 
-    # rubocop:disable Rails/BulkChangeTable
     add_column :good_jobs, :locked_by_id, :uuid
     add_column :good_jobs, :locked_at, :datetime
     add_column :good_job_executions, :process_id, :uuid
     add_column :good_job_processes, :lock_type, :integer, limit: 2
-    # rubocop:enable Rails/BulkChangeTable
   end
 end

--- a/db/migrate/20241202112407_create_good_job_process_lock_ids.rb
+++ b/db/migrate/20241202112407_create_good_job_process_lock_ids.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :locked_by_id)
+      end
+    end
+
+    # rubocop:disable Rails/BulkChangeTable
+    add_column :good_jobs, :locked_by_id, :uuid
+    add_column :good_jobs, :locked_at, :datetime
+    add_column :good_job_executions, :process_id, :uuid
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+    # rubocop:enable Rails/BulkChangeTable
+  end
+end

--- a/db/migrate/20241202112408_create_good_job_process_lock_indexes.rb
+++ b/db/migrate/20241202112408_create_good_job_process_lock_indexes.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  # rubocop:disable Metrics/AbcSize
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+          add_index :good_jobs, %i[priority scheduled_at],
+                    order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                    where: "finished_at IS NULL AND locked_by_id IS NULL",
+                    name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          add_index :good_jobs, :locked_by_id,
+                    where: "locked_by_id IS NOT NULL",
+                    name: :index_good_jobs_on_locked_by_id,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+          add_index :good_job_executions, %i[process_id created_at],
+                    name: :index_good_job_executions_on_process_id_and_created_at,
+                    algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        if connection.index_name_exists?(
+          :good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+        )
+          remove_index(:good_jobs, name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          remove_index(:good_jobs, name: :index_good_jobs_on_locked_by_id)
+        end
+
+        if connection.index_name_exists?(
+          :good_job_executions, :index_good_job_executions_on_process_id_and_created_at
+        )
+          remove_index(:good_job_executions, name: :index_good_job_executions_on_process_id_and_created_at)
+        end
+      end
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/db/migrate/20241202112409_create_good_job_execution_duration.rb
+++ b/db/migrate/20241202112409_create_good_job_execution_duration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionDuration < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :duration)
+      end
+    end
+
+    add_column :good_job_executions, :duration, :interval
+  end
+end

--- a/modules/storages/spec/workers/storages/manage_storage_integrations_job_spec.rb
+++ b/modules/storages/spec/workers/storages/manage_storage_integrations_job_spec.rb
@@ -76,11 +76,15 @@ RSpec.describe Storages::ManageStorageIntegrationsJob, type: :job do
         expect(good_job_setting.key).to eq("cron_keys_disabled")
         expect(good_job_setting.value).to eq(["Storages::ManageStorageIntegrationsJob"])
 
-        expect { described_class.disable_cron_job_if_needed }.not_to change(GoodJob::Setting, :count).from(1)
+        expect { described_class.disable_cron_job_if_needed }.to change(GoodJob::Setting, :count).from(1).to(2)
 
         good_job_setting.reload
         expect(good_job_setting.key).to eq("cron_keys_disabled")
         expect(good_job_setting.value).to eq([])
+
+        good_job_setting = GoodJob::Setting.second
+        expect(good_job_setting.key).to eq("cron_keys_enabled")
+        expect(good_job_setting.value).to eq(["Storages::ManageStorageIntegrationsJob"])
       end
 
       it "does nothing if the cron_job is not disabled" do


### PR DESCRIPTION
Preparation steps for the eventual 4.X series upgrade.

Detailed instructions are on the [gem's repo](https://github.com/bensheldon/good_job?tab=readme-ov-file#upgrading-v3-to-v4).

@machisuji Feel free to take over and run as many tests as necessary.