### PR TITLE
Check primer view components versions consistency on commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,3 +17,7 @@ pre-commit:
       files: git diff --name-only --staged
       glob: "*.rb"
       run: bin/dirty-rubocop --uncommitted --force-exclusion {files}
+    primer-view-components-version-is-the-same-everyhwere:
+      files: git diff --name-only --staged
+      glob: "{Gemfile.lock,frontend/package.json}"
+      run: script/check_same_primer_view_components_version_everywhere

--- a/script/check_same_primer_view_components_version_everywhere
+++ b/script/check_same_primer_view_components_version_everywhere
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+VERSION_REGEXP='\d+\.\d+\.\d+(-[0-9A-Za-z-]+)?'
+
+echo "Checking for same primer view components version in Gemfile.lock and frontend/package.json"
+
+versions=$(grep --color=never primer.view.components frontend/package.json Gemfile.lock \
+          | grep --extended-regexp --only-matching "$VERSION_REGEXP" \
+          | sort --unique --version-sort)
+
+if [ -z "$versions" ]
+then
+  echo "Skipping check. Unable to detect Primer view components version."
+  exit
+fi
+
+version_count=$(echo "$versions" | wc -l)
+if [ $version_count -eq 1 ]
+then
+  echo "Ok. Primer view components version is $versions everywhere"
+  exit
+fi
+
+grep --color=never primer.view.components frontend/package.json Gemfile.lock \
+  | grep --color=always --extended-regexp "$VERSION_REGEXP"
+
+echo "Error. Different Primer view components versions are used ($(echo $versions))"
+echo "Please use only one version in both Gemfile.lock and frontend/package.json"
+exit 1


### PR DESCRIPTION
So that I'll stop upgrading it in `Gemfile.lock` and not in `frontend/package.json`. See #17681
