### PR TITLE
bug/60458 The 'set reminder' action is available to users who are not signed in

### DIFF
--- a/app/models/reminder_notification.rb
+++ b/app/models/reminder_notification.rb
@@ -1,3 +1,31 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 class ReminderNotification < ApplicationRecord
   belongs_to :reminder
   belongs_to :notification, dependent: :destroy

--- a/app/models/reminder_notification.rb
+++ b/app/models/reminder_notification.rb
@@ -1,4 +1,4 @@
 class ReminderNotification < ApplicationRecord
   belongs_to :reminder
-  belongs_to :notification
+  belongs_to :notification, dependent: :destroy
 end

--- a/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
+++ b/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
@@ -1,14 +1,31 @@
 class RemoveIncorrectManageOwnRemindersPermission < ActiveRecord::Migration[7.1]
   def up
     # Remove manage_own_reminders permission from non member and anonymous roles
-    RolePermission
-      .where(
-        role: Role.where(builtin: [Role::BUILTIN_NON_MEMBER, Role::BUILTIN_ANONYMOUS]),
-        permission: :manage_own_reminders
-      ).destroy_all
+    execute <<-SQL.squish
+      DELETE FROM role_permissions
+      WHERE role_id IN (
+        SELECT id FROM roles WHERE builtin IN (#{Role::BUILTIN_NON_MEMBER}, #{Role::BUILTIN_ANONYMOUS})
+      )
+      AND permission = 'manage_own_reminders'
+    SQL
 
-    # Remove all reminders created by anonymous user
-    Reminder.where(creator_id: AnonymousUser.first.id).destroy_all
+    # Remove all reminders created by anonymous user and cascade delete related records
+    execute <<-SQL.squish
+      WITH deleted_reminders AS (
+        DELETE FROM reminders
+        WHERE creator_id IN (
+          SELECT id FROM users WHERE type = 'AnonymousUser'
+        )
+        RETURNING id
+      ),
+      deleted_reminder_notifications AS (
+        DELETE FROM reminder_notifications
+        WHERE reminder_id IN (SELECT id FROM deleted_reminders)
+        RETURNING notification_id
+      )
+      DELETE FROM notifications
+      WHERE id IN (SELECT notification_id FROM deleted_reminder_notifications)
+    SQL
   end
 
   # No-op

--- a/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
+++ b/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
@@ -1,10 +1,14 @@
 class RemoveIncorrectManageOwnRemindersPermission < ActiveRecord::Migration[7.1]
   def up
+    # Remove manage_own_reminders permission from non member and anonymous roles
     RolePermission
       .where(
         role: Role.where(builtin: [Role::BUILTIN_NON_MEMBER, Role::BUILTIN_ANONYMOUS]),
         permission: :manage_own_reminders
       ).destroy_all
+
+    # Remove all reminders created by anonymous user
+    Reminder.where(creator_id: AnonymousUser.first.id).destroy_all
   end
 
   # No-op

--- a/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
+++ b/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
@@ -1,0 +1,12 @@
+class RemoveIncorrectManageOwnRemindersPermission < ActiveRecord::Migration[7.1]
+  def up
+    RolePermission
+      .where(
+        role: Role.where(builtin: [Role::BUILTIN_NON_MEMBER, Role::BUILTIN_ANONYMOUS]),
+        permission: :manage_own_reminders
+      ).destroy_all
+  end
+
+  # No-op
+  def down; end
+end

--- a/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
+++ b/db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb
@@ -1,10 +1,14 @@
 class RemoveIncorrectManageOwnRemindersPermission < ActiveRecord::Migration[7.1]
   def up
     # Remove manage_own_reminders permission from non member and anonymous roles
+    # Use hardcoded values for `Role::BUILTIN_NON_MEMBER` and `Role::BUILTIN_ANONYMOUS`
+    # to avoid breaking the migration if the values are changed in the future
+    non_member_builtin = 1 # Role::BUILTIN_NON_MEMBER
+    anonymous_builtin = 2 # Role::BUILTIN_ANONYMOUS
     execute <<-SQL.squish
       DELETE FROM role_permissions
       WHERE role_id IN (
-        SELECT id FROM roles WHERE builtin IN (#{Role::BUILTIN_NON_MEMBER}, #{Role::BUILTIN_ANONYMOUS})
+        SELECT id FROM roles WHERE builtin IN (#{non_member_builtin}, #{anonymous_builtin})
       )
       AND permission = 'manage_own_reminders'
     SQL

--- a/spec/migrations/remove_incorrect_manage_own_reminders_permission_spec.rb
+++ b/spec/migrations/remove_incorrect_manage_own_reminders_permission_spec.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20250108100511_remove_incorrect_manage_own_reminders_permission.rb")
+
+RSpec.describe RemoveIncorrectManageOwnRemindersPermission, type: :model do
+  let(:permissions) { %i[permission1 permission2 manage_own_reminders] }
+  let(:non_member) { create(:non_member, permissions:) }
+  let(:anonymous) { create(:anonymous_role, permissions:) }
+  let(:other_role) { create(:work_package_role, permissions:) }
+
+  before do
+    non_member
+    anonymous
+    other_role
+  end
+
+  it "removes the `manage_own_reminders` permission from non member and anonymous roles" do
+    expect(non_member.permissions).to include(:manage_own_reminders)
+    expect(anonymous.permissions).to include(:manage_own_reminders)
+    expect(other_role.permissions).to include(:manage_own_reminders)
+
+    ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) }
+
+    expect(non_member.reload.permissions).not_to include(:manage_own_reminders)
+    expect(anonymous.reload.permissions).not_to include(:manage_own_reminders)
+    expect(other_role.reload.permissions).to include(:manage_own_reminders)
+  end
+end

--- a/spec/models/reminder_notification_spec.rb
+++ b/spec/models/reminder_notification_spec.rb
@@ -31,6 +31,6 @@ require "spec_helper"
 RSpec.describe ReminderNotification do
   describe "Associations" do
     it { is_expected.to belong_to(:reminder) }
-    it { is_expected.to belong_to(:notification) }
+    it { is_expected.to belong_to(:notification).dependent(:destroy) }
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/60458

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Set reminder action should not be visible anonymous users. This PR performs the data correction by removing `manage_own_reminders` permissions from non member and anonymous roles.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

| Before | After |
|--------|--------|
| <img width="1581" alt="Screenshot 2025-01-08 at 3 04 51 PM" src="https://github.com/user-attachments/assets/e4163abe-dbb8-4b92-b39b-f97e48f8fc74" /> | <img width="1511" alt="Screenshot 2025-01-08 at 3 05 49 PM" src="https://github.com/user-attachments/assets/08ba9e6f-3d51-4935-8774-9ed91005ee08" /> |


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->


17b94f6f55432d105cf5e7129ae1fdcc77d1bf4e introduced a seed migration that added the `manage_own_reminders` permission to roles with `view_project` permission via `Migration::MigrationUtils::PermissionAdder`.

However, the permission added did not correctly exclude non member and anonymous roles. This has been corrected in https://github.com/opf/openproject/pull/17554

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
