### PR TITLE
[#60294] Allow Gate to be overlapping a Stage

### DIFF
--- a/app/contracts/project_life_cycle_steps/base_contract.rb
+++ b/app/contracts/project_life_cycle_steps/base_contract.rb
@@ -50,7 +50,7 @@ module ProjectLifeCycleSteps
 
       # Compare consecutive steps in pairs
       filtered_steps.each_cons(2) do |previous_step, current_step|
-        if start_date_for(current_step) <= end_date_for(previous_step)
+        if has_invalid_dates?(previous_step, current_step)
           step = previous_step.is_a?(Project::Stage) ? "Stage" : "Gate"
           field = current_step.is_a?(Project::Stage) ? :date_range : :date
           model.errors.import(
@@ -73,6 +73,14 @@ module ProjectLifeCycleSteps
         step.date
       when Project::Stage
         step.end_date || step.start_date # Use the start_date as fallback for single date stages
+      end
+    end
+
+    def has_invalid_dates?(previous_step, current_step)
+      if previous_step.instance_of?(current_step.class)
+        start_date_for(current_step) <= end_date_for(previous_step)
+      else
+        start_date_for(current_step) < end_date_for(previous_step)
       end
     end
   end

--- a/spec/contracts/project_life_cycle_steps/base_contract_spec.rb
+++ b/spec/contracts/project_life_cycle_steps/base_contract_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe ProjectLifeCycleSteps::BaseContract do
 
     describe "validations" do
       describe "#consecutive_steps_have_increasing_dates" do
-        let(:step1) { build_stubbed(:project_gate, start_date: Date.new(2024, 1, 1)) }
-        let(:step2) { build_stubbed(:project_stage, start_date: Date.new(2024, 2, 1), end_date: Date.new(2024, 2, 28)) }
-        let(:step3) { build_stubbed(:project_gate, start_date: Date.new(2024, 3, 1), end_date: Date.new(2024, 3, 15)) }
-        let(:steps) { [step1, step2, step3] }
+        let(:gate1) { build_stubbed(:project_gate, start_date: Date.new(2024, 1, 1)) }
+        let(:stage2) { build_stubbed(:project_stage, start_date: Date.new(2024, 2, 1), end_date: Date.new(2024, 2, 28)) }
+        let(:gate3) { build_stubbed(:project_gate, start_date: Date.new(2024, 3, 1), end_date: Date.new(2024, 3, 15)) }
+        let(:steps) { [gate1, stage2, gate3] }
 
         context "when no steps are present" do
           let(:steps) { [] }
@@ -65,69 +65,146 @@ RSpec.describe ProjectLifeCycleSteps::BaseContract do
         end
 
         context "when only one step is present" do
-          let(:steps) { [step1] }
+          let(:steps) { [gate1] }
 
           it_behaves_like "contract is valid"
         end
 
         context "when steps have valid and increasing dates" do
-          let(:steps) { [step1, step2] }
+          let(:steps) { [gate1, stage2] }
 
           it_behaves_like "contract is valid"
         end
 
         context "when steps have decreasing dates" do
           context "and the erroneous step is a Gate" do
-            let(:steps) { [step3, step1] }
+            let(:steps) { [gate3, gate1] }
 
             it_behaves_like "contract is invalid",
                             "available_life_cycle_steps.date": :non_continuous_dates
 
             it "adds an error to the decreasing step" do
               contract.validate
-              expect(step1.errors.symbols_for(:date)).to include(:non_continuous_dates)
+              expect(gate1.errors.symbols_for(:date)).to include(:non_continuous_dates)
             end
           end
 
           context "and the erroneous step is a Stage" do
-            let(:steps) { [step3, step2] }
+            let(:steps) { [gate3, stage2] }
 
             it_behaves_like "contract is invalid",
                             "available_life_cycle_steps.date_range": :non_continuous_dates
 
             it "adds an error to the decreasing step" do
               contract.validate
-              expect(step2.errors.symbols_for(:date_range)).to include(:non_continuous_dates)
+              expect(stage2.errors.symbols_for(:date_range)).to include(:non_continuous_dates)
             end
           end
         end
 
         context "when steps with identical dates" do
           let(:step4) { build_stubbed(:project_gate, start_date: Date.new(2024, 1, 1)) }
-          let(:steps) { [step1, step4] }
+          let(:steps) { [gate1, step4] }
 
           it_behaves_like "contract is invalid",
                           "available_life_cycle_steps.date": :non_continuous_dates
+        end
+
+        context "when steps have touching start and end dates" do
+          context "when 2 Stages are touching" do
+            let(:stage4) { build_stubbed(:project_stage, start_date: Date.new(2024, 2, 28), end_date: Date.new(2024, 3, 1)) }
+            let(:steps) { [stage2, stage4] }
+
+            it_behaves_like "contract is invalid",
+                            "available_life_cycle_steps.date_range": :non_continuous_dates
+
+            context "when having an empty step in between" do
+              let(:step_missing_dates) { build_stubbed(:project_stage, start_date: nil, end_date: nil) }
+              let(:steps) { [stage2, step_missing_dates, stage4] }
+
+              it_behaves_like "contract is invalid",
+                              "available_life_cycle_steps.date_range": :non_continuous_dates
+            end
+          end
+
+          context "when 2 Gates are touching" do
+            let(:gate4) { build_stubbed(:project_gate, start_date: Date.new(2024, 1, 1)) }
+            let(:steps) { [gate1, gate4] }
+
+            it_behaves_like "contract is invalid",
+                            "available_life_cycle_steps.date": :non_continuous_dates
+
+            context "when having an empty step in between" do
+              let(:step_missing_dates) { build_stubbed(:project_stage, start_date: nil, end_date: nil) }
+              let(:steps) { [gate1, step_missing_dates, gate4] }
+
+              it_behaves_like "contract is invalid",
+                              "available_life_cycle_steps.date": :non_continuous_dates
+            end
+          end
+
+          context "when a Stage and a Gate are touching on the start date" do
+            let(:gate4) { build_stubbed(:project_gate, start_date: Date.new(2024, 2, 28)) }
+            let(:steps) { [stage2, gate4] }
+
+            it_behaves_like "contract is valid"
+
+            context "when having an empty step in between" do
+              let(:step_missing_dates) { build_stubbed(:project_stage, start_date: nil, end_date: nil) }
+              let(:steps) { [stage2, step_missing_dates, gate4] }
+
+              it_behaves_like "contract is valid"
+            end
+          end
+
+          context "when a Stage and a Gate are touching on the end date" do
+            let(:stage4) { build_stubbed(:project_stage, start_date: Date.new(2023, 12, 30), end_date: Date.new(2024, 1, 1)) }
+            let(:steps) { [stage4, gate1] }
+
+            it_behaves_like "contract is valid"
+
+            context "when having an empty step in between" do
+              let(:step_missing_dates) { build_stubbed(:project_stage, start_date: nil, end_date: nil) }
+              let(:steps) { [stage4, step_missing_dates, gate1] }
+
+              it_behaves_like "contract is valid"
+            end
+          end
+
+          context "when a Stage, a Gate, and anothe Stage are touching" do
+            let(:gate4) { build_stubbed(:project_gate, start_date: Date.new(2024, 2, 28)) }
+            let(:stage5) { build_stubbed(:project_stage, start_date: Date.new(2024, 2, 28), end_date: Date.new(2024, 3, 1)) }
+            let(:steps) { [stage2, gate4, stage5] }
+
+            it_behaves_like "contract is valid"
+
+            context "when having an empty step in between" do
+              let(:step_missing_dates) { build_stubbed(:project_stage, start_date: nil, end_date: nil) }
+              let(:steps) { [stage2, gate4, step_missing_dates, stage5] }
+
+              it_behaves_like "contract is valid"
+            end
+          end
         end
 
         context "when a step has missing start dates" do
           let(:step_missing_dates) { build_stubbed(:project_stage, start_date: nil, end_date: nil) }
 
           context "and the other steps have increasing dates" do
-            let(:steps) { [step1, step_missing_dates, step2] }
+            let(:steps) { [gate1, step_missing_dates, stage2] }
 
             it_behaves_like "contract is valid"
           end
 
           context "and the other steps have decreasing dates" do
-            let(:steps) { [step2, step_missing_dates, step1] }
+            let(:steps) { [stage2, step_missing_dates, gate1] }
 
             it_behaves_like "contract is invalid",
                             "available_life_cycle_steps.date": :non_continuous_dates
 
             it "adds an error to the decreasing step" do
               contract.validate
-              expect(step1.errors.symbols_for(:date)).to include(:non_continuous_dates)
+              expect(gate1.errors.symbols_for(:date)).to include(:non_continuous_dates)
             end
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60294

# What are you trying to accomplish?
Allow Gates and Stages to have touching dates.
According to the docs, the following behaviour should be implemented:

Having this is valid:

Stage 1 - 2024.01.01 -> **2024.01.02**
Gate 1  - **2024.01.02**
Stage 2 - **2024.01.02** -> 2024.01.03

Having this, is invalid:

Stage 1 - 2024.01.01 -> **2024.01.02**
Stage 2 - **2024.01.02** -> 2024.01.03


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
