### PR TITLE
[#60388] reenable custom options edit for project attributes

### DIFF
--- a/app/views/admin/settings/project_custom_fields/edit.html.erb
+++ b/app/views/admin/settings/project_custom_fields/edit.html.erb
@@ -36,14 +36,19 @@ See COPYRIGHT and LICENSE files for more details.
   ))
 %>
 
-<%= error_messages_for 'custom_field' %>
+<%= error_messages_for "custom_field" %>
+
+<% content_controller "admin--custom-fields",
+                      dynamic: true,
+                      "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config
+%>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                               url: admin_settings_project_custom_field_path(@custom_field),
-                              html: {method: :put, id: 'custom_field_form'} do |f| %>
-  <%= render partial: 'custom_fields/form', locals: { f: f, custom_field: @custom_field } %>
+                              html: {method: :put, id: "custom_field_form"} do |f| %>
+  <%= render partial: "custom_fields/form", locals: { f: f, custom_field: @custom_field } %>
   <% if @custom_field.new_record? %>
-    <%= hidden_field_tag 'type', @custom_field.type %>
+    <%= hidden_field_tag "type", @custom_field.type %>
   <% end %>
-  <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+  <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>

--- a/app/views/admin/settings/project_custom_fields/new.html.erb
+++ b/app/views/admin/settings/project_custom_fields/new.html.erb
@@ -31,19 +31,19 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Settings::ProjectCustomFields::NewFormHeaderComponent.new) %>
 
-<%= error_messages_for 'custom_field' %>
+<%= error_messages_for "custom_field" %>
 
 <% content_controller "admin--custom-fields",
                       dynamic: true,
-                      'admin--custom-fields-format-config-value': OpenProject::CustomFieldFormatDependent.stimulus_config
+                      "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config
 %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                               url: admin_settings_project_custom_fields_path,
-                              html: { id: 'custom_field_form' } do |f| %>
-  <%= render partial: 'custom_fields/form', locals: { f: f, custom_field: @custom_field } %>
+                              html: { id: "custom_field_form" } do |f| %>
+  <%= render partial: "custom_fields/form", locals: { f: f, custom_field: @custom_field } %>
   <% if @custom_field.new_record? %>
-    <%= hidden_field_tag 'type', @custom_field.type %>
+    <%= hidden_field_tag "type", @custom_field.type %>
   <% end %>
-  <%= styled_button_tag t(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+  <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>


### PR DESCRIPTION
# Ticket
[OP#60388](https://community.openproject.org/work_packages/60388)

# What are you trying to accomplish?
- fix editing of list options for project custom fields of type list

# What approach did you choose and why?
- add stimulus controller to project custom fields edit view

