### PR TITLE
Allow duration to be input with chronic duration

### DIFF
--- a/app/services/duration_converter.rb
+++ b/app/services/duration_converter.rb
@@ -96,7 +96,7 @@ class DurationConverter
       false
     end
 
-    def output(duration_in_hours)
+    def output(duration_in_hours, format: default_format)
       return duration_in_hours if duration_in_hours.nil?
 
       seconds = (duration_in_hours * 3600).to_i
@@ -142,7 +142,7 @@ class DurationConverter
                             **duration_length_options) / 3600.to_f
     end
 
-    def format
+    def default_format
       Setting.duration_format == "days_and_hours" ? :days_and_hours : :hours_only
     end
 

--- a/frontend/src/stimulus/controllers/dynamic/chronic-duration.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/chronic-duration.controller.ts
@@ -1,0 +1,68 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ *
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import { outputChronicDuration, parseChronicDuration } from 'core-app/shared/helpers/chronic_duration';
+
+export default class ChronicDurationController extends Controller<HTMLInputElement> {
+  private processChangeFn = () => this.onBlur();
+  private keyPressedFn = (evt:KeyboardEvent) => this.onKeyPress(evt);
+
+  connect() {
+    this.element.addEventListener('blur', this.processChangeFn);
+    this.element.addEventListener('keypress', this.keyPressedFn);
+  }
+
+  disconnect() {
+    super.disconnect();
+
+    this.element.removeEventListener('blur', this.processChangeFn);
+    this.element.removeEventListener('keypress', this.keyPressedFn);
+  }
+
+  private onBlur() {
+    const value = this.element.value;
+    const hours = parseChronicDuration(
+      value,
+      {
+        defaultUnit: 'hours', ignoreSecondsWhenColonSeperated: true,
+      },
+    );
+
+    this.element.value = outputChronicDuration(hours, { format: 'hours_only' }) || '';
+  }
+
+  private onKeyPress(evt:KeyboardEvent) {
+    if (evt.key === 'Enter' && evt.currentTarget === this.element) {
+      this.element.blur();
+    }
+  }
+}

--- a/modules/meeting/app/forms/meeting/time_group.rb
+++ b/modules/meeting/app/forms/meeting/time_group.rb
@@ -58,16 +58,17 @@ class Meeting::TimeGroup < ApplicationForm
       )
       group.text_field(
         name: :duration,
-        type: :number,
-        min: 0,
-        max: 24,
-        step: 0.05,
+        type: :text,
         value: @duration,
         placeholder: Meeting.human_attribute_name(:duration),
         label: Meeting.human_attribute_name(:duration),
         visually_hide_label: false,
         required: true,
-        caption: I18n.t("text_in_hours")
+        caption: I18n.t("text_in_hours"),
+        data: {
+          controller: "chronic-duration",
+          application_target: "dynamic"
+        }
       )
     end
   end
@@ -78,11 +79,18 @@ class Meeting::TimeGroup < ApplicationForm
     @meeting = meeting
     @initial_time = meeting.start_time_hour.presence || format_time(meeting.start_time, include_date: false, format: "%H:%M")
     @initial_date = meeting.start_date.presence || format_time_as_date(meeting.start_time, format: "%Y-%m-%d")
-    @duration =
-      if meeting.is_a?(RecurringMeeting) && meeting.template
-        meeting.template.duration
-      else
-        meeting.duration
-      end
+
+    duration = duration_value(meeting)
+    @duration = duration.nil? ? "" : ChronicDuration.output(duration * 3600, format: :hours_only)
+  end
+
+  private
+
+  def duration_value(meeting)
+    if meeting.is_a?(RecurringMeeting) && meeting.template
+      meeting.template.duration
+    else
+      meeting.duration
+    end
   end
 end

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -28,6 +28,7 @@
 
 class Meeting < ApplicationRecord
   include VirtualStartTime
+  include ChronicDuration
   include OpenProject::Journal::AttachmentHelper
 
   self.table_name = "meetings"
@@ -101,7 +102,9 @@ class Meeting < ApplicationRecord
 
   accepts_nested_attributes_for :participants, allow_destroy: true
 
-  validates_presence_of :title, :project_id, :duration
+  validates_presence_of :title, :project_id
+
+  validates_numericality_of :duration, greater_than: 0
 
   before_save :add_new_participants_as_watcher
 

--- a/modules/meeting/app/models/meeting/chronic_duration.rb
+++ b/modules/meeting/app/models/meeting/chronic_duration.rb
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Meeting::ChronicDuration
+  def duration=(value)
+    if value.is_a?(Numeric)
+      super
+    else
+      write_attribute(:duration, DurationConverter.parse(value))
+    end
+  end
+
+  def formatted_duration
+    DurationConverter.output(duration, format: :hours_only)
+  end
+end

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -207,4 +207,27 @@ RSpec.describe Meeting do
       expect(StructuredMeeting.acts_as_watchable_permission).to eq(:view_meetings)
     end
   end
+
+  describe "duration" do
+    it "accepts a float" do
+      meeting.duration = 1.5
+      expect(meeting).to be_valid
+      expect(meeting.duration).to eq(1.5)
+      expect(meeting.formatted_duration).to eq("1.5h")
+    end
+
+    it "accepts a string to be parsed by chronic" do
+      meeting.duration = "30m"
+      expect(meeting).to be_valid
+      expect(meeting.duration).to eq(0.5)
+      expect(meeting.formatted_duration).to eq("0.5h")
+    end
+
+    it "doesn't raise on nil" do
+      meeting.duration = nil
+      expect(meeting).not_to be_valid
+      expect(meeting.errors[:duration]).to include("is not a number.")
+      expect(meeting.formatted_duration).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/59404

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Allow entering duration with more human input than just decimals.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Parsing using ChronicDuration similar to what work is doing, and Time & Costs for Log time

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
