### PR TITLE
Eager load data required for timesheet

### DIFF
--- a/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
+++ b/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
@@ -106,11 +106,14 @@ class CostQuery::PDF::TimesheetGenerator
   end
 
   def all_entries
-    @all_entries ||= query
-                       .each_direct_result
-                       .map(&:itself)
-                       .filter { |r| r.fields["type"] == "TimeEntry" }
-                       .map { |r| TimeEntry.find(r.fields["id"]) }
+    @all_entries ||= begin
+      ids = query
+              .each_direct_result
+              .filter { |r| r.fields["type"] == "TimeEntry" }
+              .flat_map { |r| r.fields["id"] }
+
+      TimeEntry.where(id: ids).includes(%i[user activity work_package project])
+    end
   end
 
   def build_table_rows(entries)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60591

# What are you trying to accomplish?

Avoid n+1 queries when exporting timesheets:

## Screenshots

Turns:
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/d763face-33bf-46f4-a1b1-e6914d51818b" />
and more

into:

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/920d1b5a-553f-4ba0-8db0-89c2726f75ed" />
