### PR TITLE
Feature/58565 redirect users to the app

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,16 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "3YGZQ7TQ78.org.openproject.app",
+        "paths": [ "*" ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": [
+      "3YGZQ7TQ78.org.openproject.app"
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,8 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.openproject.app",
+    "sha256_cert_fingerprints": ["45:FE:6C:9C:94:21:B8:E4:4A:69:BA:5E:C1:22:9C:3D:01:6B:6A:69:22:CF:25:F6:42:78:5E:20:7B:25:99:33"]
+  }
+}]


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/mobile-app-spike/work_packages/58565/

# What are you trying to accomplish?
Adding an ability to open openproject links directly in the mobile apps. Ideally if the mobile app is installed, after clicking on the link "Notification center" in your email you'll be redirected to the app's Notification center. 

## Screenshots
<img width="589" alt="Screenshot 2024-12-06 at 14 12 18" src="https://github.com/user-attachments/assets/f09a8c02-2217-4c6a-8138-945e5c7cc2ba">

# What approach did you choose and why?
https://docs.flutter.dev/cookbook/navigation/set-up-app-links
https://docs.flutter.dev/cookbook/navigation/set-up-universal-links

# Merge checklist
- not tested. the only way for us to test is to upload to the server and check in the app. 