### PR TITLE
Simplify provider name shortening

### DIFF
--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -92,14 +92,12 @@ module Storages
     }.freeze, _prefix: :health
 
     def self.shorten_provider_type(provider_type)
-      case /Storages::(?'provider_name'.*)Storage/.match(provider_type)
-      in provider_name:
-        provider_name.underscore
-      else
-        raise ArgumentError,
-              "Unknown provider_type! Given: #{provider_type}. " \
-              "Expected the following signature: Storages::{Name of the provider}Storage"
-      end
+      short, = PROVIDER_TYPE_SHORT_NAMES.find { |_, long| provider_type == long }
+      return short.to_s if short
+
+      raise ArgumentError,
+            "Unknown provider_type! Given: #{provider_type}. " \
+            "Known provider types are defined in Storages::Storage::PROVIDER_TYPE_SHORT_NAMES."
     end
 
     def self.one_drive_without_ee_token?(provider_type)

--- a/modules/storages/spec/models/storages/shared_base_storage_spec.rb
+++ b/modules/storages/spec/models/storages/shared_base_storage_spec.rb
@@ -49,20 +49,24 @@ RSpec.shared_examples_for "base storage" do
       end
     end
 
-    context "when provider_type does not match the signature" do
+    context "when provider_type is unknown" do
       it "raises an error", :aggregate_failures do
         expect do
           described_class.shorten_provider_type("Storages::Nextcloud")
         end.to raise_error("Unknown provider_type! Given: Storages::Nextcloud. " \
-                           "Expected the following signature: Storages::{Name of the provider}Storage")
+                           "Known provider types are defined in Storages::Storage::PROVIDER_TYPE_SHORT_NAMES.")
         expect do
           described_class.shorten_provider_type("Storages:NextcloudStorage")
         end.to raise_error("Unknown provider_type! Given: Storages:NextcloudStorage. " \
-                           "Expected the following signature: Storages::{Name of the provider}Storage")
+                           "Known provider types are defined in Storages::Storage::PROVIDER_TYPE_SHORT_NAMES.")
         expect do
           described_class.shorten_provider_type("Storages::NextcloudStorag")
         end.to raise_error("Unknown provider_type! Given: Storages::NextcloudStorag. " \
-                           "Expected the following signature: Storages::{Name of the provider}Storage")
+                           "Known provider types are defined in Storages::Storage::PROVIDER_TYPE_SHORT_NAMES.")
+        expect do
+          described_class.shorten_provider_type("Storages::UnknownStorage")
+        end.to raise_error("Unknown provider_type! Given: Storages::UnknownStorage. " \
+                           "Known provider types are defined in Storages::Storage::PROVIDER_TYPE_SHORT_NAMES.")
       end
     end
   end


### PR DESCRIPTION
Instead of using a regular expression to parse the name, we try to find the provider name inside the already existing constant that knows providers short names.

# Ticket
No ticket

# What are you trying to accomplish?
Primarily: Simplify code, increase readability.

Secondarily: Side step a glitch in my VS Code that breaks syntax highlighting around the Regex :sunglasses: 

# What approach did you choose and why?

Instead of using a regex to parse the provider name, we perform a lookup in a hash that already existed before.

This changes behaviour for cases that are not covered by specs so far: Previously the method would have returned a result for unknown stores (say `Storages::DropboxStorage`), while the new method will only work for storages that are "registered" via the `PROVIDER_TYPE_SHORT_NAMES` constant.

I think this is consistent behaviour, but still it's a change in behaviour. Looking at the `StoragesController`, there seems to be a check that a selected provider is included in the constant, so it's unlikely that the change will affect any storage provider that exists in the wild.

# Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
