### PR TITLE
fix custom version fields in time entries

### DIFF
--- a/app/forms/custom_fields/inputs/base/autocomplete/multi_value_input.rb
+++ b/app/forms/custom_fields/inputs/base/autocomplete/multi_value_input.rb
@@ -40,6 +40,7 @@ class CustomFields::Inputs::Base::Autocomplete::MultiValueInput < CustomFields::
     {
       multiple: true,
       decorated: decorated?,
+      focusDirectly: false,
       append_to:
     }
   end

--- a/app/forms/custom_fields/inputs/multi_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_version_select_list.rb
@@ -30,8 +30,7 @@
 
 class CustomFields::Inputs::MultiVersionSelectList < CustomFields::Inputs::Base::Autocomplete::MultiValueInput
   include AssignableCustomFieldValues
-
-  delegate :assignable_versions, to: :@object
+  include CustomFields::Inputs::VersionSelect
 
   form do |custom_value_form|
     # autocompleter does not set key with blank value if nothing is selected or input is cleared
@@ -44,7 +43,7 @@ class CustomFields::Inputs::MultiVersionSelectList < CustomFields::Inputs::Base:
       value:
     )
 
-    custom_value_form.autocompleter(**input_attributes) do |list|
+    custom_value_form.autocompleter(**version_input_attributes) do |list|
       assignable_custom_field_values(@custom_field).each do |version|
         list.option(
           label: version.name,

--- a/app/forms/custom_fields/inputs/single_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/single_version_select_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,16 +30,15 @@
 
 class CustomFields::Inputs::SingleVersionSelectList < CustomFields::Inputs::Base::Autocomplete::SingleValueInput
   include AssignableCustomFieldValues
-
-  delegate :assignable_versions, to: :@object
+  include CustomFields::Inputs::VersionSelect
 
   form do |custom_value_form|
     # autocompleter does not set key with blank value if nothing is selected or input is cleared
     # in order to let acts_as_customizable handle the clearing of the value, we need to set the value to blank via a hidden field
     # which sends blank if autocompleter is cleared
-    custom_value_form.hidden(**input_attributes.merge(value: ""))
+    custom_value_form.hidden(**input_attributes, value: "")
 
-    custom_value_form.autocompleter(**input_attributes) do |list|
+    custom_value_form.autocompleter(**version_input_attributes) do |list|
       assignable_custom_field_values(@custom_field).each do |version|
         list.option(
           label: version.name, value: version.id,

--- a/app/forms/custom_fields/inputs/version_select.rb
+++ b/app/forms/custom_fields/inputs/version_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,26 +28,37 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class CustomFields::Inputs::Base::Autocomplete::SingleValueInput < CustomFields::Inputs::Base::Input
-  def input_attributes
-    base_input_attributes.merge(
-      autocomplete_options:,
-      wrapper_data_attributes: {
-        "qa-field-name": qa_field_name
-      }
-    )
-  end
+module CustomFields
+  module Inputs
+    module VersionSelect
+      protected
 
-  def autocomplete_options
-    {
-      multiple: false,
-      decorated: decorated?,
-      focusDirectly: false,
-      append_to:
-    }
-  end
+      def version_input_attributes
+        input_attributes.deep_merge(additional_attributes)
+      end
 
-  def decorated?
-    raise NotImplementedError
+      def additional_attributes
+        if @object.blank? || (@object.respond_to?(:project) && @object.project.blank?)
+          {
+            autocomplete_options: {
+              disabled: true,
+              placeholder: I18n.t("custom_fields.placeholder_version_select")
+            }
+          }
+        else
+          {}
+        end
+      end
+
+      def assignable_versions(only_open:)
+        if @object.is_a?(Project)
+          @object.assignable_versions(only_open: only_open)
+        elsif @object.respond_to?(:project) && @object.project.present?
+          @object.project.assignable_versions(only_open: only_open)
+        else
+          Version.none
+        end
+      end
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,7 +49,6 @@ en:
         created: "created"
         commented: "commented"
 
-
   admin:
     plugins:
       no_results_title_text: There are currently no plugins installed.
@@ -275,6 +274,7 @@ en:
     confirm_destroy_option: "Deleting an option will delete all of its occurrences (e.g. in work packages). Are you sure you want to delete it?"
     reorder_alphabetical: "Reorder values alphabetically"
     reorder_confirmation: "Warning: The current order of available values will be lost. Continue?"
+    placeholder_version_select: "Work package or project selection is required first"
     instructions:
       is_required: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new or updating existing resources."
       is_required_for_project: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects."


### PR DESCRIPTION
# Ticket
No bug ticket created, came up during chat with QA

# What are you trying to accomplish?
Currently the custom field for versions only work with projects. This PR fixes this
- Makes all autocompleters for custom field not focus directly, because this also causes the time entry form to scroll to the end automatically
- Checks for available versions using either `@object` or `@object.project`
- When the project is not yet set, it disables the version input with a placeholder (like activity in the time entry)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
