### PR TITLE
Fix auto-discovery of OIDC details to be too eager

### DIFF
--- a/modules/openid_connect/app/components/openid_connect/providers/sections/form_component.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/sections/form_component.rb
@@ -30,7 +30,7 @@
 
 module OpenIDConnect::Providers::Sections
   class FormComponent < ::Saml::Providers::Sections::SectionComponent
-    attr_reader :edit_state, :next_edit_state, :edit_mode
+    attr_reader :edit_state, :next_edit_state, :edit_mode, :fetch_metadata
 
     def initialize(provider,
                    edit_state:,
@@ -39,7 +39,8 @@ module OpenIDConnect::Providers::Sections
                    banner: nil,
                    banner_scheme: :default,
                    next_edit_state: nil,
-                   edit_mode: nil)
+                   edit_mode: nil,
+                   fetch_metadata: false)
       super(provider)
 
       @edit_state = edit_state
@@ -49,6 +50,7 @@ module OpenIDConnect::Providers::Sections
       @heading = heading
       @banner = banner
       @banner_scheme = banner_scheme
+      @fetch_metadata = fetch_metadata
     end
 
     def url
@@ -61,9 +63,9 @@ module OpenIDConnect::Providers::Sections
 
     def form_url_params
       if edit_mode
-        { edit_state:, edit_mode:, next_edit_state: }
+        { edit_state:, fetch_metadata:, edit_mode:, next_edit_state: }
       else
-        { edit_state: }
+        { edit_state:, fetch_metadata: }
       end
     end
 

--- a/modules/openid_connect/app/components/openid_connect/providers/view_component.html.erb
+++ b/modules/openid_connect/app/components/openid_connect/providers/view_component.html.erb
@@ -22,7 +22,8 @@
                                        edit_state:,
                                        next_edit_state: :client_details,
                                        edit_mode:,
-                                       heading: nil
+                                       heading: nil,
+                                       fetch_metadata: true
                                      )
                                   else
                                     OpenIDConnect::Providers::Sections::ShowComponent.new(
@@ -44,6 +45,7 @@
             edit_state:,
             edit_mode:,
             heading: nil,
+            fetch_metadata: true
           ))
         else
           render(OpenIDConnect::Providers::Sections::ShowComponent.new(
@@ -66,7 +68,8 @@
                                        edit_state:,
                                        next_edit_state: :client_details,
                                        edit_mode:,
-                                       heading: nil
+                                       heading: nil,
+                                       fetch_metadata: true
                                      )
                                   else
                                     OpenIDConnect::Providers::Sections::ShowComponent.new(
@@ -87,7 +90,8 @@
             form_class: OpenIDConnect::Providers::ClientDetailsForm,
             edit_state:,
             edit_mode:,
-            heading: nil
+            heading: nil,
+            fetch_metadata: true
           ))
         else
           render(OpenIDConnect::Providers::Sections::ShowComponent.new(
@@ -137,7 +141,8 @@
             heading: nil,
             edit_state:,
             edit_mode:,
-            next_edit_state: :metadata_details
+            next_edit_state: :metadata_details,
+            fetch_metadata: true
           ))
         else
           render(OpenIDConnect::Providers::Sections::ShowComponent.new(

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -67,7 +67,7 @@ module OpenIDConnect
                         .permit(:display_name, :oidc_provider, :limit_self_registration,
                                 *OpenIDConnect::Provider.stored_attributes[:options])
       call = OpenIDConnect::Providers::UpdateService
-        .new(model: @provider, user: User.current)
+        .new(model: @provider, user: User.current, fetch_metadata: fetch_metadata?)
         .call(update_params)
 
       if call.success?
@@ -161,6 +161,10 @@ module OpenIDConnect
       @edit_state = params[:edit_state].to_sym if params.key?(:edit_state)
       @edit_mode = ActiveRecord::Type::Boolean.new.cast(params[:edit_mode])
       @next_edit_state = params[:next_edit_state].to_sym if params.key?(:next_edit_state)
+    end
+
+    def fetch_metadata?
+      params[:fetch_metadata] == "true"
     end
   end
 end

--- a/modules/openid_connect/app/services/openid_connect/providers/update_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/providers/update_service.rb
@@ -40,10 +40,16 @@ module OpenIDConnect
         end
       end
 
+      def initialize(*, fetch_metadata: false, **)
+        super(*, **)
+
+        @fetch_metadata = fetch_metadata
+      end
+
       def after_validate(_params, call)
         model = call.result
         metadata_url = get_metadata_url(model)
-        return call if metadata_url.blank?
+        return call if metadata_url.blank? || !@fetch_metadata
 
         extract_metadata(call, metadata_url, model)
       end


### PR DESCRIPTION
For custom providers it was not possible to overwrite the discovered default settings, because the discovery would be re-triggered every time that any update was performed, thereby overwriting the custom settings just entered.

The only way out so far was to completely remove the metadata_url from the provider.

For custom providers the discovery now only takes place on the form where the metadata_url is being entered, not on other forms. For Google and Microsoft discovery remains active on all forms. Due to further implementation details this means that on creation they will first fetch their metadata when saving the client details form, while during edit they will also refetch on the name form (where Entra allows changing the tenant, which influences the URLs).

# Ticket
[OP#59928](https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/59928)

# What approach did you choose and why?

I made the fetching of settings from the OIDC Discovery endpoint an optional behaviour of the `UpdateService`. This behaviour is now controllable through a query parameter to the update endpoint.

This solution provided the smallest delta to what we already have. It's discussable whether the whole behaviour should be extracted to somewhere else. For example it surprised me at first, that during creation of an Entra provider, we do not fetch the endpoint details. However, we never did that, since the `CreateService` doesn't have the corresponding code.

This leads to the somewhat inconsistent behaviour that custom providers will only refetch their details on one form, while Google and Entra will refetch on all forms.

# Merge checklist

- [ ] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [x] Tested ~~major browsers (Chrome, Firefox, Edge, ...)~~ in a single browser
