### PR TITLE
Disable encapsulation on op-autocompleter sass

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -20,7 +20,7 @@ import {
   TemplateRef,
   Type,
   ViewChild,
-  ViewContainerRef,
+  ViewContainerRef, ViewEncapsulation,
 } from '@angular/core';
 import { DropdownPosition, NgSelectComponent } from '@ng-select/ng-select';
 import { BehaviorSubject, merge, NEVER, Observable, of, Subject } from 'rxjs';
@@ -74,6 +74,7 @@ export interface IAutocompleterTemplateComponent {
 @Component({
   selector: 'op-autocompleter',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   templateUrl: './op-autocompleter.component.html',
   styleUrls: ['./op-autocompleter.component.sass'],
   providers: [


### PR DESCRIPTION
Without encapsulation=none, the sass is scoped to the parent component, and never applied to the time entries autocompleter. Since we use BEM, we do not need further encapsulation

https://community.openproject.org/work_packages/60744
