### PR TITLE
attempt to fix flickering spec

### DIFF
--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -183,6 +183,9 @@ RSpec.describe "Work Package boards spec",
 
     # Add a new WP on the board
     board_page = board_index.open_board board_view
+
+    wait_for_network_idle
+
     board_page.expect_query "List 1", editable: true
     board_page.add_card "List 1", "Task 1"
     board_page.expect_toast message: I18n.t(:notice_successful_create)
@@ -203,7 +206,10 @@ RSpec.describe "Work Package boards spec",
     destroy_modal.expect_listed(wp)
     destroy_modal.confirm_deletion
 
-    board_page.expect_empty
+    wait_for_network_idle
+
+    board_page.expect_query "List 1", editable: true
+    board_page.expect_not_any_card
     board_page.expect_path
   end
 end

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -240,6 +240,10 @@ module Pages
       expect(page).to have_no_css(".boards-list--item", wait: 10)
     end
 
+    def expect_not_any_card
+      expect(page).to have_no_css('[data-test-selector="op-wp-single-card"]')
+    end
+
     def remove_list(name)
       click_list_dropdown name, "Delete list"
 


### PR DESCRIPTION
# What are you trying to accomplish?

Fix the flickering board_navigation_spec. The flickering is caused as the spec incorrectly expected the board to be completely empty when in fact the list that previously contained the deleted task is still present. Therefore the more appropriate expectation of the board not having any cards is introduced. 

