### PR TITLE
Beautify development highlight

### DIFF
--- a/frontend/src/global_styles/common/header/app-header.sass
+++ b/frontend/src/global_styles/common/header/app-header.sass
@@ -83,4 +83,4 @@
         padding-right: 1rem
 
   &.op-app-header_development
-    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='90' height='20'><text x='0' y='1em' fill='rgba(0, 0, 0, 0.5)'>development</text></svg>")
+    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='20'><text x='0' y='1em' fill='rgba(0, 0, 0, 0.5)'>development</text></svg>")


### PR DESCRIPTION
This might be an issue dependent on the OS or
available fonts, but to me the header in development mode read like "developmerdevelopmer", because the text was wider than the image width we allocated.

By increasing the width to 120px, there is now some whitespace left between the images (hopefully for most OSes), which looks nicer IMO and makes the dev-hint more readable.

## Screenshots

### Before

Desktop:
![image](https://github.com/user-attachments/assets/a85b1ab4-3b36-4c52-9f14-65e2d4f147f9)

Mobile:
![image](https://github.com/user-attachments/assets/2d0aa39c-c3bb-4575-9e86-dcbd0cc32130)


### After

Desktop:
![image](https://github.com/user-attachments/assets/48bad5c3-be5c-43ff-b056-d7b73adc713f)

Mobile:
![image](https://github.com/user-attachments/assets/f7c6f453-2080-4fe0-9cf7-99116132878c)


# What approach did you choose and why?

I was briefly thinking about using 100px width, which would have looked like `developmentdevelopment` on my machine. But assuming that the text width is different depending on the exact device, I figured it would be safer to always count on _some_ amount of whitespace.

# Merge checklist

- [x] ~~Added/updated tests~~
- [x] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- Tested major browsers
    - [x] Chrome (actually looked acceptable before already, with a small amount of whitespace. Now has more whitespace, but still looks nice)
    - [x] Firefox
