### PR TITLE
attempt to stabilize flickering wp ancestor spec

### DIFF
--- a/spec/features/work_packages/update_ancestors_spec.rb
+++ b/spec/features/work_packages/update_ancestors_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe "Update ancestors", :js, :with_cuprite do
   shared_let(:query) do
     create(:query,
            show_hierarchies: true,
-           column_names: %i[id status estimated_hours remaining_hours done_ratio subject])
+           column_names: %i[id status estimated_hours remaining_hours done_ratio subject],
+           sort_criteria: [["id", "asc"]])
   end
 
   let(:wp_table) { Pages::WorkPackagesTable.new project }


### PR DESCRIPTION
Stabilize flickering

`rspec ./spec/features/work_packages/update_ancestors_spec.rb:174`

This is done by specifying an order for the query. Before that, it might have happend that 'second child' which first is outdented ends up at the top of the table. When the spec then tries to indent it again, it can't since that option is only available in case there is a work package above the manipulated entry.

## Screenshots

The screenshot shows how second child is the first element in the table. Taken from a failing test run.

![Dec 9 Screenshot from OpenProject](https://github.com/user-attachments/assets/473f4485-9304-435e-beec-40e551afb08f)

