### PR TITLE
[#59879] make user hover card animation less bumpy

### DIFF
--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.html
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.html
@@ -8,7 +8,7 @@
     id="op-hover-card-body"
     [src]="turboFrameSrc">
     <op-content-loader
-      viewBox="0 0 330 60"
+      viewBox="0 0 500 95"
     >
       <svg:rect x="10" y="0" width="60%" height="16" rx="1" />
       <svg:rect x="10" y="20" width="80%" height="16" rx="1" />

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.html
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.html
@@ -7,12 +7,5 @@
     loading="lazy"
     id="op-hover-card-body"
     [src]="turboFrameSrc">
-    <op-content-loader
-      viewBox="0 0 500 95"
-    >
-      <svg:rect x="10" y="0" width="60%" height="16" rx="1" />
-      <svg:rect x="10" y="20" width="80%" height="16" rx="1" />
-      <svg:rect x="10" y="40" width="30%" height="16" rx="1" />
-    </op-content-loader>
   </turbo-frame>
 </div>

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
@@ -12,11 +12,8 @@
   background-color: var(--body-background)
   z-index: 5000
   width: 500px
+  min-height: 95px
   box-shadow: var(--shadow-floating-medium)
   pointer-events: all
   padding: var(--overlay-paddingBlock-normal)
   border-radius: var(--overlay-borderRadius)
-
-  &.user-sized
-    width: 500px
-    height: 182px

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
@@ -12,7 +12,6 @@
   background-color: var(--body-background)
   z-index: 5000
   width: 500px
-  min-height: 95px
   box-shadow: var(--shadow-floating-medium)
   pointer-events: all
   padding: var(--overlay-paddingBlock-normal)

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
@@ -7,7 +7,7 @@
     opacity: 1
 
 .op-hover-card
-  animation: fade-in-hover-card .25s ease-in-out
+  animation: fade-in-hover-card .4s ease-in
   position: absolute
   background-color: var(--body-background)
   z-index: 5000

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.sass
@@ -7,7 +7,7 @@
     opacity: 1
 
 .op-hover-card
-  animation: fade-in-hover-card .4s ease-in
+  animation: fade-in-hover-card .25s ease-in
   position: absolute
   background-color: var(--body-background)
   z-index: 5000
@@ -16,3 +16,7 @@
   pointer-events: all
   padding: var(--overlay-paddingBlock-normal)
   border-radius: var(--overlay-borderRadius)
+
+  &.user-sized
+    width: 500px
+    height: 182px

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.ts
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.ts
@@ -58,17 +58,18 @@ export class HoverCardComponent extends OpModalComponent implements OnInit {
   @ViewChild('turboFrame')
   set turboFrame(frame:ElementRef<HTMLIFrameElement>|undefined) {
     if (frame !== undefined) {
-      if (this.turboFrameSrc.includes('/users/')) {
-        // User hover cards require additional space, this must be designated before loading the turbo frame so that
-        // the rough size of the hover card can be adjusted in advance. This makes the popup appear smoothly.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-        this.elementRef.nativeElement.querySelector('.op-hover-card')?.classList.add('user-sized');
-      }
+      // When a new turbo frame is set, hide the modal until the frame is loaded.
+      // Since the size of the new content is unknown in advance, showing a loading indicator within the hover card
+      // leads to a bumpy result once the actual content is inserted and the card extends its dimensions.
+      this.setOpacity(this.elementRef, 0);
 
       frame.nativeElement?.addEventListener('turbo:frame-load', () => {
         const modal = this.elementRef.nativeElement as HTMLElement;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
         void this.reposition(modal, this.locals.event.target as HTMLElement);
+
+        // Content has been loaded, card has been positioned. Show it!
+        this.setOpacity(this.elementRef, 1);
       });
     }
   }
@@ -113,5 +114,11 @@ export class HoverCardComponent extends OpModalComponent implements OnInit {
       left: `${x}px`,
       top: `${y}px`,
     });
+  }
+
+  private setOpacity(elementRef:ElementRef, opacity:number) {
+    const element = elementRef.nativeElement as HTMLElement;
+
+    element.style.opacity = opacity.toString();
   }
 }

--- a/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.ts
+++ b/frontend/src/app/shared/components/modals/preview-modal/hover-card-modal/hover-card.modal.ts
@@ -58,6 +58,13 @@ export class HoverCardComponent extends OpModalComponent implements OnInit {
   @ViewChild('turboFrame')
   set turboFrame(frame:ElementRef<HTMLIFrameElement>|undefined) {
     if (frame !== undefined) {
+      if (this.turboFrameSrc.includes('/users/')) {
+        // User hover cards require additional space, this must be designated before loading the turbo frame so that
+        // the rough size of the hover card can be adjusted in advance. This makes the popup appear smoothly.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+        this.elementRef.nativeElement.querySelector('.op-hover-card')?.classList.add('user-sized');
+      }
+
       frame.nativeElement?.addEventListener('turbo:frame-load', () => {
         const modal = this.elementRef.nativeElement as HTMLElement;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/59879

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Reduce the bumpyness of hover cards suddenly exploding into existence.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The issue was the preview that is shown before/while loading the turbo frame with the hover card contents is much smaller than the actual content. So when the frame finishes loading, the hover card suddenly enlarges big time. The preview has now been removed and the content is shown, once loaded. This gets rid of the bumpiness.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
