### PR TITLE
bug/60719 disable wp comment submitter while the form request is in progress

### DIFF
--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -3,7 +3,7 @@
     flex_layout(my: 2, data: { test_selector: "op-work-package-journal-form" }) do |new_form_container|
       new_form_container.with_row(
         display: button_row_display_value,
-        data: { 
+        data: {
           "work-packages--activities-tab--index-target": "buttonRow"
         }) do
         flex_layout(justify_content: :space_between) do |button_row|
@@ -39,10 +39,10 @@
           id: "work-package-journal-form-element", # required for specs
           model: journal,
           method: :post,
-          data: { 
-            turbo: true, 
-            turbo_stream: true, 
-            "work-packages--activities-tab--index-target": "form", 
+          data: {
+            turbo: true,
+            turbo_stream: true,
+            "work-packages--activities-tab--index-target": "form",
             action: "submit->work-packages--activities-tab--index#onSubmit",
             "test_selector": "op-work-package-journal-form-element"
           },
@@ -61,7 +61,10 @@
                 icon: :"paper-airplane",
                 "aria-label": t("activities.work_packages.activity_tab.label_submit_comment"),
                 type: :submit,
-                data: { "test_selector": "op-submit-work-package-journal-form" }
+                data: {
+                  "test_selector": "op-submit-work-package-journal-form",
+                  "work-packages--activities-tab--index-target": "formSubmitButton"
+                }
               ))
             end
           end

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -24,13 +24,16 @@ export default class IndexController extends Controller {
     showConflictFlashMessageUrl: String,
   };
 
-  static targets = ['journalsContainer', 'buttonRow', 'formRow', 'form', 'reactionButton'];
+  static targets = ['journalsContainer', 'buttonRow', 'formRow', 'form', 'formSubmitButton', 'reactionButton'];
 
   declare readonly journalsContainerTarget:HTMLElement;
   declare readonly buttonRowTarget:HTMLInputElement;
   declare readonly formRowTarget:HTMLElement;
   declare readonly formTarget:HTMLFormElement;
+  declare readonly formSubmitButtonTarget:HTMLButtonElement;
   declare readonly reactionButtonTargets:HTMLElement[];
+
+  declare readonly hasFormSubmitButtonTarget:boolean;
 
   declare updateStreamsUrlValue:string;
   declare sortingValue:string;
@@ -648,7 +651,7 @@ export default class IndexController extends Controller {
   async onSubmit(event:Event | null = null) {
     if (this.saveInProgress === true) return;
 
-    this.saveInProgress = true;
+    this.formSubmitInProgress = true;
 
     event?.preventDefault();
 
@@ -661,8 +664,16 @@ export default class IndexController extends Controller {
         console.error('Error saving activity:', error);
       })
       .finally(() => {
-        this.saveInProgress = false;
+        this.formSubmitInProgress = false;
       });
+  }
+
+  private set formSubmitInProgress(inProgress:boolean) {
+    this.saveInProgress = inProgress;
+
+    if (this.hasFormSubmitButtonTarget) {
+      this.formSubmitButtonTarget.disabled = inProgress;
+    }
   }
 
   private prepareFormData():FormData {
@@ -711,7 +722,7 @@ export default class IndexController extends Controller {
       this.handleStemVisibility();
     }, 10);
 
-    this.saveInProgress = false;
+    this.formSubmitInProgress = false;
   }
 
   private resetJournalsContainerMargins():void {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -651,7 +651,7 @@ export default class IndexController extends Controller {
   async onSubmit(event:Event | null = null) {
     if (this.saveInProgress === true) return;
 
-    this.formSubmitInProgress = true;
+    this.setFormSubmitInProgress(true);
 
     event?.preventDefault();
 
@@ -664,11 +664,11 @@ export default class IndexController extends Controller {
         console.error('Error saving activity:', error);
       })
       .finally(() => {
-        this.formSubmitInProgress = false;
+        this.setFormSubmitInProgress(false);
       });
   }
 
-  private set formSubmitInProgress(inProgress:boolean) {
+  private setFormSubmitInProgress(inProgress:boolean) {
     this.saveInProgress = inProgress;
 
     if (this.hasFormSubmitButtonTarget) {
@@ -722,7 +722,7 @@ export default class IndexController extends Controller {
       this.handleStemVisibility();
     }, 10);
 
-    this.formSubmitInProgress = false;
+    this.setFormSubmitInProgress(false);
   }
 
   private resetJournalsContainerMargins():void {


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/60719

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Prevent possible repeat submissions that can arise from slow network connections, and the user double clicking the comment submit button

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_*Clicking the submit button twice (quickly)_

_Before_

https://github.com/user-attachments/assets/a83a580e-1d9b-4e46-a88f-2557d34188ea

_After_

https://github.com/user-attachments/assets/39333886-6209-41e9-8097-b47021b00d39

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Add submit button targets via StimulusJS to manually enable and disable the submit button onSubmit.

[Turbo does automate this when using vanilla forms](https://turbo.hotwired.dev/reference/attributes#automatically-added-attributes) natively, but since we bypass the submit request to a turbo stream- it does not apply.

# Merge checklist

- [ ] ~Added/updated tests~ I'm not sure the tests are easy to automate here
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
