### PR TITLE
bug/60568 Remove permission restriction for users to set their own reminders

### DIFF
--- a/app/contracts/reminders/base_contract.rb
+++ b/app/contracts/reminders/base_contract.rb
@@ -79,9 +79,13 @@ module Reminders
     def validate_manage_reminders_permissions
       return if errors.added?(:remindable, :not_found)
 
-      unless user.allowed_in_project?(:manage_own_reminders, model.remindable.project)
+      unless can_manage_reminders?
         errors.add :base, :error_unauthorized
       end
+    end
+
+    def can_manage_reminders?
+      user.logged? && user.allowed_in_project?(:view_work_packages, model.remindable.project)
     end
   end
 end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -232,14 +232,6 @@ Rails.application.reloader.to_prepare do
                      {},
                      permissible_on: :project_query,
                      require: :loggedin
-
-      map.permission :manage_own_reminders,
-                     {
-                       "work_packages/reminders": %i[modal_body create update destroy]
-                     },
-                     permissible_on: :project,
-                     contract_actions: { work_package_reminders: %i[modal_body] },
-                     require: :member
     end
 
     map.project_module :work_package_tracking, order: 90 do |wpt|
@@ -253,10 +245,12 @@ Rails.application.reloader.to_prepare do
                        "work_packages/activities_tab": %i[index update_streams update_sorting update_filter],
                        "work_packages/menus": %i[show],
                        "work_packages/hover_card": %i[show],
-                       work_package_relations_tab: %i[index]
+                       work_package_relations_tab: %i[index],
+                       "work_packages/reminders": %i[modal_body create update destroy]
                      },
                      permissible_on: %i[work_package project],
-                     contract_actions: { work_packages: %i[read] }
+                     contract_actions: { work_packages: %i[read],
+                                         work_package_reminders: %i[modal_body] }
 
       wpt.permission :add_work_packages,
                      {

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -250,7 +250,7 @@ Rails.application.reloader.to_prepare do
                      },
                      permissible_on: %i[work_package project],
                      contract_actions: { work_packages: %i[read],
-                                         work_package_reminders: %i[modal_body] }
+                                         work_package_reminders: %i[manage] }
 
       wpt.permission :add_work_packages,
                      {

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -249,8 +249,7 @@ Rails.application.reloader.to_prepare do
                        "work_packages/reminders": %i[modal_body create update destroy]
                      },
                      permissible_on: %i[work_package project],
-                     contract_actions: { work_packages: %i[read],
-                                         work_package_reminders: %i[manage] }
+                     contract_actions: { work_packages: %i[read] }
 
       wpt.permission :add_work_packages,
                      {

--- a/db/migrate/20250117105334_remove_manage_own_reminders_permission.rb
+++ b/db/migrate/20250117105334_remove_manage_own_reminders_permission.rb
@@ -28,37 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class RemoveIncorrectManageOwnRemindersPermission < ActiveRecord::Migration[7.1]
+class RemoveManageOwnRemindersPermission < ActiveRecord::Migration[7.1]
   def up
-    # Remove manage_own_reminders permission from non member and anonymous roles
-    # Use hardcoded values for `Role::BUILTIN_NON_MEMBER` and `Role::BUILTIN_ANONYMOUS`
-    # to avoid breaking the migration if the values are changed in the future
-    non_member_builtin = 1 # Role::BUILTIN_NON_MEMBER
-    anonymous_builtin = 2 # Role::BUILTIN_ANONYMOUS
     execute <<-SQL.squish
       DELETE FROM role_permissions
-      WHERE role_id IN (
-        SELECT id FROM roles WHERE builtin IN (#{non_member_builtin}, #{anonymous_builtin})
-      )
-      AND permission = 'manage_own_reminders'
-    SQL
-
-    # Remove all reminders created by anonymous user and cascade delete related records
-    execute <<-SQL.squish
-      WITH deleted_reminders AS (
-        DELETE FROM reminders
-        WHERE creator_id IN (
-          SELECT id FROM users WHERE type = 'AnonymousUser'
-        )
-        RETURNING id
-      ),
-      deleted_reminder_notifications AS (
-        DELETE FROM reminder_notifications
-        WHERE reminder_id IN (SELECT id FROM deleted_reminders)
-        RETURNING notification_id
-      )
-      DELETE FROM notifications
-      WHERE id IN (SELECT notification_id FROM deleted_reminder_notifications)
+      WHERE permission = 'manage_own_reminders'
     SQL
   end
 

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -28,13 +28,13 @@
 
 import { Injectable } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { CurrentUser, CurrentUserStore } from './current-user.store';
-import { CurrentUserQuery } from './current-user.query';
-import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
-import { Observable } from 'rxjs';
-import { distinctUntilChanged, map, switchMap, take } from 'rxjs/operators';
 import { ApiV3ListFilter } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
+import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 import { ICapability } from 'core-app/core/state/capabilities/capability.model';
+import { Observable, combineLatest } from 'rxjs';
+import { distinctUntilChanged, map, switchMap, take } from 'rxjs/operators';
+import { CurrentUserQuery } from './current-user.query';
+import { CurrentUser, CurrentUserStore } from './current-user.store';
 
 @Injectable({ providedIn: 'root' })
 export class CurrentUserService {
@@ -61,6 +61,15 @@ export class CurrentUserService {
       ...state,
       ...user,
     }));
+  }
+
+  public isLoggedInAndHasCapabalities$(action:string|string[], projectContext:string|null):Observable<boolean> {
+    return combineLatest([
+      this.hasCapabilities$(action, projectContext),
+      this.isLoggedIn$,
+    ]).pipe(
+      map(([hasCapabilities, isLoggedIn]) => hasCapabilities && isLoggedIn),
+    );
   }
 
   /**

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -65,10 +65,10 @@ export class CurrentUserService {
 
   public isLoggedInAndHasCapabalities$(action:string|string[], projectContext:string|null):Observable<boolean> {
     return combineLatest([
-      this.hasCapabilities$(action, projectContext),
       this.isLoggedIn$,
+      this.hasCapabilities$(action, projectContext),
     ]).pipe(
-      map(([hasCapabilities, isLoggedIn]) => hasCapabilities && isLoggedIn),
+      map(([isLoggedIn, hasCapabilities]) => isLoggedIn && hasCapabilities),
     );
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
@@ -66,7 +66,7 @@ export class WorkPackageSplitViewToolbarComponent implements OnInit {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
     this.displayShareButton$ = this.currentUserService.hasCapabilities$('work_package_shares/index', this.workPackage.project.id);
     this.displayReminderButton$ = this.currentUserService.isLoggedInAndHasCapabalities$(
-      'work_package_reminders/modal_body',
+      'work_package_reminders/manage',
       (this.workPackage.project as ProjectResource).id,
     );
   }

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
@@ -66,7 +66,7 @@ export class WorkPackageSplitViewToolbarComponent implements OnInit {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
     this.displayShareButton$ = this.currentUserService.hasCapabilities$('work_package_shares/index', this.workPackage.project.id);
     this.displayReminderButton$ = this.currentUserService.isLoggedInAndHasCapabalities$(
-      'work_package_reminders/manage',
+      'work_packages/read',
       (this.workPackage.project as ProjectResource).id,
     );
   }

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
@@ -26,15 +26,16 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import {
   HalResourceEditingService,
 } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { ConfigurationService } from 'core-app/core/config/configuration.service';
-import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'wp-details-toolbar',
@@ -47,7 +48,7 @@ export class WorkPackageSplitViewToolbarComponent implements OnInit {
   @Input() displayNotificationsButton:boolean;
 
   public displayShareButton$:false|Observable<boolean> = false;
-  public displayReminderButton$:false|Observable<boolean> = false;
+  public displayReminderButton$:Observable<boolean> = of(false);
 
   public text = {
     button_more: this.I18n.t('js.button_more'),
@@ -64,7 +65,9 @@ export class WorkPackageSplitViewToolbarComponent implements OnInit {
   ngOnInit() {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
     this.displayShareButton$ = this.currentUserService.hasCapabilities$('work_package_shares/index', this.workPackage.project.id);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-    this.displayReminderButton$ = this.currentUserService.hasCapabilities$('work_package_reminders/modal_body', this.workPackage.project.id);
+    this.displayReminderButton$ = this.currentUserService.isLoggedInAndHasCapabalities$(
+      'work_package_reminders/modal_body',
+      (this.workPackage.project as ProjectResource).id,
+    );
   }
 }

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -123,7 +123,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     this.displayTimerButton = Object.prototype.hasOwnProperty.call(wp, 'logTime');
     this.displayShareButton$ = this.currentUserService.hasCapabilities$('work_package_shares/index', (wp.project as ProjectResource).id);
     this.displayReminderButton$ = this.currentUserService.isLoggedInAndHasCapabalities$(
-      'work_package_reminders/modal_body',
+      'work_package_reminders/manage',
       (this.workPackage.project as ProjectResource).id,
     );
 

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -26,9 +26,6 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
-import { StateService } from '@uirouter/core';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -36,16 +33,19 @@ import {
   Injector,
   OnInit,
 } from '@angular/core';
-import { Observable, of } from 'rxjs';
-import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
-import { WorkPackageSingleViewBase } from 'core-app/features/work-packages/routing/wp-view-base/work-package-single-view.base';
-import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
-import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
-import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-view-base/state/wp-single-view.service';
-import { CommentService } from 'core-app/features/work-packages/components/wp-activity/comment-service';
-import { RecentItemsService } from 'core-app/core/recent-items.service';
+import { StateService } from '@uirouter/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { RecentItemsService } from 'core-app/core/recent-items.service';
+import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
+import { CommentService } from 'core-app/features/work-packages/components/wp-activity/comment-service';
+import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-view-base/state/wp-single-view.service';
+import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
+import { WorkPackageSingleViewBase } from 'core-app/features/work-packages/routing/wp-view-base/work-package-single-view.base';
+import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
+import { Observable, of } from 'rxjs';
 
 @Component({
   templateUrl: './wp-full-view.html',
@@ -63,7 +63,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
   // Watcher properties
   public isWatched:boolean;
 
-  public displayReminderButton$:false|Observable<boolean> = false;
+  public displayReminderButton$:Observable<boolean> = of(false);
 
   public displayShareButton$:false|Observable<boolean> = false;
 
@@ -122,7 +122,10 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     this.displayWatchButton = Object.prototype.hasOwnProperty.call(wp, 'unwatch') || Object.prototype.hasOwnProperty.call(wp, 'watch');
     this.displayTimerButton = Object.prototype.hasOwnProperty.call(wp, 'logTime');
     this.displayShareButton$ = this.currentUserService.hasCapabilities$('work_package_shares/index', (wp.project as ProjectResource).id);
-    this.displayReminderButton$ = this.currentUserService.hasCapabilities$('work_package_reminders/modal_body', (wp.project as ProjectResource).id);
+    this.displayReminderButton$ = this.currentUserService.isLoggedInAndHasCapabalities$(
+      'work_package_reminders/modal_body',
+      (this.workPackage.project as ProjectResource).id,
+    );
 
     // watchers
     if (wp.watchers) {

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -123,7 +123,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     this.displayTimerButton = Object.prototype.hasOwnProperty.call(wp, 'logTime');
     this.displayShareButton$ = this.currentUserService.hasCapabilities$('work_package_shares/index', (wp.project as ProjectResource).id);
     this.displayReminderButton$ = this.currentUserService.isLoggedInAndHasCapabalities$(
-      'work_package_reminders/manage',
+      'work_packages/read',
       (this.workPackage.project as ProjectResource).id,
     );
 

--- a/lib/api/v3/reminders/reminders_api.rb
+++ b/lib/api/v3/reminders/reminders_api.rb
@@ -32,7 +32,7 @@ module API
       class RemindersAPI < ::API::OpenProjectAPI
         resource :reminders do
           after_validation do
-            authorize_in_project(:manage_own_reminders, project: @work_package.project)
+            authorize_in_project(:view_work_packages, project: @work_package.project)
           end
 
           get do

--- a/spec/contracts/reminders/base_contract_spec.rb
+++ b/spec/contracts/reminders/base_contract_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reminders::BaseContract do
 
       before do
         mock_permissions_for(user) do |mock|
-          mock.allow_in_project(:manage_own_reminders, project: reminder.remindable.project)
+          mock.allow_in_project(:view_work_packages, project: reminder.remindable.project)
         end
       end
 
@@ -66,6 +66,18 @@ RSpec.describe Reminders::BaseContract do
 
       it_behaves_like "contract is invalid", base: :error_unauthorized
     end
+  end
+
+  describe "anonymous user" do
+    let(:user) { build_stubbed(:anonymous) }
+
+    before do
+      mock_permissions_for(user) do |mock|
+        mock.allow_in_project(:view_work_packages, project: reminder.remindable.project)
+      end
+    end
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
   end
 
   describe "validate creator exists" do

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -383,17 +383,17 @@ RSpec.describe "Work package reminder modal",
     end
   end
 
-  context "with anonymous user with role that can view work packages" do
-    let!(:anonymous_user) do
-      create(:anonymous).tap do
-        ProjectRole.anonymous.add_permission! :view_work_packages
-      end
+  context "with anonymous user with role that can view work packages", with_settings: { login_required: false } do
+    before do
+      ProjectRole.anonymous.add_permission! :view_work_packages
+      project.update!(public: true)
     end
 
-    current_user { anonymous_user }
+    current_user { User.anonymous }
 
     it "does not render the reminder button when visiting the work package page" do
       work_package_page.visit!
+      work_package_page.ensure_loaded
       work_package_page.expect_no_reminder_button
     end
   end

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe "Work package reminder modal",
   let!(:project) { create(:project) }
   let!(:work_package) { create(:work_package, project:) }
   let!(:role_that_allows_managing_own_reminders) do
-    create(:project_role, permissions: %i[view_work_packages manage_own_reminders])
+    create(:project_role, permissions: %i[view_work_packages])
   end
   let!(:role_that_does_not_allow_managing_own_reminders) do
-    create(:project_role, permissions: %i[view_work_packages])
+    create(:project_role, permissions: %i[view_project])
   end
 
   let!(:user_with_permissions) do
@@ -376,6 +376,21 @@ RSpec.describe "Work package reminder modal",
 
   context "without permissions to manage own reminders" do
     current_user { user_without_permissions }
+
+    it "does not render the reminder button when visiting the work package page" do
+      work_package_page.visit!
+      work_package_page.expect_no_reminder_button
+    end
+  end
+
+  context "with anonymous user with role that can view work packages" do
+    let!(:anonymous_user) do
+      create(:anonymous).tap do
+        ProjectRole.anonymous.add_permission! :view_work_packages
+      end
+    end
+
+    current_user { anonymous_user }
 
     it "does not render the reminder button when visiting the work package page" do
       work_package_page.visit!

--- a/spec/requests/api/v3/reminders/reminders_api_spec.rb
+++ b/spec/requests/api/v3/reminders/reminders_api_spec.rb
@@ -31,8 +31,8 @@ require "spec_helper"
 RSpec.describe API::V3::Reminders::RemindersAPI do
   let!(:project) { create(:project) }
 
-  let!(:role_with_permissions) { create(:project_role, permissions: %i[view_work_packages manage_own_reminders]) }
-  let!(:role_without_permissions) { create(:project_role, permissions: %i[view_work_packages]) }
+  let!(:role_with_permissions) { create(:project_role, permissions: %i[view_work_packages]) }
+  let!(:role_without_permissions) { create(:project_role, permissions: %i[view_project]) }
 
   let!(:user_with_permissions) do
     create(:user, member_with_roles: { project => role_with_permissions })
@@ -110,7 +110,7 @@ RSpec.describe API::V3::Reminders::RemindersAPI do
     current_user { other_user_without_permissions }
 
     it "responds with unprocessable entity" do
-      expect(result["errorIdentifier"]).to eq("urn:openproject-org:api:v3:errors:MissingPermission")
+      expect(result["errorIdentifier"]).to eq("urn:openproject-org:api:v3:errors:NotFound")
     end
   end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/60568

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

-  [x] Remove dedicated `manage_own_reminders` project permission and instead rely on `view_work_packages` permission - if a user can see a WP then they can create a reminder on it.
- [x] Ensure Anonymous users are excluded - as anonymous users can view_work_packages in some cases
- [x] Clean up DB of `manage_own_reminders` permission

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
