### PR TITLE
Allow editing and auto-discovering supported grant types of OIDC providers

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -61,3 +61,8 @@ end
 
 OpenProject::FeatureDecisions.add :stages_and_gates,
                                   description: "Enables the under construction feature of stages and gates."
+
+OpenProject::FeatureDecisions.add :oidc_token_exchange,
+                                  description: "Enables the under construction OAuth2 token exchange, allowing " \
+                                               "users to interact with storage providers without consenting " \
+                                               "in OAuth screens before first use."

--- a/modules/openid_connect/app/components/openid_connect/providers/metadata_details_form.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/metadata_details_form.rb
@@ -30,12 +30,22 @@ module OpenIDConnect
   module Providers
     class MetadataDetailsForm < BaseForm
       form do |f|
-        OpenIDConnect::Provider::DISCOVERABLE_ATTRIBUTES_ALL.each do |attr|
+        OpenIDConnect::Provider::DISCOVERABLE_STRING_ATTRIBUTES_ALL.each do |attr|
           f.text_field(
             name: attr,
             label: I18n.t("activemodel.attributes.openid_connect/provider.#{attr}"),
             disabled: provider.seeded_from_env?,
-            required: OpenIDConnect::Provider::DISCOVERABLE_ATTRIBUTES_MANDATORY.include?(attr),
+            required: OpenIDConnect::Provider::DISCOVERABLE_STRING_ATTRIBUTES_MANDATORY.include?(attr),
+            input_width: :large
+          )
+        end
+
+        if OpenProject::FeatureDecisions.oidc_token_exchange_active?
+          f.text_field(
+            name: :grant_types_supported,
+            label: I18n.t("activemodel.attributes.openid_connect/provider.grant_types_supported"),
+            disabled: provider.seeded_from_env?,
+            required: false,
             input_width: :large
           )
         end

--- a/modules/openid_connect/app/services/openid_connect/providers/set_attributes_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/providers/set_attributes_service.rb
@@ -44,7 +44,17 @@ module OpenIDConnect
 
         super
 
+        update_grant_types_supported if params.key?(:grant_types_supported)
         update_available_state
+      end
+
+      # This is a workaround for a non-ideal UI
+      # We only offer users to edit the supported grant types in a text input field,
+      # though they are indeed editing a list of grants.
+      def update_grant_types_supported
+        return unless params[:grant_types_supported].is_a? String
+
+        model.grant_types_supported = params[:grant_types_supported].split
       end
 
       def update_available_state

--- a/modules/openid_connect/app/services/openid_connect/providers/update_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/providers/update_service.rb
@@ -30,13 +30,15 @@ module OpenIDConnect
   module Providers
     class UpdateService < BaseServices::Update
       class AttributesContract < Dry::Validation::Contract
-        params do
-          OpenIDConnect::Provider::DISCOVERABLE_ATTRIBUTES_MANDATORY.each do |attribute|
+        json do
+          OpenIDConnect::Provider::DISCOVERABLE_STRING_ATTRIBUTES_MANDATORY.each do |attribute|
             required(attribute).filled(:string)
           end
-          OpenIDConnect::Provider::DISCOVERABLE_ATTRIBUTES_OPTIONAL.each do |attribute|
+          OpenIDConnect::Provider::DISCOVERABLE_STRING_ATTRIBUTES_OPTIONAL.each do |attribute|
             optional(attribute).filled(:string)
           end
+
+          optional(:grant_types_supported).array(:string)
         end
       end
 

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
         client_secret: Client secret
         secret: Secret
         scope: Scope
+        grant_types_supported: Supported grant types
         limit_self_registration: Limit self registration
         authorization_endpoint: Authorization endpoint
         userinfo_endpoint: User information endpoint

--- a/modules/openid_connect/spec/models/provider_spec.rb
+++ b/modules/openid_connect/spec/models/provider_spec.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "spec_helper"
+
+RSpec.describe OpenIDConnect::Provider do
+  let(:provider) do
+    create(:oidc_provider, options: {
+             "grant_types_supported" => supported_grant_types
+           })
+  end
+  let(:supported_grant_types) { %w[authorization_code implicit] }
+
+  describe "#token_exchange_capable?" do
+    subject { provider.token_exchange_capable? }
+
+    it { is_expected.to be_falsey }
+
+    context "when the provider supports the token exchange grant" do
+      let(:supported_grant_types) { %w[authorization_code implicit urn:ietf:params:oauth:grant-type:token-exchange] }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when supported grant types are nil (legacy providers)" do
+      let(:supported_grant_types) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
This is in preparation to enable authentication flows based on token exchange in the future. Using the `grant_types_supported` we can determine whether the IDP is capable of exchanging tokens and then use this information to indicate to users whether they are able to set-up token exchange based authentication for their storage provider.

# Ticket
[OP#58862](https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/58862)

# What are you trying to accomplish?
Allow to decide for a given IDP, whether it's able to perform token exchange or not.

# What approach did you choose and why?
We store the list of grant types available on the IDP, since this is a feature agnostic way to store information about the provider. This information is then used to implement the `Provider#token_exchange_capable?` method, which is specific to the token exchange feature.

For editing the discovered information, I kept the UI simple by using a text input that accepts the grants in a space-delimited fashion. This solution was merely chosen to keep implementation complexity low, but is probably not the best UX we can offer. Assuming that most users will fill this information through a discovery endpoint, the solution might be sufficient, though.

# Screenshots

![image](https://github.com/user-attachments/assets/5dc606ed-6388-4220-b734-44b07f1d8e83)

# Merge checklist

- [x] Added/updated tests
- [x] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [x] Tested ~~major browsers (Chrome, Firefox, Edge, ...)~~ in one browser
