### PR TITLE
Bug/60732 slow apiv3work packagesavailable relation candidates

### DIFF
--- a/app/models/work_packages/scopes/directly_related.rb
+++ b/app/models/work_packages/scopes/directly_related.rb
@@ -34,8 +34,10 @@ module WorkPackages::Scopes
       def directly_related(work_package, ignored_relation: nil)
         relations_without_ignored = ignored_relation ? Relation.where.not(id: ignored_relation.id) : Relation.all
 
-        where(id: relations_without_ignored.where(from_id: work_package).select(:to_id))
-        .or(where(id: relations_without_ignored.where(to_id: work_package).select(:from_id)))
+        from_id_relations = relations_without_ignored.where(from_id: work_package).select(:to_id)
+        to_id_relations = relations_without_ignored.where(to_id: work_package).select(:from_id)
+
+        where(arel_table[:id].in(Arel::Nodes::UnionAll.new(from_id_relations.arel, to_id_relations.arel)))
       end
     end
   end

--- a/app/models/work_packages/scopes/relatable.rb
+++ b/app/models/work_packages/scopes/relatable.rb
@@ -202,11 +202,11 @@ module WorkPackages::Scopes
         if relation_type == Relation::TYPE_RELATES
           # Bypassing the recursive query in this case as only children and parent needs to be excluded.
           # Using this more complicated statement since
-          # where.not(parent:id: work_package.id)
+          # where.not(parent_id: work_package.id)
           # will lead to
           # "parent_id != 123" which excludes
           # work packages having parent_id NULL.
-          where.not(id: where(id: work_package.parent_id).or(where(parent_id: work_package.id)).select(:id))
+          where.not(id: unscoped.where(id: work_package.parent_id).or(unscoped.where(parent_id: work_package.id)).select(:id))
         else
           sql = <<~SQL.squish
             WITH


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60732

# What are you trying to accomplish?

The SQL query used has two major flaws (among a whole number of additional but minor ones) that are addressed within this PR.

```SQL
SELECT
	"work_packages"."id"
FROM
	"work_packages"
	LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
WHERE
	(
		(
			(
				WORK_PACKAGES.SUBJECT ILIKE '%123%'
				OR PROJECTS.NAME ILIKE '%123%'
				OR WORK_PACKAGES.ID::VARCHAR(20) LIKE '%123%'
			)
		)
		AND ((1 = 1))
	)
	AND "work_packages"."id" NOT IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			(
				"work_packages"."id" IN (
					SELECT
						"relations"."to_id"
					FROM
						"relations"
					WHERE
						"relations"."from_id" = 785351
				)
				OR "work_packages"."id" IN (
					SELECT
						"relations"."from_id"
					FROM
						"relations"
					WHERE
						"relations"."to_id" = 785351
				)
			)
	)
	AND "work_packages"."id" NOT IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			"work_packages"."id" NOT IN (
				SELECT
					"work_packages"."id"
				FROM
					"work_packages"
				WHERE
					(
						"work_packages"."id" IN (
							SELECT
								"relations"."to_id"
							FROM
								"relations"
							WHERE
								"relations"."from_id" = 785351
						)
						OR "work_packages"."id" IN (
							SELECT
								"relations"."from_id"
							FROM
								"relations"
							WHERE
								"relations"."to_id" = 785351
						)
					)
			)
			AND (
				"work_packages"."id" = 785351
				OR "work_packages"."parent_id" = 785351
			)
	)
	AND "work_packages"."id" != 785351
	AND "work_packages"."id" IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
			INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
			INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
			AND "enabled_modules"."name" IN ('work_package_tracking')
			AND "projects"."active" = TRUE
		WHERE
			"projects"."active" = TRUE
	)
ORDER BY
	WORK_PACKAGES.UPDATED_AT DESC,
	WORK_PACKAGES.ID DESC
LIMIT
	10
OFFSET
	0
```

Those are:
* An `or` statement is used within the subquery to check for the ids of relations from and to the considered work package
```SQL
				WHERE
					(
						"work_packages"."id" IN (
							SELECT
								"relations"."to_id"
							FROM
								"relations"
							WHERE
								"relations"."from_id" = 785351
						)
						OR "work_packages"."id" IN (
							SELECT
								"relations"."from_id"
							FROM
								"relations"
							WHERE
								"relations"."to_id" = 785351
						)
					)
```

* That part of the statement is repeated twice. This weirdness only manifests on the SQL used for querying for candidates of the `RELATES` relationship. 


# What approach did you choose and why?

By applying a UNION, the OR can be avoided which leads to a much better performance. Additionally, the duplicate reference of that statement is avoided.  

```SQL
SELECT
	"work_packages"."id"
FROM
	"work_packages"
	LEFT OUTER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
WHERE
	(
		(
			(
				WORK_PACKAGES.SUBJECT ILIKE '%12345%'
				OR PROJECTS.NAME ILIKE '%12345%'
				OR WORK_PACKAGES.ID::VARCHAR(20) LIKE '%12345%'
			)
		)
		AND ((1 = 1))
	)
	AND "work_packages"."id" NOT IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			"work_packages"."id" IN (
				(
					(
						SELECT
							"relations"."to_id"
						FROM
							"relations"
						WHERE
							"relations"."from_id" = 785351
					)
					UNION ALL
					(
						SELECT
							"relations"."from_id"
						FROM
							"relations"
						WHERE
							"relations"."to_id" = 785351
					)
				)
			)
	)
	AND "work_packages"."id" NOT IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			(
				"work_packages"."id" IS NULL
				OR "work_packages"."parent_id" = 785351
			)
	)
	AND "work_packages"."id" != 785351
	AND "work_packages"."id" IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
			INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id"
			INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
			AND "enabled_modules"."name" IN ('work_package_tracking')
			AND "projects"."active" = TRUE
		WHERE
			"projects"."active" = TRUE
	)
ORDER BY
	WORK_PACKAGES.UPDATED_AT DESC,
	WORK_PACKAGES.ID DESC
LIMIT
	10
OFFSET
	0
```

This results in the performance becoming acceptable. There is still room for improvement but since it already improves the performance, it is better to have it in than to wait for an even better solution.
