### PR TITLE
[#60870] RHEL: Can't install BIM edition

### DIFF
--- a/packaging/addons/openproject-edition/bin/configure
+++ b/packaging/addons/openproject-edition/bin/configure
@@ -33,6 +33,9 @@ supported_distribution() {
 				8*)
 					return 0
 					;;
+				9*)
+					return 0
+					;;
 			esac
 			;;
 	esac


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60870

# What are you trying to accomplish?
 Fix issue that BIM edition can't be selected in the installation wizard on RHEL
