### PR TITLE
bug/60976 Setting the user display format without lastname breaks user custom fields with Group values

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -333,8 +333,11 @@ class CustomField < ApplicationRecord
                   .in_visible_project_or_me(User.current)
               end
 
-      scope
-        .select(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s), "id", "type")
+      user_format_columns = User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s)
+      # Always include lastname if not already included, as Groups always need a lastname (alias for name)
+      user_format_columns << "lastname" unless user_format_columns.include?("lastname")
+
+      scope.select(*user_format_columns, "id", "type")
     end
   end
 

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -260,6 +260,16 @@ RSpec.describe CustomField do
             .to contain_exactly([user2.name, user2.id.to_s])
         end
       end
+
+      context "with user format setting excluding lastname", with_settings: { user_format: :username } do
+        it "always includes lastname for Group#name{:lastname} aliasing" do
+          expect(field.possible_values_options)
+            .to contain_exactly([user2.name, user2.id.to_s])
+
+          expect(in_visible_scope).to have_received(:select)
+           .with("login", "lastname", "id", "type")
+        end
+      end
     end
 
     context "for a list custom field" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60976

# What are you trying to accomplish?

Fix an internal server error that occurs when using custom fields of type 'user' with user format settings that exclude 'lastname'. The error manifests when Groups are included in the possible values and the user format setting doesn't include 'lastname' (e.g., when set to 'username' only).

# What approach did you choose and why?

The root cause was that Groups rely on `lastname` (aliased as `name`) for comparison operations, but this column wasn't always being selected when loading possible values for custom fields. This would happen specifically when the user format setting didn't include lastname (e.g., `:username` or `:firstname` formats).

The solution ensures we always include the `lastname` column when selecting possible values for user custom fields, regardless of the user format setting. This maintains Group functionality while respecting user format preferences.

Follows #17350

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
