### PR TITLE
[#60518] validate enterprise action in backend 

### DIFF
--- a/app/controllers/work_packages/types/subject_configuration_controller.rb
+++ b/app/controllers/work_packages/types/subject_configuration_controller.rb
@@ -63,7 +63,7 @@ module WorkPackages
       def tab_path = edit_tab_type_path(id: @type.id, tab: :subject_configuration)
 
       def pattern_collection_update(form_params)
-        patterns = @type.patterns.to_h
+        patterns = @type.patterns.to_h.symbolize_keys
 
         subject_pattern =
           case form_params
@@ -82,10 +82,10 @@ module WorkPackages
           end
 
         if subject_pattern.nil?
-          patterns.delete("subject")
+          patterns.delete(:subject)
           patterns
         else
-          patterns.merge(subject_pattern.stringify_keys)
+          patterns.merge(subject_pattern)
         end
       end
     end

--- a/spec/controllers/work_packages/types/subject_configuration_controller_spec.rb
+++ b/spec/controllers/work_packages/types/subject_configuration_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
 
     context "if form data is invalid" do
       let(:form_data) { { subject_configuration: "generated", pattern: nil } }
-      let(:expected_pattern_data) { { "subject" => { blueprint: "", enabled: true } } }
+      let(:expected_pattern_data) { { subject: { blueprint: "", enabled: true } } }
       let(:service_result) { ServiceResult.failure }
 
       it "renders the edit template" do
@@ -85,7 +85,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
     context "if form data is valid" do
       context "with generated subject configuration" do
         let(:form_data) { { subject_configuration: "generated", pattern: "Vacation - {{assignee}}" } }
-        let(:expected_pattern_data) { { "subject" => { blueprint: "Vacation - {{assignee}}", enabled: true } } }
+        let(:expected_pattern_data) { { subject: { blueprint: "Vacation - {{assignee}}", enabled: true } } }
         let(:service_result) { ServiceResult.success }
 
         it "redirects to the current tab path" do
@@ -95,7 +95,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationController do
 
       context "with manual subject configuration, but still persisted blueprint" do
         let(:form_data) { { subject_configuration: "manual", pattern: "Vacation - {{assignee}}" } }
-        let(:expected_pattern_data) { { "subject" => { blueprint: "Vacation - {{assignee}}", enabled: false } } }
+        let(:expected_pattern_data) { { subject: { blueprint: "Vacation - {{assignee}}", enabled: false } } }
         let(:service_result) { ServiceResult.success }
 
         it "redirects to the current tab path" do


### PR DESCRIPTION
# Ticket
[OP#60519](https://community.openproject.org/work_packages/60518)

# What are you trying to accomplish?
- if UI is tricked, update of subject generation must still be controlled by enterprise guard

# What approach did you choose and why?
- validate pattern update against enterprise action before parsing it
