### PR TITLE
Make keycloak setup more consistent

### DIFF
--- a/docker/dev/keycloak/docker-compose.yml
+++ b/docker/dev/keycloak/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   db-keycloak:
     image: postgres:13
-    restart: always
+    restart: unless-stopped
     networks:
       - external
     environment:
@@ -14,7 +14,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:21.1
     command: ["start-dev", "--proxy edge", "--spi-connections-http-client-default-disable-trust-manager=true"]
-    restart: no
+    restart: unless-stopped
     networks:
       - external
     extra_hosts:
@@ -28,7 +28,7 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - KC_DB_SCHEMA=public
       - KC_HOSTNAME=keycloak.local
-      - KC_FEATURES=token-exchange
+      - KC_FEATURES=token-exchange,admin-fine-grained-authz
       - KC_TRANSACTION_XA_ENABLED=false
     volumes:
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro


### PR DESCRIPTION
Giving operator control of restart by using unless-stopped. Previously it was in two extremes at the same time: The db would always restart, even if stopped, while the app server would never restart, even if it was running.

Also opting into a feature that's necessary to properly configure token exchange according to Keycloak docs at https://www.keycloak.org/securing-apps/token-exchange (While the docs say it's not needed for the internal to internal flow, I literally couldn't follow the instructions without this feature).

# Ticket
none

# What are you trying to accomplish?
Make the default setup for Keycloak more consistent.