### PR TITLE
Fix time dependent test

### DIFF
--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe "Recurring meetings creation",
   let(:show_page) { Pages::RecurringMeeting::Show.new(meeting) }
   let(:meetings_page) { Pages::Meetings::Index.new(project:) }
 
+  before do
+    travel_to(Date.new(2024, 12, 1))
+  end
+
   context "with a user with permissions" do
     it "can create a recurring meeting" do
       login_as current_user

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe "Recurring meetings CRUD",
                with_flag: { recurring_meetings: true } do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
+  before_all do
+    travel_to(Date.new(2024, 12, 1))
+  end
+
+  after(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    travel_back
+  end
+
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   shared_let(:user) do
     create :user,
@@ -71,6 +79,7 @@ RSpec.describe "Recurring meetings CRUD",
   let(:meetings_page) { Pages::Meetings::Index.new(project:) }
 
   before do
+    travel_to(Date.new(2024, 12, 1))
     login_as current_user
 
     # Assuming the first init job has run


### PR DESCRIPTION
Test is dependent on the current time: recurring meetings are created from 31-12-2024 and the expectations to have 3 occurrences showing up fail if current time is after 01-01-2025.

Use fixed current time using `travel_to`, but it must be in a `before_all` block because some objects are created with `shared_let`. It has also to be duplicated in the `before(:each)` block of the test but I'm not sure why.