### PR TITLE
Also disable submit button when token is missing

### DIFF
--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -67,7 +67,12 @@ module WorkPackages
           )
         end
 
-        subject_form.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
+        subject_form.submit(
+          name: :submit,
+          label: I18n.t(:button_save),
+          disabled: !EnterpriseToken.active? && !has_pattern?,
+          scheme: :primary
+        )
       end
 
       private

--- a/spec/components/work_packages/types/subject_configuration_component_spec.rb
+++ b/spec/components/work_packages/types/subject_configuration_component_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
     expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
   end
 
+  it "enables the submit button" do
+    render_component
+
+    expect(page.find("button[type=submit]")).not_to be_disabled
+  end
+
   context "when enterprise edition is not activated" do
     before do
       allow(EnterpriseToken).to receive(:active?).and_return(false)
@@ -72,6 +78,12 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
       expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
     end
 
+    it "disables the submit button" do
+      render_component
+
+      expect(page.find("button[type=submit]")).to be_disabled
+    end
+
     context "and when the subject is already automatically generated" do
       let(:type) { create(:type, patterns: { subject: { blueprint: "Hello world", enabled: true } }) }
 
@@ -86,6 +98,12 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
 
         expect(page.find("input[type=radio][value=auto]")).not_to be_disabled
         expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
+      end
+
+      it "enables the submit button" do
+        render_component
+
+        expect(page.find("button[type=submit]")).not_to be_disabled
       end
     end
   end


### PR DESCRIPTION
Making it clear to the user, that the form is not
submittable. In the cases where we disable the other inputs, there is no intention for the user to be able to submit/change anything.

# Ticket
This came up during testing of https://community.openproject.org/projects/document-workflows-stream/work_packages/59929

# What are you trying to accomplish?

Making it clearer to the user, that there is nothing to do without an enterprise token.