### PR TITLE
Fix TS error in PollForChangesController

### DIFF
--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -56,7 +56,7 @@ export default class PollForChangesController extends ApplicationController {
     super.connect();
 
     if (this.intervalValue !== 0) {
-      this.interval = setInterval(() => {
+      this.interval = window.setInterval(() => {
         void this.triggerTurboStream();
       }, this.intervalValue || 10_000);
     }


### PR DESCRIPTION
ℹ️ This patch is also included in https://github.com/opf/openproject/pull/17646

# Ticket

N/A

# What are you trying to accomplish?

Fixes `Type 'Timer' is not assignable to type 'number' error when running `npm run test:watch`.

node typings for `setInterval()` specify `Timer` as its return type. This patch explicitly calls the browser variant, which returns `number`.

See also https://github.com/TypeStrong/atom-typescript/issues/1053

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
