### PR TITLE
Feature/59184 order by stages and gates on project list

### DIFF
--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -53,6 +55,7 @@ module Queries
 
       def apply_to(query_scope)
         query_scope = order(query_scope)
+        query_scope = query_scope.with(cte_name => cte_statement) if cte_name && cte_statement
         query_scope = query_scope.joins(joins) if joins
         query_scope = query_scope.left_outer_joins(left_outer_joins) if left_outer_joins
         query_scope
@@ -77,6 +80,14 @@ module Queries
       end
 
       def left_outer_joins
+        nil
+      end
+
+      def cte_name
+        nil
+      end
+
+      def cte_statement
         nil
       end
 

--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -55,7 +53,6 @@ module Queries
 
       def apply_to(query_scope)
         query_scope = order(query_scope)
-        query_scope = query_scope.with(cte_name => cte_statement) if cte_name && cte_statement
         query_scope = query_scope.joins(joins) if joins
         query_scope = query_scope.left_outer_joins(left_outer_joins) if left_outer_joins
         query_scope
@@ -80,14 +77,6 @@ module Queries
       end
 
       def left_outer_joins
-        nil
-      end
-
-      def cte_name
-        nil
-      end
-
-      def cte_statement
         nil
       end
 

--- a/app/models/queries/projects.rb
+++ b/app/models/queries/projects.rb
@@ -54,6 +54,7 @@ module Queries::Projects
     order Orders::LatestActivityAtOrder
     order Orders::RequiredDiskSpaceOrder
     order Orders::CustomFieldOrder
+    order Orders::LifeCycleStepOrder
     order Orders::ProjectStatusOrder
     order Orders::NameOrder
     order Orders::TypeaheadOrder

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
+  self.model = Project
+
+  validates :life_cycle_step_definition, presence: { message: I18n.t(:"activerecord.errors.messages.does_not_exist") }
+
+  def self.key
+    # FIXME: use RequestStore?
+    valid_ids = Project::LifeCycleStepDefinition.pluck(:id)
+
+    /\Alcsd_(#{valid_ids.join('|')})\z/
+  end
+
+  def life_cycle_step_definition
+    return @life_cycle_step_definition if defined?(@life_cycle_step_definition)
+
+    @life_cycle_step_definition = self.class.scope.find_by(id: attribute[/\Alcsd_(\d+)\z/, 1])
+  end
+
+  def available?
+    life_cycle_step_definition.present?
+  end
+
+  def self.scope
+    Project::LifeCycleStepDefinition
+  end
+
+  private
+
+  def joins
+    # LEFT JOIN project_life_cycle_steps
+    # ON projects.id = project_life_cycle_steps.project_id
+    # LEFT JOIN project_life_cycle_step_definitions
+    # ON project_life_cycle_step_definitions.id = project_life_cycle_steps.definition_id
+    # AND project_life_cycle_step_definitions.id = #{life_cycle_step_definition.id}
+
+    # TODO: this breaks when sorting by multiple life cycle step columns as the subquery will be used
+    # more than once and duplicate names are not allowed.
+    <<~SQL.squish
+      LEFT JOIN (
+        SELECT steps.*, def.name, def.id as def_id
+        FROM project_life_cycle_steps steps
+        LEFT JOIN project_life_cycle_step_definitions def
+          ON steps.definition_id = def.id
+        WHERE
+          1=1
+          AND steps.active = true
+          AND def.id = #{life_cycle_step_definition.id}
+      ) steps ON steps.project_id = projects.id
+    SQL
+  end
+
+  def order(scope)
+    # -> scope coming in. need to enrich it with definitions and their active steps and then order by date?
+    # look into joins and other base class methods -> they will be needed here
+    # Parent implementation:
+    # scope.order(name => direction)
+    with_raise_on_invalid do
+      scope.where("steps.def_id = :def_id OR steps.def_id IS NULL", def_id: life_cycle_step_definition.id)
+           .order("steps.start_date #{direction}")
+    end
+  end
+end

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -58,6 +58,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
                 steps.active = true
                 AND steps.definition_id = #{life_cycle_step_definition.id}
             ) #{subquery_table_name} ON #{subquery_table_name}.project_id = projects.id
+              AND projects.id IN (#{viewable_project_ids.join(',')})
     SQL
   end
 
@@ -67,7 +68,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   def subquery_table_name
     definition_id = life_cycle_step_definition.id
 
-    :"life_cycle_steps_subqry_#{definition_id}"
+    :"life_cycle_steps_subquery_#{definition_id}"
   end
 
   def order(scope)
@@ -75,6 +76,10 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
       scope.where(order_condition)
            .order(*order_by_start_and_end_date)
     end
+  end
+
+  def viewable_project_ids
+    Project.allowed_to(User.current, :view_project_stages_and_gates).pluck(:id)
   end
 
   def order_condition

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -73,7 +73,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   def order(scope)
     with_raise_on_invalid do
       scope.where("steps.def_id = :def_id OR steps.def_id IS NULL", def_id: life_cycle_step_definition.id)
-           # TODO: do not attempt to order by end_date for gates
+           # Note that a gate does not define an end_date. This code still works.
            .order("steps.start_date #{direction}, steps.end_date #{direction}")
     end
   end

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -52,13 +52,11 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   def joins
     <<~SQL.squish
       LEFT JOIN (
-              SELECT steps.*, def.id as def_id
+              SELECT steps.*, steps.definition_id as def_id
               FROM project_life_cycle_steps steps
-              LEFT JOIN project_life_cycle_step_definitions def
-                ON steps.definition_id = def.id
               WHERE
                 steps.active = true
-                AND def.id = #{life_cycle_step_definition.id}
+                AND steps.definition_id = #{life_cycle_step_definition.id}
             ) #{subquery_table_name} ON #{subquery_table_name}.project_id = projects.id
     SQL
   end

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -34,7 +34,6 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   validates :life_cycle_step_definition, presence: { message: I18n.t(:"activerecord.errors.messages.does_not_exist") }
 
   def self.key
-    # FIXME: use RequestStore?
     valid_ids = Project::LifeCycleStepDefinition.pluck(:id)
 
     /\Alcsd_(#{valid_ids.join('|')})\z/
@@ -57,14 +56,6 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   private
 
   def joins
-    # LEFT JOIN project_life_cycle_steps
-    # ON projects.id = project_life_cycle_steps.project_id
-    # LEFT JOIN project_life_cycle_step_definitions
-    # ON project_life_cycle_step_definitions.id = project_life_cycle_steps.definition_id
-    # AND project_life_cycle_step_definitions.id = #{life_cycle_step_definition.id}
-
-    # TODO: this breaks when sorting by multiple life cycle step columns as the subquery will be used
-    # more than once and duplicate names are not allowed.
     <<~SQL.squish
       LEFT JOIN (
         SELECT steps.*, def.name, def.id as def_id
@@ -80,8 +71,6 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   end
 
   def order(scope)
-    # -> scope coming in. need to enrich it with definitions and their active steps and then order by date?
-    # look into joins and other base class methods -> they will be needed here
     # Parent implementation:
     # scope.order(name => direction)
     with_raise_on_invalid do

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -45,6 +45,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
 
   def available?
     life_cycle_step_definition.present? &&
+      OpenProject::FeatureDecisions.stages_and_gates_active? &&
       User.current.allowed_in_any_project?(:view_project_stages_and_gates)
   end
 

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -34,9 +34,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   validates :life_cycle_step_definition, presence: { message: I18n.t(:"activerecord.errors.messages.does_not_exist") }
 
   def self.key
-    valid_ids = Project::LifeCycleStepDefinition.pluck(:id)
-
-    /\Alcsd_(#{valid_ids.join('|')})\z/
+    /\Alcsd_(\d+)\z/
   end
 
   def life_cycle_step_definition

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -40,15 +40,11 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   def life_cycle_step_definition
     return @life_cycle_step_definition if defined?(@life_cycle_step_definition)
 
-    @life_cycle_step_definition = self.class.scope.find_by(id: attribute[/\Alcsd_(\d+)\z/, 1])
+    @life_cycle_step_definition = Project::LifeCycleStepDefinition.find_by(id: attribute[/\Alcsd_(\d+)\z/, 1])
   end
 
   def available?
     life_cycle_step_definition.present?
-  end
-
-  def self.scope
-    Project::LifeCycleStepDefinition
   end
 
   private

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -55,22 +55,25 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
 
   def joins
     <<~SQL.squish
-      LEFT JOIN #{cte_name} ON #{cte_name}.project_id = projects.id
+      LEFT JOIN (
+              SELECT steps.*, def.name, def.id as def_id
+              FROM project_life_cycle_steps steps
+              LEFT JOIN project_life_cycle_step_definitions def
+                ON steps.definition_id = def.id
+              WHERE
+                steps.active = true
+                AND def.id = #{life_cycle_step_definition.id}
+            ) #{subquery_table_name} ON #{subquery_table_name}.project_id = projects.id
     SQL
   end
 
-  def cte_name
+  def subquery_table_name
     # Since we can combine multiple queries with their respective ORDER BY clauses, we need to make sure
-    # that the name of our CTE is unique. To achieve this, we use the definition_id as part of the CTE name.
+    # that the name of our tables is unique. It suffices to include the definition id into the name as there can only
+    # ever be one order statement per definition.
     definition_id = life_cycle_step_definition.id
 
     :"life_cycle_steps_cte_#{definition_id}"
-  end
-
-  def cte_statement
-    Project::LifeCycleStep.select("*, def.id as def_id")
-                          .joins("LEFT JOIN project_life_cycle_step_definitions def ON definition_id = def.id")
-                          .where(active: true, definition_id: life_cycle_step_definition.id)
   end
 
   def order(scope)
@@ -83,7 +86,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   def order_condition
     # To avoid SQL injection warnings, we use Arel to build the condition.
     # Note that this SQL query uses the CTE defined in `cte_statement`.
-    steps_cte = Arel::Table.new(cte_name.to_s)
+    steps_cte = Arel::Table.new(subquery_table_name.to_s)
 
     # WHERE cte_name.def_id = life_cycle_step_definition.id OR cte_name.def_id IS NULL
     steps_cte[:def_id]
@@ -92,7 +95,7 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   end
 
   def order_by_start_and_end_date
-    steps_table = Arel::Table.new(cte_name.to_s)
+    steps_table = Arel::Table.new(subquery_table_name.to_s)
 
     # Even though a gate does not define an end_date, this code still works.
     [

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -62,13 +62,15 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   end
 
   def cte_name
+    # Since we can combine multiple queries with their respective ORDER BY clauses, we need to make sure
+    # that the name of our CTE is unique. To achieve this, we use the definition_id as part of the CTE name.
     definition_id = life_cycle_step_definition.id
 
     :"life_cycle_steps_cte_#{definition_id}"
   end
 
   def cte_statement
-    Project::LifeCycleStep.select("*, def.name, def.id as def_id")
+    Project::LifeCycleStep.select("*, def.id as def_id")
                           .joins("LEFT JOIN project_life_cycle_step_definitions def ON definition_id = def.id")
                           .where(active: true, definition_id: life_cycle_step_definition.id)
   end

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -44,7 +44,8 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   end
 
   def available?
-    life_cycle_step_definition.present?
+    life_cycle_step_definition.present? &&
+      User.current.allowed_in_any_project?(:view_project_stages_and_gates)
   end
 
   private

--- a/app/models/queries/projects/orders/life_cycle_step_order.rb
+++ b/app/models/queries/projects/orders/life_cycle_step_order.rb
@@ -71,11 +71,10 @@ class Queries::Projects::Orders::LifeCycleStepOrder < Queries::Orders::Base
   end
 
   def order(scope)
-    # Parent implementation:
-    # scope.order(name => direction)
     with_raise_on_invalid do
       scope.where("steps.def_id = :def_id OR steps.def_id IS NULL", def_id: life_cycle_step_definition.id)
-           .order("steps.start_date #{direction}")
+           # TODO: do not attempt to order by end_date for gates
+           .order("steps.start_date #{direction}, steps.end_date #{direction}")
     end
   end
 end

--- a/spec/features/projects/lists/order_spec.rb
+++ b/spec/features/projects/lists/order_spec.rb
@@ -306,5 +306,14 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
       projects_page.expect_project_at_place(project, 1)
       projects_page.expect_project_at_place(public_project, 2)
     end
+
+    it "sorts projects by life cycle stage desc" do
+      projects_page.click_table_header_to_open_action_menu(stage.column_name)
+      projects_page.sort_via_action_menu(stage.column_name, direction: :desc)
+      wait_for_reload
+
+      projects_page.expect_project_at_place(public_project, 5)
+      projects_page.expect_project_at_place(project, 6)
+    end
   end
 end

--- a/spec/features/projects/lists/order_spec.rb
+++ b/spec/features/projects/lists/order_spec.rb
@@ -277,35 +277,55 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
   end
 
   context "when sorting by life cycle", with_flag: { stages_and_gates: true } do
+    let(:stage_def) { create(:project_stage_definition) }
+    let(:stage) do
+      create(:project_stage,
+             project:,
+             definition: stage_def,
+             start_date: Date.new(2025, 1, 1),
+             end_date: Date.new(2025, 1, 13))
+    end
+    let!(:other_stage) do
+      create(:project_stage,
+             project: public_project,
+             definition: stage_def,
+             start_date: Date.new(2025, 2, 12),
+             end_date: Date.new(2025, 2, 20))
+    end
+    let!(:last_stage) do
+      create(:project_stage,
+             project: development_project,
+             definition: stage_def,
+             start_date: other_stage.start_date,
+             end_date: other_stage.end_date + 1.day)
+    end
+
+    let(:gate_def) { create(:project_gate_definition) }
+    let(:gate) do
+      create(:project_gate,
+             project:,
+             definition: gate_def,
+             date: Date.new(2025, 1, 1))
+    end
+    let!(:other_gate) do
+      create(:project_gate,
+             project: public_project,
+             definition: gate_def,
+             date: Date.new(2025, 2, 12))
+    end
+    let!(:last_gate) do
+      create(:project_gate,
+             project: development_project,
+             definition: gate_def,
+             date: other_gate.date + 1.day)
+    end
+
+    before do
+      Setting.enabled_projects_columns += [stage.column_name, gate.column_name]
+      visit projects_path
+    end
+
     context "when sorting by life cycle stage definition" do
-      let(:stage_def) { create(:project_stage_definition) }
-      let(:stage) do
-        create(:project_stage,
-               project:,
-               definition: stage_def,
-               start_date: Date.new(2025, 1, 1),
-               end_date: Date.new(2025, 1, 13))
-      end
-      let!(:other_stage) do
-        create(:project_stage,
-               project: public_project,
-               definition: stage_def,
-               start_date: Date.new(2025, 2, 12),
-               end_date: Date.new(2025, 2, 20))
-      end
-      let!(:last_stage) do
-        create(:project_stage,
-               project: development_project,
-               definition: stage_def,
-               start_date: other_stage.start_date,
-               end_date: other_stage.end_date + 1.day)
-      end
-
-      before do
-        Setting.enabled_projects_columns += [stage.column_name]
-        visit projects_path
-      end
-
       it "sorts projects by life cycle stage asc" do
         projects_page.click_table_header_to_open_action_menu(stage.column_name)
         projects_page.sort_via_action_menu(stage.column_name, direction: :asc)
@@ -330,31 +350,6 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
     end
 
     context "when sorting by life cycle gate definition" do
-      let(:gate_def) { create(:project_gate_definition) }
-      let(:gate) do
-        create(:project_gate,
-               project:,
-               definition: gate_def,
-               date: Date.new(2025, 1, 1))
-      end
-      let!(:other_gate) do
-        create(:project_gate,
-               project: public_project,
-               definition: gate_def,
-               date: Date.new(2025, 2, 12))
-      end
-      let!(:last_gate) do
-        create(:project_gate,
-               project: development_project,
-               definition: gate_def,
-               date: other_gate.date + 1.day)
-      end
-
-      before do
-        Setting.enabled_projects_columns += [gate.column_name]
-        visit projects_path
-      end
-
       it "sorts projects by life cycle gate asc" do
         projects_page.click_table_header_to_open_action_menu(gate.column_name)
         projects_page.sort_via_action_menu(gate.column_name, direction: :asc)
@@ -368,6 +363,22 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
       it "sorts projects by life cycle gate desc" do
         projects_page.click_table_header_to_open_action_menu(gate.column_name)
         projects_page.sort_via_action_menu(gate.column_name, direction: :desc)
+        wait_for_reload
+
+        projects_page.expect_project_at_place(development_project, 4)
+        projects_page.expect_project_at_place(public_project, 5)
+        projects_page.expect_project_at_place(project, 6)
+      end
+    end
+
+    context "when sorting by both stage and gate at once" do
+      it "sorts correctly" do
+        projects_page.click_table_header_to_open_action_menu(gate.column_name)
+        projects_page.sort_via_action_menu(gate.column_name, direction: :asc)
+        wait_for_reload
+
+        projects_page.click_table_header_to_open_action_menu(stage.column_name)
+        projects_page.sort_via_action_menu(stage.column_name, direction: :desc)
         wait_for_reload
 
         projects_page.expect_project_at_place(development_project, 4)

--- a/spec/features/projects/lists/order_spec.rb
+++ b/spec/features/projects/lists/order_spec.rb
@@ -33,9 +33,6 @@ require "spec_helper"
 RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { login_required?: false } do
   shared_let(:admin) { create(:admin) }
 
-  shared_let(:manager)   { create(:project_role, name: "Manager") }
-  shared_let(:developer) { create(:project_role, name: "Developer") }
-
   shared_let(:custom_field) { create(:text_project_custom_field) }
   shared_let(:invisible_custom_field) { create(:project_custom_field, admin_only: true) }
 
@@ -54,7 +51,7 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
   # first but then reorders in ruby
   shared_let(:child_project_z) { create(:project, parent: project, name: "Z Child") }
 
-  # intentionally written lowercase to test for case insensitive sorting
+  # intentionally written lowercase to test for case-insensitive sorting
   shared_let(:child_project_m) { create(:project, parent: project, name: "m Child") }
 
   shared_let(:child_project_a) { create(:project, parent: project, name: "A Child") }
@@ -285,19 +282,26 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
              start_date: Date.new(2025, 1, 1),
              end_date: Date.new(2025, 1, 13))
     end
-    let!(:other_stage) do
+    let!(:public_stage) do
       create(:project_stage,
              project: public_project,
              definition: stage_def,
              start_date: Date.new(2025, 2, 12),
              end_date: Date.new(2025, 2, 20))
     end
+    let!(:child_stage) do
+      create(:project_stage,
+             project: child_project_m,
+             definition: stage_def,
+             start_date: public_stage.start_date,
+             end_date: public_stage.end_date + 1.day)
+    end
     let!(:last_stage) do
       create(:project_stage,
              project: development_project,
              definition: stage_def,
-             start_date: other_stage.start_date,
-             end_date: other_stage.end_date + 1.day)
+             start_date: public_stage.start_date,
+             end_date: public_stage.end_date + 2.days)
     end
 
     let(:gate_def) { create(:project_gate_definition) }
@@ -307,17 +311,35 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
              definition: gate_def,
              date: Date.new(2025, 1, 1))
     end
-    let!(:other_gate) do
+    let!(:public_gate) do
       create(:project_gate,
              project: public_project,
              definition: gate_def,
              date: Date.new(2025, 2, 12))
     end
+    let!(:child_gate) do
+      create(:project_gate,
+             project: child_project_m,
+             definition: gate_def,
+             date: public_gate.date + 1.day)
+    end
     let!(:last_gate) do
       create(:project_gate,
              project: development_project,
              definition: gate_def,
-             date: other_gate.date + 1.day)
+             date: public_gate.date + 2.days)
+    end
+
+    shared_let(:life_cycle_permissions) { %i(view_project view_project_stages_and_gates) }
+    shared_let(:basic_permissions) { %i(view_project) }
+
+    shared_let(:user) do
+      create(:user, member_with_permissions: { project => life_cycle_permissions,
+                                               development_project => life_cycle_permissions,
+                                               child_project_z => basic_permissions,
+                                               child_project_m => basic_permissions,
+                                               child_project_a => basic_permissions,
+                                               public_project => life_cycle_permissions })
     end
 
     before do
@@ -332,10 +354,11 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
         wait_for_reload
 
         projects_page.expect_project_at_place(project, 1)
-        # For the next two projects, the start date is the same, but the end date differs.
+        # For the next three projects, the start date is the same, but the end date differs.
         # Ensure the end date is used as a secondary sorting criterion:
         projects_page.expect_project_at_place(public_project, 2)
-        projects_page.expect_project_at_place(development_project, 3)
+        projects_page.expect_project_at_place(child_project_m, 3)
+        projects_page.expect_project_at_place(development_project, 4)
       end
 
       it "sorts projects by life cycle stage desc" do
@@ -343,7 +366,8 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
         projects_page.sort_via_action_menu(stage.column_name, direction: :desc)
         wait_for_reload
 
-        projects_page.expect_project_at_place(development_project, 4)
+        projects_page.expect_project_at_place(development_project, 3)
+        projects_page.expect_project_at_place(child_project_m, 4)
         projects_page.expect_project_at_place(public_project, 5)
         projects_page.expect_project_at_place(project, 6)
       end
@@ -357,7 +381,8 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
 
         projects_page.expect_project_at_place(project, 1)
         projects_page.expect_project_at_place(public_project, 2)
-        projects_page.expect_project_at_place(development_project, 3)
+        projects_page.expect_project_at_place(child_project_m, 3)
+        projects_page.expect_project_at_place(development_project, 4)
       end
 
       it "sorts projects by life cycle gate desc" do
@@ -365,7 +390,8 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
         projects_page.sort_via_action_menu(gate.column_name, direction: :desc)
         wait_for_reload
 
-        projects_page.expect_project_at_place(development_project, 4)
+        projects_page.expect_project_at_place(development_project, 3)
+        projects_page.expect_project_at_place(child_project_m, 4)
         projects_page.expect_project_at_place(public_project, 5)
         projects_page.expect_project_at_place(project, 6)
       end
@@ -381,9 +407,34 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
         projects_page.sort_via_action_menu(stage.column_name, direction: :desc)
         wait_for_reload
 
-        projects_page.expect_project_at_place(development_project, 4)
+        projects_page.expect_project_at_place(development_project, 3)
+        projects_page.expect_project_at_place(child_project_m, 4)
         projects_page.expect_project_at_place(public_project, 5)
         projects_page.expect_project_at_place(project, 6)
+      end
+    end
+
+    context "without permission to view stages and gates" do
+      before do
+        login_as(user)
+        visit projects_path
+      end
+
+      it "does not consider the life cycle dates of projects without permission" do
+        projects_page.click_table_header_to_open_action_menu(gate.column_name)
+        projects_page.sort_via_action_menu(gate.column_name, direction: :desc)
+        wait_for_reload
+
+        projects_page
+          .expect_projects_in_order(child_project_a,
+                                    # child project M has life cycles, but user has no permission
+                                    # to see them. That is why they are ignored for sorting.
+                                    child_project_m,
+                                    child_project_z,
+                                    # Regular life cycle sorting for the remaining projects:
+                                    development_project,
+                                    public_project,
+                                    project)
       end
     end
   end

--- a/spec/features/projects/lists/order_spec.rb
+++ b/spec/features/projects/lists/order_spec.rb
@@ -277,19 +277,34 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
   end
 
   context "when sorting by life cycle", with_flag: { stages_and_gates: true } do
-    let(:stage) { create(:project_stage, project:) }
+    let(:stage_def) { create(:project_stage_definition) }
+    let(:stage) do
+      create(:project_stage,
+             project:,
+             definition: stage_def,
+             start_date: Date.new(2025, 1, 1),
+             end_date: Date.new(2025, 1, 13))
+    end
+    let!(:other_stage) do
+      create(:project_stage,
+             project: public_project,
+             definition: stage_def,
+             start_date: Date.new(2025, 2, 12),
+             end_date: Date.new(2025, 2, 20))
+    end
 
     before do
       Setting.enabled_projects_columns += [stage.column_name]
       visit projects_path
     end
 
-    it "sorts projects by life cycle stage" do
+    it "sorts projects by life cycle stage asc" do
       projects_page.click_table_header_to_open_action_menu(stage.column_name)
       projects_page.sort_via_action_menu(stage.column_name, direction: :asc)
       wait_for_reload
 
       projects_page.expect_project_at_place(project, 1)
+      projects_page.expect_project_at_place(public_project, 2)
     end
   end
 end

--- a/spec/features/projects/lists/order_spec.rb
+++ b/spec/features/projects/lists/order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH
@@ -272,5 +274,22 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
     wait_for_reload
 
     projects_page.expect_project_at_place(project, 1)
+  end
+
+  context "when sorting by life cycle", with_flag: { stages_and_gates: true } do
+    let(:stage) { create(:project_stage, project:) }
+
+    before do
+      Setting.enabled_projects_columns += [stage.column_name]
+      visit projects_path
+    end
+
+    it "sorts projects by life cycle stage" do
+      projects_page.click_table_header_to_open_action_menu(stage.column_name)
+      projects_page.sort_via_action_menu(stage.column_name, direction: :asc)
+      wait_for_reload
+
+      projects_page.expect_project_at_place(project, 1)
+    end
   end
 end

--- a/spec/features/projects/lists/order_spec.rb
+++ b/spec/features/projects/lists/order_spec.rb
@@ -292,6 +292,13 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
              start_date: Date.new(2025, 2, 12),
              end_date: Date.new(2025, 2, 20))
     end
+    let!(:last_stage) do
+      create(:project_stage,
+             project: development_project,
+             definition: stage_def,
+             start_date: other_stage.start_date,
+             end_date: other_stage.end_date + 1.day)
+    end
 
     before do
       Setting.enabled_projects_columns += [stage.column_name]
@@ -304,7 +311,10 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
       wait_for_reload
 
       projects_page.expect_project_at_place(project, 1)
+      # For the next two projects, the start date is the same, but the end date differs.
+      # Ensure the end date is used as a secondary sorting criterion:
       projects_page.expect_project_at_place(public_project, 2)
+      projects_page.expect_project_at_place(development_project, 3)
     end
 
     it "sorts projects by life cycle stage desc" do
@@ -312,6 +322,7 @@ RSpec.describe "Projects lists ordering", :js, :with_cuprite, with_settings: { l
       projects_page.sort_via_action_menu(stage.column_name, direction: :desc)
       wait_for_reload
 
+      projects_page.expect_project_at_place(development_project, 4)
       projects_page.expect_project_at_place(public_project, 5)
       projects_page.expect_project_at_place(project, 6)
     end

--- a/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
+++ b/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
@@ -52,7 +52,15 @@ RSpec.describe Queries::Projects::Orders::LifeCycleStepOrder do
   describe "#available?" do
     let(:instance) { described_class.new("lcsd_#{life_cycle_def.id}") }
 
-    current_user { build_stubbed(:admin) }
+    let(:permissions) { %i(view_project_stages_and_gates) }
+    let(:project) { create(:project) }
+    let(:user) do
+      create(:user, member_with_permissions: {
+               project => permissions
+             })
+    end
+
+    current_user { user }
 
     context "for a stage definition" do
       let!(:life_cycle_def) { create(:project_stage_definition) }
@@ -67,6 +75,15 @@ RSpec.describe Queries::Projects::Orders::LifeCycleStepOrder do
 
       it "allows to sort by it" do
         expect(instance).to be_available
+      end
+    end
+
+    context "without permission in any project" do
+      let!(:life_cycle_def) { create(:project_gate_definition) }
+      let(:permissions) { [] }
+
+      it "is not available" do
+        expect(instance).not_to be_available
       end
     end
   end

--- a/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
+++ b/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
@@ -32,16 +32,8 @@ require "spec_helper"
 
 RSpec.describe Queries::Projects::Orders::LifeCycleStepOrder do
   describe ".key" do
-    before do
-      allow(Project::LifeCycleStepDefinition).to receive(:pluck).with(:id).and_return([42])
-    end
-
     it "matches key in correct format for life cycles" do
       expect(described_class.key).to match("lcsd_42")
-    end
-
-    it "doesn't match key in correct format for not found life cycles" do
-      expect(described_class.key).not_to match("lcsd_43")
     end
 
     it "doesn't match non numerical id" do
@@ -85,7 +77,6 @@ RSpec.describe Queries::Projects::Orders::LifeCycleStepOrder do
     let(:id) { 42 }
 
     before do
-      allow(Project::LifeCycleStepDefinition).to receive(:pluck).with(:id).and_return([id])
       allow(Project::LifeCycleStepDefinition).to receive(:find_by).with(id: id.to_s).and_return(step_definition)
     end
 

--- a/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
+++ b/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Projects::Orders::LifeCycleStepOrder do
+  describe ".key" do
+    before do
+      allow(Project::LifeCycleStepDefinition).to receive(:pluck).with(:id).and_return([42])
+    end
+
+    it "matches key in correct format for life cycles" do
+      expect(described_class.key).to match("lcsd_42")
+    end
+
+    it "doesn't match key in correct format for not found life cycles" do
+      expect(described_class.key).not_to match("lcsd_43")
+    end
+
+    it "doesn't match non numerical id" do
+      expect(described_class.key).not_to match("lcsd_lcsd")
+    end
+
+    it "doesn't match with prefix" do
+      expect(described_class.key).not_to match("xlcsd_42")
+    end
+
+    it "doesn't match with suffix" do
+      expect(described_class.key).not_to match("lcsd_42x")
+    end
+  end
+
+  describe "#available?" do
+    let(:instance) { described_class.new("lcsd_#{life_cycle_def.id}") }
+
+    current_user { build_stubbed(:admin) }
+
+    context "for a stage definition" do
+      let!(:life_cycle_def) { create(:project_stage_definition) }
+
+      it "allows to sort by it" do
+        expect(instance).to be_available
+      end
+    end
+
+    context "for a gate definition" do
+      let!(:life_cycle_def) { create(:project_gate_definition) }
+
+      it "allows to sort by it" do
+        expect(instance).to be_available
+      end
+    end
+  end
+
+  describe "#life_cycle_step_definition" do
+    let(:instance) { described_class.new(name) }
+    let(:name) { "lcsd_42" }
+    let(:id) { 42 }
+
+    before do
+      allow(Project::LifeCycleStepDefinition).to receive(:pluck).with(:id).and_return([id])
+      allow(Project::LifeCycleStepDefinition).to receive(:find_by).with(id: id.to_s).and_return(step_definition)
+    end
+
+    context "when life cycle definition exists" do
+      let(:step_definition) { instance_double(Project::LifeCycleStepDefinition) }
+
+      it "returns the life cycle definition" do
+        expect(instance.life_cycle_step_definition).to eq(step_definition)
+      end
+
+      it "memoizes the life cycle definition" do
+        2.times { instance.life_cycle_step_definition }
+
+        expect(Project::LifeCycleStepDefinition).to have_received(:find_by).once
+      end
+    end
+
+    context "when life cycle definition doesn't exist" do
+      let(:step_definition) { nil }
+
+      it "returns the life cycle" do
+        expect(instance.life_cycle_step_definition).to be_nil
+      end
+
+      it "memoizes the life cycle" do
+        2.times { instance.life_cycle_step_definition }
+
+        expect(Project::LifeCycleStepDefinition).to have_received(:find_by).once
+      end
+    end
+  end
+end

--- a/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
+++ b/spec/models/queries/projects/orders/life_cycle_step_order_spec.rb
@@ -62,28 +62,38 @@ RSpec.describe Queries::Projects::Orders::LifeCycleStepOrder do
 
     current_user { user }
 
-    context "for a stage definition" do
+    context "without feature flag set" do
       let!(:life_cycle_def) { create(:project_stage_definition) }
 
-      it "allows to sort by it" do
-        expect(instance).to be_available
-      end
-    end
-
-    context "for a gate definition" do
-      let!(:life_cycle_def) { create(:project_gate_definition) }
-
-      it "allows to sort by it" do
-        expect(instance).to be_available
-      end
-    end
-
-    context "without permission in any project" do
-      let!(:life_cycle_def) { create(:project_gate_definition) }
-      let(:permissions) { [] }
-
-      it "is not available" do
+      it "does not allow to sort by it" do
         expect(instance).not_to be_available
+      end
+    end
+
+    context "with feature flag set", with_flag: { stages_and_gates: true } do
+      context "for a stage definition" do
+        let!(:life_cycle_def) { create(:project_stage_definition) }
+
+        it "allows to sort by it" do
+          expect(instance).to be_available
+        end
+      end
+
+      context "for a gate definition" do
+        let!(:life_cycle_def) { create(:project_gate_definition) }
+
+        it "allows to sort by it" do
+          expect(instance).to be_available
+        end
+      end
+
+      context "without permission in any project" do
+        let!(:life_cycle_def) { create(:project_gate_definition) }
+        let(:permissions) { [] }
+
+        it "is not available" do
+          expect(instance).not_to be_available
+        end
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/59184

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots

![order1](https://github.com/user-attachments/assets/66717754-69e3-491c-a2d7-a76d6fc99b7f)
![order2](https://github.com/user-attachments/assets/b8a8beca-b167-44a1-8dc2-88ae6dbf76f6)
![order3](https://github.com/user-attachments/assets/c1271de0-28c7-4422-a660-7697b65093e0)
![order4](https://github.com/user-attachments/assets/43d7bfa5-4dbc-48b4-9634-9d9dac35cb9a)
![order5](https://github.com/user-attachments/assets/63deecde-7946-45b7-9ad9-196f68f3519e)
![order6](https://github.com/user-attachments/assets/2b8ad477-ce29-4a8b-852e-9be9cda94377)

# What approach did you choose and why?

Since projects are related to the LifeCycleSteps table, which is in turn reliant on the LifeCycleStepDefinition table - which is the attribute we are sorting on, I looked for a way to query the relevant rows without having to do a lot of aggregation and group by magic.

I found two approaches that work and seem to be performant. The first used a CTE, the second a subquery. In both cases, I join the projects table on a subset of life cycle step definitions. This gets rid of obsolete rows while not requiring further aggregation.

Both approaches seem to have a similar performance impact. I found the subquery more readable, so I chose that.

There is a caveat: since we can order by multiple columns, we must ensure that our subquery identifier (-> SELECT * FROM **identifier**) is not used twice. I added the definition id to that name to make it unique per request.

# Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
