### PR TITLE
Restore fetch changesets functionality

### DIFF
--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -43,6 +43,24 @@ class SysController < ActionController::Base
     end
   end
 
+  def fetch_changesets
+    projects = []
+    if params[:id]
+      projects << Project.active.has_module(:repository).find_by!(identifier: params[:id])
+    else
+      projects = Project.active.has_module(:repository)
+                        .includes(:repository).references(:repositories)
+    end
+    projects.each do |project|
+      if project.repository
+        project.repository.fetch_changesets
+      end
+    end
+    head :ok
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
   private
 
   def authorized?(project, user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -703,8 +703,8 @@ Rails.application.routes.draw do
 
   scope controller: "sys" do
     match "/sys/repo_auth", action: "repo_auth", via: %i[get post]
+    get "/sys/fetch_changesets", action: "fetch_changesets"
     match "/sys/projects", to: proc { [410, {}, [""]] }, via: :all
-    match "/sys/fetch_changesets", to: proc { [410, {}, [""]] }, via: :all
     match "/sys/projects/:id/repository/update_storage", to: proc { [410, {}, [""]] }, via: :all
   end
 


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/details/59922/overview?query_id=5309

Restores the `fetch_changeset` functionality removed in https://github.com/opf/openproject/pull/17048, as not unused and no replacement available.