### PR TITLE
implementation/60018 Add notification polymorphic resource as part of the eager loading list to avoid isolated query

### DIFF
--- a/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
+++ b/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
@@ -35,23 +35,6 @@ module API
             notifications
               .includes(API::V3::Notifications::NotificationRepresenter.to_eager_load)
               .to_a
-              .tap { |loaded_notifications| set_resource(loaded_notifications) }
-          end
-
-          private
-
-          # The resource cannot be loaded by rails eager loading means (include)
-          # because it is a polymorphic association. That being as it is, currently only
-          # work packages are assigned.
-          def set_resource(notifications)
-            work_packages_by_id = WorkPackage
-                                    .includes(:project)
-                                    .where(id: notifications.pluck(:resource_id).uniq)
-                                    .index_by(&:id)
-
-            notifications.each do |notification|
-              notification.resource = work_packages_by_id[notification.resource_id]
-            end
           end
         end
       end

--- a/lib/api/v3/notifications/notification_representer.rb
+++ b/lib/api/v3/notifications/notification_representer.rb
@@ -104,7 +104,7 @@ module API
           "Notification"
         end
 
-        self.to_eager_load = %i[actor journal reminder]
+        self.to_eager_load = [:actor, :journal, :reminder, { resource: :project }]
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/work_packages/60018

The comment in https://github.com/opf/openproject/pull/11592/commits/aff984255058182524f406dd149e38dcbdd2902d suggests eager loading via includes is not possible for polymorphic resources, however it would seem that's not the case. As the work package & project can be loaded as part of the same eager load chain

```ruby
API::V3::Notifications::NotificationEagerLoadingWrapper.wrap(Notification.where(reason: :reminder))
  Notification Load (11.1ms)  SELECT "notifications".* FROM "notifications" WHERE "notifications"."reason" = $1  [["reason", 13]]
  User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."type" = $1 AND "users"."id" = $2  [["type", "User"], ["id", 435]]
  ReminderNotification Load (0.7ms)  SELECT "reminder_notifications".* FROM "reminder_notifications" WHERE "reminder_notifications"."notification_id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)  [["notification_id", 266232], ["notification_id", 266234], ["notification_id", 266235], ["notification_id", 266348], ["notification_id", 266349], ["notification_id", 266231], ["notification_id", 266273], ["notification_id", 266274], ["notification_id", 266118], ["notification_id", 266233], ["notification_id", 266135], ["notification_id", 266148], ["notification_id", 266147], ["notification_id", 266161], ["notification_id", 266162], ["notification_id", 266312], ["notification_id", 266313], ["notification_id", 266314], ["notification_id", 266172], ["notification_id", 266174], ["notification_id", 266173], ["notification_id", 266187], ["notification_id", 266188], ["notification_id", 266215], ["notification_id", 266216], ["notification_id", 266217]]
  Reminder Load (0.4ms)  SELECT "reminders".* FROM "reminders" WHERE "reminders"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)  [["id", 1], ["id", 2], ["id", 3], ["id", 4], ["id", 5], ["id", 6], ["id", 7], ["id", 8], ["id", 9], ["id", 10], ["id", 11], ["id", 12], ["id", 13], ["id", 14], ["id", 15], ["id", 17], ["id", 18], ["id", 19], ["id", 20]]
  WorkPackage Load (0.5ms)  SELECT "work_packages".* FROM "work_packages" WHERE "work_packages"."id" IN ($1, $2, $3, $4, $5, $6, $7)  [["id", 10245], ["id", 4], ["id", 160], ["id", 10396], ["id", 1], ["id", 9720], ["id", 9322]]
  Project Load (0.4ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" IN ($1, $2, $3)  [["id", 1], ["id", 861], ["id", 787]]
``` 

There are no performance gains AFAICT as the resulting queries are the same, purely a conventional semantic change.
