### PR TITLE
Add an enterprise banner on top of automatic subject configuration

### DIFF
--- a/app/components/enterprise_edition/banner_component.rb
+++ b/app/components/enterprise_edition/banner_component.rb
@@ -29,9 +29,9 @@
 # ++
 
 module EnterpriseEdition
-  # Add a general description of component here
-  # Add additional usage considerations or best practices that may aid the user to use the component correctly.
-  # @accessibility Add any accessibility considerations
+  # A banner indicating that a given feature requires the enterprise edition of OpenProject.
+  # This component uses conventional names for translation keys or URL look-ups based on the feature_key passed in.
+  # It will only be rendered if necessary.
   class BannerComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
@@ -50,6 +50,7 @@ module EnterpriseEdition
                    **system_arguments)
       @system_arguments = system_arguments
       @system_arguments[:tag] = "div"
+      @system_arguments[:test_selector] = "op-ee-banner-#{feature_key.to_s.tr('_', '-')}"
       super
 
       @feature_key = feature_key

--- a/app/components/work_packages/types/subject_configuration_component.html.erb
+++ b/app/components/work_packages/types/subject_configuration_component.html.erb
@@ -28,6 +28,10 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
+  render(EnterpriseEdition::BannerComponent.new(:automatic_subject_generation, mb: 3))
+%>
+
+<%=
   primer_form_with(**form_options) do |f|
     render(WorkPackages::Types::SubjectConfigurationForm.new(f))
   end

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -45,6 +45,7 @@ module WorkPackages
             checked: has_pattern?,
             label: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.label"),
             caption: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.caption"),
+            disabled: !EnterpriseToken.active? && !has_pattern?,
             data: { action: "admin--subject-configuration#showPatternInput" }
           )
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1909,6 +1909,8 @@ en:
     upsale:
       title: "Enterprise add-on"
       link_title: "More information"
+      automatic_subject_generation:
+        description: "Create automatically generated subjects using referenced attributes and text."
       customize_life_cycle:
         description: "Create and organize different project stages and gates than the ones provided by PM2 project cycle planning."
       form_configuration:

--- a/docs/system-admin-guide/manage-work-packages/work-package-types/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-types/README.md
@@ -104,3 +104,7 @@ The **Activated for new projects by default** setting in the Types will only act
 This can be also configured in the [project settings](../../../user-guide/projects/project-settings).
 
 ![activate projects for work package types](image-20200116150513323.png)
+
+## Work package subject configuration (Enterprise add-on)
+
+Under **Administration -> Work packages -> Types** on the tab **Subject configuration** you can choose whether work package subjects should be defined automatically.

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -251,6 +251,9 @@ module OpenProject
               href: "https://www.openproject.org/docs/user-guide/time-and-costs/progress-tracking/"
             },
             enterprise_docs: {
+              automatic_subject_generation: {
+                href: "https://www.openproject.org/docs/system-admin-guide/manage-work-packages/work-package-types/#work-package-subject-configuration-enterprise-add-on"
+              },
               form_configuration: {
                 href: "https://www.openproject.org/docs/system-admin-guide/manage-work-packages/work-package-types/#work-package-form-configuration-enterprise-add-on"
               },

--- a/spec/components/enterprise_edition/banner_component_spec.rb
+++ b/spec/components/enterprise_edition/banner_component_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
     it "renders the component" do
       render_component_in_mo
 
+      expect(page).to have_test_selector("op-ee-banner-some-enterprise-feature")
       expect(page).to have_css ".op-ee-banner--title-container", text: title
       expect(page).to have_css ".op-ee-banner--description-container", text: description
       expect(page).to have_link link_title, href:

--- a/spec/components/work_packages/types/subject_configuration_component_spec.rb
+++ b/spec/components/work_packages/types/subject_configuration_component_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :component do
+  subject(:render_component) do
+    render_inline(described_class.new(type))
+  end
+
+  let(:type) { create(:type) }
+
+  before do
+    allow(EnterpriseToken).to receive(:active?).and_return(true)
+  end
+
+  it "shows no enterprise banner" do
+    render_component
+
+    expect(page).not_to have_test_selector("op-ee-banner-automatic-subject-generation")
+  end
+
+  it "enables mode selectors", :aggregate_failures do
+    render_component
+
+    expect(page.find("input[type=radio][value=auto]")).not_to be_disabled
+    expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
+  end
+
+  context "when enterprise edition is not activated" do
+    before do
+      allow(EnterpriseToken).to receive(:active?).and_return(false)
+    end
+
+    it "shows the enterprise banner" do
+      render_component
+
+      expect(page).to have_test_selector("op-ee-banner-automatic-subject-generation")
+    end
+
+    it "disables only automatic mode selector", :aggregate_failures do
+      render_component
+
+      expect(page.find("input[type=radio][value=auto]")).to be_disabled
+      expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
+    end
+
+    context "and when the subject is already automatically generated" do
+      let(:type) { create(:type, patterns: { subject: { blueprint: "Hello world", enabled: true } }) }
+
+      it "shows the enterprise banner" do
+        render_component
+
+        expect(page).to have_test_selector("op-ee-banner-automatic-subject-generation")
+      end
+
+      it "enables mode selectors", :aggregate_failures do
+        render_component
+
+        expect(page.find("input[type=radio][value=auto]")).not_to be_disabled
+        expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are making sure that users can revert back to manual subjects at any time and even keep using the feature if it's still enabled after their enterprise token expired. They will merely not be able to set new types to automatic and have to live with an enterprise banner being shown to them whenever they change the subject config.

# Ticket
https://community.openproject.org/projects/document-workflows-stream/work_packages/59929

# What are you trying to accomplish?
Show users that this feature is enterprise-exclusive, while retaining their ability to use the feature (or stop using it) once their EE license has expired

## Screenshots

![image](https://github.com/user-attachments/assets/a0f86641-e82e-4b92-b909-8fc8cad55fda)

# What approach did you choose and why?
Our new standard component for EE banners, because standardization is great!

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
