### PR TITLE
Fix typo in user_format: s/coma/comma/

### DIFF
--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -83,7 +83,7 @@ module Reactable
         "users.firstname"
       when :lastname_firstname
         "concat_ws(' ', users.lastname, users.firstname)"
-      when :lastname_coma_firstname
+      when :lastname_comma_firstname
         "concat_ws(', ', users.lastname, users.firstname)"
       when :lastname_n_firstname
         "concat_ws('', users.lastname, users.firstname)"

--- a/app/models/principals/scopes/ordered_by_name.rb
+++ b/app/models/principals/scopes/ordered_by_name.rb
@@ -57,7 +57,7 @@ module Principals::Scopes
           "concat_ws(' ', users.firstname, users.lastname)"
         when :firstname
           "users.firstname"
-        when :lastname_firstname, :lastname_coma_firstname, :lastname_n_firstname
+        when :lastname_firstname, :lastname_comma_firstname, :lastname_n_firstname
           "concat_ws(' ', users.lastname, users.firstname)"
         when :username
           "users.login"

--- a/app/models/queries/filters/shared/user_name_filter.rb
+++ b/app/models/queries/filters/shared/user_name_filter.rb
@@ -71,7 +71,7 @@ module Queries::Filters::Shared::UserNameFilter
         "LOWER(CONCAT(users.firstname, ' ', users.lastname))"
       when :firstname
         "LOWER(users.firstname)"
-      when :lastname_firstname, :lastname_coma_firstname
+      when :lastname_firstname, :lastname_comma_firstname
         "LOWER(CONCAT(users.lastname, CONCAT(' ', users.firstname)))"
       when :lastname_n_firstname
         "LOWER(CONCAT(users.lastname, users.firstname))"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < Principal
     firstname: [:firstname],
     lastname_firstname: %i[lastname firstname],
     lastname_n_firstname: %i[lastname firstname],
-    lastname_coma_firstname: %i[lastname firstname],
+    lastname_comma_firstname: %i[lastname firstname],
     username: [:login]
   }.freeze
 
@@ -295,7 +295,7 @@ class User < Principal
     when :firstname_lastname then "#{firstname} #{lastname}"
     when :lastname_firstname then "#{lastname} #{firstname}"
     when :lastname_n_firstname then "#{lastname}#{firstname}"
-    when :lastname_coma_firstname then "#{lastname}, #{firstname}"
+    when :lastname_comma_firstname then "#{lastname}, #{firstname}"
     when :firstname then firstname
     when :username then login
 

--- a/db/migrate/20250213193012_fix_typo_in_settings_user_format_value.rb
+++ b/db/migrate/20250213193012_fix_typo_in_settings_user_format_value.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class FixTypoInSettingsUserFormatValue < ActiveRecord::Migration[7.1]
+  def up
+    Setting
+      .where(name: "user_format", value: "lastname_coma_firstname")
+      .update(value: "lastname_comma_firstname")
+  end
+
+  def down
+    Setting
+      .where(name: "user_format", value: "lastname_comma_firstname")
+      .update(value: "lastname_coma_firstname")
+  end
+end

--- a/lib/api/decorators/sql/hal_associated_resource.rb
+++ b/lib/api/decorators/sql/hal_associated_resource.rb
@@ -58,7 +58,7 @@ module API
 
           def associated_user_link_title(table_name)
             -> {
-              join_string = if Setting.user_format == :lastname_coma_firstname
+              join_string = if Setting.user_format == :lastname_comma_firstname
                               " || ', ' || "
                             else
                               " || ' ' || "

--- a/lib/api/v3/users/user_sql_representer.rb
+++ b/lib/api/v3/users/user_sql_representer.rb
@@ -39,7 +39,7 @@ module API
               "firstname"
             when :lastname_firstname
               "concat(lastname, ' ', firstname)"
-            when :lastname_coma_firstname
+            when :lastname_comma_firstname
               "concat(lastname, ', ', firstname)"
             when :lastname_n_firstname
               "concat_ws(lastname, '', firstname)"

--- a/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe API::V3::Users::UserSqlRepresenter, "rendering" do
       it_behaves_like "name property depending on user format setting"
     end
 
-    context "when user_format is set to lastname_coma_firstname", with_settings: { user_format: :lastname_coma_firstname } do
+    context "when user_format is set to lastname_comma_firstname", with_settings: { user_format: :lastname_comma_firstname } do
       it_behaves_like "name property depending on user format setting"
     end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe UserMailer do
     # and last name whereby an unescaped comma will lead to have two email addresses
     # defined instead of one (['Bobbi', 'bob.bobbi@example.com'] vs. ['bob.bobbi@example.com'])
     context "with the user name setting prone to trip up email address separation",
-            with_settings: { user_format: :lastname_coma_firstname } do
+            with_settings: { user_format: :lastname_comma_firstname } do
       it_behaves_like "mail is sent"
     end
 

--- a/spec/models/concerns/reactable_spec.rb
+++ b/spec/models/concerns/reactable_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Reactable do
       end
     end
 
-    context "when user format is set to :lastname_coma_firstname", with_settings: { user_format: :lastname_coma_firstname } do
+    context "when user format is set to :lastname_comma_firstname", with_settings: { user_format: :lastname_comma_firstname } do
       it "returns grouped emoji reactions with last coma firstname" do
         result = Journal.grouped_emoji_reactions(reactable_id: wp_journal1.id, reactable_type: "Journal")
 

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Principal do
     shared_let(:placeholder_user_id) { create(:placeholder_user, name: "Wannabejohn").id }
 
     shared_examples "name formatting" do
-      context "for lastname_coma_firstname formatter", with_settings: { user_format: :lastname_coma_firstname } do
+      context "for lastname_comma_firstname formatter", with_settings: { user_format: :lastname_comma_firstname } do
         it "returns formatted user name" do
           expect(user.name).to eq "Smith, John"
         end

--- a/spec/models/principals/scopes/ordered_by_name_spec.rb
+++ b/spec/models/principals/scopes/ordered_by_name_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Principals::Scopes::OrderedByName do
       end
     end
 
-    context "with lastname_coma_firstname user sort", with_settings: { user_format: :lastname_coma_firstname } do
+    context "with lastname_comma_firstname user sort", with_settings: { user_format: :lastname_comma_firstname } do
       it_behaves_like "sorted results" do
         let(:order) { [anonymous.id, eve.id, group.id, placeholder_user.id, alice.id] }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe User do
         it { is_expected.to eq "SmithJohn" }
       end
 
-      context "for lastname_coma_firstname", with_settings: { user_format: :lastname_coma_firstname } do
+      context "for lastname_comma_firstname", with_settings: { user_format: :lastname_comma_firstname } do
         it { is_expected.to eq "Smith, John" }
       end
 
@@ -350,8 +350,8 @@ RSpec.describe User do
 
       let(:user) { described_class.select_for_name(formatter).last }
 
-      context "for lastname_coma_firstname" do
-        let(:formatter) { :lastname_coma_firstname }
+      context "for lastname_comma_firstname" do
+        let(:formatter) { :lastname_comma_firstname }
 
         it { is_expected.to eq "Smith, John" }
       end


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Fixing a typo in one of possible `Settings.user_format` values.

## Screenshots


# What approach did you choose and why?


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
