### PR TITLE
[60358] Document the DangerDialog from a UX point of view

### DIFF
--- a/lookbook/docs/patterns/14-danger-confirmation-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-confirmation-dialog.md.erb
@@ -1,6 +1,6 @@
-The DangerConfirmationDialog is used to get a second layer of confirmation before they execute a potentially breaking, non-reversible action such as deletion.
+The DangerConfirmationDialog is used to get a second layer of confirmation from the user before they execute a potentially breaking, non-reversible action such as deletion.
 
-The goal of the dialog is to inform the user that the action is not reversible and require one additional interaction before the user can confirm the deletion.
+The dial will inform the user that the action is not reversible and require one additional interaction before the user can confirm the deletion.
 
 The DangerConfirmationDialog is a sub-component of FeedbackDialog.
 
@@ -19,7 +19,7 @@ The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 - A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
 - Footer actions: "Cancel" and "Delete permanently" (danger red)
 
-The "Delete permanently" button is disabled until the user checks the confirmation checkbox
+The "Delete permanently" button is disabled until the user checks the confirmation checkbox.
 
 The additional content area can be replaced with other options, such as different text, a list of work packages or additional interaction.
 
@@ -38,15 +38,15 @@ If you need a variant with a different structure, please contact the UX and Fron
 
 #### Do:
 
-- Give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted.f
-- Use the simplest variant that will do the job, usually the default with customised text tailored to the specific context. Only choose variations or add additional elements if absolutely required.
+- Do give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted.
+- Do use the simplest variant that will do the job, usually the default with customised text tailored to the specific context. Only choose variations or add additional elements if absolutely required.
 
 #### Don't:
 
-- Overload the content slot with too much information or additional interactions; we want the user to read and understand the consequences of this action. If the context that is needed is particularly complicated, consult the Design team for help on how to proceed.
-- Use it to provide feedback. Use the FeedbackDialog instead.
-- Add additional margins or spacing.
-- Change the danger icon
+- Don't overload the content slot with too much information or additional interactions; we want the user to read and understand the consequences of this action. If the context that is needed is particularly complicated, consult the Design team for help on how to proceed.
+- Don't use it to provide feedback. Use the FeedbackDialog instead.
+- Don't add additional margins or spacing.
+- Don't change the danger icon
 
 ### Used in
 

--- a/lookbook/docs/patterns/14-danger-confirmation-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-confirmation-dialog.md.erb
@@ -1,34 +1,36 @@
-The Danger Confirmation Dialog is used to get a second layer of confirmation before they execute a potentially breaking, non-reversible action such as deletion.
+The DangerConfirmationDialog is used to get a second layer of confirmation before they execute a potentially breaking, non-reversible action such as deletion.
 
 The goal of the dialog is to inform the user that the action is not reversible and require one additional interaction before the user can confirm the deletion.
 
-The Danger Confirmation Dialog is a sub-component of Feedback Dialog.
+The DangerConfirmationDialog is a sub-component of FeedbackDialog.
 
 ### Overview
 
-[EMBED CODE EXAMPLE HERE]
+<%= embed Patterns::DangerConfirmationDialogPreview, :default, panels: %i[source] %>
 
 ### Anatomy
 
-The Feedback Dialog is a variation of Feedback Dialog. It consists of:
+The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 
 - A red warning icon
 - A heading with a confirmation question such as "Permanently delete?"
-- A content slot. By default this will contain text: "This action is not reversible. Please proceed with caution."
+- A message explaining the consequences
+- An additional content slot
 - A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
 - Footer actions: "Cancel" and "Delete permanently" (danger red)
 
 The "Delete permanently" button is disabled until the user checks the confirmation checkbox
 
-The Content area can be replaced with other options, such as different text, a list of work packages or additional interaction.
+The additional content area can be replaced with other options, such as different text, a list of work packages or additional interaction.
 
 ### Options
 
-Three elements can be customised:
+Some elements can be customised:
 
 - The heading text
 - The contents of the content slot
 - The text of the confirmation checkbox
+- The texts of the footer action buttons
 
 If you need a variant with a different structure, please contact the UX and Front-end Primer teams.
 
@@ -36,19 +38,19 @@ If you need a variant with a different structure, please contact the UX and Fron
 
 #### Do:
 
-- Give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted.f 
+- Give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted.f
 - Use the simplest variant that will do the job, usually the default with customised text tailored to the specific context. Only choose variations or add additional elements if absolutely required.
 
 #### Don't:
 
 - Overload the content slot with too much information or additional interactions; we want the user to read and understand the consequences of this action. If the context that is needed is particularly complicated, consult the Design team for help on how to proceed.
-- Use it to provide feedback. Use the Feedback Dialog instead.
+- Use it to provide feedback. Use the FeedbackDialog instead.
 - Add additional margins or spacing.
 - Change the danger icon
 
 ### Used in
 
-The Danger Confirmation Dialog will replace the traditional Rails danger zone area in at least these places:
+The DangerConfirmationDialog will replace the traditional Rails danger zone area in at least these places:
 
 - work_packages: bulk/destroyusers: deletion
 - repositories: destroy
@@ -63,14 +65,11 @@ The Danger Confirmation Dialog will replace the traditional Rails danger zone ar
 
 The confirmation dialog should also be used where we are currently using browser dialogs or a non-Primer modal for high-risk operations, such as:
 
-- Bulk deleting wo- rk packages
+- Bulk deleting work packages
 - Deleting a custom field
 
 ### Technical notes
 
-[Add technical notes here, if any]
-
-
-### Examples
-
-[Add examples here]
+* In order to actually delete some object, you will most likely need a form which the "delete" button then submits. We have two ways to achieve that:
+  * ([`With form_arguments`](../../inspect/primer/open_project/danger_confirmation_dialog/with_form))
+  * ([`With a form builder`](../../inspect/primer/open_project/danger_confirmation_dialog/with_form_builder_form))

--- a/lookbook/docs/patterns/14-danger-confirmation-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-confirmation-dialog.md.erb
@@ -1,0 +1,76 @@
+The Danger Confirmation Dialog is used to get a second layer of confirmation before they execute a potentially breaking, non-reversible action such as deletion.
+
+The goal of the dialog is to inform the user that the action is not reversible and require one additional interaction before the user can confirm the deletion.
+
+The Danger Confirmation Dialog is a sub-component of Feedback Dialog.
+
+### Overview
+
+[EMBED CODE EXAMPLE HERE]
+
+### Anatomy
+
+The Feedback Dialog is a variation of Feedback Dialog. It consists of:
+
+- A red warning icon
+- A heading with a confirmation question such as "Permanently delete?"
+- A content slot. By default this will contain text: "This action is not reversible. Please proceed with caution."
+- A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
+- Footer actions: "Cancel" and "Delete permanently" (danger red)
+
+The "Delete permanently" button is disabled until the user checks the confirmation checkbox
+
+The Content area can be replaced with other options, such as different text, a list of work packages or additional interaction.
+
+### Options
+
+Three elements can be customised:
+
+- The heading text
+- The contents of the content slot
+- The text of the confirmation checkbox
+
+If you need a variant with a different structure, please contact the UX and Front-end Primer teams.
+
+### Best practices
+
+#### Do:
+
+- Give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted.f 
+- Use the simplest variant that will do the job, usually the default with customised text tailored to the specific context. Only choose variations or add additional elements if absolutely required.
+
+#### Don't:
+
+- Overload the content slot with too much information or additional interactions; we want the user to read and understand the consequences of this action. If the context that is needed is particularly complicated, consult the Design team for help on how to proceed.
+- Use it to provide feedback. Use the Feedback Dialog instead.
+- Add additional margins or spacing.
+- Change the danger icon
+
+### Used in
+
+The Danger Confirmation Dialog will replace the traditional Rails danger zone area in at least these places:
+
+- work_packages: bulk/destroyusers: deletion
+- repositories: destroy
+- projects: change identifier
+- placeholder_users: deletion
+- projects: destroy
+- storages: destroy
+- openid_connect: destroy
+- ldap_groups/synchronized_filters: destroy
+- ldap_groups/synchronized_groups: destroy
+- saml/providers: destroy
+
+The confirmation dialog should also be used where we are currently using browser dialogs or a non-Primer modal for high-risk operations, such as:
+
+- Bulk deleting wo- rk packages
+- Deleting a custom field
+
+### Technical notes
+
+[Add technical notes here, if any]
+
+
+### Examples
+
+[Add examples here]

--- a/lookbook/previews/patterns/danger_confirmation_dialog_preview.rb
+++ b/lookbook/previews/patterns/danger_confirmation_dialog_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Patterns
+  # @hidden
+  class DangerConfirmationDialogPreview < ViewComponent::Preview
+    # @display min_height 400px
+    def default
+      render_with_template
+    end
+  end
+end

--- a/lookbook/previews/patterns/danger_confirmation_dialog_preview/default.html.erb
+++ b/lookbook/previews/patterns/danger_confirmation_dialog_preview/default.html.erb
@@ -1,0 +1,9 @@
+<%=
+  render(Primer::OpenProject::DangerConfirmationDialog.new(open: true)) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { "Are you sure?" }
+      message.with_description_content( "You are going to delete the whole project and all it's WorkPackages!" )
+    end
+    dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed")
+  end
+%>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/60358/github

# What are you trying to accomplish?
Write draft Lookbook documention for the new danger confirmation dialog so that a front-end dev can add code examples and complete the documentation
