### PR TITLE
Wrap reminder note so that it is always visible

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.sass
@@ -1,16 +1,15 @@
 @import "helpers"
 
+.op-ian-item
+  &:has(.op-ian-reminder-alert--note)
+    height: unset
+
 .op-ian-reminder-alert
-  display: grid
-  grid-template-columns: auto 1fr
-  grid-column-gap: $spot-spacing-0_25
-  align-items: center
+  display: flex
+  gap: $spot-spacing-0_25
+  flex-wrap: wrap
   color: var(--fgColor-muted)
 
   &--note
-    @include text-shortener
     line-height: 1rem
     color: var(--fgColor-default)
-
-    > *
-      flex-shrink: 0


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/60196

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

When a notification entry has a reminder note, unset the height allowing the reminder note to expand the height of the notification entry. By default, *_reminder notes are limited to 128 chars_* so we shouldn't have overly extensive heights.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/e52f4ea5-60c9-4c60-aa3c-f91f34303ebf

<img width="364" alt="Screenshot 2024-12-20 at 2 11 58 PM" src="https://github.com/user-attachments/assets/4f22cdc7-7fca-4220-8bd5-2c1c333cf812" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Define the reminder alert layout as a multi-line flex container

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
