### PR TITLE
improve performance of relations visible scope

### DIFF
--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -38,7 +38,7 @@ class WorkPackageRelationsTab::RelationsMediator
   end
 
   def visible_relations
-    @visible_relations ||= work_package.relations.includes(:to, :from).visible
+    @visible_relations ||= work_package.visible_relations.includes(:to, :from)
   end
 
   def visible_children

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -38,7 +38,7 @@ class WorkPackageRelationsTab::RelationsMediator
   end
 
   def visible_relations
-    @visible_relations ||= work_package.visible_relations.includes(:to, :from)
+    @visible_relations ||= work_package.relations.visible.includes(:to, :from)
   end
 
   def visible_children

--- a/app/models/relations/scopes/visible.rb
+++ b/app/models/relations/scopes/visible.rb
@@ -45,9 +45,9 @@ module Relations::Scopes
       # @param [User] user
       # @param [ActiveRecord::Relation, Arel::SelectManager] work_package_focus_scope
       def visible(user = User.current, work_package_focus_scope: nil)
-        wp_arel = work_package_focus_scope.respond_to?(:arel) ? work_package_focus_scope.arel : work_package_focus_scope
         visible_work_packages = WorkPackage.visible(user)
 
+        wp_arel = work_package_focus_scope.respond_to?(:arel) ? work_package_focus_scope.arel : work_package_focus_scope
         visible_work_packages = visible_work_packages.where(WorkPackage.arel_table[:id].in(wp_arel)) if wp_arel
 
         with(visible_work_packages:)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -242,11 +242,6 @@ class WorkPackage < ApplicationRecord
       .exists?
   end
 
-  def visible_relations(user)
-    relations
-      .visible(user)
-  end
-
   def add_time_entry(attributes = {})
     attributes.reverse_merge!(
       project:,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -645,7 +645,8 @@ module API
         def relations
           self_path = api_v3_paths.work_package_relations(represented.id)
           visible_relations = represented
-            .visible_relations(current_user)
+            .relations
+            .visible(current_user)
             .includes(::API::V3::Relations::RelationCollectionRepresenter.to_eager_load)
 
           ::API::V3::Relations::RelationCollectionRepresenter.new(visible_relations,

--- a/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
+++ b/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
@@ -155,7 +155,7 @@ module XlsExport::WorkPackage::Exporter
     end
 
     def work_package_relations(work_package)
-      work_package.relations.visible
+      work_package.visible_relations
     end
   end
 end

--- a/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
+++ b/modules/xls_export/app/models/xls_export/work_package/exporter/xls.rb
@@ -155,7 +155,7 @@ module XlsExport::WorkPackage::Exporter
     end
 
     def work_package_relations(work_package)
-      work_package.visible_relations
+      work_package.relations.visible
     end
   end
 end

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1233,15 +1233,13 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
         end
 
         before do
-          scope = instance_double(ActiveRecord::Relation)
+          scope = double(ActiveRecord::Relation, # rubocop:disable RSpec/VerifiedDoubles
+                         visible: instance_double(ActiveRecord::Relation,
+                                                  includes: [relation]))
 
           allow(work_package)
-            .to receive(:visible_relations)
-                  .with(current_user)
+            .to receive(:relations)
                   .and_return(scope)
-          allow(scope)
-            .to receive(:includes)
-                  .and_return([relation])
         end
 
         it "embeds a collection" do

--- a/spec/models/work_package/work_package_relations_spec.rb
+++ b/spec/models/work_package/work_package_relations_spec.rb
@@ -255,7 +255,8 @@ RSpec.describe WorkPackage do
     end
   end
 
-  describe "#visible_relations" do
+  # The combination is speced because it is implemented in a non trivial way.
+  describe "#relations.visible" do
     let!(:user) { create(:user) }
     let!(:view_work_packages_role) { create(:project_role, permissions: %i[view_work_packages]) }
     let!(:no_permission_role) { create(:project_role, permissions: %i[]) }
@@ -282,7 +283,7 @@ RSpec.describe WorkPackage do
     let!(:other_relation) { create(:relation, from: other_work_package, to: visible_work_package) }
 
     it "returns all relations from the called on work package visible to the user" do
-      expect(origin.visible_relations(user))
+      expect(origin.relations.visible(user))
         .to contain_exactly(visible_relation, inverted_visible_relation, shared_relation)
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61058

# What are you trying to accomplish?

When calling `some_work_package.relations.visible` or its alias `some_work_package.visible_relations`, the following SQL is executed for a non admin user.

```SQL
SELECT
	"relations".*
FROM
	"relations"
WHERE
	(
		"relations"."from_id" = 1030549
		OR "relations"."to_id" = 1030549
	)
	AND "relations"."from_id" IN (
		WITH
			"allowed_work_packages" AS (
				SELECT
					"work_packages"."id"
				FROM
					"members"
					INNER JOIN "work_packages" ON "members"."entity_id" = "work_packages"."id"
					INNER JOIN "projects" ON "projects"."active" = TRUE
					AND "projects"."id" = "work_packages"."project_id"
					INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
					AND "enabled_modules"."name" IN ('work_package_tracking')
					AND "projects"."active" = TRUE
					INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
					INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
					INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
					AND (
						FALSE
						OR "role_permissions"."permission" = 'view_work_packages'
						AND "enabled_modules"."name" = 'work_package_tracking'
					)
				WHERE
					"members"."user_id" = 33612
					AND "members"."entity_type" = 'WorkPackage'
			),
			"allowed_projects" AS (
				SELECT
					"projects"."id"
				FROM
					"projects"
				WHERE
					"projects"."id" IN (
						(
							(
								SELECT
									"projects"."id"
								FROM
									"members"
									INNER JOIN "projects" ON "projects"."active" = TRUE
									AND "members"."project_id" = "projects"."id"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
									INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
								WHERE
									"members"."user_id" = 33612
									AND "members"."entity_id" IS NULL
									AND "members"."entity_type" IS NULL
							)
							UNION ALL
							(
								SELECT
									"projects"."id"
								FROM
									"projects"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "roles" ON "roles"."builtin" = 1
									AND "projects"."active"
									AND "projects"."public"
									AND NOT (
										EXISTS (
											SELECT
												1
											FROM
												"members"
											WHERE
												"members"."user_id" = 33612
												AND "members"."entity_id" IS NULL
												AND "members"."entity_type" IS NULL
												AND "members"."project_id" = "projects"."id"
										)
									)
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
							)
						)
					)
			)
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			(
				WORK_PACKAGES.PROJECT_ID IN (
					SELECT
						ID
					FROM
						ALLOWED_PROJECTS
				)
				OR WORK_PACKAGES.ID IN (
					SELECT
						ID
					FROM
						ALLOWED_WORK_PACKAGES
				)
			)
	)
	AND "relations"."to_id" IN (
		WITH
			"allowed_work_packages" AS (
				SELECT
					"work_packages"."id"
				FROM
					"members"
					INNER JOIN "work_packages" ON "members"."entity_id" = "work_packages"."id"
					INNER JOIN "projects" ON "projects"."active" = TRUE
					AND "projects"."id" = "work_packages"."project_id"
					INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
					AND "enabled_modules"."name" IN ('work_package_tracking')
					AND "projects"."active" = TRUE
					INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
					INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
					INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
					AND (
						FALSE
						OR "role_permissions"."permission" = 'view_work_packages'
						AND "enabled_modules"."name" = 'work_package_tracking'
					)
				WHERE
					"members"."user_id" = 33612
					AND "members"."entity_type" = 'WorkPackage'
			),
			"allowed_projects" AS (
				SELECT
					"projects"."id"
				FROM
					"projects"
				WHERE
					"projects"."id" IN (
						(
							(
								SELECT
									"projects"."id"
								FROM
									"members"
									INNER JOIN "projects" ON "projects"."active" = TRUE
									AND "members"."project_id" = "projects"."id"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
									INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
								WHERE
									"members"."user_id" = 33612
									AND "members"."entity_id" IS NULL
									AND "members"."entity_type" IS NULL
							)
							UNION ALL
							(
								SELECT
									"projects"."id"
								FROM
									"projects"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "roles" ON "roles"."builtin" = 1
									AND "projects"."active"
									AND "projects"."public"
									AND NOT (
										EXISTS (
											SELECT
												1
											FROM
												"members"
											WHERE
												"members"."user_id" = 33612
												AND "members"."entity_id" IS NULL
												AND "members"."entity_type" IS NULL
												AND "members"."project_id" = "projects"."id"
										)
									)
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
							)
						)
					)
			)
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			(
				WORK_PACKAGES.PROJECT_ID IN (
					SELECT
						ID
					FROM
						ALLOWED_PROJECTS
				)
				OR WORK_PACKAGES.ID IN (
					SELECT
						ID
					FROM
						ALLOWED_WORK_PACKAGES
				)
			)
	)
```

This sometimes performs poorly in cases where there are a lot of work packages. The exact trigger for when Postgres starts to perform poorly is unknown. But `EXPLAIN` shows why the performance is poor:

<img width="1842" alt="image" src="https://github.com/user-attachments/assets/8bef5ec9-9221-47a8-af58-c4b0c3c23761" />

The planner is way off estimating the number of work packages that would be returned as visible ones and chooses a full table scan. And it does so twice within the same query as the visible scope is applied two times. 

Some API responses like `GET api/v3/work_packages/:id` and `PATCH api/v3/work_packages/:id` the visible relations are queried twice when rendering the response as the relations are embedded in the work package resource. This can lead to poor performance on those requests.

Without checking for confirmation, the code indicates that the reworked relations tab fetches the visible scope multiple times as well. 

# What approach did you choose and why?

The problem arrises when `some_work_package.relations.visible` is concatenated. While it leads to the desired results, it does not make use of the fact that the number of relations directly connected to a work package will likely be small. For most work packages the number will be below 10 and even more connected work packages will not have thousands of relations. Using this, `relations.visible` can be employed to combine the visible scope with a subselect so that it focuses on work packages that are related to the work package the relations are searched for. Additionally, instead of providing the visible scope as subselects twice, the visible scope is provided once as a CTE which the `from_id`/`to_id` condition both reference.  

This results in the following SQL:

```SQL
WITH
	"visible_work_packages" AS (
		WITH
			"allowed_work_packages" AS (
				SELECT
					"work_packages"."id"
				FROM
					"members"
					INNER JOIN "work_packages" ON "members"."entity_id" = "work_packages"."id"
					INNER JOIN "projects" ON "projects"."active" = TRUE
					AND "projects"."id" = "work_packages"."project_id"
					INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
					AND "enabled_modules"."name" IN ('work_package_tracking')
					AND "projects"."active" = TRUE
					INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
					INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
					INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
					AND (
						FALSE
						OR "role_permissions"."permission" = 'view_work_packages'
						AND "enabled_modules"."name" = 'work_package_tracking'
					)
				WHERE
					"members"."user_id" = 33612
					AND "members"."entity_type" = 'WorkPackage'
			),
			"allowed_projects" AS (
				SELECT
					"projects"."id"
				FROM
					"projects"
				WHERE
					"projects"."id" IN (
						(
							(
								SELECT
									"projects"."id"
								FROM
									"members"
									INNER JOIN "projects" ON "projects"."active" = TRUE
									AND "members"."project_id" = "projects"."id"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
									INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
								WHERE
									"members"."user_id" = 33612
									AND "members"."entity_id" IS NULL
									AND "members"."entity_type" IS NULL
							)
							UNION ALL
							(
								SELECT
									"projects"."id"
								FROM
									"projects"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "roles" ON "roles"."builtin" = 1
									AND "projects"."active"
									AND "projects"."public"
									AND NOT (
										EXISTS (
											SELECT
												1
											FROM
												"members"
											WHERE
												"members"."user_id" = 33612
												AND "members"."entity_id" IS NULL
												AND "members"."entity_type" IS NULL
												AND "members"."project_id" = "projects"."id"
										)
									)
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
							)
						)
					)
			)
		SELECT
			"work_packages".*
		FROM
			"work_packages"
		WHERE
			(
				WORK_PACKAGES.PROJECT_ID IN (
					SELECT
						ID
					FROM
						ALLOWED_PROJECTS
				)
				OR WORK_PACKAGES.ID IN (
					SELECT
						ID
					FROM
						ALLOWED_WORK_PACKAGES
				)
			)
			AND "work_packages"."id" IN (
				(
					(
						SELECT
							CASE
								WHEN FROM_ID = 1030549 THEN TO_ID
								ELSE FROM_ID
							END ID
						FROM
							"relations"
						WHERE
							(
								RELATIONS.FROM_ID = 1030549
								OR RELATIONS.TO_ID = 1030549
							)
					)
					UNION ALL
					SELECT
						1030549 AS ID
				)
			)
	)
SELECT
	"relations".*
FROM
	"relations"
WHERE
	(
		"relations"."from_id" = 1030549
		OR "relations"."to_id" = 1030549
	)
	AND "relations"."from_id" IN (
		SELECT
			"work_packages"."id"
		FROM
			VISIBLE_WORK_PACKAGES WORK_PACKAGES
	)
	AND "relations"."to_id" IN (
		SELECT
			"work_packages"."id"
		FROM
			VISIBLE_WORK_PACKAGES WORK_PACKAGES
	)
```

The `EXPLAIN` outputs show that the planned rows are closer to the actual ones and that indices are used now:

<img width="933" alt="image" src="https://github.com/user-attachments/assets/56e2158e-3def-45e9-be62-81730f56722a" />

The performance is also stable when querying like it is done in the relations tab by now e.g.:

```
work_package.relations.includes(:to, :from).where.not(id: visible_relations.select(:id))
```