### PR TITLE
[#60972] Autocompleters for user cf filter values on the project list

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -67,15 +67,15 @@ module Filter
       case filter
       when Queries::Filters::Shared::ProjectFilter::Required,
            Queries::Filters::Shared::ProjectFilter::Optional
-        { autocomplete_options: project_autocompleter_options }
+        { autocomplete_options: project_autocomplete_options }
       when Queries::Filters::Shared::CustomFields::User
-        { autocomplete_options: user_autocomplete_options(filter) }
+        { autocomplete_options: user_autocomplete_options }
       else
         {}
       end
     end
 
-    def project_autocompleter_options
+    def project_autocomplete_options
       {
         component: "opce-project-autocompleter",
         resource: "projects",
@@ -85,7 +85,7 @@ module Filter
       }
     end
 
-    def user_autocomplete_options(filter)
+    def user_autocomplete_options
       {
         component: "opce-user-autocompleter",
         hideSelected: true,

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -88,6 +88,7 @@ module Filter
     def user_autocomplete_options(filter)
       {
         component: "opce-user-autocompleter",
+        hideSelected: true,
         defaultData: false,
         placeholder: I18n.t(:label_user_search),
         resource: "principals",
@@ -98,7 +99,6 @@ module Filter
           { name: "member", operator: "=", values: Project.visible.pluck(:id) }
         ],
         searchKey: "any_name_attribute",
-        inputValue: filter.values,
         focusDirectly: false
       }
     end

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -67,15 +67,7 @@ module Filter
       case filter
       when Queries::Filters::Shared::ProjectFilter::Required,
            Queries::Filters::Shared::ProjectFilter::Optional
-        {
-          autocomplete_options: {
-            component: "opce-project-autocompleter",
-            resource: "projects",
-            filters: [
-              { name: "active", operator: "=", values: ["t"] }
-            ]
-          }
-        }
+        { autocomplete_options: project_autocompleter_options }
       when Queries::Filters::Shared::CustomFields::User
         { autocomplete_options: user_autocomplete_options(filter) }
       else
@@ -83,38 +75,32 @@ module Filter
       end
     end
 
+    def project_autocompleter_options
+      {
+        component: "opce-project-autocompleter",
+        resource: "projects",
+        filters: [
+          { name: "active", operator: "=", values: ["t"] }
+        ]
+      }
+    end
+
     def user_autocomplete_options(filter)
       {
         component: "opce-user-autocompleter",
         defaultData: false,
         placeholder: I18n.t(:label_user_search),
-        resource:,
+        resource: "principals",
         url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals,
-        filters:,
-        searchKey: search_key,
-        inputValue: custom_input_value(filter),
+        filters: [
+          { name: "type", operator: "=", values: ["User"] },
+          { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] },
+          { name: "member", operator: "=", values: Project.visible.pluck(:id) }
+        ],
+        searchKey: "any_name_attribute",
+        inputValue: filter.values,
         focusDirectly: false
       }
-    end
-
-    def resource
-      "principals"
-    end
-
-    def search_key
-      "any_name_attribute"
-    end
-
-    def filters
-      [
-        { name: "type", operator: "=", values: ["User"] },
-        { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] },
-        { name: "member", operator: "=", values: Project.visible.pluck(:id) }
-      ]
-    end
-
-    def custom_input_value(filter)
-      filter.values
     end
   end
 end

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -76,9 +76,45 @@ module Filter
             ]
           }
         }
+      when Queries::Filters::Shared::CustomFields::User
+        { autocomplete_options: user_autocomplete_options(filter) }
       else
         {}
       end
+    end
+
+    def user_autocomplete_options(filter)
+      {
+        component: "opce-user-autocompleter",
+        defaultData: false,
+        placeholder: I18n.t(:label_user_search),
+        resource:,
+        url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals,
+        filters:,
+        searchKey: search_key,
+        inputValue: custom_input_value(filter),
+        focusDirectly: false
+      }
+    end
+
+    def resource
+      "principals"
+    end
+
+    def search_key
+      "any_name_attribute"
+    end
+
+    def filters
+      [
+        { name: "type", operator: "=", values: ["User"] },
+        { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] },
+        { name: "member", operator: "=", values: Project.visible.pluck(:id) }
+      ]
+    end
+
+    def custom_input_value(filter)
+      filter.values
     end
   end
 end

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -12,7 +12,6 @@
                               # of the #connect lifecycle hook of the filter--filters-form
                               # Stimulus controller.
                             }.merge(autocomplete_options.except(:component)),
-                            class: 'form--field',
                             id: "#{filter.name}_value",
                             data: {
                               'filter-autocomplete': true,

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -594,6 +594,14 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
 
         projects_page.expect_projects_listed(project)
       end
+
+      it "displays the visible project members as available options" do
+        load_and_open_filters admin
+
+        autcomplete_options = projects_page.autocomplete_options_for(user_cf)
+
+        expect(autcomplete_options).to eq([{ name: some_user.name, email: some_user.mail }])
+      end
     end
   end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -349,24 +349,32 @@ module Pages
 
       def set_custom_field_filter(selected_filter, human_operator, values, send_keys: false)
         if selected_filter.has_css?('[data-filter-autocomplete="true"]', wait: 0)
-          values.each do |query|
-            select_autocomplete find('[data-filter-autocomplete="true"]'),
-                                query:,
-                                results_selector: "body"
-          end
-        elsif selected_filter[:"data-filter-type"] == "list_optional"
-          if values.size == 1
-            value_select = find('.single-select select[name="value"]')
-            value_select.select values.first
-          end
-        elsif selected_filter[:"data-filter-type"] == "date"
-          if human_operator == "on"
-            if send_keys
-              find_field("value").send_keys values.first
-            else
-              fill_in "value", with: values.first
-            end
-          end
+          set_autocomplete_filter(values)
+        elsif selected_filter[:"data-filter-type"] == "list_optional" && values.size == 1
+          set_list_filter(values)
+        elsif selected_filter[:"data-filter-type"] == "date" && human_operator == "on"
+          set_date_filter(values, send_keys)
+        end
+      end
+
+      def set_autocomplete_filter(values)
+        values.each do |query|
+          select_autocomplete find('[data-filter-autocomplete="true"]'),
+                              query:,
+                              results_selector: "body"
+        end
+      end
+
+      def set_list_filter(values)
+        value_select = find('.single-select select[name="value"]')
+        value_select.select values.first
+      end
+
+      def set_date_filter(values, send_keys)
+        if send_keys
+          find_field("value").send_keys values.first
+        else
+          fill_in "value", with: values.first
         end
       end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -265,8 +265,7 @@ module Pages
       end
 
       def set_advanced_filter(name, human_name, human_operator = nil, values = [], send_keys: false)
-        select human_name, from: "add_filter_select"
-        selected_filter = page.find("li[data-filter-name='#{name}']")
+        selected_filter = select_filter(name, human_name)
         select(human_operator, from: "operator") unless boolean_filter?(name)
 
         within(selected_filter) do
@@ -282,6 +281,20 @@ module Pages
             set_custom_field_filter(selected_filter, human_operator, values)
           end
         end
+      end
+
+      def autocomplete_options_for(custom_field)
+        selected_filter = select_filter(custom_field.column_name, custom_field.name)
+
+        within(selected_filter) do
+          find('[data-filter-autocomplete="true"]').click
+          visible_user_auto_completer_options
+        end
+      end
+
+      def select_filter(name, human_name)
+        select human_name, from: "add_filter_select"
+        page.find("li[data-filter-name='#{name}']")
       end
 
       def remove_filter(name)
@@ -335,7 +348,13 @@ module Pages
       end
 
       def set_custom_field_filter(selected_filter, human_operator, values, send_keys: false)
-        if selected_filter[:"data-filter-type"] == "list_optional"
+        if selected_filter.has_css?('[data-filter-autocomplete="true"]', wait: 0)
+          values.each do |query|
+            select_autocomplete find('[data-filter-autocomplete="true"]'),
+                                query:,
+                                results_selector: "body"
+          end
+        elsif selected_filter[:"data-filter-type"] == "list_optional"
           if values.size == 1
             value_select = find('.single-select select[name="value"]')
             value_select.select values.first


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60972

# What are you trying to accomplish?
Add autocompleters to project custom field user filters.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Use the existing autocompleter component.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
