### PR TITLE
implementation/60342 Update reminder email subject to include the note

### DIFF
--- a/app/views/reminders/notification_mailer/reminder_notification.text.erb
+++ b/app/views/reminders/notification_mailer/reminder_notification.text.erb
@@ -1,14 +1,12 @@
 <%= I18n.t(:'mail.salutation', user: @user.firstname) %>
 <%= reminder_summary_text %>
-<%= "-" * 100 %>
+<%= text_email_wrapper %>
 
-<% work_package = @notification.resource %>
-
-<%= "=" * (('# ' + work_package.id.to_s + work_package.subject).length + 4) %>
-= #<%= work_package.id %> <%= work_package.subject %> =
-<%= "=" * (('# ' + work_package.id.to_s + work_package.subject).length + 4) %>
+<%= work_package_subject_text_wrapper %>
+= #<%= @work_package.id %> <%= @work_package.subject %> =
+<%= work_package_subject_text_wrapper %>
 
 <%= reminder_timestamp_text %>
 <%= reminder_note_text %>
 
-<%= "-" * 100 %>
+<%= text_email_wrapper %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2990,7 +2990,8 @@ en:
       see_all: "See all"
       updated_at: "Updated at %{timestamp} by %{user}"
     reminder_notifications:
-      subject: "You have a new reminder"
+      subject: "Reminder: %{note}"
+      heading: "You have a new reminder"
       note: "Note: “%{note}”"
     sharing:
       work_packages:

--- a/spec/mailers/reminders/notification_mailer_spec.rb
+++ b/spec/mailers/reminders/notification_mailer_spec.rb
@@ -43,8 +43,22 @@ RSpec.describe Reminders::NotificationMailer do
 
     let(:mail_body) { mail.body.parts.detect { |part| part["Content-Type"].value == "text/html" }.body.to_s }
 
-    it "notes reminder in subject" do
-      expect(mail.subject).to eql("OpenProject - You have a new reminder")
+    describe "Email subject" do
+      context "when the reminder has a note" do
+        it "includes the note" do
+          expect(mail.subject).to eql("OpenProject - Reminder: This is an important reminder")
+        end
+      end
+
+      context "when the reminder does not have a note" do
+        before do
+          notification.reminder.note = ""
+        end
+
+        it "includes the work package subject" do
+          expect(mail.subject).to eql("OpenProject - Reminder: #{work_package.subject}")
+        end
+      end
     end
 
     it "sends to the recipient" do


### PR DESCRIPTION
https://community.openproject.org/work_packages/60342

Reminder email template will be redesigned to differentiate from notifications. In the meantime, we add the note or work package subject in the email subject as a tiny enhancements.

@brunopagno will be pleased to see some helper method extractions 🙈

<img width="1996" alt="Screenshot 2024-12-19 at 2 42 06 PM" src="https://github.com/user-attachments/assets/eda4f180-ad3f-4bfe-b336-07c426c86b00" />
<img width="799" alt="Screenshot 2024-12-19 at 2 41 46 PM" src="https://github.com/user-attachments/assets/05dc1d8f-df61-4b70-8588-c71bb2c74025" />
