### PR TITLE
use advisory lock in AddWorkPackageNoteService

### DIFF
--- a/app/services/add_work_package_note_service.rb
+++ b/app/services/add_work_package_note_service.rb
@@ -32,6 +32,8 @@
 
 class AddWorkPackageNoteService
   include Contracted
+  include Shared::ServiceContext
+
   attr_accessor :user, :work_package
 
   def initialize(user:, work_package:)
@@ -41,7 +43,7 @@ class AddWorkPackageNoteService
   end
 
   def call(notes, send_notifications: nil)
-    Journal::NotificationConfiguration.with send_notifications do
+    in_context(work_package, send_notifications:) do
       work_package.add_journal(user:, notes:)
 
       success, errors = validate_and_yield(work_package, user) do


### PR DESCRIPTION
https://community.openproject.org/wp/60741

# What are you trying to accomplish?
`Journals::CreateService` is expected to have a lock around it

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
