### PR TITLE
Chore/add frozen string literal true

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CORE_OR_MODULE_MIGRATIONS_REGEX = %r{(modules/.*)?db/migrate/.*\.rb}
 
 def added_or_modified_migrations?

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/admin_only_contract.rb
+++ b/app/contracts/admin_only_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attachments/create_contract.rb
+++ b/app/contracts/attachments/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attachments/delete_contract.rb
+++ b/app/contracts/attachments/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attachments/prepare_upload_contract.rb
+++ b/app/contracts/attachments/prepare_upload_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attachments/validate_replacements.rb
+++ b/app/contracts/attachments/validate_replacements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attribute_help_texts/base_contract.rb
+++ b/app/contracts/attribute_help_texts/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attribute_help_texts/create_contract.rb
+++ b/app/contracts/attribute_help_texts/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/attribute_help_texts/update_contract.rb
+++ b/app/contracts/attribute_help_texts/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/concerns/admin_writable_timestamps.rb
+++ b/app/contracts/concerns/admin_writable_timestamps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/concerns/assignable_custom_field_values.rb
+++ b/app/contracts/concerns/assignable_custom_field_values.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/concerns/assignable_values_contract.rb
+++ b/app/contracts/concerns/assignable_values_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AssignableValuesContract
   def assignable_values(column, _user)
     method_name = "assignable_#{column.to_s.pluralize}"

--- a/app/contracts/concerns/requires_admin_guard.rb
+++ b/app/contracts/concerns/requires_admin_guard.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/concerns/single_table_inheritance_model_contract.rb
+++ b/app/contracts/concerns/single_table_inheritance_model_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/concerns/unchanged_project.rb
+++ b/app/contracts/concerns/unchanged_project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/base_contract.rb
+++ b/app/contracts/shares/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/create_contract.rb
+++ b/app/contracts/shares/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/delete_contract.rb
+++ b/app/contracts/shares/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/project_queries/create_contract.rb
+++ b/app/contracts/shares/project_queries/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/project_queries/delete_contract.rb
+++ b/app/contracts/shares/project_queries/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/project_queries/update_contract.rb
+++ b/app/contracts/shares/project_queries/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/update_contract.rb
+++ b/app/contracts/shares/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/work_packages/base_extension.rb
+++ b/app/contracts/shares/work_packages/base_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/work_packages/create_contract.rb
+++ b/app/contracts/shares/work_packages/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/work_packages/delete_contract.rb
+++ b/app/contracts/shares/work_packages/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/shares/work_packages/update_contract.rb
+++ b/app/contracts/shares/work_packages/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/user_preferences/base_contract.rb
+++ b/app/contracts/user_preferences/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/user_preferences/update_contract.rb
+++ b/app/contracts/user_preferences/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/users/base_contract.rb
+++ b/app/contracts/users/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/users/delete_contract.rb
+++ b/app/contracts/users/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/versions/base_contract.rb
+++ b/app/contracts/versions/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/versions/create_contract.rb
+++ b/app/contracts/versions/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/versions/delete_contract.rb
+++ b/app/contracts/versions/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/versions/update_contract.rb
+++ b/app/contracts/versions/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/views/base_contract.rb
+++ b/app/contracts/views/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/views/create_contract.rb
+++ b/app/contracts/views/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/views/update_contract.rb
+++ b/app/contracts/views/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/wiki_pages/base_contract.rb
+++ b/app/contracts/wiki_pages/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/wiki_pages/copy_contract.rb
+++ b/app/contracts/wiki_pages/copy_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/wiki_pages/create_contract.rb
+++ b/app/contracts/wiki_pages/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/wiki_pages/update_contract.rb
+++ b/app/contracts/wiki_pages/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/copy_project_contract.rb
+++ b/app/contracts/work_packages/copy_project_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/create_note_contract.rb
+++ b/app/contracts/work_packages/create_note_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/delete_contract.rb
+++ b/app/contracts/work_packages/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/skip_authorization_checks.rb
+++ b/app/contracts/work_packages/skip_authorization_checks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/work_packages/update_dependent_contract.rb
+++ b/app/contracts/work_packages/update_dependent_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/app/controllers/admin/attachments/quarantined_attachments_controller.rb
+++ b/app/controllers/admin/attachments/quarantined_attachments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/admin/settings/progress_tracking_controller.rb
+++ b/app/controllers/admin/settings/progress_tracking_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/admin/settings/users_settings_controller.rb
+++ b/app/controllers/admin/settings/users_settings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/admin/settings/work_packages_general_controller.rb
+++ b/app/controllers/admin/settings/work_packages_general_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/admin/settings/working_days_and_hours_settings_controller.rb
+++ b/app/controllers/admin/settings/working_days_and_hours_settings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/enumerations_controller.rb
+++ b/app/controllers/enumerations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/my/auto_login_tokens_controller.rb
+++ b/app/controllers/my/auto_login_tokens_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module My
   class AutoLoginTokensController < ::ApplicationController
     before_action :require_login

--- a/app/controllers/my/sessions_controller.rb
+++ b/app/controllers/my/sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module My
   class SessionsController < ::ApplicationController
     before_action :require_login

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/users/memberships_controller.rb
+++ b/app/controllers/users/memberships_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/work_packages/auto_completes_controller.rb
+++ b/app/controllers/work_packages/auto_completes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/work_packages/bulk_error_message.rb
+++ b/app/controllers/work_packages/bulk_error_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/work_packages/hover_card_controller.rb
+++ b/app/controllers/work_packages/hover_card_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/work_packages/reports_controller.rb
+++ b/app/controllers/work_packages/reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/controllers/work_packages/split_view_controller.rb
+++ b/app/controllers/work_packages/split_view_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/menus/members/menu.rb
+++ b/app/menus/members/menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/menus/notifications/menu.rb
+++ b/app/menus/notifications/menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/menus/projects/menu.rb
+++ b/app/menus/projects/menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/menus/submenu.rb
+++ b/app/menus/submenu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/menus/work_packages/menu.rb
+++ b/app/menus/work_packages/menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/changeset_activity_provider.rb
+++ b/app/models/activities/changeset_activity_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/event.rb
+++ b/app/models/activities/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/event_mapper.rb
+++ b/app/models/activities/event_mapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/fetcher.rb
+++ b/app/models/activities/fetcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/message_activity_provider.rb
+++ b/app/models/activities/message_activity_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/news_activity_provider.rb
+++ b/app/models/activities/news_activity_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/project_activity_provider.rb
+++ b/app/models/activities/project_activity_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/activities/wiki_page_activity_provider.rb
+++ b/app/models/activities/wiki_page_activity_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/associations/groupable.rb
+++ b/app/models/associations/groupable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/attribute_help_text/project.rb
+++ b/app/models/attribute_help_text/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/attribute_help_text/work_package.rb
+++ b/app/models/attribute_help_text/work_package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/backup.rb
+++ b/app/models/backup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Backup < Export
   class << self
     def permission

--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/colors/hex_color.rb
+++ b/app/models/colors/hex_color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Colors
   module HexColor
     ##

--- a/app/models/concerns/has_members.rb
+++ b/app/models/concerns/has_members.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/concerns/inexistent_model.rb
+++ b/app/models/concerns/inexistent_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH

--- a/app/models/concerns/remindable.rb
+++ b/app/models/concerns/remindable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH

--- a/app/models/concerns/subclass_registry.rb
+++ b/app/models/concerns/subclass_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/concerns/tableless.rb
+++ b/app/models/concerns/tableless.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/concerns/virtual_attribute.rb
+++ b/app/models/concerns/virtual_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_field_section.rb
+++ b/app/models/custom_field_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_fields_project.rb
+++ b/app/models/custom_fields_project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_option.rb
+++ b/app/models/custom_option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_style.rb
+++ b/app/models/custom_style.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CustomStyle < ApplicationRecord
   mount_uploader :logo, OpenProject::Configuration.file_uploader
   mount_uploader :export_logo, OpenProject::Configuration.file_uploader

--- a/app/models/custom_value/ar_object_strategy.rb
+++ b/app/models/custom_value/ar_object_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/bool_strategy.rb
+++ b/app/models/custom_value/bool_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/empty_strategy.rb
+++ b/app/models/custom_value/empty_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/format_strategy.rb
+++ b/app/models/custom_value/format_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/formattable_strategy.rb
+++ b/app/models/custom_value/formattable_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/link_strategy.rb
+++ b/app/models/custom_value/link_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -37,7 +37,7 @@ class CustomValue::ListStrategy < CustomValue::ARObjectStrategy
 
   def typed_value
     super_value = super
-    (super_value && super_value.to_s) || nil
+    super_value&.to_s || nil
   end
 
   private

--- a/app/models/custom_value/string_strategy.rb
+++ b/app/models/custom_value/string_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/deleted_user.rb
+++ b/app/models/deleted_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeletedUser < User
   def self.first
     super || create(type: to_s, status: statuses[:locked])

--- a/app/models/design_color.rb
+++ b/app/models/design_color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH

--- a/app/models/enabled_module.rb
+++ b/app/models/enabled_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/exports/concerns/csv.rb
+++ b/app/models/exports/concerns/csv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/exports/export_error.rb
+++ b/app/models/exports/export_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/exports/exporter.rb
+++ b/app/models/exports/exporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/exports/formatters/custom_field.rb
+++ b/app/models/exports/formatters/custom_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Exports
   module Formatters
     class CustomField < Default

--- a/app/models/exports/formatters/custom_field_pdf.rb
+++ b/app/models/exports/formatters/custom_field_pdf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Exports
   module Formatters
     class CustomFieldPdf < CustomField

--- a/app/models/exports/formatters/default.rb
+++ b/app/models/exports/formatters/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Exports
   module Formatters
     class Default

--- a/app/models/exports/register.rb
+++ b/app/models/exports/register.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/exports/result.rb
+++ b/app/models/exports/result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/global_role.rb
+++ b/app/models/global_role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/group_custom_field.rb
+++ b/app/models/group_custom_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/groups/scopes/visible.rb
+++ b/app/models/groups/scopes/visible.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journable/historic_active_record_relation.rb
+++ b/app/models/journable/historic_active_record_relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/associated_journal.rb
+++ b/app/models/journal/associated_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/attachable_journal.rb
+++ b/app/models/journal/attachable_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/attachment_journal.rb
+++ b/app/models/journal/attachment_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/base_journal.rb
+++ b/app/models/journal/base_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_duplicate_work_package_close.rb
+++ b/app/models/journal/caused_by_duplicate_work_package_close.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_progress_mode_changed_to_status_based.rb
+++ b/app/models/journal/caused_by_progress_mode_changed_to_status_based.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_status_changed.rb
+++ b/app/models/journal/caused_by_status_changed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_system_update.rb
+++ b/app/models/journal/caused_by_system_update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_total_percent_complete_mode_changed_to_simple_average.rb
+++ b/app/models/journal/caused_by_total_percent_complete_mode_changed_to_simple_average.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_total_percent_complete_mode_changed_to_work_weighted_average.rb
+++ b/app/models/journal/caused_by_total_percent_complete_mode_changed_to_work_weighted_average.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_work_package_child_change.rb
+++ b/app/models/journal/caused_by_work_package_child_change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_work_package_parent_change.rb
+++ b/app/models/journal/caused_by_work_package_parent_change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_work_package_predecessor_change.rb
+++ b/app/models/journal/caused_by_work_package_predecessor_change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_work_package_related_change.rb
+++ b/app/models/journal/caused_by_work_package_related_change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/caused_by_working_day_changes.rb
+++ b/app/models/journal/caused_by_working_day_changes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/changeset_journal.rb
+++ b/app/models/journal/changeset_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/customizable_journal.rb
+++ b/app/models/journal/customizable_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/message_journal.rb
+++ b/app/models/journal/message_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/news_journal.rb
+++ b/app/models/journal/news_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/project_journal.rb
+++ b/app/models/journal/project_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/timestamps.rb
+++ b/app/models/journal/timestamps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/wiki_page_journal.rb
+++ b/app/models/journal/wiki_page_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journal/work_package_journal.rb
+++ b/app/models/journal/work_package_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/journals/scopes/with_sequence_version.rb
+++ b/app/models/journals/scopes/with_sequence_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NotificationSetting < ApplicationRecord
   WATCHED = :watched
   ASSIGNEE = :assignee

--- a/app/models/notification_settings/scopes/applicable.rb
+++ b/app/models/notification_settings/scopes/applicable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/notifications/scopes/mail_alert_unsent.rb
+++ b/app/models/notifications/scopes/mail_alert_unsent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/notifications/scopes/mail_reminder_unsent.rb
+++ b/app/models/notifications/scopes/mail_reminder_unsent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/notifications/scopes/recipient.rb
+++ b/app/models/notifications/scopes/recipient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/notifications/scopes/unsent_reminders_before.rb
+++ b/app/models/notifications/scopes/unsent_reminders_before.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/notifications/scopes/visible.rb
+++ b/app/models/notifications/scopes/visible.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/ordered_work_package.rb
+++ b/app/models/ordered_work_package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/placeholder_user.rb
+++ b/app/models/placeholder_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/placeholder_users/scopes/visible.rb
+++ b/app/models/placeholder_users/scopes/visible.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project/gate.rb
+++ b/app/models/project/gate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project/gate_definition.rb
+++ b/app/models/project/gate_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project/life_cycle_step.rb
+++ b/app/models/project/life_cycle_step.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project/life_cycle_step_definition.rb
+++ b/app/models/project/life_cycle_step_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project/stage.rb
+++ b/app/models/project/stage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project/stage_definition.rb
+++ b/app/models/project/stage_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/project_query.rb
+++ b/app/models/project_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/activity.rb
+++ b/app/models/projects/activity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/ancestors_from_root.rb
+++ b/app/models/projects/ancestors_from_root.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/export.rb
+++ b/app/models/projects/export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Projects::Export < Export
   acts_as_attachable view_permission: :view_project,
                      add_permission: :view_project,

--- a/app/models/projects/exports/csv.rb
+++ b/app/models/projects/exports/csv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/exports/formatters/active.rb
+++ b/app/models/projects/exports/formatters/active.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/exports/formatters/description.rb
+++ b/app/models/projects/exports/formatters/description.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/exports/formatters/public.rb
+++ b/app/models/projects/exports/formatters/public.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/exports/formatters/status.rb
+++ b/app/models/projects/exports/formatters/status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/exports/query_exporter.rb
+++ b/app/models/projects/exports/query_exporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/hierarchy.rb
+++ b/app/models/projects/hierarchy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/scopes/activated_in_storage.rb
+++ b/app/models/projects/scopes/activated_in_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/scopes/allowed_to.rb
+++ b/app/models/projects/scopes/allowed_to.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/scopes/available_custom_fields.rb
+++ b/app/models/projects/scopes/available_custom_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/scopes/visible.rb
+++ b/app/models/projects/scopes/visible.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/storage.rb
+++ b/app/models/projects/storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/types.rb
+++ b/app/models/projects/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/versions.rb
+++ b/app/models/projects/versions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/projects/work_package_custom_fields.rb
+++ b/app/models/projects/work_package_custom_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/attribute_group.rb
+++ b/app/models/type/attribute_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -180,7 +180,7 @@ module Type::AttributeGroups
   # Custom fields should not get included into the default form configuration.
   # This method might get patched by modules.
   def default_attribute?(active_cfs, key)
-    !(CustomField.custom_field_attribute?(key) && !active_cfs.include?(key))
+    !(CustomField.custom_field_attribute?(key) && active_cfs.exclude?(key))
   end
 
   def to_attribute_group_class(groups)

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/form_group.rb
+++ b/app/models/type/form_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/inexistent_type.rb
+++ b/app/models/type/inexistent_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/query_group.rb
+++ b/app/models/type/query_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/type/query_group.rb
+++ b/app/models/type/query_group.rb
@@ -27,7 +27,7 @@
 #++
 
 class Type::QueryGroup < Type::FormGroup
-  MEMBER_PREFIX = "query_".freeze
+  MEMBER_PREFIX = "query_"
 
   def self.query_attribute?(name)
     name.to_s.match?(/#{Type::QueryGroup::MEMBER_PREFIX}(\d+)/o)

--- a/app/models/users/function_user.rb
+++ b/app/models/users/function_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/inexistent_user.rb
+++ b/app/models/users/inexistent_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/project_authorization_cache.rb
+++ b/app/models/users/project_authorization_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/project_role_cache.rb
+++ b/app/models/users/project_role_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/scopes/find_by_login.rb
+++ b/app/models/users/scopes/find_by_login.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/scopes/having_reminder_mail_to_send.rb
+++ b/app/models/users/scopes/having_reminder_mail_to_send.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/scopes/newest.rb
+++ b/app/models/users/scopes/newest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/scopes/notified_globally.rb
+++ b/app/models/users/scopes/notified_globally.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/scopes/watcher_recipients.rb
+++ b/app/models/users/scopes/watcher_recipients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/users/scopes/with_time_zone.rb
+++ b/app/models/users/scopes/with_time_zone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/models/week_day.rb
+++ b/app/models/week_day.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WeekDay
   DAY_RANGE = Array(1..7)
 

--- a/app/services/attachments/base_service.rb
+++ b/app/services/attachments/base_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/build_service.rb
+++ b/app/services/attachments/build_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/clamav_service.rb
+++ b/app/services/attachments/clamav_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/delete_service.rb
+++ b/app/services/attachments/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/prepare_upload_service.rb
+++ b/app/services/attachments/prepare_upload_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/replace_attachments.rb
+++ b/app/services/attachments/replace_attachments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/set_attributes_service.rb
+++ b/app/services/attachments/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/set_replacements.rb
+++ b/app/services/attachments/set_replacements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attachments/touch_container.rb
+++ b/app/services/attachments/touch_container.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attribute_help_texts/create_service.rb
+++ b/app/services/attribute_help_texts/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attribute_help_texts/set_attributes_service.rb
+++ b/app/services/attribute_help_texts/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/attribute_help_texts/update_service.rb
+++ b/app/services/attribute_help_texts/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/backups/create_service.rb
+++ b/app/services/backups/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/backups/set_attributes_service.rb
+++ b/app/services/backups/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/base_callable.rb
+++ b/app/services/base_services/base_callable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/create.rb
+++ b/app/services/base_services/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/delete.rb
+++ b/app/services/base_services/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/set_attributes.rb
+++ b/app/services/base_services/set_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/update.rb
+++ b/app/services/base_services/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/changesets/log_time_service.rb
+++ b/app/services/changesets/log_time_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/concerns/contracted.rb
+++ b/app/services/concerns/contracted.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/concerns/reminders/service_helpers.rb
+++ b/app/services/concerns/reminders/service_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/concerns/with_reversible_state.rb
+++ b/app/services/concerns/with_reversible_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_actions/base_service.rb
+++ b/app/services/custom_actions/base_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_actions/update_work_package_service.rb
+++ b/app/services/custom_actions/update_work_package_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_fields/custom_field_projects/delete_service.rb
+++ b/app/services/custom_fields/custom_field_projects/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_fields/custom_field_projects/set_attributes_service.rb
+++ b/app/services/custom_fields/custom_field_projects/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_fields/set_attributes_service.rb
+++ b/app/services/custom_fields/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/custom_fields/update_service.rb
+++ b/app/services/custom_fields/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/emoji_reactions/create_service.rb
+++ b/app/services/emoji_reactions/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH

--- a/app/services/emoji_reactions/delete_service.rb
+++ b/app/services/emoji_reactions/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH

--- a/app/services/emoji_reactions/set_attributes_service.rb
+++ b/app/services/emoji_reactions/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH

--- a/app/services/grids/copy/widgets_dependent_service.rb
+++ b/app/services/grids/copy/widgets_dependent_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/grids/copy_service.rb
+++ b/app/services/grids/copy_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/add_users_service.rb
+++ b/app/services/groups/add_users_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/cleanup_inherited_roles_service.rb
+++ b/app/services/groups/cleanup_inherited_roles_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -57,7 +59,7 @@ module Groups
 
     def remove_member_roles_sql(member_role_ids)
       if member_role_ids.present?
-        sql_query = <<~SQL
+        sql_query = <<~SQL.squish
           DELETE FROM #{MemberRole.table_name}
           WHERE id IN (:member_role_ids)
           RETURNING member_roles.member_id
@@ -67,7 +69,7 @@ module Groups
           .sanitize sql_query,
                     member_role_ids:
       else
-        <<~SQL
+        <<~SQL.squish
           DELETE FROM #{MemberRole.table_name}
           USING #{MemberRole.table_name} user_member_roles
           WHERE

--- a/app/services/groups/concerns/membership_manipulation.rb
+++ b/app/services/groups/concerns/membership_manipulation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/create_inherited_roles_service.rb
+++ b/app/services/groups/create_inherited_roles_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/delete_service.rb
+++ b/app/services/groups/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/set_attributes_service.rb
+++ b/app/services/groups/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/update_roles_service.rb
+++ b/app/services/groups/update_roles_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/journals/set_attributes_service.rb
+++ b/app/services/journals/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/journals/update_service.rb
+++ b/app/services/journals/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/members/cleanup_service.rb
+++ b/app/services/members/cleanup_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/members/delete_by_principal_service.rb
+++ b/app/services/members/delete_by_principal_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/members/delete_service.rb
+++ b/app/services/members/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/members/set_attributes_service.rb
+++ b/app/services/members/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/news/create_service.rb
+++ b/app/services/news/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/news/delete_service.rb
+++ b/app/services/news/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/news/set_attributes_service.rb
+++ b/app/services/news/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/news/update_service.rb
+++ b/app/services/news/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/bulk/bulked_service.rb
+++ b/app/services/work_packages/bulk/bulked_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/bulk/copy_service.rb
+++ b/app/services/work_packages/bulk/copy_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/bulk/move_service.rb
+++ b/app/services/work_packages/bulk/move_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/bulk/update_service.rb
+++ b/app/services/work_packages/bulk/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_status_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_status_based.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
+++ b/app/services/work_packages/set_attributes_service/derive_progress_values_work_based.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/shared/all_days.rb
+++ b/app/services/work_packages/shared/all_days.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/shared/days.rb
+++ b/app/services/work_packages/shared/days.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/update_ancestors/loader.rb
+++ b/app/services/work_packages/update_ancestors/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/script/api/spec
+++ b/script/api/spec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 if /((-h)|(--help))/.match?(ARGV.join(" "))
   puts "Prints the self-contained OpenAPI 3.0 specification of OpenProject's APIv3"

--- a/script/api/validate_spec
+++ b/script/api/validate_spec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "pathname"
 require "tempfile"

--- a/script/bulk_run_rspec
+++ b/script/bulk_run_rspec
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Runs the given specs multiple times to check if they are reliable.
 #

--- a/script/i18n/generate_languages_translations
+++ b/script/i18n/generate_languages_translations
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 begin
   require "cldr"

--- a/script/i18n/generate_seeders_i18n_source_file
+++ b/script/i18n/generate_seeders_i18n_source_file
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #-- copyright
 # OpenProject is an open source project management software.

--- a/script/i18n/print_packager_languages_choices
+++ b/script/i18n/print_packager_languages_choices
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Outputs the Choices and Translations lines for openproject/default_language
 # select option in packager installation.

--- a/script/pdf_export/generate_styles_doc
+++ b/script/pdf_export/generate_styles_doc
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Generates the PDF export styling yaml documentation.
 

--- a/script/pdf_export/validate_styles
+++ b/script/pdf_export/validate_styles
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "md_to_pdf/style/validation"
 require "md_to_pdf/core"


### PR DESCRIPTION
Following #17481 , make a bunch of our files use `frozen_string_literal: true`

To do so, I filtered out all files that only violate one or both of `Layout/EmptyLineAfterMagicComment` and `Style/FrozenStringLiteralComment`. Files violating more rules would trigger a CI fail.

Then, I rejected changes that caused our pipeline to fail. Those folders/files will slowly be adjusted over time as we further develop OP.

## Script for finding files violating only the frozen string literal cop

To filter for files matching this criterion, I executed

`rubocop --format=json > rubocop_results.json`

Afterwards, I ran this Ruby script to filter out the matching files. `xargs` the file list and toss them into `rubocop -A`.

```ruby
require 'json'

file = File.read('rubocop_results.json')
results = JSON.parse(file)

matching_files = []

results['files'].each do |file|
  path = file['path']
  offenses = file['offenses']

  offense_types = offenses.map { |offense| offense['cop_name'] }.uniq

  if offense_types.all? { |type| %w[Layout/EmptyLineAfterMagicComment Style/FrozenStringLiteralComment].include?(type) } &&
     offense_types.size <= 2 # Ensure no extra offenses
    matching_files << path
  end
end

matching_files.each { |file| puts file }
```