### PR TITLE
[59772] Buttons not visible on iOS in edit relations modal

### DIFF
--- a/app/components/work_package_relations_tab/add_work_package_child_dialog_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_dialog_component.html.erb
@@ -3,7 +3,7 @@
                                    size: :large,
                                    id: DIALOG_ID)) do |d|
     d.with_header(variant: :large)
-    d.with_body(classes: "Overlay-body_autocomplete_height") do
+    d.with_body(classes: body_classes) do
       render(WorkPackageRelationsTab::AddWorkPackageChildFormComponent.new(
         work_package: @work_package
       ))

--- a/app/components/work_package_relations_tab/add_work_package_child_dialog_component.rb
+++ b/app/components/work_package_relations_tab/add_work_package_child_dialog_component.rb
@@ -51,4 +51,8 @@ class WorkPackageRelationsTab::AddWorkPackageChildDialogComponent < ApplicationC
     child_label = t("#{I18N_NAMESPACE}.relations.label_child_singular")
     t("#{I18N_NAMESPACE}.label_add_x", x: child_label)
   end
+
+  def body_classes
+    "Overlay-body_autocomplete_height"
+  end
 end

--- a/app/components/work_package_relations_tab/work_package_relation_dialog_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_dialog_component.html.erb
@@ -3,7 +3,7 @@
                                    size: :large,
                                    id: DIALOG_ID)) do |d|
     d.with_header(variant: :large)
-    d.with_body(classes: "Overlay-body_autocomplete_height") do
+    d.with_body(classes: body_classes) do
       render(WorkPackageRelationsTab::WorkPackageRelationFormComponent.new(
         work_package: @work_package,
         relation: @relation

--- a/app/components/work_package_relations_tab/work_package_relation_dialog_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_dialog_component.rb
@@ -58,4 +58,8 @@ class WorkPackageRelationsTab::WorkPackageRelationDialogComponent < ApplicationC
       t("#{I18N_NAMESPACE}.label_add_x", x: relation_label)
     end
   end
+
+  def body_classes
+    @relation.persisted? ? nil : "Overlay-body_autocomplete_height"
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/59772/activity

# What are you trying to accomplish?
Make the dialog smaller in edit mode as the increased height is not necessary when the autocompleter is disabled.

Please note, that this will not solve the issue when adding a new relation. There, we have to increase the height as the autocompleter dropdown otherwise does not fit into the dialog

## Screenshots

**After**
<img width="674" alt="Bildschirmfoto 2024-12-03 um 12 39 48" src="https://github.com/user-attachments/assets/023fec6c-956f-4206-8030-e6b90a4c0d8b">

