### PR TITLE
[#59853] allow editing of hierarchy cfs in wp table

### DIFF
--- a/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
@@ -104,8 +104,9 @@ export function initializeCoreDisplayFields(displayFieldService:DisplayFieldServ
         'TimeEntriesActivity',
         'Version',
         'Category',
+        'CustomField::Hierarchy::Item',
         'CustomOption'])
-      .addFieldType(ResourcesDisplayField, 'resources', ['[]CustomOption'])
+      .addFieldType(ResourcesDisplayField, 'resources', ['[]CustomOption', '[]CustomField::Hierarchy::Item'])
       .addFieldType(ResourcesDisplayField, 'resources', ['[]Version'])
       .addFieldType(MultipleUserFieldModule, 'users', ['[]User'])
       .addFieldType(FormattableDisplayField, 'formattable', ['Formattable'])

--- a/frontend/src/app/shared/components/fields/display/field-types/text-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/text-display-field.module.ts
@@ -27,22 +27,5 @@
 //++
 
 import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import isArrayOf from 'core-app/core/state/is-array-of';
 
-export class TextDisplayField extends DisplayField {
-  public get valueString():string {
-    // render a text representation for the assigned attribute, independent of the attribute being a resource,
-    // an array of resources or a single text value.
-
-    if (this.value instanceof HalResource) {
-      return this.value.name;
-    }
-
-    if (isArrayOf(this.value, HalResource)) {
-      return this.value.map((r) => r.name).join(', ');
-    }
-
-    return this.value as string;
-  }
-}
+export class TextDisplayField extends DisplayField {}


### PR DESCRIPTION
# Ticket
[OP#59853](https://community.openproject.org/wp/59853)

# What are you trying to accomplish?
- enable editing of multi-select custom fields of type hierarchy in the work package table

# What approach did you choose and why?
- revert change to TextDisplayField
- add correct types of custom field values to display field registry service

