### PR TITLE
Translate hint about auto-generated subjects

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -50,7 +50,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
   def mark_templated_subject
     if work_package.type&.replacement_pattern_defined_for?(:subject)
-      work_package.subject = "Templated by #{work_package.type.name}"
+      work_package.subject = I18n.t("work_packages.templated_subject_hint", type: work_package.type.name)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,6 +717,7 @@ en:
         title: "Workflow missing for work package sharing"
         message: "No workflow is configured for the 'Work package editor' role. Without a workflow, the shared with user cannot alter the status of the work package. Workflows can be copied. Select a source type (e.g. 'Task') and source role (e.g. 'Member'). Then select the target types. To start with, you could select all the types as targets. Finally, select the 'Work package editor' role as the target and press 'Copy'. After having thus created the defaults, fine tune the workflows as you do for every other role."
         link_message: "Configure the workflows in the administration."
+    templated_subject_hint: Automatically generated through type %{type}
 
     summary:
       reports:

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1969,16 +1969,16 @@ RSpec.describe WorkPackages::SetAttributesService,
     let(:type) { build_stubbed(:type, patterns: { subject: { blueprint: "{{type}} {{project_name}}", enabled: true } }) }
     let(:work_package) { WorkPackage.new(type:) }
 
-    it "assigns a to be updated value to the field" do
+    it "assigns a placeholder value to the field" do
       instance.call({})
 
-      expect(work_package.subject).to eq("Templated by #{type.name}")
+      expect(work_package.subject).to eq(I18n.t("work_packages.templated_subject_hint", type: type.name))
     end
 
     it "overrides even a passed subject" do
       instance.call(subject: "I will be overwritten")
 
-      expect(work_package.subject).to eq("Templated by #{type.name}")
+      expect(work_package.subject).to eq(I18n.t("work_packages.templated_subject_hint", type: type.name))
     end
 
     context "when the pattern is disabled" do


### PR DESCRIPTION
Previously this hint would have always been shown in english, regardless of the user's selected language. Now it's possible to add a translation for this message.

I also slightly rephrased the message, so that it's more in line with the words we use on the configuration pages. E.g. we didn't use the word "template" there at all.

# What are you trying to accomplish?

Make sure that UI is always presented to the user in a single language.

## Screenshots
![image](https://github.com/user-attachments/assets/e52f72cd-edf6-4293-a4e5-7c86bacdd8d0)


# Merge checklist

- [x] Tested Firefox
