### PR TITLE
Make it possible to use workers in TLS setup

### DIFF
--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -1,27 +1,44 @@
+# Some containers (e.g. backend and workers) need some variables to be configured properly
+x-op-env-override: &environment
+  OPENPROJECT_CLI_PROXY: "${OPENPROJECT_DEV_URL}"
+  OPENPROJECT_DEV_EXTRA_HOSTS: "${OPENPROJECT_DEV_HOST}"
+  OPENPROJECT_HTTPS: true
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  # uncomment and set all the envs below to integrate keycloak with OpenProject
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_DISPLAY__NAME: Keycloak
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_HOST: keycloak.local
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_IDENTIFIER: https://openproject.local
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_SECRET: <The client secret you copied from keycloak>
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_ISSUER: https://keycloak.local/realms/<REALM>
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_AUTHORIZATION__ENDPOINT: /realms/<REALM>/protocol/openid-connect/auth
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_TOKEN__ENDPOINT: /realms/<REALM>/protocol/openid-connect/token
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_USERINFO__ENDPOINT: /realms/<REALM>/protocol/openid-connect/userinfo
+  # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_END__SESSION__ENDPOINT: https://keycloak.local/realms/<REALM>/protocol/openid-connect/logout
+
 services:
   backend:
-    # The backend container needs some variables to be configured properly
     environment:
-      OPENPROJECT_CLI_PROXY: "${OPENPROJECT_DEV_URL}"
-      OPENPROJECT_DEV_EXTRA_HOSTS: "${OPENPROJECT_DEV_HOST}"
-      OPENPROJECT_HTTPS: true
-      SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
-      # uncomment and set all the envs below to integrate keycloak with OpenProject
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_DISPLAY__NAME: Keycloak
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_HOST: keycloak.local
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_IDENTIFIER: https://openproject.local
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_SECRET: <The client secret you copied from keycloak>
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_ISSUER: https://keycloak.local/realms/<REALM>
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_AUTHORIZATION__ENDPOINT: /realms/<REALM>/protocol/openid-connect/auth
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_TOKEN__ENDPOINT: /realms/<REALM>/protocol/openid-connect/token
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_USERINFO__ENDPOINT: /realms/<REALM>/protocol/openid-connect/userinfo
-      # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_END__SESSION__ENDPOINT: https://keycloak.local/realms/<REALM>/protocol/openid-connect/logout
+      <<: *environment
     networks:
       - external
     volumes:
-      # This volume mount is the usual volume mount for a linux environment.
-      # It must be amended accordingly to OS.
+      # Linux
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+      # Mac OS
+      # - ~/.step/certs:/etc/ssl/certs
+      # - ~/.step/certs:/usr/local/share/ca-certificates
+
+  worker:
+    environment:
+      <<: *environment
+    networks:
+      - external
+    volumes:
+      # Linux
+      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+      # Mac OS
+      # - ~/.step/certs:/etc/ssl/certs
+      # - ~/.step/certs:/usr/local/share/ca-certificates
 
   backend-test:
     # Connect the backend-test container to the same network as the backend for nextcloud HTTP interactions


### PR DESCRIPTION
The example overrides file was missing overrides
for the workers, which means their network was not configured to include the gateway network, thus they didn't resolve IP addresses to the Traefik proxy.

Even if they had, it was also necessary to setup environment variables the same way that the backend service gets them, because otherwise the development TLS certificates would not be recognized and configuration of KeyCloak would not be taken into account for workers, which may be an issue in the future.

# Ticket
No ticket

# What approach did you choose and why?
Extracted environment variables into a shared section so they only need to be edited once (e.g. KeyCloak credentials) for both the backend and the worker.

I was considering to do the same for certificate volume mounts, because they are kinda repetitive, but there may be use cases where one wants to include additional volume mounts next to the certificate. As far as I can tell, this would not be easily possible, since the volume mounts are an array, not a map.

# Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
