### PR TITLE
Remove no-op emoji reactions tooltip icon definition

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
@@ -22,8 +22,7 @@
                     classes: "op-reactions-button"
                   )) do |button|
               button.with_tooltip(text: number_of_user_reactions_text(data[:users]),
-                                  test_selector: "reaction-tooltip-#{reaction}") do
-                button.with_icon(EmojiReactions.emoji(reaction), size: :small)
+                                  test_selector: "reaction-tooltip-#{reaction}")
               end
               "#{EmojiReaction.emoji(reaction)} #{data[:count]}"
             end


### PR DESCRIPTION
Button tooltip does not support icons, further the linked code would fail with a NoMethodError as `EmojiReactions.emoji` is not defined _(note the plural definition)_ which should be singular [`EmojiReaction.emoji`](https://github.com/opf/openproject/blob/dev/app/models/emoji_reaction.rb#L53)

This was just forgotten, never gets executed. See unit specs for the component: https://github.com/opf/openproject/blob/dev/spec/components/work_packages/activities_tab/journals/item_component/reactions_spec.rb

_Primer ref:_
https://qa.openproject-edge.com/lookbook/inspect/primer/beta/button/with_tooltip
https://github.com/opf/primer_view_components/blob/main/app/components/primer/beta/button.rb#L94

<img width="745" alt="Screenshot 2025-01-24 at 12 06 26 PM" src="https://github.com/user-attachments/assets/61b5ae94-cdf2-4d03-976a-62c8a54e8d92" />
