### PR TITLE
Make RecurringMeetings::InitNextOccurrenceJob more robust

### DIFF
--- a/config/initializers/cronjobs.rb
+++ b/config/initializers/cronjobs.rb
@@ -65,6 +65,10 @@ Rails.application.config.after_initialize do
       "Ldap::SynchronizationJob": {
         cron: "30 23 * * *",
         class: Ldap::SynchronizationJob.name
+      },
+      "RecurringMeetings::InitNextOccurrenceWatchdogJob": {
+        cron: "11 05 * * *",
+        class: RecurringMeetings::InitNextOccurrenceWatchdogJob.name
       }
     }
   )

--- a/modules/meeting/app/services/recurring_meetings/create_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/create_service.rb
@@ -37,22 +37,8 @@ module RecurringMeetings
 
       recurring_meeting = call.result
       call.merge! create_meeting_template(recurring_meeting) if call.success?
-      schedule_init_job(recurring_meeting) if call.success?
 
       call
-    end
-
-    ##
-    # We want to automatically schedule the next occurrence
-    # AFTER the first occurrence has passed.
-    # We do not create initially as you still need to update the template.
-    def schedule_init_job(recurring_meeting)
-      first_occurrence = recurring_meeting.first_occurrence
-      return if first_occurrence.nil?
-
-      ::RecurringMeetings::InitNextOccurrenceJob
-        .set(wait_until: first_occurrence.to_time)
-        .perform_later(recurring_meeting)
     end
 
     def create_meeting_template(recurring_meeting)

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -32,7 +32,12 @@ module RecurringMeetings
     discard_on ActiveJob::DeserializationError
 
     good_job_control_concurrency_with(
-      total_limit: 1,
+      # Allow the running job to enqueue the next one
+      total_limit: 2,
+      # But allow only one enqueued job
+      enqueue_limit: 1,
+      # And one running job
+      perform_limit: 1,
       key: -> { self.class.unique_key(arguments.first) }
     )
 
@@ -45,35 +50,36 @@ module RecurringMeetings
       "RecurringMeetings::InitNextOccurrenceJob-#{recurring_meeting.id}"
     end
 
-    attr_accessor :recurring_meeting
+    attr_accessor :recurring_meeting, :scheduled_time
 
-    def perform(recurring_meeting)
+    def perform(recurring_meeting, scheduled_time)
       self.recurring_meeting = recurring_meeting
-
-      if next_scheduled_time.nil?
-        Rails.logger.debug { "Meeting series #{recurring_meeting} is ending." }
-        return
-      end
+      self.scheduled_time = scheduled_time
 
       # Schedule the next job
       schedule_next_job
 
-      # Schedule the next occurrence, if not instantiated
-      check_next_occurrence
+      # Schedule the given occurrence, if not instantiated
+      check_occurrence
     rescue StandardError => e
-      Rails.logger.error { "Error while initializing next occurrence for series ##{recurring_meeting}: #{e.message}" }
+      Rails.logger.error { "Error while initializing next occurrence for series ##{recurring_meeting.id}: #{e.message}" }
     end
 
     private
 
-    def check_next_occurrence
-      if next_occurrence_instantiated?
-        Rails.logger.debug { "Will not create next occurrence for series #{recurring_meeting} as already instantiated" }
+    def check_occurrence # rubocop:disable Metrics/AbcSize
+      if occurrence_instantiated?
+        Rails.logger.debug { "Will not create next occurrence for series ##{recurring_meeting.id} as already instantiated" }
         return
       end
 
-      if next_occurrence_cancelled?
-        Rails.logger.debug { "Will not create next occurrence for series #{recurring_meeting} is already cancelled" }
+      if occurrence_cancelled?
+        Rails.logger.debug { "Will not create next occurrence for series ##{recurring_meeting.id} is already cancelled" }
+        return
+      end
+
+      unless occurring_at_scheduled_time?
+        Rails.logger.debug { "The given schedule #{scheduled_time} is (no longer) existing for series ##{recurring_meeting.id}" }
         return
       end
 
@@ -83,10 +89,10 @@ module RecurringMeetings
     def init_meeting
       call = ::RecurringMeetings::InitOccurrenceService
         .new(user: User.system, recurring_meeting:)
-        .call(start_time: next_scheduled_time)
+        .call(start_time: scheduled_time)
 
       call.on_success do
-        Rails.logger.debug { "Initialized occurrence for series ##{recurring_meeting} at #{next_scheduled_time}" }
+        Rails.logger.debug { "Initialized occurrence for series ##{recurring_meeting} at #{scheduled_time}" }
       end
 
       call.on_failure do
@@ -98,38 +104,51 @@ module RecurringMeetings
 
     ##
     # Schedule when this job should be run the next time
+    # When the next meeting takes place
     def schedule_next_job
-      # Do not schedule if the series is ending
-      return if next_scheduled_time.nil?
+      if next_scheduled_time.nil?
+        Rails.logger.info { "Meeting series ##{recurring_meeting.id} is ending." }
+        return
+      end
 
       self
         .class
-        .set(wait_until: next_scheduled_time)
-        .perform_later(recurring_meeting)
+        .set(wait_until: scheduled_time)
+        .perform_later(recurring_meeting, next_scheduled_time)
+    end
+
+    ##
+    # Return whether the given scheduled_time is occurring
+    # This might no longer be the case if the meeting was rescheduled.
+    def occurring_at_scheduled_time?
+      recurring_meeting.schedule.occurs_at?(scheduled_time)
     end
 
     ##
     # Return if there is already an instantiated upcoming meeting
-    def next_occurrence_instantiated?
+    # for the current scheduled_time
+    def occurrence_instantiated?
       recurring_meeting
         .scheduled_instances
         .where.not(meeting_id: nil)
-        .exists?(start_time: next_scheduled_time)
+        .exists?(start_time: scheduled_time)
     end
 
     ##
-    # Return if the next occurrence is cancelled
-    def next_occurrence_cancelled?
+    # Return if the current scheduled time is cancelled
+    def occurrence_cancelled?
       recurring_meeting
         .scheduled_instances
         .where(cancelled: true)
-        .exists?(start_time: next_scheduled_time)
+        .exists?(start_time: scheduled_time)
     end
 
     def next_scheduled_time
       return @next_scheduled_time if defined?(@next_scheduled_time)
 
-      @next_scheduled_time = recurring_meeting.next_occurrence&.to_time
+      @next_scheduled_time = recurring_meeting
+        .next_occurrence(from_time: scheduled_time)
+        &.to_time
     end
   end
 end

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -31,6 +31,8 @@ module RecurringMeetings
     include GoodJob::ActiveJobExtensions::Concurrency
     discard_on ActiveJob::DeserializationError
 
+    CONCURRENCY_KEY_BASE = "RecurringMeetings::InitNextOccurrenceJob-".freeze
+
     good_job_control_concurrency_with(
       # Allow the running job to enqueue the next one
       total_limit: 2,
@@ -47,7 +49,7 @@ module RecurringMeetings
     end
 
     def self.unique_key(recurring_meeting)
-      "RecurringMeetings::InitNextOccurrenceJob-#{recurring_meeting.id}"
+      "#{CONCURRENCY_KEY_BASE}#{recurring_meeting.id}"
     end
 
     attr_accessor :recurring_meeting, :scheduled_time
@@ -74,12 +76,12 @@ module RecurringMeetings
       end
 
       if occurrence_cancelled?
-        Rails.logger.debug { "Will not create next occurrence for series ##{recurring_meeting.id} is already cancelled" }
+        Rails.logger.debug { "Will not create next occurrence for series ##{recurring_meeting.id} as already cancelled" }
         return
       end
 
       unless occurring_at_scheduled_time?
-        Rails.logger.debug { "The given schedule #{scheduled_time} is (no longer) existing for series ##{recurring_meeting.id}" }
+        Rails.logger.debug { "The given schedule #{scheduled_time} (no longer) exists for series ##{recurring_meeting.id}" }
         return
       end
 

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_watchdog_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_watchdog_job.rb
@@ -1,0 +1,49 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class RecurringMeetings::InitNextOccurrenceWatchdogJob < ApplicationJob
+  queue_with_priority :low
+
+  def perform
+    key = RecurringMeetings::InitNextOccurrenceJob::CONCURRENCY_KEY_BASE
+
+    RecurringMeeting
+      .joins("LEFT JOIN good_jobs ON good_jobs.concurrency_key = CONCAT('#{key}', recurring_meetings.id)")
+      .where(good_jobs: { id: nil })
+      .find_each do |series|
+      next_occurrence = series.next_occurrence
+
+      if next_occurrence
+        Rails.logger.warn { "Meeting series ##{series.id} lost its InitNextOccurrenceJob. Re-scheduling." }
+        RecurringMeetings::InitNextOccurrenceJob.perform_later(series, next_occurrence)
+      else
+        Rails.logger.debug { "Meeting series ##{series.id} has no next occurrence. Skipping resetting init job" }
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Recurring meetings CRUD",
     login_as current_user
 
     # Assuming the first init job has run
-    RecurringMeetings::InitNextOccurrenceJob.perform_now(meeting)
+    RecurringMeetings::InitNextOccurrenceJob.perform_now(meeting, meeting.first_occurrence.to_time)
   end
 
   it "can delete a recurring meeting from the show page and return to the index page" do

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Recurring meetings complete template",
   end
 
   context "when first occurrence is not existing" do
-    it "instantiates the first occurrence from template" do
+    it "instantiates the first occurrence from template and schedules the init job" do
       expect { subject }.to change(recurring_meeting.scheduled_meetings, :count).by(1)
       expect(response).to be_redirect
 
@@ -72,6 +72,10 @@ RSpec.describe "Recurring meetings complete template",
       meeting = first.meeting
       expect(meeting.agenda_items.count).to eq(1)
       expect(meeting.agenda_items.first.title).to eq("My template item")
+
+      expect(RecurringMeetings::InitNextOccurrenceJob)
+        .to have_been_enqueued.with(recurring_meeting, DateTime.parse("2024-12-06T10:00:00Z"))
+                              .at(DateTime.parse("2024-12-05T10:00:00Z"))
     end
   end
 

--- a/modules/meeting/spec/services/recurring_meetings/create_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/create_service_integration_spec.rb
@@ -54,11 +54,7 @@ RSpec.describe RecurringMeetings::CreateService, "integration", type: :model do
       }
     end
 
-    it "creates the series, template, and schedule the init job" do
-      expect { subject }.to have_enqueued_job(RecurringMeetings::InitNextOccurrenceJob)
-      job = enqueued_jobs.detect { |h| h["job_class"] == "RecurringMeetings::InitNextOccurrenceJob" }
-      expect(DateTime.parse(job["scheduled_at"])).to eq(Time.zone.tomorrow + 10.hours)
-
+    it "creates the series and template" do
       expect(service_result).to be_success
       expect(series).to be_persisted
 

--- a/modules/meeting/spec/workers/recurring_meetings/init_next_occurrence_job_spec.rb
+++ b/modules/meeting/spec/workers/recurring_meetings/init_next_occurrence_job_spec.rb
@@ -39,9 +39,12 @@ RSpec.describe RecurringMeetings::InitNextOccurrenceJob, type: :model do
            end_date: 1.month.from_now)
   end
 
-  subject { described_class.perform_now(series) }
+  let(:scheduled_time) { series.first_occurrence.to_time }
+  let(:next_occurrence) { Time.zone.tomorrow + 1.day + 10.hours }
 
-  it "schedules the next occurrence" do
+  subject { described_class.perform_now(series, scheduled_time) }
+
+  it "schedules the first occurrence" do
     expect { subject }.to change(StructuredMeeting, :count).by(1)
     expect(subject).to be_success
 
@@ -57,9 +60,13 @@ RSpec.describe RecurringMeetings::InitNextOccurrenceJob, type: :model do
              start_time: Time.zone.tomorrow + 10.hours)
     end
 
-    it "does not schedule anything" do
+    it "does not instantiate anything, but schedules the next job" do
       expect { subject }.not_to change(StructuredMeeting, :count)
       expect(subject).to be_nil
+
+      expect(described_class)
+        .to have_been_enqueued.with(series, next_occurrence)
+                              .at(schedule.start_time)
     end
   end
 
@@ -77,9 +84,15 @@ RSpec.describe RecurringMeetings::InitNextOccurrenceJob, type: :model do
              start_time: Time.zone.tomorrow + 10.hours)
     end
 
-    it "does not schedule anything" do
+    let(:next_occurrence) { Time.zone.tomorrow + 1.day + 10.hours }
+
+    it "does not instantiate anything, but schedules the next job" do
       expect { subject }.not_to change(StructuredMeeting, :count)
       expect(subject).to be_nil
+
+      expect(described_class)
+        .to have_been_enqueued.with(series, next_occurrence)
+                              .at(schedule.start_time)
     end
   end
 
@@ -97,9 +110,14 @@ RSpec.describe RecurringMeetings::InitNextOccurrenceJob, type: :model do
              start_time: Time.zone.tomorrow + 10.hours)
     end
 
-    it "does not schedule anything" do
+    let(:next_occurrence) { Time.zone.tomorrow + 1.day + 10.hours }
+
+    it "does not instantiate anything, but schedules the next one" do
       expect { subject }.not_to change(StructuredMeeting, :count)
       expect(subject).to be_nil
+      expect(described_class)
+        .to have_been_enqueued.with(series, next_occurrence)
+                              .at(schedule.start_time)
     end
   end
 
@@ -117,30 +135,40 @@ RSpec.describe RecurringMeetings::InitNextOccurrenceJob, type: :model do
              start_time: Time.zone.tomorrow + 1.day + 10.hours)
     end
 
+    let(:next_occurrence) { Time.zone.tomorrow + 1.day + 10.hours }
+
     it "schedules the one for tomorrow" do
       expect { subject }.to change(StructuredMeeting, :count).by(1)
       expect(subject).to be_success
 
       created_meeting = subject.result
       expect(created_meeting.start_time).to eq(Time.zone.tomorrow + 10.hours)
+
+      expect(described_class)
+        .to have_been_enqueued.with(series, next_occurrence)
+                              .at(Time.zone.tomorrow + 10.hours)
     end
   end
 
   context "when called after end_date" do
-    it "does not schedule the next occurrence" do
-      Timecop.freeze(series.end_date + 1.day) do
-        expect { subject }.not_to change(StructuredMeeting, :count)
-        expect(subject).to be_nil
-      end
+    let(:scheduled_time) { series.end_date + 1.day }
+
+    it "does not create a meeting nor schedule a job the next occurrence" do
+      expect { subject }.not_to enqueue_job(described_class)
+
+      expect(subject).to be_nil
     end
   end
 
   context "when called on last occurrence" do
+    let(:scheduled_time) { series.last_occurrence }
+
     it "does not schedule the next occurrence" do
-      Timecop.freeze(series.last_occurrence) do
-        expect { subject }.not_to change(StructuredMeeting, :count)
-        expect(subject).to be_nil
-      end
+      expect { subject }.not_to enqueue_job(described_class)
+      expect(subject).to be_success
+
+      created_meeting = subject.result
+      expect(created_meeting.start_time).to eq(scheduled_time)
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60621

Does two things:

1. Improve the way the InitNextOccurrenceJob schedules meetings by passing the explicit scheduled_time, and then rescheduling for the next time.
2. Introduces a cronjob to ensure these jobs are present in case unexpected errors happen (timeouts, network issues), but only once per day