### PR TITLE
[60430] Distance between sticky buttons and form field above is too small in scrollable modals

### DIFF
--- a/app/components/work_packages/exports/generate/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/generate/modal_dialog_component.html.erb
@@ -1,7 +1,7 @@
 <%= render(Primer::Alpha::Dialog.new(
   title: I18n.t("pdf_generator.dialog.title"),
   id: MODAL_ID,
-  size: :large
+  size: :medium_portrait
 )) do |dialog|
   dialog.with_header(variant: :large)
   dialog.with_body do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60430

# What are you trying to accomplish?
Change height of export modal to not cut off content unnecessarily

### Before
<img width="594" alt="Bildschirmfoto 2025-01-10 um 10 39 12" src="https://github.com/user-attachments/assets/0ae58de3-4616-4eb9-a57b-c9d046ae3970" />

### After
<img width="598" alt="Bildschirmfoto 2025-01-10 um 10 39 01" src="https://github.com/user-attachments/assets/6ca97ba8-0702-4da0-9a96-125d269484d4" />
