### PR TITLE
UserTokens::FetchService

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -304,16 +304,16 @@ class User < Principal
     end
   end
 
-  # Return user's authentication provider for display
   def authentication_provider
-    return if identity_url.blank?
+    return nil if identity_url.blank?
 
-    identity_url.split(":", 2).first
+    slug = identity_url.split(":", 2).first
+    AuthProvider.find_by(slug:)
   end
 
   # Return user's authentication provider for display
   def human_authentication_provider
-    authentication_provider&.titleize
+    authentication_provider&.display_name
   end
 
   ##

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -137,7 +137,7 @@ module Users
     end
 
     def provider_name(user)
-      user.authentication_provider&.downcase
+      user.authentication_provider&.slug&.downcase
     end
 
     def register_by_email_activation

--- a/modules/openid_connect/app/services/openid_connect/jwt_parser.rb
+++ b/modules/openid_connect/app/services/openid_connect/jwt_parser.rb
@@ -38,8 +38,9 @@ module OpenIDConnect
       RS512
     ].freeze
 
-    def initialize(verify_audience: true, required_claims: [])
+    def initialize(verify_audience: true, verify_expiration: true, required_claims: [])
       @verify_audience = verify_audience
+      @verify_expiration = verify_expiration
       @required_claims = required_claims
     end
 
@@ -56,6 +57,7 @@ module OpenIDConnect
           true,
           {
             algorithm: alg,
+            verify_expiration: @verify_expiration,
             verify_aud: @verify_audience,
             aud: provider.client_id,
             required_claims: all_required_claims

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/fetch_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/fetch_service.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenIDConnect
+  module UserTokens
+    ##
+    # Provides APIs to obtain access tokens of a given user for use at a third-party
+    # application for which we know the audience name, which is typically the application's
+    # client_id at an identity provider that OpenProject and the application have in common.
+    class FetchService
+      include Dry::Monads[:result]
+
+      def initialize(user:, jwt_parser: JwtParser.new(verify_audience: false, verify_expiration: false))
+        @user = user
+        @provider = user.authentication_provider
+        @jwt_parser = jwt_parser
+      end
+
+      ##
+      # Obtains an access token that can be used to make requests in the user's name at the
+      # remote service identified by the +audience+ parameter.
+      #
+      # The access token will be refreshed before being returned by this method, if it can be
+      # identified as being expired. There is no guarantee that all access tokens will be properly
+      # recognized as expired, so client's still need to make sure to handle rejected access tokens
+      # properly. Also see #refreshed_access_token_for.
+      def access_token_for(audience:)
+        token = token_with_audience(audience)
+        token = token.bind do |t|
+          if expired?(t.access_token)
+            refresh(t)
+          else
+            Success(t)
+          end
+        end
+
+        token.fmap(&:access_token)
+      end
+
+      ##
+      # Obtains an access token that can be used to make requests in the user's name at the
+      # remote service identified by the +audience+ parameter.
+      #
+      # The access token will always be refreshed before being returned by this method.
+      # It is advised to use this method, after learning that a remote service rejected
+      # an access token, because it was expired.
+      def refreshed_access_token_for(audience:)
+        token_with_audience(audience)
+          .bind { |t| refresh(t) }
+          .fmap(&:access_token)
+      end
+
+      private
+
+      def token_with_audience(aud)
+        token = @user.oidc_user_tokens.where("audiences ? :aud", aud:).first
+        token ? Success(token) : Failure("No token for given audience")
+      end
+
+      def refresh(token)
+        return Failure("Can't refresh the access token") if token.refresh_token.blank?
+
+        refresh_token_request(token.refresh_token).bind do |json|
+          access_token = json["access_token"]
+          refresh_token = json["refresh_token"]
+          break Failure("Refresh token response invalid") if access_token.blank?
+
+          token.update!(access_token:, refresh_token:)
+
+          Success(token)
+        end
+      end
+
+      def refresh_token_request(refresh_token)
+        response = OpenProject.httpx
+                              .basic_auth(@provider.client_id, @provider.client_secret)
+                              .post(@provider.token_endpoint, form: {
+                                      grant_type: :refresh_token,
+                                      refresh_token:
+                                    })
+        response.raise_for_status
+
+        Success(response.json)
+      rescue HTTPX::Error => e
+        Failure(e)
+      end
+
+      def expired?(token_string)
+        exp = @jwt_parser.parse(token_string).fmap { |decoded, _| decoded["exp"] }.value_or(nil)
+        return false if exp.nil?
+
+        exp <= Time.now.to_i
+      end
+    end
+  end
+end

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/fetch_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/fetch_service_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "spec_helper"
+
+RSpec.describe OpenIDConnect::UserTokens::FetchService, :webmock do
+  let(:service) { described_class.new(user:, jwt_parser:) }
+  let(:user) { create(:user, identity_url: "#{provider.slug}:1337") }
+  let(:provider) { create(:oidc_provider) }
+  let(:jwt_parser) { instance_double(OpenIDConnect::JwtParser, parse: Success([parsed_jwt, nil])) }
+  let(:parsed_jwt) { { "exp" => Time.now.to_i + 60 } }
+
+  let(:access_token) { "the-access-token" }
+  let(:refresh_token) { "the-refresh-token" }
+
+  let(:existing_audience) { "existing-audience" }
+  let(:queried_audience) { existing_audience }
+
+  let(:refresh_response) do
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: { access_token: "#{access_token}-refreshed", refresh_token: "#{refresh_token}-refreshed" }.to_json
+    }
+  end
+
+  before do
+    user.oidc_user_tokens.create!(access_token:, refresh_token:, audiences: [existing_audience])
+    stub_request(:post, provider.token_endpoint).to_return(**refresh_response)
+  end
+
+  shared_examples_for "returns a refreshed access token" do
+    it { is_expected.to be_success }
+
+    it "returns a refreshed access token" do
+      expect(result.value!).to eq("the-access-token-refreshed")
+    end
+
+    it "updates the stored access token" do
+      expect { subject }.to change { user.oidc_user_tokens.first.access_token }.to("the-access-token-refreshed")
+    end
+
+    it "updates the stored refresh token" do
+      expect { subject }.to change { user.oidc_user_tokens.first.refresh_token }.to("the-refresh-token-refreshed")
+    end
+
+    context "when the refresh response is unexpected JSON" do
+      let(:refresh_response) do
+        {
+          status: 200, # misbehaving server responds with wrong JSON for success status
+          headers: { "Content-Type": "application/json" },
+          body: { error: "I can't let you do that Dave!" }.to_json
+        }
+      end
+
+      it { is_expected.to be_failure }
+    end
+
+    context "when the refresh response has unexpected status" do
+      let(:refresh_response) do
+        {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+          body: "<html><body>502 Bad Gateway</body></html>"
+        }
+      end
+
+      it { is_expected.to be_failure }
+    end
+  end
+
+  describe "#access_token_for" do
+    subject(:result) { service.access_token_for(audience: queried_audience) }
+
+    it { is_expected.to be_success }
+
+    it "returns the stored access token" do
+      expect(result.value!).to eq(access_token)
+    end
+
+    context "when the token can't be parsed as JWT" do
+      let(:jwt_parser) { instance_double(OpenIDConnect::JwtParser, parse: Failure("Not a valid JWT")) }
+
+      it { is_expected.to be_success }
+
+      it "returns the stored access token" do
+        expect(result.value!).to eq(access_token)
+      end
+    end
+
+    context "when the token is expired" do
+      let(:parsed_jwt) { { "exp" => Time.now.to_i } }
+
+      it_behaves_like "returns a refreshed access token"
+
+      context "and there is no refresh token" do
+        let(:refresh_token) { nil }
+
+        it { is_expected.to be_failure }
+
+        it "does not try to perform a token refresh" do
+          subject
+          expect(WebMock).not_to have_requested(:post, provider.token_endpoint)
+        end
+      end
+    end
+
+    context "when audience can't be found" do
+      let(:queried_audience) { "wrong-audience" }
+
+      it { is_expected.to be_failure }
+    end
+  end
+
+  describe "#refreshed_access_token_for" do
+    subject(:result) { service.refreshed_access_token_for(audience: queried_audience) }
+
+    it_behaves_like "returns a refreshed access token"
+
+    context "when audience can't be found" do
+      let(:queried_audience) { "wrong-audience" }
+
+      it { is_expected.to be_failure }
+    end
+
+    context "and there is no refresh token" do
+      let(:refresh_token) { nil }
+
+      it { is_expected.to be_failure }
+
+      it "does not try to perform a token refresh" do
+        subject
+        expect(WebMock).not_to have_requested(:post, provider.token_endpoint)
+      end
+    end
+  end
+end

--- a/spec/features/auth/lost_password_spec.rb
+++ b/spec/features/auth/lost_password_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe "Lost password" do
   end
 
   context "when user has identity_url" do
+    let!(:provider) { create(:saml_provider, slug: "saml", display_name: "The SAML provider") }
     let!(:user) { create(:user, identity_url: "saml:foobar") }
 
     it "sends an email with external auth info" do
@@ -105,7 +106,7 @@ RSpec.describe "Lost password" do
       expect(ActionMailer::Base.deliveries.size).to be 1
       mail = ActionMailer::Base.deliveries.first
       expect(mail.subject).to eq I18n.t("mail_password_change_not_possible.title")
-      expect(mail.body.parts.first.body.to_s).to include "Saml"
+      expect(mail.body.parts.first.body.to_s).to include "(The SAML provider)"
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -365,17 +365,44 @@ RSpec.describe User do
   end
 
   describe "#authentication_provider" do
+    let!(:provider) { create(:oidc_provider, slug: "test_provider") }
+
     before do
       user.identity_url = "test_provider:veryuniqueid"
       user.save!
     end
 
-    it "returns the internal provider slug" do
-      expect(user.authentication_provider).to eql("test_provider")
+    it "returns the provider" do
+      expect(user.authentication_provider).to eql(provider)
     end
 
-    it "creates a human readable name" do
-      expect(user.human_authentication_provider).to eql("Test Provider")
+    context "when no matching provider exists" do
+      let!(:provider) { nil }
+
+      it "returns nil" do
+        expect(user.authentication_provider).to be_nil
+      end
+    end
+  end
+
+  describe "#human_authentication_provider" do
+    let!(:provider) { create(:oidc_provider, slug: "test_provider", display_name: "Karl") }
+
+    before do
+      user.identity_url = "test_provider:veryuniqueid"
+      user.save!
+    end
+
+    it "returns a human readable name" do
+      expect(user.human_authentication_provider).to eql("Karl")
+    end
+
+    context "when no matching provider exists" do
+      let!(:provider) { nil }
+
+      it "returns nil" do
+        expect(user.authentication_provider).to be_nil
+      end
     end
   end
 

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "users/edit" do
       build(:user, id: 1, # id is required to create route to edit
                    identity_url: "test_provider:veryuniqueid")
     end
+    let!(:provider) { create(:oidc_provider, slug: "test_provider", display_name: "The Test Provider") }
 
     before do
       assign(:user, user)
@@ -56,7 +57,7 @@ RSpec.describe "users/edit" do
     it "shows the authentication provider" do
       render
 
-      expect(rendered).to include("Test Provider")
+      expect(rendered).to include("The Test Provider")
     end
 
     it "does not show a no-login warning when password login is disabled" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/60637

# What are you trying to accomplish?
Providing a way to make `OpenIDConnect::UserToken` practically usable for authentication.

When you want to use such a token during authentication, you need to find the correct token for your target service and you also want to be able to ensure that it has been refreshed, if necessary.

This service is also intended to later be able to perform Token Exchange, which will be used to obtain an entirely new token, if none is yet available.

# What approach did you choose and why?
Providing a single service class that can be used to obtain an access token. For most practical use-cases the `access_token_for` method will be enough, because we will be able to parse an expiration date from the token.

However, if a client notices that the access token is rejected, they still might need to refresh it manually, before being able to make a successful call. For that case they can force refreshing the token via `refreshed_access_token_for`.

# Merge checklist

- [x] Added/updated tests
