### PR TITLE
Activate frozen string literal cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -453,7 +453,8 @@ Style/WordArray:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: always_true
 
 Style/NumericLiterals:
   Enabled: false


### PR DESCRIPTION
**Do not merge**, see disclaimer at the bottom.

As discussed in the dev weekly today (December 17, 2024), we want to activate frozen string literals for all of our files.

This PR does just that.

The cop is activated in strict mode, so `frozen_string_literal` must be there and on top of that, it must be set to `true`.

After this PR has been merged, all **new** and **modified files** must follow the rule and include a magic comment activating frozen string literals. I intentionally did not update all files here as we have ~7.5k more rubocop offenses that come up _after_ fixing this one rule. Since every file is modified, every file is checked. And we broke a lot of cops in the past 🫠 Fixing all at once is too risky. So we do this gradually.

> 7833 files inspected, 7423 offenses detected, 2304 offenses autocorrectable

**Attention**: intentionally set to draft. Do **not merge** before the next feature freeze (15.2). As of now, this means we can merge after December 20, 2024.