### PR TITLE
wrap form autocompleters into primer form classes

### DIFF
--- a/app/forms/statuses/form.rb
+++ b/app/forms/statuses/form.rb
@@ -106,7 +106,8 @@ module Statuses
       statuses_form.color_select_list(
         label: attribute_name(:color_id),
         name: :color_id,
-        caption: I18n.t("statuses.edit.status_color_text")
+        caption: I18n.t("statuses.edit.status_color_text"),
+        input_width: :medium
       )
 
       statuses_form.submit(

--- a/lib/primer/open_project/forms/autocompleter.html.erb
+++ b/lib/primer/open_project/forms/autocompleter.html.erb
@@ -1,26 +1,28 @@
 <%= render(FormControl.new(input: @input, data: @wrapper_data_attributes)) do %>
-  <% if decorated_select? %>
-    <%= render partial: '/augmented/autocomplete_select_decoration',
-               formats: %i[html],
-               locals: {
-                 input_name: @autocomplete_options.fetch(:inputName) { builder.field_name(@input.name) },
-                 input_id: @autocomplete_options.fetch(:inputId) { builder.field_id(@input.name) },
-                 select_options: select_options.map(&:to_h),
-                 multiple: @autocomplete_options.fetch(:multiple, false),
-                 key: @autocomplete_options.fetch(:resource, ''),
-                 append_to: @autocomplete_options.fetch(:append_to, 'body')
-               } %>
-  <% else %>
-    <%= content_tag(:div, class: ("projects-autocomplete-with-search-icon" if @autocomplete_options.delete(:with_search_icon))) do %>
-      <%= angular_component_tag @autocomplete_options.fetch(:component),
-                                data: @autocomplete_options.delete(:data) { {} },
-                                inputs: @autocomplete_options.merge(
-                                  classes: "ng-select--primerized #{@input.invalid? ? '-error' : ''}",
-                                  inputName: @autocomplete_options.fetch(:inputName) { builder.field_name(@input.name) },
-                                  inputValue: @autocomplete_options.fetch(:inputValue) { builder.object.send(@input.name) },
-                                  defaultData: @autocomplete_options.fetch(:defaultData) { true }
-                                )
-      %>
+  <%= content_tag(:div, **@field_wrap_arguments) do %>
+    <% if decorated_select? %>
+      <%= render partial: '/augmented/autocomplete_select_decoration',
+                 formats: %i[html],
+                 locals: {
+                   input_name: @autocomplete_options.fetch(:inputName) { builder.field_name(@input.name) },
+                   input_id: @autocomplete_options.fetch(:inputId) { builder.field_id(@input.name) },
+                   select_options: select_options.map(&:to_h),
+                   multiple: @autocomplete_options.fetch(:multiple, false),
+                   key: @autocomplete_options.fetch(:resource, ''),
+                   append_to: @autocomplete_options.fetch(:append_to, 'body')
+                 } %>
+    <% else %>
+      <%= content_tag(:div, class: ("projects-autocomplete-with-search-icon" if @autocomplete_options.delete(:with_search_icon))) do %>
+        <%= angular_component_tag @autocomplete_options.fetch(:component),
+                                  data: @autocomplete_options.delete(:data) { {} },
+                                  inputs: @autocomplete_options.merge(
+                                    classes: "ng-select--primerized #{@input.invalid? ? '-error' : ''}",
+                                    inputName: @autocomplete_options.fetch(:inputName) { builder.field_name(@input.name) },
+                                    inputValue: @autocomplete_options.fetch(:inputValue) { builder.object.send(@input.name) },
+                                    defaultData: @autocomplete_options.fetch(:defaultData) { true }
+                                  )
+        %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/lib/primer/open_project/forms/autocompleter.rb
+++ b/lib/primer/open_project/forms/autocompleter.rb
@@ -6,6 +6,7 @@ module Primer
       # :nodoc:
       class Autocompleter < Primer::Forms::BaseComponent
         include AngularHelper
+        prepend WrappedInput
 
         delegate :builder, :form, :select_options, to: :@input
 

--- a/lib/primer/open_project/forms/color_select.html.erb
+++ b/lib/primer/open_project/forms/color_select.html.erb
@@ -1,10 +1,12 @@
 <%= render(FormControl.new(input: @input)) do %>
-  <%= builder.hidden_field :color_id %>
-  <%= angular_component_tag("opce-colors-autocompleter",
-                            class: "colors-autocomplete form--select-container -middle",
-                            data: {
-                              colors:,
-                              classes: "ng-select--primerized",
-                              update_input: "#{builder.object_name}[color_id]"
-                            }) %>
+  <%= content_tag(:div, **@field_wrap_arguments) do %>
+    <%= builder.hidden_field :color_id %>
+    <%= angular_component_tag("opce-colors-autocompleter",
+                              class: "colors-autocomplete form--select-container -middle",
+                              data: {
+                                colors:,
+                                classes: "ng-select--primerized",
+                                update_input: "#{builder.object_name}[color_id]"
+                              }) %>
+  <% end %>
 <% end %>

--- a/lib/primer/open_project/forms/color_select.rb
+++ b/lib/primer/open_project/forms/color_select.rb
@@ -7,6 +7,7 @@ module Primer
       class ColorSelect < Primer::Forms::BaseComponent
         include AngularHelper
         include ColorsHelper
+        prepend WrappedInput
 
         delegate :builder, :form, to: :@input
 

--- a/lib/primer/open_project/forms/wrapped_input.rb
+++ b/lib/primer/open_project/forms/wrapped_input.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Primer
+  module OpenProject
+    module Forms
+      # Prepend this module to a subclass of Primer::Forms::BaseComponent.
+      # Together with a corresponding dom element in the template this will wrap the input field in
+      # the classes expected by the Primer CSS framework.
+      # The template of the prepended to class would look like this:
+      #
+      # <%= render(FormControl.new(input: @input)) do %>
+      #   <%= content_tag(:div, **@field_wrap_arguments) do %>
+      #     ... actual input field here ...
+      #   <% end %>
+      # <% end %>
+      module WrappedInput
+        extend ActiveSupport::Concern
+
+        included do
+          raise "This module needs to be prepended."
+        end
+
+        def initialize(**)
+          super
+
+          set_field_wrap_arguments
+        end
+
+        def set_field_wrap_arguments
+          wrap_classes = [
+            "FormControl-input-wrap"
+          ]
+          wrap_classes << Primer::Forms::Dsl::Input::INPUT_WIDTH_MAPPINGS[@input.input_width] if @input.input_width
+
+          @field_wrap_arguments = {
+            class: class_names(wrap_classes),
+            hidden: @input.hidden?
+          }
+        end
+      end
+    end
+  end
+end

--- a/lookbook/previews/open_project/common/autocomplete_preview.rb
+++ b/lookbook/previews/open_project/common/autocomplete_preview.rb
@@ -48,6 +48,10 @@ module OpenProject
       def project_with_search_icon
         render_with_template
       end
+
+      def color
+        render_with_template
+      end
     end
   end
 end

--- a/lookbook/previews/open_project/common/autocomplete_preview/color.html.erb
+++ b/lookbook/previews/open_project/common/autocomplete_preview/color.html.erb
@@ -1,0 +1,27 @@
+
+<%= stylesheet_link_tag "/highlighting/styles/#{highlight_css_version_tag}",
+                        media: :all,
+                        skip_pipeline: true %>
+
+<%
+  the_form = Class.new(ApplicationForm) do
+    form do |f|
+      f.color_select_list(
+        name: :id,
+        label: Color.model_name.human,
+        caption: 'Caption: The dropdown might be offset due to the iFrame around it. This will not happen in production.'
+      )
+    end
+  end
+
+  model = Status.new
+%>
+
+
+<%= primer_form_with(
+      model:,
+      url: '/abc',
+      id: 'asdf') do |f|
+  render(the_form.new(f))
+end
+%>


### PR DESCRIPTION
# What are you trying to accomplish?

Wraps the OP specific form inputs for autocompletion (work package, project, color and the generic autocompleter) into a div just like the input fields provided by primer. That div then receives the css classes the primer inputs receive as well. Additionally, it allows providing the `input_width` parameter so that the width of the input is limited when needed. 

Before the change, the dom structure for the color autocompleter looks like this:

<img width="704" alt="image" src="https://github.com/user-attachments/assets/a3bbed96-f004-496b-ae58-d71916f845c3" />

After, it looks like this:

<img width="701" alt="image" src="https://github.com/user-attachments/assets/20e8b673-fc2c-4237-add2-23bc7170b670" />

That change is then applied to the status form where the color select now has the same width as the input for the name attribute:

<img width="879" alt="image" src="https://github.com/user-attachments/assets/1b4dc4e9-b6bb-41ba-9f24-2b5fdb14ea90" />

The PR also adds  a preview for the color select which was missing before.



