### PR TITLE
Do not focus custom fields in the create child dialog

### DIFF
--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -84,9 +84,7 @@ module CustomFields::CustomFieldRendering
       CustomFields::Inputs::Int.new(builder, **form_args)
     when "float"
       CustomFields::Inputs::Float.new(builder, **form_args)
-    when "hierarchy"
-      CustomFields::Inputs::SingleSelectList.new(builder, **form_args)
-    when "list"
+    when "hierarchy", "list"
       CustomFields::Inputs::SingleSelectList.new(builder, **form_args)
     when "date"
       CustomFields::Inputs::Date.new(builder, **form_args)
@@ -103,9 +101,7 @@ module CustomFields::CustomFieldRendering
     form_args = form_arguments(custom_field)
 
     case custom_field.field_format
-    when "hierarchy"
-      CustomFields::Inputs::MultiSelectList.new(builder, **form_args)
-    when "list"
+    when "hierarchy", "list"
       CustomFields::Inputs::MultiSelectList.new(builder, **form_args)
     when "user"
       CustomFields::Inputs::MultiUserSelectList.new(builder, **form_args)

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -205,8 +205,6 @@ module CustomFieldsHelper
   # Return an array of custom field formats which can be used in select_tag
   def custom_field_formats_for_select(custom_field)
     OpenProject::CustomFieldFormat.all_for_field(custom_field)
-                                  .sort_by(&:order)
-                                  .reject { |format| format.label.nil? }
                                   .map do |custom_field_format|
       [label_for_custom_field_format(custom_field_format.name), custom_field_format.name]
     end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -296,7 +296,7 @@ class CustomField < ApplicationRecord
   end
 
   def multi_value_possible?
-    version? || user? || list? || field_format_hierarchy?
+    OpenProject::CustomFieldFormat.find_by(name: field_format)&.multi_value_possible?
   end
 
   def allow_non_open_versions_possible?

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -50,6 +50,7 @@ OpenProject::CustomFieldFormat.map do |fields|
   fields.register OpenProject::CustomFieldFormat.new("list",
                                                      label: :label_list,
                                                      order: 6,
+                                                     multi_value_possible: true,
                                                      formatter: "CustomValue::ListStrategy")
   fields.register OpenProject::CustomFieldFormat.new("date",
                                                      label: :label_date,
@@ -64,12 +65,14 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      only: %w(WorkPackage TimeEntry Version Project),
                                                      edit_as: "list",
                                                      order: 9,
+                                                     multi_value_possible: true,
                                                      formatter: "CustomValue::UserStrategy")
   fields.register OpenProject::CustomFieldFormat.new("version",
                                                      label: Proc.new { Version.model_name.human },
                                                      only: %w(WorkPackage TimeEntry Version Project),
                                                      edit_as: "list",
                                                      order: 10,
+                                                     multi_value_possible: true,
                                                      formatter: "CustomValue::VersionStrategy")
   # This is an internal formatter used as a fallback in case a value is not found.
   # Setting the label to nil in order to avoid it becoming available for selection as a custom value format.
@@ -82,5 +85,6 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      label: :label_hierarchy,
                                                      only: %w(WorkPackage),
                                                      order: 12,
+                                                     multi_value_possible: true,
                                                      formatter: "CustomValue::HierarchyStrategy")
 end

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -167,6 +167,15 @@ FactoryBot.define do
 
     trait :hierarchy do
       field_format { "hierarchy" }
+      hierarchy_root do
+        service = CustomFields::Hierarchy::HierarchicalItemService.new
+        service.generate_root(instance).value!
+      end
+    end
+
+    trait :multi_hierarchy do
+      hierarchy
+      multi_value
     end
 
     factory :project_custom_field, class: "ProjectCustomField" do

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 require "support/edit_fields/edit_field"
 
 RSpec.describe "Relations children tab", :js, :with_cuprite do
+  include CustomFieldsHelpers
+
   shared_let(:normal_cf) { create(:string_wp_custom_field, is_required: false) }
   shared_let(:required_cf) { create(:string_wp_custom_field, is_required: true) }
   shared_let(:type_milestone) { create(:type_milestone) }
@@ -118,20 +120,13 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
     let!(:user) { create(:admin) }
 
     before do
-      # Introspect FactoryBot to find all traits used to create work package custom fields
-      traits = FactoryBot.factories[:wp_custom_field].defined_traits
-      traits = traits.reject { |t| t.name == "multi_value" }
-      traits = traits.map { |t| t.name.to_sym }
-
-      traits.each do |trait|
-        [true, false].each do |required| # rubocop:disable Performance/CollectionLiteralInLoop
-          cf = create(:wp_custom_field,
-                      trait,
-                      is_required: required)
+      factory_bot_custom_field_traits_for("WorkPackage")
+        .product([true, false])
+        .each do |trait, is_required|
+          cf = create(:wp_custom_field, trait, is_required:)
           project.types.first.custom_fields << cf
           project.work_package_custom_fields << cf
         end
-      end
     end
 
     it "displays a field for each required custom field" do

--- a/spec/lib/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/journal_formatter/custom_field_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
   context "for hierarchy custom field" do
     shared_let(:custom_field) { create(:hierarchy_wp_custom_field) }
     shared_let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
-    shared_let(:root) { service.generate_root(custom_field).value! }
+    shared_let(:root) { custom_field.hierarchy_root }
     shared_let(:luke) { service.insert_item(parent: root, label: "luke", short: "LS").value! }
     shared_let(:mara) { service.insert_item(parent: luke, label: "mara").value! }
 

--- a/spec/migrations/adds_position_cache_to_hierarchy_items_spec.rb
+++ b/spec/migrations/adds_position_cache_to_hierarchy_items_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require Rails.root.join("db/migrate/20250102161733_adds_position_cache_to_hierarchy_items.rb")
 
 RSpec.describe AddsPositionCacheToHierarchyItems, type: :model do
-  let(:custom_field) { create(:hierarchy_wp_custom_field) }
+  let(:custom_field) { create(:hierarchy_wp_custom_field, hierarchy_root: nil) }
   let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
 
   it "backfills the position_cache value on already existing hierarchy items" do

--- a/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
+++ b/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe RenameVisibleToAdminOnlyInCustomFields, type: :model do
     # Roll back the migration so we can migrate up
     before do
       ActiveRecord::Migration.suppress_messages { described_class.new.migrate(:down) }
+      CustomField.reset_column_information
     end
 
     # Silencing migration logs, since we are not interested in that during testing

--- a/spec/models/custom_field/order_statements_spec.rb
+++ b/spec/models/custom_field/order_statements_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CustomField::OrderStatements do
   # integration tests at spec/models/query/results_cf_sorting_integration_spec.rb
   context "when hierarchy" do
     let(:service) { CustomFields::Hierarchy::HierarchicalItemService.new }
-    let(:item) { service.generate_root(custom_field).value! }
+    let(:item) { custom_field.hierarchy_root }
 
     subject(:custom_field) { create(:hierarchy_wp_custom_field) }
 

--- a/spec/support/components/work_packages/create_dialog.rb
+++ b/spec/support/components/work_packages/create_dialog.rb
@@ -64,6 +64,14 @@ module Components
         end
       end
 
+      def expect_subject_field_focused
+        in_dialog do
+          subject_field = page.find_field("Subject")
+          subject_field_id_selector = "##{subject_field[:id]}"
+          expect(page).to have_focus_on(subject_field_id_selector)
+        end
+      end
+
       def set_description(value)
         @description.set_markdown(value)
       end

--- a/spec/support/custom_fields_helpers.rb
+++ b/spec/support/custom_fields_helpers.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomFieldsHelpers
+  def factory_bot_custom_field_traits_for(class_name)
+    OpenProject::CustomFieldFormat
+      .all_for_class_name(class_name)
+      .flat_map do |format|
+        trait_name = trait_name(format.name)
+        [
+          trait_name,
+          format.multi_value_possible? ? "multi_#{trait_name}" : nil
+        ].compact
+      end
+  end
+
+  def trait_name(custom_field_format_name)
+    case custom_field_format_name
+    when "int" then "integer"
+    when "bool" then "boolean"
+    else custom_field_format_name
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

PR #17625
Late review revealed an issue. This PR is a follow-up about it.

# What are you trying to accomplish?

In the create child dialog, displayable from the relations tab of a work package, custom fields using the autocompleter input field are getting the focus by default. This is visible only if the work package type has some specific kind of custom fields like `hierarchy`, `version` or `list`.

This is not correct: the field to focus is the subject field.

Also add a test to ensure that all different kind of custom fields are displayed in the create child dialog and no error is reported.

# What approach did you choose and why?

Pass in `focusDirectly: false` so that the focus is not stolen. This may benefit some other areas of the app.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
