### PR TITLE
[60619] Add relation dialog is overflowing when the ticket name is rather long

### DIFF
--- a/app/components/work_package_relations_tab/index_component.sass
+++ b/app/components/work_package_relations_tab/index_component.sass
@@ -4,3 +4,9 @@
 #new-child-action-menu-list
   max-height: 450px
   max-width: 280px
+
+#work-package-child-form
+#work-package-relation-form
+  .form-autocompleter-container
+    overflow: hidden
+    margin-bottom: 0.25rem

--- a/app/components/work_package_relations_tab/index_component.sass
+++ b/app/components/work_package_relations_tab/index_component.sass
@@ -4,9 +4,3 @@
 #new-child-action-menu-list
   max-height: 450px
   max-width: 280px
-
-#work-package-child-form
-#work-package-relation-form
-  .form-autocompleter-container
-    overflow: hidden
-    margin-bottom: 0.25rem

--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -967,3 +967,6 @@ input[type=date], input[type=time]
     display: inline-block
     width: 100%
     overflow: auto
+
+.form-autocompleter-container
+  overflow: hidden

--- a/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
+++ b/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
@@ -10,5 +10,6 @@
       &:before
         @include icon-font-common
         padding-left: 10px
+    // Reduce width of search icon from width of ng-container value which is calc(100% - 30px)
     .ng-value-container
       width: calc(100% - 60px)

--- a/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
+++ b/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
@@ -10,3 +10,5 @@
       &:before
         @include icon-font-common
         padding-left: 10px
+    .ng-value-container
+      width: calc(100% - 60px)

--- a/lib/primer/open_project/forms/autocompleter.html.erb
+++ b/lib/primer/open_project/forms/autocompleter.html.erb
@@ -1,6 +1,6 @@
 <%= render(FormControl.new(input: @input, data: @wrapper_data_attributes)) do %>
   <%= content_tag(:div, **@field_wrap_arguments) do %>
-    <%= content_tag(:div, class: ("projects-autocomplete-with-search-icon" if @with_search_icon)) do %>
+    <%= content_tag(:div, class: ["form-autocompleter-container", ("projects-autocomplete-with-search-icon" if @with_search_icon)]) do %>
       <%= angular_component_tag(@autocomplete_component,
                                 data: @autocomplete_data,
                                 inputs: @autocomplete_inputs) %>

--- a/modules/meeting/app/forms/meeting/project_autocompleter.rb
+++ b/modules/meeting/app/forms/meeting/project_autocompleter.rb
@@ -43,6 +43,7 @@ class Meeting::ProjectAutocompleter < ApplicationForm
         dropdownPosition: "bottom",
         inputName: "project_id",
         inputValue: @project&.id,
+        appendTo: "#new-meeting-dialog",
         filters: [{ name: "user_action", operator: "=", values: ["meetings/create"] }]
       }
     )


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60619

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Avoid the selected value of autocompleter from overflowing.

## Screenshots
Before: 
https://github.com/user-attachments/assets/7b5b7554-9782-4229-ab83-092fbebc25d1

After:
https://github.com/user-attachments/assets/f80093b9-bfb3-4f98-ad07-d685190f717f


# What approach did you choose and why?
Hide overflow text for the parent element of autocompleter.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
