### PR TITLE
[60358] Document the two variants of the DangerDialog

### DIFF
--- a/lookbook/docs/patterns/14-danger-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-dialog.md.erb
@@ -19,7 +19,6 @@ The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 
 - A red warning icon
 - A heading with a confirmation question such as "Permanently delete?"
-
 - A message explaining the consequences
 - An additional content slot
 - (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
@@ -46,7 +45,6 @@ If you need a variant with a different structure, please contact the UX and Fron
 
 - Do give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted. If the relevant details are too detailed (for example, there are over 10 work packages to be deleted), provide a summary instead of listing all individual items.
 - Do use the simplest variant that will do the job, usually the default with customised text tailored to the specific context. Only choose variations or add additional elements if absolutely required.
-
 
 #### Don't:
 

--- a/lookbook/docs/patterns/14-danger-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-dialog.md.erb
@@ -1,6 +1,11 @@
-The DangerDialog is used to get a second layer of confirmation from the user before they execute a potentially breaking, non-reversible action such as deletion.
+The DangerDialog is used to direct the user's attention towards a potentially destructive, non-reversible action such as deletion.
 
-The dial will inform the user that the action is not reversible and require one additional interaction before the user can confirm the deletion.
+There are two variants:
+
+1. **Danger Confirmation** requires an addition interaction from the user (i.e, checking a checkbox) in addition to a visual and text warning before they are able to confirm the action
+2. **Danger Warning** simply presents the user with a visual and text warning before they confirm the action
+
+The dialog aims to reduce cases of accidental deletion that may result from the browser "Are you sure?" confirmation dialog not sufficiently conveying the potential risks of a particular user action.
 
 The DangerDialog is a sub-component of FeedbackDialog.
 
@@ -14,12 +19,13 @@ The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 
 - A red warning icon
 - A heading with a confirmation question such as "Permanently delete?"
+
 - A message explaining the consequences
 - An additional content slot
-- A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
+- (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
 - Footer actions: "Cancel" and "Delete permanently" (danger red)
 
-The "Delete permanently" button is disabled until the user checks the confirmation checkbox.
+For the Danger Confirmation, the primary button text is "Delete permanently" and it is disabled until the user checks the confirmation checkbox
 
 The additional content area can be replaced with other options, such as different text, a list of work packages or additional interaction.
 
@@ -38,8 +44,9 @@ If you need a variant with a different structure, please contact the UX and Fron
 
 #### Do:
 
-- Do give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted.
+- Do give the user relevant detail possible. For example, when bulk deleting, list the work packages that will be deleted. If the relevant details are too detailed (for example, there are over 10 work packages to be deleted), provide a summary instead of listing all individual items.
 - Do use the simplest variant that will do the job, usually the default with customised text tailored to the specific context. Only choose variations or add additional elements if absolutely required.
+
 
 #### Don't:
 
@@ -62,11 +69,20 @@ The DangerDialog will replace the traditional Rails danger zone area in at least
 - ldap_groups/synchronized_filters: destroy
 - ldap_groups/synchronized_groups: destroy
 - saml/providers: destroy
+- Deleting a meeting series
 
-The confirmation dialog should also be used where we are currently using browser dialogs or a non-Primer modal for high-risk operations, such as:
+The DangerDialog should also be used where we are currently using browser dialogs or a non-Primer modal for high-risk operations, such as:
 
 - Bulk deleting work packages
 - Deleting a custom field
+
+The Danger Warning dialog should replace the default browser native "Are you sure?" dialog if the action is destructive and non reversible, for example:
+
+- Deleting work packages
+- Deleting individual meetings (or individual occurrences of a meeting series)
+- Deleting a custom field
+- Deleting a custom action
+- Deleting a wiki
 
 ### Technical notes
 

--- a/lookbook/docs/patterns/14-danger-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-dialog.md.erb
@@ -7,7 +7,7 @@ There are two variants:
 
 The dialog aims to reduce cases of accidental deletion that may result from the browser "Are you sure?" confirmation dialog not sufficiently conveying the potential risks of a particular user action.
 
-The DangerDialog is a sub-component of FeedbackDialog.
+The DangerDialog is related to the FeedbackDialog, sharing some common behavior.
 
 ### Overview
 

--- a/lookbook/docs/patterns/14-danger-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-dialog.md.erb
@@ -29,7 +29,9 @@ The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 - (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
 - Footer actions: "Cancel" and "Delete" (danger red)
 
-For the Danger Confirmation, the primary button text is "Delete permanently" and it is disabled until the user checks the confirmation checkbox
+For the Danger Confirmation, the primary button text is "Delete permanently" and it is disabled until the user checks the confirmation checkbox.
+
+The button text can be customized if the dialog action is not a deletion.
 
 The additional content area can be replaced with other options, such as different text, a list of work packages or additional interaction.
 

--- a/lookbook/docs/patterns/14-danger-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-dialog.md.erb
@@ -18,7 +18,12 @@ The DangerDialog is a sub-component of FeedbackDialog.
 The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 
 - A red warning icon
-- A heading with a confirmation question such as "Permanently delete?"
+- A title: a short description of the dialog action. This should be written in a neutral tone. The title is currently only used for accessibility purposes. Examples:
+    - "Delete work package"
+    - "Delete project"
+- A heading: a question inviting the user to take a decision, This should be written in an active tone. You may also to give the full descriptive name of the resource on which the action will take place (e.g. "meeting occurrence" rather than just "meeting"). Examples:
+    - "Permanently delete this work package?"
+    - "Cancel this meeting occurrence?"
 - A message explaining the consequences
 - An additional content slot
 - (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed"

--- a/lookbook/docs/patterns/14-danger-dialog.md.erb
+++ b/lookbook/docs/patterns/14-danger-dialog.md.erb
@@ -27,7 +27,7 @@ The FeedbackDialog is a variation of FeedbackDialog. It consists of:
 - A message explaining the consequences
 - An additional content slot
 - (For the Danger Confirmation) A confirmation checkbox with text: "I understand that this deletion cannot be reversed"
-- Footer actions: "Cancel" and "Delete permanently" (danger red)
+- Footer actions: "Cancel" and "Delete" (danger red)
 
 For the Danger Confirmation, the primary button text is "Delete permanently" and it is disabled until the user checks the confirmation checkbox
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/60588/activity

# What are you trying to accomplish?
 Document that the Primer DangerDialog should have a simple variant without second step confirmation

see also 

- https://github.com/opf/primer_view_components/pull/234
- https://github.com/opf/openproject/pull/17820
