### PR TITLE
Save pattern changes

### DIFF
--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -36,8 +36,8 @@ module WorkPackages
 
       def form_options
         {
-          url: "https://example.com",
-          method: :put,
+          url: update_type_tab_path(id: model.id, tab: "subject_configuration"),
+          method: :patch,
           model:,
           data: {
             application_target: "dynamic",

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -42,7 +42,8 @@ module WorkPackages
           data: {
             application_target: "dynamic",
             controller: "admin--subject-configuration",
-            admin__subject_configuration_hide_pattern_input_value: true
+            admin__subject_configuration_hide_pattern_input_value:
+              !WorkPackages::Types::SubjectConfigurationForm.has_pattern?(model)
           }
         }
       end

--- a/app/contracts/types/base_contract.rb
+++ b/app/contracts/types/base_contract.rb
@@ -42,6 +42,7 @@ module Types
     attribute :project_ids
     attribute :description
     attribute :attribute_groups
+    attribute :patterns
 
     validate :validate_current_user_is_admin
     validate :validate_attribute_group_names

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -58,7 +58,8 @@ module WorkPackages
 
         subject_form.group(data: { "admin--subject-configuration-target": "patternInput" }) do |toggleable_group|
           toggleable_group.text_field(
-            name: :pattern,
+            name: :subject_pattern,
+            value: subject_pattern,
             label: I18n.t("types.edit.subject_configuration.pattern.label"),
             caption: I18n.t("types.edit.subject_configuration.pattern.caption"),
             required: true,
@@ -73,6 +74,12 @@ module WorkPackages
 
       def has_pattern?
         self.class.has_pattern?(model)
+      end
+
+      def subject_pattern
+        return "" if model.patterns.nil? || model.patterns[:subject].nil?
+
+        model.patterns[:subject].blueprint
       end
     end
   end

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -31,6 +31,12 @@
 module WorkPackages
   module Types
     class SubjectConfigurationForm < ApplicationForm
+      class << self
+        def has_pattern?(type)
+          type.replacement_pattern_defined_for?(:subject)
+        end
+      end
+
       form do |subject_form|
         subject_form.radio_button_group(name: :subject_configuration) do |group|
           group.radio_button(
@@ -66,7 +72,7 @@ module WorkPackages
       private
 
       def has_pattern?
-        model.replacement_pattern_defined_for?(:subject)
+        self.class.has_pattern?(model)
       end
     end
   end

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -77,9 +77,9 @@ module WorkPackages
       end
 
       def subject_pattern
-        return "" if model.patterns.nil? || model.patterns[:subject].nil?
+        return "" if model.patterns.subject.nil?
 
-        model.patterns[:subject].blueprint
+        model.patterns.subject.blueprint
       end
     end
   end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -614,6 +614,8 @@ class PermittedParams
           :color_id,
           :default,
           :description,
+          :subject_configuration,
+          :subject_pattern,
           { project_ids: [] }
         ],
         user: %i(

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -109,8 +109,6 @@ class Type < ApplicationRecord
   end
 
   def enabled_patterns
-    return {} if patterns.blank?
-
     patterns.all_enabled
   end
 

--- a/app/models/types/patterns/collection.rb
+++ b/app/models/types/patterns/collection.rb
@@ -34,6 +34,10 @@ module Types
       extend Dry::Monads[:result]
       private_class_method :new
 
+      def self.empty
+        new(patterns: {})
+      end
+
       def self.build(patterns:, contract: CollectionContract.new)
         contract.call(patterns).to_monad.fmap { |success| new(success.to_h) }
       rescue ArgumentError => e
@@ -46,12 +50,16 @@ module Types
         super(patterns: transformed)
       end
 
+      def subject
+        patterns[:subject]
+      end
+
       def all_enabled
         patterns.select { |_, pattern| pattern.enabled? }
       end
 
-      def [](value)
-        patterns[value]
+      def update_pattern(name, blueprint:, enabled:)
+        self.class.build(patterns: patterns.to_h.merge(name => { blueprint:, enabled: }))
       end
 
       def to_h

--- a/app/models/types/patterns/collection.rb
+++ b/app/models/types/patterns/collection.rb
@@ -51,7 +51,7 @@ module Types
       end
 
       def [](value)
-        patterns.fetch(value)
+        patterns[value]
       end
 
       def to_h

--- a/app/models/types/patterns/collection_contract.rb
+++ b/app/models/types/patterns/collection_contract.rb
@@ -32,7 +32,7 @@ module Types
   module Patterns
     class CollectionContract < Dry::Validation::Contract
       params do
-        required(:subject).hash do
+        optional(:subject).hash do
           required(:blueprint).filled(:string)
           required(:enabled).filled(:bool)
         end

--- a/app/models/types/patterns/collection_type.rb
+++ b/app/models/types/patterns/collection_type.rb
@@ -36,7 +36,9 @@ module Types
       end
 
       def cast(value)
-        Collection.build(patterns: value).value_or { nil }
+        return value if value.is_a?(Collection)
+
+        Collection.build(patterns: value).value_or { Collection.empty }
       end
 
       def serialize(pattern)
@@ -46,7 +48,7 @@ module Types
       end
 
       def deserialize(value)
-        return if value.blank?
+        return Collection.empty if value.blank?
 
         data = YAML.safe_load(value)
         cast(data)

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -106,12 +108,9 @@ class BaseTypeService
   end
 
   def set_subject_pattern(params)
-    type.patterns = {
-      subject: {
-        blueprint: params[:subject_pattern],
-        enabled: params[:subject_configuration] == "auto"
-      }
-    }
+    type.patterns = type.patterns.update_pattern(:subject,
+                                                 blueprint: params[:subject_pattern],
+                                                 enabled: params[:subject_configuration] == "auto").value!
   end
 
   def parse_attribute_groups_params(params)

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -71,7 +71,9 @@ class BaseTypeService
   def set_params_and_validate(params)
     # Only set attribute groups when it exists
     # (Regression #28400)
-    set_attribute_groups(params) unless params[:attribute_groups].nil?
+    set_attribute_groups(params) if params[:attribute_groups]
+
+    set_subject_pattern(params) if params[:subject_configuration]
 
     # This should go before `set_scalar_params` call to get the
     # project_ids, custom_field_ids diffs from the type and the params.
@@ -92,7 +94,7 @@ class BaseTypeService
   end
 
   def set_scalar_params(params)
-    type.attributes = params.except(:attribute_groups)
+    type.attributes = params.except(:attribute_groups, :subject_configuration, :subject_pattern)
   end
 
   def set_attribute_groups(params)
@@ -101,6 +103,15 @@ class BaseTypeService
     else
       type.attribute_groups = parse_attribute_groups_params(params)
     end
+  end
+
+  def set_subject_pattern(params)
+    type.patterns = {
+      subject: {
+        blueprint: params[:subject_pattern],
+        enabled: params[:subject_configuration] == "auto"
+      }
+    }
   end
 
   def parse_attribute_groups_params(params)

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -312,6 +312,57 @@ RSpec.describe TypesController do
           expect(Type.find_by(name: "My type").projects.count).to eq(0)
         end
       end
+
+      describe "when updating the subject pattern" do
+        let(:params) do
+          { "id" => type.id,
+            "type" => { subject_pattern: blueprint, subject_configuration: "auto" },
+            "tab" => "subject_configuration" }
+        end
+        let(:blueprint) { "I choose you {{assignee}}!" }
+
+        before do
+          patch :update, params:
+        end
+
+        it { expect(response).to be_redirect }
+
+        it do
+          expect(response).to(
+            redirect_to(edit_type_tab_path(id: type.id, tab: "subject_configuration"))
+          )
+        end
+
+        it "stores the pattern" do
+          pattern = Type.find(type.id).patterns[:subject]
+
+          expect(pattern).to be_present
+          expect(pattern).to be_enabled
+          expect(pattern.blueprint).to eq(blueprint)
+        end
+
+        context "and when the subject is configured manually" do
+          let(:params) do
+            { "id" => type.id,
+              "type" => { subject_pattern: blueprint, subject_configuration: "manual" },
+              "tab" => "subject_configuration" }
+          end
+
+          it "disables the pattern" do
+            pattern = Type.find(type.id).patterns[:subject]
+
+            expect(pattern).to be_present
+            expect(pattern).not_to be_enabled
+          end
+
+          it "stores the previously used blueprint" do
+            pattern = Type.find(type.id).patterns[:subject]
+
+            expect(pattern).to be_present
+            expect(pattern.blueprint).to eq(blueprint)
+          end
+        end
+      end
     end
 
     describe "POST move" do

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe TypesController do
         end
 
         it "stores the pattern" do
-          pattern = Type.find(type.id).patterns[:subject]
+          pattern = Type.find(type.id).patterns.subject
 
           expect(pattern).to be_present
           expect(pattern).to be_enabled
@@ -349,14 +349,14 @@ RSpec.describe TypesController do
           end
 
           it "disables the pattern" do
-            pattern = Type.find(type.id).patterns[:subject]
+            pattern = Type.find(type.id).patterns.subject
 
             expect(pattern).to be_present
             expect(pattern).not_to be_enabled
           end
 
           it "stores the previously used blueprint" do
-            pattern = Type.find(type.id).patterns[:subject]
+            pattern = Type.find(type.id).patterns.subject
 
             expect(pattern).to be_present
             expect(pattern.blueprint).to eq(blueprint)

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -129,10 +129,10 @@ RSpec.describe Type do
   end
 
   describe "#patterns" do
-    it "returns nil when no patterns are defined" do
+    it "returns an empty collection when no patterns are defined" do
       type = create(:type)
 
-      expect(type.patterns).to be_nil
+      expect(type.patterns).to eq(Types::Patterns::Collection.empty)
     end
 
     it "returns a PatternCollection" do
@@ -141,7 +141,7 @@ RSpec.describe Type do
                     })
 
       expect(type.patterns).to be_a(Types::Patterns::Collection)
-      expect(type.patterns[:subject])
+      expect(type.patterns.subject)
         .to eq(Types::Pattern.new("{{work_package:custom_field_123}} - {{project:custom_field_321}}", true))
     end
   end
@@ -149,22 +149,35 @@ RSpec.describe Type do
   describe "#patterns=" do
     subject(:type) { build(:type) }
 
+    it "assigns a patterns collection as-is" do
+      collection = Types::Patterns::Collection.build(patterns: {
+                                                       subject: { blueprint: "some_string", enabled: false }
+                                                     }).value!
+
+      type.patterns = collection
+
+      expect(type.patterns).to eq(collection)
+      expect { type.save! }.not_to raise_error
+    end
+
     context "when an invalid value is passed" do
-      it "defaults to nil" do
+      it "defaults to an empty collection" do
         type.patterns = 4
 
-        expect(type.patterns).to be_nil
+        expect(type.patterns).to eq(Types::Patterns::Collection.empty)
         expect { type.save! }.not_to raise_error
       end
     end
 
-    it "converts the incoming hash into a PatternCollection" do
-      type.patterns = { subject: { blueprint: "some_string", enabled: false } }
+    context "when a hash is passed" do
+      it "converts the incoming hash into a PatternCollection" do
+        type.patterns = { subject: { blueprint: "some_string", enabled: false } }
 
-      expect(type.patterns).to be_a(Types::Patterns::Collection)
-      expect(type.patterns[:subject]).to be_a(Types::Pattern)
+        expect(type.patterns).to be_a(Types::Patterns::Collection)
+        expect(type.patterns.subject).to be_a(Types::Pattern)
 
-      expect { type.save! }.not_to raise_error
+        expect { type.save! }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/document-workflows-stream/work_packages/60498

# What are you trying to accomplish?
Replace the current mock implementation of the subject configuration form with one that is actually storing the values we enter into it.

# What approach did you choose and why?
The `Type::BaseService` was extended to take the new parameters and update the type accordingly. To keep aligned with the structure of the `patterns` collection, I made sure that we'd only change the `subject` portion of that collection and not any other (future) elements in it, since it's already designed to carry more than just a subject pattern.

To simplify code that relies on `type.patterns`, I made sure that the collection would always be present and can't be `nil` anymore. This allows us to avoid nil-checks and avoids branching code in the form of "if patterns exists update, else create".

# Merge checklist

- [x] Updating implemented
- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
