### PR TITLE
Fix parsing of claims through ENVs

### DIFF
--- a/modules/openid_connect/app/services/openid_connect/configuration_mapper.rb
+++ b/modules/openid_connect/app/services/openid_connect/configuration_mapper.rb
@@ -47,7 +47,7 @@ module OpenIDConnect
         "host" => options["host"],
         "port" => options["port"],
         "scheme" => options["scheme"],
-        "claims" => options["claims"],
+        "claims" => extract_claims(options["claims"]),
         "tenant" => options["tenant"],
         "post_logout_redirect_uri" => options["post_logout_redirect_uri"],
         "limit_self_registration" => options["limit_self_registration"],
@@ -68,6 +68,15 @@ module OpenIDConnect
     end
 
     private
+
+    def extract_claims(claims_value)
+      case claims_value
+      when Hash
+        claims_value.to_json
+      else
+        claims_value.to_s
+      end
+    end
 
     def extract_scope(value)
       return if value.blank?

--- a/modules/openid_connect/spec/services/openid_connect/configuration_mapper_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/configuration_mapper_spec.rb
@@ -136,6 +136,45 @@ RSpec.describe OpenIDConnect::ConfigurationMapper, type: :model do
     end
   end
 
+  describe "claims" do
+    subject { result["claims"] }
+
+    let(:parsed_hash) do
+      {
+        "id_token" => {
+          "roles" => {
+            "essential" => true,
+            "values" => ["openproject.login"]
+          }
+        }
+      }
+    end
+
+    context "when provided as string" do
+      let(:configuration) { { claims: parsed_hash.to_json } }
+
+      it "outputs as a string", :aggregate_failures do
+        expect(subject).to be_a String
+        expect(JSON.parse(subject)).to eq(parsed_hash)
+      end
+    end
+
+    context "when provided as Hash" do
+      let(:configuration) { { claims: parsed_hash } }
+
+      it "converts to string", :aggregate_failures do
+        expect(subject).to be_a String
+        expect(JSON.parse(subject)).to eq(parsed_hash)
+      end
+    end
+
+    context "when not provided" do
+      let(:configuration) { {} }
+
+      it { is_expected.to be_blank }
+    end
+  end
+
   %w[authorization_endpoint token_endpoint userinfo_endpoint end_session_endpoint jwks_uri].each do |key|
     describe "setting #{key}" do
       subject { result }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/59962

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Be more lax in the configuration mapper for OIDC settings, and allow a Hash being passed that our settings parse automatically given on the quoting.
