### PR TITLE
Introduce relations tab mediator

### DIFF
--- a/app/controllers/work_package_children_relations_controller.rb
+++ b/app/controllers/work_package_children_relations_controller.rb
@@ -66,12 +66,7 @@ class WorkPackageChildrenRelationsController < ApplicationController
   def respond_with_relations_tab_update(service_result, **)
     if service_result.success?
       @work_package.reload
-      component = WorkPackageRelationsTab::IndexComponent.new(
-        work_package: @work_package,
-        relations: @work_package.relations.visible,
-        children: @work_package.children.visible,
-        **
-      )
+      component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package, **)
       replace_via_turbo_stream(component:)
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
 

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -62,8 +62,6 @@ class WorkPackageRelationsController < ApplicationController
     if service_result.success?
       @work_package.reload
       component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package,
-                                                              relations: @work_package.relations.visible,
-                                                              children: @work_package.children.visible,
                                                               relation_to_scroll_to: service_result.result)
       replace_via_turbo_stream(component:)
       respond_with_turbo_streams
@@ -80,9 +78,7 @@ class WorkPackageRelationsController < ApplicationController
 
     if service_result.success?
       @work_package.reload
-      component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package,
-                                                              relations: @work_package.relations.visible,
-                                                              children: @work_package.children.visible)
+      component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package)
       replace_via_turbo_stream(component:)
       respond_with_turbo_streams
     else
@@ -94,16 +90,7 @@ class WorkPackageRelationsController < ApplicationController
     service_result = Relations::DeleteService.new(user: current_user, model: @relation).call
 
     if service_result.success?
-      @children = WorkPackage.where(parent_id: @work_package.id).visible
-      @relations = @work_package
-        .relations
-        .reload
-        .includes(:to, :from)
-        .visible
-
-      component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package,
-                                                              relations: @relations,
-                                                              children: @children)
+      component = WorkPackageRelationsTab::IndexComponent.new(work_package: @work_package.reload)
       replace_via_turbo_stream(component:)
       respond_with_turbo_streams
     else

--- a/app/views/work_package_relations_tab/_index.html.erb
+++ b/app/views/work_package_relations_tab/_index.html.erb
@@ -1,6 +1,0 @@
-<%= render(
-  WorkPackageRelationsTab::IndexComponent.new(
-    work_package: @work_package,
-    relations: @relations
-  )
-) %>

--- a/spec/controllers/work_package_children_relations_controller_spec.rb
+++ b/spec/controllers/work_package_children_relations_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe WorkPackageChildrenRelationsController do
       send_delete_request
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [], children: [])
+        .with(work_package:)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
     end

--- a/spec/controllers/work_package_relations_controller_spec.rb
+++ b/spec/controllers/work_package_relations_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe WorkPackageRelationsController do
       new_relation = Relation.last
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [relation, new_relation], children:, relation_to_scroll_to: new_relation)
+        .with(work_package:, relation_to_scroll_to: new_relation)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
     end
@@ -142,7 +142,7 @@ RSpec.describe WorkPackageRelationsController do
       expect(response).to be_successful
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [relation], children:)
+        .with(work_package:)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
     end
@@ -160,7 +160,7 @@ RSpec.describe WorkPackageRelationsController do
       expect(response).to be_successful
 
       expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
-        .with(work_package:, relations: [], children:)
+        .with(work_package:)
       expect(controller).to have_received(:replace_via_turbo_stream)
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
       expect { relation.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/controllers/work_package_relations_tab_controller_spec.rb
+++ b/spec/controllers/work_package_relations_tab_controller_spec.rb
@@ -55,11 +55,8 @@ RSpec.describe WorkPackageRelationsTabController do
 
     it "renders the relations tab" do
       get("index", params: { work_package_id: work_package.id }, as: :turbo_stream)
-      expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new).with(
-        work_package:,
-        relations:,
-        children:
-      )
+      expect(WorkPackageRelationsTab::IndexComponent)
+        .to have_received(:new).with(work_package:)
 
       expect(response).to be_successful
     end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.shared_examples "work package relations tab", :js, :selenium do
+RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
   include_context "ng-select-autocomplete helpers"
 
   let(:user) { create(:admin) }


### PR DESCRIPTION
Introduce a mediator for the relations tab index component rendering. It is responsible for providing the relations and children from a work package for the relations tab. 

This moves the responsibility of relations and children visibility in one central place: the component asks for relations and children, and the mediator replies with the relations and children the user is allowed to see.
