### PR TITLE
Ldap sync not lock users OP#60566

### DIFF
--- a/app/services/ldap/base_service.rb
+++ b/app/services/ldap/base_service.rb
@@ -124,7 +124,7 @@ module Ldap
           filter: ldap.login_filter(login),
           attributes: ldap.search_attributes
         )
-        .map { |entry| ldap.get_user_attributes_from_ldap_entry(entry).except(:dn) }
+        &.map { |entry| ldap.get_user_attributes_from_ldap_entry(entry).except(:dn) } || []
     end
 
     def new_ldap_connection


### PR DESCRIPTION
# Ticket
[https://community.openproject.org/projects/openproject/work_packages/60566/activity](https://community.openproject.org/projects/openproject/work_packages/60566/activity)

# What are you trying to accomplish?
The goal is to resolve a bug in the `ldap_users_sync_status` feature where inactive users are not disabled during synchronization. The issue arises due to a .map operation being executed on a `nil` object, causing the process to fail.

# What approach did you choose and why?
The chosen approach is to add a safeguard for the `.map` operation, ensuring it handles nil values gracefully. This eliminates the error and restores the intended functionality of disabling inactive users during LDAP sync.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
