### PR TITLE
[#60700] Ending series via number of occurrences does not work if the ending condition was originally after a specific date

### DIFF
--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -168,7 +168,7 @@ class RecurringMeeting < ApplicationRecord
   end
 
   def remaining_occurrences
-    if end_date.present?
+    if end_after_specific_date?
       schedule.occurrences_between(Time.current, modified_end_date)
     else
       schedule.remaining_occurrences(Time.current)


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/60700

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
Took me a while to figure out what was going on, but it turns out the condition for `remaining_occurrences` never went to the else side as the `end_date` is set for both types of ending options.

As the `end_date` isn't affected when ending after a number of intervals is chosen, that value never got updated and so the count of scheduled meetings was always capped by the original (earlier) end date, affecting the total count.