### PR TITLE
[#58848] Link to Nextcloud file is duplicated to new work package

### DIFF
--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -296,6 +296,7 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
     document.body.removeEventListener('dragleave', this.onGlobalDragLeave);
     document.body.removeEventListener('dragend', this.onGlobalDragEnd);
     document.body.removeEventListener('drop', this.onGlobalDragEnd);
+    this.fileLinkResourceService.clear('new')
   }
 
   public removeFileLink(fileLink:IFileLink):void {


### PR DESCRIPTION
https://community.openproject.org/work_packages/58848

# What are you trying to accomplish?
Removes file links stored in the fileLinkResourceService when the storage component gets destroyed.
