### PR TITLE
[60973] Wrong order of successor / predecessor in relations tab dropdown

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -51,20 +51,13 @@ class Relation < ApplicationRecord
     TYPE_RELATES => {
       name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: TYPE_RELATES
     },
-    TYPE_PRECEDES => {
-      name: :label_precedes, sym_name: :label_follows, order: 6,
-      sym: TYPE_FOLLOWS, reverse: TYPE_FOLLOWS
-    },
     TYPE_FOLLOWS => {
       name: :label_follows, sym_name: :label_precedes, order: 7,
       sym: TYPE_PRECEDES
     },
-    TYPE_BLOCKS => {
-      name: :label_blocks, sym_name: :label_blocked_by, order: 4, sym: TYPE_BLOCKED
-    },
-    TYPE_BLOCKED => {
-      name: :label_blocked_by, sym_name: :label_blocks, order: 5,
-      sym: TYPE_BLOCKS, reverse: TYPE_BLOCKS
+    TYPE_PRECEDES => {
+      name: :label_precedes, sym_name: :label_follows, order: 6,
+      sym: TYPE_FOLLOWS, reverse: TYPE_FOLLOWS
     },
     TYPE_DUPLICATES => {
       name: :label_duplicates, sym_name: :label_duplicated_by, order: 6, sym: TYPE_DUPLICATED
@@ -72,6 +65,13 @@ class Relation < ApplicationRecord
     TYPE_DUPLICATED => {
       name: :label_duplicated_by, sym_name: :label_duplicates, order: 7,
       sym: TYPE_DUPLICATES, reverse: TYPE_DUPLICATES
+    },
+    TYPE_BLOCKS => {
+      name: :label_blocks, sym_name: :label_blocked_by, order: 4, sym: TYPE_BLOCKED
+    },
+    TYPE_BLOCKED => {
+      name: :label_blocked_by, sym_name: :label_blocks, order: 5,
+      sym: TYPE_BLOCKS, reverse: TYPE_BLOCKS
     },
     TYPE_INCLUDES => {
       name: :label_includes, sym_name: :label_part_of, order: 8,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60973

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Change the order of relations in add relation action menu list

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
