### PR TITLE
Feature/60718 remove ability to set default time tracking activity

### DIFF
--- a/app/components/enumerations/table_component.rb
+++ b/app/components/enumerations/table_component.rb
@@ -30,12 +30,15 @@
 
 module Enumerations
   class TableComponent < ::TableComponent
+    attr_reader :enumeration
+
+    def initialize(enumeration:, rows: [], **)
+      super(rows: rows, **)
+      @enumeration = enumeration
+    end
+
     def columns
-      %i[name is_default active sort].tap do |default|
-        if with_colors
-          default.insert 3, :color
-        end
-      end
+      headers.map(&:first)
     end
 
     def sortable?
@@ -43,16 +46,13 @@ module Enumerations
     end
 
     def headers
-      [
+      @headers ||= [
         ["name", { caption: Enumeration.human_attribute_name(:name) }],
-        ["is_default", { caption: Enumeration.human_attribute_name(:is_default) }],
+        enumeration.can_have_default_value? ? ["is_default", { caption: Enumeration.human_attribute_name(:is_default) }] : nil,
         ["active", { caption: Enumeration.human_attribute_name(:active) }],
+        with_colors ? ["color", { caption: Enumeration.human_attribute_name(:color) }] : nil,
         ["sort", { caption: I18n.t(:label_sort) }]
-      ].tap do |default|
-        if with_colors
-          default.insert 3, ["color", { caption: Enumeration.human_attribute_name(:color) }]
-        end
-      end
+      ].compact
     end
 
     def with_colors

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -75,6 +75,11 @@ class Enumeration < ApplicationRecord
     end
   end
 
+  # boolean to define if the enumeration can set a default
+  def self.can_have_default_value?
+    true
+  end
+
   # Destroys enumerations in a single transaction
   # It ensures, that the transactions can be safely transferred to each
   # entry's parent

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -37,7 +37,10 @@ See COPYRIGHT and LICENSE files for more details.
   <%= f.hidden_field 'type' %>
   <div class="form--field -required"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
   <div class="form--field"><%= f.check_box 'active' %></div>
-  <div class="form--field"><%= f.check_box 'is_default' %></div>
+
+  <% if @enumeration.class.can_have_default_value? %>
+    <div class="form--field"><%= f.check_box 'is_default' %></div>
+  <% end %>
 
   <% if @enumeration.class.colored? %>
     <%= render partial: '/colors/color_autocomplete_field',

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -38,5 +38,5 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% Enumeration.subclasses.each do |klass| %>
   <h3 class="-no-border"><%= t(klass::OptionName) %></h3>
-  <%= render(::Enumerations::TableComponent.new(rows: klass.shared)) %>
+  <%= render(::Enumerations::TableComponent.new(rows: klass.shared, enumeration: klass)) %>
 <% end %>

--- a/db/migrate/20250128164217_remove_is_default_for_time_entry_activities.rb
+++ b/db/migrate/20250128164217_remove_is_default_for_time_entry_activities.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class RemoveIsDefaultForTimeEntryActivities < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE "enumerations"
+      SET "is_default" = false
+      WHERE "type" = 'TimeEntryActivity'
+    SQL
+  end
+end

--- a/modules/costs/app/models/time_entry_activity.rb
+++ b/modules/costs/app/models/time_entry_activity.rb
@@ -64,6 +64,10 @@ class TimeEntryActivity < Enumeration
     Project.activated_time_activity(self)
   end
 
+  def self.can_have_default_value?
+    false
+  end
+
   private
 
   def detect_project_time_entry_activity_active_state(project)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/60718

# What are you trying to accomplish?
We are already ignoring the default for the Time Tracking Activity. This PR finishes the work by also removing the column and checkbox from the enumerations page

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
