### PR TITLE
[#59976] Meeting name is not in a lighter shade on the recurring meeting overview page

### DIFF
--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
@@ -64,8 +64,17 @@ module RecurringMeetings
       I18n.t(:label_recurring_meeting)
     end
 
-    def page_title
-      @meeting.present? ? "#{@meeting.title} (Meeting series)" : I18n.t(:label_recurring_meeting_plural)
+    def page_title(breadcrumb = nil)
+      @meeting.present? ? meeting_series_title(breadcrumb).to_s : I18n.t(:label_recurring_meeting_plural)
+    end
+
+    def meeting_series_title(breadcrumb)
+      concat @meeting.title
+      if breadcrumb
+        concat render(Primer::Beta::Text.new) { " (#{I18n.t(:label_meeting_series)})" }
+      else
+        concat render(Primer::Beta::Text.new(color: :muted)) { " (#{I18n.t(:label_meeting_series)})" }
+      end
     end
 
     def page_description
@@ -76,7 +85,7 @@ module RecurringMeetings
       [parent_element,
        { href: @project.present? ? project_meetings_path(@project.id) : meetings_path,
          text: I18n.t(:label_meeting_plural) },
-       page_title]
+       page_title(true)]
     end
 
     def parent_element


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/59976
