### PR TITLE
[61053] Buttons can't fit on the Activity Tab for Russian and German

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.html
@@ -3,11 +3,9 @@
   [attr.title]="text.mark_as_read"
   class="button">
 
-  <op-icon icon-classes="button--icon icon-mark-read"></op-icon>
-  <span
-    *ngIf="showWithText"
-    class="button--text"
-    [textContent]="text.mark_as_read"
-  >
-  </span>
+  <svg
+    read-icon
+    class="button--icon"
+    size="small"
+  ></svg>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.ts
@@ -11,8 +11,6 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
 export class WorkPackageMarkNotificationButtonComponent {
   @Input() public workPackage:WorkPackageResource;
 
-  @Input() public showWithText:boolean;
-
   text = {
     mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
   };

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.html
@@ -1,6 +1,7 @@
 <button
   class="button toolbar-icon"
   data-test-selector="op-wp-share-button"
+  [title]="text.share"
   (click)="openModal()"
 >
   <svg
@@ -8,10 +9,8 @@
     class="button--icon"
     size="small"
   ></svg>
-  <span class="button--text">
-    {{ text.share }}
-    <span *ngIf="(shareCount$ | async) as shareCount"
-          class="badge -secondary"
+  <span class="button--text" *ngIf="(shareCount$ | async) as shareCount">
+    <span class="badge -secondary"
           [textContent]="shareCount"></span>
   </span>
 

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
@@ -1,12 +1,10 @@
 <div class="work-packages--details-toolbar">
-  <wp-watcher-button [workPackage]="workPackage"
-                     [showText]="true">
+  <wp-watcher-button [workPackage]="workPackage">
   </wp-watcher-button>
 
   <op-work-package-mark-notification-button
     *ngIf="displayNotificationsButton"
     [workPackage]="workPackage"
-    [showWithText]="true"
     data-test-selector="mark-notification-read-button"
   ></op-work-package-mark-notification-button>
 
@@ -20,10 +18,13 @@
 
   <button class="button dropdown-relative"
           [attr.accesskey]="7"
-
+          [title]="text.button_more"
           wpSingleContextMenu
           [wpSingleContextMenu-workPackage]="workPackage">
-    <span class="button--text button--text_without_icon" [textContent]="text.button_more"></span>
-    <op-icon icon-classes="button--dropdown-indicator"></op-icon>
+    <svg
+      op-kebab-vertical-icon
+      class="button--icon"
+      size="small"
+    ></svg>
   </button>
 </div>

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
@@ -43,11 +43,7 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin implements OnInit {
   @Input('workPackage') public workPackage:WorkPackageResource;
 
-  @Input('showText') public showText = false;
-
   @Input('disabled') public disabled = false;
-
-  public buttonText:string;
 
   public buttonTitle:string;
 
@@ -55,12 +51,14 @@ export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin imple
 
   public buttonId:string;
 
-  public watchIconClass:string;
+  public watched:boolean;
 
-  constructor(readonly I18n:I18nService,
+  constructor(
+    readonly I18n:I18nService,
     readonly wpWatchersService:WorkPackageWatchersService,
     readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef) {
+    readonly cdRef:ChangeDetectorRef,
+  ) {
     super();
   }
 
@@ -106,19 +104,17 @@ export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin imple
     return this.workPackage[linkName];
   }
 
-  private setWatchStatus() {
+  private setWatchStatus():void {
     if (this.isWatched) {
       this.buttonTitle = this.I18n.t('js.label_unwatch_work_package');
-      this.buttonText = this.I18n.t('js.label_unwatch');
       this.buttonClass = '-active';
       this.buttonId = 'unwatch-button';
-      this.watchIconClass = 'icon-watched';
+      this.watched = true;
     } else {
       this.buttonTitle = this.I18n.t('js.label_watch_work_package');
-      this.buttonText = this.I18n.t('js.label_watch');
       this.buttonClass = '';
       this.buttonId = 'watch-button';
-      this.watchIconClass = 'icon-unwatched';
+      this.watched = false;
     }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.html
@@ -6,6 +6,16 @@
         class="button toolbar-icon"
         [id]="buttonId">
 
-  <op-icon icon-classes="button--icon {{watchIconClass}}"></op-icon>
-  <span class="button--text" *ngIf="showText" [textContent]="buttonText"></span>
+  <svg
+    *ngIf="watched"
+    eye-icon
+    class="button--icon"
+    size="small"
+  ></svg>
+  <svg
+    *ngIf="!watched"
+    eye-closed-icon
+    class="button--icon"
+    size="small"
+  ></svg>
 </button>

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -38,8 +38,7 @@
           </op-wp-timer-button>
         </li>
         <li class="toolbar-item" *ngIf="displayWatchButton">
-          <wp-watcher-button [workPackage]="workPackage"
-                             [showText]="false">
+          <wp-watcher-button [workPackage]="workPackage">
           </wp-watcher-button>
         </li>
         <li class="toolbar-item" *ngIf="displayReminderButton$ | async">

--- a/frontend/src/app/shared/components/icon/icon.module.ts
+++ b/frontend/src/app/shared/components/icon/icon.module.ts
@@ -52,6 +52,10 @@ import {
   OpGitlabPipelineStatusSuccessIconComponent,
   OpGitlabPipelineStatusWaitingIconComponent,
   XCircleIconComponent,
+  OpKebabVerticalIconComponent,
+  ReadIconComponent,
+  EyeIconComponent,
+  EyeClosedIconComponent,
 } from '@openproject/octicons-angular';
 
 @NgModule({
@@ -108,7 +112,13 @@ import {
     OpGitlabPipelineStatusSkippedIconComponent,
     OpGitlabPipelineStatusSuccessIconComponent,
     OpGitlabPipelineStatusWaitingIconComponent,
+
     XCircleIconComponent,
+
+    OpKebabVerticalIconComponent,
+    ReadIconComponent,
+    EyeIconComponent,
+    EyeClosedIconComponent,
   ],
   declarations: [
     OpIconComponent,
@@ -168,6 +178,11 @@ import {
     OpGitlabPipelineStatusSuccessIconComponent,
     OpGitlabPipelineStatusWaitingIconComponent,
     XCircleIconComponent,
+
+    OpKebabVerticalIconComponent,
+    ReadIconComponent,
+    EyeIconComponent,
+    EyeClosedIconComponent,
   ],
 })
 export class IconModule {}

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -275,7 +275,7 @@ $scrollbar-size: 10px
   text-align: inherit
 
 @mixin hide-button-texts
-  .button--text:not(.button--text_without_icon)
+  .button--text
     display: none
 
 @mixin board-header-editable-toolbar-title

--- a/spec/features/work_packages/details/details_toolbar_spec.rb
+++ b/spec/features/work_packages/details/details_toolbar_spec.rb
@@ -44,15 +44,15 @@ RSpec.describe "Work package details toolbar", :js, :selenium do
 
     it "toggles the watch state" do
       expect(work_package.watcher_users).not_to include(user)
-      expect(page).to have_css(".work-packages--details-toolbar button", text: "Watch")
+      expect(page).to have_css(".work-packages--details-toolbar button[title='Watch work package']")
       within ".work-packages--details-toolbar" do
         click_button "Watch"
       end
 
-      expect(page).to have_css(".work-packages--details-toolbar button", text: "Unwatch")
+      expect(page).to have_css(".work-packages--details-toolbar button[title='Unwatch work package']")
 
       expect(work_package.reload.watcher_users).to include(user)
-      expect(page).to have_css(".work-packages--details-toolbar button", text: "Unwatch")
+      expect(page).to have_css(".work-packages--details-toolbar button[title='Unwatch work package']")
     end
   end
 end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe "Watcher tab", :js, :selenium, :with_cuprite do
   def expect_button_is_watching
     title = I18n.t("js.label_unwatch_work_package")
     expect(page).to have_css("#unwatch-button[title='#{title}']", wait: 10)
-    expect(page).to have_css("#unwatch-button .button--icon.icon-watched", wait: 10)
+    expect(page).to have_css("#unwatch-button .button--icon[eye-icon]", wait: 10)
   end
 
   def expect_button_is_not_watching
     title = I18n.t("js.label_watch_work_package")
     expect(page).to have_css("#watch-button[title='#{title}']")
-    expect(page).to have_css("#watch-button .button--icon.icon-unwatched")
+    expect(page).to have_css("#watch-button .button--icon[eye-closed-icon]")
   end
 
   shared_examples "watch and unwatch with button" do


### PR DESCRIPTION

# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/61053/activity

# What are you trying to accomplish?
* Use icon only buttons in the split screen toolbar at the bottom to avoid overflows.
* Use Octicons instead of old icons

## Screenshots
**Before**
<img width="674" alt="Bildschirmfoto 2025-01-31 um 09 45 30" src="https://github.com/user-attachments/assets/0248e2f9-bffd-43b4-a338-a8032c84caa9" />

**After**
<img width="281" alt="Bildschirmfoto 2025-01-31 um 10 31 10" src="https://github.com/user-attachments/assets/adc990b1-00c4-41b5-9740-c7f9321e16a4" />


