### PR TITLE
bug/60449 Reminders generate two or more lines for a work package in notification center, clicking one selects all

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -681,11 +681,11 @@ en:
       date_alerts:
         milestone_date: "Milestone date"
         overdue: "Overdue"
-        overdue_since: "since %{difference_in_days}"
-        property_today: "is today"
-        property_is: "is in %{difference_in_days}"
-        property_was: "was %{difference_in_days} ago"
-        property_is_deleted: "is deleted"
+        overdue_since: "since %{difference_in_days}."
+        property_today: "is today."
+        property_is: "is in %{difference_in_days}."
+        property_was: "was %{difference_in_days} ago."
+        property_is_deleted: "is deleted."
         upsale:
           title: "Date alerts"
           description: "With date alerts, you will be notified of upcoming start or finish dates so that you never miss or forget an important deadline."

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -111,28 +111,7 @@ export class IanCenterService extends UntilDestroyedMixin {
   notifications$ = this
     .aggregatedCenterNotifications$
     .pipe(
-      map((items) => {
-        return Object.values(items).reduce((acc, workPackageNotificationGroup) => {
-          const { reminders, others } = workPackageNotificationGroup.reduce((result, notification) => {
-            if (notification.reason === 'reminder') {
-              result.reminders.push(notification);
-            } else {
-              result.others.push(notification);
-            }
-            return result;
-          }, { reminders: [] as INotification[], others: [] as INotification[] });
-
-          // Extract reminders into standalone groups so they can be displayed individually
-          if (reminders.length > 0) {
-            reminders.forEach((reminder) => acc.push([reminder]));
-          }
-          if (others.length > 0) {
-            acc.push(others);
-          }
-
-          return acc;
-        }, [] as INotification[][]);
-      }),
+      map((items) => Object.values(items)),
       distinctUntilChanged(),
     );
 

--- a/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.html
@@ -1,7 +1,13 @@
+<op-in-app-notification-date-alert
+  *ngIf="hasDateAlert"
+  [aggregatedNotifications]="dateAlerts">
+</op-in-app-notification-date-alert>
 <op-in-app-notification-relative-time
+  *ngIf="!hasDateAlert"
   [notification]="reminderAlert"
-  [hasActorByLine]="false"
-/>
+  [hasActorByLine]="false">
+</op-in-app-notification-relative-time>
+
 <span
   class="op-ian-reminder-alert--note"
   [textContent]="reminderNote"

--- a/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.ts
@@ -23,6 +23,8 @@ export class InAppNotificationReminderAlertComponent implements OnInit {
 
   reminderNote:string;
   reminderAlert:INotification;
+  hasDateAlert = false;
+  dateAlerts:INotification[] = [];
 
   constructor(
     private I18n:I18nService,
@@ -31,6 +33,8 @@ export class InAppNotificationReminderAlertComponent implements OnInit {
   ngOnInit():void {
     this.reminderAlert = this.deriveMostRecentReminder(this.aggregatedNotifications);
     this.reminderNote = this.extractReminderNoteValue(this.reminderAlert._embedded.details);
+    this.dateAlerts = this.aggregatedNotifications.filter((notification) => notification.reason === 'dateAlert');
+    this.hasDateAlert = this.dateAlerts.length > 0;
   }
 
   private deriveMostRecentReminder(aggregatedNotifications:INotification[]):INotification {

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
     it "shows the upsale page" do
       side_menu.click_item "Date alert"
 
-      expect(page).to have_current_path /notifications\/date_alerts/
+      expect(page).to have_current_path(/notifications\/date_alerts/)
       expect(page).to have_text "Date alerts is an Enterprise"
       expect(page).to have_text "Please upgrade to a paid plan "
 
@@ -207,18 +207,18 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
 
   context "with date alerts ee", with_ee: %i[date_alerts] do
     it "shows the date alerts according to specification" do
-      center.expect_item(notification_wp_start_past, "Start date was 1 day ago")
-      center.expect_item(notification_wp_start_future, "Start date is in 7 days")
+      center.expect_item(notification_wp_start_past, "Start date was 1 day ago.")
+      center.expect_item(notification_wp_start_future, "Start date is in 7 days.")
 
-      center.expect_item(notification_wp_due_past, "Overdue since 3 days")
-      center.expect_item(notification_wp_due_future, "Finish date is in 3 days")
+      center.expect_item(notification_wp_due_past, "Overdue since 3 days.")
+      center.expect_item(notification_wp_due_future, "Finish date is in 3 days.")
 
-      center.expect_item(notification_milestone_past, "Overdue since 2 days")
-      center.expect_item(notification_milestone_future, "Milestone date is in 1 day")
+      center.expect_item(notification_milestone_past, "Overdue since 2 days.")
+      center.expect_item(notification_milestone_future, "Milestone date is in 1 day.")
 
-      center.expect_item(notification_wp_unset_date, "Finish date is deleted")
+      center.expect_item(notification_wp_unset_date, "Finish date is deleted.")
 
-      center.expect_item(notification_wp_due_today, "Finish date is today")
+      center.expect_item(notification_wp_due_today, "Finish date is today.")
 
       # Doesn't show the date alert for the mention, not the alert
       center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)
@@ -227,7 +227,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       # When switch to date alerts, it shows the alert, no longer the mention
       side_menu.click_item "Date alert"
       wait_for_network_idle
-      center.expect_item(notification_wp_double_date_alert, "Finish date is in 1 day")
+      center.expect_item(notification_wp_double_date_alert, "Finish date is in 1 day.")
       center.expect_no_item(notification_wp_double_mention)
 
       # Ensure that start is created later than due for implicit ID sorting
@@ -236,7 +236,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
 
       # We see that start is actually the newest ID, hence shown as the primary notification
       # but the date alert still shows the finish date
-      center.expect_item(double_alert_start, "Finish date is in 1 day")
+      center.expect_item(double_alert_start, "Finish date is in 1 day.")
       center.expect_no_item(double_alert_due)
 
       # Opening a date alert opens in overview
@@ -262,7 +262,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       page.driver.refresh
       wait_for_reload
 
-      center.expect_item(notification_wp_double_date_alert, "Finish date is in 5 days")
+      center.expect_item(notification_wp_double_date_alert, "Finish date is in 5 days.")
       center.expect_no_item(notification_wp_double_mention)
     end
   end

--- a/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
@@ -47,18 +47,10 @@ RSpec.describe "Notification center reminder, mention and date alert",
     wait_for_reload
   end
 
-  it "shows the reminder alert in own entry" do
+  it "shows the reminder alert within aggregation with reminder note" do
     center.within_item(notification_reminder) do
-      expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nReminder")
-      expect(page).to have_no_text("Actor user")
+      expect(page).to have_text("Date alert, Mentioned, Reminder")
       expect(page).to have_text("a few seconds ago.\nNote: “This is an important reminder”")
-    end
-  end
-
-  it "shows other notification reasons aggregated" do
-    center.within_item(notification_date_alert) do
-      expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nDate alert, Mentioned")
-      expect(page).to have_no_text("Actor user")
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->


https://community.openproject.org/projects/communicator-stream/work_packages/60449/activity#activity-9

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Aggregate the Reminder notifications with other notifications (regular aggregation) so that only one item per work package is visible in the notification center.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1455" alt="Screenshot 2025-01-15 at 1 07 00 PM" src="https://github.com/user-attachments/assets/23762471-16a6-4c4b-8d73-3c3e6574ec3a" />
<img width="1684" alt="Screenshot 2025-01-15 at 1 23 56 PM" src="https://github.com/user-attachments/assets/a3d75946-f9cb-4d71-87ca-757aa91a77d5" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

This reverts: https://github.com/opf/openproject/pull/17426 where we previously defined reminder notifications as standalone.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
