### PR TITLE
Fix WP creation with required hierarchy CFs

### DIFF
--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -68,6 +68,7 @@ module CustomFields::CustomFieldRendering
   # - initial values for user inputs are not displayed
   # - allow/disallow-non-open version setting is not yet respected in the version selector
   # - rich text editor is not yet supported
+  # - hierarchy should not use a flat list
 
   def single_value_custom_field_input(builder, custom_field)
     form_args = form_arguments(custom_field)
@@ -81,6 +82,8 @@ module CustomFields::CustomFieldRendering
       CustomFields::Inputs::Int.new(builder, **form_args)
     when "float"
       CustomFields::Inputs::Float.new(builder, **form_args)
+    when "hierarchy"
+      CustomFields::Inputs::SingleSelectList.new(builder, **form_args)
     when "list"
       CustomFields::Inputs::SingleSelectList.new(builder, **form_args)
     when "date"
@@ -98,6 +101,8 @@ module CustomFields::CustomFieldRendering
     form_args = form_arguments(custom_field)
 
     case custom_field.field_format
+    when "hierarchy"
+      CustomFields::Inputs::MultiSelectList.new(builder, **form_args)
     when "list"
       CustomFields::Inputs::MultiSelectList.new(builder, **form_args)
     when "user"

--- a/app/forms/custom_fields/inputs/multi_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_select_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -39,11 +41,11 @@ class CustomFields::Inputs::MultiSelectList < CustomFields::Inputs::Base::Autoco
     )
 
     custom_value_form.autocompleter(**input_attributes) do |list|
-      @custom_field.custom_options.each do |custom_option|
+      list_items.each do |item|
         list.option(
-          label: custom_option.value,
-          value: custom_option.id,
-          selected: selected?(custom_option)
+          label: item.fetch(:label),
+          value: item.fetch(:value),
+          selected: item.fetch(:selected)
         )
       end
     end
@@ -53,6 +55,33 @@ class CustomFields::Inputs::MultiSelectList < CustomFields::Inputs::Base::Autoco
 
   def decorated?
     true
+  end
+
+  def list_items
+    case @custom_field.field_format
+    when "hierarchy"
+      hierarchy_items.map do |item|
+        {
+          label: item.ancestry_path,
+          value: item.id,
+          selected: @custom_values.pluck(:value).map(&:to_i).include?(item.id)
+        }
+      end
+    else
+      @custom_field.custom_options.map do |custom_option|
+        {
+          label: custom_option.value,
+          value: custom_option.id,
+          selected: selected?(custom_option)
+        }
+      end
+    end
+  end
+
+  def hierarchy_items
+    CustomFields::Hierarchy::HierarchicalItemService.new
+      .get_descendants(item: @custom_field.hierarchy_root, include_self: false)
+      .value_or([])
   end
 
   def selected?(custom_option)


### PR DESCRIPTION
In some cases, such as creation through the "New Child" button in the relations tab, we were not able to render a selector for the hierarchy custom fields and thus rendering the dialog failed entirely.

We don't yet have a good component for hierarchical custom fields, so as a quick fix we enable the SelectList components to also be usable for hierarchy CFs. We should later introduce proper hierarchical components for them.

# Ticket
https://community.openproject.org/projects/openproject/work_packages/60590

# What are you trying to accomplish?
Making it possible to create WPs from the relations tab, even if they have a required custom field of type hierarchy.

## Screenshots
![image](https://github.com/user-attachments/assets/48288875-e75f-4ee9-bd54-6979c1ceca56)
