### PR TITLE
Implementation/59970 introduce enterprise banner viewcomponent

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -19,3 +19,4 @@
 @import "work_packages/exports/modal_dialog_component"
 @import "work_package_relations_tab/index_component"
 @import "users/hover_card_component"
+@import "enterprise_edition/banner_component"

--- a/app/components/enterprise_edition/banner_component.html.erb
+++ b/app/components/enterprise_edition/banner_component.html.erb
@@ -1,0 +1,19 @@
+<%=
+  grid_layout("op-ee-banner", **@system_arguments) do |grid|
+    grid.with_area(:'icon-container') do
+      content_tag :div, class: "op-ee-banner--shield" do
+        render(Primer::Beta::Octicon.new(icon: 'op-enterprise-addons',
+                                         size: :medium,
+                                         classes: "op-ee-banner--icon"))
+      end
+    end
+    grid.with_area(:'title-container') { render(Primer::Beta::Text.new) { title } }
+    grid.with_area(:'description-container') { render(Primer::Beta::Text.new) { description } }
+    grid.with_area(:'link-container') do
+      render(Primer::Beta::Link.new(href: href)) do |link|
+        link.with_trailing_visual_icon(icon: 'link-external')
+        link_title
+      end
+    end
+  end
+%>

--- a/app/components/enterprise_edition/banner_component.rb
+++ b/app/components/enterprise_edition/banner_component.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module EnterpriseEdition
+  # Add a general description of component here
+  # Add additional usage considerations or best practices that may aid the user to use the component correctly.
+  # @accessibility Add any accessibility considerations
+  class BannerComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    # @param feature_key [Symbol, NilClass] The key of the feature to show the banner for.
+    # @param title [String] The title of the banner.
+    # @param description [String] The description of the banner.
+    # @param href [String] The URL to link to.
+    # @param skip_render [Boolean] Whether to skip rendering the banner.
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(feature_key,
+                   title: nil,
+                   description: nil,
+                   link_title: nil,
+                   href: nil,
+                   skip_render: !EnterpriseToken.show_banners?,
+                   **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = "div"
+      super
+
+      @feature_key = feature_key
+      @title = title
+      @description = description
+      @link_title = link_title
+      @href = href
+      @skip_render = skip_render
+    end
+
+    private
+
+    attr_reader :skip_render,
+                :feature_key
+
+    def title
+      @title || I18n.t("ee.upsale.#{feature_key}.title", default: I18n.t("ee.upsale.title"))
+    end
+
+    def description
+      @description || begin
+        I18n.t("ee.upsale.#{feature_key}.description")
+      rescue StandardError
+        I18n.t("ee.upsale.#{feature_key}.description_html")
+      end
+    rescue I18n::MissingTranslationData => e
+      raise e.exception(
+        <<~TEXT.squish
+          The expected '#{I18n.locale}.ee.upsale.#{feature_key}.description' key does not exist.
+          Ideally, provide it in the locale file.
+          If that isn't applicable, a description parameter needs to be provided.
+        TEXT
+      )
+    end
+
+    def link_title
+      @link_title || I18n.t("ee.upsale.#{feature_key}.link_title", default: I18n.t("ee.upsale.link_title"))
+    end
+
+    def href
+      href_value = @href || OpenProject::Static::Links.links.dig(:enterprise_docs, feature_key, :href)
+
+      unless href_value
+        raise "Neither a custom href is provided nor is a value set " \
+              "in OpenProject::Static::Links.enterprise_docs[#{feature_key}][:href]"
+      end
+
+      href_value
+    end
+
+    def render?
+      !skip_render
+    end
+  end
+end

--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -1,0 +1,68 @@
+/*!
+ / -- copyright
+ / OpenProject is an open source project management software.
+ / Copyright (C) 2024 the OpenProject GmbH
+ /
+ / This program is free software; you can redistribute it and/or
+ / modify it under the terms of the GNU General Public License version 3.
+ /
+ / OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ / Copyright (C) 2006-2013 Jean-Philippe Lang
+ / Copyright (C) 2010-2013 the ChiliProject Team
+ /
+ / This program is free software; you can redistribute it and/or
+ / modify it under the terms of the GNU General Public License
+ / as published by the Free Software Foundation; either version 2
+ / of the License, or (at your option) any later version.
+ /
+ / This program is distributed in the hope that it will be useful,
+ / but WITHOUT ANY WARRANTY; without even the implied warranty of
+ / MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ / GNU General Public License for more details.
+ /
+ / You should have received a copy of the GNU General Public License
+ / along with this program; if not, write to the Free Software
+ / Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ /
+ / See COPYRIGHT and LICENSE files for more details.
+ / ++
+ /
+
+$op-ee-banner--shield-width: 32px
+
+// This is not named op-enterprise-banner because as of now, there is still a legacy angular component that uses that block name.
+.op-ee-banner
+  display: grid
+  grid-template-columns: $op-ee-banner--shield-width auto auto
+  grid-template-areas: "icon-container title-container" "icon-container description-container" "icon-container link-container"
+  grid-column-gap: 0.5rem
+  justify-content: left
+  @media screen and (min-width: $breakpoint-md)
+    grid-template-areas: "icon-container title-container title-container" "icon-container description-container link-container"
+
+  &--icon-container
+    @extend .upsale-colored
+    align-self: start
+    justify-self: center
+
+  &--shield
+    @extend .upsale-border-colored
+    width: $op-ee-banner--shield-width
+    height: 42px
+    border-width: 10px 5px 10px 5px
+    border-radius: 0 0 10px 10px
+    border-style: solid
+    display: flex
+    align-items: center
+    justify-content: center
+
+  &--icon
+    width: $op-ee-banner--shield-width
+    height: $op-ee-banner--shield-width
+
+  &--title-container
+    @extend .upsale-colored
+    font-weight: bold
+
+  &--link-container
+    align-self: end

--- a/app/components/shares/project_queries/upsale_component.html.erb
+++ b/app/components/shares/project_queries/upsale_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   modal_content.with_row(data: { 'test-selector': 'op-share-dialog-upsale-block' }) do
     render Primer::OpenProject::FeedbackMessage.new(icon_arguments: { icon: :"op-enterprise-addons", classes: "upsale-colored" }, border: true) do |component|
-      component.with_heading(tag: :h2, classes: 'upsale-colored').with_content(I18n.t(:label_enterprise_addon))
+      component.with_heading(tag: :h2, classes: 'upsale-colored').with_content(I18n.t(:"ee.upsale.title"))
       component.with_description { I18n.t('sharing.project_queries.upsale.message') }
 
       href = "#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=project-list-sharing-modal"

--- a/app/components/shares/work_packages/modal_upsale_component.html.erb
+++ b/app/components/shares/work_packages/modal_upsale_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   component_wrapper(tag: 'turbo-frame') do
     render Primer::OpenProject::FeedbackMessage.new(icon_arguments: { icon: :"op-enterprise-addons", classes: "upsale-colored" }, border: true) do |component|
-      component.with_heading(tag: :h2, classes: 'upsale-colored').with_content(I18n.t(:label_enterprise_addon))
+      component.with_heading(tag: :h2, classes: 'upsale-colored').with_content(I18n.t(:"ee.upsale.title"))
       component.with_description { I18n.t('mail.sharing.work_packages.enterprise_text') }
 
       href = "#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=work-package-sharing-modal"

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -224,7 +224,7 @@ module CustomFieldsHelper
     label = format.label.is_a?(Proc) ? format.label.call : I18n.t(format.label)
 
     show_enterprise_text = format_string == "hierarchy" && !EnterpriseToken.allows_to?(:custom_field_hierarchies)
-    suffix = show_enterprise_text ? " (#{I18n.t(:label_enterprise_addon)})" : ""
+    suffix = show_enterprise_text ? " (#{I18n.t(:"ee.upsale.title")})" : ""
 
     "#{label}#{suffix}"
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1854,8 +1854,6 @@ en:
         description: "Customize the form configuration with these additional add-ons:"
         add_groups: "Add new attribute groups"
         rename_groups: "Rename attributes groups"
-      project_filters:
-        description_html: "Filtering and sorting on custom fields is an Enterprise edition add-on."
 
   enumeration_activities: "Time tracking activities"
   enumeration_work_package_priorities: "Work package priorities"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1848,6 +1848,8 @@ en:
 
   ee:
     upsale:
+      title: "Enterprise add-on"
+      link_title: "More information"
       form_configuration:
         description: "Customize the form configuration with these additional add-ons:"
         add_groups: "Add new attribute groups"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2407,7 +2407,6 @@ en:
   label_enterprise_active_users: "%{current}/%{limit} booked active users"
   label_enterprise_edition: "Enterprise edition"
   label_enterprise_support: "Enterprise support"
-  label_enterprise_addon: "Enterprise add-on"
   label_environment: "Environment"
   label_estimates_and_progress: "Estimates and progress"
   label_equals: "is"

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -55,6 +55,9 @@
 .upsale-colored
   color: $spot-color-feedback-warning-dark
 
+.upsale-border-colored
+  border-color: $spot-color-feedback-warning-dark
+
 .widget-box--blocks--upsale-title
   font-weight: 400
   font-size: 20px

--- a/lookbook/previews/open_project/enterprise_edition/banner_component_preview.rb
+++ b/lookbook/previews/open_project/enterprise_edition/banner_component_preview.rb
@@ -1,0 +1,79 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module OpenProject
+  module EnterpriseEdition
+    # @logical_path OpenProject/EnterpriseEdition
+    class BannerComponentPreview < Lookbook::Preview
+      # The easiest way to render the banner component is to provide a feature key and
+      # have the assorted data structures match the expectations.
+      # The text will be fetched from the i18n files:
+      # ```
+      # en:
+      #   ee:
+      #     # Title used unless it is overwritten for the specific feature
+      #     title: "Enterprise add-on"
+      #     # Title of the link used unless it is overwritten for the specific feature
+      #     link_title: "More information"
+      #     upsale:
+      #       [feature_key]:
+      #         # Title used for this feature only. If this is missing, the default title is used.
+      #         title: "A splendid feature"
+      #         # Could also be description_html if necessary
+      #         description: "This is a splendid feature that you should use. It just might transform your life."
+      #         # Title of the link used for this feature only. If this is missing, the default link title is used.
+      #         title_link: "Even more information"
+      # ```
+      #
+      # The href is inferred from `OpenProject::Static::Links.enterprise_docs[feature_key][:href]`.
+      #
+      # The value of `EnterpriseToken.show_banners?` is used to determine whether the banner should be shown. For this
+      # example, that value is overwritten as the banner might otherwise not show up in the preview.
+      def default
+        render(
+          ::EnterpriseEdition::BannerComponent
+            .new(:form_configuration,
+                 skip_render: false)
+        )
+      end
+
+      # The defaults can be completely overwritten. This should be used sparingly.
+      def manual_overwrite
+        render(
+          ::EnterpriseEdition::BannerComponent
+            .new(nil,
+                 title: "A splendid feature",
+                 description: "This is a splendid feature that you should use. It just might transform your life.",
+                 href: "https://www.openproject.org",
+                 link_title: "Get more information",
+                 skip_render: false)
+        )
+      end
+    end
+  end
+end

--- a/spec/components/enterprise_edition/banner_component_spec.rb
+++ b/spec/components/enterprise_edition/banner_component_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
+  let(:title) { "Some title" }
+  let(:description) { "Some description" }
+  let(:href) { "https://www.example.org" }
+  let(:link_title) { "Get more information" }
+  let(:ee_show_banners) { true }
+  let(:enforce_available_locales) { I18n.config.enforce_available_locales }
+  let(:i18n_upsale) do
+    {
+      title:,
+      link_title:,
+      some_enterprise_feature: {
+        description:
+      }
+    }
+  end
+  let(:static_links) do
+    {
+      enterprise_docs: {
+        some_enterprise_feature: {
+          href:
+        }
+      }
+    }
+  end
+
+  let(:render_component) do
+    render_inline(described_class.new(:some_enterprise_feature))
+  end
+
+  let(:render_component_in_mo) do
+    I18n.with_locale :mo do
+      render_component
+    end
+  end
+
+  before do
+    allow(EnterpriseToken)
+      .to receive(:show_banners?)
+            .and_return(ee_show_banners)
+    allow(OpenProject::Static::Links)
+      .to receive(:links)
+            .and_return(static_links)
+
+    I18n.config.enforce_available_locales = !enforce_available_locales
+
+    I18n.backend.store_translations(
+      :mo,
+      {
+        ee: {
+          upsale: i18n_upsale
+        }
+      }
+    )
+  end
+
+  after do
+    I18n.backend.translations.delete(:mo)
+    I18n.config.enforce_available_locales = enforce_available_locales
+  end
+
+  shared_examples_for "renders the component" do
+    it "renders the component" do
+      render_component_in_mo
+
+      expect(page).to have_css ".op-ee-banner--title-container", text: title
+      expect(page).to have_css ".op-ee-banner--description-container", text: description
+      expect(page).to have_link link_title, href:
+    end
+  end
+
+  it_behaves_like "renders the component"
+
+  context "with a description_html in the i18n file" do
+    let(:i18n_upsale) do
+      {
+        title:,
+        link_title:,
+        some_enterprise_feature: {
+          description_html: description
+        }
+      }
+    end
+
+    it_behaves_like "renders the component"
+  end
+
+  context "with a more specific title in the i18n file" do
+    let(:i18n_upsale) do
+      {
+        title: "The general title",
+        link_title:,
+        some_enterprise_feature: {
+          title:,
+          description:
+        }
+      }
+    end
+
+    it_behaves_like "renders the component"
+  end
+
+  context "with a more specific link title in the i18n file" do
+    let(:i18n_upsale) do
+      {
+        title:,
+        link_title: "The general link title",
+        some_enterprise_feature: {
+          link_title:,
+          description:
+        }
+      }
+    end
+
+    it_behaves_like "renders the component"
+  end
+
+  context "without a description key in the i18n file" do
+    let(:i18n_upsale) do
+      {
+        title:,
+        link_title:,
+        some_enterprise_feature: {}
+      }
+    end
+
+    it "raises an error" do
+      expect { render_component_in_mo }.to raise_error(I18n::MissingTranslationData)
+    end
+  end
+
+  context "without a link key in the static_link file" do
+    let(:static_links) do
+      {
+        enterprise_docs: {
+          some_enterprise_feature: {}
+        }
+      }
+    end
+
+    it "raises an error" do
+      expect { render_component_in_mo }.to raise_error(RuntimeError)
+    end
+  end
+
+  context "if banners are hidden" do
+    let(:ee_show_banners) { false }
+
+    it "hides the component" do
+      render_component_in_mo
+
+      expect(page).to have_no_css ".op-ee-banner"
+    end
+  end
+
+  context "if banners are hidden but skip_render is overwritten" do
+    let(:ee_show_banners) { false }
+    let(:render_component) do
+      render_inline(described_class.new(:some_enterprise_feature,
+                                        skip_render: false))
+    end
+
+    it_behaves_like "renders the component"
+  end
+end

--- a/spec/support/components/sharing/share_modal.rb
+++ b/spec/support/components/sharing/share_modal.rb
@@ -380,7 +380,7 @@ module Components
       def expect_upsale_banner
         within_modal do
           expect(page)
-            .to have_text(I18n.t(:label_enterprise_addon))
+            .to have_text(I18n.t(:"ee.upsale.title"))
         end
       end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59970

# What are you trying to accomplish?

Introduce a ViewComponent to be used when rendering a banner. It will be used first within the project lifecycle administration but should ideally be used throughout the application eventually.

## Screenshots

<img width="783" alt="image" src="https://github.com/user-attachments/assets/be39a098-c62c-4350-92a7-c517a3e60b30">


# What approach did you choose and why?

The component enforces i18n and link href to be at a standard location so that it is easier to find the appropriate place for this kind of information.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
