### PR TITLE
Add documentation links to error messages

### DIFF
--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -44,8 +44,10 @@ module OpenProject
           @links ||= static_links.merge(dynamic_links)
         end
 
-        def url_for(item)
-          links.dig(item, :href)
+        def url_for(*items, anchor: nil)
+          url = links.dig(*items, :href)
+          url += "##{anchor}" if anchor.present?
+          url
         end
 
         def has?(name)

--- a/modules/storages/app/components/storages/admin/side_panel/health_status_component.html.erb
+++ b/modules/storages/app/components/storages/admin/side_panel/health_status_component.html.erb
@@ -77,6 +77,13 @@ See COPYRIGHT and LICENSE files for more details.
                 formatted_health_reason
               end
             end
+
+            health_status_container.with_row(mt: 2) do
+              render(Primer::Beta::Link.new(href: OpenProject::Static::Links.url_for(:storage_docs, :health_status, anchor: "file-storage-errors-description"))) do |link|
+                link.with_trailing_visual_icon(icon: 'link-external')
+                I18n.t("storages.health.ampf_docs_link")
+              end
+            end
           end
         end
       end

--- a/modules/storages/app/components/storages/admin/side_panel/validation_result_component.html.erb
+++ b/modules/storages/app/components/storages/admin/side_panel/validation_result_component.html.erb
@@ -46,7 +46,15 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       if @result.description.present?
-        prefix = @result.error_code? ? "#{@result.error_code.upcase}: " : ""
+        prefix = if @result.error_code?
+          link_to(
+            @result.error_code.upcase,
+            OpenProject::Static::Links.url_for(:storage_docs, :health_status, anchor: "connection-validation"),
+            target: "_blank"
+          ) + ": "
+        else
+          ""
+        end
 
         container.with_row(mt: 2) do
           render(Primer::Beta::Text.new(color: :muted, test_selector: "validation-result--description")) do

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -210,6 +210,7 @@ en:
       redirect_uri: Redirect URI
       storage_provider: Storage provider
     health:
+      ampf_docs_link: See error documentation
       checked: Last checked %{datetime}
       connection_validation:
         action: Recheck connection


### PR DESCRIPTION
Linking to two places in the documentation from the two connection checks we have for storages.

# Ticket
https://community.openproject.org/projects/openproject/work_packages/57337

# What are you trying to accomplish?
Adding cross references between error messages and 

## Screenshots
![image](https://github.com/user-attachments/assets/84c30e0a-6477-4a1f-b07b-fa71ad54ff10)


# What approach did you choose and why?
The error message for manually triggered connection checks was changed as requested. However, in contrast to acceptance criteria two changes were made:

* The format of the manual check error message was not changed
* The doc link for the periodic check was added into a separate link

Both are because the error message of the periodic check is much less structured. That check purely shows a string stored in the database as an error message. Thus it was easy to wrap the link around the error code for the manual check, but much harder to do the same for the periodic check.
