### PR TITLE
allow available_project_modules to be sorted

### DIFF
--- a/app/views/admin/settings/new_project_settings/show.html.erb
+++ b/app/views/admin/settings/new_project_settings/show.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="form--field"><%= setting_check_box :default_projects_public %></div>
     <div class="form--field">
       <%= setting_multiselect(:default_projects_modules,
-        OpenProject::AccessControl.available_project_modules.collect {|m| [l_or_humanize(m, prefix: "project_module_"), m.to_s]}) %>
+        OpenProject::AccessControl.available_project_modules(sorted: true).collect {|m| [l_or_humanize(m, prefix: "project_module_"), m.to_s]}) %>
     </div>
     <div class="form--field"><%= setting_select :new_project_user_role_id,
                       Role.givable.collect {|r| [r.name, r.id.to_s]},

--- a/app/views/projects/settings/modules/_form.html.erb
+++ b/app/views/projects/settings/modules/_form.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% sorted_modules = OpenProject::AccessControl.available_project_modules.sort_by { |name| t(:"project_module_#{name}") } %>
+<% sorted_modules = OpenProject::AccessControl.available_project_modules(sorted: true) %>
 <% sorted_modules.each do |name| %>
 
   <div class="form--field">

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -131,11 +131,11 @@ module OpenProject
       end
 
       def available_project_modules(sorted: false)
-        project_modules
-          .reject { |name| disabled_project_modules.include? name }
-          .tap do |modules|
-            modules.sort_by! { |name| I18n.t(:"project_module_#{name}") } if sorted
-          end
+        modules = project_modules - disabled_project_modules
+
+        modules.sort_by! { |name| I18n.t(:"project_module_#{name}") } if sorted
+
+        modules
       end
 
       def disabled_project_modules

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -130,9 +130,12 @@ module OpenProject
         @global_permissions ||= permissions.select(&:global?)
       end
 
-      def available_project_modules
+      def available_project_modules(sorted: false)
         project_modules
           .reject { |name| disabled_project_modules.include? name }
+          .tap do |modules|
+            modules.sort_by! { |name| I18n.t(:"project_module_#{name}") } if sorted
+          end
       end
 
       def disabled_project_modules

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -372,6 +374,20 @@ RSpec.describe OpenProject::AccessControl do
           if_state[:available] = false
           expect(described_class.available_project_modules).not_to include(:dynamic_module)
         end
+      end
+    end
+
+    describe "sorting by label" do
+      before do
+        allow(I18n).to receive(:t, &:to_s)
+      end
+
+      it "is not sorted by default" do
+        expect(described_class.available_project_modules).to eq(%i[project_module mixed_module dependent_module])
+      end
+
+      it "is sorted when requested" do
+        expect(described_class.available_project_modules(sorted: true)).to eq(%i[dependent_module mixed_module project_module])
       end
     end
   end


### PR DESCRIPTION
# What are you trying to accomplish?
* Make order of modules in project new project admin human friendly and same as in Project settings / Modules

## Screenshots
|was|now|
|---|---|
| <img width="433" alt="image" src="https://github.com/user-attachments/assets/c76c7e5c-3efc-4a71-8510-d20da7ba5f44" /> | <img width="433" alt="image" src="https://github.com/user-attachments/assets/b3a1dfa1-bc3e-42e7-8ac0-b11fe15c74f8" /> |

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
