### PR TITLE
Fix code comment for frontend ports

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -8,7 +8,7 @@ services:
       - "${PORT:-3000}:3000"
 
   frontend:
-    # use these ports to be able to access the stack under http://localhost:3000
+    # use these ports to be able to access the stack under http://localhost:4200
     ports:
       - "${FE_PORT:-4200}:4200"
 


### PR DESCRIPTION
This was most likely a copy & paste mistake.

Looking at this, I am still wondering whether more guidance would be useful on when to use which port to access the application. The comments in the `docker-compose.override.example.yml` merely state the obvious ("these things are port mappings"). But if I am asking myself whether I should access the app via port 3000 or 4200, I am lost.

[Elsewhere](https://github.com/opf/openproject/tree/dev/docs/development/development-environment/docker#4-start-the-stack) I can find:

> You can now access OpenProject under http://localhost:3000/, and via the live-reloaded under http://localhost:4200/.

So there seems to be no big difference between the two? However, @mereghost wrote me in a DM:

> Accessing by 3000 will break most of the pages that have angular components

So my take is, that for anything where I access the UI, 4200 is preferable?

# Merge checklist

- [x] ~~Added/updated tests~~
- [x] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [x] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
