### PR TITLE
Update omniauth-open_id_connect gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/omniauth-openid-connect.git
-  revision: d63f5967514d10db9ddece798dadfa2ac532cbe0
-  ref: d63f5967514d10db9ddece798dadfa2ac532cbe0
+  revision: 3d5fec65072fb4566fb975a9cbe401d758d22317
+  ref: 3d5fec65072fb4566fb975a9cbe401d758d22317
   specs:
-    omniauth-openid-connect (0.4.0)
+    omniauth-openid-connect (0.4.1)
       addressable (~> 2.5)
       omniauth (~> 1.6)
       openid_connect (~> 2.2.0)

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -14,7 +14,7 @@ gem 'omniauth-openid_connect-providers',
 
 gem 'omniauth-openid-connect',
     git: 'https://github.com/opf/omniauth-openid-connect.git',
-    ref: 'd63f5967514d10db9ddece798dadfa2ac532cbe0'
+    ref: '3d5fec65072fb4566fb975a9cbe401d758d22317'
 
 group :opf_plugins do
     # included so that engines can reference OpenProject::Version


### PR DESCRIPTION
We [addressed a bug](https://github.com/opf/omniauth-openid-connect/pull/14) with handling error responses during OAuth 2.0 interaction with the identity provider.

# Ticket
https://community.openproject.org/projects/openproject/work_packages/59960