### PR TITLE
Rename AssociateUserToken to CreateService

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -41,7 +41,7 @@ module OpenProject::OpenIDConnect
         # We clear previous tokens while adding this one to avoid keeping
         # stale tokens around (and to avoid piling up duplicate IDP tokens)
         # -> Fresh login causes fresh set of tokens
-        OpenIDConnect::AssociateUserToken.new(user).call(
+        OpenIDConnect::UserTokens::CreateService.new(user).call(
           access_token: session["omniauth.oidc_access_token"],
           refresh_token: session["omniauth.oidc_refresh_token"],
           known_audiences: [OpenIDConnect::UserToken::IDP_AUDIENCE],

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/create_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/create_service_spec.rb
@@ -29,7 +29,7 @@
 #++
 require "spec_helper"
 
-RSpec.describe OpenIDConnect::AssociateUserToken do
+RSpec.describe OpenIDConnect::UserTokens::CreateService do
   subject { described_class.new(user, jwt_parser: parser).call(**args) }
 
   let(:user) { create(:user) }


### PR DESCRIPTION
This is more aligned with how we call other similar services, since the focus of this service is about creating user tokens.

# What are you trying to accomplish?

Increase code consistency. This is in response to a previous review comment: https://github.com/opf/openproject/pull/16940#discussion_r1913297405