### PR TITLE
[60869] No error message shows on Relations modal if no WP is selected

### DIFF
--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
@@ -23,6 +23,7 @@
             my_form.work_package_autocompleter(
               name: :id,
               label: WorkPackage.model_name.human,
+              required: true,
               visually_hide_label: false,
               autocomplete_options: {
                 resource: 'work_packages',

--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
@@ -1,7 +1,7 @@
 <%= component_wrapper do %>
   <%= primer_form_with(
     id: FORM_ID,
-    model: WorkPackage.new,
+    model: @child,
     **submit_url_options,
     data: {
       turbo: true,

--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.rb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.rb
@@ -38,10 +38,11 @@ class WorkPackageRelationsTab::AddWorkPackageChildFormComponent < ApplicationCom
   ID_FIELD_TEST_SELECTOR = "work-package-child-form-id"
   I18N_NAMESPACE = "work_package_relations_tab"
 
-  def initialize(work_package:, base_errors: nil)
+  def initialize(work_package:, child: nil, base_errors: nil)
     super()
 
     @work_package = work_package
+    @child = child.presence || WorkPackage.new
     @base_errors = base_errors
   end
 

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -20,15 +20,16 @@
           # so we need to re-define them here. Figure out solution for this.
           relation = @relation
           lag_shown = show_lag?
-          to_id_field_value = relation.to.present? ? "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}" : nil
+          field_value = displayable_field_value
+          relation_direction = direction
           url = ::API::V3::Utilities::PathHelper::ApiV3Path.work_package_available_relation_candidates(@work_package.id, type: relation.relation_type_for(@work_package))
           render_inline_form(f) do |my_form|
             if relation.persisted?
               my_form.text_field(
-                name: :to_id,
+                name: relation_direction,
                 label: WorkPackage.model_name.human,
                 visually_hide_label: false,
-                value: to_id_field_value,
+                value: field_value,
                 readonly: true
               )
             else
@@ -38,7 +39,7 @@
               )
 
               my_form.autocompleter(
-                name: :to_id,
+                name: relation_direction,
                 label: WorkPackage.model_name.human,
                 required: true,
                 visually_hide_label: false,

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -40,6 +40,7 @@
               my_form.autocompleter(
                 name: :to_id,
                 label: WorkPackage.model_name.human,
+                required: true,
                 visually_hide_label: false,
                 autocomplete_options: {
                   resource: 'work_packages',

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.rb
@@ -48,23 +48,26 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
 
   def related_work_package
     @related_work_package ||= begin
-      related = @relation.to
       # We cannot rely on the related WorkPackage being the "to",
       # depending on the relation it can also be "from"
-      related.present? && related.id == @work_package.id ? @relation.from : related
+      relation_to_matches_wp? ? @relation.from : @relation.to
     end
   end
 
   def displayable_field_value
     return nil if related_work_package.nil?
 
-    if @relation.to.present?
+    if relation_to_matches_wp?
       "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}"
     end
   end
 
   def direction
-    @relation.to.present? ? :from_id : :to_id
+    relation_to_matches_wp? ? :from_id : :to_id
+  end
+
+  def relation_to_matches_wp?
+    @relation.to == @work_package
   end
 
   def submit_url_options

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.rb
@@ -51,8 +51,20 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
       related = @relation.to
       # We cannot rely on the related WorkPackage being the "to",
       # depending on the relation it can also be "from"
-      related.id == @work_package.id ? @relation.from : related
+      related.present? && related.id == @work_package.id ? @relation.from : related
     end
+  end
+
+  def displayable_field_value
+    return nil if related_work_package.nil?
+
+    if @relation.to.present?
+      "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}"
+    end
+  end
+
+  def direction
+    @relation.to.present? ? :from_id : :to_id
   end
 
   def submit_url_options
@@ -66,6 +78,6 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
   end
 
   def show_lag?
-    @relation.relation_type == Relation::TYPE_PRECEDES || @relation.relation_type == Relation::TYPE_FOLLOWS
+    [Relation::TYPE_PRECEDES, Relation::TYPE_FOLLOWS].include?(@relation.relation_type)
   end
 end

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -55,6 +55,13 @@ module Relations
     end
 
     def validate_nodes_relatable
+      # when creating a relation from the work package relations tab and not selecting a WorkPackage
+      # the to_id is not set
+      # in this case we only want to show the "WorkPackage can't be blank" error instead of a
+      # misleading circular dependencies error
+      # the error is added by the models presence validation
+      return if model.to_id.nil?
+
       if (model.from_id_changed? || model.to_id_changed?) &&
          WorkPackage.relatable(model.from, model.relation_type, ignored_relation: model).where(id: model.to_id).empty?
         errors.add :base, I18n.t(:"activerecord.errors.messages.circular_dependency")

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -47,11 +49,11 @@ module Relations
     private
 
     def validate_from_exists
-      errors.add :from, :error_not_found unless visible_work_packages.exists? model.from_id
+      errors.add :from_id, :error_not_found unless visible_work_packages.exists? model.from_id
     end
 
     def validate_to_exists
-      errors.add :to, :error_not_found unless visible_work_packages.exists? model.to_id
+      errors.add :to_id, :error_not_found unless visible_work_packages.exists? model.to_id
     end
 
     def validate_nodes_relatable
@@ -60,7 +62,7 @@ module Relations
       # in this case we only want to show the "WorkPackage can't be blank" error instead of a
       # misleading circular dependencies error
       # the error is added by the models presence validation
-      return if model.to_id.nil?
+      return if model.to_id.nil? || model.from_id.nil?
 
       if (model.from_id_changed? || model.to_id_changed?) &&
          WorkPackage.relatable(model.from, model.relation_type, ignored_relation: model).where(id: model.to_id).empty?
@@ -85,6 +87,8 @@ module Relations
     end
 
     def manage_relations?
+      return true if model.from.nil?
+
       user.allowed_in_work_package?(:manage_work_package_relations, model.from)
     end
   end

--- a/app/contracts/relations/update_contract.rb
+++ b/app/contracts/relations/update_contract.rb
@@ -34,11 +34,11 @@ module Relations
     private
 
     def from_immutable
-      errors.add :from, :error_readonly if from_id_changed_and_not_swapped?
+      errors.add :from_id, :error_readonly if from_id_changed_and_not_swapped?
     end
 
     def to_immutable
-      errors.add :to, :error_readonly if to_id_changed_and_not_swapped?
+      errors.add :to_id, :error_readonly if to_id_changed_and_not_swapped?
     end
 
     def from_id_changed_and_not_swapped?

--- a/app/controllers/work_package_children_relations_controller.rb
+++ b/app/controllers/work_package_children_relations_controller.rb
@@ -43,14 +43,7 @@ class WorkPackageChildrenRelationsController < ApplicationController
   end
 
   def create
-    if params[:work_package][:id].present?
-      child = WorkPackage.find(params[:work_package][:id])
-      service_result = set_relation(child:, parent: @work_package)
-    else
-      child = WorkPackage.new
-      child.errors.add(:id, :blank)
-      service_result = ServiceResult.failure(result: child)
-    end
+    service_result = create_service_result
 
     if service_result.failure?
       update_via_turbo_stream(
@@ -72,6 +65,17 @@ class WorkPackageChildrenRelationsController < ApplicationController
   end
 
   private
+
+  def create_service_result
+    if params[:work_package][:id].present?
+      child = WorkPackage.find(params[:work_package][:id])
+      set_relation(child:, parent: @work_package)
+    else
+      child = WorkPackage.new
+      child.errors.add(:id, :blank)
+      ServiceResult.failure(result: child)
+    end
+  end
 
   def set_relation(child:, parent:)
     WorkPackages::UpdateService.new(user: current_user, model: child)

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -69,15 +69,6 @@ class WorkPackageRelationsController < ApplicationController
     end
 
     respond_with_relations_tab_update(service_result, relation_to_scroll_to: service_result.result)
-
-    if service_result.failure?
-      update_via_turbo_stream(
-        component: WorkPackageRelationsTab::WorkPackageRelationFormComponent.new(work_package: @work_package,
-                                                                                 relation: service_result.result,
-                                                                                 base_errors: service_result.errors[:base]),
-        status: :bad_request
-      )
-    end
   end
 
   def update
@@ -87,6 +78,7 @@ class WorkPackageRelationsController < ApplicationController
       .call(update_relation_params)
 
     respond_with_relations_tab_update(service_result)
+
     if service_result.failure?
       update_via_turbo_stream(
         component: WorkPackageRelationsTab::WorkPackageRelationFormComponent.new(work_package: @work_package,
@@ -127,9 +119,15 @@ class WorkPackageRelationsController < ApplicationController
   end
 
   def create_relation_params
-    params.require(:relation)
-          .permit(:relation_type, :to_id, :description, :lag)
-          .merge(from_id: @work_package.id)
+    if params[:relation][:from_id].present?
+      params.require(:relation)
+            .permit(:relation_type, :from_id, :description, :lag)
+            .merge(to_id: @work_package.id)
+    else
+      params.require(:relation)
+            .permit(:relation_type, :to_id, :description, :lag)
+            .merge(from_id: @work_package.id)
+    end
   end
 
   def update_relation_params

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -59,6 +59,15 @@ class WorkPackageRelationsController < ApplicationController
     service_result = Relations::CreateService.new(user: current_user)
                                              .call(create_relation_params)
 
+    unless service_result.success?
+      update_via_turbo_stream(
+        component: WorkPackageRelationsTab::WorkPackageRelationFormComponent.new(work_package: @work_package,
+                                                                                 relation: service_result.result,
+                                                                                 base_errors: service_result.errors[:base]),
+        status: :bad_request
+      )
+    end
+
     respond_with_relations_tab_update(service_result, relation_to_scroll_to: service_result.result)
 
     if service_result.failure?

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -59,7 +59,7 @@ class WorkPackageRelationsController < ApplicationController
     service_result = Relations::CreateService.new(user: current_user)
                                              .call(create_relation_params)
 
-    unless service_result.success?
+    if service_result.failure?
       update_via_turbo_stream(
         component: WorkPackageRelationsTab::WorkPackageRelationFormComponent.new(work_package: @work_package,
                                                                                  relation: service_result.result,

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -109,7 +109,8 @@ class Relation < ApplicationRecord
     greater_than_or_equal_to: 0
   }
 
-  validates :to, uniqueness: { scope: :from }
+  # The primer form depends on to_id being validated
+  validates :to_id, uniqueness: { scope: :from }, presence: true
 
   before_validation :reverse_if_needed
 

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,22 +32,22 @@ class Relation < ApplicationRecord
   belongs_to :from, class_name: "WorkPackage"
   belongs_to :to, class_name: "WorkPackage"
 
-  TYPE_RELATES      = "relates".freeze
-  TYPE_PRECEDES     = "precedes".freeze
-  TYPE_FOLLOWS      = "follows".freeze
-  TYPE_BLOCKS       = "blocks".freeze
-  TYPE_BLOCKED      = "blocked".freeze
-  TYPE_DUPLICATES   = "duplicates".freeze
-  TYPE_DUPLICATED   = "duplicated".freeze
-  TYPE_INCLUDES     = "includes".freeze
-  TYPE_PARTOF       = "partof".freeze
-  TYPE_REQUIRES     = "requires".freeze
-  TYPE_REQUIRED     = "required".freeze
+  TYPE_RELATES      = "relates"
+  TYPE_PRECEDES     = "precedes"
+  TYPE_FOLLOWS      = "follows"
+  TYPE_BLOCKS       = "blocks"
+  TYPE_BLOCKED      = "blocked"
+  TYPE_DUPLICATES   = "duplicates"
+  TYPE_DUPLICATED   = "duplicated"
+  TYPE_INCLUDES     = "includes"
+  TYPE_PARTOF       = "partof"
+  TYPE_REQUIRES     = "requires"
+  TYPE_REQUIRED     = "required"
   # The parent/child relation is maintained separately
   # (in WorkPackage and WorkPackageHierarchy) and a relation cannot
   # have the type 'parent' but this is abstracted to simplify the code.
-  TYPE_PARENT       = "parent".freeze
-  TYPE_CHILD        = "child".freeze
+  TYPE_PARENT       = "parent"
+  TYPE_CHILD        = "child"
 
   TYPES = {
     TYPE_RELATES => {
@@ -109,8 +111,7 @@ class Relation < ApplicationRecord
     greater_than_or_equal_to: 0
   }
 
-  # The primer form depends on to_id being validated
-  validates :to_id, uniqueness: { scope: :from }, presence: true
+  validates :to, uniqueness: { scope: :from }
 
   before_validation :reverse_if_needed
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -976,7 +976,7 @@ en:
         timeline_labels: "Timeline labels"
       relation:
         lag: "Lag"
-        from: "Work package"
+        from: "Related work package"
         to: "Related work package"
       reminder:
         remind_at_date: "Date"
@@ -1302,10 +1302,10 @@ en:
             circular_dependency: "The relationship creates a circle of relationships."
           attributes:
             to_id:
-              error_not_found: "work package not found or not visible"
+              error_not_found: "not found or not visible"
               error_readonly: "an existing relation's `to` link is immutable"
             from_id:
-              error_not_found: "work package not found or not visible"
+              error_not_found: "not found or not visible"
               error_readonly: "an existing relation's `from` link is immutable"
             lag:
               greater_than_or_equal_to:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1302,11 +1302,11 @@ en:
             circular_dependency: "The relationship creates a circle of relationships."
           attributes:
             to_id:
-              error_not_found: "not found or not visible"
-              error_readonly: "an existing relation's `to` link is immutable"
+              error_not_found: "not found or not visible."
+              error_readonly: "cannot be changed for existing relations."
             from_id:
-              error_not_found: "not found or not visible"
-              error_readonly: "an existing relation's `from` link is immutable"
+              error_not_found: "not found or not visible."
+              error_readonly: "cannot be changed for existing relations."
             lag:
               greater_than_or_equal_to:
                 zero: "cannot be negative."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1301,11 +1301,11 @@ en:
           typed_dag:
             circular_dependency: "The relationship creates a circle of relationships."
           attributes:
-            to:
-              error_not_found: "work package in `to` position not found or not visible"
+            to_id:
+              error_not_found: "work package not found or not visible"
               error_readonly: "an existing relation's `to` link is immutable"
-            from:
-              error_not_found: "work package in `from` position not found or not visible"
+            from_id:
+              error_not_found: "work package not found or not visible"
               error_readonly: "an existing relation's `from` link is immutable"
             lag:
               greater_than_or_equal_to:

--- a/spec/contracts/relations/shared_contract_examples.rb
+++ b/spec/contracts/relations/shared_contract_examples.rb
@@ -112,13 +112,13 @@ RSpec.shared_examples_for "relation contract" do
     context "when the work package for from is not visible" do
       let(:relation_from_visible) { false }
 
-      it_behaves_like "contract is invalid", from: :error_not_found
+      it_behaves_like "contract is invalid", from_id: :error_not_found
     end
 
     context "when the work package for to is not visible" do
       let(:relation_to_visible) { false }
 
-      it_behaves_like "contract is invalid", to: :error_not_found
+      it_behaves_like "contract is invalid", to_id: :error_not_found
     end
 
     Relation::TYPES.each_key do |available_type|

--- a/spec/contracts/relations/update_contract_spec.rb
+++ b/spec/contracts/relations/update_contract_spec.rb
@@ -46,8 +46,13 @@ RSpec.describe Relations::UpdateContract do
     let(:contract) { described_class.new(relation, current_user) }
 
     context "when an isolated relation is reversed" do
+      let(:relation_from_wp) { create(:work_package) }
+      let(:relation_to_wp) { create(:work_package) }
       let(:relation) do
-        create(:relation, relation_type: Relation::TYPE_BLOCKS)
+        create(:relation,
+               from: relation_from_wp,
+               to: relation_to_wp,
+               relation_type: Relation::TYPE_BLOCKS)
       end
 
       before do

--- a/spec/models/queries/relations/filters/from_filter_spec.rb
+++ b/spec/models/queries/relations/filters/from_filter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Queries::Relations::Filters::FromFilter do
     let(:class_key) { :from_id }
     let(:type) { :integer }
     # The name is not very good but as long as the filter is not displayed in the UI ...
-    let(:human_name) { "Work package" }
+    let(:human_name) { "Related work package" }
 
     describe "#allowed_values" do
       it "is nil" do

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe Relation do
     expect(relation).to be_valid
   end
 
+  it "validates relation uniqueness on both from_id and to_id" do
+    create(:relation, from:, to:)
+
+    relation = build(:relation, from:, to:)
+    expect(relation).not_to be_valid
+    expect(relation.errors.as_json).to include(to_id: ["has already been taken."])
+
+    other = create(:work_package)
+    relation = build(:relation, from:, to: other)
+    expect(relation).to be_valid
+
+    relation = build(:relation, from: other, to:)
+    expect(relation).to be_valid
+  end
+
   describe "all relation types" do
     Relation::TYPES.each do |key, type_hash|
       let(:type) { key }

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Relation do
 
     relation = build(:relation, from:, to:)
     expect(relation).not_to be_valid
-    expect(relation.errors.as_json).to include(to_id: ["has already been taken."])
+    expect(relation.errors.as_json).to include(to: ["has already been taken."])
 
     other = create(:work_package)
     relation = build(:relation, from:, to: other)

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       it "lets the user know the attribute is read-only" do
         msg = JSON.parse(last_response.body)["message"]
 
-        expect(msg).to include "Work package an existing relation's `from` link is immutable"
+        expect(msg).to include "Related work package an existing relation's `from` link is immutable"
       end
     end
   end

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       it "lets the user know the attribute is read-only" do
         msg = JSON.parse(last_response.body)["message"]
 
-        expect(msg).to include "Related work package an existing relation's `from` link is immutable"
+        expect(msg).to include "Related work package cannot be changed for existing relations."
       end
     end
   end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -183,10 +183,7 @@ module Components
         expect(page).to have_text(modal_heading_label)
 
         # Enter the query and select the child
-        autocomplete_field = page.find_test_selector("work-package-relation-form-to-id")
-        select_autocomplete(autocomplete_field,
-                            query: relatable.subject,
-                            results_selector: "body")
+        search_in_autocompleter(relatable)
 
         if description.present?
           fill_in "Description", with: description
@@ -204,6 +201,13 @@ module Components
         new_relation = work_package.reload.relations.last
         target_wp = new_relation.other_work_package(work_package)
         find_row(target_wp)
+      end
+
+      def search_in_autocompleter(relatable)
+        autocomplete_field = page.find_test_selector("work-package-relation-form-to-id")
+        select_autocomplete(autocomplete_field,
+                            query: relatable.subject,
+                            results_selector: "body")
       end
 
       def edit_relation_description(relatable, description)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/60869/activity

# What are you trying to accomplish?
Show an error when trying to submit the relation dialog without having selected a WorkPackage.

 - [x] Relation dialog
 - [x] Child dialog

## Screenshots
<img width="656" alt="Bildschirmfoto 2025-02-12 um 15 21 27" src="https://github.com/user-attachments/assets/488d1345-63d6-4164-b689-5f03317f5486" />
