### PR TITLE
implementation/59815 Add email setting to send an email reminder immediately

### DIFF
--- a/app/mailers/reminders/notification_mailer.rb
+++ b/app/mailers/reminders/notification_mailer.rb
@@ -1,0 +1,65 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Reminders::NotificationMailer < ApplicationMailer
+  include MailNotificationHelper
+  include Redmine::I18n
+
+  helper :mail_notification
+  helper_method :reminder_summary_text,
+                :reminder_timestamp_text,
+                :reminder_note_text
+
+  def reminder_notification(notification)
+    @notification = notification
+    @user = notification.recipient
+
+    open_project_headers User: notification.recipient.name
+    message_id "reminder", notification.recipient
+
+    send_localized_mail(notification.recipient) do
+      "#{Setting.app_title} - #{reminder_summary_text}"
+    end
+  end
+
+  private
+
+  def reminder_summary_text
+    I18n.t(:"mail.reminder_notifications.subject")
+  end
+
+  def reminder_timestamp_text
+    "#{format_time(@notification.created_at)}."
+  end
+
+  def reminder_note_text
+    return if @notification.reminder.note.blank?
+
+    I18n.t(:"mail.reminder_notifications.note", note: @notification.reminder.note)
+  end
+end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -140,7 +140,7 @@ class UserPreference < ApplicationRecord
   end
 
   def immediate_reminders
-    super.presence || { mentioned: true, personalReminder: true }.with_indifferent_access
+    super.presence || { mentioned: true, personal_reminder: true }.with_indifferent_access
   end
 
   def pause_reminders

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -140,7 +140,7 @@ class UserPreference < ApplicationRecord
   end
 
   def immediate_reminders
-    super.presence || { mentioned: true }.with_indifferent_access
+    super.presence || { mentioned: true, personalReminder: true }.with_indifferent_access
   end
 
   def pause_reminders

--- a/app/views/reminders/notification_mailer/reminder_notification.html.erb
+++ b/app/views/reminders/notification_mailer/reminder_notification.html.erb
@@ -1,0 +1,54 @@
+<table <%= placeholder_table_styles %>>
+  <tr>
+    <%= placeholder_cell('20px', vertical: false) %>
+  </tr>
+</table>
+
+<table <%= placeholder_table_styles(width: '100%', style: 'width:100%;max-width:700px;') %>>
+  <tr>
+    <%= placeholder_cell('12px', vertical: true) %>
+    <td>
+      <%= render partial: 'mailer/mailer_header',
+                 locals: {
+                   summary: reminder_summary_text,
+                   button_href: notifications_url,
+                   button_text: I18n.t(:'mail.notification.center'),
+                   user: @user,
+                 } %>
+
+      <%= render layout: 'mailer/notification_row',
+                  locals: {
+                    work_package: @notification.resource,
+                    unique_reasons: [@notification.reason],
+                    show_count: true,
+                    count: 1,
+                    user: @user
+                  } do %>
+        <table <%= placeholder_table_styles %>>
+          <tr>
+            <td style="line-height: 24px; font-size: 14px; white-space: normal;">
+              <span style="color: #878787;">
+                <%= reminder_timestamp_text %>
+              </span>
+              <%= reminder_note_text %>
+            </td>
+          </tr>
+        </table>
+      <% end %>
+
+      <%= render layout: 'mailer/notification_settings_table',
+                 locals: {
+                   button_url: my_reminders_url,
+                   button_text: I18n.t(:'mail.notification.settings')
+                 } do %>
+      <% end %>
+
+      <table>
+        <tr>
+          <%= placeholder_cell('40px', vertical: false) %>
+        </tr>
+      </table>
+    </td>
+    <%= placeholder_cell('12px', vertical: true) %>
+  </tr>
+</table>

--- a/app/views/reminders/notification_mailer/reminder_notification.text.erb
+++ b/app/views/reminders/notification_mailer/reminder_notification.text.erb
@@ -1,0 +1,14 @@
+<%= I18n.t(:'mail.salutation', user: @user.firstname) %>
+<%= reminder_summary_text %>
+<%= "-" * 100 %>
+
+<% work_package = @notification.resource %>
+
+<%= "=" * (('# ' + work_package.id.to_s + work_package.subject).length + 4) %>
+= #<%= work_package.id %> <%= work_package.subject %> =
+<%= "=" * (('# ' + work_package.id.to_s + work_package.subject).length + 4) %>
+
+<%= reminder_timestamp_text %>
+<%= reminder_note_text %>
+
+<%= "-" * 100 %>

--- a/app/workers/mails/reminders/notification_delivery_job.rb
+++ b/app/workers/mails/reminders/notification_delivery_job.rb
@@ -27,7 +27,7 @@
 #++
 
 class Mails::Reminders::NotificationDeliveryJob < Mails::DeliverJob
-  include ::Notifications::WithMarkedNotifications
+  include Notifications::WithMarkedNotifications
 
   def perform(notification)
     @notification = notification

--- a/app/workers/mails/reminders/notification_delivery_job.rb
+++ b/app/workers/mails/reminders/notification_delivery_job.rb
@@ -1,0 +1,48 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Mails::Reminders::NotificationDeliveryJob < Mails::DeliverJob
+  include ::Notifications::WithMarkedNotifications
+
+  def perform(notification)
+    @notification = notification
+    super(notification.recipient)
+  end
+
+  private
+
+  def notification_marked_attribute
+    :mail_alert_sent
+  end
+
+  def render_mail
+    with_marked_notifications([@notification.id]) do
+      ::Reminders::NotificationMailer.reminder_notification(@notification)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2938,8 +2938,12 @@ en:
         prefix: "Received because of the notification setting: %{reason}"
         date_alert_start_date: "Date alert"
         date_alert_due_date: "Date alert"
+        reminder: "Reminder"
       see_all: "See all"
       updated_at: "Updated at %{timestamp} by %{user}"
+    reminder_notifications:
+      subject: "You have a new reminder"
+      note: "Note: “%{note}”"
     sharing:
       work_packages:
         allowed_actions: "You may %{allowed_actions} this work package. This can change depending on your project role and permissions."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -805,6 +805,7 @@ en:
         immediate:
           title: "Send me an email reminder"
           mentioned: "Immediately when someone @mentions me"
+          personal_reminder: "Immediately when I receive a personal reminder"
         alerts:
           title: "Email alerts for other items (that are not work packages)"
           explanation: >

--- a/config/schemas/user_preferences.schema.json
+++ b/config/schemas/user_preferences.schema.json
@@ -74,6 +74,9 @@
           "properties": {
             "mentioned": {
               "type": "boolean"
+            },
+            "personalReminder": {
+              "type": "boolean"
             }
           },
           "required": [

--- a/config/schemas/user_preferences.schema.json
+++ b/config/schemas/user_preferences.schema.json
@@ -75,7 +75,7 @@
             "mentioned": {
               "type": "boolean"
             },
-            "personalReminder": {
+            "personal_reminder": {
               "type": "boolean"
             }
           },

--- a/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.html
@@ -14,4 +14,16 @@
       data-qa-immediate-reminder="mentioned"
     />
   </spot-selector-field>
+
+  <spot-selector-field
+    [label]="text.personalReminder"
+    [control]="form.get('personalReminder')"
+  >
+    <input
+      slot="input"
+      type="checkbox"
+      formControlName="personalReminder"
+      data-qa-immediate-reminder="personalReminder"
+    />
+  </spot-selector-field>
 </ng-container>

--- a/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.ts
+++ b/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.ts
@@ -22,6 +22,7 @@ export class ImmediateReminderSettingsComponent implements OnInit {
     title: this.I18n.t('js.reminders.settings.immediate.title'),
     explanation: this.I18n.t('js.reminders.settings.immediate.explanation'),
     mentioned: this.I18n.t('js.reminders.settings.immediate.mentioned'),
+    personalReminder: this.I18n.t('js.reminders.settings.immediate.personal_reminder'),
   };
 
   constructor(

--- a/frontend/src/app/features/user-preferences/reminder-settings/page/reminder-settings-page.component.ts
+++ b/frontend/src/app/features/user-preferences/reminder-settings/page/reminder-settings-page.component.ts
@@ -39,6 +39,7 @@ export class ReminderSettingsPageComponent extends UntilDestroyedMixin implement
   public form = this.fb.group({
     immediateReminders: this.fb.group({
       mentioned: this.fb.control(false),
+      personalReminder: this.fb.control(false),
     }),
     dailyReminders: this.fb.group({
       enabled: this.fb.control(false),
@@ -112,6 +113,7 @@ export class ReminderSettingsPageComponent extends UntilDestroyedMixin implement
 
   private buildForm(settings:IUserPreference, globalSetting:INotificationSetting) {
     this.form.get('immediateReminders.mentioned')?.setValue(settings.immediateReminders.mentioned);
+    this.form.get('immediateReminders.personalReminder')?.setValue(settings.immediateReminders.personalReminder);
 
     this.form.get('dailyReminders.enabled')?.setValue(settings.dailyReminders.enabled);
 

--- a/frontend/src/app/features/user-preferences/state/user-preferences.model.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.model.ts
@@ -11,6 +11,7 @@ export interface PauseRemindersSettings {
 }
 export interface ImmediateRemindersSettings {
   mentioned:boolean;
+  personalReminder:boolean;
 }
 
 export interface IUserPreference {

--- a/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
@@ -46,6 +46,7 @@ function createInitialState():IUserPreference {
     workdays: [1, 2, 3, 4, 5],
     immediateReminders: {
       mentioned: false,
+      personalReminder: false,
     },
     pauseReminders: {
       enabled: false,

--- a/lib/api/v3/user_preferences/user_preference_representer.rb
+++ b/lib/api/v3/user_preferences/user_preference_representer.rb
@@ -75,7 +75,13 @@ module API
                    daily_reminders["times"].map! { |time| time.gsub(/\A(\d{2}:\d{2})\z/, '\1:00+00:00') }
                  end
 
-        property :immediate_reminders
+        property :immediate_reminders,
+                 getter: ->(*) do
+                   immediate_reminders.transform_keys { |k| k.camelize(:lower) }
+                 end,
+                 setter: ->(fragment:, **) do
+                   self.immediate_reminders = fragment.transform_keys(&:underscore)
+                 end
 
         property :pause_reminders,
                  getter: ->(*) do

--- a/spec/features/notifications/settings/immediate_reminder_spec.rb
+++ b/spec/features/notifications/settings/immediate_reminder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Immediate reminder settings", :js, :with_cuprite do
       reminders_settings_page.expect_immediate_reminder :mentioned, true
 
       # By default the personal reminder is checked
-      expect(pref.immediate_reminders[:personalReminder]).to be(true)
+      expect(pref.immediate_reminders[:personal_reminder]).to be(true)
       reminders_settings_page.expect_immediate_reminder :personalReminder, true
 
       reminders_settings_page.set_immediate_reminder :mentioned, false
@@ -30,7 +30,7 @@ RSpec.describe "Immediate reminder settings", :js, :with_cuprite do
       reminders_settings_page.expect_immediate_reminder :personalReminder, false
 
       expect(pref.reload.immediate_reminders[:mentioned]).to be(false)
-      expect(pref.reload.immediate_reminders[:personalReminder]).to be(false)
+      expect(pref.reload.immediate_reminders[:personal_reminder]).to be(false)
     end
   end
 

--- a/spec/features/notifications/settings/immediate_reminder_spec.rb
+++ b/spec/features/notifications/settings/immediate_reminder_spec.rb
@@ -10,10 +10,15 @@ RSpec.describe "Immediate reminder settings", :js, :with_cuprite do
       reminders_settings_page.visit!
 
       # By default the immediate reminder is checked
-      expect(pref.immediate_reminders[:mentioned]).to be true
+      expect(pref.immediate_reminders[:mentioned]).to be(true)
       reminders_settings_page.expect_immediate_reminder :mentioned, true
 
+      # By default the personal reminder is checked
+      expect(pref.immediate_reminders[:personalReminder]).to be(true)
+      reminders_settings_page.expect_immediate_reminder :personalReminder, true
+
       reminders_settings_page.set_immediate_reminder :mentioned, false
+      reminders_settings_page.set_immediate_reminder :personalReminder, false
 
       reminders_settings_page.save
 
@@ -22,8 +27,10 @@ RSpec.describe "Immediate reminder settings", :js, :with_cuprite do
       reminders_settings_page.reload!
 
       reminders_settings_page.expect_immediate_reminder :mentioned, false
+      reminders_settings_page.expect_immediate_reminder :personalReminder, false
 
-      expect(pref.reload.immediate_reminders[:mentioned]).to be false
+      expect(pref.reload.immediate_reminders[:mentioned]).to be(false)
+      expect(pref.reload.immediate_reminders[:personalReminder]).to be(false)
     end
   end
 

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_parsing_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe API::V3::UserPreferences::UserPreferenceRepresenter,
   let(:user) { build_stubbed(:user) }
   let(:representer) { described_class.new(preference, current_user: user) }
 
+  describe "immediate_reminders" do
+    let(:request_body) do
+      {
+        "immediateReminders" => {
+          "mentioned" => true,
+          "personalReminder" => false
+        }
+      }
+    end
+
+    it "parses the enabled flag" do
+      expect(parsed.immediate_reminders).to eql({ "mentioned" => true, "personal_reminder" => false })
+    end
+  end
+
   describe "notification_settings" do
     let(:request_body) do
       {

--- a/spec/mailers/previews/reminders/notification_mailer_preview.rb
+++ b/spec/mailers/previews/reminders/notification_mailer_preview.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Preview all emails at http://localhost:3000/rails/mailers/reminders/notification_mailer
+class Reminders::NotificationMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/reminders/notification_mailer/reminder_notification
+  def reminder_notification
+    notification = Notification.where(reason: :reminder).first
+    Reminders::NotificationMailer.reminder_notification(notification)
+  end
+end

--- a/spec/mailers/reminders/notification_mailer_spec.rb
+++ b/spec/mailers/reminders/notification_mailer_spec.rb
@@ -1,0 +1,69 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Reminders::NotificationMailer do
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:user) { build_stubbed(:user) }
+  let(:recipient) { user }
+
+  let(:notification) do
+    reminder = build_stubbed(:reminder, remindable: work_package, creator: user, note: "This is an important reminder")
+    build_stubbed(:notification, reason: :reminder, recipient:, resource: work_package, reminder:)
+  end
+
+  describe "#reminder_notification" do
+    subject(:mail) { described_class.reminder_notification(notification) }
+
+    let(:mail_body) { mail.body.parts.detect { |part| part["Content-Type"].value == "text/html" }.body.to_s }
+
+    it "notes reminder in subject" do
+      expect(mail.subject).to eql("OpenProject - You have a new reminder")
+    end
+
+    it "sends to the recipient" do
+      expect(mail.to)
+        .to contain_exactly(recipient.mail)
+    end
+
+    it "sets the expected message_id header" do
+      expect(mail.message_id)
+        .to eql "op.reminder.#{Time.current.strftime('%Y%m%d%H%M%S')}.#{recipient.id}@example.net"
+    end
+
+    it "sets the expected openproject headers" do
+      expect(mail["X-OpenProject-User"]&.value)
+        .to eql(recipient.name)
+    end
+
+    it "mail body includes the reminder note" do
+      expect(mail_body).to include("Note: “This is an important reminder”")
+    end
+  end
+end

--- a/spec/workers/mails/reminders/notification_delivery_job_spec.rb
+++ b/spec/workers/mails/reminders/notification_delivery_job_spec.rb
@@ -1,0 +1,57 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Mails::Reminders::NotificationDeliveryJob do
+  shared_let(:work_package) { create(:work_package) }
+  shared_let(:user) { create(:user) }
+
+  shared_let(:notification) do
+    reminder = create(:reminder, remindable: work_package, creator: user)
+    create(:notification, reason: :reminder, recipient: user, resource: work_package, reminder:)
+  end
+
+  before do
+    allow(Reminders::NotificationMailer).to receive(:reminder_notification).and_call_original
+  end
+
+  describe "#perform" do
+    subject { described_class.new.perform(notification) }
+
+    it "sends the reminder notification" do
+      expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(Reminders::NotificationMailer).to have_received(:reminder_notification).with(notification)
+
+      aggregate_failures "notification marked as sent" do
+        notification.reload
+        expect(notification.mail_alert_sent).to be(true)
+      end
+    end
+  end
+end

--- a/spec/workers/reminders/schedule_reminder_job_spec.rb
+++ b/spec/workers/reminders/schedule_reminder_job_spec.rb
@@ -73,5 +73,26 @@ RSpec.describe Reminders::ScheduleReminderJob do
         expect { subject }.not_to change(Notification, :count)
       end
     end
+
+    context "when the recipient has immediate reminders enabled" do
+      it "enqueues a NotificationDeliveryJob" do
+        expect { subject }
+          .to have_enqueued_job(Mails::Reminders::NotificationDeliveryJob)
+                .with(a_kind_of(Notification))
+      end
+    end
+
+    context "when the recipient has immediate reminders disabled" do
+      before do
+        recipient = reminder.creator
+        recipient.pref.immediate_reminders = { personal_reminder: false }
+        recipient.pref.save
+      end
+
+      it "does not enqueue a NotificationDeliveryJob" do
+        expect { subject }
+          .not_to have_enqueued_job(Mails::Reminders::NotificationDeliveryJob)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/59815

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- [x] Add email setting to send an email reminder immediately
  - [x] Dispatch personal reminder emails based on setting
  - [ ] Update email template design (Starts out as similar to notification, will be updated separately once there is a design in https://community.openproject.org/wp/60201)

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1691" alt="Screenshot 2024-12-14 at 1 27 19 AM" src="https://github.com/user-attachments/assets/1cd0ca10-9c1c-4d43-925d-fdfb22830ca6" />

<img width="1664" alt="Screenshot 2024-12-17 at 1 15 45 PM" src="https://github.com/user-attachments/assets/5562406a-d245-4a1e-a71b-8f6fa091b888" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
