### PR TITLE
Add configuration for authentication method

### DIFF
--- a/modules/storages/app/contracts/storages/storages/nextcloud_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/nextcloud_contract.rb
@@ -36,6 +36,12 @@ module Storages::Storages
     # But only do so if the validations above for URL were successful.
     validates :host, secure_context_uri: true, nextcloud_compatible_host: true, unless: -> { errors.include?(:host) }
 
+    attribute :authentication_method
+    validates :authentication_method, presence: true, inclusion: { in: ::Storages::NextcloudStorage::AUTHENTICATION_METHODS }
+
+    attribute :nextcloud_audience
+    validates :nextcloud_audience, presence: true, if: :nextcloud_storage_authenticate_via_idp?
+
     attribute :automatically_managed
 
     attribute :username
@@ -66,6 +72,10 @@ module Storages::Storages
       return false unless nextcloud_storage?
 
       @model.username == @model.provider_fields_defaults[:username]
+    end
+
+    def nextcloud_storage_authenticate_via_idp?
+      nextcloud_storage? && @model.authenticate_via_idp?
     end
 
     def nextcloud_storage?

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -35,11 +35,15 @@ module Storages
       username: "OpenProject"
     }.freeze
 
+    AUTHENTICATION_METHODS = %w[two_way_oauth2 oauth2_sso].freeze
+
     store_attribute :provider_fields, :automatically_managed, :boolean
     store_attribute :provider_fields, :username, :string
     store_attribute :provider_fields, :password, :string
     store_attribute :provider_fields, :group, :string
     store_attribute :provider_fields, :group_folder, :string
+    store_attribute :provider_fields, :authentication_method, :string, default: "two_way_oauth2"
+    store_attribute :provider_fields, :nextcloud_audience, :string
 
     def oauth_configuration
       Peripherals::OAuthConfigurations::NextcloudConfiguration.new(self)
@@ -60,6 +64,10 @@ module Storages
       else
         ["inactive", "manual"]
       end
+    end
+
+    def authenticate_via_idp?
+      authentication_method == "oauth2_sso"
     end
 
     def configuration_checks

--- a/modules/storages/db/migrate/20250115100336_set_default_authentication_method.rb
+++ b/modules/storages/db/migrate/20250115100336_set_default_authentication_method.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class SetDefaultAuthenticationMethod < ActiveRecord::Migration[7.1]
+  def change
+    update_sql = <<~SQL.squish
+      UPDATE storages
+      SET provider_fields = provider_fields || '{ "authentication_method": "two_way_oauth2" }'::jsonb
+      WHERE provider_type = 'Storages::NextcloudStorage' AND NOT provider_fields ? 'authentication_method'
+    SQL
+
+    ActiveRecord::Base.connection.execute(update_sql)
+  end
+end

--- a/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
@@ -294,8 +294,7 @@ RSpec.shared_examples_for "nextcloud storage contract", :storage_server_helpers,
 
     context "when not automatically managed, no username or password" do
       before do
-        storage.provider_fields = {}
-        storage.assign_attributes(automatic_management_enabled: false)
+        storage.assign_attributes(automatic_management_enabled: false, username: nil, password: nil)
       end
 
       it_behaves_like "contract is valid"

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -91,6 +91,8 @@ FactoryBot.define do
           class: "::Storages::NextcloudStorage" do
     provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
     sequence(:host) { |n| "https://host#{n}.example.com/" }
+    authentication_method { "two_way_oauth2" }
+    nextcloud_audience { "nextcloud" }
 
     trait :as_automatically_managed do
       automatic_management_enabled { true }


### PR DESCRIPTION
Preparing for users to choose how they want to authenticate their nextcloud storage and if using a common IDP, what the client_id of nextcloud is.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/60153

# What are you trying to accomplish?
Adding configuration for the authentication method to the storage provider, so that we can work on two pieces of code afterwards:

* Building the UI that sets this configuration
* Consuming these settings to perform authentication using either method

# Merge checklist

- [x] Added/updated tests
