### PR TITLE
[#59963] Sort order on index page is off when recurring meeting schedule is changed

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -192,7 +192,7 @@ class RecurringMeetingsController < ApplicationController
     end
 
     # Ensure we keep any remaining future meetings that exceed the limit
-    merged + meetings.values.sort_by(&:start_time)
+    (merged + meetings.values).sort_by(&:start_time)
   end
 
   def scheduled_meeting(start_time)


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/59963