### PR TITLE
Run version check always when not in draft

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   version-check:
-    if: github.event.pull_request.draft == false
+    if: !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   version-check:
-    if: contains(github.event.pull_request.labels.*.name, 'needs review')
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Regarding the version check action, right now it's only run if you have "needs review" selected. I think it should run whenever outside draft mode