### PR TITLE
Disable browser`s autocompleter on date picker fields

### DIFF
--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
@@ -2,6 +2,7 @@
   *ngIf="!mobile"
   #input
   type="text"
+  autocomplete="off"
   class="spot-input op-basic-range-datepicker--input"
   data-test-selector="op-basic-range-date-picker"
   [ngClass]="inputClassNames"

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
@@ -2,6 +2,7 @@
   *ngIf="!mobile"
   #input
   type="text"
+  autocomplete="off"
   class="spot-input"
   data-filter--filters-form-target="singleDay"
   [ngClass]="inputClassNames"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60286

# What are you trying to accomplish?

Prevent the brower's autocomplete to appear on date picker powered input fields.

## Screenshots

The browser's autocompleter impedes selecting dates from the date picker:

![image](https://github.com/user-attachments/assets/588ed13e-a467-4b15-a29e-064c5623af5f)
 

# What approach did you choose and why?

Adding `autocomlete="off"` to the input fields.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
