### PR TITLE
Changing the where into a find to avoid random weird ordering

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2369,6 +2369,7 @@ en:
   label_delete: "Delete"
   label_deleted: "deleted"
   label_deleted_custom_field: "(deleted custom field)"
+  label_deleted_custom_item: "(deleted item)"
   label_deleted_custom_option: "(deleted option)"
   label_empty_element: "(empty)"
   label_missing_or_hidden_custom_option: "(missing value or lacking permissions to access)"

--- a/lib/open_project/journal_formatter/custom_field/plain.rb
+++ b/lib/open_project/journal_formatter/custom_field/plain.rb
@@ -96,7 +96,7 @@ class OpenProject::JournalFormatter::CustomField::Plain < JournalFormatter::Base
     items = CustomField::Hierarchy::Item.where(id: ids).index_by(&:id)
 
     ids.map do |id|
-      next I18n.t(:label_deleted_custom_option) unless items[id]
+      next I18n.t(:label_deleted_custom_item) unless items[id]
 
       items[id].ancestry_path
     end.join(", ")

--- a/lib/open_project/journal_formatter/custom_field/plain.rb
+++ b/lib/open_project/journal_formatter/custom_field/plain.rb
@@ -93,7 +93,7 @@ class OpenProject::JournalFormatter::CustomField::Plain < JournalFormatter::Base
   def find_item_value(value, _custom_field)
     ids = value.split(",").map(&:to_i)
 
-    CustomField::Hierarchy::Item.where(id: ids).map do |item|
+    CustomField::Hierarchy::Item.find(ids).map do |item|
       next I18n.t(:label_deleted_custom_option) unless ids.include?(item.id)
 
       item.ancestry_path

--- a/lib/open_project/journal_formatter/custom_field/plain.rb
+++ b/lib/open_project/journal_formatter/custom_field/plain.rb
@@ -93,10 +93,12 @@ class OpenProject::JournalFormatter::CustomField::Plain < JournalFormatter::Base
   def find_item_value(value, _custom_field)
     ids = value.split(",").map(&:to_i)
 
-    CustomField::Hierarchy::Item.find(ids).map do |item|
-      next I18n.t(:label_deleted_custom_option) unless ids.include?(item.id)
+    items = CustomField::Hierarchy::Item.where(id: ids).index_by(&:id)
 
-      item.ancestry_path
+    ids.map do |id|
+      next I18n.t(:label_deleted_custom_option) unless items[id]
+
+      items[id].ancestry_path
     end.join(", ")
   end
 

--- a/spec/lib/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/journal_formatter/custom_field_spec.rb
@@ -469,6 +469,22 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
 
         it { expect(rendered).to be_html_eql(expected) }
       end
+
+      describe "with a deleted item" do
+        let(:values) { [[luke.id, -100].join(","), luke.id.to_s] }
+        let(:original_value) { [luke.ancestry_path, I18n.t(:label_deleted_custom_option)].join(", ") }
+        let(:formatted_value) { luke.ancestry_path }
+
+        let(:expected) do
+          I18n.t(:text_journal_changed_plain,
+                 label: "<strong>#{custom_field.name}</strong>",
+                 linebreak: "",
+                 old: "<i>#{original_value}</i>",
+                 new: "<i>#{formatted_value}</i>")
+        end
+
+        it { expect(rendered).to be_html_eql(expected) }
+      end
     end
   end
 end

--- a/spec/lib/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/journal_formatter/custom_field_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
 
       describe "with a deleted item" do
         let(:values) { [[luke.id, -100].join(","), luke.id.to_s] }
-        let(:original_value) { [luke.ancestry_path, I18n.t(:label_deleted_custom_option)].join(", ") }
+        let(:original_value) { [luke.ancestry_path, I18n.t(:label_deleted_custom_item)].join(", ") }
         let(:formatted_value) { luke.ancestry_path }
 
         let(:expected) do


### PR DESCRIPTION
We need to enforce a certain order on the returned items from the Plain formatter