### PR TITLE
Allow adding children through a work package create dialog

### DIFF
--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -18,7 +18,7 @@
               t(:label_relation)
             end
 
-            render_child_items(menu)
+            render_child_menu_items(menu)
 
             if should_render_add_relations?
               Relation::TYPES.each do |relation_type, type_configuration_hash|

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -18,6 +18,8 @@
               t(:label_relation)
             end
 
+            render_child_items(menu)
+
             if should_render_add_relations?
               Relation::TYPES.each do |relation_type, type_configuration_hash|
                 label_key = "#{I18N_NAMESPACE}.relations.#{type_configuration_hash[:name]}_singular"
@@ -31,19 +33,6 @@
                 ) do |item|
                   item.with_description.with_content(t("#{I18N_NAMESPACE}.relations.#{relation_type}_description"))
                 end
-              end
-            end
-
-            if should_render_add_child?
-              menu.with_item(
-                label: t("#{I18N_NAMESPACE}.relations.label_child_singular").capitalize,
-                href: new_work_package_children_relation_path(@work_package),
-                test_selector: new_button_test_selector(relation_type: :child),
-                content_arguments: {
-                  data: { turbo_stream: true }
-                }
-              ) do |item|
-                item.with_description.with_content(t("#{I18N_NAMESPACE}.relations.child_description"))
               end
             end
           end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -85,7 +85,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
 
   def render_children_header(border_box, title, items)
     border_box.with_header(py: 3) do
-      flex_layout(justify_content: :space_between) do |header|
+      flex_layout(justify_content: :space_between, align_items: :center) do |header|
         header.with_column(mr: 2) do
           concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
           concat render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -110,7 +110,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
 
     menu.with_item(
       label: t("work_package_relations_tab.relations.new_child"),
-      href: "#",
+      href: new_project_work_packages_dialog_path(work_package.project),
       content_arguments: {
         data: { turbo_stream: true }
       }

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -98,28 +98,34 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
               t("work_package_relations_tab.label_add_child_button")
             end
 
-            menu.with_item(
-              label: t("work_package_relations_tab.relations.new_child"),
-              href: "#",
-              content_arguments: {
-                data: { turbo_stream: true }
-              }
-            ) do |item|
-              item.with_description.with_content(t("work_package_relations_tab.relations.new_child_text"))
-            end
-
-            menu.with_item(
-              label: t("work_package_relations_tab.relations.existing_child"),
-              href: "#",
-              content_arguments: {
-                data: { turbo_stream: true }
-              }
-            ) do |item|
-              item.with_description.with_content(t("work_package_relations_tab.relations.child_description"))
-            end
+            render_child_items(menu)
           end
         end
       end
+    end
+  end
+
+  def render_child_items(menu)
+    return unless should_render_add_child?
+
+    menu.with_item(
+      label: t("work_package_relations_tab.relations.new_child"),
+      href: "#",
+      content_arguments: {
+        data: { turbo_stream: true }
+      }
+    ) do |item|
+      item.with_description.with_content(t("work_package_relations_tab.relations.new_child_text"))
+    end
+
+    menu.with_item(
+      label: t("work_package_relations_tab.relations.existing_child"),
+      href: new_work_package_children_relation_path(work_package),
+      content_arguments: {
+        data: { turbo_stream: true }
+      }
+    ) do |item|
+      item.with_description.with_content(t("work_package_relations_tab.relations.child_description"))
     end
   end
 

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -110,7 +110,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
 
     menu.with_item(
       label: t("work_package_relations_tab.relations.new_child"),
-      href: new_project_work_packages_dialog_path(work_package.project),
+      href: new_project_work_packages_dialog_path(work_package.project, parent_id: work_package.id),
       content_arguments: {
         data: { turbo_stream: true }
       }

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -98,14 +98,14 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
               t("work_package_relations_tab.label_add_child_button")
             end
 
-            render_child_items(menu)
+            render_child_menu_items(menu)
           end
         end
       end
     end
   end
 
-  def render_child_items(menu) # rubocop:disable Metrics/AbcSize
+  def render_child_menu_items(menu) # rubocop:disable Metrics/AbcSize
     return unless should_render_add_child?
 
     if helpers.current_user.allowed_in_project?(:add_work_packages, @work_package.project)

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -83,7 +83,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     end
   end
 
-  def render_children_header(border_box, title, items)
+  def render_children_header(border_box, title, items) # rubocop:disable Metrics/AbcSize
     border_box.with_header(py: 3) do
       flex_layout(justify_content: :space_between, align_items: :center) do |header|
         header.with_column(mr: 2) do
@@ -105,7 +105,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     end
   end
 
-  def render_child_items(menu)
+  def render_child_items(menu) # rubocop:disable Metrics/AbcSize
     return unless should_render_add_child?
 
     menu.with_item(

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -9,6 +9,7 @@
 class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   FRAME_ID = "work-package-relations-tab-content"
   NEW_RELATION_ACTION_MENU = "new-relation-action-menu"
+  NEW_CHILD_ACTION_MENU = "new-child-action-menu"
   I18N_NAMESPACE = "work_package_relations_tab"
   include ApplicationHelper
   include OpPrimer::ComponentHelpers
@@ -91,7 +92,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
           concat render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
         end
         header.with_column do
-          render(Primer::Alpha::ActionMenu.new(menu_id: "new-child-relation")) do |menu|
+          render(Primer::Alpha::ActionMenu.new(menu_id: NEW_CHILD_ACTION_MENU)) do |menu|
             menu.with_show_button do |button|
               button.with_leading_visual_icon(icon: :plus)
               button.with_trailing_action_icon(icon: :"triangle-down")

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -108,14 +108,16 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   def render_child_items(menu) # rubocop:disable Metrics/AbcSize
     return unless should_render_add_child?
 
-    menu.with_item(
-      label: t("work_package_relations_tab.relations.new_child"),
-      href: new_project_work_packages_dialog_path(work_package.project, parent_id: work_package.id),
-      content_arguments: {
-        data: { turbo_stream: true }
-      }
-    ) do |item|
-      item.with_description.with_content(t("work_package_relations_tab.relations.new_child_text"))
+    if helpers.current_user.allowed_in_project?(:add_work_packages, @work_package.project)
+      menu.with_item(
+        label: t("work_package_relations_tab.relations.new_child"),
+        href: new_project_work_packages_dialog_path(work_package.project, parent_id: work_package.id),
+        content_arguments: {
+          data: { turbo_stream: true }
+        }
+      ) do |item|
+        item.with_description.with_content(t("work_package_relations_tab.relations.new_child_text"))
+      end
     end
 
     menu.with_item(

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -66,19 +66,58 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
              padding: :condensed,
              data: { test_selector: "op-relation-group-#{relation_type}" }
            )) do |border_box|
-      render_header(border_box, title, items)
+      if relation_type == :children && should_render_add_child?
+        render_children_header(border_box, title, items)
+      else
+        render_header(border_box, title, items)
+      end
+
       render_items(border_box, items, &_block)
     end
   end
 
   def render_header(border_box, title, items)
     border_box.with_header(py: 3) do
-      flex_layout(align_items: :center) do |flex|
-        flex.with_column(mr: 2) do
-          render(Primer::Beta::Text.new(font_size: :normal, font_weight: :bold)) { title }
+      concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
+      concat render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
+    end
+  end
+
+  def render_children_header(border_box, title, items)
+    border_box.with_header(py: 3) do
+      flex_layout(justify_content: :space_between) do |header|
+        header.with_column(mr: 2) do
+          concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
+          concat render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
         end
-        flex.with_column do
-          render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
+        header.with_column do
+          render(Primer::Alpha::ActionMenu.new(menu_id: "new-child-relation")) do |menu|
+            menu.with_show_button do |button|
+              button.with_leading_visual_icon(icon: :plus)
+              button.with_trailing_action_icon(icon: :"triangle-down")
+              t("work_package_relations_tab.label_add_child_button")
+            end
+
+            menu.with_item(
+              label: t("work_package_relations_tab.relations.new_child"),
+              href: "#",
+              content_arguments: {
+                data: { turbo_stream: true }
+              }
+            ) do |item|
+              item.with_description.with_content(t("work_package_relations_tab.relations.new_child_text"))
+            end
+
+            menu.with_item(
+              label: t("work_package_relations_tab.relations.existing_child"),
+              href: "#",
+              content_arguments: {
+                data: { turbo_stream: true }
+              }
+            ) do |item|
+              item.with_description.with_content(t("work_package_relations_tab.relations.child_description"))
+            end
+          end
         end
       end
     end

--- a/app/components/work_package_relations_tab/index_component.sass
+++ b/app/components/work_package_relations_tab/index_component.sass
@@ -1,5 +1,6 @@
 // We reference an ID as one is required to be specified for the action menu list.
 // It can't be nested inside the BEM model as it's placed as a #top-layer element.
-#new-relation-action-menu-list
+#new-relation-action-menu-list,
+#new-child-action-menu-list
   max-height: 450px
   max-width: 280px

--- a/app/components/work_packages/dialogs/create_dialog_component.html.erb
+++ b/app/components/work_packages/dialogs/create_dialog_component.html.erb
@@ -7,7 +7,7 @@
   )) do |dialog|
     dialog.with_header(variant: :large)
     dialog.with_body do
-      render(WorkPackages::Dialogs::CreateFormComponent.new(work_package:))
+      render(WorkPackages::Dialogs::CreateFormComponent.new(work_package:, project:))
     end
 
     dialog.with_footer do

--- a/app/components/work_packages/dialogs/create_dialog_component.html.erb
+++ b/app/components/work_packages/dialogs/create_dialog_component.html.erb
@@ -3,7 +3,9 @@
     id: "create-work-package-dialog",
     title: I18n.t(:label_work_package_new),
     size: :xlarge,
-    data: { 'keep-open-on-submit': true }
+    data: {
+      'keep-open-on-submit': true,
+    }
   )) do |dialog|
     dialog.with_header(variant: :large)
     dialog.with_body do

--- a/app/components/work_packages/dialogs/create_dialog_component.html.erb
+++ b/app/components/work_packages/dialogs/create_dialog_component.html.erb
@@ -1,0 +1,37 @@
+<%=
+  render(Primer::Alpha::Dialog.new(
+    id: "create-work-package-dialog",
+    title: I18n.t(:label_work_package_new),
+    size: :xlarge,
+    data: { 'keep-open-on-submit': true }
+  )) do |dialog|
+    dialog.with_header(variant: :large)
+    dialog.with_body do
+      render(WorkPackages::Dialogs::CreateFormComponent.new(work_package:))
+    end
+
+    dialog.with_footer do
+      component_collection do |modal_footer|
+        modal_footer.with_component(
+          Primer::ButtonComponent.new(
+            data: { 'close-dialog-id': "create-work-package-dialog" }
+          )) do
+          I18n.t(:button_cancel)
+        end
+
+        modal_footer.with_component(
+          Primer::ButtonComponent.new(
+            scheme: :primary,
+            form: "create-work-package-form",
+            type: :submit
+          )) do
+          if @work_package.persisted?
+            I18n.t(:button_save)
+          else
+            I18n.t(:button_create)
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/dialogs/create_dialog_component.rb
+++ b/app/components/work_packages/dialogs/create_dialog_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/components/work_packages/dialogs/create_dialog_component.rb
+++ b/app/components/work_packages/dialogs/create_dialog_component.rb
@@ -1,0 +1,45 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages::Dialogs
+  class CreateDialogComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpenProject::FormTagHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :work_package
+
+    def initialize(work_package:)
+      super
+
+      @work_package = work_package
+      @project = work_package.project
+    end
+  end
+end

--- a/app/components/work_packages/dialogs/create_dialog_component.rb
+++ b/app/components/work_packages/dialogs/create_dialog_component.rb
@@ -33,13 +33,13 @@ module WorkPackages::Dialogs
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    attr_reader :work_package
+    attr_reader :work_package, :project
 
-    def initialize(work_package:)
+    def initialize(work_package:, project:)
       super
 
       @work_package = work_package
-      @project = work_package.project
+      @project = project
     end
   end
 end

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -2,7 +2,9 @@
   component_wrapper do
     primer_form_with(
       scope: :work_package,
-      model: @work_package,
+      model: work_package,
+      url: project_work_packages_dialog_path(project),
+      method: :post,
       html: {
         id: 'create-work-package-form',
         data: {
@@ -11,16 +13,14 @@
       }
     ) do |f|
       flex_layout(mb: 3) do |modal_body|
-        if @work_package.errors[:base].present?
+        if work_package.errors[:base].present?
           modal_body.with_row do
-            render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @work_package.errors[:base].join("\n") }
+            render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { work_package.errors[:base].join("\n") }
           end
         end
 
-        if @project.nil?
-          modal_body.with_row(mt: 3) do
-            render(WorkPackages::Dialogs::CreateForm.new(f, work_package: work_package, wrapper_id: "#create-work-package-dialog"))
-          end
+        modal_body.with_row(mt: 3) do
+          render(WorkPackages::Dialogs::CreateForm.new(f, work_package:, wrapper_id: "#create-work-package-dialog"))
         end
       end
     end

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -1,0 +1,25 @@
+<%=
+  component_wrapper do
+    primer_form_with(
+      scope: :work_package,
+      model: @work_package,
+      html: {
+        id: 'create-work-package-form'
+      }
+    ) do |f|
+      flex_layout(mb: 3) do |modal_body|
+        if @work_package.errors[:base].present?
+          modal_body.with_row do
+            render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @work_package.errors[:base].join("\n") }
+          end
+        end
+
+        if @project.nil?
+          modal_body.with_row(mt: 3) do
+            render(WorkPackages::Dialogs::CreateForm.new(f, work_package: work_package, wrapper_id: "create-work-package-dialog"))
+          end
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -8,7 +8,9 @@
       html: {
         id: 'create-work-package-form',
         data: {
-          controller: "work-packages--create-dialog"
+          controller: "work-packages--create-dialog",
+          application_target: "dynamic",
+          "work-packages--create-dialog-refresh-url-value": refresh_form_project_work_packages_dialog_path(project)
         }
       }
     ) do |f|

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -4,7 +4,10 @@
       scope: :work_package,
       model: @work_package,
       html: {
-        id: 'create-work-package-form'
+        id: 'create-work-package-form',
+        data: {
+          controller: "work-packages--create-dialog"
+        }
       }
     ) do |f|
       flex_layout(mb: 3) do |modal_body|

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -19,7 +19,7 @@
 
         if @project.nil?
           modal_body.with_row(mt: 3) do
-            render(WorkPackages::Dialogs::CreateForm.new(f, work_package: work_package, wrapper_id: "create-work-package-dialog"))
+            render(WorkPackages::Dialogs::CreateForm.new(f, work_package: work_package, wrapper_id: "#create-work-package-dialog"))
           end
         end
       end

--- a/app/components/work_packages/dialogs/create_form_component.rb
+++ b/app/components/work_packages/dialogs/create_form_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/components/work_packages/dialogs/create_form_component.rb
+++ b/app/components/work_packages/dialogs/create_form_component.rb
@@ -1,0 +1,43 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages::Dialogs
+  class CreateFormComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :work_package
+
+    def initialize(work_package:)
+      super
+
+      @work_package = work_package
+    end
+  end
+end

--- a/app/components/work_packages/dialogs/create_form_component.rb
+++ b/app/components/work_packages/dialogs/create_form_component.rb
@@ -32,12 +32,13 @@ module WorkPackages::Dialogs
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    attr_reader :work_package
+    attr_reader :work_package, :project
 
-    def initialize(work_package:)
+    def initialize(work_package:, project:)
       super
 
       @work_package = work_package
+      @project = project
     end
   end
 end

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -53,8 +53,9 @@ class WorkPackages::DialogsController < ApplicationController
       .new(model: initial, user: current_user, contract_class: WorkPackages::CreateContract)
       .call(create_params)
 
-    # Ignore call errors here, as we only want to build the work package
+    # We ignore errors here, as we only want to build the work package
     @work_package = call.result
+    @work_package.errors.clear
   end
 
   def create_params

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -81,6 +81,7 @@ class WorkPackages::DialogsController < ApplicationController
     # We ignore errors here, as we only want to build the work package
     @work_package = call.result
     @work_package.errors.clear
+    @work_package.custom_values.each { |cv| cv.errors.clear }
   end
 
   def new_params

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -98,4 +98,6 @@ class WorkPackages::DialogsController < ApplicationController
       project: @project
     }
   end
+
+  def default_breadcrumb; end
 end

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -46,6 +46,7 @@ class WorkPackages::DialogsController < ApplicationController
     call = WorkPackages::CreateService.new(user: current_user).call(create_params)
 
     if call.success?
+      flash[:notice] = I18n.t("work_package_relations_tab.relations.label_new_child_created")
       redirect_back fallback_location: project_work_package_path(@project, call.result), status: :see_other
     else
       form_component = WorkPackages::Dialogs::CreateFormComponent.new(work_package: call.result, project: @project)

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -51,7 +51,7 @@ class WorkPackages::DialogsController < ApplicationController
 
     call = WorkPackages::SetAttributesService
       .new(model: initial, user: current_user, contract_class: WorkPackages::CreateContract)
-      .call(create_params)
+      .call(create_params.reverse_merge(default_params(initial)))
 
     # We ignore errors here, as we only want to build the work package
     @work_package = call.result
@@ -60,5 +60,13 @@ class WorkPackages::DialogsController < ApplicationController
 
   def create_params
     params.permit(*PermittedParams.permitted_attributes[:new_work_package])
+  end
+
+  def default_params(work_package)
+    contract = WorkPackages::CreateContract.new(work_package, current_user)
+
+    {
+      type: contract.assignable_types.first
+    }
   end
 end

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class WorkPackages::DialogsController < ApplicationController
+  include OpTurbo::ComponentStream
+  include OpTurbo::DialogStreamHelper
+  layout false
+
+  before_action :find_project_by_project_id
+  before_action :build_work_package, only: %i[new]
+  before_action do
+    do_authorize :add_work_packages
+  end
+  authorization_checked! :new
+
+  def new
+    respond_with_dialog WorkPackages::Dialogs::CreateDialogComponent.new(work_package: @work_package)
+  end
+
+  private
+
+  def build_work_package
+    initial = WorkPackage.new(project: @project)
+
+    call = WorkPackages::SetAttributesService
+      .new(model: initial, user: current_user, contract_class: WorkPackages::CreateContract)
+      .call(create_params)
+
+    # Ignore call errors here, as we only want to build the work package
+    @work_package = call.result
+  end
+
+  def create_params
+    params.permit(*PermittedParams.permitted_attributes[:new_work_package])
+  end
+end

--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -1,0 +1,107 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomFields::CustomFieldRendering
+  def render_custom_fields(form:)
+    custom_fields.each do |custom_field|
+      form.fields_for(:custom_field_values) do |builder|
+        custom_field_input(builder, custom_field)
+      end
+    end
+  end
+
+  # override if you want to pass more attributes
+  def additional_custom_field_input_arguments
+    {}
+  end
+
+  def custom_fields
+    raise NotImplementedError, "#custom_fields method needs to be overwritten and provide all custom fields we want to show"
+  end
+
+  private
+
+  def custom_field_input(builder, custom_field)
+    if custom_field.multi_value?
+      multi_value_custom_field_input(builder, custom_field)
+    else
+      single_value_custom_field_input(builder, custom_field)
+    end
+  end
+
+  def form_arguments(custom_field)
+    {
+      custom_field: custom_field,
+      object: model
+    }.merge(additional_custom_field_input_arguments)
+  end
+
+  # TBD: transform inputs called below to primer form dsl instead of form classes?
+  # TODOS:
+  # - initial values for user inputs are not displayed
+  # - allow/disallow-non-open version setting is not yet respected in the version selector
+  # - rich text editor is not yet supported
+
+  def single_value_custom_field_input(builder, custom_field)
+    form_args = form_arguments(custom_field)
+
+    case custom_field.field_format
+    when "string", "link"
+      CustomFields::Inputs::String.new(builder, **form_args)
+    when "text"
+      CustomFields::Inputs::Text.new(builder, **form_args)
+    when "int"
+      CustomFields::Inputs::Int.new(builder, **form_args)
+    when "float"
+      CustomFields::Inputs::Float.new(builder, **form_args)
+    when "list"
+      CustomFields::Inputs::SingleSelectList.new(builder, **form_args)
+    when "date"
+      CustomFields::Inputs::Date.new(builder, **form_args)
+    when "bool"
+      CustomFields::Inputs::Bool.new(builder, **form_args)
+    when "user"
+      CustomFields::Inputs::SingleUserSelectList.new(builder, **form_args)
+    when "version"
+      CustomFields::Inputs::SingleVersionSelectList.new(builder, **form_args)
+    end
+  end
+
+  def multi_value_custom_field_input(builder, custom_field)
+    form_args = form_arguments(custom_field)
+
+    case custom_field.field_format
+    when "list"
+      CustomFields::Inputs::MultiSelectList.new(builder, **form_args)
+    when "user"
+      CustomFields::Inputs::MultiUserSelectList.new(builder, **form_args)
+    when "version"
+      CustomFields::Inputs::MultiVersionSelectList.new(builder, **form_args)
+    end
+  end
+end

--- a/app/forms/custom_fields/inputs/base/autocomplete/user_query_utils.rb
+++ b/app/forms/custom_fields/inputs/base/autocomplete/user_query_utils.rb
@@ -51,10 +51,17 @@ module CustomFields::Inputs::Base::Autocomplete::UserQueryUtils
   end
 
   def filters
-    [
+    filters = [
       { name: "type", operator: "=", values: ["User", "Group", "PlaceholderUser"] },
-      { name: "member", operator: "=", values: [@object.id.to_s] },
       { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] }
     ]
+
+    if @object.is_a?(Project)
+      filters << { name: "member", operator: "=", values: [@object.id.to_s] }
+    elsif @object.respond_to?(:project_id)
+      filters << { name: "member", operator: "=", values: [@object.project_id.to_s] }
+    end
+
+    filters
   end
 end

--- a/app/forms/custom_fields/inputs/base/input.rb
+++ b/app/forms/custom_fields/inputs/base/input.rb
@@ -32,6 +32,8 @@ class CustomFields::Inputs::Base::Input < ApplicationForm
   attr_reader :options
 
   def initialize(custom_field:, object:, **options)
+    super()
+
     @custom_field = custom_field
     @object = object
     @options = options

--- a/app/forms/custom_fields/inputs/multi_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_select_list.rb
@@ -31,16 +31,18 @@ class CustomFields::Inputs::MultiSelectList < CustomFields::Inputs::Base::Autoco
     # autocompleter does not set key with blank value if nothing is selected or input is cleared
     # in order to let acts_as_customizable handle the clearing of the value, we need to set the value to blank via a hidden field
     # which sends blank if autocompleter is cleared
-    custom_value_form.hidden(**input_attributes.merge(
+    custom_value_form.hidden(
+      **input_attributes,
       scope_name_to_model: false,
-      name: "#{@object.class.name.downcase}[custom_field_values][#{input_attributes[:name]}][]",
+      name: "#{@object.model_name.element}[custom_field_values][#{input_attributes[:name]}][]",
       value:
-    ))
+    )
 
     custom_value_form.autocompleter(**input_attributes) do |list|
       @custom_field.custom_options.each do |custom_option|
         list.option(
-          label: custom_option.value, value: custom_option.id,
+          label: custom_option.value,
+          value: custom_option.id,
           selected: selected?(custom_option)
         )
       end

--- a/app/forms/custom_fields/inputs/multi_user_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_user_select_list.rb
@@ -33,11 +33,12 @@ class CustomFields::Inputs::MultiUserSelectList < CustomFields::Inputs::Base::Au
     # autocompleter does not set key with blank value if nothing is selected or input is cleared
     # in order to let acts_as_customizable handle the clearing of the value, we need to set the value to blank via a hidden field
     # which sends blank if autocompleter is cleared
-    custom_value_form.hidden(**input_attributes.merge(
+    custom_value_form.hidden(
+      **input_attributes,
       scope_name_to_model: false,
-      name: "#{@object.class.name.downcase}[custom_field_values][#{input_attributes[:name]}][]",
+      name: "#{@object.model_name.element}[custom_field_values][#{input_attributes[:name]}][]",
       value:
-    ))
+    )
 
     custom_value_form.autocompleter(**input_attributes)
   end

--- a/app/forms/custom_fields/inputs/multi_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_version_select_list.rb
@@ -35,16 +35,18 @@ class CustomFields::Inputs::MultiVersionSelectList < CustomFields::Inputs::Base:
     # autocompleter does not set key with blank value if nothing is selected or input is cleared
     # in order to let acts_as_customizable handle the clearing of the value, we need to set the value to blank via a hidden field
     # which sends blank if autocompleter is cleared
-    custom_value_form.hidden(**input_attributes.merge(
+    custom_value_form.hidden(
+      **input_attributes,
       scope_name_to_model: false,
-      name: "#{@object.class.name.downcase}[custom_field_values][#{input_attributes[:name]}][]",
+      name: "#{@object.model_name.element}[custom_field_values][#{input_attributes[:name]}][]",
       value:
-    ))
+    )
 
     custom_value_form.autocompleter(**input_attributes) do |list|
       assignable_custom_field_values(@custom_field).each do |version|
         list.option(
-          label: version.name, value: version.id,
+          label: version.name,
+          value: version.id,
           selected: selected?(version)
         )
       end

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -52,7 +52,8 @@ module WorkPackages::Dialogs
           multiple: false,
           decorated: true,
           hiddenFieldAction: "change->work-packages--create-dialog#refreshForm",
-          append_to: wrapper_id
+          append_to: wrapper_id,
+          data: { test_selector: "work_package_create_dialog_type" }
         }
       ) do |select|
         contract

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -58,7 +58,12 @@ module WorkPackages::Dialogs
         contract
           .assignable_types
           .pluck(:id, :name)
-          .map { |value, label| select.option(label:, value:, selected: work_package.type_id == value) }
+          .map do |value, label|
+          select.option(label:,
+                        value:,
+                        classes: "__hl_inline_type_#{value}",
+                        selected: work_package.type_id == value)
+        end
       end
 
       f.text_field(

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -75,7 +75,7 @@ module WorkPackages::Dialogs
         name: :subject,
         label: WorkPackage.human_attribute_name(:subject),
         required: true,
-        autofocus: true,
+        autofocus: autofocus_subject?,
         input_width: :large
       )
 
@@ -98,6 +98,10 @@ module WorkPackages::Dialogs
 
     def additional_custom_field_input_arguments
       { wrapper_id: }
+    end
+
+    def autofocus_subject?
+      work_package.errors.empty? && work_package.custom_values.all? { |cv| cv.errors.empty? }
     end
 
     private

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -51,6 +51,7 @@ module WorkPackages::Dialogs
         autocomplete_options: {
           multiple: false,
           decorated: true,
+          hiddenFieldAction: "change->work-packages--create-dialog#submitForm",
           append_to: wrapper_id
         }
       ) do |select|
@@ -69,7 +70,7 @@ module WorkPackages::Dialogs
 
       f.rich_text_area(
         name: :description,
-        label: MeetingAgendaItem.human_attribute_name(:description),
+        label: WorkPackage.human_attribute_name(:description),
         rich_text_options: {
           resource: work_package,
           showAttachments: false

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -28,6 +28,8 @@
 
 module WorkPackages::Dialogs
   class CreateForm < ApplicationForm
+    include CustomFields::CustomFieldRendering
+
     attr_reader :work_package, :wrapper_id, :contract
 
     def initialize(work_package:, wrapper_id:)
@@ -49,7 +51,7 @@ module WorkPackages::Dialogs
         autocomplete_options: {
           multiple: false,
           decorated: true,
-          append_to: "##{wrapper_id}"
+          append_to: wrapper_id
         }
       ) do |select|
         contract
@@ -74,9 +76,21 @@ module WorkPackages::Dialogs
         }
       )
 
+      render_custom_fields(form: f)
+
       work_package.changes.each do |attribute, value|
         f.hidden(name: attribute, value:)
       end
+    end
+
+    def additional_custom_field_input_arguments
+      { wrapper_id: }
+    end
+
+    private
+
+    def custom_fields
+      @custom_fields ||= work_package.available_custom_fields.required
     end
   end
 end

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -54,6 +54,7 @@ module WorkPackages::Dialogs
           multiple: false,
           decorated: true,
           clearable: false,
+          focusDirectly: false,
           hiddenFieldAction: "change->work-packages--create-dialog#refreshForm",
           append_to: wrapper_id,
           data: { test_selector: "work_package_create_dialog_type" }
@@ -74,6 +75,7 @@ module WorkPackages::Dialogs
         name: :subject,
         label: WorkPackage.human_attribute_name(:subject),
         required: true,
+        autofocus: true,
         input_width: :large
       )
 

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -58,7 +58,7 @@ module WorkPackages::Dialogs
         contract
           .assignable_types
           .pluck(:id, :name)
-          .map { |value, label| select.option(label:, value:) }
+          .map { |value, label| select.option(label:, value:, selected: work_package.type_id == value) }
       end
 
       f.text_field(

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -64,6 +64,19 @@ module WorkPackages::Dialogs
         required: true,
         input_width: :large
       )
+
+      f.rich_text_area(
+        name: :description,
+        label: MeetingAgendaItem.human_attribute_name(:description),
+        rich_text_options: {
+          resource: work_package,
+          showAttachments: false
+        }
+      )
+
+      work_package.changes.each do |attribute, value|
+        f.hidden(name: attribute, value:)
+      end
     end
   end
 end

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -53,6 +53,7 @@ module WorkPackages::Dialogs
         autocomplete_options: {
           multiple: false,
           decorated: true,
+          clearable: false,
           hiddenFieldAction: "change->work-packages--create-dialog#refreshForm",
           append_to: wrapper_id,
           data: { test_selector: "work_package_create_dialog_type" }

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -51,7 +51,7 @@ module WorkPackages::Dialogs
         autocomplete_options: {
           multiple: false,
           decorated: true,
-          hiddenFieldAction: "change->work-packages--create-dialog#submitForm",
+          hiddenFieldAction: "change->work-packages--create-dialog#refreshForm",
           append_to: wrapper_id
         }
       ) do |select|

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -79,7 +79,8 @@ module WorkPackages::Dialogs
 
       render_custom_fields(form: f)
 
-      work_package.changes.each do |attribute, value|
+      # Keep hidden fields for relevant changes
+      work_package.changes.except(:description, :subject, :type_id).each do |attribute, value|
         f.hidden(name: attribute, value:)
       end
     end
@@ -91,7 +92,7 @@ module WorkPackages::Dialogs
     private
 
     def custom_fields
-      @custom_fields ||= work_package.available_custom_fields.required
+      @custom_fields ||= work_package.available_custom_fields.select(&:required?)
     end
   end
 end

--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -1,0 +1,69 @@
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module WorkPackages::Dialogs
+  class CreateForm < ApplicationForm
+    attr_reader :work_package, :wrapper_id, :contract
+
+    def initialize(work_package:, wrapper_id:)
+      super()
+
+      @work_package = work_package
+      @wrapper_id = wrapper_id
+      @contract = WorkPackages::CreateContract.new(work_package, User.current)
+    end
+
+    form do |f|
+      f.autocompleter(
+        name: :type_id,
+        required: true,
+        include_blank: false,
+        input_width: :small,
+        label: Type.model_name.human,
+        visually_hide_label: true,
+        autocomplete_options: {
+          multiple: false,
+          decorated: true,
+          append_to: "##{wrapper_id}"
+        }
+      ) do |select|
+        contract
+          .assignable_types
+          .pluck(:id, :name)
+          .map { |value, label| select.option(label:, value:) }
+      end
+
+      f.text_field(
+        name: :subject,
+        label: WorkPackage.human_attribute_name(:subject),
+        required: true,
+        input_width: :large
+      )
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -740,6 +740,7 @@ en:
       no_results_title_text: There are currently no relations available.
       blankslate_heading: "No relations"
       blankslate_description: "This work package does not have any relations yet."
+    label_add_child_button: "Child"
     label_add_x: "Add %{x}"
     label_edit_x: "Edit %{x}"
     label_add_description: "Add description"
@@ -762,6 +763,9 @@ en:
       follows_description: "The related work package necessarily needs to finish before this one can start"
       label_child_singular: "child"
       label_child_plural: "children"
+      new_child: "New child"
+      new_child_text: "Creates a related work package as a sub-item of the current (parent) work package"
+      existing_child: "Existing child"
       child_description: "Makes the related work package a sub-item of the current (parent) work package"
       label_blocks_singular: "blocks"
       label_blocks_plural: "blocks"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -749,6 +749,7 @@ en:
       title: "Lag (in days)"
       caption: "The minimum number of working days to keep in between the two work packages."
     relations:
+      label_new_child_created: "New work package created and added as a child"
       label_relates_singular: "related to"
       label_relates_plural: "related to"
       label_relates_to_singular: "related to"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -349,7 +349,9 @@ Rails.application.routes.draw do
     end
 
     namespace :work_packages do
-      resource :dialog, only: %i[new create]
+      resource :dialog, only: %i[new create] do
+        post :refresh_form
+      end
     end
 
     resources :activity, :activities, only: :index, controller: "activities" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,12 +339,17 @@ Rails.application.routes.draw do
       end
 
       # states managed by client-side routing on work_package#index
-      get "(/*state)" => "work_packages#index", on: :collection, as: ""
+      get "(/*state)" => "work_packages#index", on: :collection, as: "", constraints: { state: /(?!(dialog)).+/ }
+
       get "/create_new" => "work_packages#index", on: :collection, as: "new_split"
       get "/new" => "work_packages#index", on: :collection, as: "new"
 
       # state for show view in project context
-      get "(/*state)" => "work_packages#show", on: :member, as: ""
+      get "(/*state)" => "work_packages#show", on: :member, as: "", constraints: { id: /\d+/, state: /(?!(dialog)).+/ }
+    end
+
+    namespace :work_packages do
+      resource :dialog, only: %i[new create]
     end
 
     resources :activity, :activities, only: :index, controller: "activities" do

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -10,7 +10,10 @@ export class TurboRequestsService {
 
   }
 
-  public request(url:string, init:RequestInit = {}, suppressErrorToast = false):Promise<{ html:string, headers:Headers }> {
+  public request(url:string, init:RequestInit = {}, suppressErrorToast = false):Promise<{
+    html:string,
+    headers:Headers
+  }> {
     return fetch(url, init)
       .then((response) => {
         return response.text().then((html) => ({
@@ -40,6 +43,26 @@ export class TurboRequestsService {
         }
         throw error;
       });
+  }
+
+  public submitForm(
+    form:HTMLFormElement,
+    params:URLSearchParams|null = null,
+    url = form.action,
+  ):Promise<{ html:string, headers:Headers }> {
+    const formData = new FormData(form);
+    const requestParmas = params ? `?${params.toString()}` : '';
+    return this.request(
+      `${url}${requestParmas}`,
+      {
+        method: form.method,
+        body: formData,
+        headers: {
+          'X-CSRF-Token': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement).content,
+        },
+      },
+      true,
+    );
   }
 
   public requestStream(url:string):Promise<{ html:string, headers:Headers }> {

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -51,9 +51,9 @@ export class TurboRequestsService {
     url = form.action,
   ):Promise<{ html:string, headers:Headers }> {
     const formData = new FormData(form);
-    const requestParmas = params ? `?${params.toString()}` : '';
+    const requestParams = params ? `?${params.toString()}` : '';
     return this.request(
-      `${url}${requestParmas}`,
+      `${url}${requestParams}`,
       {
         method: form.method,
         body: formData,

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -204,7 +204,10 @@
 
   <ng-container
     *ngSwitchCase="resource ==='subproject' || resource ==='version' || resource ==='status' || resource ==='default' || (!resource && !item.depth)">
-    <span [ngOptionHighlight]="search">{{ item.name }}</span>
+    <span
+      [ngClass]=" additionalClassProperty ? item[additionalClassProperty] : ''"
+      [ngOptionHighlight]="search">{{ item.name }}
+    </span>
     <span
       class="op-autocompleter__option-principal-email"
       *ngIf="item.email"
@@ -228,6 +231,7 @@
     <span class="ng-value-icon left" (click)="clear(item)">×</span>
     <span
       [ngOptionHighlight]="search"
+      [ngClass]=" additionalClassProperty ? item[additionalClassProperty] : ''"
       class="ng-value-label">{{ item.name }}</span>
   </ng-container>
 </ng-template>

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -119,6 +119,8 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   @Input() public inputBindValue = 'id';
 
+  @Input() public additionalClassProperty:string|null = null;
+
   @Input() public hiddenFieldAction = '';
 
   @Input() public required?:boolean = false;

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -26,7 +26,16 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, OnInit, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
@@ -166,10 +175,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
       });
   }
 
-  public markEdited() {
-    window.OpenProject.pageWasEdited = true;
-  }
-
   public async saveForm(evt?:SubmitEvent):Promise<void> {
     this.saveRequested.emit(); // Provide a hook for the parent component to do something before the form is submitted
     this.inFlight = true;
@@ -209,7 +214,9 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     return editor;
   }
 
-  private syncToTextarea() {
+  public syncToTextarea() {
+    window.OpenProject.pageWasEdited = true;
+
     try {
       this.wrappedTextArea.value = this.ckEditorInstance.getTransformedContent(true);
     } catch (e) {

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -3,7 +3,7 @@
     [context]="context"
     [content]="initialContent"
     (initializeDone)="setup($event)"
-    (contentChanged)="markEdited()"
+    (contentChanged)="syncToTextarea()"
     (saveRequested)="saveForm()"
     (editorKeyup)="editorKeyup.emit()"
     (editorBlur)="editorBlur.emit()"

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -12,7 +12,7 @@
 </div>
 
 <fieldset
-  class="form--fieldset"
+  class="form--fieldset op-ckeditor--attachments"
   *ngIf="showAttachments && halResource?.attachments"
 >
   <legend class="form--fieldset-legend">

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -10,8 +10,8 @@
     @include op-uc-table-header-styles
 
 // Wrapper for full text element
-opce-ckeditor-augmented-textarea .op-ckeditor--wrapper
-  margin-bottom: 2rem
+opce-ckeditor-augmented-textarea .op-ckeditor--attachments
+  margin-top: 2rem
 
 // Ensure same border and min-height for preview
 .ck-content,

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
@@ -1,0 +1,36 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class CreateDialogController extends Controller {
+  connect() {
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
@@ -36,15 +36,23 @@ export default class CreateDialogController extends Controller<HTMLFormElement> 
   private turboRequests:TurboRequestsService;
   private pathHelper:PathHelperService;
 
+  static values = {
+    refreshUrl: String,
+  };
+
+  declare refreshUrlValue:string;
+
   async connect() {
     const context = await window.OpenProject.getPluginContext();
     this.turboRequests = context.services.turboRequests;
     this.pathHelper = context.services.pathHelperService;
   }
 
-  updateForm() {
-    void this
-      .turboRequests
-      .submitForm(this.element);
+  refreshForm() {
+    void this.turboRequests.submitForm(
+      this.element,
+      null,
+      this.refreshUrlValue,
+    );
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
@@ -30,11 +30,9 @@
 
 import { Controller } from '@hotwired/stimulus';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 export default class CreateDialogController extends Controller<HTMLFormElement> {
   private turboRequests:TurboRequestsService;
-  private pathHelper:PathHelperService;
 
   static values = {
     refreshUrl: String,
@@ -45,7 +43,6 @@ export default class CreateDialogController extends Controller<HTMLFormElement> 
   async connect() {
     const context = await window.OpenProject.getPluginContext();
     this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
   }
 
   refreshForm() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/create-dialog.controller.ts
@@ -29,8 +29,22 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
+import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
-export default class CreateDialogController extends Controller {
-  connect() {
+export default class CreateDialogController extends Controller<HTMLFormElement> {
+  private turboRequests:TurboRequestsService;
+  private pathHelper:PathHelperService;
+
+  async connect() {
+    const context = await window.OpenProject.getPluginContext();
+    this.turboRequests = context.services.turboRequests;
+    this.pathHelper = context.services.pathHelperService;
+  }
+
+  updateForm() {
+    void this
+      .turboRequests
+      .submitForm(this.element);
   }
 }

--- a/frontend/src/turbo/dialog-stream-action.ts
+++ b/frontend/src/turbo/dialog-stream-action.ts
@@ -24,6 +24,6 @@ export function registerDialogStreamAction() {
     setTimeout(() => {
       const width = dialog.offsetWidth;
       dialog.style.width = `${width + 1}px`;
-    }, 50);
+    }, 100);
   };
 }

--- a/lib/primer/open_project/forms/autocompleter.rb
+++ b/lib/primer/open_project/forms/autocompleter.rb
@@ -20,7 +20,7 @@ module Primer
           @wrapper_data_attributes = wrapper_data_attributes
         end
 
-        def extend_autocomplete_inputs(inputs) # rubocop:disable Metrics/AbcSize
+        def extend_autocomplete_inputs(inputs) # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
           inputs[:classes] = "ng-select--primerized #{@input.invalid? ? '-error' : ''}"
           inputs[:inputName] ||= builder.field_name(@input.name)
           inputs[:labelForId] ||= builder.field_id(@input.name)

--- a/lib/primer/open_project/forms/autocompleter.rb
+++ b/lib/primer/open_project/forms/autocompleter.rb
@@ -31,6 +31,7 @@ module Primer
             selected = @input.select_options.filter_map { |option| option.to_h if option.selected }
             inputs[:model] = inputs[:multiple] ? selected : selected.first
             inputs[:defaultData] = false
+            inputs[:additionalClassProperty] = "classes"
             inputs[:bindLabel] = "name"
           elsif builder.object
             inputs[:inputValue] ||= builder.object.send(@input.name)

--- a/lib/primer/open_project/forms/dsl/autocompleter_input.rb
+++ b/lib/primer/open_project/forms/dsl/autocompleter_input.rb
@@ -8,19 +8,21 @@ module Primer
           attr_reader :name, :label, :autocomplete_options, :select_options, :wrapper_data_attributes
 
           class Option
-            attr_reader :label, :value, :selected
+            attr_reader :label, :value, :selected, :classes
 
-            def initialize(label:, value:, selected: false)
+            def initialize(label:, value:, classes: nil, selected: false)
               @label = label
               @value = value
               @selected = selected
+              @classes = classes
             end
 
             def to_h
               {
                 id: value,
-                name: label
-              }
+                name: label,
+                classes:
+              }.compact
             end
           end
 

--- a/spec/features/work_packages/details/relations/hierarchy_milestone_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_milestone_spec.rb
@@ -50,12 +50,14 @@ RSpec.describe "work package hierarchies for milestones", :js, :with_cuprite do
   end
 
   it "does not provide links to add children or existing children (Regression #28745 and #60512)" do
-    # A work package has a menu entry to link a child
+    # A work package has a menu entry to link or create a child
     visit_relations_tab_for(task_work_package)
-    relations.expect_new_relation_type("Child")
+    relations.expect_new_relation_type("New child")
+    relations.expect_new_relation_type("Existing child")
 
-    # A milestone work package does NOT have a menu entry to link a child
+    # A milestone work package does NOT have a menu entry to link or create a child
     visit_relations_tab_for(milestone_work_package)
-    relations.expect_no_new_relation_type("Child")
+    relations.expect_no_new_relation_type("New child")
+    relations.expect_no_new_relation_type("Existing child")
   end
 end

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe "Primerized work package relations tab",
     end
 
     it "doesn't autocomplete parent, children, and WP itself" do
-      relations_tab.select_relation_type "Child"
+      relations_tab.select_relation_type "Existing child"
 
       wait_for_reload
 

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
     it "can add a new child" do
       wp_page.visit_tab!("relations")
       relations_tab.expect_add_relation_button
+      relations_tab.expect_new_relation_type("New child")
+      relations_tab.expect_new_relation_type("Existing child")
+
       relations_tab.select_relation_type "New child"
 
       create_dialog.select_type "Task"
@@ -77,6 +80,19 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
     it "does not show the action" do
       wp_page.visit_tab!("relations")
       relations_tab.expect_no_add_relation_button
+    end
+  end
+
+  context "with permission to manage_subtasks, but not add_work_packages" do
+    let!(:user) do
+      create(:user, member_with_permissions: { project => %i[view_work_packages manage_subtasks] })
+    end
+
+    it "does not show the action" do
+      wp_page.visit_tab!("relations")
+      relations_tab.expect_add_relation_button
+      relations_tab.expect_new_relation_type("Existing child")
+      relations_tab.expect_no_new_relation_type("New child")
     end
   end
 end

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "support/edit_fields/edit_field"

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+require "support/edit_fields/edit_field"
+
+RSpec.describe "Relations children tab", :js, :with_cuprite do
+  shared_let(:normal_cf) { create(:string_wp_custom_field, is_required: false) }
+  shared_let(:required_cf) { create(:string_wp_custom_field, is_required: true) }
+  shared_let(:type_milestone) { create(:type_milestone) }
+  shared_let(:type_task) { create(:type, name: "Task", custom_fields: [normal_cf]) }
+  shared_let(:type_risk) { create(:type, name: "Risk", custom_fields: [required_cf]) }
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+
+  shared_let(:project) do
+    create(:project,
+           types: [type_task, type_risk, type_milestone],
+           work_package_custom_fields: [normal_cf, required_cf])
+  end
+
+  shared_let(:work_package) { create(:work_package, type: type_task, project:, subject: "Parent") }
+
+  let(:relations_tab) { Components::WorkPackages::Relations.new(work_package) }
+  let(:create_dialog) { Components::WorkPackages::CreateDialog.new }
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+
+  current_user { user }
+
+  context "with permissions to add children" do
+    let!(:user) do
+      create(:user, member_with_permissions: { project => %i[view_work_packages add_work_packages manage_subtasks] })
+    end
+
+    it "can add a new child" do
+      wp_page.visit_tab!("relations")
+      relations_tab.expect_add_relation_button
+      relations_tab.select_relation_type "New child"
+
+      create_dialog.select_type "Task"
+      create_dialog.set_subject "Hello there"
+      create_dialog.set_description "Some *markdown* content"
+      create_dialog.expect_no_custom_field(normal_cf)
+
+      create_dialog.select_type "Risk"
+      # Retains subject and description
+      create_dialog.expect_subject "Hello there"
+      create_dialog.expect_description "Some markdown content"
+
+      # Shows a custom field
+      create_dialog.set_custom_field(required_cf, "Custom value")
+      create_dialog.submit
+
+      wait_for_network_idle
+
+      page.within("#work-package-relations-tab-content") do
+        expect(page).to have_content("Hello there")
+        expect(page).to have_content("RISK")
+      end
+    end
+
+    context "when work package is a milestone" do
+      let(:work_package) { create(:work_package, type: type_milestone, project:, subject: "Parent") }
+
+      it "does not show the action" do
+        wp_page.visit_tab!("relations")
+        relations_tab.expect_no_add_relation_button
+      end
+    end
+  end
+
+  context "without permissions to add children" do
+    let!(:user) do
+      create(:user, member_with_permissions: { project => %i[view_work_packages] })
+    end
+
+    it "does not show the action" do
+      wp_page.visit_tab!("relations")
+      relations_tab.expect_no_add_relation_button
+    end
+  end
+end

--- a/spec/support/components/work_packages/create_dialog.rb
+++ b/spec/support/components/work_packages/create_dialog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/create_dialog.rb
+++ b/spec/support/components/work_packages/create_dialog.rb
@@ -1,0 +1,96 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/components/autocompleter/ng_select_autocomplete_helpers"
+
+module Components
+  module WorkPackages
+    class CreateDialog
+      include Capybara::DSL
+      include Capybara::RSpecMatchers
+      include RSpec::Matchers
+      include RSpec::Wait
+      include ::Components::Autocompleter::NgSelectAutocompleteHelpers
+
+      def initialize
+        @description = ::Components::WysiwygEditor.new("#create-work-package-dialog")
+      end
+
+      def select_type(value)
+        retry_block do
+          select_autocomplete page.find_test_selector("work_package_create_dialog_type"),
+                              query: value,
+                              select_text: value.upcase,
+                              results_selector: "#create-work-package-dialog"
+        end
+      end
+
+      def set_subject(value)
+        in_dialog do
+          fill_in "Subject", with: value
+        end
+      end
+
+      def expect_subject(value)
+        in_dialog do
+          expect(page).to have_field "Subject", with: value
+        end
+      end
+
+      def set_description(value)
+        @description.set_markdown(value)
+      end
+
+      def expect_description(value)
+        @description.expect_value(value)
+      end
+
+      def expect_custom_field(custom_field, **args)
+        expect(page).to have_field "work_package_custom_field_values_#{custom_field.id}", **args
+      end
+
+      def expect_no_custom_field(custom_field)
+        expect(page).to have_no_field "work_package_custom_field_values_#{custom_field.id}"
+      end
+
+      def set_custom_field(custom_field, value)
+        fill_in "work_package_custom_field_values_#{custom_field.id}", with: value
+      end
+
+      def in_dialog(&)
+        page.within("#create-work-package-dialog", &)
+      end
+
+      def submit
+        page.within("#create-work-package-dialog") do
+          click_on "Create"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -305,7 +305,7 @@ module Components
         SeleniumHubWaiter.wait
 
         retry_block do
-          select_relation_type "Child"
+          select_relation_type "Existing child"
         end
 
         within "##{WorkPackageRelationsTab::AddWorkPackageChildFormComponent::DIALOG_ID}" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60273

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Allow adding children through a very basic work package creation dialog.

## Screenshots
<img width="759" alt="Bildschirmfoto 2025-01-10 um 07 35 39" src="https://github.com/user-attachments/assets/946d55ef-7d5a-4a70-a899-6049469ce141" />

<img width="984" alt="Bildschirmfoto 2025-01-10 um 07 35 51" src="https://github.com/user-attachments/assets/6a0639cf-7de3-4626-8934-ec39fe6ca45a" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
