### PR TITLE
[#59997] create subject configuration admin UI iteration 1

### DIFF
--- a/app/components/work_packages/types/subject_configuration_component.html.erb
+++ b/app/components/work_packages/types/subject_configuration_component.html.erb
@@ -28,16 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { @type.name }
-    header.with_breadcrumbs(breadcrumb_items)
-
-    header.with_tab_nav(label: nil) do |tab_nav|
-      @tabs.each do |tab|
-        tab_nav.with_tab(selected: selected_tab(@tabs) == tab, href: tab[:path]) do |t|
-          t.with_text { I18n.t(tab[:label]) }
-        end
-      end
-    end if @tabs.present?
+  primer_form_with(**form_options) do |f|
+    render(WorkPackages::Types::SubjectConfigurationForm.new(f))
   end
 %>

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -38,7 +38,12 @@ module WorkPackages
         {
           url: "https://example.com",
           method: :put,
-          model:
+          model:,
+          data: {
+            application_target: "dynamic",
+            controller: "admin--subject-configuration",
+            admin__subject_configuration_hide_pattern_input_value: true
+          }
         }
       end
     end

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Types
+    class SubjectConfigurationComponent < ApplicationComponent
+      include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
+
+      def form_options
+        {
+          url: "https://example.com",
+          method: :put,
+          model:
+        }
+      end
+    end
+  end
+end

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Types
+    class SubjectConfigurationForm < ApplicationForm
+      form do |subject_form|
+        subject_form.radio_button_group(name: :subject_configuration) do |group|
+          group.radio_button(
+            value: "manual",
+            checked: !has_pattern?,
+            label: I18n.t("types.edit.subject_configuration.manually_editable_subjects.label"),
+            caption: I18n.t("types.edit.subject_configuration.manually_editable_subjects.caption")
+          )
+          group.radio_button(
+            value: "auto",
+            checked: has_pattern?,
+            label: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.label"),
+            caption: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.caption")
+          )
+        end
+
+        subject_form.text_field(
+          name: :pattern,
+          label: I18n.t("types.edit.subject_configuration.pattern.label"),
+          caption: I18n.t("types.edit.subject_configuration.pattern.caption"),
+          required: true,
+          input_width: :large
+        )
+
+        subject_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
+      end
+
+      private
+
+      def has_pattern?
+        false
+      end
+    end
+  end
+end

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -37,23 +37,27 @@ module WorkPackages
             value: "manual",
             checked: !has_pattern?,
             label: I18n.t("types.edit.subject_configuration.manually_editable_subjects.label"),
-            caption: I18n.t("types.edit.subject_configuration.manually_editable_subjects.caption")
+            caption: I18n.t("types.edit.subject_configuration.manually_editable_subjects.caption"),
+            data: { action: "admin--subject-configuration#hidePatternInput" }
           )
           group.radio_button(
             value: "auto",
             checked: has_pattern?,
             label: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.label"),
-            caption: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.caption")
+            caption: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.caption"),
+            data: { action: "admin--subject-configuration#showPatternInput" }
           )
         end
 
-        subject_form.text_field(
-          name: :pattern,
-          label: I18n.t("types.edit.subject_configuration.pattern.label"),
-          caption: I18n.t("types.edit.subject_configuration.pattern.caption"),
-          required: true,
-          input_width: :large
-        )
+        subject_form.group(data: { "admin--subject-configuration-target": "patternInput" }) do |toggleable_group|
+          toggleable_group.text_field(
+            name: :pattern,
+            label: I18n.t("types.edit.subject_configuration.pattern.label"),
+            caption: I18n.t("types.edit.subject_configuration.pattern.caption"),
+            required: true,
+            input_width: :large
+          )
+        end
 
         subject_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
       end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -33,19 +33,25 @@ module ::TypesHelper
         name: "settings",
         partial: "types/form/settings",
         path: edit_type_tab_path(id: @type.id, tab: :settings),
-        label: "types.edit.settings"
+        label: "types.edit.settings.tab"
       },
       {
         name: "form_configuration",
         partial: "types/form/form_configuration",
         path: edit_type_tab_path(id: @type.id, tab: :form_configuration),
-        label: "types.edit.form_configuration"
+        label: "types.edit.form_configuration.tab"
+      },
+      {
+        name: "subject_configuration",
+        path: edit_type_tab_path(id: @type.id, tab: :subject_configuration),
+        label: "types.edit.subject_configuration.tab",
+        view_component: WorkPackages::Types::SubjectConfigurationComponent
       },
       {
         name: "projects",
         partial: "types/form/projects",
         path: edit_type_tab_path(id: @type.id, tab: :projects),
-        label: "types.edit.projects"
+        label: "types.edit.projects.tab"
       }
     ]
   end

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -33,12 +33,19 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: tabs) %>
 
-<%= form_for @type,
+<%=
+  selected_tab = selected_tab(tabs)
+
+  if selected_tab.key?(:view_component)
+    render selected_tab[:view_component].new(@type)
+  else
+    form_for @type,
              url: update_type_tab_path(id: @type.id, tab: @tab),
              builder: TabularFormBuilder,
-             lang: current_language do |f| %>
-
-  <%= render_tabs tabs, f, with_tab_nav: false %>
-<% end %>
+             lang: current_language do |f|
+      render partial: "common/tabs", locals: { f:, tabs:, selected_tab:, with_tab_nav: false }
+    end
+  end
+%>
 
 <%= error_messages_for 'type' %>

--- a/app/views/types/form/_projects.html.erb
+++ b/app/views/types/form/_projects.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if @projects.any? %>
         <fieldset class="form--fieldset" id="type_project_ids">
           <legend class="form--fieldset-legend" >
-            <%= t('types.edit.enabled_projects') %>
+            <%= t('types.edit.projects.enabled_projects') %>
           </legend>
             <div class="form--toolbar">
               <span class="form--toolbar-item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -628,8 +628,8 @@ en:
       no_results_title_text: There are currently no types.
       no_results_content_text: Create a new type
     edit:
-      settings: "Settings"
-      form_configuration: "Form configuration"
+      form_configuration:
+        tab: "Form configuration"
       more_info_text_html: >
         Enterprise edition allows you to customize form configuration with these additional add-ons: <br>
         <ul class="%{list_styling_class}">
@@ -637,14 +637,23 @@ en:
           <li><b>Rename attribute groups</b></li>
           <li><b>Add a table of related work packages</b></li>
         </ul>
-      projects: "Projects"
-      enabled_projects: "Enabled projects"
-      edit_query: "Edit table"
-      query_group_placeholder: "Give the table a name"
-      reset: "Reset to defaults"
-      type_color_text: |
-        The selected color distinguishes different types
-        in Gantt charts or work packages tables. It is therefore recommended to use a strong color.
+      projects:
+        tab: "Projects"
+        enabled_projects: "Enabled projects"
+      settings:
+        tab: "Settings"
+        type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.
+      subject_configuration:
+        tab: "Subject configuration"
+        manually_editable_subjects:
+          label: "Manually editable subjects"
+          caption: "Users can manually enter and edit work package subjects without restrictions."
+        automatically_generated_subjects:
+          label: "Automatically generated subjects"
+          caption: "Define a pattern using referenced attributes and text to automatically generate work package subjects. Users will not be able to manually edit subjects."
+        pattern:
+          label: "Subject pattern"
+          caption: "Search for an attribute or add text. To create a space between elements add it as a text."
 
   versions:
     overview:
@@ -1693,7 +1702,7 @@ en:
   create_new_page: "Wiki page"
 
   date:
-    abbr_day_names: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    abbr_day_names: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ]
     abbr_month_names:
       [
         ~,
@@ -2022,20 +2031,20 @@ en:
   pdf_generator:
     page_nr_footer: "Page %{page} of %{total}"
     dialog:
-       title: Generate PDF
-       submit: Generate
-       header_right:
-         label: Header right
-         caption: Text to be displayed in the right of the header
-       footer_center:
-         label: Footer center
-         caption: Text to be displayed in the center of the footer
-       hyphenation:
-         label: Hyphenation
-         caption: Break words between lines to improve text justification and readability.
-       paper_size:
-         label: Paper size
-         caption: The size of the paper to use for the PDF.
+      title: Generate PDF
+      submit: Generate
+      header_right:
+        label: Header right
+        caption: Text to be displayed in the right of the header
+      footer_center:
+        label: Footer center
+        caption: Text to be displayed in the center of the footer
+      hyphenation:
+        label: Hyphenation
+        caption: Break words between lines to improve text justification and readability.
+      paper_size:
+        label: Paper size
+        caption: The size of the paper to use for the PDF.
 
   extraction:
     available:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -838,10 +838,6 @@ en:
         upgrade_to_ee_text: "Wow! If you need this add-on you are a super pro! Would you mind supporting us OpenSource developers by becoming an Enterprise edition client?"
         more_information: "More information"
         nevermind: "Nevermind"
-      edit:
-        form_configuration: "Form Configuration"
-        projects: "Projects"
-        settings: "Settings"
 
     time_entry:
       work_package_required: "Requires selecting a work package first."

--- a/frontend/src/stimulus/controllers/dynamic/admin/subject-configuration.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/subject-configuration.controller.ts
@@ -1,0 +1,67 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class SubjectConfigurationController extends Controller {
+  static targets = [
+    'patternInput',
+  ];
+
+  static values = {
+    hidePatternInput: Boolean,
+  };
+
+  declare readonly hidePatternInputValue:boolean;
+
+  declare readonly patternInputTarget:HTMLDivElement;
+
+  connect() {
+    if (this.hidePatternInputValue) {
+      this.hidePatternInput();
+    }
+  }
+
+  showPatternInput() {
+    this.togglePatternInput('show');
+  }
+
+  hidePatternInput() {
+    this.togglePatternInput('hide');
+  }
+
+  private togglePatternInput(toggle:'show'|'hide') {
+    if (toggle === 'show') {
+      this.patternInputTarget.classList.remove('d-none');
+    } else {
+      this.patternInputTarget.classList.add('d-none');
+    }
+  }
+}


### PR DESCRIPTION
# Ticket
[OP#59997](https://community.openproject.org/work_packages/59997)

# What are you trying to accomplish?
- add a new tab for work package type subject configuration
- no connection to model yet

# What approach did you choose and why?
- add new form component
- add switch for old rendering of tab content and new rendering (view component based)