### PR TITLE
Update the Gemfile.lock to use the newer version of bundler that comes with ruby 3.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1425,4 +1425,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.5.13
+   2.6.3


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Avoid the warning `Bundler 2.6.2 is running, but your lockfile was generated with 2.5.13. Installing Bundler 2.5.13 and restarting using that version.`

# What approach did you choose and why?
Update the Gemfile.lock to use a newer bundler with `bundle update --bundler`
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
