### PR TITLE
Bug/60540 adding a work package as a child via the activity tab broken

### DIFF
--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -9,16 +9,16 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   include Turbo::FramesHelper
   include OpTurbo::Streamable
 
-  attr_reader :work_package, :relations, :children, :directionally_aware_grouped_relations, :scroll_to_id
+  attr_reader :work_package, :relations, :children, :directionally_aware_grouped_relations, :relation_to_scroll_to
 
-  def initialize(work_package:, relations:, children:, scroll_to_id: nil)
+  def initialize(work_package:, relations:, children:, relation_to_scroll_to: nil)
     super()
 
     @work_package = work_package
     @relations = relations
     @children = children
     @directionally_aware_grouped_relations = group_relations_by_directional_context
-    @scroll_to_id = scroll_to_id
+    @relation_to_scroll_to = relation_to_scroll_to
   end
 
   def self.wrapper_key
@@ -74,15 +74,14 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
 
   def render_items(border_box, items)
     items.each do |item|
-      related_work_package_id = find_related_work_package_id(item)
-      data_attribute = nil
-      if related_work_package_id.to_s == @scroll_to_id
-        data_attribute = {
-          controller: "work-packages--relations-tab--scroll",
-          application_target: "dynamic",
-          "work-packages--relations-tab--scroll-target": "scrollToRow"
-        }
-      end
+      data_attribute = if relation_to_scroll_to && item.id == relation_to_scroll_to.id
+                         {
+                           controller: "work-packages--relations-tab--scroll",
+                           application_target: "dynamic",
+                           "work-packages--relations-tab--scroll-target": "scrollToRow"
+                         }
+                       end
+
       border_box.with_row(
         test_selector: row_test_selector(item),
         data: data_attribute

--- a/app/controllers/work_package_children_relations_controller.rb
+++ b/app/controllers/work_package_children_relations_controller.rb
@@ -46,7 +46,7 @@ class WorkPackageChildrenRelationsController < ApplicationController
     child = WorkPackage.find(params[:work_package][:id])
     service_result = set_relation(child:, parent: @work_package)
 
-    respond_with_relations_tab_update(service_result, scroll_to_id: child.id.to_s)
+    respond_with_relations_tab_update(service_result, relation_to_scroll_to: service_result.result)
   end
 
   def destroy

--- a/app/controllers/work_package_children_relations_controller.rb
+++ b/app/controllers/work_package_children_relations_controller.rb
@@ -46,7 +46,7 @@ class WorkPackageChildrenRelationsController < ApplicationController
     child = WorkPackage.find(params[:work_package][:id])
     service_result = set_relation(child:, parent: @work_package)
 
-    respond_with_relations_tab_update(service_result, scroll_to_id: child.id)
+    respond_with_relations_tab_update(service_result, scroll_to_id: child.id.to_s)
   end
 
   def destroy

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -60,12 +60,11 @@ class WorkPackageRelationsController < ApplicationController
                                              .call(create_relation_params)
 
     if service_result.success?
-      target_work_package_id = params[:relation][:to_id]
       @work_package.reload
       component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package,
                                                               relations: @work_package.relations.visible,
                                                               children: @work_package.children.visible,
-                                                              scroll_to_id: target_work_package_id)
+                                                              relation_to_scroll_to: service_result.result)
       replace_via_turbo_stream(component:)
       respond_with_turbo_streams
     else

--- a/spec/controllers/work_package_relations_controller_spec.rb
+++ b/spec/controllers/work_package_relations_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe WorkPackageRelationsController do
       new_relation = Relation.last
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [relation, new_relation], children:, scroll_to_id: unrelated_work_package.id)
+        .with(work_package:, relations: [relation, new_relation], children:, relation_to_scroll_to: new_relation)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60540

# What are you trying to accomplish?

While working on this, the original error has been fixed but without correctly fixing the scrolling behaviour.

Fix scrolling to the newly added child work package which got broken in when [merging 15.1 into 15.2](https://github.com/opf/openproject/commit/de565583b2c81691c2eba71e5636004a2f72dfe6#diff-f7a3f6ceb8a1b0173a5e80dea088a0937596ae4ac26179f9182dbddab832dcc5L49-L52). This fails because it is now comparing an int to a string. This is fixed in ec4a8b2465254bdb16d530a6471f05a6d8ab45bc. The second commit tries to improve the expressiveness of the scrolling functionality and is not related to the bug fix.