### PR TITLE
Do not reschedule meeting init job on error, and add total limit

### DIFF
--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -27,6 +27,7 @@ class RecurringMeeting < ApplicationRecord
 
   after_initialize :set_defaults
   after_save :unset_schedule
+  before_destroy :remove_jobs
 
   enum frequency: {
     daily: 0,
@@ -207,5 +208,9 @@ class RecurringMeeting < ApplicationRecord
 
   def set_defaults
     self.end_date ||= 1.year.from_now
+  end
+
+  def remove_jobs
+    RecurringMeetings::InitNextOccurrenceJob.delete_jobs(self)
   end
 end

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -55,11 +55,11 @@ module RecurringMeetings
         return
       end
 
-      # Schedule the next occurrence, if not instantiated
-      check_next_occurrence
-
       # Schedule the next job
       schedule_next_job
+
+      # Schedule the next occurrence, if not instantiated
+      check_next_occurrence
     rescue StandardError => e
       Rails.logger.error { "Error while initializing next occurrence for series ##{recurring_meeting}: #{e.message}" }
     end
@@ -99,6 +99,9 @@ module RecurringMeetings
     ##
     # Schedule when this job should be run the next time
     def schedule_next_job
+      # Do not schedule if the series is ending
+      return if next_scheduled_time.nil?
+
       self
         .class
         .set(wait_until: next_scheduled_time)

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -36,6 +36,11 @@ module RecurringMeetings
       key: -> { self.class.unique_key(arguments.first) }
     )
 
+    def self.delete_jobs(recurring_meeting)
+      concurrency_key = unique_key(recurring_meeting)
+      GoodJob::Job.where(concurrency_key:).delete_all
+    end
+
     def self.unique_key(recurring_meeting)
       "RecurringMeetings::InitNextOccurrenceJob-#{recurring_meeting.id}"
     end


### PR DESCRIPTION
On QA, a deleted recurring meeting left the InitNextOccurrenceJob running. This resulted in the ensure block being run, and always scheduling the next job to run immediately.