### PR TITLE
Bug/59916 on narrow screens (including mobile) the view always scrolls to the activity

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -350,7 +350,7 @@ export default class IndexController extends Controller {
     if (window.location.hash.includes('#activity-')) {
       const activityId = window.location.hash.replace('#activity-', '');
       this.scrollToActivity(activityId);
-    } else if (this.sortingValue === 'asc' && !this.isMobile()) {
+    } else if (this.sortingValue === 'asc' && (!this.isMobile() || this.isWithinNotificationCenter())) {
       this.scrollToBottom();
     }
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -350,7 +350,7 @@ export default class IndexController extends Controller {
     if (window.location.hash.includes('#activity-')) {
       const activityId = window.location.hash.replace('#activity-', '');
       this.scrollToActivity(activityId);
-    } else if (this.sortingValue === 'asc') {
+    } else if (this.sortingValue === 'asc' && !this.isMobile()) {
       this.scrollToBottom();
     }
   }

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2024 the OpenProject GmbH
@@ -978,12 +980,14 @@ RSpec.describe "Work package activity", :js, with_flag: { primerized_work_packag
         # the scroll position is at around 700, some other part of the frontend code seems to trigger a scroll
         # happens for the files tab as well for example
         #
-        # it "does not scroll to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
-        #   sleep 1 # wait for a potential auto scrolling to finish
-        #   # expect activity tab not to be visibe, as the page is not scrolled to the bottom
-        #   scroll_position = page.evaluate_script("document.querySelector(\"#content-body\").scrollTop")
-        #   expect(scroll_position).to eq(0)
-        # end
+        it "does not scroll to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+          pending "bug/59916-on-narrow-screens-(including-mobile)-the-view-always-scrolls-to-the-activity"
+
+          sleep 1 # wait for a potential auto scrolling to finish
+          # expect activity tab not to be visibe, as the page is not scrolled to the bottom
+          scroll_position = page.evaluate_script("document.querySelector(\"#content-body\").scrollTop")
+          expect(scroll_position).to eq(0)
+        end
       end
     end
 

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -922,24 +922,68 @@ RSpec.describe "Work package activity", :js, with_flag: { primerized_work_packag
         wp_page.wait_for_activity_tab
       end
 
-      it "scrolls to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
-        sleep 1 # wait for auto scrolling to finish
-        activity_tab.expect_journal_container_at_bottom
+      context "when on desktop" do
+        it "scrolls to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+          sleep 1 # wait for auto scrolling to finish
+          activity_tab.expect_journal_container_at_bottom
 
-        # auto-scrolls to the bottom when a new comment is added by the user
-        # add a comment
-        activity_tab.add_comment(text: "New comment by admin")
-        activity_tab.expect_journal_container_at_bottom
+          # auto-scrolls to the bottom when a new comment is added by the user
+          # add a comment
+          activity_tab.add_comment(text: "New comment by admin")
+          activity_tab.expect_journal_container_at_bottom
 
-        # auto-scrolls to the bottom when a new comment is added by another user
-        # add a comment
-        latest_journal_version = work_package.journals.last.version
-        create(:work_package_journal, user: member, notes: "New comment by member", journable: work_package,
-                                      version: latest_journal_version + 1)
-        # wait for the comment to be added
-        wait_for { page }.to have_test_selector("op-journal-notes-body", text: "New comment by member")
-        sleep 1 # wait for auto scrolling to finish
-        activity_tab.expect_journal_container_at_bottom
+          # auto-scrolls to the bottom when a new comment is added by another user
+          # add a comment
+          latest_journal_version = work_package.journals.last.version
+          create(:work_package_journal, user: member, notes: "New comment by member", journable: work_package,
+                                        version: latest_journal_version + 1)
+          # wait for the comment to be added
+          wait_for { page }.to have_test_selector("op-journal-notes-body", text: "New comment by member")
+          sleep 1 # wait for auto scrolling to finish
+          activity_tab.expect_journal_container_at_bottom
+        end
+      end
+
+      context "when on narrow desktop screen size" do
+        before do
+          page.current_window.resize_to(900, 1200)
+          # simulate a desktop screen which was resized to a smaller width
+          # the height in this spec is important as the activity tab must be visible
+          # otherwise the (in this case undesired) auto scrolling would not be triggered
+
+          wp_page.visit!
+          wp_page.wait_for_activity_tab
+        end
+
+        it "does not scroll to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+          sleep 1 # wait for a potential auto scrolling to finish
+          # expect activity tab not to be visibe, as the page is not scrolled to the bottom
+          scroll_position = page.evaluate_script("document.querySelector(\"#content-body\").scrollTop")
+          expect(scroll_position).to eq(0)
+        end
+      end
+
+      context "when on mobile screen size" do
+        before do
+          page.current_window.resize_to(500, 1000)
+          # simulate a mobile screen size
+          # the height in this spec is important as the activity tab must be visible
+          # otherwise the (in this case undesired) auto scrolling would not be triggered
+
+          wp_page.visit!
+          wp_page.wait_for_activity_tab
+        end
+
+        # this one is actually failing, but it's not caused by the activity tab
+        # the scroll position is at around 700, some other part of the frontend code seems to trigger a scroll
+        # happens for the files tab as well for example
+        #
+        # it "does not scroll to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+        #   sleep 1 # wait for a potential auto scrolling to finish
+        #   # expect activity tab not to be visibe, as the page is not scrolled to the bottom
+        #   scroll_position = page.evaluate_script("document.querySelector(\"#content-body\").scrollTop")
+        #   expect(scroll_position).to eq(0)
+        # end
       end
     end
 


### PR DESCRIPTION
[Ticket](https://community.openproject.org/projects/communicator-stream/work_packages/59916)

- the described issue is resolved and covered with a spec
- I've encountered another scroll behavior on screens below 550px, which seems not to be related to the implementation of the activity tab (-> happens for files/other tabs as well): The page scrolls down around 700px on page load on these small screens. I didn't find the reason for that