### PR TITLE
[#60652] Mandatory fields not visible during project creation

### DIFF
--- a/frontend/src/app/features/projects/components/copy-project/copy-project.component.ts
+++ b/frontend/src/app/features/projects/components/copy-project/copy-project.component.ts
@@ -1,3 +1,31 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
 import {
   IDynamicFieldGroupConfig,
   IOPFormlyFieldSettings,
@@ -8,11 +36,11 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { JobStatusModalService } from 'core-app/features/job-status/job-status-modal.service';
 
-
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './copy-project.component.html',
 })
 export class CopyProjectComponent extends UntilDestroyedMixin implements OnInit {
@@ -70,16 +98,16 @@ export class CopyProjectComponent extends UntilDestroyedMixin implements OnInit 
       .map((field) => ({ ...field, hide: this.isHiddenField(field.key) }));
   }
 
-  private isPrimaryAttribute(to?:IOPFormlyTemplateOptions):boolean {
-    if (!to) {
+  private isPrimaryAttribute(templateOptions?:IOPFormlyTemplateOptions):boolean {
+    if (!templateOptions) {
       return false;
     }
 
-    return (to.required
-      && !to.hasDefault
-      && to.payloadValue == null)
-      || to.property === 'name'
-      || to.property === 'parent';
+    const nameOrParent = ['name', 'parent'].includes(templateOptions.property as string);
+    const noPayload = templateOptions.payloadValue == null
+      || (templateOptions.payloadValue as { href?:string|null })?.href == null;
+
+    return (templateOptions.required && !templateOptions.hasDefault && noPayload) || nameOrParent;
   }
 
   private isMeta(property:string|undefined):boolean {

--- a/frontend/src/app/features/projects/components/new-project/new-project.component.ts
+++ b/frontend/src/app/features/projects/components/new-project/new-project.component.ts
@@ -1,6 +1,38 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import { IDynamicFieldGroupConfig, IOPFormlyFieldSettings } from 'core-app/shared/components/dynamic-forms/typings';
+import {
+  IDynamicFieldGroupConfig,
+  IOPFormlyFieldSettings,
+  IOPFormlyTemplateOptions,
+} from 'core-app/shared/components/dynamic-forms/typings';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -20,6 +52,7 @@ export interface ProjectTemplateOption {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './new-project.component.html',
   styleUrls: ['./new-project.component.sass'],
 })
@@ -89,11 +122,8 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     this.resourcePath = this.apiV3Service.projects.path;
     this.fieldGroups = [{
       name: this.text.advancedSettingsLabel,
-      fieldsFilter: (field) => !['name', 'parent'].includes(field.templateOptions?.property as string)
-        && !this.isMeta(field.templateOptions?.property)
-        && !(field.templateOptions?.required
-        && !field.templateOptions.hasDefault
-        && field.templateOptions.payloadValue == null),
+      fieldsFilter: (field) => !this.isMeta(field.templateOptions?.property)
+        && !this.isPrimaryAttribute(field.templateOptions),
     },
     {
       name: this.text.copySettingsLabel,
@@ -138,6 +168,18 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
 
   private isMeta(property:string|undefined):boolean {
     return !!property && (property.startsWith('copy') || property === 'sendNotifications');
+  }
+
+  private isPrimaryAttribute(templateOptions?:IOPFormlyTemplateOptions):boolean {
+    if (!templateOptions) {
+      return false;
+    }
+
+    const nameOrParent = ['name', 'parent'].includes(templateOptions.property as string);
+    const noPayload = templateOptions.payloadValue == null
+      || (templateOptions.payloadValue as { href?:string|null })?.href == null;
+
+    return (templateOptions.required && !templateOptions.hasDefault && noPayload) || nameOrParent;
   }
 
   private setParentAsPayload(parentId:string) {

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -125,16 +127,27 @@ RSpec.describe "Projects", "creation",
                                     project_custom_field_section:)
     end
 
-    it "separates optional and required custom fields for new" do
-      visit new_project_path
+    context "with required custom fields" do
+      let!(:required_user_custom_field) do
+        create(:user_project_custom_field, name: "Required User",
+                                           is_for_all: true,
+                                           is_required: true,
+                                           project_custom_field_section:)
+      end
 
-      expect(page).to have_content "Required Foo"
+      it "separates optional and required custom fields for new" do
+        visit new_project_path
 
-      click_on "Advanced settings"
+        expect(page).to have_content "Required Foo"
+        expect(page).to have_content "Required User"
 
-      within(".op-fieldset") do
-        expect(page).to have_text "Optional Foo"
-        expect(page).to have_no_text "Required Foo"
+        click_on "Advanced settings"
+
+        within(".op-fieldset") do
+          expect(page).to have_text "Optional Foo"
+          expect(page).to have_no_text "Required Foo"
+          expect(page).to have_no_text "Required User"
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60652

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Some required fields do not show up as primary attributes on the project create and copy forms. The issue is present with the select fields.

# What approach did you choose and why?
The reason was a condition that displayed the required field when its value is `null`. However the user select types have a different representation of an empty value which is the `HalLinkSource` object `{href: null, title: null}`. Adding this to the condition displays the required user fields correctly.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
