### PR TITLE
Bug/60722 should start and end time be deletable once entered

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/time-entry.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/time-entry.controller.ts
@@ -107,6 +107,20 @@ export default class TimeEntryController extends Controller {
       return;
     }
 
+    // The time entry input fields are currently not valid, so we do not need to calculate anything.
+    // A time entry input field is invalid when it is only partially filled out.
+    if (!this.startTimeInputTarget.checkValidity() || !this.endTimeInputTarget.checkValidity()) {
+      return;
+    }
+
+    // when we have reset one of the input fields for start- or end-time, we want to unset both fields
+    if ((initiatedBy === this.startTimeInputTarget && this.startTimeInputTarget.value === '') || (initiatedBy === this.endTimeInputTarget && this.endTimeInputTarget.value === '')) {
+      this.startTimeInputTarget.value = '';
+      this.endTimeInputTarget.value = '';
+      this.toggleEndTimePlusCaption(0, 0);
+      return;
+    }
+
     const startTimeParts = this.startTimeInputTarget.value.split(':');
     const endTimeParts = this.endTimeInputTarget.value.split(':');
 

--- a/modules/costs/app/components/time_entries/days_and_hours_form.rb
+++ b/modules/costs/app/components/time_entries/days_and_hours_form.rb
@@ -50,6 +50,7 @@ module TimeEntries
                        required: start_and_end_time_required?,
                        label: TimeEntry.human_attribute_name(:start_time),
                        value: model.start_timestamp&.strftime("%H:%M"),
+                       show_clear_button: true,
                        data: {
                          "time-entry-target" => "startTimeInput",
                          "action" => "input->time-entry#timeInputChanged"
@@ -60,6 +61,7 @@ module TimeEntries
                        required: start_and_end_time_required?,
                        label: TimeEntry.human_attribute_name(:end_time),
                        value: model.end_timestamp&.strftime("%H:%M"),
+                       show_clear_button: true,
                        caption: end_time_caption,
                        data: {
                          "time-entry-target" => "endTimeInput",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60722

# What are you trying to accomplish?
Allow clearing the input fields for start- & end-time

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
