### PR TITLE
Subject pattern improvements

### DIFF
--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -65,7 +65,7 @@ module WorkPackages
       private
 
       def has_pattern?
-        false
+        model.replacement_pattern_defined_for?(:subject)
       end
     end
   end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -104,10 +104,8 @@ class Type < ApplicationRecord
     object.types.include?(self)
   end
 
-  def replacement_patterns_defined?
-    return false if patterns.blank?
-
-    enabled_patterns.any?
+  def replacement_pattern_defined_for?(attribute)
+    enabled_patterns.key?(attribute)
   end
 
   def enabled_patterns

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -73,8 +73,7 @@ class WorkPackages::CreateService < BaseServices::BaseCallable
   end
 
   def set_templated_subject(work_package)
-    return true unless work_package.type&.replacement_patterns_defined?
-    return true unless work_package.type.enabled_patterns[:subject]
+    return true unless work_package.type&.replacement_pattern_defined_for?(:subject)
 
     work_package.subject = work_package.type.enabled_patterns[:subject].resolve(work_package)
     work_package.save

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -49,9 +49,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   end
 
   def mark_templated_subject
-    return true unless work_package.type&.replacement_patterns_defined?
-
-    if work_package.type.patterns.all_enabled[:subject]
+    if work_package.type&.replacement_pattern_defined_for?(:subject)
       work_package.subject = "Templated by #{work_package.type.name}"
     end
   end

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -42,9 +42,7 @@ class WorkPackages::UpdateService < BaseServices::Update
   private
 
   def set_templated_attributes
-    return unless model.type.replacement_patterns_defined?
-
-    model.type.patterns.all_enabled.each do |key, pattern|
+    model.type.enabled_patterns.each do |key, pattern|
       model.public_send(:"#{key}=", pattern.resolve(model))
     end
   end


### PR DESCRIPTION
# Ticket
There is no ticket directly associated to this cleanup.

# What are you trying to accomplish?
Reducing the error potential when working with patterns. Right now one could believe that `replacement_patterns_defined? == has_subject_replacement_pattern?`.

# What approach did you choose and why?

By requiring to pass an attribute into the method, we can't ask the (arguably meaningless) question whether _any_ patterns are defined, but we are forced to ask whether a pattern is defined for a specific attribute. This prevents certain kinds of errors, while hopefully there will not be code that even needs to ask whether _any_ patterns are defined.

Also starting to more consistently use helpers that (probably) became available while developing the larger feature of automatic subject generation (e.g. `enabled_patterns`, which never returns `nil`) and removing some mock implementations.