### PR TITLE
attempt to stabilize flickering relations spec

### DIFF
--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe "Primerized work package relations tab",
                             results_selector: "body")
 
         expect_no_ng_option(autocomplete_field,
-                            work_package.id,
+                            work_package.subject,
                             results_selector: "body")
       end
     end


### PR DESCRIPTION
The spec used to check for the non existence of an .ng-option element with the text being the id of the current work package. Depending on the order the specs are run in it could happen that another work package ended up having that number as part of its subject. In such a case, that work package was returned.
Looking for the subject avoids the unspecificity.

## Screenshots

This screenshot shows the case where the searched for id is matching parts of the subject of the other work package. 

<img width="581" alt="image" src="https://github.com/user-attachments/assets/8869241f-d26d-4846-932e-94abc759aed5">
