### PR TITLE
fix unexpected passing of US-ASCII string into Commonmarker on search

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -124,13 +124,19 @@ module SearchHelper
 
   def attachment_fulltexts(event)
     only_if_tsv_supported(event) do
-      Attachment.where(id: event.attachment_ids).pluck(:fulltext).join(" ")
+      # The compact is important here as the fulltext can be nil.
+      # A nil value in combination with another journal would lead to
+      # [nil, "The fulltext of the attachment"].join to be in US-ASCII encoding
+      # instead of the expected UTF-8.
+      # When this is then passed into Commonmarker, that will raise an error.
+      # https://community.openproject.org/wp/61110
+      Attachment.where(id: event.attachment_ids).pluck(:fulltext).compact.join
     end
   end
 
   def attachment_filenames(event)
     only_if_tsv_supported(event) do
-      event.attachments&.map(&:filename)&.join(" ")
+      event.attachments.map(&:filename).join
     end
   end
 

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "search/index" do
   describe "#highlight_tokens_in_event" do
     let(:journal_notes) { "Journals notes" }
     let(:event_description) { "The description of the event" }
-    let(:attachment_fulltext) { "The fulltext of the attachment" }
+    let(:attachment_fulltext) { ["The fulltext of the attachment"] }
     let(:attachment_filename) { "attachment_filename.txt" }
     let(:journal) { build_stubbed(:work_package_journal, notes: journal_notes) }
     let(:event) do
@@ -114,7 +114,7 @@ RSpec.describe "search/index" do
         allow(scope)
           .to receive(:pluck)
                 .with(:fulltext)
-                .and_return [attachment_fulltext]
+                .and_return attachment_fulltext
       end
     end
 
@@ -147,6 +147,18 @@ RSpec.describe "search/index" do
     end
 
     context "with the token in the attachment text" do
+      let(:tokens) { %w(fulltext) }
+
+      it "shows the text in the fulltext" do
+        expect(helper.highlight_tokens_in_event(event, tokens))
+          .to eql 'The <span class="search-highlight token-0">fulltext</span> of the attachment'
+      end
+    end
+
+    context "with the token in the second attachment's text with the first one being nil" do
+      # Bug happening if [nil, "The fulltext of the attachment"].join leads to a US-ASCII encoding.
+      # https://community.openproject.org/wp/61110
+      let(:attachment_fulltext) { [nil, "The fulltext of the attachment"] }
       let(:tokens) { %w(fulltext) }
 
       it "shows the text in the fulltext" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61110

# What are you trying to accomplish?

Avoid passing a US-ASCII string into Commonmarker which leads to an error therein. 

# What approach did you choose and why?

By compacting, nil values are returned from the set of fetched attachment fulltexts. Otherwise a 

`[nil, "Some text"].join` 

leads to a US-ASCII encoded string.

The same problem does not happen for filenames as those have a default value of `''` defined on the table and shouldn't be empty to begin with.

# Merge checklist

- [x] Added/updated tests
