### PR TITLE
Move title and message from controller to view

### DIFF
--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -88,12 +88,7 @@ module ::TwoFactorAuthentication
       ##
       # Request (if needed) the token for entering
       def request_device_confirmation_token
-        request_token_for_device(
-          @device,
-          confirm_path: url_for(action: :confirm, device_id: @device.id),
-          title: I18n.t("two_factor_authentication.devices.confirm_device"),
-          message: I18n.t("two_factor_authentication.devices.text_confirm_to_complete_html", identifier: @device.identifier)
-        )
+        request_token_for_device(@device, confirm_path: url_for(action: :confirm, device_id: @device.id))
       end
 
       def request_token_for_device(device, locals)

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
@@ -3,8 +3,8 @@
                     t('two_factor_authentication.devices.confirm_device') -%>
 
 <%= styled_form_tag(confirm_path, method: :post, id: 'login-form', class: 'form -bordered', autocomplete: "off") do %>
-  <h2><%= title %></h2>
-  <p><%= message.html_safe %></p>
+  <h2><%= t("two_factor_authentication.devices.confirm_device") %></h2>
+  <p><%= t("two_factor_authentication.devices.text_confirm_to_complete_html", identifier: @device.identifier) %></p>
   <hr class="form--separator">
   <%= back_url_hidden_field_tag %>
   <div class="form--field -required -wide-label">


### PR DESCRIPTION
This allows us to use the Rails-provided translate method, which has built-in support for html translations.

# Ticket
https://community.openproject.org/work_packages/61089

# What are you trying to accomplish?
Making use of the `t` helper by Rails.

# What approach did you choose and why?
As far as I can tell, the view only ever rendered exactly the same message and title, based on the `@device` name. I thus moved the translation into the view.

# Merge checklist

- [x] Tested in Firefox
