### PR TITLE
Do not reload the relations tab after a hierarchy change.

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
@@ -93,7 +93,9 @@ export class WorkPackageRelationsComponent extends UntilDestroyedMixin implement
       .events$
       .pipe(
         filter((e:RelatedWorkPackageEvent) => {
-          return e.eventType === 'association' && e.id.toString() === this.workPackage.id?.toString();
+          return e.eventType === 'association'
+            && e.id.toString() === this.workPackage.id?.toString()
+            && e.relationType !== 'parent';
         }),
         debounceTime(500),
         this.untilDestroyed(),


### PR DESCRIPTION

# What are you trying to accomplish?
Stabilize the `relations/hierarchy_spec.rb`


# What approach did you choose and why?
The test always failed after a parent and a child have been removed from a WorkPackage. After the parent is removed, the relations tab was updated. I assume, that the test was so fast, that it deleted the Child before the tab content was updated and thus someting went wrong. However, since Parents are not part of the relations tab (or the counter), it is not necessary to reload the tab after parent change.
This appears due to the changes made in the scope of https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/58345/activity

