### PR TITLE
fix(timesheetPDF): safeguarding time entries without a work package

### DIFF
--- a/modules/reporting/spec/workers/cost_query/pdf/timesheet_generator_spec.rb
+++ b/modules/reporting/spec/workers/cost_query/pdf/timesheet_generator_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe CostQuery::PDF::TimesheetGenerator do
   def expected_entry_columns(t_entry, with_times_column)
     time_column = generator.format_spent_on_time(t_entry)
     [
-      t_entry.work_package&.subject || '',
+      t_entry.work_package&.subject || "",
       with_times_column && time_column.present? ? time_column : nil,
       generator.format_hours(t_entry.hours),
       t_entry.activity.name,

--- a/modules/reporting/spec/workers/cost_query/pdf/timesheet_generator_spec.rb
+++ b/modules/reporting/spec/workers/cost_query/pdf/timesheet_generator_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe CostQuery::PDF::TimesheetGenerator do
   def expected_entry_columns(t_entry, with_times_column)
     time_column = generator.format_spent_on_time(t_entry)
     [
-      t_entry.work_package.subject,
+      t_entry.work_package&.subject || '',
       with_times_column && time_column.present? ? time_column : nil,
       generator.format_hours(t_entry.hours),
       t_entry.activity.name,


### PR DESCRIPTION
# Ticket

https://appsignal.com/openproject-gmbh/sites/673c529383eb67b55471dda2/exceptions/incidents/590/samples/timestamp/2024-12-19T13:45:19Z

# What are you trying to accomplish?
Safeguarding a time entry without an associated work package (which should© not happen, but does) 

# What approach did you choose and why?
Insert an empty string instead of failing the whole PDF generation process
