### PR TITLE
[#60291] Apply view permissions on the Project List page

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -98,7 +98,7 @@ module Projects
     end
 
     def life_cycle_step_column(column)
-      return nil unless user_can_view_project?
+      return nil unless user_can_view_project_stages_and_gates?
 
       life_cycle_step = project_life_cycle_step_by_definition(column.life_cycle_step_definition, project)
 
@@ -381,6 +381,10 @@ module Projects
 
     def user_can_view_project?
       User.current.allowed_in_project?(:view_project_attributes, project)
+    end
+
+    def user_can_view_project_stages_and_gates?
+      User.current.allowed_in_project?(:view_project_stages_and_gates, project)
     end
 
     def custom_field_column?(column)

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -197,7 +197,7 @@ module Projects
 
     def project_life_cycle_step_by_definition(definition, project)
       @project_life_cycle_steps_by_definition ||= Project::LifeCycleStep
-                                                    .where(active: true)
+                                                    .visible
                                                     .index_by { |s| [s.definition_id, s.project_id] }
 
       @project_life_cycle_steps_by_definition[[definition.id, project.id]]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -88,7 +88,7 @@ class Project < ApplicationRecord
   has_many :storages, through: :project_storages
   has_many :life_cycle_steps, class_name: "Project::LifeCycleStep", dependent: :destroy
   has_many :available_life_cycle_steps,
-           -> { active.eager_load(:definition).order(position: :asc) },
+           -> { visible.eager_load(:definition).order(position: :asc) },
            class_name: "Project::LifeCycleStep",
            inverse_of: :project,
            dependent: :destroy

--- a/app/models/project/life_cycle_step.rb
+++ b/app/models/project/life_cycle_step.rb
@@ -42,6 +42,13 @@ class Project::LifeCycleStep < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
+  class << self
+    def visible(user = User.current)
+      allowed_projects = Project.allowed_to(user, :view_project_stages_and_gates)
+      active.where(project: allowed_projects)
+    end
+  end
+
   def validate_type_and_class_name_are_identical
     if type != self.class.name
       errors.add(:type, :type_and_class_name_mismatch)

--- a/app/models/queries/projects/selects/life_cycle_step.rb
+++ b/app/models/queries/projects/selects/life_cycle_step.rb
@@ -55,7 +55,8 @@ class Queries::Projects::Selects::LifeCycleStep < Queries::Selects::Base
   end
 
   def self.available?
-    OpenProject::FeatureDecisions.stages_and_gates_active?
+    OpenProject::FeatureDecisions.stages_and_gates_active? &&
+    User.current.allowed_in_any_project?(:view_project_stages_and_gates)
   end
 
   def available?

--- a/spec/features/projects/lists/columns_spec.rb
+++ b/spec/features/projects/lists/columns_spec.rb
@@ -251,14 +251,15 @@ RSpec.describe "Projects lists columns", :js, :with_cuprite, with_settings: { lo
   end
 
   context "with life cycle columns" do
-    shared_let(:life_cycle_gate) { create(:project_gate, date: Date.new(2024, 12, 13)) }
+    shared_let(:life_cycle_gate) { create(:project_gate, project:, date: Date.new(2024, 12, 13)) }
     shared_let(:life_cycle_stage) do
       create(:project_stage,
+             project: development_project,
              start_date: Date.new(2024, 12, 1),
              end_date: Date.new(2024, 12, 13))
     end
-    shared_let(:inactive_life_cycle_gate) { create(:project_gate, active: false) }
-    shared_let(:inactive_life_cycle_stage) { create(:project_stage, active: false) }
+    shared_let(:inactive_life_cycle_gate) { create(:project_gate, project:, active: false) }
+    shared_let(:inactive_life_cycle_stage) { create(:project_stage, project: development_project, active: false) }
 
     context "with the feature flag disabled", with_flag: { stages_and_gates: false } do
       specify "life cycle columns cannot be configured to show up" do
@@ -267,102 +268,133 @@ RSpec.describe "Projects lists columns", :js, :with_cuprite, with_settings: { lo
 
         element_selector = "#columns-select_autocompleter ng-select.op-draggable-autocomplete--input"
         results_selector = "#columns-select_autocompleter ng-dropdown-panel .ng-dropdown-panel-items"
-        projects_page.expect_no_config_columns(life_cycle_gate.definition.name,
-                                               life_cycle_stage.definition.name,
-                                               inactive_life_cycle_gate.definition.name,
-                                               inactive_life_cycle_stage.definition.name,
+        projects_page.expect_no_config_columns(life_cycle_gate.name,
+                                               life_cycle_stage.name,
+                                               inactive_life_cycle_gate.name,
+                                               inactive_life_cycle_stage.name,
                                                element_selector:,
                                                results_selector:)
       end
     end
 
     context "with the feature flag enabled", with_flag: { stages_and_gates: true } do
-      specify "life cycle columns cannot be configured to show up for users without view_project_stages_and_gates permission" do
-        user = create(:user, member_with_permissions: { project => %i(view_project),
-                                                        development_project => %i(view_project) })
-
-        login_as(user)
-        projects_page.visit!
-
-        element_selector = "#columns-select_autocompleter ng-select.op-draggable-autocomplete--input"
-        results_selector = "#columns-select_autocompleter ng-dropdown-panel .ng-dropdown-panel-items"
-        projects_page.expect_no_config_columns(life_cycle_gate.definition.name,
-                                               life_cycle_stage.definition.name,
-                                               inactive_life_cycle_gate.definition.name,
-                                               inactive_life_cycle_stage.definition.name,
-                                               element_selector:,
-                                               results_selector:)
-      end
-
-      specify "life cycle columns show up when configured to do so for users with view_project_stages_and_gates permission" do
-        user = create(:user, member_with_permissions: { project => %i(view_project_stages_and_gates),
-                                                        development_project => %i(view_project_stages_and_gates) })
-        login_as(user)
-        projects_page.visit!
-
-        projects_page.expect_columns("Name")
-        projects_page.set_columns(life_cycle_gate.definition.name)
-
-        expect(page).to have_text(life_cycle_gate.definition.name.upcase)
-      end
-
-      specify "life cycle columns do not show up by default" do
-        login_as(admin)
-        projects_page.visit!
-
-        expect(page).to have_no_text(life_cycle_gate.definition.name.upcase)
-        expect(page).to have_no_text(life_cycle_stage.definition.name.upcase)
-        expect(page).to have_no_text(inactive_life_cycle_gate.definition.name.upcase)
-        expect(page).to have_no_text(inactive_life_cycle_stage.definition.name.upcase)
-      end
-
-      specify "life cycle columns show up when configured to do so" do
-        login_as(admin)
-        projects_page.visit!
-
-        projects_page.expect_columns("Name")
-        projects_page.set_columns(life_cycle_gate.definition.name)
-
-        expect(page).to have_text(life_cycle_gate.definition.name.upcase)
-      end
-
-      specify "inactive life cycle columns have no cell content" do
-        login_as(admin)
-        projects_page.visit!
-
-        projects_page.expect_columns("Name")
-
-        col_names = [life_cycle_gate, life_cycle_stage,
-                     inactive_life_cycle_gate,
-                     inactive_life_cycle_stage].map { |l| l.definition.name }
-
-        projects_page.set_columns(*col_names)
-        # Inactive columns are still displayed in the header:
-        projects_page.expect_columns("Name", *col_names)
-
-        gate_project = life_cycle_gate.project
-        projects_page.within_row(gate_project) do
-          expect(page).to have_css(".name", text: gate_project.name)
-          expect(page).to have_css(".lcsd_#{life_cycle_gate.definition.id}", text: "12/13/2024")
-          # life cycle assigned to other project, no text here
-          expect(page).to have_css(".lcsd_#{life_cycle_stage.definition.id}", text: "")
-          # inactive life cycles, no text here
-          expect(page).to have_css(".lcsd_#{inactive_life_cycle_stage.definition.id}", text: "")
-          expect(page).to have_css(".lcsd_#{inactive_life_cycle_gate.definition.id}", text: "")
+      context "with an admin" do
+        before do
+          login_as(admin)
+          projects_page.visit!
         end
 
-        stage_project = life_cycle_stage.project
-        projects_page.within_row(stage_project) do
-          expect(page).to have_css(".name", text: stage_project.name)
-          expect(page).to have_css(".lcsd_#{life_cycle_stage.definition.id}", text: "12/01/2024 - 12/13/2024")
-          # life cycle assigned to other project, no text here
-          expect(page).to have_css(".lcsd_#{life_cycle_gate.definition.id}", text: "")
+        specify "configuring life cycle column display" do
+          # life cycle columns do not show up by default
+          expect(page).to have_no_text(life_cycle_gate.name.upcase)
+          expect(page).to have_no_text(life_cycle_stage.name.upcase)
+          expect(page).to have_no_text(inactive_life_cycle_gate.name.upcase)
+          expect(page).to have_no_text(inactive_life_cycle_stage.name.upcase)
+
+          # life cycle columns show up when configured to do so
+          projects_page.expect_columns("Name")
+          projects_page.set_columns(life_cycle_gate.name)
+
+          expect(page).to have_text(life_cycle_gate.name.upcase)
         end
 
-        # Inactive life cycle steps never show their date values
-        other_proj = inactive_life_cycle_stage.project
-        projects_page.within_row(other_proj) do
-          expect(page).to have_css(".lcsd_#{inactive_life_cycle_stage.definition.id}", text: "")
+        specify "inactive life cycle columns have no cell content" do
+          col_names = [life_cycle_gate, life_cycle_stage,
+                       inactive_life_cycle_gate,
+                       inactive_life_cycle_stage].collect(&:name)
+
+          projects_page.set_columns(*col_names)
+          # Inactive columns are still displayed in the header:
+          projects_page.expect_columns("Name", *col_names)
+
+          gate_project = life_cycle_gate.project
+          projects_page.within_row(gate_project) do
+            expect(page).to have_css(".name", text: gate_project.name)
+            expect(page).to have_css(".lcsd_#{life_cycle_gate.definition_id}", text: "12/13/2024")
+            # life cycle assigned to other project, no text here
+            expect(page).to have_css(".lcsd_#{life_cycle_stage.definition_id}", text: "")
+            # inactive life cycles, no text here
+            expect(page).to have_css(".lcsd_#{inactive_life_cycle_stage.definition_id}", text: "")
+            expect(page).to have_css(".lcsd_#{inactive_life_cycle_gate.definition_id}", text: "")
+          end
+
+          stage_project = life_cycle_stage.project
+          projects_page.within_row(stage_project) do
+            expect(page).to have_css(".name", text: stage_project.name)
+            expect(page).to have_css(".lcsd_#{life_cycle_stage.definition_id}", text: "12/01/2024 - 12/13/2024")
+            # life cycle assigned to other project, no text here
+            expect(page).to have_css(".lcsd_#{life_cycle_gate.definition_id}", text: "")
+          end
+
+          # Inactive life cycle steps never show their date values
+          other_proj = inactive_life_cycle_stage.project
+          projects_page.within_row(other_proj) do
+            expect(page).to have_css(".lcsd_#{inactive_life_cycle_stage.definition_id}", text: "")
+          end
+        end
+      end
+
+      context "with a user" do
+        let(:permissions) { %i(view_project) }
+        let(:user) do
+          create(:user, member_with_permissions: { project => permissions,
+                                                   development_project => %i(view_project) })
+        end
+
+        before do
+          login_as(user)
+          projects_page.visit!
+        end
+
+        context "for users without view_project_stages_and_gates permission" do
+          specify "life cycle columns cannot be configured to show up" do
+            element_selector = "#columns-select_autocompleter ng-select.op-draggable-autocomplete--input"
+            results_selector = "#columns-select_autocompleter ng-dropdown-panel .ng-dropdown-panel-items"
+            projects_page.expect_no_config_columns(life_cycle_gate.name,
+                                                   life_cycle_stage.name,
+                                                   inactive_life_cycle_gate.name,
+                                                   inactive_life_cycle_stage.name,
+                                                   element_selector:,
+                                                   results_selector:)
+          end
+        end
+
+        context "for users with view_project_stages_and_gates permission" do
+          let(:permissions) { %i(view_project view_project_stages_and_gates) }
+
+          specify "life cycle columns show up when configured to do so" do
+            projects_page.expect_columns("Name")
+            projects_page.set_columns(life_cycle_gate.name)
+
+            expect(page).to have_text(life_cycle_gate.name.upcase)
+          end
+
+          specify "not permitted life cycle columns have no cell content" do
+            col_names = [life_cycle_gate, life_cycle_stage,
+                         inactive_life_cycle_gate,
+                         inactive_life_cycle_stage].collect(&:name)
+
+            projects_page.set_columns(*col_names)
+            # Inactive columns are still displayed in the header:
+            projects_page.expect_columns("Name", *col_names)
+
+            permitted_project = project
+            projects_page.within_row(permitted_project) do
+              expect(page).to have_css(".name", text: permitted_project.name)
+              expect(page).to have_css(".lcsd_#{life_cycle_gate.definition_id}", text: "12/13/2024")
+              # life cycle assigned to other project, no text here
+              expect(page).to have_css(".lcsd_#{life_cycle_stage.definition_id}", text: "")
+              # inactive life cycles, no text here
+              expect(page).to have_css(".lcsd_#{inactive_life_cycle_stage.definition_id}", text: "")
+              expect(page).to have_css(".lcsd_#{inactive_life_cycle_gate.definition_id}", text: "")
+            end
+
+            # Not permitted life cycle steps never show their date values
+            not_permitted_project = development_project
+            projects_page.within_row(not_permitted_project) do
+              expect(page).to have_css(".lcsd_#{life_cycle_stage.definition_id}", text: "")
+            end
+          end
         end
       end
     end

--- a/spec/models/project/life_cycle_step_spec.rb
+++ b/spec/models/project/life_cycle_step_spec.rb
@@ -48,6 +48,28 @@ RSpec.describe Project::LifeCycleStep do
     end
   end
 
+  describe ".visible" do
+    let(:project) { create(:project) }
+    let(:development_project) { create(:project) }
+    let(:user) do
+      create(:user,
+             member_with_permissions:
+             { project => %i(view_project view_project_stages_and_gates),
+               development_project => %i(view_project) })
+    end
+
+    let!(:life_cycle_gate) { create(:project_gate, project:) }
+    let!(:life_cycle_stage) { create(:project_stage, project:) }
+    let!(:life_cycle_stage_dev) { create(:project_stage, project: development_project) }
+    let!(:inactive_life_cycle_gate) { create(:project_gate, project:, active: false) }
+    let!(:inactive_life_cycle_stage) { create(:project_stage, project: development_project, active: false) }
+
+    it "returns active steps where the user has a view_project_stages_and_gates permission" do
+      expected_steps = [life_cycle_gate, life_cycle_stage]
+      expect(described_class.visible(user)).to eq(expected_steps)
+    end
+  end
+
   # For more specs see:
   # - spec/support/shared/project_life_cycle_helpers.rb
   # - spec/models/project/gate_spec.rb

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -389,8 +389,18 @@ RSpec.describe Project do
                     .class_name("Project::LifeCycleStep")
                     .inverse_of(:project)
                     .dependent(:destroy)
-                    .conditions(active: true)
                     .order(position: :asc)
+    end
+
+    it "checks for active flag" do
+      expect(subject.available_life_cycle_steps.to_sql)
+        .to include("\"project_life_cycle_steps\".\"active\" = TRUE")
+    end
+
+    it "checks for :view_project_stages_and_gates permission" do
+      project_condition = described_class.allowed_to(User.current, :view_project_stages_and_gates).select(:id)
+
+      expect(subject.available_life_cycle_steps.to_sql).to include(project_condition.to_sql)
     end
 
     it "eager loads :definition" do
@@ -399,7 +409,12 @@ RSpec.describe Project do
     end
 
     describe ".validates_associated" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i(view_project view_project_stages_and_gates) })
+      end
       let!(:project_stage) { create :project_stage, :skip_validate, project:, start_date: nil }
+
+      before { allow(User).to receive(:current).and_return user }
 
       it "is valid without a validation context" do
         expect(project).to be_valid


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60291

# What are you trying to accomplish?
Apply stages and gates view permissions on the project list page. 
 - Do not display the Stage and Gate definitions, if the user does not have the `:view_project_stages_and_gates` permission in any projects.
 - Do not display Stages and Gates value entries for projects without the `:view_project_stages_and_gates`.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
