### PR TITLE
Fix flaky `cost_entries/add_cost_entry_spec.rb` spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,12 @@ AllCops:
   Exclude:
     - '**/node_modules/**/*'
 
+# Disable it as it is deprecated
+# From https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
+# "This cop is deprecated. We plan to remove this in the next major version update to 3.0."
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
+
 FactoryBot/ConsistentParenthesesStyle:
   Enabled: false
 

--- a/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
@@ -70,12 +70,8 @@ RSpec.describe "Work Package cost fields", :js do
 
   it "does not show read-only fields" do
     full_view.visit!
-    # Go to add cost entry page
-    SeleniumHubWaiter.wait
-    find("#action-show-more-dropdown-menu .button").click
-    find(".menu-item", text: "Log unit costs").click
+    full_view.select_log_unit_costs_action
 
-    SeleniumHubWaiter.wait
     # Set single value, should update suffix
     select "A", from: "cost_entry_cost_type_id"
     fill_in "cost_entry_units", with: "1"
@@ -116,15 +112,12 @@ RSpec.describe "Work Package cost fields", :js do
       I18n.locale = :de
 
       full_view.visit!
+      full_view.select_log_unit_costs_action
 
-      # Go to add cost entry page
-      SeleniumHubWaiter.wait
-      find("#action-show-more-dropdown-menu .button").click
-      find(".menu-item", text: I18n.t(:button_log_costs)).click
+      fill_in CostEntry.human_attribute_name(:units), with: "1,42"
+      expect(page).to have_css("#cost_entry_costs", text: "1,42 EUR")
 
-      SeleniumHubWaiter.wait
-      fill_in "cost_entry_units", with: "1,42"
-      select "B", from: "cost_entry_cost_type_id"
+      select "B", from: CostEntry.human_attribute_name(:cost_type)
       expect(page).to have_css("#cost_entry_unit_name", text: "B plural")
       expect(page).to have_css("#cost_entry_costs", text: "2,84 EUR")
 
@@ -174,11 +167,7 @@ RSpec.describe "Work Package cost fields", :js do
       expect(placeholder_user).to be_present
       expect(Principal.possible_assignee(project).to_a).to include placeholder_user
       full_view.visit!
-
-      # Go to add cost entry page
-      SeleniumHubWaiter.wait
-      find("#action-show-more-dropdown-menu .button").click
-      find(".menu-item", text: I18n.t(:button_log_costs)).click
+      full_view.select_log_unit_costs_action
 
       SeleniumHubWaiter.wait
       expect(page).to have_no_css("#cost_entry_user_id option", text: placeholder_user.name, visible: :all)

--- a/spec/support/pages/work_packages/cost_entries.rb
+++ b/spec/support/pages/work_packages/cost_entries.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module WorkPackages
+    class CostEntries < Page
+      # Wait for the :spent_on date field to be loaded. It's backed by a
+      # flatpickr instance.
+      #
+      # The javascript on the "Log unit costs" creation page won't work until
+      # this date field is correctly loaded and displayed
+      def wait_for_spent_on_date_field_to_be_loaded
+        page.has_field?(CostEntry.human_attribute_name(:spent_on))
+      end
+    end
+  end
+end

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -87,6 +87,13 @@ module Pages
       end
     end
 
+    def select_log_unit_costs_action
+      SeleniumHubWaiter.wait
+      click_button(I18n.t("js.button_more"))
+      find(:menuitem, text: I18n.t(:button_log_costs)).click
+      Pages::WorkPackages::CostEntries.new.wait_for_spent_on_date_field_to_be_loaded
+    end
+
     def wait_for_activity_tab
       expect(page).to have_test_selector("op-wp-activity-tab", wait: 10)
       # wait for stimulus js component to be mounted


### PR DESCRIPTION
Flaky spec was `./modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb:114` It was failing for instance in https://github.com/opf/openproject/actions/runs/12934263465/job/36078482478

The flakiness is due to the js on the page not working until the spent_on date field is fully loaded. When the unit cost values are input, when the js is not working, then the computed "Costs" value is not updated, and so the test fails.

The fix is simple: wait for the spent_on date field to be loaded with `page.has_field?(CostEntry.human_attribute_name(:spent_on))`.

Then I refactored things a bit to remove some duplicate code and use some accessible selectors instead of css selectors.

And disabled a cop which never made sense to me anyway.