### PR TITLE
[60680] Click on hamburger icon does not always open the sidebar on iOS

### DIFF
--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -55,8 +55,6 @@ export class MainMenuToggleService {
 
   private mainMenu = jQuery('#main-menu')[0]; // main menu, containing sidebar and resizer
 
-  private hideElements = jQuery('.can-hide-navigation');
-
   // Title needs to be sync in main-menu-toggle.component.ts and main-menu-resizer.component.ts
   private titleData = new BehaviorSubject<string>('');
 
@@ -203,6 +201,7 @@ export class MainMenuToggleService {
 
   private toggleClassHidden():void {
     const isHidden = this.elementWidth < this.elementMinWidth;
-    this.hideElements.toggleClass('hidden-navigation', isHidden);
+    const hideElements = jQuery('.can-hide-navigation');
+    hideElements.toggleClass('hidden-navigation', isHidden);
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60680

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show sidebar menu after pressing on hamburger icon

## Screenshots
https://github.com/user-attachments/assets/3cc3090d-64e9-40b9-9f45-854e54797dc5


# What approach did you choose and why?
Select hidden elements while setting a class to make them hidden. Every time that we press on hamburger icon, we should select them.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
