### PR TITLE
Include ongoing in upcoming scope of schedule meeting

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -53,12 +53,11 @@ class RecurringMeetingsController < ApplicationController
         params[:count].to_i + 5
       end
 
-
-      if @direction == "past"
-        @meetings = @recurring_meeting.scheduled_instances(upcoming: false).limit(@count)
-      else
-        @meetings, @planned_meetings =upcoming_meetings(count: @count)
-      end
+    if @direction == "past"
+      @meetings = @recurring_meeting.scheduled_instances(upcoming: false).limit(@count)
+    else
+      @meetings, @planned_meetings = upcoming_meetings(count: @count)
+    end
 
     respond_to do |format|
       format.html do
@@ -252,7 +251,7 @@ class RecurringMeetingsController < ApplicationController
 
   def upcoming_meetings(count:)
     opened = @recurring_meeting
-      .upcoming_not_cancelled_meetings
+      .upcoming_instantiated_meetings
       .index_by(&:start_time)
 
     cancelled = @recurring_meeting
@@ -262,10 +261,10 @@ class RecurringMeetingsController < ApplicationController
     # Planned meetings consist of scheduled occurrences and cancelled meetings
     # Open meetings are removed from the scheduled occurrences as they are displayed separately
     planned = @recurring_meeting
-               .scheduled_occurrences(limit: count + opened.count)
-               .reject { |start_time| opened.include?(start_time) }
-               .map { |start_time| cancelled[start_time] || scheduled_meeting(start_time) }
-               .first(count)
+      .scheduled_occurrences(limit: count + opened.count)
+      .reject { |start_time| opened.include?(start_time) }
+      .map { |start_time| cancelled[start_time] || scheduled_meeting(start_time) }
+      .first(count)
 
     [opened.values.sort_by(&:start_time), planned]
   end

--- a/modules/meeting/app/helpers/recurring_meetings_helper.rb
+++ b/modules/meeting/app/helpers/recurring_meetings_helper.rb
@@ -31,7 +31,7 @@ module RecurringMeetingsHelper
     if @direction == "past"
       @recurring_meeting.scheduled_instances(upcoming: false).count
     else
-      open = @recurring_meeting.upcoming_not_cancelled_meetings
+      open = @recurring_meeting.upcoming_instantiated_meetings
 
       @recurring_meeting.remaining_occurrences&.count&.- open.count
     end

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -194,11 +194,12 @@ class RecurringMeeting < ApplicationRecord
       .order(start_time: direction)
   end
 
-  def upcoming_not_cancelled_meetings
+  def upcoming_instantiated_meetings
     scheduled_meetings
       .includes(:meeting)
-      .upcoming
       .not_cancelled
+      .joins(:meeting)
+      .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.current)
       .order(start_time: :asc)
   end
 

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -222,4 +222,16 @@ RSpec.describe RecurringMeeting,
       expect { subject.last_occurrence }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#upcoming_instantiated_meetings" do
+    let!(:recurring_meeting) { create(:recurring_meeting) }
+    let!(:ongoing_meeting) do
+      create(:scheduled_meeting, :persisted, start_time: 5.minutes.ago, recurring_meeting: recurring_meeting)
+    end
+    let!(:cancelled_meeting) { create(:scheduled_meeting, recurring_meeting: recurring_meeting, cancelled: true) }
+
+    it "returns only upcoming and not cancelled meetings" do
+      expect(recurring_meeting.upcoming_instantiated_meetings).to eq [ongoing_meeting]
+    end
+  end
 end


### PR DESCRIPTION
For listing the upcoming instantiated meetings, we want to include the start_time + duration check, similar to the regular meetings upcoming filter.
https://community.openproject.org/work_packages/60727
