### PR TITLE
Make Keycloak remember things

### DIFF
--- a/docker/dev/keycloak/docker-compose.yml
+++ b/docker/dev/keycloak/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     restart: unless-stopped
     networks:
       - external
+    volumes:
+      - "pgdata:/var/lib/postgresql/data"
     environment:
       - POSTGRES_DB=keycloak
       - POSTGRES_USER=keycloak
@@ -44,6 +46,7 @@ services:
 
 volumes:
   keycloak-data:
+  pgdata:
 
 networks:
   external:


### PR DESCRIPTION
The default configuration for keycloak didn't attach any kind of volume to its database, so after

    docker compose down

everything was gone. I learned this today.
