### PR TITLE
Remove inappropriate status tripping up turbo

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -88,7 +88,7 @@ class TypesController < ApplicationController
 
       call.on_failure do |result|
         flash[:error] = result.errors.full_messages.join("\n")
-        render_edit_tab(@type)
+        render_edit_tab(@type, status: :unprocessable_entity)
       end
     end
   end
@@ -139,12 +139,12 @@ class TypesController < ApplicationController
                 notice:)
   end
 
-  def render_edit_tab(type)
+  def render_edit_tab(type, status: :ok)
     @tab = params[:tab]
     @projects = Project.all
     @type = type
 
-    render action: :edit, status: :unprocessable_entity
+    render action: :edit, status:
   end
 
   def show_local_breadcrumb

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe TypesController do
         get "edit", params: { id: type.id, tab: :settings }
       end
 
-      it { expect(response).to have_http_status(:unprocessable_entity) }
+      it { expect(response).to have_http_status(:ok) }
       it { expect(response).to render_template "edit" }
       it { expect(response).to render_template "types/form/_settings" }
       it { expect(response.body).to have_css "input[@name='type[name]'][@value='My type']" }
@@ -233,7 +233,7 @@ RSpec.describe TypesController do
         get "edit", params: { id: type.id, tab: :projects }
       end
 
-      it { expect(response).to have_http_status(:unprocessable_entity) }
+      it { expect(response).to have_http_status(:ok) }
       it { expect(response).to render_template "edit" }
       it { expect(response).to render_template "types/form/_projects" }
 
@@ -242,7 +242,7 @@ RSpec.describe TypesController do
       }
     end
 
-    describe "POST update" do
+    describe "PATCH update" do
       let(:project2) { create(:project) }
       let(:type) do
         create(:type, name: "My type",
@@ -258,7 +258,7 @@ RSpec.describe TypesController do
         end
 
         before do
-          put :update, params:
+          patch :update, params:
         end
 
         it { expect(response).to be_redirect }
@@ -274,6 +274,21 @@ RSpec.describe TypesController do
         end
       end
 
+      describe "WITH the name being erroneously blank" do
+        let(:params) do
+          { "id" => type.id,
+            "type" => { name: "" },
+            "tab" => "settings" }
+        end
+
+        before do
+          patch :update, params:
+        end
+
+        it { expect(response).to have_http_status(:unprocessable_entity) }
+        it { expect(response).to render_template "edit" }
+      end
+
       describe "WITH projects removed" do
         let(:params) do
           { "id" => type.id,
@@ -282,7 +297,7 @@ RSpec.describe TypesController do
         end
 
         before do
-          put :update, params:
+          patch :update, params:
         end
 
         it { expect(response).to be_redirect }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59369

# What are you trying to accomplish?

Fix the issue described in the linked bug.

# What approach did you choose and why?

Returning `unprocessable_entity` on a GET request, with no parameters provided is not appropriate and trips up turbo leading to a reinitialization of the angular app and ckeditor.
It was added when enabling turbo drive (#16486) where when rendering a response to a POST form request a non ok status needs to be returned. I believe here, it was added erroneously.

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
