### PR TITLE
Optimizing the life cycle dialog

### DIFF
--- a/app/forms/projects/life_cycles/form.rb
+++ b/app/forms/projects/life_cycles/form.rb
@@ -53,7 +53,7 @@ module Projects::LifeCycles
         label: "#{icon} #{text}".html_safe, # rubocop:disable Rails/OutputSafety
         leading_visual: { icon: :calendar },
         datepicker_options: {
-          inDialog: true,
+          inDialog: ProjectLifeCycles::Sections::EditDialogComponent::DIALOG_ID,
           data: { action: "change->overview--project-life-cycles-form#handleChange" }
         },
         wrapper_data_attributes: {

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
@@ -16,6 +16,7 @@
   [ngModel]="stringValue"
   (ngModelChange)="changeValueFromInputDebounced($event)"
   (focus)="showDatePicker()"
+  (click)="sentCalendarToTopLayer()"
 />
 <ng-container *ngIf="mobile">
   <input

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -185,6 +185,7 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
         allowInput: true,
         mode: 'range',
         showMonths: 2,
+        clickOpens: false,
         onReady: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
           instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
         },

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -115,7 +115,7 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
 
   @Input() inputClassNames = '';
 
-  @Input() inDialog = false;
+  @Input() inDialog:string;
 
   @Input() dataAction = '';
 
@@ -207,7 +207,8 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
             !!this.minimalDate && dayElem.dateObj <= this.minimalDate,
           );
         },
-        static: false, //this.inDialog,
+        static: false,
+        appendTo: this.appendToBodyOrDialog(),
       },
       this.input.nativeElement as HTMLInputElement,
     );
@@ -256,5 +257,13 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
     calendarContainer.setAttribute('popover', '');
     calendarContainer.showPopover();
     calendarContainer.style.marginTop = '0';
+  }
+
+  private appendToBodyOrDialog():HTMLElement|undefined {
+    if (this.inDialog) {
+      return document.querySelector(`#${this.inDialog}`) as HTMLElement;
+    }
+
+    return undefined;
   }
 }

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -185,7 +185,6 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
         allowInput: true,
         mode: 'range',
         showMonths: 2,
-        clickOpens: false,
         onReady: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
           instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
         },
@@ -198,6 +197,9 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
           }
 
           this.cdRef.detectChanges();
+        },
+        onOpen: () => {
+          this.sentCalendarToTopLayer();
         },
         onDayCreate: async (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
           onDayCreate(

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -184,6 +184,7 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
         showMonths: 2,
         onReady: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
           instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
+          instance.calendarContainer.setAttribute('popover', '');
         },
         onChange: (dates:Date[], dateStr:string) => {
           if (dates.length === 2) {
@@ -195,6 +196,12 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
 
           this.cdRef.detectChanges();
         },
+        onOpen: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
+          setTimeout(() => {
+            instance.calendarContainer.showPopover();
+            instance.calendarContainer.style.marginTop = '0';
+          });
+        },
         onDayCreate: async (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
           onDayCreate(
             dayElem,
@@ -203,7 +210,7 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
             !!this.minimalDate && dayElem.dateObj <= this.minimalDate,
           );
         },
-        static: this.inDialog,
+        static: false, //this.inDialog,
       },
       this.input.nativeElement as HTMLInputElement,
     );

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -170,7 +170,10 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
   }
 
   showDatePicker():void {
-    this.datePickerInstance?.show();
+    if (!this.datePickerInstance?.isOpen) {
+      this.datePickerInstance?.show();
+      this.sentCalendarToTopLayer();
+    }
   }
 
   private initializeDatePicker() {
@@ -184,7 +187,6 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
         showMonths: 2,
         onReady: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
           instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
-          instance.calendarContainer.setAttribute('popover', '');
         },
         onChange: (dates:Date[], dateStr:string) => {
           if (dates.length === 2) {
@@ -195,12 +197,6 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
           }
 
           this.cdRef.detectChanges();
-        },
-        onOpen: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
-          setTimeout(() => {
-            instance.calendarContainer.showPopover();
-            instance.calendarContainer.style.marginTop = '0';
-          });
         },
         onDayCreate: async (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
           onDayCreate(
@@ -240,5 +236,24 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
   // eslint-disable-next-line class-methods-use-this
   private resolveDateArrayToString(dates:string[]):string {
     return dates.join(` ${rangeSeparator} `);
+  }
+
+  // In case the date picker is opened in a dialog, it needs to be in the top layer
+  // since the dialog is also there. This method is called in two cases:
+  // 1. When the date picker is opened
+  // 2. When the date picker is already opened and the user clicks on the input
+  // The later is necessary as otherwise the date picker would be removed from the top layer
+  // when the user clicks on the input. That is because the input is not part of the date picker
+  // so clicking on it would be considered a click on the backdrop which removes an item from
+  // the top layer again.
+  public sentCalendarToTopLayer() {
+    if (!this.datePickerInstance.isOpen || !this.inDialog) {
+      return;
+    }
+
+    const calendarContainer = this.datePickerInstance.datepickerInstance.calendarContainer;
+    calendarContainer.setAttribute('popover', '');
+    calendarContainer.showPopover();
+    calendarContainer.style.marginTop = '0';
   }
 }

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
@@ -16,6 +16,7 @@
   [disabled]="disabled"
   (input)="changeValueFromInput($event.target.value)"
   (focus)="showDatePicker()"
+  (click)="sentCalendarToTopLayer()"
   [attr.data-remote-field-key]="remoteFieldKey"
 />
 

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -161,7 +161,6 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, O
         allowInput: true,
         mode: 'single',
         showMonths: 1,
-        clickOpens: false,
         onReady: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
           instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
         },
@@ -177,6 +176,9 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, O
           }
 
           this.cdRef.detectChanges();
+        },
+        onOpen: () => {
+          this.sentCalendarToTopLayer();
         },
         onDayCreate: async (_dObj:Date[], _dStr:string, _fp:flatpickr.Instance, dayElem:DayElement) => {
           onDayCreate(

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -161,6 +161,7 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, O
         allowInput: true,
         mode: 'single',
         showMonths: 1,
+        clickOpens: false,
         onReady: (_date:Date[], _datestr:string, instance:flatpickr.Instance) => {
           instance.calendarContainer.classList.add('op-datepicker-modal--flatpickr-instance');
         },

--- a/frontend/src/app/shared/components/datepicker/datepicker.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.ts
@@ -136,6 +136,8 @@ export class DatePicker {
       },
       dateFormat: this.datepickerFormat,
       defaultDate: this.date,
+      position: 'auto',
+      appendTo: document.querySelector('#edit-project-life-cycles-dialog'),
       locale: {
         weekdays: {
           shorthand: this.I18n.t('date.abbr_day_names'),

--- a/frontend/src/app/shared/components/datepicker/datepicker.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.ts
@@ -136,8 +136,6 @@ export class DatePicker {
       },
       dateFormat: this.datepickerFormat,
       defaultDate: this.date,
-      position: 'auto',
-      appendTo: document.querySelector('#edit-project-life-cycles-dialog'),
       locale: {
         weekdays: {
           shorthand: this.I18n.t('date.abbr_day_names'),

--- a/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.html.erb
+++ b/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.html.erb
@@ -1,10 +1,9 @@
 <%=
   render(Primer::Alpha::Dialog.new(title: t("label_life_cycle_step_plural"),
-                                   size: :auto,
-                                   id: dialog_id,
-                                   style: "max-width: 650px")) do |d|
+                                   size: :medium_portrait,
+                                   id: dialog_id)) do |d|
     d.with_header(variant: :large)
-    d.with_body(classes: "Overlay-body_autocomplete_height") do
+    d.with_body do
       render(::ProjectLifeCycles::Sections::EditComponent.new(model))
     end
     d.with_footer do

--- a/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.html.erb
+++ b/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   render(Primer::Alpha::Dialog.new(title: t("label_life_cycle_step_plural"),
                                    size: :medium_portrait,
-                                   id: dialog_id)) do |d|
+                                   id: DIALOG_ID)) do |d|
     d.with_header(variant: :large)
     d.with_body do
       render(::ProjectLifeCycles::Sections::EditComponent.new(model))
@@ -10,7 +10,7 @@
       component_collection do |footer_collection|
         footer_collection.with_component(Primer::ButtonComponent.new(
           data: {
-            "close-dialog-id": dialog_id
+            "close-dialog-id": DIALOG_ID
           }
         )) do
           t("button_cancel")

--- a/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.html.erb
+++ b/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.html.erb
@@ -1,7 +1,8 @@
 <%=
   render(Primer::Alpha::Dialog.new(title: t("label_life_cycle_step_plural"),
-                                   size: :large,
-                                   id: dialog_id)) do |d|
+                                   size: :auto,
+                                   id: dialog_id,
+                                   style: "max-width: 650px")) do |d|
     d.with_header(variant: :large)
     d.with_body(classes: "Overlay-body_autocomplete_height") do
       render(::ProjectLifeCycles::Sections::EditComponent.new(model))

--- a/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.rb
+++ b/modules/overviews/app/components/project_life_cycles/sections/edit_dialog_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -33,9 +35,7 @@ module ProjectLifeCycles
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
-      def dialog_id
-        "edit-project-life-cycles-dialog"
-      end
+      DIALOG_ID = "edit-project-life-cycles-dialog"
     end
   end
 end

--- a/spec/support/components/projects/project_life_cycles/edit_dialog.rb
+++ b/spec/support/components/projects/project_life_cycles/edit_dialog.rb
@@ -50,10 +50,12 @@ module Components
         end
 
         def set_date_for(step, value:)
+          dialog_selector = "##{::ProjectLifeCycles::Sections::EditDialogComponent::DIALOG_ID}"
+
           datepicker = if value.is_a?(Array)
-                         Components::RangeDatepicker.new
+                         Components::RangeDatepicker.new(dialog_selector)
                        else
-                         Components::BasicDatepicker.new
+                         Components::BasicDatepicker.new(dialog_selector)
                        end
 
           datepicker.open(


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60330

# What are you trying to accomplish?

Improve the UX of date pickers in modals i.e. on the lifecycle modal:
* The date picker can now reach out of the modal which prevents the modal needing to increase and the user to scroll to the added content

## Screenshots

![Kapture 2024-12-19 at 21 21 14](https://github.com/user-attachments/assets/56365ab5-8eba-442c-9943-bafe11026371)

# What approach did you choose and why?

The approach is to append the date picker to the modal. However, that is not enough. The date picker dom element also needs to be leveraged to the top-layer which is done right after opening the date picker. Positioning can easily be fixed by removing their top margin. 

Because of the backdrop added when moving the date picker to the top layer, this move to the top layer needs to be repeated also when the input is clicked on again as that is treated as a click on the backdrop which removes an item from the top layer.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
