### PR TITLE
Do not implicitly handle errors on notification center

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -157,7 +157,7 @@ export class IanCenterService extends UntilDestroyedMixin {
     }),
     switchMap(() => this
       .resourceService
-      .fetchCollection(this.params)
+      .fetchCollection(this.params, { handleErrors: false })
       .pipe(
         switchMap(
           (results) => from(this.sideLoadInvolvedWorkPackages(results._embedded.elements))

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -200,7 +200,6 @@ RSpec.describe "Notification center date alerts", :js, with_settings: { journal_
 
       # It does not allows direct url access
       visit notifications_center_path(filter: "reason", name: "dateAlert")
-      toaster.expect_error("Filters Reason filter has invalid values.")
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59328

# What are you trying to accomplish?

There's an error notification that is confusing to users and useless to developers. The idea is to hide it.

# What approach did you choose and why?

Not expose backend errors on the notifications page.