### PR TITLE
[#60578] Unable to use the date picker for stages

### DIFF
--- a/app/forms/projects/life_cycles/form.rb
+++ b/app/forms/projects/life_cycles/form.rb
@@ -54,7 +54,7 @@ module Projects::LifeCycles
         leading_visual: { icon: :calendar },
         datepicker_options: {
           inDialog: true,
-          data: { action: "change->overview--project-life-cycles-form#handleChange" }
+          data: { action: "change->overview--project-life-cycles-form#previewForm" }
         },
         wrapper_data_attributes: {
           "qa-field-name": qa_field_name

--- a/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycles-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycles-form.controller.ts
@@ -35,7 +35,7 @@ export default class ProjectLifeCyclesFormController extends Controller {
 
   declare readonly formTarget:HTMLFormElement;
 
-  handleChange(event:Event) {
+  previewForm(event:Event) {
     const target = event.target as HTMLElement;
     const previewUrl = this.formTarget.dataset.previewUrl;
 
@@ -50,9 +50,6 @@ export default class ProjectLifeCyclesFormController extends Controller {
   }
 
   datePickerVisible(element:HTMLElement) {
-    const nextElement = element.nextElementSibling;
-    return nextElement
-           && nextElement.classList.contains('flatpickr-calendar')
-           && nextElement.classList.contains('open');
+    return element.classList.contains('active');
   }
 }

--- a/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
@@ -88,9 +88,13 @@ RSpec.describe "Edit project stages and gates on project overview page", :js, :w
           # Retrying due to a race condition between filling the input vs submitting the form preview.
           original_dates = [life_cycle_initiating.start_date, life_cycle_initiating.end_date]
           dialog.set_date_for(life_cycle_initiating, value: original_dates)
+
+          page.driver.clear_network_traffic
           dialog.set_date_for(life_cycle_initiating, value: initiating_dates)
 
           dialog.expect_caption(life_cycle_initiating, text: "Duration: 8 working days")
+          # Ensure that only 1 ajax request is triggered after setting the date range.
+          expect(page.driver.browser.network.traffic.size).to eq(1)
         end
 
         ready_for_planning_date = start_date + 1.day


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60578

# What are you trying to accomplish?
Fix the date range picker's validation preview logic on the Stages and Gates dialog. Due to a bug, the preview was triggered too early, before selecting both start and end dates. This led to an inconsistent behaviour of clearing out the input value and the selected date preventing the form to be usable. 

# What approach did you choose and why?
Instead of relying on the datepicker's element visiblity rely on the `active` class of the input field to decide whether a form preview update is required. The `active` class is automatically added and removed from the datepicker input, when the datepicker is open, and it's a good cue to rely on.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
