### PR TITLE
[59769] When adding new relations, auto-scroll to show the newly added relation

### DIFF
--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -55,8 +55,7 @@
   <%=
     flex_layout(mb: 3, data: {
       "application-target": "dynamic",
-      controller: "work-packages--relations-tab--scroll",
-      "work-packages--relations-tab--scroll-target-id-value": @scroll_target_id,
+      controller: "work-packages--relations-tab--scroll"
     }) do |flex|
       if any_relations?
         key_namespace = "#{I18N_NAMESPACE}.relations"

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -53,10 +53,7 @@
   %>
 
   <%=
-    flex_layout(mb: 3, data: {
-      "application-target": "dynamic",
-      controller: "work-packages--relations-tab--scroll"
-    }) do |flex|
+    flex_layout(mb: 3) do |flex|
       if any_relations?
         key_namespace = "#{I18N_NAMESPACE}.relations"
 

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -53,7 +53,11 @@
   %>
 
   <%=
-    flex_layout(mb: 3) do |flex|
+    flex_layout(mb: 3, data: {
+      "application-target": "dynamic",
+      controller: "work-packages--relations-tab--scroll",
+      "work-packages--relations-tab--scroll-target-id-value": @scroll_target_id,
+    }) do |flex|
       if any_relations?
         key_namespace = "#{I18N_NAMESPACE}.relations"
 

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -67,11 +67,9 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
                                   else
                                     item.id
                                   end
-
-        scroll_to = related_work_package_id.to_s == @scroll_to_id
         border_box.with_row(
           test_selector: row_test_selector(item),
-          data: { scroll_to: scroll_to }
+          data: { scroll_to: related_work_package_id.to_s == @scroll_to_id }
         ) do
           yield(item)
         end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -68,10 +68,10 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
                                     item.id
                                   end
 
-        scroll_active = related_work_package_id.to_s == @scroll_to_id
+        scroll_to = related_work_package_id.to_s == @scroll_to_id
         border_box.with_row(
           test_selector: row_test_selector(item),
-          data: { scroll_active: scroll_active }
+          data: { scroll_to: scroll_to }
         ) do
           yield(item)
         end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -9,16 +9,16 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   include Turbo::FramesHelper
   include OpTurbo::Streamable
 
-  attr_reader :work_package, :relations, :children, :directionally_aware_grouped_relations
+  attr_reader :work_package, :relations, :children, :directionally_aware_grouped_relations, :scroll_to_id
 
-  def initialize(work_package:, relations:, children:, scroll_target_id: nil)
+  def initialize(work_package:, relations:, children:, scroll_to_id: nil)
     super()
 
     @work_package = work_package
     @relations = relations
     @children = children
     @directionally_aware_grouped_relations = group_relations_by_directional_context
-    @scroll_target_id = scroll_target_id
+    @scroll_to_id = scroll_to_id
   end
 
   def self.wrapper_key
@@ -62,7 +62,17 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
       end
 
       items.each do |item|
-        border_box.with_row(test_selector: row_test_selector(item)) do
+        related_work_package_id = if item.is_a?(Relation)
+                                    item.from_id == work_package.id ? item.to_id : item.from_id
+                                  else
+                                    item.id
+                                  end
+
+        scroll_active = related_work_package_id.to_s == @scroll_to_id
+        border_box.with_row(
+          test_selector: row_test_selector(item),
+          data: { scroll_active: scroll_active }
+        ) do
           yield(item)
         end
       end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -73,9 +73,17 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   def render_items(border_box, items)
     items.each do |item|
       related_work_package_id = find_related_work_package_id(item)
+      data_attribute = nil
+      if related_work_package_id.to_s == @scroll_to_id
+        data_attribute = {
+          controller: "work-packages--relations-tab--scroll",
+          application_target: "dynamic",
+          "work-packages--relations-tab--scroll-target": "scrollToRow"
+        }
+      end
       border_box.with_row(
         test_selector: row_test_selector(item),
-        data: { scroll_to: related_work_package_id.to_s == @scroll_to_id }
+        data: data_attribute
       ) do
         yield(item)
       end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -62,11 +62,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
       end
 
       items.each do |item|
-        related_work_package_id = if item.is_a?(Relation)
-                                    item.from_id == work_package.id ? item.to_id : item.from_id
-                                  else
-                                    item.id
-                                  end
+        related_work_package_id = find_related_work_package_id(item)
         border_box.with_row(
           test_selector: row_test_selector(item),
           data: { scroll_to: related_work_package_id.to_s == @scroll_to_id }
@@ -92,11 +88,15 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   end
 
   def row_test_selector(item)
+    related_work_package_id = find_related_work_package_id(item)
+    "op-relation-row-#{related_work_package_id}"
+  end
+
+  def find_related_work_package_id(item)
     if item.is_a?(Relation)
-      target = item.to == work_package ? item.from : item.to
-      "op-relation-row-#{target.id}"
-    else # Work Package object
-      "op-relation-row-#{item.id}"
+      item.from_id == work_package.id ? item.to_id : item.from_id
+    else
+      item.id
     end
   end
 end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -48,27 +48,36 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   def any_relations? = relations.any? || children.any?
 
   def render_relation_group(title:, relation_type:, items:, &_block)
-    render(border_box_container(padding: :condensed,
-                                data: { test_selector: "op-relation-group-#{relation_type}" })) do |border_box|
-      border_box.with_header(py: 3) do
-        flex_layout(align_items: :center) do |flex|
-          flex.with_column(mr: 2) do
-            render(Primer::Beta::Text.new(font_size: :normal, font_weight: :bold)) { title }
-          end
-          flex.with_column do
-            render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
-          end
+    render(border_box_container(
+             padding: :condensed,
+             data: { test_selector: "op-relation-group-#{relation_type}" }
+           )) do |border_box|
+      render_header(border_box, title, items)
+      render_items(border_box, items, &_block)
+    end
+  end
+
+  def render_header(border_box, title, items)
+    border_box.with_header(py: 3) do
+      flex_layout(align_items: :center) do |flex|
+        flex.with_column(mr: 2) do
+          render(Primer::Beta::Text.new(font_size: :normal, font_weight: :bold)) { title }
+        end
+        flex.with_column do
+          render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
         end
       end
+    end
+  end
 
-      items.each do |item|
-        related_work_package_id = find_related_work_package_id(item)
-        border_box.with_row(
-          test_selector: row_test_selector(item),
-          data: { scroll_to: related_work_package_id.to_s == @scroll_to_id }
-        ) do
-          yield(item)
-        end
+  def render_items(border_box, items)
+    items.each do |item|
+      related_work_package_id = find_related_work_package_id(item)
+      border_box.with_row(
+        test_selector: row_test_selector(item),
+        data: { scroll_to: related_work_package_id.to_s == @scroll_to_id }
+      ) do
+        yield(item)
       end
     end
   end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -11,13 +11,14 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
 
   attr_reader :work_package, :relations, :children, :directionally_aware_grouped_relations
 
-  def initialize(work_package:, relations:, children:)
+  def initialize(work_package:, relations:, children:, scroll_target_id: nil)
     super()
 
     @work_package = work_package
     @relations = relations
     @children = children
     @directionally_aware_grouped_relations = group_relations_by_directional_context
+    @scroll_target_id = scroll_target_id
   end
 
   def self.wrapper_key

--- a/app/controllers/work_package_children_controller.rb
+++ b/app/controllers/work_package_children_controller.rb
@@ -59,7 +59,7 @@ class WorkPackageChildrenController < ApplicationController
         work_package: @work_package,
         relations: @relations,
         children: @children,
-        scroll_target_id: target_work_package_id
+        scroll_to_id: target_work_package_id
       )
       replace_via_turbo_stream(component:)
       update_flash_message_via_turbo_stream(

--- a/app/controllers/work_package_children_controller.rb
+++ b/app/controllers/work_package_children_controller.rb
@@ -58,7 +58,8 @@ class WorkPackageChildrenController < ApplicationController
       component = WorkPackageRelationsTab::IndexComponent.new(
         work_package: @work_package,
         relations: @relations,
-        children: @children
+        children: @children,
+        scroll_target_id: target_work_package_id
       )
       replace_via_turbo_stream(component:)
       update_flash_message_via_turbo_stream(

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -65,7 +65,7 @@ class WorkPackageRelationsController < ApplicationController
       component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package,
                                                               relations: @work_package.relations,
                                                               children: @work_package.children,
-                                                              scroll_target_id: target_work_package_id)
+                                                              scroll_to_id: target_work_package_id)
       replace_via_turbo_stream(component:)
       respond_with_turbo_streams
     else

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -60,10 +60,12 @@ class WorkPackageRelationsController < ApplicationController
                                              .call(create_relation_params)
 
     if service_result.success?
+      target_work_package_id = params[:relation][:to_id]
       @work_package.reload
       component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package,
                                                               relations: @work_package.relations,
-                                                              children: @work_package.children)
+                                                              children: @work_package.children,
+                                                              scroll_target_id: target_work_package_id)
       replace_via_turbo_stream(component:)
       respond_with_turbo_streams
     else

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
@@ -1,17 +1,16 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class ScrollController extends Controller {
-  connect() {
-    this.waitForRenderAndAct();
-  }
+  static targets = ['scrollToRow'];
 
-  waitForRenderAndAct() {
-    const element = document.querySelector('[data-scroll-to="true"]');
+  declare readonly scrollToRowTarget:HTMLElement;
+  declare readonly hasScrollToRowTarget:boolean;
 
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    } else {
-      requestAnimationFrame(this.waitForRenderAndAct.bind(this));
+  scrollToRowTargetConnected() {
+    if (this.hasScrollToRowTarget) {
+      setTimeout(() => {
+        this.scrollToRowTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      });
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
@@ -6,7 +6,7 @@ export default class ScrollController extends Controller {
   }
 
   waitForRenderAndAct() {
-    const element = document.querySelector('[data-scroll-active="true"]');
+    const element = document.querySelector('[data-scroll-to="true"]');
 
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
@@ -1,18 +1,17 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class ScrollController extends Controller {
-  static values = { targetId: String };
-  declare targetIdValue:string;
-
   connect() {
-    // Wait to ensure DOM is fully loaded
-    setTimeout(() => {
-      if (this.targetIdValue) {
-         const element = document.querySelector(`[data-test-selector='op-relation-row-${this.targetIdValue}']`) as HTMLElement;
-        if (element) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      }
-    });
+    this.waitForRenderAndAct();
+  }
+
+  waitForRenderAndAct() {
+    const element = document.querySelector('[data-scroll-active="true"]');
+
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } else {
+      requestAnimationFrame(this.waitForRenderAndAct.bind(this));
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class ScrollController extends Controller {
+  static values = { targetId: String };
+  declare targetIdValue:string;
+
+  connect() {
+    setTimeout(() => {
+      if (this.targetIdValue) {
+         const element = document.querySelector(`[data-test-selector='op-relation-row-${this.targetIdValue}']`) as HTMLElement;
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }
+    });
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
@@ -5,6 +5,7 @@ export default class ScrollController extends Controller {
   declare targetIdValue:string;
 
   connect() {
+    // Wait to ensure DOM is fully loaded
     setTimeout(() => {
       if (this.targetIdValue) {
          const element = document.querySelector(`[data-test-selector='op-relation-row-${this.targetIdValue}']`) as HTMLElement;

--- a/spec/controllers/work_package_relations_controller_spec.rb
+++ b/spec/controllers/work_package_relations_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe WorkPackageRelationsController do
       new_relation = Relation.last
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [relation, new_relation], children:, scroll_target_id: unrelated_work_package.id)
+        .with(work_package:, relations: [relation, new_relation], children:, scroll_to_id: unrelated_work_package.id)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
     end

--- a/spec/controllers/work_package_relations_controller_spec.rb
+++ b/spec/controllers/work_package_relations_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe WorkPackageRelationsController do
       new_relation = Relation.last
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [relation, new_relation], children:)
+        .with(work_package:, relations: [relation, new_relation], children:, scroll_target_id: unrelated_work_package.id)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/59769/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Screen recording

https://github.com/user-attachments/assets/4bb6d130-2199-4957-ba59-01d11503fee4

# What are you trying to accomplish?
Scroll to the currently created relation in relations tab. 

# What approach did you choose and why?
After creating a relation, pass the relation-wp-id to the component for initializing it.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
