### PR TITLE
[60410] Fetch calendar non-working days for the full date range

### DIFF
--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -147,8 +147,8 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     }
   }
 
-  async requireNonWorkingDays(date:Date|string) {
-    this.nonWorkingDays = await firstValueFrom(this.dayService.requireNonWorkingYear$(date));
+  async requireNonWorkingDays(start:Date|string, end:Date|string) {
+    this.nonWorkingDays = await firstValueFrom(this.dayService.requireNonWorkingYears$(start, end));
   }
 
   isNonWorkingDay(date:Date|string):boolean {
@@ -160,8 +160,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     fetchInfo:{ start:Date, end:Date, timeZone:string },
     projectIdentifier:string|undefined,
   ):Promise<unknown> {
-    await this.requireNonWorkingDays(fetchInfo.start);
-    await this.requireNonWorkingDays(fetchInfo.end);
+    await this.requireNonWorkingDays(fetchInfo.start, fetchInfo.end);
 
     if (this.areFiltersEmpty && this.querySpace.query.value) {
       // nothing to do

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -181,8 +181,9 @@ export class TimeEntryCalendarComponent {
     void this.weekdayService.loadWeekdays()
       .toPromise()
       .then(async () => {
-        const date = moment(new Date()).toString();
-        await this.requireNonWorkingDays(date);
+        const startOfWeek = moment().startOf('week').format('YYYY-MM-DD');
+        const endOfWeek = moment().endOf('week').format('YYYY-MM-DD');
+        await this.requireNonWorkingDays(startOfWeek, endOfWeek);
         this.additionalOptions.hiddenDays = this.setHiddenDays(displayedDayss);
         this.calendarOptions$.next(
           this.additionalOptions,
@@ -211,8 +212,8 @@ export class TimeEntryCalendarComponent {
     readonly dayService:DayResourceService,
   ) {}
 
-  async requireNonWorkingDays(date:Date|string) {
-    this.nonWorkingDays = await firstValueFrom(this.dayService.requireNonWorkingYear$(date));
+  async requireNonWorkingDays(start:Date|string, end:Date|string) {
+    this.nonWorkingDays = await firstValueFrom(this.dayService.requireNonWorkingYears$(start, end));
   }
 
   public calendarEventsFunction(
@@ -255,8 +256,7 @@ export class TimeEntryCalendarComponent {
 
   private async buildEntries(entries:TimeEntryResource[], fetchInfo:{ start:Date, end:Date }):Promise<EventInput[]> {
     this.setRatio(entries);
-    await this.requireNonWorkingDays(fetchInfo.start);
-    await this.requireNonWorkingDays(fetchInfo.end);
+    await this.requireNonWorkingDays(fetchInfo.start, fetchInfo.end);
     return this.buildTimeEntryEntries(entries)
       .concat(this.buildAuxEntries(entries, fetchInfo));
   }


### PR DESCRIPTION
When calendar widget displays a range of dates spanning multiple years, non-working days need to be fetched for the entire range or the widget may miss some of them. This is especially true for weeks spanning over two years like from 30-12-2024 to 05-01-2025.

This was detected by having test `./modules/my_page/spec/features/my/my_spent_time_widget_with_a_negative_time_zone_spec.rb:79` failing on new year 2025.

# Ticket

https://community.openproject.org/wp/60410


# What are you trying to accomplish?

Display non working days in "my spent time" and "calendar" widgets when the week is spanning over 2 years (for instance from 30-12-2024 to 05-01-2025) and there are some non-working days in both years.

## Screenshots

Week is from 30-12-2024 to 05-01-2025
Non-working days are 31-12-2024 and 03-01-2025

Before:

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/45db43bd-c218-47bd-9c91-ce484766757f" />

After:

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/09197d3a-211f-4e2a-9b28-a6ad49f5749b" />

# What approach did you choose and why?

Use `requireNonWorkingYears$` (note the `s`) instead of `requireNonWorkingYear$` to fetch non working days over multiple dates instead of just one date. That's the approach that was already used in `frontend/src/app/features/work-packages/components/wp-table/timeline/container/wp-timeline-container.directive.ts`.

There is also something that feels wrong with the headers not being in dark gray for non-working days, but it was already like this before.

# Merge checklist

- [ ] Added/updated tests
  - nope, there was already a test which started failing on the new year 2025
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
