### PR TITLE
improve performance of involving_user scope which improves date alert…

### DIFF
--- a/app/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages.rb
+++ b/app/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages.rb
@@ -113,8 +113,8 @@ class Notifications::CreateDateAlertsNotificationsJob::AlertableWorkPackages
 
   def alertable_work_packages
     work_packages = WorkPackage
-      .with_status_open
-      .involving_user(user)
+                      .involving_user(user)
+                      .with_status_open
 
     # `work_packages.to_sql` was producing SQL with weird select clauses that could
     # not be used in a CTE, while doing `work_packages.pluck(:something)` was producing


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60932

# What are you trying to accomplish?

The performance of the `CreateDateAlertsNotificationsJob` job on instances with a larger set of work packages and users is suboptimal. This can be traced down to the way the `WorkPackage.involving_user` scope is performing which is included in the SQL for fetching all work packages for which a user should get notified.

The SQL before the start is like this:

```SQL
SELECT
	"work_packages".*
FROM
	"work_packages"
	LEFT OUTER JOIN "watchers" ON "watchers"."watchable_type" = 'WorkPackage'
	AND "watchers"."watchable_id" = "work_packages"."id"
WHERE
	(
		"watchers"."user_id" = 31032
		OR "work_packages"."assigned_to_id" = 31032
		OR "work_packages"."assigned_to_id" IN (
			SELECT
				"group_users"."group_id"
			FROM
				"group_users"
			WHERE
				"group_users"."user_id" = 31032
		)
		OR "work_packages"."responsible_id" = 31032
		OR "work_packages"."responsible_id" IN (
			SELECT
				"group_users"."group_id"
			FROM
				"group_users"
			WHERE
				"group_users"."user_id" = 31032
		)
	)
```

This leads to the following execution plan:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/a3a0de31-1448-4dbf-b71d-5d3bdd114bc6" />

The statement does a full scan on work packages and it does so three times. The reason for this is are the OR statements on three different attributes where indices are not applied

# What approach did you choose and why?

By changing the statement to use UNIONS the OR can be avoided. Additionally using a CTE to only do the repetitive filtering for users and groups once, the statement now looks like this:

```SQL
WITH
	"user_and_groups" AS (
		SELECT
			"group_users"."group_id"
		FROM
			"group_users"
		WHERE
			(USER_ID = 31032)
		UNION
		SELECT
			31032
	)
SELECT
	"work_packages".*
FROM
	"work_packages"
WHERE
	"work_packages"."id" IN (
		(
			(
				SELECT
					"work_packages"."id"
				FROM
					"work_packages"
					LEFT OUTER JOIN "watchers" ON "watchers"."watchable_type" = 'WorkPackage'
					AND "watchers"."watchable_id" = "work_packages"."id"
				WHERE
					"watchers"."user_id" = 31032
			)
			UNION
			(
				SELECT
					"work_packages"."id"
				FROM
					"work_packages"
				WHERE
					(
						ASSIGNED_TO_ID IN (
							SELECT
								*
							FROM
								USER_AND_GROUPS
						)
					)
			)
			UNION
			(
				SELECT
					"work_packages"."id"
				FROM
					"work_packages"
				WHERE
					(
						RESPONSIBLE_ID IN (
							SELECT
								*
							FROM
								USER_AND_GROUPS
						)
					)
			)
		)
	)
```

which admittedly is more complicated. 

So is the execution plan:

<img width="926" alt="image" src="https://github.com/user-attachments/assets/09489fe4-3306-4d52-bc4f-4df5476dd5e1" />

But that plan also shows that index scans are used now.

This approach might not be best in scenarios where the majority of the work packages are assigned to/watched by/responsible for by the same user. But that is a rather unlikely scenario.

The performance measurements vary especially for the former statement. Measurements have shown execution times between 400ms and 1.7s. But the result for the reworked statement seems to constantly be below 10ms. 
