### PR TITLE
Bug/60718 activity field populates automatically

### DIFF
--- a/modules/costs/app/services/time_entries/set_attributes_service.rb
+++ b/modules/costs/app/services/time_entries/set_attributes_service.rb
@@ -58,7 +58,6 @@ module TimeEntries
     def set_default_attributes(*)
       set_default_user
       set_default_hours
-      set_default_activity if model.activity.nil?
     end
 
     def set_logged_by
@@ -70,28 +69,6 @@ module TimeEntries
     def set_default_user
       model.change_by_system do
         model.user ||= user
-      end
-    end
-
-    def set_default_activity
-      return unless TimeEntryActivity.default
-
-      if model.project
-        assign_default_project_activity
-      else
-        assign_default_activity
-      end
-    end
-
-    def assign_default_project_activity
-      if TimeEntryActivity.active_in_project(model.project).exists?(id: TimeEntryActivity.default.id)
-        assign_default_activity
-      end
-    end
-
-    def assign_default_activity
-      model.change_by_system do
-        model.activity = TimeEntryActivity.default
       end
     end
 

--- a/modules/costs/spec/services/time_entries/set_attributes_service_spec.rb
+++ b/modules/costs/spec/services/time_entries/set_attributes_service_spec.rb
@@ -40,14 +40,12 @@ RSpec.describe TimeEntries::SetAttributesService, type: :model do
   let(:hours) { 5.0 }
   let(:comments) { "some comment" }
   let(:contract_instance) do
-    contract = double("contract_instance") # rubocop:disable RSpec/VerifiedDoubles
-    allow(contract)
-      .to receive(:validate)
-      .and_return(contract_valid)
-    allow(contract)
-      .to receive(:errors)
-      .and_return(contract_errors)
-    contract
+    double("contract_instance").tap do |contract| # rubocop:disable RSpec/VerifiedDoubles
+      allow(contract).to receive_messages(
+        validate: contract_valid,
+        errors: contract_errors
+      )
+    end
   end
 
   let(:contract_errors) { double("contract_errors") } # rubocop:disable RSpec/VerifiedDoubles
@@ -101,17 +99,6 @@ RSpec.describe TimeEntries::SetAttributesService, type: :model do
 
     expect(time_entry_instance.changed_by_system["user_id"])
       .to eql [nil, user.id]
-  end
-
-  it "assigns the default TimeEntryActivity" do
-    allow(TimeEntryActivity)
-      .to receive(:default)
-      .and_return(default_activity)
-
-    subject
-
-    expect(time_entry_instance.activity)
-      .to eql default_activity
   end
 
   context "with params" do

--- a/spec/models/changeset_spec.rb
+++ b/spec/models/changeset_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -80,7 +82,7 @@ RSpec.describe Changeset do
   end
 
   describe "stripping commit" do
-    let(:comment) { "This is a looooooooooooooong comment" + (((" " * 80) + "\n") * 5) }
+    let(:comment) { "This is a looooooooooooooong comment#{"#{' ' * 80}\n" * 5}" }
 
     with_virtual_subversion_repository do
       let(:changeset) do
@@ -219,9 +221,11 @@ RSpec.describe Changeset do
         repository.project.save!
       end
 
-      it "refs keywords any with timelog" do
-        allow(Setting).to receive(:commit_ref_keywords).and_return "*"
-        allow(Setting).to receive(:commit_logtime_enabled?).and_return true
+      it "refs keywords any with timelog" do # rubocop:disable RSpec/ExampleLength
+        allow(Setting).to receive_messages(
+          commit_ref_keywords: "*",
+          commit_logtime_enabled?: true
+        )
 
         {
           "2" => 2.0,
@@ -259,7 +263,7 @@ RSpec.describe Changeset do
           expect(time.hours).to eq expected_hours
           expect(time.spent_on).to eq Date.yesterday
 
-          expect(time.activity.is_default).to be true
+          expect(time.activity).to be_nil
           expect(time.comments).to include "r520"
         end
       end
@@ -268,10 +272,12 @@ RSpec.describe Changeset do
         let!(:work_package2) { create(:work_package, project: repository.project, status: open_status) }
 
         it "refs keywords closing with timelog" do
-          allow(Setting).to receive(:commit_fix_status_id).and_return closed_status.id
-          allow(Setting).to receive(:commit_ref_keywords).and_return "*"
-          allow(Setting).to receive(:commit_fix_keywords).and_return "fixes , closes"
-          allow(Setting).to receive(:commit_logtime_enabled?).and_return true
+          allow(Setting).to receive_messages(
+            commit_fix_status_id: closed_status.id,
+            commit_ref_keywords: "*",
+            commit_fix_keywords: "fixes , closes",
+            commit_logtime_enabled?: true
+          )
 
           c = build(:changeset,
                     repository:,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/60718

# What are you trying to accomplish?
The `SetAttributeService` used to set a default activity. As we do not consistently use that and a default feels odd according to UX, we should remove it in that place as well

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
