### PR TITLE
Bug/59235 notification center activity tab goes into mobile layout even when the browser window is smaller desktop wide

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -31,13 +31,9 @@
                   journals_wrapper_container.with_row(
                     classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
                     mt: 3,
-                    mb: [3, nil, nil, nil, 0],
                     pt: 2,
                     pb: 2,
                     pl: 3,
-                    pr: [3, nil, nil, nil, 2],
-                    border: [nil, nil, nil, nil, :top],
-                    border_radius: [2, nil, nil, nil, 0],
                     bg: :subtle
                   ) do
                     render(

--- a/app/components/work_packages/activities_tab/index_component.sass
+++ b/app/components/work_packages/activities_tab/index_component.sass
@@ -1,10 +1,10 @@
-.work-packages-activities-tab-index-component
+@mixin activities-tab-component($breakpoint, $input-container-padding-right: 10px, $input-container-margin-bottom: 20px)
     overflow-y: hidden
     &--errors
         position: absolute
         width: calc(100% - 22px)
         z-index: 11
-        @media screen and (max-width: $breakpoint-xl)
+        @media screen and (max-width: $breakpoint)
             position: fixed
             bottom: 20px
             width: calc(100% - 30px)
@@ -15,12 +15,12 @@
 
         &_with-initial-input-compensation
             margin-bottom: 65px // initial margin-bottom, will be increased by stimulus when opening ckeditor
-            @media screen and (max-width: $breakpoint-xl)
+            @media screen and (max-width: $breakpoint)
                 margin-bottom: -16px
 
         &_with-input-compensation
             margin-bottom: 180px
-            @media screen and (max-width: $breakpoint-xl)
+            @media screen and (max-width: $breakpoint)
                 margin-bottom: -16px
                 
     &--input-container
@@ -28,8 +28,8 @@
         border-radius: var(--borderRadius-medium)
         border: none
         padding-right: 16px
-        margin-bottom: 20px
-        @media screen and (min-width: $breakpoint-xl)
+        margin-bottom: $input-container-margin-bottom
+        @media screen and (min-width: $breakpoint)
             position: absolute
             min-height: 60px
             bottom: 0
@@ -37,102 +37,20 @@
             right: 0
             border-radius: 0px
             border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
-            padding-right: 10px
+            padding-right: $input-container-padding-right
             margin-bottom: 0px
+
         &_sort-desc
-            @media screen and (max-width: $breakpoint-xl)
+            @media screen and (max-width: $breakpoint)
                 order: -1
+
+.work-packages-activities-tab-index-component
+    @include activities-tab-component($breakpoint-xl)
 
 .work-packages-activities-tab-index-component--within-notification-center
     .work-packages-activities-tab-index-component
-        overflow-y: hidden
-        &--errors
-            position: absolute
-            width: calc(100% - 22px)
-            z-index: 11
-            @media screen and (max-width: $breakpoint-lg)
-                position: fixed
-                bottom: 20px
-                width: calc(100% - 30px)
-        &--journals-container
-            z-index: 10
-            padding-top: 3px
-            overflow-y: auto
-
-            &_with-initial-input-compensation
-                margin-bottom: 65px // initial margin-bottom, will be increased by stimulus when opening ckeditor
-                @media screen and (max-width: $breakpoint-lg)
-                    margin-bottom: -16px
-
-            &_with-input-compensation
-                margin-bottom: 180px
-                @media screen and (max-width: $breakpoint-lg)
-                    margin-bottom: -16px
-                    
-        &--input-container
-            z-index: 10
-            border-radius: var(--borderRadius-medium)
-            border: none
-            padding-right: 16px
-            margin-bottom: 20px
-            @media screen and (min-width: $breakpoint-lg)
-                position: absolute
-                min-height: 60px
-                bottom: 0
-                left: 0
-                right: 0
-                border-radius: 0px
-                border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
-                padding-right: 15px
-                margin-bottom: 0px
-
-            &_sort-desc
-                @media screen and (max-width: $breakpoint-lg)
-                    order: -1
+        @include activities-tab-component($breakpoint-lg, 15px)
 
 .work-packages-activities-tab-index-component--within-split-screen
     .work-packages-activities-tab-index-component
-        overflow-y: hidden
-        &--errors
-            position: absolute
-            width: calc(100% - 22px)
-            z-index: 11
-            @media screen and (max-width: $breakpoint-sm)
-                position: fixed
-                bottom: 20px
-                width: calc(100% - 30px)
-        &--journals-container
-            z-index: 10
-            padding-top: 3px
-            overflow-y: auto
-
-            &_with-initial-input-compensation
-                margin-bottom: 65px // initial margin-bottom, will be increased by stimulus when opening ckeditor
-                @media screen and (max-width: $breakpoint-sm)
-                    margin-bottom: -16px
-
-            &_with-input-compensation
-                margin-bottom: 180px
-                @media screen and (max-width: $breakpoint-sm)
-                    margin-bottom: -16px
-                    
-        &--input-container
-            z-index: 10
-            border-radius: var(--borderRadius-medium)
-            border: none
-            padding-right: 16px
-            margin-bottom: 10px
-            @media screen and (min-width: $breakpoint-sm)
-                position: absolute
-                min-height: 60px
-                bottom: 0
-                left: 0
-                right: 0
-                border-radius: 0px
-                border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
-                padding-right: 10px
-                margin-bottom: 0px
-
-            &_sort-desc
-                @media screen and (max-width: $breakpoint-sm)
-                    order: -1
+        @include activities-tab-component($breakpoint-sm, 10px, 10px)

--- a/app/components/work_packages/activities_tab/index_component.sass
+++ b/app/components/work_packages/activities_tab/index_component.sass
@@ -25,13 +25,114 @@
                 
     &--input-container
         z-index: 10
+        border-radius: var(--borderRadius-medium)
+        border: none
+        padding-right: 16px
+        margin-bottom: 20px
         @media screen and (min-width: $breakpoint-xl)
             position: absolute
             min-height: 60px
             bottom: 0
             left: 0
             right: 0
-
+            border-radius: 0px
+            border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
+            padding-right: 10px
+            margin-bottom: 0px
         &_sort-desc
             @media screen and (max-width: $breakpoint-xl)
                 order: -1
+
+.work-packages-activities-tab-index-component--within-notification-center
+    .work-packages-activities-tab-index-component
+        overflow-y: hidden
+        &--errors
+            position: absolute
+            width: calc(100% - 22px)
+            z-index: 11
+            @media screen and (max-width: $breakpoint-lg)
+                position: fixed
+                bottom: 20px
+                width: calc(100% - 30px)
+        &--journals-container
+            z-index: 10
+            padding-top: 3px
+            overflow-y: auto
+
+            &_with-initial-input-compensation
+                margin-bottom: 65px // initial margin-bottom, will be increased by stimulus when opening ckeditor
+                @media screen and (max-width: $breakpoint-lg)
+                    margin-bottom: -16px
+
+            &_with-input-compensation
+                margin-bottom: 180px
+                @media screen and (max-width: $breakpoint-lg)
+                    margin-bottom: -16px
+                    
+        &--input-container
+            z-index: 10
+            border-radius: var(--borderRadius-medium)
+            border: none
+            padding-right: 16px
+            margin-bottom: 20px
+            @media screen and (min-width: $breakpoint-lg)
+                position: absolute
+                min-height: 60px
+                bottom: 0
+                left: 0
+                right: 0
+                border-radius: 0px
+                border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
+                padding-right: 15px
+                margin-bottom: 0px
+
+            &_sort-desc
+                @media screen and (max-width: $breakpoint-lg)
+                    order: -1
+
+.work-packages-activities-tab-index-component--within-split-screen
+    .work-packages-activities-tab-index-component
+        overflow-y: hidden
+        &--errors
+            position: absolute
+            width: calc(100% - 22px)
+            z-index: 11
+            @media screen and (max-width: $breakpoint-sm)
+                position: fixed
+                bottom: 20px
+                width: calc(100% - 30px)
+        &--journals-container
+            z-index: 10
+            padding-top: 3px
+            overflow-y: auto
+
+            &_with-initial-input-compensation
+                margin-bottom: 65px // initial margin-bottom, will be increased by stimulus when opening ckeditor
+                @media screen and (max-width: $breakpoint-sm)
+                    margin-bottom: -16px
+
+            &_with-input-compensation
+                margin-bottom: 180px
+                @media screen and (max-width: $breakpoint-sm)
+                    margin-bottom: -16px
+                    
+        &--input-container
+            z-index: 10
+            border-radius: var(--borderRadius-medium)
+            border: none
+            padding-right: 16px
+            margin-bottom: 10px
+            @media screen and (min-width: $breakpoint-sm)
+                position: absolute
+                min-height: 60px
+                bottom: 0
+                left: 0
+                right: 0
+                border-radius: 0px
+                border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
+                padding-right: 10px
+                margin-bottom: 0px
+
+            &_sort-desc
+                @media screen and (max-width: $breakpoint-sm)
+                    order: -1

--- a/app/components/work_packages/activities_tab/journals/index_component.sass
+++ b/app/components/work_packages/activities_tab/journals/index_component.sass
@@ -2,12 +2,12 @@
     &--journals-inner-container
         z-index: 10
     &--stem-connection
-        @media screen and (min-width: $breakpoint-xl)
+        @media screen and (min-width: $breakpoint-lg)
             position: absolute
             z-index: 9
             border-left: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
             margin-left: 19px
             margin-top: 20px
             height: 100vh
-        @media screen and (max-width: $breakpoint-xl)
+        @media screen and (max-width: $breakpoint-lg)
             display: none

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -74,6 +74,7 @@ export default class IndexController extends Controller {
 
     this.setLatestKnownChangesetUpdatedAt();
     this.startPolling();
+    this.setCssClasses();
   }
 
   disconnect() {
@@ -459,6 +460,9 @@ export default class IndexController extends Controller {
 
   // Code Maintenance: Get rid of this JS based view port checks when activities are rendered in fully primierized activity tab in all contexts
   private isMobile():boolean {
+    if (this.isWithinNotificationCenter() || this.isWithinSplitScreen()) {
+      return window.innerWidth < 1013;
+    }
     return window.innerWidth < 1279;
   }
 
@@ -468,6 +472,15 @@ export default class IndexController extends Controller {
 
   private isWithinSplitScreen():boolean {
     return window.location.pathname.includes('work_packages/details');
+  }
+
+  private setCssClasses() {
+    if (this.isWithinNotificationCenter()) {
+      this.element.classList.add('work-packages-activities-tab-index-component--within-notification-center');
+    }
+    if (this.isWithinSplitScreen()) {
+      this.element.classList.add('work-packages-activities-tab-index-component--within-split-screen');
+    }
   }
 
   private addEventListenersToCkEditorInstance() {


### PR DESCRIPTION
# Ticket
[59235](https://community.openproject.org/work_packages/59235)

# What approach did you choose and why?

- The activity tab is rendered in three different contexts: wp-full-screen, wp-split-screen, notification-center
- The mobile breakpoints are different on all of them
- The implementation before was just optimized for the breakpoints of the wp-full-screen
- I've now adjusted the JS code to take the context into account when deciding to apply the mobile JS-driven behavior
- I've added 3 different CSS blocks enabling to control the CSS breakpoint behavior (not elegant, but it's working)
- Keep in mind that a lot of this will be removed when the primierized wp-tabs will be rolled out to all three bespoken contexts. I've therefore gone for a simple, straight forward "quick-fix" approach here