### PR TITLE
cache vendor/bundle in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,6 +186,16 @@ jobs:
             type=semver,pattern={{version}},value=${{ needs.setup.outputs.version }}
           images: |
             ${{ env.REGISTRY_IMAGE }}
+      - name: Restore vendor/bundle
+        id: restore-vendor-bundle
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            vendor/bundle
+          key: ${{ matrix.platform }}-vendor-bundle-${{ github.ref }}
+      - name: Include vendor/bundle in this build (so we can use it from the cache above)
+        run: |
+          sed -i 's/vendor\/bundle//g' .dockerignore
       - name: Build image
         id: build
         uses: docker/build-push-action@v6
@@ -195,12 +205,26 @@ jobs:
           target: ${{ matrix.target }}
           build-args: |
             BIM_SUPPORT=${{ matrix.bim_support }}
+            BUILDKIT_PROGRESS=plain
           pull: true
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+      - name: Extract vendor/bundle from container
+        run: |
+          docker create --name bundle ${{ steps.build.outputs.imageid }}
+          rm -rf vendor/bundle || true
+          docker cp bundle:/app/vendor/bundle vendor/bundle
+          docker rm bundle
+      - name: Save vendor/bundle
+        id: save-vendor-bundle
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            vendor/bundle
+          key: ${{ steps.restore-vendor-bundle.outputs.cache-primary-key }}
       - name: Test
         # We only test the native container. If that fails the builds for the others
         # will be cancelled as well.

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -58,15 +58,8 @@ COPY vendor ./vendor
 # Add lib in case a plugin tries to load VERSION file under lib
 COPY lib ./lib
 
-RUN \
-  bundle config set --local path 'vendor/bundle' && \
-  bundle config set --local without 'test development' && \
-  bundle install --quiet --no-cache --jobs=8 --retry=3 && \
-  bundle config set deployment 'true' && \
-  cp Gemfile.lock Gemfile.lock.bak && \
-  rm -rf vendor/bundle/ruby/*/cache && \
-  rm -rf vendor/bundle/ruby/*/gems/*/spec && \
-  rm -rf vendor/bundle/ruby/*/gems/*/test
+COPY ./docker/prod/setup/bundle-install.sh ./vendor/bundle* ./vendor/
+RUN bash vendor/bundle-install.sh && rm vendor/bundle-install.sh
 
 COPY . .
 

--- a/docker/prod/setup/bundle-install.sh
+++ b/docker/prod/setup/bundle-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+# temporary 'seed' for working ppc64 cached vendor/bundle
+if [ ! -d vendor/bundle ] && [ -n "$(uname -a | grep ppc64)" ]; then
+  wget https://openproject-public.s3.eu-central-1.amazonaws.com/ruby/bundle/openproject-release-15.2-836aec00b1-vendor-bundle.tar.gz
+  tar -xf openproject-release-15.2-836aec00b1-vendor-bundle.tar.gz
+fi
+
+bundle config set --local path 'vendor/bundle'
+bundle config set --local without 'test development'
+bundle install --jobs=8 --retry=3
+bundle config set deployment 'true'
+cp Gemfile.lock Gemfile.lock.bak
+rm -rf vendor/bundle/ruby/*/cache
+rm -rf vendor/bundle/ruby/*/gems/*/spec
+rm -rf vendor/bundle/ruby/*/gems/*/test


### PR DESCRIPTION
'seed' ppc64 bundle cache with state from release/15.2

Speeds up ppc64 build to run in under 10 minutes and avoid segfaults during native extension installation ... for now.

Since segfaults don't always happen either it's perfectly possible this solves the issue even when we update some gems with native extensions.

The PR adds the following to the docker workflow and build:

1) Restores vendor/bundle from cache (if present)
2) Copies vendor/bundle into container for build if present, if not, seeds pre-built bundle for ppc64, builds from scratch for other arches
3) Builds image
4) Extracts vendor/bundle from image
5) Overrides cache with extracted vendor/bundle

The cache key includes the git ref so is separate for each branch.

This way future builds of, say, `release/15.2`, will use the existing `vendor/bundle` folder and only rebuild gems that need updating.

Tested in two consecutive builds for this branch ([1](https://github.com/opf/openproject/actions/runs/12892281771), [2](https://github.com/opf/openproject/actions/runs/12891637565)).