### PR TITLE
[#60431] Hyphenation feature in generated pdf files removes space before italic text

### DIFF
--- a/app/models/work_package/pdf_export/generator/generator.rb
+++ b/app/models/work_package/pdf_export/generator/generator.rb
@@ -29,6 +29,7 @@
 #++
 
 require "md_to_pdf/core"
+require 'md_to_pdf/hyphen'
 
 module WorkPackage::PDFExport::Generator::Generator
   class MD2PDFGenerator
@@ -65,7 +66,7 @@ module WorkPackage::PDFExport::Generator::Generator
                  .merge(@styles.default_fields)
                  .merge(options)
       doc = parse_frontmatter_markdown(markdown, fields)
-      @hyphens = Text::Hyphen.new(language: options[:language], left: 2, right: 2) if options[:language].present?
+      @hyphens = Hyphen.new(options[:language], true) if options[:language].present?
       render_doc(doc)
     end
 
@@ -89,7 +90,7 @@ module WorkPackage::PDFExport::Generator::Generator
     def hyphenate(text)
       return text if @hyphens.nil?
 
-      @hyphens.visualize(text, Prawn::Text::SHY)
+      @hyphens.hyphenate(text)
     end
 
     def handle_mention_html_tag(tag, node, opts)

--- a/app/models/work_package/pdf_export/generator/generator.rb
+++ b/app/models/work_package/pdf_export/generator/generator.rb
@@ -29,7 +29,7 @@
 #++
 
 require "md_to_pdf/core"
-require 'md_to_pdf/hyphen'
+require "md_to_pdf/hyphen"
 
 module WorkPackage::PDFExport::Generator::Generator
   class MD2PDFGenerator


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/60431

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix the removal of spaces when hyphenation is turned on

## Screenshots
Before
![before](https://github.com/user-attachments/assets/adc08d43-fc93-4056-8131-8b3a5018fe6f)


After
<img width="379" alt="after" src="https://github.com/user-attachments/assets/4c7b24f7-da34-4c35-8bb3-88a5f3cbfdb6" />

# What approach did you choose and why?
Hyphenation library expects words not full strings. So we use the hyphenate method of the `md-to-pdf `gem, which also does a splitting.

