### PR TITLE
[#58637] replaced deletion confirmation with danger dialog

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/delete_item_dialog_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/delete_item_dialog_component.html.erb
@@ -28,27 +28,15 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Alpha::Dialog.new(id: DIALOG_ID, title: "Delete item", test_selector: TEST_SELECTOR)) do |dialog|
-    dialog.with_header(variant: :large)
-    dialog.with_body do
-      "Are you sure you want to delete this item from the current hierarchy level?"
+  render(Primer::OpenProject::DangerConfirmationDialog.new(
+    form_arguments:,
+    size: :large,
+    test_selector: TEST_SELECTOR
+  )) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { I18n.t("custom_fields.admin.items.delete_dialog.title") }
+      message.with_description_content(I18n.t("custom_fields.admin.items.delete_dialog.description"))
     end
-
-    dialog.with_footer do
-      concat(render(Primer::ButtonComponent.new(data: { "close-dialog-id": DIALOG_ID })) do
-        I18n.t(:button_cancel)
-      end)
-
-      concat(primer_form_with(
-        model: @custom_field,
-        url: custom_field_item_path(custom_field_id: @custom_field.id, id: @hierarchy_item.id),
-        method: :delete,
-        data: { turbo: true }
-      ) do
-        render(Primer::ButtonComponent.new(scheme: :danger, type: :submit, data: { "close-dialog-id": DIALOG_ID })) do
-          I18n.t(:button_delete)
-        end
-      end)
-    end
+    dialog.with_confirmation_check_box_content(I18n.t(:text_permanent_delete_confirmation_checkbox_label))
   end
 %>

--- a/app/components/admin/custom_fields/hierarchy/delete_item_dialog_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/delete_item_dialog_component.rb
@@ -34,13 +34,19 @@ module Admin
       class DeleteItemDialogComponent < ApplicationComponent
         include OpTurbo::Streamable
 
-        DIALOG_ID = "op-hierarchy-item--deletion-confirmation"
         TEST_SELECTOR = "op-custom-fields--delete-item-dialog"
 
         def initialize(custom_field:, hierarchy_item:)
           super
           @custom_field = custom_field
           @hierarchy_item = hierarchy_item
+        end
+
+        def form_arguments
+          {
+            action: custom_field_item_path(custom_field_id: @custom_field.id, id: @hierarchy_item.id),
+            method: :delete
+          }
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
             description: Add items to this list to create sub-items inside another one
         delete_dialog:
           title: "Delete custom field item"
-          description: "This action is irreversible and will remove all containing sub-items. Assigned values of this item or its descendants will get removed. If the custom field is marked as required, this will render the elements invalid."
+          description: "This action will irreversibly remove the item and all its sub-items. Any assigned values will be permanently deleted. If this field is required, removing items may cause existing work packages to become invalid."
         placeholder:
           label: "Item label"
           short: "Short name"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,6 +252,9 @@ en:
           item:
             title: This item doesn't have any hierarchy level below
             description: Add items to this list to create sub-items inside another one
+        delete_dialog:
+          title: "Delete custom field item"
+          description: "This action is irreversible and will remove all containing sub-items. Assigned values of this item or its descendants will get removed. If the custom field is marked as required, this will render the elements invalid."
         placeholder:
           label: "Item label"
           short: "Short name"
@@ -1665,8 +1668,9 @@ en:
   button_copy_and_follow: "Copy and follow"
   button_create: "Create"
   button_create_and_continue: "Create and continue"
-  button_delete: "Delete"
   button_decline: "Decline"
+  button_delete: "Delete"
+  button_delete_permanently: "Delete permanently"
   button_delete_watcher: "Delete watcher %{name}"
   button_download: "Download"
   button_duplicate: "Duplicate"
@@ -3947,6 +3951,7 @@ en:
     The badge will check your current OpenProject version against the official OpenProject release database to alert you of any updates or known vulnerabilities.
     For more information on what the check provides, what data is needed to provide available updates, and how to disable this check, please visit <a href="%{more_info_url}">the configuration documentation</a>.
   text_own_membership_delete_confirmation: "You are about to remove some or all of your permissions and may no longer be able to edit this project after that.\nAre you sure you want to continue?"
+  text_permanent_delete_confirmation_checkbox_label: "I understand that this deletion cannot be reversed"
   text_plugin_assets_writable: "Plugin assets directory writable"
   text_powered_by: "Powered by %{link}"
   text_project_identifier_info: "Only lower case letters (a-z), numbers, dashes and underscores are allowed, must start with a lower case letter."

--- a/spec/features/custom_fields/hierarchy_custom_field_spec.rb
+++ b/spec/features/custom_fields/hierarchy_custom_field_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe "custom fields of type hierarchy", :js do
     hierarchy_page.open_action_menu_for("Phoenix Squad")
     click_on "Delete"
     expect(page).to have_test_selector("op-custom-fields--delete-item-dialog")
-    click_on "Delete"
+    check "I understand that this deletion cannot be reversed"
+    click_on "Delete permanently"
     expect(page).not_to have_test_selector("op-custom-fields--delete-item-dialog")
     expect(page).to have_test_selector("op-custom-fields--hierarchy-item", count: 1)
     expect(page).not_to have_test_selector("op-custom-fields--hierarchy-item", text: "Phoenix Squad")


### PR DESCRIPTION
# Ticket
[OP#58637](https://community.openproject.org/work_packages/58637)

# What are you trying to accomplish?
- make deletion better guarded

# What approach did you choose and why?
- deleting a custom field hierarchy item now is guarded by a danger dialog

![image](https://github.com/user-attachments/assets/7fc14cd0-b9c0-4627-ba16-acccfa689cb7)
