### PR TITLE
Prevent editing subject for new work packages with auto-generated subject

### DIFF
--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -38,6 +38,7 @@ module WorkPackages::Dialogs
       super()
 
       @work_package = work_package
+      @schema = API::V3::WorkPackages::Schema::SpecificWorkPackageSchema.new(work_package:)
       @wrapper_id = wrapper_id
       @contract = WorkPackages::CreateContract.new(work_package, User.current)
     end
@@ -76,7 +77,8 @@ module WorkPackages::Dialogs
         label: WorkPackage.human_attribute_name(:subject),
         required: true,
         autofocus: autofocus_subject?,
-        input_width: :large
+        input_width: :large,
+        disabled: !@schema.writable?(:subject)
       )
 
       f.rich_text_area(
@@ -85,7 +87,8 @@ module WorkPackages::Dialogs
         rich_text_options: {
           resource: work_package,
           showAttachments: false
-        }
+        },
+        disabled: !@schema.writable?(:description)
       )
 
       render_custom_fields(form: f)

--- a/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
@@ -184,6 +184,10 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   }
 
   public activateOnForm(noWarnings = false):Promise<void|EditFieldHandler> {
+    if (!this.isEditable) {
+      return Promise.reject();
+    }
+
     // Activate the field
     this.setActive(true);
 

--- a/spec/components/work_packages/dialogs/create_form_component_spec.rb
+++ b/spec/components/work_packages/dialogs/create_form_component_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::Dialogs::CreateFormComponent, type: :component do
+  subject(:render_component) { render_inline(described_class.new(work_package:, project: work_package.project)) }
+
+  let(:work_package) { create(:work_package) }
+  let(:user) { create(:admin) }
+
+  before do
+    User.current = user
+  end
+
+  it "enables the subject input" do
+    render_component
+    expect(page.find('input[name="work_package[subject]"]')).not_to be_disabled
+  end
+
+  context "when the user has no edit permissions" do
+    let(:user) { User.anonymous }
+
+    it "disables the subject input" do
+      render_component
+      expect(page.find('input[name="work_package[subject]"]')).to be_disabled
+    end
+  end
+
+  context "when the work package subject is generated automatically" do
+    let(:work_package) { create(:work_package, type:) }
+    let(:type) { create(:type, patterns: { subject: { enabled: true, blueprint: "My Subject" } }) }
+
+    it "disables the subject input" do
+      render_component
+      expect(page.find('input[name="work_package[subject]"]')).to be_disabled
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/59910

# What are you trying to accomplish?
Ensure that non-writable fields are also not writable during WP creation.

# What approach did you choose and why?

For the angular-based form, I extended the existing `isEditable` check to also cover the code path that's called from a form that wants to activate all its fields. A field may now reject being activated this way.

For the primer-based form there was no code handling unwritable fields yet, most likely because the covered fields could so far only be writable. To provide a consistent experience, we now rely on `API::V3::WorkPackages::Schema::SpecificWorkPackageSchema` directly there. I find this slightly questionable, because of the `API::V3` namespace of the schema. But on the other hand it seems to make sense, because only this way can we ensure exactly the same limitations that we would impose on any outside API callers.

# Merge checklist

- [ ] Added/updated tests
- [x] Tested Firefox
