### PR TITLE
Enable Style/EndlessMethod cop for single line endless method.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -326,9 +326,6 @@ Style/ColonMethodCall:
 Style/CommentAnnotation:
   Enabled: false
 
-Style/PreferredHashMethods:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
 
@@ -340,6 +337,9 @@ Style/EachWithObject:
 
 Style/EmptyLiteral:
   Enabled: false
+
+Style/EndlessMethod:
+  Enabled: true
 
 Style/EvenOdd:
   Enabled: false
@@ -399,6 +399,9 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 
 Style/PerlBackrefs:
+  Enabled: false
+
+Style/PreferredHashMethods:
   Enabled: false
 
 Style/Proc:


### PR DESCRIPTION
# What are you trying to accomplish?
Enable `EndlessMethod` style cop to prefer endless methods instead of single line methods.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
