### PR TITLE
[#60183] add pattern contract validation to subject configuration

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -135,8 +137,7 @@ class TypesController < ApplicationController
 
   def redirect_to_type_tab_path(type, notice)
     tab = params["tab"] || "settings"
-    redirect_to(edit_type_tab_path(type, tab:),
-                notice:)
+    redirect_to(edit_tab_type_path(type, tab:), notice:)
   end
 
   def render_edit_tab(type, status: :ok)

--- a/app/controllers/work_packages/types/subject_configuration_controller.rb
+++ b/app/controllers/work_packages/types/subject_configuration_controller.rb
@@ -63,19 +63,29 @@ module WorkPackages
       def tab_path = edit_tab_type_path(id: @type.id, tab: :subject_configuration)
 
       def pattern_collection_update(form_params)
-        case form_params
-        in { subject_configuration: "generated", pattern: String => blueprint }
-          { subject: { blueprint:, enabled: true } }
-        in { subject_configuration: "manual", pattern: String => blueprint }
-          if blueprint.empty?
-            # Submitting the form with an empty blueprint and manual subject configuration will
-            # remove the subject pattern from the collection
-            nil
+        patterns = @type.patterns.to_h
+
+        subject_pattern =
+          case form_params
+          in { subject_configuration: "generated", pattern: String => blueprint }
+            { subject: { blueprint:, enabled: true } }
+          in { subject_configuration: "manual", pattern: String => blueprint }
+            if blueprint.empty?
+              # Submitting the form with an empty blueprint and manual subject configuration will
+              # remove the subject pattern from the collection
+              nil
+            else
+              { subject: { blueprint:, enabled: false } }
+            end
           else
-            { subject: { blueprint:, enabled: false } }
+            nil
           end
+
+        if subject_pattern.nil?
+          patterns.delete("subject")
+          patterns
         else
-          nil
+          patterns.merge(subject_pattern.stringify_keys)
         end
       end
     end

--- a/app/controllers/work_packages/types/subject_configuration_controller.rb
+++ b/app/controllers/work_packages/types/subject_configuration_controller.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module Types
+    class SubjectConfigurationController < ApplicationController
+      layout "admin"
+
+      before_action :require_admin
+      before_action :find_type, only: %i[update_subject_configuration]
+
+      def update_subject_configuration
+        form_params = params.require(:types_forms_subject_configuration_form_model)
+                            .permit(:subject_configuration, :pattern)
+                            .to_h
+
+        UpdateTypeService.new(@type, current_user)
+                         .call({ patterns: pattern_collection_update(form_params) }) do |call|
+          call.on_success do
+            redirect_to tab_path, notice: I18n.t(:notice_successful_update)
+          end
+
+          call.on_failure do
+            @default_tab = "subject_configuration"
+            render template: "types/edit", status: :unprocessable_entity
+          end
+        end
+      end
+
+      private
+
+      def find_type
+        @type = ::Type.find(params[:id])
+      end
+
+      def tab_path = edit_tab_type_path(id: @type.id, tab: :subject_configuration)
+
+      def pattern_collection_update(form_params)
+        case form_params
+        in { subject_configuration: "generated", pattern: String => blueprint }
+          { subject: { blueprint:, enabled: true } }
+        in { subject_configuration: "manual", pattern: String => blueprint }
+          if blueprint.empty?
+            # Submitting the form with an empty blueprint and manual subject configuration will
+            # remove the subject pattern from the collection
+            nil
+          else
+            { subject: { blueprint:, enabled: false } }
+          end
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -31,60 +31,55 @@
 module WorkPackages
   module Types
     class SubjectConfigurationForm < ApplicationForm
-      class << self
-        def has_pattern?(type)
-          type.replacement_pattern_defined_for?(:subject)
-        end
-      end
-
       form do |subject_form|
         subject_form.radio_button_group(name: :subject_configuration) do |group|
           group.radio_button(
-            value: "manual",
-            checked: !has_pattern?,
+            value: :manual,
+            checked: subject_configuration_manual?,
             label: I18n.t("types.edit.subject_configuration.manually_editable_subjects.label"),
             caption: I18n.t("types.edit.subject_configuration.manually_editable_subjects.caption"),
             data: { action: "admin--subject-configuration#hidePatternInput" }
           )
           group.radio_button(
-            value: "auto",
-            checked: has_pattern?,
+            value: :generated,
+            checked: !subject_configuration_manual?,
             label: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.label"),
             caption: I18n.t("types.edit.subject_configuration.automatically_generated_subjects.caption"),
-            disabled: !EnterpriseToken.active? && !has_pattern?,
+            disabled: !enterprise? && subject_configuration_manual?,
             data: { action: "admin--subject-configuration#showPatternInput" }
           )
         end
 
         subject_form.group(data: { "admin--subject-configuration-target": "patternInput" }) do |toggleable_group|
           toggleable_group.text_field(
-            name: :subject_pattern,
-            value: subject_pattern,
+            name: :pattern,
             label: I18n.t("types.edit.subject_configuration.pattern.label"),
             caption: I18n.t("types.edit.subject_configuration.pattern.caption"),
             required: true,
-            input_width: :large
+            input_width: :large,
+            validation_message: validation_message_for(:patterns)
           )
         end
 
         subject_form.submit(
           name: :submit,
           label: I18n.t(:button_save),
-          disabled: !EnterpriseToken.active? && !has_pattern?,
           scheme: :primary
         )
       end
 
       private
 
-      def has_pattern?
-        self.class.has_pattern?(model)
+      def subject_configuration_manual?
+        model.subject_configuration == :manual
       end
 
-      def subject_pattern
-        return "" if model.patterns.subject.nil?
+      def enterprise?
+        EnterpriseToken.allows_to?(:work_package_subject_generation)
+      end
 
-        model.patterns.subject.blueprint
+      def validation_message_for(attribute)
+        model.validation_errors.messages_for(attribute).to_sentence.presence
       end
     end
   end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -37,8 +39,8 @@ module TabsHelper
     end
   end
 
-  def selected_tab(tabs)
-    tabs.detect { |t| t[:name] == params[:tab] } || tabs.first
+  def selected_tab(tabs, default_tab = nil)
+    tabs.detect { |t| t[:name] == params[:tab] || t[:name] == default_tab } || tabs.first
   end
 
   def tabs_for_key(key, params = {})

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -40,7 +40,9 @@ module TabsHelper
   end
 
   def selected_tab(tabs, default_tab = nil)
-    tabs.detect { |t| t[:name] == params[:tab] || t[:name] == default_tab } || tabs.first
+    tabs.detect { |t| t[:name] == params[:tab] } ||
+      tabs.detect { |t| t[:name] == default_tab } ||
+      tabs.first
   end
 
   def tabs_for_key(key, params = {})

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -33,19 +35,25 @@ module ::TypesHelper
       {
         name: "settings",
         partial: "types/form/settings",
-        path: edit_type_tab_path(id: @type.id, tab: :settings),
+        path: edit_tab_type_path(id: @type.id, tab: :settings),
         label: "types.edit.settings.tab"
       },
       {
         name: "form_configuration",
         partial: "types/form/form_configuration",
-        path: edit_type_tab_path(id: @type.id, tab: :form_configuration),
+        path: edit_tab_type_path(id: @type.id, tab: :form_configuration),
         label: "types.edit.form_configuration.tab"
+      },
+      {
+        name: "subject_configuration",
+        path: edit_tab_type_path(id: @type.id, tab: :subject_configuration),
+        label: "types.edit.subject_configuration.tab",
+        view_component: WorkPackages::Types::SubjectConfigurationComponent
       },
       {
         name: "projects",
         partial: "types/form/projects",
-        path: edit_type_tab_path(id: @type.id, tab: :projects),
+        path: edit_tab_type_path(id: @type.id, tab: :projects),
         label: "types.edit.projects.tab"
       }
     ]

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -614,8 +614,6 @@ class PermittedParams
           :color_id,
           :default,
           :description,
-          :subject_configuration,
-          :subject_pattern,
           { project_ids: [] }
         ],
         user: %i(

--- a/app/models/types/forms/subject_configuration_form_model.rb
+++ b/app/models/types/forms/subject_configuration_form_model.rb
@@ -28,37 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
-  module Types
-    class SubjectConfigurationComponent < ApplicationComponent
-      include OpPrimer::ComponentHelpers
-      include OpTurbo::Streamable
+module Types
+  module Forms
+    class SubjectConfigurationFormModel
+      extend ActiveModel::Naming
 
-      def form_options
-        form_model = subject_form_object
+      attr_reader :subject_configuration, :pattern, :validation_errors
 
-        {
-          url: subject_configuration_type_path(id: model.id),
-          method: :put,
-          model: form_model,
-          data: {
-            application_target: "dynamic",
-            controller: "admin--subject-configuration",
-            admin__subject_configuration_hide_pattern_input_value: form_model.subject_configuration == :manual
-          }
-        }
-      end
-
-      private
-
-      def subject_form_object
-        subject_pattern = model.patterns.subject || ::Types::Pattern.new(blueprint: "", enabled: false)
-
-        ::Types::Forms::SubjectConfigurationFormModel.new(
-          subject_configuration: subject_pattern.enabled ? :generated : :manual,
-          pattern: subject_pattern.blueprint,
-          validation_errors: model.errors
-        )
+      def initialize(subject_configuration:, pattern:, validation_errors: {})
+        @subject_configuration = subject_configuration
+        @pattern = pattern
+        @validation_errors = validation_errors
       end
     end
   end

--- a/app/models/types/patterns/collection.rb
+++ b/app/models/types/patterns/collection.rb
@@ -58,10 +58,6 @@ module Types
         patterns.select { |_, pattern| pattern.enabled? }
       end
 
-      def update_pattern(name, blueprint:, enabled:)
-        self.class.build(patterns: patterns.to_h.merge(name => { blueprint:, enabled: }))
-      end
-
       def to_h
         patterns.stringify_keys.transform_values(&:to_h)
       end

--- a/app/models/types/patterns/collection_contract.rb
+++ b/app/models/types/patterns/collection_contract.rb
@@ -31,6 +31,8 @@
 module Types
   module Patterns
     class CollectionContract < Dry::Validation::Contract
+      config.messages.backend = :i18n
+
       params do
         optional(:subject).hash do
           required(:blueprint).filled(:string)

--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -52,6 +54,7 @@ class Authorization::EnterpriseService
     virus_scanning
     work_package_query_relation_columns
     work_package_sharing
+    work_package_subject_generation
   ].freeze
 
   def initialize(token)

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -75,13 +75,12 @@ class BaseTypeService
     # (Regression #28400)
     set_attribute_groups(params) if params[:attribute_groups]
 
-    set_subject_pattern(params) if params[:subject_configuration]
-
     # This should go before `set_scalar_params` call to get the
     # project_ids, custom_field_ids diffs from the type and the params.
     # For determining the active custom fields for the type, it is necessary
     # to know whether the type is a milestone or not.
     set_milestone_param(params) unless params[:is_milestone].nil?
+
     set_active_custom_fields
 
     set_active_custom_fields_for_project_ids(params[:project_ids]) if params[:project_ids].present?
@@ -105,12 +104,6 @@ class BaseTypeService
     else
       type.attribute_groups = parse_attribute_groups_params(params)
     end
-  end
-
-  def set_subject_pattern(params)
-    type.patterns = type.patterns.update_pattern(:subject,
-                                                 blueprint: params[:subject_pattern],
-                                                 enabled: params[:subject_configuration] == "auto").value!
   end
 
   def parse_attribute_groups_params(params)

--- a/app/services/update_type_service.rb
+++ b/app/services/update_type_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -34,5 +36,25 @@ class UpdateTypeService < BaseTypeService
     end
 
     super(params, {})
+  end
+
+  private
+
+  def set_params_and_validate(params)
+    # Set patterns includes a data validation before assigning the value to the attribute.
+    # A failure should return a failure.
+    set_patterns(params) if params[:patterns].present?
+    return [false, type.errors] if type.errors.any?
+
+    super
+  end
+
+  def set_patterns(params)
+    Types::Patterns::Collection
+      .build(patterns: params[:patterns])
+      .either(
+        ->(collection) { type.patterns = collection },
+        ->(result) { type.errors.add(:patterns, result.errors(full: true).messages.join(", ")) }
+      )
   end
 end

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -140,7 +140,7 @@ See COPYRIGHT and LICENSE files for more details.
                     <%= t(:label_x_projects, count: custom_field.projects.count) %></td>
                   <% end %>
                 <td>
-                  <% type_links = custom_field.types.map { |t| link_to(t.name, edit_type_tab_path(id: t.id, tab: 'form_configuration')) } %>
+                  <% type_links = custom_field.types.map { |t| link_to(t.name, edit_tab_type_path(id: t.id, tab: "form_configuration")) } %>
                   <% if type_links.empty? %>
                     <span class="icon-context icon-warning">
                       <%= link_to t(:label_custom_field_add_no_type), types_path %>

--- a/app/views/projects/settings/custom_fields/_form.html.erb
+++ b/app/views/projects/settings/custom_fields/_form.html.erb
@@ -96,7 +96,7 @@ See COPYRIGHT and LICENSE files for more details.
               </td>
               <td>
                 <% if current_user.admin? %>
-                  <% type_links = custom_field.types.map { |t| link_to(t.name, edit_type_tab_path(id: t.id, tab: 'form_configuration')) } %>
+                  <% type_links = custom_field.types.map { |t| link_to(t.name, edit_tab_type_path(id: t.id, tab: "form_configuration")) } %>
                   <%= safe_join type_links, ', '.html_safe %>
                 <% else %>
                   <%= custom_field.types.map(&:name).join(', ') %>

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -34,13 +34,13 @@ See COPYRIGHT and LICENSE files for more details.
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: tabs) %>
 
 <%=
-  selected_tab = selected_tab(tabs)
+  selected_tab = selected_tab(tabs, @default_tab)
 
   if selected_tab.key?(:view_component)
     render selected_tab[:view_component].new(@type)
   else
     form_for @type,
-             url: update_type_tab_path(id: @type.id, tab: @tab),
+             url: update_tab_type_path(id: @type.id, tab: @tab),
              builder: TabularFormBuilder,
              lang: current_language do |f|
       render partial: "common/tabs", locals: { f:, tabs:, selected_tab:, with_tab_nav: false }
@@ -48,4 +48,5 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<%= error_messages_for 'type' %>
+<!-- Remove those once all tab contents are using view components -->
+<%= error_messages_for "type" %>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -121,7 +121,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% for type in @types %>
             <tr>
               <td class="timelines-pet-name">
-                <%= link_to type.name, edit_type_tab_path(type, tab: "settings") %>
+                <%= link_to type.name, edit_tab_type_path(type, tab: "settings") %>
               </td>
               <td>
                 <% if type.workflows.empty? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
       label: "Label"
       short: "Short name"
       parent: "Parent"
+      blueprint: "Pattern blueprint"
 
   global_search:
     placeholder: "Search in %{app_title}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -129,13 +131,18 @@ Rails.application.routes.draw do
 
   get "/roles/workflow/:id/:role_id/:type_id" => "roles#workflow"
 
-  get "/types/:id/edit/:tab" => "types#edit",
-      as: "edit_type_tab"
-  match "/types/:id/update/:tab" => "types#update",
-        as: "update_type_tab",
-        via: %i[post patch]
   resources :types do
-    post "move/:id", action: "move", on: :collection
+    member do
+      get "edit/:tab" => "types#edit", as: "edit_tab"
+      match "update/:tab" => "types#update", as: "update_tab", via: %i[post patch]
+      put :subject_configuration,
+          controller: "work_packages/types/subject_configuration",
+          action: "update_subject_configuration"
+    end
+
+    collection do
+      post "move/:id", action: "move"
+    end
   end
 
   resources :statuses, except: :show

--- a/spec/components/work_packages/types/subject_configuration_component_spec.rb
+++ b/spec/components/work_packages/types/subject_configuration_component_spec.rb
@@ -37,34 +37,22 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
 
   let(:type) { create(:type) }
 
-  before do
-    allow(EnterpriseToken).to receive(:active?).and_return(true)
-  end
+  context "when enterprise edition is activated", with_ee: %i[work_package_subject_generation] do
+    it "shows no enterprise banner" do
+      render_component
 
-  it "shows no enterprise banner" do
-    render_component
-
-    expect(page).not_to have_test_selector("op-ee-banner-automatic-subject-generation")
-  end
-
-  it "enables mode selectors", :aggregate_failures do
-    render_component
-
-    expect(page.find("input[type=radio][value=auto]")).not_to be_disabled
-    expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
-  end
-
-  it "enables the submit button" do
-    render_component
-
-    expect(page.find("button[type=submit]")).not_to be_disabled
-  end
-
-  context "when enterprise edition is not activated" do
-    before do
-      allow(EnterpriseToken).to receive(:active?).and_return(false)
+      expect(page).not_to have_test_selector("op-ee-banner-automatic-subject-generation")
     end
 
+    it "enables mode selectors", :aggregate_failures do
+      render_component
+
+      expect(page.find("input[type=radio][value=generated]")).not_to be_disabled
+      expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
+    end
+  end
+
+  context "when enterprise edition is not activated", with_ee: %i[] do
     it "shows the enterprise banner" do
       render_component
 
@@ -74,14 +62,8 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
     it "disables only automatic mode selector", :aggregate_failures do
       render_component
 
-      expect(page.find("input[type=radio][value=auto]")).to be_disabled
+      expect(page.find("input[type=radio][value=generated]")).to be_disabled
       expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
-    end
-
-    it "disables the submit button" do
-      render_component
-
-      expect(page.find("button[type=submit]")).to be_disabled
     end
 
     context "and when the subject is already automatically generated" do
@@ -96,14 +78,8 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
       it "enables mode selectors", :aggregate_failures do
         render_component
 
-        expect(page.find("input[type=radio][value=auto]")).not_to be_disabled
+        expect(page.find("input[type=radio][value=generated]")).not_to be_disabled
         expect(page.find("input[type=radio][value=manual]")).not_to be_disabled
-      end
-
-      it "enables the submit button" do
-        render_component
-
-        expect(page.find("button[type=submit]")).not_to be_disabled
       end
     end
   end

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -265,7 +267,7 @@ RSpec.describe TypesController do
 
         it do
           expect(response).to(
-            redirect_to(edit_type_tab_path(id: type.id, tab: "settings"))
+            redirect_to(edit_tab_type_path(id: type.id, tab: "settings"))
           )
         end
 
@@ -304,63 +306,12 @@ RSpec.describe TypesController do
 
         it do
           expect(response).to(
-            redirect_to(edit_type_tab_path(id: type.id, tab: :projects))
+            redirect_to(edit_tab_type_path(id: type.id, tab: :projects))
           )
         end
 
         it "has no projects assigned" do
           expect(Type.find_by(name: "My type").projects.count).to eq(0)
-        end
-      end
-
-      describe "when updating the subject pattern" do
-        let(:params) do
-          { "id" => type.id,
-            "type" => { subject_pattern: blueprint, subject_configuration: "auto" },
-            "tab" => "subject_configuration" }
-        end
-        let(:blueprint) { "I choose you {{assignee}}!" }
-
-        before do
-          patch :update, params:
-        end
-
-        it { expect(response).to be_redirect }
-
-        it do
-          expect(response).to(
-            redirect_to(edit_type_tab_path(id: type.id, tab: "subject_configuration"))
-          )
-        end
-
-        it "stores the pattern" do
-          pattern = Type.find(type.id).patterns.subject
-
-          expect(pattern).to be_present
-          expect(pattern).to be_enabled
-          expect(pattern.blueprint).to eq(blueprint)
-        end
-
-        context "and when the subject is configured manually" do
-          let(:params) do
-            { "id" => type.id,
-              "type" => { subject_pattern: blueprint, subject_configuration: "manual" },
-              "tab" => "subject_configuration" }
-          end
-
-          it "disables the pattern" do
-            pattern = Type.find(type.id).patterns.subject
-
-            expect(pattern).to be_present
-            expect(pattern).not_to be_enabled
-          end
-
-          it "stores the previously used blueprint" do
-            pattern = Type.find(type.id).patterns.subject
-
-            expect(pattern).to be_present
-            expect(pattern.blueprint).to eq(blueprint)
-          end
         end
       end
     end

--- a/spec/controllers/work_packages/types/subject_configuration_controller_spec.rb
+++ b/spec/controllers/work_packages/types/subject_configuration_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::Types::SubjectConfigurationController do
+  let(:user) { create(:admin) }
+  let(:wp_type) { create(:type) }
+
+  current_user { user }
+
+  context "when the user is not logged in" do
+    let(:user) { User.anonymous }
+
+    it "responds with forbidden" do
+      put :update_subject_configuration, params: { id: wp_type.id }
+      expect(response.status).to redirect_to signin_url(back_url: subject_configuration_type_url(wp_type))
+    end
+  end
+
+  context "when the user is not an admin" do
+    let(:user) { create(:user) }
+
+    it "responds with forbidden" do
+      put :update_subject_configuration, params: { id: wp_type.id }
+      expect(response).to have_http_status :forbidden
+    end
+  end
+
+  describe "PUT #update_subject_configuration" do
+    before do
+      service_double = instance_double(UpdateTypeService)
+      allow(service_double)
+        .to(receive(:call))
+        .with({ patterns: expected_pattern_data })
+        .and_yield(service_result)
+      allow(UpdateTypeService).to receive(:new).and_return(service_double)
+
+      put :update_subject_configuration,
+          params: {
+            id: wp_type.id,
+            types_forms_subject_configuration_form_model: form_data
+          }
+    end
+
+    context "if form data is invalid" do
+      let(:form_data) { { subject_configuration: "generated", pattern: nil } }
+      let(:expected_pattern_data) { { subject: { blueprint: "", enabled: true } } }
+      let(:service_result) { ServiceResult.failure }
+
+      it "renders the edit template" do
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to render_template "types/edit"
+      end
+    end
+
+    context "if form data is valid" do
+      context "with generated subject configuration" do
+        let(:form_data) { { subject_configuration: "generated", pattern: "Vacation - {{assignee}}" } }
+        let(:expected_pattern_data) { { subject: { blueprint: "Vacation - {{assignee}}", enabled: true } } }
+        let(:service_result) { ServiceResult.success }
+
+        it "redirects to the current tab path" do
+          expect(response).to redirect_to edit_tab_type_path(id: wp_type.id, tab: :subject_configuration)
+        end
+      end
+
+      context "with manual subject configuration, but still persisted blueprint" do
+        let(:form_data) { { subject_configuration: "manual", pattern: "Vacation - {{assignee}}" } }
+        let(:expected_pattern_data) { { subject: { blueprint: "Vacation - {{assignee}}", enabled: false } } }
+        let(:service_result) { ServiceResult.success }
+
+        it "redirects to the current tab path" do
+          expect(response).to redirect_to edit_tab_type_path(id: wp_type.id, tab: :subject_configuration)
+        end
+      end
+
+      context "with manual subject configuration and no blueprint" do
+        let(:form_data) { { subject_configuration: "manual", pattern: nil } }
+        let(:expected_pattern_data) { nil }
+        let(:service_result) { ServiceResult.success }
+
+        it "redirects to the current tab path" do
+          expect(response).to redirect_to edit_tab_type_path(id: wp_type.id, tab: :subject_configuration)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/work_packages/types/subject_configuration_controller_spec.rb
+++ b/spec/controllers/work_packages/types/subject_configuration_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
   context "when the user is not logged in" do
     let(:user) { User.anonymous }
 
-    it "responds with forbidden" do
+    it "requires login" do
       put :update_subject_configuration, params: { id: wp_type.id }
       expect(response.status).to redirect_to signin_url(back_url: subject_configuration_type_url(wp_type))
     end
@@ -73,7 +73,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
 
     context "if form data is invalid" do
       let(:form_data) { { subject_configuration: "generated", pattern: nil } }
-      let(:expected_pattern_data) { { subject: { blueprint: "", enabled: true } } }
+      let(:expected_pattern_data) { { "subject" => { blueprint: "", enabled: true } } }
       let(:service_result) { ServiceResult.failure }
 
       it "renders the edit template" do
@@ -85,7 +85,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
     context "if form data is valid" do
       context "with generated subject configuration" do
         let(:form_data) { { subject_configuration: "generated", pattern: "Vacation - {{assignee}}" } }
-        let(:expected_pattern_data) { { subject: { blueprint: "Vacation - {{assignee}}", enabled: true } } }
+        let(:expected_pattern_data) { { "subject" => { blueprint: "Vacation - {{assignee}}", enabled: true } } }
         let(:service_result) { ServiceResult.success }
 
         it "redirects to the current tab path" do
@@ -95,7 +95,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
 
       context "with manual subject configuration, but still persisted blueprint" do
         let(:form_data) { { subject_configuration: "manual", pattern: "Vacation - {{assignee}}" } }
-        let(:expected_pattern_data) { { subject: { blueprint: "Vacation - {{assignee}}", enabled: false } } }
+        let(:expected_pattern_data) { { "subject" => { blueprint: "Vacation - {{assignee}}", enabled: false } } }
         let(:service_result) { ServiceResult.success }
 
         it "redirects to the current tab path" do
@@ -105,7 +105,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
 
       context "with manual subject configuration and no blueprint" do
         let(:form_data) { { subject_configuration: "manual", pattern: nil } }
-        let(:expected_pattern_data) { nil }
+        let(:expected_pattern_data) { {} }
         let(:service_result) { ServiceResult.success }
 
         it "redirects to the current tab path" do

--- a/spec/features/types/form_configuration_query_spec.rb
+++ b/spec/features/types/form_configuration_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -87,7 +89,7 @@ RSpec.describe "form query configuration", :js do
   describe "with EE token", with_ee: %i[edit_attribute_groups] do
     before do
       login_as(admin)
-      visit edit_type_tab_path(id: type_bug.id, tab: "form_configuration")
+      visit edit_tab_type_path(id: type_bug.id, tab: "form_configuration")
     end
 
     it "can save an empty query group" do
@@ -160,7 +162,7 @@ RSpec.describe "form query configuration", :js do
 
         archived.update_attribute(:active, false)
 
-        visit edit_type_tab_path(id: type_bug.id, tab: "form_configuration")
+        visit edit_tab_type_path(id: type_bug.id, tab: "form_configuration")
         form.edit_query_group("Archived project")
 
         # Expect we now get the valid subset without the invalid project
@@ -283,7 +285,7 @@ RSpec.describe "form query configuration", :js do
         embedded_table.reference_work_package unrelated_task
 
         # Go back to type configuration
-        visit edit_type_tab_path(id: type_bug.id, tab: "form_configuration")
+        visit edit_tab_type_path(id: type_bug.id, tab: "form_configuration")
 
         # Edit query to remove filters
         form.edit_query_group("Subtasks")

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -51,7 +53,7 @@ RSpec.describe "form configuration", :js, :selenium do
 
       before do
         login_as(admin)
-        visit edit_type_tab_path(id: type.id, tab: "form_configuration")
+        visit edit_tab_type_path(id: type.id, tab: "form_configuration")
       end
 
       it "resets the form properly after changes" do
@@ -256,7 +258,7 @@ RSpec.describe "form configuration", :js, :selenium do
         custom_field
 
         login_as(admin)
-        visit edit_type_tab_path(id: type.id, tab: "form_configuration")
+        visit edit_tab_type_path(id: type.id, tab: "form_configuration")
       end
 
       it "shows the field" do
@@ -286,7 +288,7 @@ RSpec.describe "form configuration", :js, :selenium do
         custom_field
 
         login_as(admin)
-        visit edit_type_tab_path(id: type.id, tab: "form_configuration")
+        visit edit_tab_type_path(id: type.id, tab: "form_configuration")
 
         # Should be initially disabled
         form.expect_inactive(cf_identifier)
@@ -370,7 +372,7 @@ RSpec.describe "form configuration", :js, :selenium do
 
     it "must disable adding and renaming groups" do
       login_as(admin)
-      visit edit_type_tab_path(id: type.id, tab: "form_configuration")
+      visit edit_tab_type_path(id: type.id, tab: "form_configuration")
 
       find(".group-edit-handler", text: "DETAILS").click
       dialog.expect_open

--- a/spec/features/types/reset_form_configuration_spec.rb
+++ b/spec/features/types/reset_form_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -49,7 +51,7 @@ RSpec.describe "Reset form configuration",
       custom_field
 
       login_as(admin)
-      visit edit_type_tab_path(id: type.id, tab: "form_configuration")
+      visit edit_tab_type_path(id: type.id, tab: "form_configuration")
     end
 
     it "resets the form properly after changes with CFs (Regression test #27487)" do


### PR DESCRIPTION
# Ticket
[OP#60183](https://community.openproject.org/work_packages/60183)

# What are you trying to accomplish?
- subject configuration form for work package type must react on data contract validation
- allow persistence of pattern blueprint if configuration is set to `manual`

# What approach did you choose and why?
- added data contract validation to service
- use specific controller & action to update form configuration
- introduce form object model
- harmonized route definition
