### PR TITLE
[60462] Improve comprehensibility of the "Add relations" modal

### DIFF
--- a/app/components/work_package_relations_tab/work_package_relation_dialog_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_dialog_component.html.erb
@@ -21,7 +21,11 @@
           form: FORM_ID,
           data: { turbo: true },
           type: :submit)) do
-          t(:button_save)
+          if @relation.id.present?
+            t(:button_save)
+          else
+            t(:button_add)
+          end
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -746,7 +746,7 @@ en:
     lag:
       subject: "Lag"
       title: "Lag (in days)"
-      caption: "The gap in number of working days in between the two work packages"
+      caption: "The minimum number of working days to keep in between the two work packages."
     relations:
       label_relates_singular: "related to"
       label_relates_plural: "related to"

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -160,7 +160,7 @@ module Components
           fill_in "Description", with: description
         end
 
-        click_link_or_button "Save"
+        click_link_or_button "Add"
 
         wait_for_reload if using_cuprite?
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60462

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
In WP relation modal, when adding a new relation, change the primary button to "Add" instead of "Save".
Change the caption for lag.

## Screenshots
![Screenshot 2025-01-08 at 14 38 57](https://github.com/user-attachments/assets/555762da-5d76-439a-b2b2-59c37b200849)

![Screenshot 2025-01-08 at 14 38 42](https://github.com/user-attachments/assets/bccd891f-891e-43d4-ba3b-6cbc2b650ab6)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
