### PR TITLE
Do not allow time tracking for users that are not visible to you

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -31,12 +31,12 @@ class Principal < ApplicationRecord
 
   # Account statuses
   # Disables enum scopes to include not_builtin (cf. Principals::Scopes::Status)
-  enum status: {
+  enum :status, {
     active: 1,
     registered: 2,
     locked: 3,
     invited: 4
-  }.freeze, _scopes: false
+  }.freeze, scopes: false
 
   self.table_name = "#{table_name_prefix}users#{table_name_suffix}"
 
@@ -174,6 +174,11 @@ class Principal < ApplicationRecord
   # Must be overridden by User
   def activatable?
     false
+  end
+
+  # Returns true if usr or current user is allowed to view the user
+  def visible?(usr = User.current)
+    User.visible(usr).exists?(id: id)
   end
 
   def <=>(other)

--- a/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe TimeEntries::CreateContract do
       end
     end
 
+    context "if the user is set to a user that the user has no access to" do
+      let(:user_visible) { false }
+
+      it "is invalid" do
+        expect_valid(false, user_id: %i(invalid))
+      end
+    end
+
     context "if time_entry user was not set by system" do
       let(:other_user) { build_stubbed(:user) }
       let(:time_entry_user) { other_user }

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -51,6 +51,7 @@ RSpec.shared_examples_for "time entry contract" do
   let(:time_entry_hours) { 5 }
   let(:time_entry_comments) { "A comment" }
   let(:work_package_visible) { true }
+  let(:user_visible) { true }
   let(:time_entry_day_sum) { 5 }
   let(:activities_scope) do
     scope = class_double(TimeEntryActivity)
@@ -97,6 +98,8 @@ RSpec.shared_examples_for "time entry contract" do
       .to receive(:active_in_project)
       .with(time_entry_project)
       .and_return(activities_scope)
+
+    allow(time_entry_user).to receive(:visible?).and_return(user_visible)
   end
 
   def expect_valid(valid, symbols = {})

--- a/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TimeEntries::UpdateContract do
     end
     subject(:contract) { described_class.new(time_entry, current_user) }
 
-    let(:permissions) { %i(edit_time_entries) }
+    let(:permissions) { %i(edit_time_entries log_time) }
 
     context "if user is not allowed to edit time entries" do
       let(:permissions) { [] }
@@ -124,6 +124,19 @@ RSpec.describe TimeEntries::UpdateContract do
       it "is invalid" do
         time_entry.user = other_user
         expect_valid(false, base: %i(error_unauthorized))
+      end
+    end
+
+    context "if the user is changed to a user that the user has no access to" do
+      let(:new_user) do
+        create(:user).tap do |user|
+          allow(user).to receive(:visible?).and_return(false)
+        end
+      end
+
+      it "is invalid" do
+        time_entry.user = new_user
+        expect_valid(false, user_id: %i(invalid))
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61084

# What are you trying to accomplish?
Prevent logging time for users that cannot be accessed by the user. This is currently only prevented by the auto completer, but not by the backend.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
