### PR TITLE
Allow authorization before_action using given permission

### DIFF
--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -85,7 +85,7 @@ module Accounts::Authorization
   # Action can be:
   # * a parameter-like Hash (eg. { controller: '/projects', action: 'edit' })
   # * a permission Symbol (eg. :edit_project)
-  def do_authorize(action, global: false)
+  def do_authorize(action, global: false) # rubocop:disable Metrics/PerceivedComplexity
     is_authorized = if global
                       User.current.allowed_based_on_permission_context?(action)
                     else

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -85,7 +85,7 @@ module Accounts::Authorization
   # Action can be:
   # * a parameter-like Hash (eg. { controller: '/projects', action: 'edit' })
   # * a permission Symbol (eg. :edit_project)
-  def do_authorize(action, global: false) # rubocop:disable Metrics/PerceivedComplexity
+  def do_authorize(action, global: false)
     is_authorized = if global
                       User.current.allowed_based_on_permission_context?(action)
                     else
@@ -195,6 +195,28 @@ module Accounts::Authorization
                                      except: authorization_ensured[:except].dup,
                                      generally_allowed: authorization_ensured[:generally_allowed],
                                      controller: self }
+    end
+
+    # Authorize on the given permission
+    def authorize_with_permission(permission, global: false, **args)
+      authorization_checked_by_default_action(**args.slice(:only, :except))
+
+      before_action(**args) do
+        do_authorize(permission, global:)
+      end
+    end
+
+    # Find a project based on params[:project_id]
+    # and authorize on a given permission
+    def load_and_authorize_with_permission_in_optional_project(permission, **args)
+      authorization_checked_by_default_action(**args.slice(:only, :except))
+
+      before_action(**args) do
+        @project = Project.find(params[:project_id]) if params[:project_id].present?
+        do_authorize(permission, global: params[:project_id].blank?)
+      rescue ActiveRecord::RecordNotFound
+        render_404
+      end
     end
   end
 end

--- a/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
@@ -1,9 +1,6 @@
 module RecurringMeetings
   class ScheduleController < ApplicationController
-    before_action do
-      do_authorize :create_meetings, global: true
-    end
-    authorization_checked! :humanize_schedule
+    authorize_with_permission :create_meetings, global: true
 
     around_action :with_user_time_zone
     before_action :build_meeting

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
 
       authorize_with_permission :view_project
 
-      def do_authorize(_permission, global: false)
+      def do_authorize(*)
         true
       end
     end
@@ -142,7 +142,7 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
         render plain: "OK"
       end
 
-      def do_authorize(_permission, global: true)
+      def do_authorize(*)
         true
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
 
       load_and_authorize_with_permission_in_optional_project :view_project
 
-      def do_authorize(_permission, global: true)
+      def do_authorize(*)
         true
       end
     end
@@ -209,7 +209,7 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
         render plain: "OK"
       end
 
-      def do_authorize(_permission, global: true)
+      def do_authorize(*)
         true
       end
     end

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -54,18 +54,18 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
 
   current_user { user }
 
-  shared_examples "succeeds" do
+  shared_examples "succeeds" do |action_name = :index|
     it "succeeds" do
-      get :index
+      get action_name
 
       expect(response)
         .to have_http_status :ok
     end
   end
 
-  shared_examples "is prevented" do
+  shared_examples "is prevented" do |action_name = :index|
     it "fails with a RuntimeError" do
-      expect { get :index }
+      expect { get action_name }
         .to raise_error RuntimeError
     end
   end
@@ -106,6 +106,123 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     end
 
     it_behaves_like "succeeds"
+  end
+
+  context "with authorization checked with authorize_with_permission" do
+    controller do
+      include Accounts::Authorization
+      include controller_setup
+
+      authorize_with_permission :view_project
+
+      def do_authorize(_permission, global: false)
+        true
+      end
+    end
+
+    it_behaves_like "succeeds"
+
+    it "calls the authorization method" do
+      allow(controller).to receive(:do_authorize)
+
+      get :index
+
+      expect(controller).to have_received(:do_authorize).with(:view_project, global: false)
+    end
+  end
+
+  context "with authorization checked with authorize_with_permission on a single action" do
+    controller do
+      include Accounts::Authorization
+      include controller_setup
+
+      authorize_with_permission :view_project, only: %i[test]
+
+      def test
+        render plain: "OK"
+      end
+
+      def do_authorize(_permission, global: true)
+        true
+      end
+    end
+
+    before do
+      @routes.draw do # rubocop:disable RSpec/InstanceVariable
+        get "/anonymous/index"
+        get "/anonymous/test"
+      end
+    end
+
+    it "allows calling test" do
+      allow(controller).to receive(:do_authorize)
+
+      get :test
+
+      expect(controller).to have_received(:do_authorize).with(:view_project, global: false)
+    end
+
+    it_behaves_like "is prevented", :index
+  end
+
+  context "with authorization checked with load_and_authorize_with_permission_in_optional_project" do
+    controller do
+      include Accounts::Authorization
+      include controller_setup
+
+      load_and_authorize_with_permission_in_optional_project :view_project
+
+      def do_authorize(_permission, global: true)
+        true
+      end
+    end
+
+    it "loads the project if present" do
+      allow(controller).to receive(:do_authorize)
+      allow(Project).to receive(:find)
+
+      get :index, params: { project_id: "1" }
+
+      expect(Project).to have_received(:find).with("1")
+      expect(controller).to have_received(:do_authorize).with(:view_project, global: false)
+    end
+
+    it "uses the global call if not present" do
+      allow(controller).to receive(:do_authorize)
+      allow(Project).to receive(:find)
+
+      get :index
+
+      expect(Project).not_to have_received(:find)
+      expect(controller).to have_received(:do_authorize).with(:view_project, global: true)
+    end
+  end
+
+  context "with authorization checked on single action with load_and_authorize_with_permission_in_optional_project" do
+    controller do
+      include Accounts::Authorization
+      include controller_setup
+
+      load_and_authorize_with_permission_in_optional_project :view_project, only: %i[test]
+
+      def test
+        render plain: "OK"
+      end
+
+      def do_authorize(_permission, global: true)
+        true
+      end
+    end
+
+    before do
+      @routes.draw do # rubocop:disable RSpec/InstanceVariable
+        get "/anonymous/index"
+        get "/anonymous/test"
+      end
+    end
+
+    it_behaves_like "succeeds", :test
+    it_behaves_like "is prevented", :index
   end
 
   context "with authorization checked with load_and_authorize_in_optional_project" do


### PR DESCRIPTION
With more and more smaller actions that happen on controllers for e.g., turbo-specific actions, adding all of them in the engine is becoming cumbersome and harder to understand.

Instead, this PR suggests to allow authorization to happen on permissions, not only actions. This was possibly already but required us to manually whitelist the action from the default authorization checks. By providing two helper methods, we can re-use most of the same logic but extend them for permissions.