### PR TITLE
Make migration reversible

### DIFF
--- a/modules/storages/db/migrate/20250115100336_set_default_authentication_method.rb
+++ b/modules/storages/db/migrate/20250115100336_set_default_authentication_method.rb
@@ -29,7 +29,7 @@
 #++
 
 class SetDefaultAuthenticationMethod < ActiveRecord::Migration[7.1]
-  def change
+  def up
     update_sql = <<~SQL.squish
       UPDATE storages
       SET provider_fields = provider_fields || '{ "authentication_method": "two_way_oauth2" }'::jsonb
@@ -37,5 +37,10 @@ class SetDefaultAuthenticationMethod < ActiveRecord::Migration[7.1]
     SQL
 
     ActiveRecord::Base.connection.execute(update_sql)
+  end
+
+  def down
+    # up-direction is backwards-compatible, no need to restrict a migration rollback
+    # but also nothing to do in case of a rollback
   end
 end


### PR DESCRIPTION
# What are you trying to accomplish?
Allowing to revert the migration, in case it's needed (e.g. because you want to rollback the migration before it).

This migration itself is something that you probably don't need to revert, but it can make life easier to be able to revert it.
