### PR TITLE
Eager load CF available formats

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -66,7 +66,7 @@ class CustomField < ApplicationRecord
     errors.add(:name, :taken) if name.in?(taken_names)
   end
 
-  validates :field_format, inclusion: { in: OpenProject::CustomFieldFormat.available_formats }
+  validates :field_format, inclusion: { in: -> { OpenProject::CustomFieldFormat.available_formats } }
 
   validate :validate_default_value
   validate :validate_regex


### PR DESCRIPTION
# What are you trying to accomplish?
Eager load OpenProject::CustomFieldFormat.available_formats in CF validation. 

# What approach did you choose and why?
While developing a plugin which adds new CF format(time), encountered problem: unable to create new CF of the new type at certain environments: semi-prod(docker-compose), developer env with dependencies on host(without containers) and dev with docker — all environments gave different results. (Because of zeitwerk and hot reload?)

To create new type i'm using `OpenProject::CustomFieldFormat.register` with to_prepare block. And we have 
`validates :field_format, inclusion: { in: OpenProject::CustomFieldFormat.available_formats }` in CF model. This validator evaluates on boot stage, before module with registrations is runned so we have correct forms filled in runtime and wrong validations when updating and creating CFs. So one of the solutions is to wrap fetching formats into lambda.

Not sure if it relevant for project, as all custom fields types are registered in initializers and there's no such problem, but still I think it's a kinda bug :) 