### PR TITLE
Reorder meeting series sidebar menu by title

### DIFF
--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -58,7 +58,9 @@ module Meetings
     end
 
     def meeting_series_menu_items
-      series = RecurringMeeting.visible
+      series = RecurringMeeting
+        .visible
+        .reorder("LOWER(title)")
 
       if project
         series = series.where(project_id: project.id)


### PR DESCRIPTION
>  Meeting index list in the left panel order changes when viewing a template vs the show page
