### PR TITLE
Limit select for user cf value options

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -326,12 +326,15 @@ class CustomField < ApplicationRecord
 
   def possible_user_values_options(obj)
     mapped_with_deduced_project(obj) do |project|
-      if project&.persisted?
-        project.principals
-      else
-        Principal
-          .in_visible_project_or_me(User.current)
-      end
+      scope = if project&.persisted?
+                project.principals
+              else
+                Principal
+                  .in_visible_project_or_me(User.current)
+              end
+
+      scope
+        .select(*(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s) << "id"))
     end
   end
 

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -255,6 +255,7 @@ RSpec.describe CustomFieldFormBuilder do
       let(:project) { build_stubbed(:project) }
       let(:user1) { build_stubbed(:user) }
       let(:user2) { build_stubbed(:user) }
+      let(:scope) { instance_double(ActiveRecord::Relation) }
 
       let(:resource) { project }
 
@@ -268,8 +269,12 @@ RSpec.describe CustomFieldFormBuilder do
         end
 
         allow(project)
-          .to(receive(:principals))
-          .and_return([user1, user2])
+          .to receive(:principals)
+                .and_return(scope)
+
+        allow(scope)
+          .to receive(:select)
+                .and_return([user1, user2])
       end
 
       it_behaves_like "wrapped in container", "select-container" do

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -441,12 +441,17 @@ RSpec.describe CustomActions::Actions::CustomField do
          build_stubbed(:user),
          build_stubbed(:user)]
       end
+      let(:scope) { instance_double(ActiveRecord::Relation) }
 
       before do
         allow(Principal)
           .to receive(:in_visible_project_or_me)
-          .with(User.current)
-          .and_return(users)
+                .with(User.current)
+                .and_return(scope)
+
+        allow(scope)
+          .to receive(:select)
+                .and_return(users)
       end
 
       context "for a non required field" do
@@ -515,12 +520,17 @@ RSpec.describe CustomActions::Actions::CustomField do
          build_stubbed(:user),
          build_stubbed(:user)]
       end
+      let(:scope) { instance_double(ActiveRecord::Relation) }
 
       before do
         allow(Principal)
           .to receive(:in_visible_project_or_me)
-          .with(User.current)
-          .and_return(users)
+                .with(User.current)
+                .and_return(scope)
+
+        allow(scope)
+          .to receive(:select)
+                .and_return(users)
       end
 
       it_behaves_like "associated custom action validations" do

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -215,17 +215,27 @@ RSpec.describe CustomField do
     let(:project) { build_stubbed(:project) }
     let(:user1) { build_stubbed(:user) }
     let(:user2) { build_stubbed(:user) }
+    let(:in_visible_scope) { instance_double(ActiveRecord::Relation) }
+    let(:principals_scope) { instance_double(ActiveRecord::Relation) }
 
     context "for a user custom field" do
       before do
         field.field_format = "user"
         allow(project)
           .to receive(:principals)
-          .and_return([user1, user2])
+                .and_return(principals_scope)
+
+        allow(principals_scope)
+          .to receive(:select)
+                .and_return([user1, user2])
 
         allow(Principal)
           .to receive(:in_visible_project_or_me)
-          .and_return([user2])
+                .and_return(in_visible_scope)
+
+        allow(in_visible_scope)
+          .to receive(:select)
+                .and_return([user2])
       end
 
       context "for a project" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59872

# What are you trying to accomplish?

Improve the performance of rendering the filter section in the project list in case a lot of users (which need to members in projects visible to the calling user) exist in the instance and multiple user custom fields are configured.

# What approach did you choose and why?

Easy to achieve improvement by selecting only the fields necessary for filling the selects. A long term solution would be to apply autocompleters there which load the data on demand. This would be require way more work. The proposal for doing this is already tracked.

