### PR TITLE
RxJS deprecation fixes

### DIFF
--- a/frontend/src/app/core/loading-indicator/loading-indicator.service.ts
+++ b/frontend/src/app/core/loading-indicator/loading-indicator.service.ts
@@ -38,11 +38,11 @@ export function withLoadingIndicator<T>(indicator:LoadingIndicator, delayStopTim
     indicator.start();
 
     return source$.pipe(
-      tap(
-        () => indicator.delayedStop(delayStopTime),
-        () => indicator.stop(),
-        () => indicator.stop(),
-      ),
+      tap({
+        next: () => indicator.delayedStop(delayStopTime),
+        error: () => indicator.stop(),
+        complete: () => indicator.stop(),
+      }),
     );
   };
 }
@@ -52,11 +52,11 @@ export function withDelayedLoadingIndicator<T>(indicator:() => LoadingIndicator)
     setTimeout(() => indicator().start());
 
     return source$.pipe(
-      tap(
-        () => undefined,
-        () => indicator().stop(),
-        () => indicator().stop(),
-      ),
+      tap({
+        next: () => undefined,
+        error: () => indicator().stop(),
+        complete: () => indicator().stop(),
+      }),
     );
   };
 }

--- a/frontend/src/app/core/state/file-links/file-links.service.ts
+++ b/frontend/src/app/core/state/file-links/file-links.service.ts
@@ -77,7 +77,7 @@ export class FileLinksResourceService extends ResourceStoreService<IFileLink> {
         switchMap((collection) => from(collection._embedded.elements)),
         groupBy(
           (fileLink) => fileLink._links.storage.href,
-          (fileLink) => fileLink,
+          { element: (fileLink) => fileLink },
         ),
         mergeMap((group$) => {
           const seed = { storage: group$.key, fileLinks: [] as IFileLink[] };

--- a/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
@@ -86,15 +86,15 @@ export class IanBellService {
       )
       .pipe(
         map((result) => result.total),
-        tap(
-          (count) => {
+        tap({
+          next: (count) => {
             this.store.update({ totalUnread: count });
           },
-          (error) => {
+          error: (error) => {
             console.error('Failed to load notifications: %O', error);
             this.store.update({ totalUnread: -1 });
           },
-        ),
+        }),
         catchError(() => EMPTY),
       );
   }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -493,10 +493,10 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
         return NEVER;
       }),
-      tap(
-        () => this.loading$.next(false),
-        () => this.loading$.next(false),
-      ),
+      tap({
+        next: () => this.loading$.next(false),
+        error: () => this.loading$.next(false),
+      }),
     );
   }
 

--- a/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.ts
@@ -99,7 +99,7 @@ export class AttributeModelLoaderService {
       .values$()
       .pipe(
         take(1),
-        tap((val) => console.log(`VAL ${val}`), (err) => console.error(`ERR ${err}`)),
+        tap({ next: (val) => console.log(`VAL ${val}`), error: (err) => console.error(`ERR ${err}`) }),
       );
   }
 


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

I came across various RxJS deprecation warnings while working on another bug fix. This PR deals with those potential breaking changes preemptively to make upgrading easier (e.g. the deprecated `groupBy` function overload will be removed in RxJS 8).

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
