### PR TITLE
[#60649] Change op-autocompleter debounce to 250ms

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -466,7 +466,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
       filter(() => !!(this.defaultData || this.getOptionsFn)),
       distinctUntilChanged(),
       tap(() => this.loading$.next(true)),
-      debounceTime(this.debounceTimeMs),
+      debounceTime(this.debounceTimeForCurrentEnvironment),
       switchMap((queryString:string) => {
         if (this.relations && this.url) {
           return this.fetchFromUrl(queryString);
@@ -520,6 +520,10 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
       .pipe(
         map((collection:CollectionResource<T>) => collection.elements),
       );
+  }
+
+  private get debounceTimeForCurrentEnvironment():number {
+    return (window.OpenProject.environment === 'test') ? 0 : this.debounceTimeMs;
   }
 
   writeValue(value:T|T[]|null):void {

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -527,7 +527,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
       this.initialDebounce = false;
       return 0;
     }
-    return 50;
+    return 250;
   }
 
   writeValue(value:T|T[]|null):void {

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -85,43 +85,84 @@ describe('autocompleter', () => {
     });
   });
 
-  it('should load WorkPackages', fakeAsync(() => {
-    tick();
-    fixture.detectChanges();
-    fixture.componentInstance.ngAfterViewInit();
-    tick(1000);
-    fixture.detectChanges();
-    const select = fixture.componentInstance.ngSelectInstance;
-    expect(select.isOpen).toBeFalse();
-    select.open();
-    select.focus();
-    expect(select.isOpen).toBeTrue();
+  describe('without debounce', () => {
+    it('should load items', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      fixture.componentInstance.ngAfterViewInit();
+      tick(1000);
+      fixture.detectChanges();
+      const select = fixture.componentInstance.ngSelectInstance;
+      expect(select.isOpen).toBeFalse();
+      select.open();
+      select.focus();
+      expect(select.isOpen).toBeTrue();
 
-    expect(select.itemsList.items.length).toEqual(0);
+      expect(select.itemsList.items.length).toEqual(0);
 
-    const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
-    const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+      const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+      const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
 
-    fixture.detectChanges();
-    tick();
-    expect(getOptionsFnSpy).toHaveBeenCalledWith("");
+      fixture.detectChanges();
+      tick();
+      expect(getOptionsFnSpy).toHaveBeenCalledWith("");
 
-    inputElement.value = "Wor";
-    inputElement.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    tick();
-    expect(getOptionsFnSpy).toHaveBeenCalledWith("Wor");
+      inputElement.value = "Wor";
+      inputElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      tick();
+      expect(getOptionsFnSpy).toHaveBeenCalledWith("Wor");
 
-    fixture.detectChanges();
-    expect(select.itemsList.items.length).toEqual(2);
+      fixture.detectChanges();
+      expect(select.itemsList.items.length).toEqual(2);
 
-    inputElement.value = "package 2";
-    inputElement.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    tick();
-    expect(getOptionsFnSpy).toHaveBeenCalledWith("package 2");
+      inputElement.value = "package 2";
+      inputElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      tick();
+      expect(getOptionsFnSpy).toHaveBeenCalledWith("package 2");
 
-    fixture.detectChanges();
-    expect(select.itemsList.items.length).toEqual(1);
-  }));
+      fixture.detectChanges();
+      expect(select.itemsList.items.length).toEqual(1);
+    }));
+  });
+
+  describe('with debounce', () => {
+    beforeEach(() => {
+      fixture.componentInstance.debounceTimeMs = 50;
+    });
+
+    it('should load items with debounce', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      fixture.componentInstance.ngAfterViewInit();
+      tick(1000);
+      fixture.detectChanges();
+      const select = fixture.componentInstance.ngSelectInstance;
+      expect(select.isOpen).toBeFalse();
+      select.open();
+      select.focus();
+      expect(select.isOpen).toBeTrue();
+
+      expect(select.itemsList.items.length).toEqual(0);
+
+      const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+      const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+
+      fixture.detectChanges();
+      tick();
+      expect(getOptionsFnSpy).not.toHaveBeenCalled();
+      tick(50);
+      expect(getOptionsFnSpy).toHaveBeenCalledWith("");
+      getOptionsFnSpy.calls.reset();
+
+      inputElement.value = "Wor";
+      inputElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      tick();
+      expect(getOptionsFnSpy).not.toHaveBeenCalled();
+      tick(50);
+      expect(getOptionsFnSpy).toHaveBeenCalledWith("Wor");
+    }));
+  });
 });

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -1,16 +1,16 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { States } from 'core-app/core/states/states.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
-import { of } from 'rxjs';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, map } from 'rxjs';
 import { NgSelectModule } from '@ng-select/ng-select';
 
-import { By } from '@angular/platform-browser';
-import { OpAutocompleterService } from './services/op-autocompleter.service';
 import { OpAutocompleterComponent } from './op-autocompleter.component';
+import { By } from '@angular/platform-browser';
 
 describe('autocompleter', () => {
   let fixture:ComponentFixture<OpAutocompleterComponent>;
-  let opAutocompleterServiceSpy:jasmine.SpyObj<OpAutocompleterService>;
+  let getOptionsFnSpy: jasmine.Spy;
   const workPackagesStub = [
     {
       id: 1,
@@ -51,26 +51,20 @@ describe('autocompleter', () => {
   ];
 
   beforeEach(() => {
-    opAutocompleterServiceSpy = jasmine.createSpyObj('OpAutocompleterService', ['loadData']);
-
     TestBed.configureTestingModule({
-      declarations: [
-        OpAutocompleterComponent],
-      providers: [
-        // { provide: OpAutocompleterService, useValue: opAutocompleterServiceSpyFactory }
-      ],
+      declarations: [OpAutocompleterComponent],
+      providers: [States],
       imports: [HttpClientTestingModule, NgSelectModule],
       schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideComponent(
-        OpAutocompleterComponent,
-        { set: { providers: [{ provide: OpAutocompleterService, useValue: opAutocompleterServiceSpy }] } },
-      )
-      .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(OpAutocompleterComponent);
+    getOptionsFnSpy = jasmine.createSpy("getOptionsFn").and.callFake((searchTerm:string) => {
+      return of(workPackagesStub).pipe(
+        map((wps) => wps.filter((wp) => searchTerm !== "" && wp.subject.includes(searchTerm)))
+      )
+    });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     fixture.componentInstance.resource = 'work_packages' as TOpAutocompleterResource;
     fixture.componentInstance.filters = [];
     fixture.componentInstance.searchKey = 'subjectOrId';
@@ -79,11 +73,8 @@ describe('autocompleter', () => {
     fixture.componentInstance.closeOnSelect = true;
     fixture.componentInstance.virtualScroll = true;
     fixture.componentInstance.classes = 'wp-relations-autocomplete';
-    fixture.componentInstance.defaultData = true;
+    fixture.componentInstance.getOptionsFn = getOptionsFnSpy;
     fixture.componentInstance.debounceTimeMs = 0;
-
-    // @ts-ignore
-    opAutocompleterServiceSpy.loadData.and.returnValue(of(workPackagesStub));
   });
 
   it('should load the ng-select correctly', () => {
@@ -101,20 +92,36 @@ describe('autocompleter', () => {
     tick(1000);
     fixture.detectChanges();
     const select = fixture.componentInstance.ngSelectInstance;
-    expect(fixture.componentInstance.ngSelectInstance.isOpen).toBeFalse();
-    fixture.componentInstance.ngSelectInstance.open();
-    fixture.componentInstance.ngSelectInstance.focus();
-    expect(fixture.componentInstance.ngSelectInstance.isOpen).toBeTrue();
-    select.filter('a');
+    expect(select.isOpen).toBeFalse();
+    select.open();
+    select.focus();
+    expect(select.isOpen).toBeTrue();
+
+    expect(select.itemsList.items.length).toEqual(0);
+
+    const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+    const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
 
     fixture.detectChanges();
-    tick(1000);
+    tick();
+    expect(getOptionsFnSpy).toHaveBeenCalledWith("");
+
+    inputElement.value = "Wor";
+    inputElement.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    tick(1000);
+    tick();
+    expect(getOptionsFnSpy).toHaveBeenCalledWith("Wor");
 
-    expect(opAutocompleterServiceSpy.loadData).toHaveBeenCalledWith('a',
-      fixture.componentInstance.resource, fixture.componentInstance.filters, fixture.componentInstance.searchKey);
+    fixture.detectChanges();
+    expect(select.itemsList.items.length).toEqual(2);
 
-    expect(fixture.componentInstance.ngSelectInstance.itemsList.items.length).toEqual(2);
+    inputElement.value = "package 2";
+    inputElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    tick();
+    expect(getOptionsFnSpy).toHaveBeenCalledWith("package 2");
+
+    fixture.detectChanges();
+    expect(select.itemsList.items.length).toEqual(1);
   }));
 });

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -80,6 +80,7 @@ describe('autocompleter', () => {
     fixture.componentInstance.virtualScroll = true;
     fixture.componentInstance.classes = 'wp-relations-autocomplete';
     fixture.componentInstance.defaultData = true;
+    fixture.componentInstance.debounceTimeMs = 0;
 
     // @ts-ignore
     opAutocompleterServiceSpy.loadData.and.returnValue(of(workPackagesStub));

--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -56,7 +56,7 @@ export default class PollForChangesController extends ApplicationController {
     super.connect();
 
     if (this.intervalValue !== 0) {
-      this.interval = setInterval(() => {
+      this.interval = window.setInterval(() => {
         void this.triggerTurboStream();
       }, this.intervalValue || 10_000);
     }


### PR DESCRIPTION
⚠️ **This change affects all subclasses of `OpAutocompleterComponent`, not just the work package relations autocompleter `WorkPackageRelationsAutocompleteComponent`**

# Ticket

https://community.openproject.org/wp/60649

# What are you trying to accomplish?

Change op-autocompleter debounce to 250ms

Increases the debounce to a more typical value (200-300ms) for a complex web application. The current value (50ms)* results in a large number of unnecessary API requests - on installatons with large numbers of work packages, this can lead to severe performance degradation.

* it's worth noting that most users don't even type this fast!

## Screenshots

https://github.com/user-attachments/assets/27c3f664-25e4-477f-8f0c-efafe248ab45


# What approach did you choose and why?

⚠️ **This PR also includes the patch from #17648** - without it, I cannot run the frontend tests locally.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
