### PR TITLE
Include type in select to have correct behaviour in name method

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -334,7 +334,7 @@ class CustomField < ApplicationRecord
               end
 
       scope
-        .select(*(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s) << "id"))
+        .select(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s), "id", "type")
     end
   end
 

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -576,6 +576,25 @@ RSpec.describe "Projects list filters", :js, :with_cuprite, with_settings: { log
         projects_page.expect_projects_not_listed(project)
       end
     end
+
+    describe "user cf filter" do
+      let(:some_user) { create(:user, member_with_roles: { project => [developer] }) }
+      let!(:user_cf) do
+        create(:user_project_custom_field,
+               name: "A user CF",
+               projects: [project, development_project]).tap do |cf|
+          project.update(custom_field_values: { cf.id => [some_user.id] })
+        end
+      end
+
+      it "filters for the project that has the corresponding value" do
+        load_and_open_filters admin
+
+        projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_user.name])
+
+        projects_page.expect_projects_listed(project)
+      end
+    end
   end
 
   describe "blocked filter" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60563

# What are you trying to accomplish?

Fix:

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/c890483a-69a6-4606-bdc2-89451b1f26a1" />

# What approach did you choose and why?

Including the type in the select will lead to the correct class being instantiated which will cause the correct `#name` method to be called.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
