### PR TITLE
Disable subject editing

### DIFF
--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -53,6 +53,7 @@ module API
 
           def writable?(property)
             property = property.to_s
+            return false if property == "subject" && type&.replacement_pattern_defined_for?(:subject)
 
             # Special case for milestones + date property
             property = "start_date" if property == "date" && milestone?

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -299,6 +299,16 @@ RSpec.describe API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
         expect(subject).to be_writable(:priority)
       end
     end
+
+    describe "subject" do
+      it { is_expected.to be_writable(:subject) }
+
+      context "when the type has automatic subject generation enabled" do
+        let(:type) { build_stubbed(:type, patterns: { subject: { blueprint: "Hello world", enabled: true } }) }
+
+        it { is_expected.not_to be_writable(:subject) }
+      end
+    end
   end
 
   describe "#assignable_custom_field_values" do

--- a/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
@@ -83,6 +83,18 @@ RSpec.describe API::V3::WorkPackages::Schema::TypedWorkPackageSchema do
     it "finish date is writable" do
       expect(subject).to be_writable(:due_date)
     end
+
+    it "subject is writable" do
+      expect(subject).to be_writable(:subject)
+    end
+
+    context "when the type has automatic subject generation enabled" do
+      let(:type) { create(:type, patterns: { subject: { blueprint: "Hello world", enabled: true } }) }
+
+      it "subject is not writable" do
+        expect(subject).not_to be_writable(:subject)
+      end
+    end
   end
 
   describe "#milestone?" do


### PR DESCRIPTION
# Ticket

This PR covers two tickets:
* https://community.openproject.org/projects/document-workflows-stream/work_packages/59911
* https://community.openproject.org/projects/document-workflows-stream/work_packages/59910

# What are you trying to accomplish?
Block users from changing subjects that were automatically set because of the WP type's configuration.

## Screenshots
![image](https://github.com/user-attachments/assets/0aa7cfbf-52c6-4f35-a45a-b00d7c60af7b)

# What approach did you choose and why?
Changing the schema response for `writable` dynamically, based on whether the WP type has a subject pattern defined or not. This is already respected by our own table views and also allows third party clients to recognize that the subject can't be changed.

Admittedly, I was unsure about how "deep" I should define the attribute as non-writable. I've now chosen the `WorkpackageSchemaRepresenter`, where my other options would have been to do it on the work package schema (probably `SpecificWorkPackageSchema`, because that one knows the type) or maybe even the create and update contracts.

# Merge checklist

- [x] Added/updated tests
- [x] Tested Firefox
