### PR TITLE
fix PermissionAdder to only add permissions that could also be assigned via the contract

### DIFF
--- a/db/migrate/migration_utils/permission_adder.rb
+++ b/db/migrate/migration_utils/permission_adder.rb
@@ -32,6 +32,8 @@ module Migration
       module_function
 
       def add(having, add)
+        added_permission = OpenProject::AccessControl.permission(add)
+
         role_scope = Role
           .joins(:role_permissions)
           .where(role_permissions: { permission: having.to_s })
@@ -40,8 +42,6 @@ module Migration
         role_scope.find_each do |role|
           # Check if the add-permission already exists before adding
           next if RolePermission.exists?(role_id: role.id, permission: add.to_s)
-
-          added_permission = OpenProject::AccessControl.permission(add)
 
           # we cannot add permissions that require a member to a non-member role
           next if added_permission.require_member? && role.builtin == Role::BUILTIN_NON_MEMBER

--- a/spec/migrations/permission_adder_spec.rb
+++ b/spec/migrations/permission_adder_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/migration_utils/permission_adder.rb")
+
+RSpec.describe Migration::MigrationUtils::PermissionAdder, type: :model do # rubocop:disable RSpec/SpecFilePathFormat
+  let!(:role) { create(:project_role) }
+  let!(:non_member_role) { create(:non_member) }
+  let!(:anonymous_role) { create(:anonymous_role) }
+
+  let(:roles) { [role, non_member_role, anonymous_role] }
+
+  context "with a permission without special requirements" do
+    it "adds the permission to all roles" do
+      expect(role.permissions).not_to include(:view_project_attributes)
+      expect(non_member_role.permissions).not_to include(:view_project_attributes)
+      expect(anonymous_role.permissions).not_to include(:view_project_attributes)
+
+      described_class.add(:view_project, :view_project_attributes)
+      roles.map(&:reload)
+
+      expect(role.permissions).to include(:view_project_attributes)
+      expect(non_member_role.permissions).to include(:view_project_attributes)
+      expect(anonymous_role.permissions).to include(:view_project_attributes)
+    end
+
+    context "when the permission already exists in role" do
+      let!(:role) { create(:project_role, permissions: [:view_project_attributes]) }
+
+      it "does not add a permission that already exists" do
+        described_class.add(:view_project, :view_project_attributes)
+        role.reload
+
+        expect(role.permissions.count(:view_project_attributes)).to eq(1)
+      end
+    end
+  end
+
+  context "when adding a permission that has `required: :loggedin` attribute" do
+    it "does not add the permission to the anonymous role" do
+      described_class.add(:view_project, :move_work_packages)
+      roles.map(&:reload)
+
+      expect(role.permissions).to include(:move_work_packages)
+      expect(non_member_role.permissions).to include(:move_work_packages)
+      expect(anonymous_role.permissions).not_to include(:move_work_packages)
+    end
+  end
+
+  context "when adding a permission that has `required: :member` attribute" do
+    it "does not add the permission to the non-member and anonymous roles" do
+      described_class.add(:view_project, :archive_project)
+      roles.map(&:reload)
+
+      expect(role.permissions).to include(:archive_project)
+      expect(non_member_role.permissions).not_to include(:archive_project)
+      expect(anonymous_role.permissions).not_to include(:archive_project)
+    end
+  end
+end

--- a/spec/migrations/permission_adder_spec.rb
+++ b/spec/migrations/permission_adder_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Migration::MigrationUtils::PermissionAdder, type: :model do # rub
       expect(anonymous_role.permissions).not_to include(:view_project_attributes)
 
       described_class.add(:view_project, :view_project_attributes)
-      roles.map(&:reload)
+      roles.each(&:reload)
 
       expect(role.permissions).to include(:view_project_attributes)
       expect(non_member_role.permissions).to include(:view_project_attributes)
@@ -67,7 +67,7 @@ RSpec.describe Migration::MigrationUtils::PermissionAdder, type: :model do # rub
   context "when adding a permission that has `required: :loggedin` attribute" do
     it "does not add the permission to the anonymous role" do
       described_class.add(:view_project, :move_work_packages)
-      roles.map(&:reload)
+      roles.each(&:reload)
 
       expect(role.permissions).to include(:move_work_packages)
       expect(non_member_role.permissions).to include(:move_work_packages)
@@ -78,7 +78,7 @@ RSpec.describe Migration::MigrationUtils::PermissionAdder, type: :model do # rub
   context "when adding a permission that has `required: :member` attribute" do
     it "does not add the permission to the non-member and anonymous roles" do
       described_class.add(:view_project, :archive_project)
-      roles.map(&:reload)
+      roles.each(&:reload)
 
       expect(role.permissions).to include(:archive_project)
       expect(non_member_role.permissions).not_to include(:archive_project)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/gmbh/work_packages/60500

# What are you trying to accomplish?

We are using the `PermissionAdder` to add permissions in a migration, when a role already has a given other permission.

In the contract to add permissions to a role, we have a check that we do not allow to add roles that have `require: :loggedin` to the _anonymous role_ and roles that have `require: :member` to the _anonymous role_ or the _non-member role_.

# What approach did you choose and why?
Added checks to the `PermissionAdder` that compares the `require:` attribute with the `builtin` of the role, so that we only add those permissions that make sense.

I also added tests for this and the existing behavior.

# Merge checklist

- [x] Added/updated tests