### PR TITLE
Revert "Remove recurring meeting feature flag"

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -47,6 +47,9 @@ OpenProject::FeatureDecisions.add :generate_pdf_from_work_package,
                                   description: "Allows to generate a PDF document from a work package description. " \
                                                "See #45896 for details."
 
+OpenProject::FeatureDecisions.add :recurring_meetings,
+                                  description: "Differentiate between one-time and recurring meetings."
+
 # TODO: Remove once the feature flag primerized_work_package_activities is removed altogether
 OpenProject::FeatureDecisions.define_singleton_method(:primerized_work_package_activities_active?) do
   Rails.env.production? ||

--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -23,20 +23,30 @@
           I18n.t(:label_meeting)
         end
 
-        menu.with_item(label: I18n.t("meeting.types.structured"),
-                       tag: :a,
-                       href: new_dialog_meetings_path(project_id: @project&.id, type: :structured),
-                       content_arguments: { data: { controller: "async-dialog" }}
-        ) do |item|
-          item.with_description.with_content(t("meeting.types.structured_text"))
-        end
+        if OpenProject::FeatureDecisions.recurring_meetings_active?
+          menu.with_item(label: I18n.t("meeting.types.one_time"),
+                         tag: :a,
+                         href: new_dialog_meetings_path(project_id: @project&.id, type: :structured),
+                         content_arguments: { data: { controller: "async-dialog" }}
+          ) do |item|
+            item.with_description.with_content(t("meeting.types.structured_text"))
+          end
 
-        menu.with_item(label: I18n.t("meeting.types.recurring"),
-                       tag: :a,
-                       href: new_dialog_meetings_path(project_id: @project&.id, type: :recurring),
-                       content_arguments: { data: { controller: "async-dialog" }}
-        ) do |item|
-          item.with_description.with_content(t("meeting.types.recurring_text"))
+          menu.with_item(label: I18n.t("meeting.types.recurring"),
+                         tag: :a,
+                         href: new_dialog_meetings_path(project_id: @project&.id, type: :recurring),
+                         content_arguments: { data: { controller: "async-dialog" }}
+          ) do |item|
+            item.with_description.with_content(t("meeting.types.recurring_text"))
+          end
+        else
+          menu.with_item(label: I18n.t("meeting.types.structured"),
+                         tag: :a,
+                         href: new_dialog_meetings_path(project_id: @project&.id, type: :structured),
+                         content_arguments: { data: { controller: "async-dialog" }}
+          ) do |item|
+            item.with_description.with_content(t("meeting.types.structured_text"))
+          end
         end
 
         menu.with_item(label: I18n.t("meeting.types.classic"),

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -34,9 +34,9 @@ module Meetings
     def menu_items
       [
         OpenProject::Menu::MenuGroup.new(header: nil, children: top_level_menu_items),
-        OpenProject::Menu::MenuGroup.new(header: I18n.t(:label_meeting_series), children: meeting_series_menu_items),
+        meeting_series_menu_group,
         OpenProject::Menu::MenuGroup.new(header: I18n.t(:label_involvement), children: involvement_sidebar_menu_items)
-      ]
+      ].compact
     end
 
     def top_level_menu_items
@@ -49,7 +49,13 @@ module Meetings
         recurring_menu_item,
         menu_item(title: I18n.t(:label_all_meetings),
                   query_params: { filters: all_filter })
-      ]
+      ].compact
+    end
+
+    def meeting_series_menu_group
+      return unless OpenProject::FeatureDecisions.recurring_meetings_active?
+
+      OpenProject::Menu::MenuGroup.new(header: I18n.t(:label_meeting_series), children: meeting_series_menu_items)
     end
 
     def meeting_series_menu_items
@@ -71,6 +77,8 @@ module Meetings
     end
 
     def recurring_menu_item
+      return unless OpenProject::FeatureDecisions.recurring_meetings_active?
+
       recurring_filter = [{ type: { operator: "=", values: ["t"] } }].to_json
 
       menu_item(title: I18n.t("label_recurring_meeting_plural"),

--- a/modules/meeting/app/models/queries/meetings/filters/recurring_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/recurring_filter.rb
@@ -37,6 +37,10 @@ class Queries::Meetings::Filters::RecurringFilter < Queries::Meetings::Filters::
     I18n.t("label_recurring_meeting_part_of")
   end
 
+  def available?
+    OpenProject::FeatureDecisions.recurring_meetings_active?
+  end
+
   def apply_to(query_scope)
     if allowed_values.first.intersect?(values)
       query_scope.recurring

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -206,7 +206,8 @@ en:
     types:
       classic: "Classic"
       classic_text: "Organize your meeting as a single formattable text agenda and protocol."
-      structured: "One-time"
+      structured: "Structured"
+      one_time: "One-time"
       recurring: "Recurring"
       recurring_text: "Create meeting series with dynamic template for each occurrence."
       structured_text: "Organize your meeting as a dynamic list of agenda items, optionally linking them to a work package."

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe "Meetings", "Index", :js, :with_cuprite do
         meetings_page.expect_create_new_button
       end
 
-      it "allows creation of both types of meetings" do
+      it "allows creation of both types of meetings", with_flag: { recurring_meetings: true } do
         meetings_page.visit!
 
         meetings_page.expect_create_new_types

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -35,7 +35,8 @@ require_relative "../../support/pages/meetings/index"
 
 RSpec.describe "Recurring meetings creation",
                :js,
-               :with_cuprite do
+               :with_cuprite,
+               with_flag: { recurring_meetings: true } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -35,7 +35,8 @@ require_relative "../../support/pages/meetings/index"
 
 RSpec.describe "Recurring meetings CRUD",
                :js,
-               :with_cuprite do
+               :with_cuprite,
+               with_flag: { recurring_meetings: true } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -34,7 +34,8 @@ require_relative "../../support/pages/meetings/index"
 
 RSpec.describe "Structured meetings CRUD",
                :js,
-               :with_cuprite do
+               :with_cuprite,
+               with_flag: { recurring_meetings: true } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings work_package_tracking]) }


### PR DESCRIPTION
This reverts commit 06b7e611e2a7c99d26dbd8a3b3f5e2a7d0b0d569.

We decided to keep the feature flag of meetings for 15.2, to get some more time for properly testing on community