### PR TITLE
Wrapper of autocompleter is a grid box without setting a column

### DIFF
--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -172,3 +172,7 @@ div.autocomplete
 
 .work-package-table--container .ng-dropdown-panel
   z-index: auto !important
+
+
+.FormControl-input-wrap:has(ng-select)
+  grid-template-columns: minmax(0, auto)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60619

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Avoid the selected value of autocompleter from overflowing.

## Screenshots
Before:
https://github.com/user-attachments/assets/3a75d437-9814-492f-bfc4-3be23a715f25

After:
https://github.com/user-attachments/assets/a2f559d5-9630-4e59-9769-67058dd26a45


# What approach did you choose and why?
With our new implementation for form input fields we are wrapping them in a 'FormControl-input-wrap'. It works for all inputs  except autocompleter. We could use 'FormControl-select-wrap' class, but it doesn't work either in ng-select. By setting a minmax(0, auto) on a column, the column will not cause layout issues by expanding beyond the container.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
