### PR TITLE
Bug/60449 reminders generate two or more lines for a work package in notification center clicking one selects all

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -681,11 +681,11 @@ en:
       date_alerts:
         milestone_date: "Milestone date"
         overdue: "Overdue"
-        overdue_since: "since %{difference_in_days}"
-        property_today: "is today"
-        property_is: "is in %{difference_in_days}"
-        property_was: "was %{difference_in_days} ago"
-        property_is_deleted: "is deleted"
+        overdue_since: "since %{difference_in_days}."
+        property_today: "is today."
+        property_is: "is in %{difference_in_days}."
+        property_was: "was %{difference_in_days} ago."
+        property_is_deleted: "is deleted."
         upsale:
           title: "Date alerts"
           description: "With date alerts, you will be notified of upcoming start or finish dates so that you never miss or forget an important deadline."

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -111,28 +111,7 @@ export class IanCenterService extends UntilDestroyedMixin {
   notifications$ = this
     .aggregatedCenterNotifications$
     .pipe(
-      map((items) => {
-        return Object.values(items).reduce((acc, workPackageNotificationGroup) => {
-          const { reminders, others } = workPackageNotificationGroup.reduce((result, notification) => {
-            if (notification.reason === 'reminder') {
-              result.reminders.push(notification);
-            } else {
-              result.others.push(notification);
-            }
-            return result;
-          }, { reminders: [] as INotification[], others: [] as INotification[] });
-
-          // Extract reminders into standalone groups so they can be displayed individually
-          if (reminders.length > 0) {
-            reminders.forEach((reminder) => acc.push([reminder]));
-          }
-          if (others.length > 0) {
-            acc.push(others);
-          }
-
-          return acc;
-        }, [] as INotification[][]);
-      }),
+      map((items) => Object.values(items)),
       distinctUntilChanged(),
     );
 

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -107,7 +107,8 @@ export class InAppNotificationDateAlertComponent implements OnInit {
   private deriveMostRelevantAlert(aggregatedNotifications:INotification[]) {
     // Second case: We have one date alert + some others
     const dateAlerts = aggregatedNotifications.filter((notification) => notification.reason === 'dateAlert');
-    const first = aggregatedNotifications[0];
+    const first = dateAlerts[0];
+
     if (dateAlerts.length > 1) {
       const found = dateAlerts.find((notification) => notification._embedded.details[0].property === 'dueDate');
       return found || first;

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -9,7 +9,6 @@ import {
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IInAppNotificationDetailsAttribute, INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
-import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import * as moment from 'moment';
 import { Moment } from 'moment';
 
@@ -22,8 +21,6 @@ import { Moment } from 'moment';
 })
 export class InAppNotificationDateAlertComponent implements OnInit {
   @Input() aggregatedNotifications:INotification[];
-
-  @Input() workPackage:WorkPackageResource;
 
   @HostBinding('class.op-ian-date-alert') className = true;
 

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -95,7 +95,6 @@
       <ng-container *ngIf="!hasReminderAlert">
         <op-in-app-notification-date-alert
           *ngIf="showDateAlert"
-          [workPackage]="workPackage"
           [aggregatedNotifications]="aggregatedNotifications"
         ></op-in-app-notification-date-alert>
         <op-in-app-notification-actors-line

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -63,20 +63,15 @@ export class InAppNotificationEntryComponent implements OnInit {
     const href = this.notification._links.resource?.href;
     this.workPackageId = href && HalResource.matchFromLink(href, 'work_packages');
 
-    this.hasReminderAlert = this.aggregatedNotifications.some((notification) => notification.reason === 'reminder');
-    this.showDateAlert = this.hasActiveDateAlert();
+    this.hasReminderAlert = this.hasNotificationReason('reminder');
+    this.showDateAlert = this.hasNotificationReason('dateAlert');
     this.buildTranslatedReason();
     this.buildProject();
     this.loadWorkPackage();
   }
 
-  private hasActiveDateAlert():boolean {
-    if (this.urlParams.get('filter') === 'reason' && this.urlParams.get('name') === 'date_alert') {
-      return true;
-    }
-
-    const dateAlerts = this.aggregatedNotifications.filter((notification) => notification.reason === 'dateAlert');
-    return dateAlerts.length === this.aggregatedNotifications.length;
+  private hasNotificationReason(reason:string):boolean {
+    return this.aggregatedNotifications.some((notification) => notification.reason === reason);
   }
 
   private loadWorkPackage() {

--- a/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.html
@@ -1,7 +1,13 @@
+<op-in-app-notification-date-alert
+  *ngIf="hasDateAlert"
+  [aggregatedNotifications]="dateAlerts">
+</op-in-app-notification-date-alert>
 <op-in-app-notification-relative-time
+  *ngIf="!hasDateAlert"
   [notification]="reminderAlert"
-  [hasActorByLine]="false"
-/>
+  [hasActorByLine]="false">
+</op-in-app-notification-relative-time>
+
 <span
   class="op-ian-reminder-alert--note"
   [textContent]="reminderNote"

--- a/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.ts
@@ -23,6 +23,8 @@ export class InAppNotificationReminderAlertComponent implements OnInit {
 
   reminderNote:string;
   reminderAlert:INotification;
+  hasDateAlert = false;
+  dateAlerts:INotification[] = [];
 
   constructor(
     private I18n:I18nService,
@@ -31,6 +33,8 @@ export class InAppNotificationReminderAlertComponent implements OnInit {
   ngOnInit():void {
     this.reminderAlert = this.deriveMostRecentReminder(this.aggregatedNotifications);
     this.reminderNote = this.extractReminderNoteValue(this.reminderAlert._embedded.details);
+    this.dateAlerts = this.aggregatedNotifications.filter((notification) => notification.reason === 'dateAlert');
+    this.hasDateAlert = this.dateAlerts.length > 0;
   }
 
   private deriveMostRecentReminder(aggregatedNotifications:INotification[]):INotification {

--- a/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe "Notification center date alert and mention",
   context "with date alerts ee", with_ee: %i[date_alerts] do
     it "shows only the date alert time, not the mentioned author" do
       center.within_item(notification_date_alert) do
-        expect(page).to have_text("Date alert, Mentioned")
-        expect(page).to have_no_text("Actor user")
+        expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nDate alert, Mentioned")
+        expect(page).to have_no_text("Actor User")
+        expect(page).to have_text("Overdue since 1 day.")
       end
     end
   end

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
     it "shows the upsale page" do
       side_menu.click_item "Date alert"
 
-      expect(page).to have_current_path /notifications\/date_alerts/
+      expect(page).to have_current_path(/notifications\/date_alerts/)
       expect(page).to have_text "Date alerts is an Enterprise"
       expect(page).to have_text "Please upgrade to a paid plan "
 
@@ -207,18 +207,18 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
 
   context "with date alerts ee", with_ee: %i[date_alerts] do
     it "shows the date alerts according to specification" do
-      center.expect_item(notification_wp_start_past, "Start date was 1 day ago")
-      center.expect_item(notification_wp_start_future, "Start date is in 7 days")
+      center.expect_item(notification_wp_start_past, "Start date was 1 day ago.")
+      center.expect_item(notification_wp_start_future, "Start date is in 7 days.")
 
-      center.expect_item(notification_wp_due_past, "Overdue since 3 days")
-      center.expect_item(notification_wp_due_future, "Finish date is in 3 days")
+      center.expect_item(notification_wp_due_past, "Overdue since 3 days.")
+      center.expect_item(notification_wp_due_future, "Finish date is in 3 days.")
 
-      center.expect_item(notification_milestone_past, "Overdue since 2 days")
-      center.expect_item(notification_milestone_future, "Milestone date is in 1 day")
+      center.expect_item(notification_milestone_past, "Overdue since 2 days.")
+      center.expect_item(notification_milestone_future, "Milestone date is in 1 day.")
 
-      center.expect_item(notification_wp_unset_date, "Finish date is deleted")
+      center.expect_item(notification_wp_unset_date, "Finish date is deleted.")
 
-      center.expect_item(notification_wp_due_today, "Finish date is today")
+      center.expect_item(notification_wp_due_today, "Finish date is today.")
 
       # Doesn't show the date alert for the mention, not the alert
       center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)
@@ -227,7 +227,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       # When switch to date alerts, it shows the alert, no longer the mention
       side_menu.click_item "Date alert"
       wait_for_network_idle
-      center.expect_item(notification_wp_double_date_alert, "Finish date is in 1 day")
+      center.expect_item(notification_wp_double_date_alert, "Finish date is in 1 day.")
       center.expect_no_item(notification_wp_double_mention)
 
       # Ensure that start is created later than due for implicit ID sorting
@@ -236,7 +236,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
 
       # We see that start is actually the newest ID, hence shown as the primary notification
       # but the date alert still shows the finish date
-      center.expect_item(double_alert_start, "Finish date is in 1 day")
+      center.expect_item(double_alert_start, "Finish date is in 1 day.")
       center.expect_no_item(double_alert_due)
 
       # Opening a date alert opens in overview
@@ -262,7 +262,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       page.driver.refresh
       wait_for_reload
 
-      center.expect_item(notification_wp_double_date_alert, "Finish date is in 5 days")
+      center.expect_item(notification_wp_double_date_alert, "Finish date is in 5 days.")
       center.expect_no_item(notification_wp_double_mention)
     end
   end

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "Notification center date alerts", :js, :with_cuprite,
       center.expect_item(notification_wp_due_today, "Finish date is today.")
 
       # Doesn't show the date alert for the mention, not the alert
-      center.expect_item(notification_wp_double_mention, /(seconds|minutes) ago by Anonymous/)
+      center.expect_item(notification_wp_double_mention, "Finish date is in 1 day.")
       center.expect_no_item(notification_wp_double_date_alert)
 
       # When switch to date alerts, it shows the alert, no longer the mention

--- a/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
@@ -47,18 +47,10 @@ RSpec.describe "Notification center reminder, mention and date alert",
     wait_for_reload
   end
 
-  it "shows the reminder alert in own entry" do
+  it "shows the reminder alert within aggregation with reminder note" do
     center.within_item(notification_reminder) do
-      expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nReminder")
-      expect(page).to have_no_text("Actor user")
+      expect(page).to have_text("Date alert, Mentioned, Reminder")
       expect(page).to have_text("a few seconds ago.\nNote: “This is an important reminder”")
-    end
-  end
-
-  it "shows other notification reasons aggregated" do
-    center.within_item(notification_date_alert) do
-      expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nDate alert, Mentioned")
-      expect(page).to have_no_text("Actor user")
     end
   end
 end

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Start date was 1 day ago")
+          expect(mail_body).to have_text("Start date was 1 day ago.")
         end
       end
 
@@ -175,7 +175,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Start date is in 2 days")
+          expect(mail_body).to have_text("Start date is in 2 days.")
         end
       end
 
@@ -191,7 +191,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Overdue since 3 days")
+          expect(mail_body).to have_text("Overdue since 3 days.")
         end
       end
 
@@ -207,7 +207,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Finish date is in 3 days")
+          expect(mail_body).to have_text("Finish date is in 3 days.")
         end
       end
 
@@ -224,7 +224,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to include('<span style="color: #C92A2A">Overdue since 2 days</span>')
+          expect(mail_body).to include('<span style="color: #C92A2A">Overdue since 2 days.</span>')
         end
       end
 
@@ -241,7 +241,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Milestone date is in 1 day")
+          expect(mail_body).to have_text("Milestone date is in 1 day.")
         end
       end
 
@@ -255,7 +255,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Finish date is deleted")
+          expect(mail_body).to have_text("Finish date is deleted.")
         end
       end
 
@@ -271,7 +271,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Finish date is today")
+          expect(mail_body).to have_text("Finish date is today.")
         end
       end
 
@@ -287,7 +287,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Finish date is in 1 day")
+          expect(mail_body).to have_text("Finish date is in 1 day.")
         end
       end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->


https://community.openproject.org/projects/communicator-stream/work_packages/60449/activity#activity-9

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- [x] Aggregate the Reminder notifications with other notifications (regular aggregation) so that only one item per work package is visible in the notification center.
- [x] Add missing full stops to due dates
- [x] Elevate date alerts above actor mentions 

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1464" alt="Screenshot 2025-01-16 at 1 07 37 PM" src="https://github.com/user-attachments/assets/34e65162-dfea-40bd-96b3-0e7e9c883274" />

<img width="1691" alt="Screenshot 2025-01-16 at 1 09 43 PM" src="https://github.com/user-attachments/assets/2d912849-0646-4be4-83c4-1eb32c70ab8e" />

<img width="1691" alt="Screenshot 2025-01-16 at 1 09 33 PM" src="https://github.com/user-attachments/assets/15ff7c94-59f9-4769-9599-5a1ad2d65293" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

This reverts: https://github.com/opf/openproject/pull/17426 where we previously defined reminder notifications as standalone.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
