### PR TITLE
Add docker-compose.yml for nextcloud development

### DIFF
--- a/docker/dev/nextcloud/README.md
+++ b/docker/dev/nextcloud/README.md
@@ -1,0 +1,15 @@
+A minimal setup to run a Nextcloud inside the TLS-enabled docker development stack.
+
+# First installation steps
+
+1. Allow accessing OP through `openproject.local`:
+    * `docker compose exec --user www-data nextcloud php occ config:system:set allow_local_remote_servers --value 1`
+2. Import Dev CA cert into Nextcloud's own certificate store:
+    * `docker compose cp /path/to/your/OpenProject_Development_Root_CA.crt nextcloud:/tmp/root.crt`
+    * `docker compose exec nextcloud chown www-data /tmp/root.crt`
+    * `docker compose exec --user www-data nextcloud php occ security:certificates:import /tmp/root.crt`
+3. Following [docs](https://docs.nextcloud.com/server/30/admin_manual/configuration_server/reverse_proxy_configuration.html#defining-trusted-proxies) configure Traefik as trusted proxy
+    * e.g. add `'trusted_proxies' => ['172.0.0.0/8'],` to `config/config.php` for a pretty broad allowance for most docker services (verify that your `gateway` network uses IPs in the given address range)
+4. Download/Activate Nextcloud plugins:
+    * `integration_openproject`
+    * `groupfolders` (dependency for certain OP functions)

--- a/docker/dev/nextcloud/docker-compose.yml
+++ b/docker/dev/nextcloud/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  nextcloud:
+    image: nextcloud:stable
+    restart: unless-stopped
+    networks:
+      - gateway
+    volumes:
+      - nextcloud:/var/www/html
+      #   If you want to use a local version of a plugin, mount a local folder
+      #   more detailed instructions available at https://github.com/nextcloud/integration_openproject/blob/master/docs/setup_via_docker.md
+      # - ../nextcloud_apps:/var/www/html/custom_apps
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.local`)"
+      - "traefik.http.routers.nextcloud.entrypoints=websecure"
+
+  cron:
+    image: nextcloud:stable
+    restart: unless-stopped
+    volumes:
+      - nextcloud:/var/www/html
+      #   If you want to use a local version of a plugin, mount a local folder
+      #   more detailed instructions available at https://github.com/nextcloud/integration_openproject/blob/master/docs/setup_via_docker.md
+      # - ../nextcloud_apps:/var/www/html/custom_apps
+    networks:
+      - gateway
+    entrypoint: /cron.sh
+
+networks:
+  gateway:
+    external: true
+    name: gateway
+
+volumes:
+  nextcloud:


### PR DESCRIPTION
This is similar to what we already have for Keycloak and GitLab in providing a minimal docker-compose file for integration work.

# Ticket
https://community.openproject.org/projects/document-workflows-stream/work_packages/59937/activity