### PR TITLE
Do not allow time tracking for users that are not visible to you

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -31,12 +31,12 @@ class Principal < ApplicationRecord
 
   # Account statuses
   # Disables enum scopes to include not_builtin (cf. Principals::Scopes::Status)
-  enum status: {
+  enum :status, {
     active: 1,
     registered: 2,
     locked: 3,
     invited: 4
-  }.freeze, _scopes: false
+  }.freeze, scopes: false
 
   self.table_name = "#{table_name_prefix}users#{table_name_suffix}"
 
@@ -174,6 +174,11 @@ class Principal < ApplicationRecord
   # Must be overridden by User
   def activatable?
     false
+  end
+
+  # Returns true if usr or current user is allowed to view the user
+  def visible?(usr = User.current)
+    User.visible(usr).exists?(id: id)
   end
 
   def <=>(other)

--- a/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe TimeEntries::CreateContract do
       end
     end
 
+    context "if the user is set to a user that the user has no access to" do
+      let(:user_visible) { false }
+
+      it "is invalid" do
+        expect_valid(false, user_id: %i(invalid))
+      end
+    end
+
     context "if time_entry user was not set by system" do
       let(:other_user) { build_stubbed(:user) }
       let(:time_entry_user) { other_user }

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -51,6 +51,7 @@ RSpec.shared_examples_for "time entry contract" do
   let(:time_entry_hours) { 5 }
   let(:time_entry_comments) { "A comment" }
   let(:work_package_visible) { true }
+  let(:user_visible) { true }
   let(:time_entry_day_sum) { 5 }
   let(:activities_scope) do
     scope = class_double(TimeEntryActivity)
@@ -97,6 +98,8 @@ RSpec.shared_examples_for "time entry contract" do
       .to receive(:active_in_project)
       .with(time_entry_project)
       .and_return(activities_scope)
+
+    allow(time_entry_user).to receive(:visible?).and_return(user_visible)
   end
 
   def expect_valid(valid, symbols = {})

--- a/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TimeEntries::UpdateContract do
     end
     subject(:contract) { described_class.new(time_entry, current_user) }
 
-    let(:permissions) { %i(edit_time_entries) }
+    let(:permissions) { %i(edit_time_entries log_time) }
 
     context "if user is not allowed to edit time entries" do
       let(:permissions) { [] }
@@ -124,6 +124,19 @@ RSpec.describe TimeEntries::UpdateContract do
       it "is invalid" do
         time_entry.user = other_user
         expect_valid(false, base: %i(error_unauthorized))
+      end
+    end
+
+    context "if the user is changed to a user that the user has no access to" do
+      let(:new_user) do
+        create(:user).tap do |user|
+          allow(user).to receive(:visible?).and_return(false)
+        end
+      end
+
+      it "is invalid" do
+        time_entry.user = new_user
+        expect_valid(false, user_id: %i(invalid))
       end
     end
 

--- a/modules/costs/spec/controllers/time_entries_controller_spec.rb
+++ b/modules/costs/spec/controllers/time_entries_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe TimeEntriesController do
         context "and the user has the edit_own_time_entries permission on the project" do
           before do
             role = create(:project_role, permissions: %i[view_own_time_entries edit_own_time_entries])
-            create(:member, user: user, project: project1, roles: [role])
+            user.members.find_by(project: project1).roles << role
           end
 
           it "allows the user to open the dialog" do
@@ -92,7 +92,7 @@ RSpec.describe TimeEntriesController do
         context "and the user has the edit_time_entries permission on the project" do
           before do
             role = create(:project_role, permissions: %i[view_time_entries edit_time_entries])
-            create(:member, user: user, project: project1, roles: [role])
+            user.members.find_by(project: project1).roles << role
           end
 
           it "allows the user to open the dialog" do

--- a/modules/costs/spec/factories/time_entry_factory.rb
+++ b/modules/costs/spec/factories/time_entry_factory.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
   factory :time_entry do
     user
     work_package
-    spent_on { Date.today }
+    spent_on { Time.zone.today }
     activity factory: :time_entry_activity
     hours { 1.0 }
     logged_by { user }
@@ -43,9 +43,9 @@ FactoryBot.define do
       time_entry.update(project: time_entry.work_package.project)
 
       # ensure user is member of project
-      unless time_entry.user.member_of?(time_entry.project)
+      unless Member.exists?(principal: time_entry.user, project: time_entry.project)
         role = create(:project_role, permissions: [:view_project])
-        create(:member, user: time_entry.user, project: time_entry.project, roles: [role])
+        create(:member, principal: time_entry.user, project: time_entry.project, roles: [role])
       end
     end
 

--- a/modules/costs/spec/factories/time_entry_factory.rb
+++ b/modules/costs/spec/factories/time_entry_factory.rb
@@ -40,7 +40,9 @@ FactoryBot.define do
     end
 
     after(:create) do |time_entry|
-      time_entry.update(project: time_entry.work_package.project)
+      if time_entry.work_package.present?
+        time_entry.update(project: time_entry.work_package.project)
+      end
 
       # ensure user is member of project
       unless Member.exists?(principal: time_entry.user, project: time_entry.project)

--- a/modules/costs/spec/factories/time_entry_factory.rb
+++ b/modules/costs/spec/factories/time_entry_factory.rb
@@ -39,6 +39,16 @@ FactoryBot.define do
       time_entry.project ||= time_entry.work_package.project
     end
 
+    after(:create) do |time_entry|
+      time_entry.update(project: time_entry.work_package.project)
+
+      # ensure user is member of project
+      unless time_entry.user.member_of?(time_entry.project)
+        role = create(:project_role, permissions: [:view_project])
+        create(:member, user: time_entry.user, project: time_entry.project, roles: [role])
+      end
+    end
+
     trait :with_start_and_end_time do
       time_zone { "Asia/Tokyo" }
       start_time { 390 } # 6:30 AM

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe TimeEntry do
   end
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
-  let(:date) { Date.today }
+  let(:date) { Time.zone.today }
   let(:rate) { build(:cost_rate) }
   let!(:hourly_one) { create(:hourly_rate, valid_from: 2.days.ago, project:, user:) }
   let!(:hourly_three) { create(:hourly_rate, valid_from: 4.days.ago, project:, user:) }
@@ -80,10 +80,16 @@ RSpec.describe TimeEntry do
   end
 
   def ensure_membership(project, user, permissions)
-    create(:member,
-           project:,
-           user:,
-           roles: [create(:project_role, permissions:)])
+    member = Member.find_by(principal: user, project: project)
+
+    if member
+      member.roles << create(:project_role, permissions:)
+    else
+      create(:member,
+             project:,
+             user:,
+             roles: [create(:project_role, permissions:)])
+    end
   end
 
   describe "#hours=" do

--- a/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
@@ -196,10 +196,10 @@ RSpec.describe API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
         let(:user) do
           user = time_entry.user
 
-          create(:member,
-                 project: time_entry.project,
-                 roles: [create(:project_role, permissions:)],
-                 principal: user)
+          user
+            .members
+            .find_by(project: project)
+            .update(roles: [create(:project_role, permissions: permissions)])
 
           user
         end

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -286,10 +286,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
 
       before do
-        create(:member,
-               roles: [role],
-               project: other_project,
-               user: current_user)
+        current_user.members.find_by(project: other_project).roles << role
         get path
       end
 

--- a/modules/dashboards/spec/features/time_entries_spec.rb
+++ b/modules/dashboards/spec/features/time_entries_spec.rb
@@ -34,18 +34,14 @@ RSpec.describe "Time entries widget on dashboard", :js, :with_cuprite do
   let!(:type) { create(:type) }
   let!(:project) { create(:project, types: [type]) }
   let!(:other_project) { create(:project, types: [type]) }
-  let!(:work_package) do
-    create(:work_package,
-           project:,
-           type:,
-           author: user)
-  end
+  let!(:work_package) { create(:work_package, project:, type:, author: user) }
+  let!(:other_work_package) { create(:work_package, project: other_project, type:, author: user) }
   let!(:visible_time_entry) do
     create(:time_entry,
            work_package:,
            project:,
            user:,
-           spent_on: Date.today,
+           spent_on: Time.zone.today,
            hours: 6,
            comments: "My comment")
   end
@@ -54,13 +50,13 @@ RSpec.describe "Time entries widget on dashboard", :js, :with_cuprite do
            work_package:,
            project:,
            user: other_user,
-           spent_on: Date.today - 1.day,
+           spent_on: 1.day.ago.to_date,
            hours: 5,
            comments: "Another`s comment")
   end
   let!(:invisible_time_entry) do
     create(:time_entry,
-           work_package:,
+           work_package: other_work_package,
            project: other_project,
            user:,
            hours: 4)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61084

# What are you trying to accomplish?
Prevent logging time for users that cannot be accessed by the user. This is currently only prevented by the auto completer, but not by the backend.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
