### PR TITLE
[60423] Changed error message for when a folder can not be created

### DIFF
--- a/modules/storages/config/locales/js-en.yml
+++ b/modules/storages/config/locales/js-en.yml
@@ -50,7 +50,7 @@ en:
           newest data, and try again.
         managed_project_folder_no_access: >
           You have no access yet to the managed project folder. Please wait a bit and try again.
-        cannot_create_folder: Failed to create folder. Avoid using special characters and symbols.
+        cannot_create_folder: Failed to create folder. Avoid using special characters and symbols and make sure the folder does not exist already.
         upload_keep_both: "Keep both"
         upload_replace: "Replace"
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/document-workflows-stream/work_packages/60423/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Make the experince better for the user if the folder they wish to create can not be created.

## Screenshots
![image](https://github.com/user-attachments/assets/f55f95c3-e2dd-4062-97ac-d2570f1dc7bd)

# What approach did you choose and why?
I chose to change the error text, as changing the error handling itself need more careful thought. I suggest do a code maintanance to rethink the error handling.
