### PR TITLE
Code maintenance/60714 ci broken with chromedriver for chrome 132

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -11,8 +11,7 @@ ENV PGVERSION=13
 RUN wget --quiet -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
   echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
-# Temporarily use a mirror for Chrome until the official one is not having the problems to spin up sessions with selenium any more.
-ENV CHROME_SOURCE_URL="https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_131.0.6778.85-1_amd64.deb"
+ENV CHROME_SOURCE_URL="https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb"
 RUN --mount=type=cache,target=/var/cache/apt export f="/tmp/chrome.deb" && wget --no-verbose -O $f $CHROME_SOURCE_URL && \
   apt-get update -qq && apt-get install -y "$f" postgresql-$PGVERSION postgresql-client-$PGVERSION time imagemagick default-jre-headless firefox-esr && \
   rm -f "$f" && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/postgresql && find /usr/share/locale/* -maxdepth 0 -type d ! -name 'en' -exec rm -rf {} \;

--- a/modules/reporting/spec/features/export_timesheet_spec.rb
+++ b/modules/reporting/spec/features/export_timesheet_spec.rb
@@ -29,7 +29,7 @@
 require_relative "../spec_helper"
 require_relative "support/pages/cost_report_page"
 
-RSpec.describe "Timesheet PDF export", :js, :selenium do
+RSpec.describe "Timesheet PDF export", :js do
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
   shared_let(:cost_type) { create(:cost_type, name: "Post-war", unit: "cap", unit_plural: "caps") }
@@ -37,28 +37,25 @@ RSpec.describe "Timesheet PDF export", :js, :selenium do
   shared_let(:cost_entry) { create(:cost_entry, user:, work_package:, project:, cost_type:) }
   let(:report_page) { Pages::CostReportPage.new project }
 
-  subject { @download_list.refresh_from(page).latest_download.to_s } # rubocop:disable RSpec/InstanceVariable
-
-  before do
-    @download_list = DownloadList.new
-    login_as(user)
-  end
-
-  after do
-    DownloadList.clear
-  end
+  current_user { user }
 
   it "can download the PDF" do
     report_page.visit!
-    click_on I18n.t("export.timesheet.button")
 
-    expect(page).to have_content I18n.t("job_status_dialog.generic_messages.in_queue"),
-                                 wait: 10
-    perform_enqueued_jobs
+    # The export opens a new tab with the result
+    new_window = window_opened_by do
+      click_on I18n.t("export.timesheet.button")
 
-    expect(page).to have_text(I18n.t("export.succeeded"),
-                              wait: 10)
+      expect(page).to have_content I18n.t("job_status_dialog.generic_messages.in_queue")
 
-    expect(subject).to have_text(".pdf")
+      perform_enqueued_jobs
+
+      expect(page).to have_text(I18n.t("export.succeeded"))
+    end
+
+    # Switching to that tab and checking that the content is a PDF
+    within_window new_window do
+      expect(page.source).to have_css("[type='application/pdf']")
+    end
   end
 end

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -106,6 +106,9 @@ RSpec.describe "Inline editing work packages", :js do
       subject_field.expect_invalid
 
       subject_field.save!
+
+      wp_table.expect_and_dismiss_toaster(type: :error, message: "Subject can't be blank.")
+
       expect(work_package.reload.subject).to eq "Foobar"
     end
   end

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -1,5 +1,5 @@
 # rubocop:disable Metrics/PerceivedComplexity
-def register_chrome(language, name: :"chrome_#{language}", headless: "old", override_time_zone: nil)
+def register_chrome(language, name: :"chrome_#{language}", headless: "new", override_time_zone: nil)
   Capybara.register_driver name do |app|
     options = Selenium::WebDriver::Chrome::Options.new
 

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -70,7 +70,10 @@ def clear_input_field_contents(input_element)
 
   return unless input_element.value.length.positive?
 
+  # Move to the end of the input field and then backspace to clear the field.
+  rights = Array.new(input_element.value.length, :right)
   backspaces = Array.new(input_element.value.length, :backspace)
+  input_element.native.node.type(*rights)
   input_element.native.node.type(*backspaces)
 end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60714

# What are you trying to accomplish?

Rely on the current chrome again by switching to the new headless mode as:

>  Old Headless mode has been removed from the Chrome binary. Please use the new Headless mode (https://developer.chrome.com/docs/chromium/new-headless) or the chrome-headless-shell which is a standalone implementation of the old Headless mode (https://developer.chrome.com/blog/chrome-headless-shell).

Additionally, this fixes the flickering spec for `spec/features/work_packages/table/edit_work_packages_spec.rb`. The spec tried to clear an input field with the value 'Foobar'. But because the click to activate the field was happening in the middle of the string and then backspace was used, only the 'Foo' part was removed leaving 'bar'. Now the browser first goes to the end of the input before backspacing.