### PR TITLE
Add a TurboAction that appends a caption to a primer form element

### DIFF
--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -74,8 +74,8 @@ module OpTurbo
       turbo_streams << target_component.insert_as_turbo_stream(component:, view_context:, action: :before)
     end
 
-    def render_error_flash_message_via_turbo_stream(**kwargs)
-      update_flash_message_via_turbo_stream(**kwargs.merge(scheme: :danger, icon: :stop))
+    def render_error_flash_message_via_turbo_stream(**)
+      update_flash_message_via_turbo_stream(**, scheme: :danger, icon: :stop)
     end
 
     def update_flash_message_via_turbo_stream(message:, component: OpPrimer::FlashComponent, **)
@@ -86,6 +86,12 @@ module OpTurbo
     def scroll_into_view_via_turbo_stream(target, behavior: :auto, block: :start)
       turbo_streams << OpTurbo::StreamComponent
         .new(action: :scroll_into_view, target:, behavior:, block:)
+        .render_in(view_context)
+    end
+
+    def add_caption_to_input_element_via_turbo_stream(target, caption:, clean_other_captions: true)
+      turbo_streams << OpTurbo::StreamComponent
+        .new(action: :addInputCaption, target:, caption:, clean_other_captions:)
         .render_in(view_context)
     end
 

--- a/frontend/src/turbo/input-caption-stream-action.ts
+++ b/frontend/src/turbo/input-caption-stream-action.ts
@@ -1,0 +1,24 @@
+import { StreamActions, StreamElement } from '@hotwired/turbo';
+
+export function registerInputCaptionStreamAction() {
+  StreamActions.addInputCaption = function addInputCaptionAction(this:StreamElement) {
+    const target = document.querySelector(this.target);
+    if (target) {
+      const formControl = (target as HTMLElement).closest('.FormControl') as HTMLElement;
+
+      if (this.getAttribute('clean_other_captions') === 'true') {
+        formControl
+          .querySelectorAll('.FormControl-caption')
+          .forEach((caption) => caption.remove());
+      }
+
+      const caption = this.getAttribute('caption');
+      if (caption && caption !== '') {
+        const span = document.createElement('span');
+        span.className = 'FormControl-caption';
+        span.innerText = caption;
+        formControl.append(span);
+      }
+    }
+  };
+}

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -4,6 +4,7 @@ import TurboPower from 'turbo_power';
 import { registerDialogStreamAction } from './dialog-stream-action';
 import { addTurboEventListeners } from './turbo-event-listeners';
 import { registerFlashStreamAction } from './flash-stream-action';
+import { registerInputCaptionStreamAction } from './input-caption-stream-action';
 import { addTurboGlobalListeners } from './turbo-global-listeners';
 import { applyTurboNavigationPatch } from './turbo-navigation-patch';
 import { debugLog, whenDebugging } from 'core-app/shared/helpers/debug_output';
@@ -29,6 +30,7 @@ addTurboEventListeners();
 addTurboGlobalListeners();
 registerDialogStreamAction();
 registerFlashStreamAction();
+registerInputCaptionStreamAction();
 
 // Apply navigational patch
 // https://github.com/hotwired/turbo/issues/1300
@@ -39,7 +41,9 @@ TurboPower.initialize(Turbo.StreamActions);
 
 // Error handling when "Content missing" returned
 document.addEventListener('turbo:frame-missing', (event:CustomEvent) => {
-  const { detail: { response, visit } } = event as { detail:{ response:Response, visit:(url:string) => void } };
+  const {
+    detail: { response, visit },
+  } = event as { detail:{ response:Response; visit:(url:string) => void } };
   event.preventDefault();
   visit(response.url);
 });


### PR DESCRIPTION
# Ticket
Part of https://community.openproject.org/work_packages/59037

# What are you trying to accomplish?
This turbo action allows to append a caption to a primer form control.

Example
```ruby
    def caption
      user = User.visible.find_by(id: params[:user_id])
      caption = if user.time_zone == User.current.time_zone
                  ""
                else
                  "time will be logged in the user's time zone: <strong>#{user.time_zone.name}</strong>"
                end
      add_caption_to_input_element_via_turbo_stream("#time_entry_hours", caption: caption, clean_other_captions: true)
      respond_with_turbo_streams
    end
```

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
