### PR TITLE
Fix flickering SharesController spec

### DIFF
--- a/spec/controllers/shares_controller_spec.rb
+++ b/spec/controllers/shares_controller_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe SharesController do
       it "responds with updated permission buttons" do
         make_request
         expect(controller).to have_received(:respond_with_bulk_updated_permission_buttons)
-          .with([view_member, edit_member])
+          .with(a_collection_containing_exactly(view_member, edit_member))
       end
     end
 


### PR DESCRIPTION
The spec expected a specific order of the items being passed, when the items had no strongly defined order with which they were requested from the database, so tests success was dependent on internal database state always leading to results being returned in the same order.

I've seen this spec fail at least once due to wrong result order.