### PR TITLE
Ensure mailer jobs also have a priority

### DIFF
--- a/app/workers/mails/mailer_job.rb
+++ b/app/workers/mails/mailer_job.rb
@@ -42,6 +42,9 @@
 #
 # It also adds retry logic to the job.
 class Mails::MailerJob < ActionMailer::MailDeliveryJob
+  include JobPriority
+  queue_with_priority :high
+
   include SharedJobSetup
 
   # Retry mailing jobs 14 times with polynomial backoff (retries for ~ 1.5 days).


### PR DESCRIPTION
Found two issues in good_job prioritization:

1. We did not set a default priority
2. MailerJob did not inherit from ApplicationJob, and thus could not be prioritized using the same way.

https://community.openproject.org/wp/60856
