### PR TITLE
[#60666] User can't save lifecycle modal if project is invalid

### DIFF
--- a/app/contracts/project_life_cycle_steps/base_contract.rb
+++ b/app/contracts/project_life_cycle_steps/base_contract.rb
@@ -31,9 +31,7 @@ module ProjectLifeCycleSteps
     validate :select_custom_fields_permission
     validate :consecutive_steps_have_increasing_dates
 
-    def valid?(context = :saving_life_cycle_steps)
-      super
-    end
+    def valid?(context = :saving_life_cycle_steps) = super
 
     def select_custom_fields_permission
       return if user.allowed_in_project?(:edit_project_stages_and_gates, model)

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -57,9 +57,7 @@ module Projects
 
     validate :validate_user_allowed_to_manage
 
-    def valid?(context = :saving_custom_fields)
-      super
-    end
+    def valid?(context = :saving_custom_fields) = super
 
     def assignable_parents
       Project

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -57,6 +57,10 @@ module Projects
 
     validate :validate_user_allowed_to_manage
 
+    def valid?(context = :saving_custom_fields)
+      super
+    end
+
     def assignable_parents
       Project
         .allowed_to(user, :add_subprojects)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -100,7 +100,8 @@ class Project < ApplicationRecord
 
   acts_as_favorable
 
-  acts_as_customizable # extended in Projects::CustomFields in order to support sections
+  acts_as_customizable validate_on: :saving_custom_fields
+  # extended in Projects::CustomFields in order to support sections
   # and project-level activation of custom fields
 
   acts_as_searchable columns: %W(#{table_name}.name #{table_name}.identifier #{table_name}.description),

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -110,8 +110,8 @@ class Project < ApplicationRecord
   # Providing a custom context while creating the project, will not execute the callbacks on the
   # `:create` or `:update` contexts, meaning the identifier will not get initialised.
   # In order to initialise the identifier, the `default_validation_context` (`:create`, or `:update`)
-  # should be included when validating via the `:saving_custom_fields`. This way ever create or update
-  # callback will also be executed alongside the `:saving_custom_fields` callbacks.
+  # should be included when validating via the `:saving_custom_fields`. This way every create
+  # or update callback will also be executed alongside the `:saving_custom_fields` callbacks.
   # This problem does not affect the contextless callbacks, they are always executed.
 
   def validation_context

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -122,6 +122,7 @@ class Project < ApplicationRecord
       @validation_context
     end
   end
+
   acts_as_searchable columns: %W(#{table_name}.name #{table_name}.identifier #{table_name}.description),
                      date_column: "#{table_name}.created_at",
                      project_key: "id",

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -49,7 +49,9 @@ module Redmine
              dependent: :delete_all,
              validate: false,
              autosave: true
-          validate :validate_custom_values
+
+          validation_options = options[:validate_on] ? { on: options[:validate_on] } : {}
+          validate :validate_custom_values, **validation_options
           send :include, Redmine::Acts::Customizable::InstanceMethods
 
           before_save :ensure_custom_values_complete

--- a/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
@@ -154,5 +154,24 @@ RSpec.describe "Edit project stages and gates on project overview page", :js, wi
         dialog.expect_closed
       end
     end
+
+    context "when there is an invalid custom field on the project (Regression#60666)" do
+      let(:custom_field) { create(:string_project_custom_field, is_required: true, is_for_all: true) }
+
+      before do
+        project.custom_field_values = { custom_field.id => nil }
+        project.save(validate: false)
+      end
+
+      it "allows saving and closing the dialog without the custom field validation to interfere" do
+        dialog = overview_page.open_edit_dialog_for_life_cycles
+
+        expect_angular_frontend_initialized
+
+        # Saving the dialog is successful
+        dialog.submit
+        dialog.expect_closed
+      end
+    end
   end
 end

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -224,9 +224,9 @@ RSpec.describe Project, "customizable" do
                           bool_custom_field.id => true
                         })
 
-        expect(project).not_to be_valid
+        expect(project).not_to be_valid(:saving_custom_fields)
 
-        expect { project.save! }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { project.save!(context: :saving_custom_fields) }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
       it "validates only custom values of a section if section scope is provided while updating" do
@@ -236,7 +236,7 @@ RSpec.describe Project, "customizable" do
                            required_text_custom_field.id => "bar"
                          })
 
-        expect(project).to be_valid
+        expect(project).to be_valid(:saving_custom_fields)
 
         # after a project is created, a new required custom field is added
         # which gets automatically activated for all projects
@@ -245,20 +245,20 @@ RSpec.describe Project, "customizable" do
                project_custom_field_section: another_section)
 
         # thus, the project is invalid in total
-        expect(project.reload).not_to be_valid
-        expect { project.save! }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(project.reload).not_to be_valid(:saving_custom_fields)
+        expect { project.save!(context: :saving_custom_fields) }.to raise_error(ActiveRecord::RecordInvalid)
 
         # but we still want to allow updating other sections without invalid required custom field values
         # by limiting the validation scope to a section temporarily
         project._limit_custom_fields_validation_to_section_id = section.id
 
-        expect(project).to be_valid
+        expect(project).to be_valid(:saving_custom_fields)
 
-        expect { project.save! }.not_to raise_error
+        expect { project.save!(context: :saving_custom_fields) }.not_to raise_error
 
         # Removing the section scoped limitation should result a validation error again.
         project._limit_custom_fields_validation_to_section_id = nil
-        expect { project.save! }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { project.save!(context: :saving_custom_fields) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Project, "customizable" do
           bool_custom_field.id => true
         }
 
-        project.save!
+        project.save!(context: :saving_custom_fields)
       end
 
       it_behaves_like "implicitly enabled and saved custom values"
@@ -426,7 +426,7 @@ RSpec.describe Project, "customizable" do
       before do
         project.send(:"custom_field_#{text_custom_field.id}=", "foo")
         project.send(:"custom_field_#{bool_custom_field.id}=", true)
-        project.save!
+        project.save!(context: :saving_custom_fields)
       end
 
       it_behaves_like "implicitly enabled and saved custom values"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60666

# What are you trying to accomplish?
Avoid validating the project custom fields when saving the project with a different contract than the `Projects::BaseContract` and its descendants. This decoupling resolves issues where custom field validations blocked the saving of objects associated with a project when they were being saved through the project.

A few example of such cases:
- Saving the life cycle steps happens via the project, but having an invalid custom field will prevent saving them. See https://community.openproject.org/wp/60666 .
- Saving the project settings `Show attachments in the work packages files tab` on the `/projects/<project_id>/settings/project_storages/attachments` page is also fails when there is an invalid custom field on the project. See https://community.openproject.org/wp/55789 .

# What approach did you choose and why?

Since the project custom field validations are happening on the model level, there was no way to avoid them even when using different contracts than `Projects::BaseContract`. Ideally the solution would be to move all the custom field validations to the contract layer of the application, this way we can have more control over where the validation is activated for each entity. Unfortunately that is a massive overhaul, because the `acts_as_customizable` plugin is used across all the application. Additionally, some models using the plugin are not even updated via a service or contract, meaning the model layer validations are mandatory for them.

A more feasible solution is to introduce context based validation on the custom fields. This way we can easily turn on and off custom field validations on the project model when it is being saved.

The custom field validations will remain enabled on all the models using the `acts_as_customizable` plugin. The following declaration `acts_as_customizable validate_on: :saving_custom_fields` will enable custom validation context on a model basis. This means calling the custom field validations are not triggered when calling `valid?` on the model, but they are triggered when calling `valid?(:saving_custom_fields)`.

Since we are saving custom fields only via the `Projects::BaseContract` descendants, we only have to enable the context based validations in this contract. This code will enable it:

```ruby
    def valid?(context = :saving_custom_fields)
      super
    end
```

As a result, the project custom field validations are only triggered when the project is saved via the `Projects::BaseContract` and they are not triggered when using other contracts such as the `Projects::SettingsContract` or the `ProjectLifeCycleSteps::BaseContract`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
