### PR TITLE
Fix translation typos

### DIFF
--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
               not_found: "%{current_path} wasn't found."
             set_folders_permissions:
               permission_not_set: could not set permissions on %{path}.
-          error: An unexpected error occurred. Please ensure that you Nextcloud instance is reachable and check OpenProject worker logs for more information
+          error: An unexpected error occurred. Please ensure that your Nextcloud instance is reachable and check OpenProject worker logs for more information
           group_does_not_exist: "%{group} does not exist. Check your Nextcloud instance configuration."
           insufficient_privileges: OpenProject does not have enough privileges to add %{user} to %{group}. Check you group settings in Nextcloud.
           not_allowed: Nextcloud block the request.
@@ -146,7 +146,7 @@ en:
               not_found: "%{current_path} wasn't found."
             set_folders_permissions:
               permission_not_set: could not set permissions on %{path}.
-          error: An unexpected error occurred. Please ensure that you Nextcloud instance is reachable and check OpenProject worker logs for more information
+          error: An unexpected error occurred. Please ensure that OneDrive/SharePoint is reachable and check OpenProject worker logs for more information
           not_allowed: OpenProject wasn't allowed to access your OneDrive drive. Please check the permissions set on the Azure Application.
           unauthorized: OpenProject could not sync with OneDrive. Please check your storage and Azure Application configuration.
           user_does_not_exist: "%{user} does not exist in Nextcloud."


### PR DESCRIPTION
Two simple fixes:

* "you" instead of "your"
* Copy & Pasting a Nextcloud error message into the OneDrive integration

# Ticket
none

# What approach did you choose and why?
I fixed the english translations only. As far as I understood, the rest should then automagically be fixed through CrowdIn (the offending text appears a few more times for other languages as well).

# Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
