### PR TITLE
[#59898] fix: redundant user popover in profile

### DIFF
--- a/app/components/users/show_page_header_component.html.erb
+++ b/app/components/users/show_page_header_component.html.erb
@@ -28,7 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { "#{avatar @user} #{h(@user.name)}".html_safe }
+    header.with_title do
+      "#{avatar(@user, hover_card: { active: false })} #{h(@user.name)}".html_safe
+    end
     header.with_breadcrumbs(breadcrumb_items)
 
     if @current_user.allowed_globally?(:manage_user)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/59898
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Hovering over the avatar in the user profile should not trigger a user info popover.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
