### PR TITLE
[#60633] Add start and end times to the API

### DIFF
--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -186,3 +186,8 @@ en:
 
   js:
     text_are_you_sure: "Are you sure?"
+
+  api_v3:
+    errors:
+      validation:
+        start_time_different_date: "Date part of startTime (%{start_time}) must be the same as the spentOn (%{spent_on}) date."

--- a/modules/costs/lib/api/v3/time_entries/schemas/time_entry_schema_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/schemas/time_entry_schema_representer.rb
@@ -50,6 +50,15 @@ module API
           schema :spent_on,
                  type: "Date"
 
+          schema :start_time,
+                 type: "DateTime",
+                 required: -> { TimeEntry.must_track_start_and_end_time? },
+                 writable: -> { TimeEntry.can_track_start_and_end_time? }
+
+          schema :end_time,
+                 type: "DateTime",
+                 writable: false
+
           schema :hours,
                  type: "Duration"
 

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -90,12 +90,12 @@ module API
 
         date_time_property :start_time,
                            exec_context: :decorator,
-                           getter: ->(*) { datetime_formatter.format_datetime(represented.start_timestamp) },
+                           getter: ->(*) { datetime_formatter.format_datetime(represented.start_timestamp, allow_nil: true) },
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         date_time_property :end_time,
                            exec_context: :decorator,
-                           getter: ->(*) { datetime_formatter.format_datetime(represented.end_timestamp) },
+                           getter: ->(*) { datetime_formatter.format_datetime(represented.end_timestamp, allow_nil: true) },
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         date_time_property :created_at

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -88,6 +88,16 @@ module API
                    datetime_formatter.format_duration_from_hours(represented.hours) if represented.hours
                  end
 
+        date_time_property :start_time,
+                           exec_context: :decorator,
+                           getter: ->(*) { represented.start_timestamp },
+                           if: ->(*) { TimeEntry.can_track_start_and_end_time? }
+
+        date_time_property :end_time,
+                           exec_context: :decorator,
+                           getter: ->(*) { represented.end_timestamp },
+                           if: ->(*) { TimeEntry.can_track_start_and_end_time? }
+
         date_time_property :created_at
         date_time_property :updated_at
 

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -90,12 +90,12 @@ module API
 
         date_time_property :start_time,
                            exec_context: :decorator,
-                           getter: ->(*) { represented.start_timestamp },
+                           getter: ->(*) { datetime_formatter.format_datetime(represented.start_timestamp) },
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         date_time_property :end_time,
                            exec_context: :decorator,
-                           getter: ->(*) { represented.end_timestamp },
+                           getter: ->(*) { datetime_formatter.format_datetime(represented.end_timestamp) },
                            if: ->(*) { TimeEntry.can_track_start_and_end_time? }
 
         date_time_property :created_at
@@ -137,6 +137,20 @@ module API
           represented.hours = datetime_formatter.parse_duration_to_hours(value,
                                                                          "hours",
                                                                          allow_nil: true)
+        end
+
+        def start_time=(value) # rubocop:disable Metrics/AbcSize
+          ts = datetime_formatter.parse_datetime(value, "start_time", allow_nil: true)
+
+          if ts.nil?
+            represented.start_timestamp = nil
+          elsif ts.to_date != represented.spent_on
+            raise API::Errors::Validation.new("start_time",
+                                              I18n.t("api_v3.errors.validation.start_time_different_date",
+                                                     spent_on: represented.spent_on, start_time: ts.to_date))
+          else
+            represented.start_time = ts.strftime("%H:%M")
+          end
         end
 
         self.to_eager_load = [:work_package,

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -144,12 +144,19 @@ module API
 
           if ts.nil?
             represented.start_timestamp = nil
-          elsif ts.to_date != represented.spent_on
+            return
+          end
+
+          if represented.user.present?
+            ts = ts.in_time_zone(represented.user.time_zone)
+          end
+
+          if ts.to_date == represented.spent_on
+            represented.start_time = ts.strftime("%H:%M")
+          else
             raise API::Errors::Validation.new("start_time",
                                               I18n.t("api_v3.errors.validation.start_time_different_date",
                                                      spent_on: represented.spent_on, start_time: ts.to_date))
-          else
-            represented.start_time = ts.strftime("%H:%M")
           end
         end
 

--- a/modules/costs/lib/costs/patches/permitted_params_patch.rb
+++ b/modules/costs/lib/costs/patches/permitted_params_patch.rb
@@ -66,13 +66,17 @@ module Costs::Patches::PermittedParamsPatch
     end
 
     def time_entries
+      additional_fields = []
+
+      additional_fields << :start_time if TimeEntry.can_track_start_and_end_time?
+
       params
         .require(:time_entry)
         .permit(
+          *additional_fields,
           :hours,
           :comments,
           :spent_on,
-          :start_time,
           :work_package_id,
           :activity_id,
           :project_id,

--- a/modules/costs/spec/factories/time_entry_factory.rb
+++ b/modules/costs/spec/factories/time_entry_factory.rb
@@ -38,5 +38,11 @@ FactoryBot.define do
     after(:build) do |time_entry|
       time_entry.project ||= time_entry.work_package.project
     end
+
+    trait :with_start_and_end_time do
+      time_zone { "Asia/Tokyo" }
+      start_time { 390 } # 6:30 AM
+      hours { 2.5 }
+    end
   end
 end

--- a/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
@@ -108,6 +108,53 @@ RSpec.describe API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
       end
     end
 
+    describe "startTime" do
+      let(:path) { "startTime" }
+
+      before do
+        allow(TimeEntry).to receive_messages(
+          can_track_start_and_end_time?: can_track_times,
+          must_track_start_and_end_time?: must_track_times
+        )
+      end
+
+      context "when start- and end-time tracking is disabled" do
+        let(:can_track_times) { false }
+        let(:must_track_times) { false }
+
+        it_behaves_like "has basic schema properties" do
+          let(:type) { "DateTime" }
+          let(:name) { TimeEntry.human_attribute_name("start_time") }
+          let(:required) { false }
+          let(:writable) { false }
+        end
+      end
+
+      context "when start- and end-time tracking is enabled" do
+        let(:can_track_times) { true }
+        let(:must_track_times) { false }
+
+        it_behaves_like "has basic schema properties" do
+          let(:type) { "DateTime" }
+          let(:name) { TimeEntry.human_attribute_name("start_time") }
+          let(:required) { false }
+          let(:writable) { true }
+        end
+      end
+
+      context "when start- and end-time tracking is enforced" do
+        let(:can_track_times) { true }
+        let(:must_track_times) { true }
+
+        it_behaves_like "has basic schema properties" do
+          let(:type) { "DateTime" }
+          let(:name) { TimeEntry.human_attribute_name("start_time") }
+          let(:required) { true }
+          let(:writable) { true }
+        end
+      end
+    end
+
     describe "hours" do
       let(:path) { "hours" }
 

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -174,12 +174,18 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "parsing" do
         end
 
         it "sets start_time" do
+          user.pref[:time_zone] = "Asia/Tokyo"
+
           time_entry = representer.from_hash(hash)
 
-          # timezone will be set by the UpdateAttributeService, so we do it manually here in the test
-          time_entry.time_zone = "Etc/UTC"
+          # timezone on the TimeEntry would be set to the user's TimeZone via the SetAttribute service, so we need to
+          # manually set it here
+          time_entry.time_zone = "Asia/Tokyo"
 
-          expect(time_entry.start_time).to eq((12 * 60) + 30) # 12:30
+          # We are sending in 12:30:00 UTC as the start time, in Tokyo time (for 2017-07-28) that equals
+          # 21:30:00 in Japan Standard Time (JST), so the time should be set to 21:30
+
+          expect(time_entry.start_time).to eq((21 * 60) + 30) # 12:30
 
           expect(time_entry.start_timestamp).to eq(DateTime.parse("2017-07-28T12:30:00Z"))
           expect(time_entry.end_timestamp).to eq(DateTime.parse("2017-07-28T17:30:00Z"))

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -345,11 +345,11 @@ RSpec.describe "API v3 time_entry resource" do
           get api_v3_paths.time_entries
 
           expect(subject.body)
-            .to be_json_eql(time_entry.start_timestamp.to_json)
+            .to be_json_eql(time_entry.start_timestamp.utc.to_json)
             .at_path("_embedded/elements/0/startTime")
 
           expect(subject.body)
-            .to be_json_eql(time_entry.end_timestamp.to_json)
+            .to be_json_eql(time_entry.end_timestamp.utc.to_json)
             .at_path("_embedded/elements/0/endTime")
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60633

# What are you trying to accomplish?

Add the new start_time and end_time fields to the API

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
