### PR TITLE
[60615] The right-side pane scrolls with the rest of the page after adding a child via the Relations tab

### DIFF
--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -107,7 +107,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     if helpers.current_user.allowed_in_project?(:add_work_packages, work_package.project)
       menu.with_item(
         label: t("work_package_relations_tab.relations.new_child"),
-        href: new_project_work_packages_dialog_path(work_package.project, parent_id: work_package.id),
+        href: new_project_work_packages_dialog_path(work_package.project, parent_id: work_package.id, is_in_relations_tab: true),
         content_arguments: {
           data: { turbo_stream: true }
         }

--- a/app/components/work_packages/dialogs/create_dialog_component.html.erb
+++ b/app/components/work_packages/dialogs/create_dialog_component.html.erb
@@ -6,7 +6,7 @@
   )) do |dialog|
     dialog.with_header(variant: :large)
     dialog.with_body do
-      render(WorkPackages::Dialogs::CreateFormComponent.new(work_package:, project:))
+      render(WorkPackages::Dialogs::CreateFormComponent.new(work_package:, project:, is_in_relations_tab: @is_in_relations_tab))
     end
 
     dialog.with_footer do

--- a/app/components/work_packages/dialogs/create_dialog_component.html.erb
+++ b/app/components/work_packages/dialogs/create_dialog_component.html.erb
@@ -3,9 +3,6 @@
     id: "create-work-package-dialog",
     title: I18n.t(:label_work_package_new),
     size: :xlarge,
-    data: {
-      'keep-open-on-submit': true,
-    }
   )) do |dialog|
     dialog.with_header(variant: :large)
     dialog.with_body do

--- a/app/components/work_packages/dialogs/create_dialog_component.rb
+++ b/app/components/work_packages/dialogs/create_dialog_component.rb
@@ -35,13 +35,14 @@ module WorkPackages::Dialogs
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    attr_reader :work_package, :project
+    attr_reader :work_package, :project, :is_in_relations_tab
 
-    def initialize(work_package:, project:)
+    def initialize(work_package:, project:, is_in_relations_tab: false)
       super
 
       @work_package = work_package
       @project = project
+      @is_in_relations_tab = is_in_relations_tab
     end
   end
 end

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -3,7 +3,7 @@
     primer_form_with(
       scope: :work_package,
       model: work_package,
-      url: project_work_packages_dialog_path(project),
+      url: project_work_packages_dialog_path(project, is_in_relations_tab: @is_in_relations_tab),
       method: :post,
       html: {
         id: 'create-work-package-form',

--- a/app/components/work_packages/dialogs/create_form_component.rb
+++ b/app/components/work_packages/dialogs/create_form_component.rb
@@ -34,13 +34,14 @@ module WorkPackages::Dialogs
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    attr_reader :work_package, :project
+    attr_reader :work_package, :project, :is_in_relations_tab
 
-    def initialize(work_package:, project:)
+    def initialize(work_package:, project:, is_in_relations_tab: false)
       super
 
       @work_package = work_package
       @project = project
+      @is_in_relations_tab = is_in_relations_tab
     end
   end
 end

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -45,18 +45,14 @@ class WorkPackages::DialogsController < ApplicationController
   def create
     call = WorkPackages::CreateService.new(user: current_user).call(create_params)
 
-    respond_with_relations_tab_update(call, relation_to_scroll_to: call.result)
-  end
-
-  def respond_with_relations_tab_update(service_result, **)
-    if service_result.success?
-      component = WorkPackageRelationsTab::IndexComponent.new(work_package: service_result.result.parent, **)
-      replace_via_turbo_stream(component:)
-      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
+    if call.success?
+      flash[:notice] = I18n.t("work_package_relations_tab.relations.label_new_child_created")
+      redirect_back fallback_location: project_work_package_path(@project, call.result), status: :see_other
+    else
+      form_component = WorkPackages::Dialogs::CreateFormComponent.new(work_package: call.result, project: @project)
+      update_via_turbo_stream(component: form_component, status: :bad_request)
 
       respond_with_turbo_streams
-    else
-      respond_with_turbo_streams(status: :unprocessable_entity)
     end
   end
 

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -101,9 +101,5 @@ class WorkPackages::DialogsController < ApplicationController
     }
   end
 
-  def work_package_params
-    params.require(:work_package).permit(:type_id, :subject, :project_id, :status_id, :priority_id, :author_id, :parent_id)
-  end
-
   def default_breadcrumb; end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60615
https://community.openproject.org/wp/60629

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
After creating a new child and setting as a new relation for parent, in relations tab, we should scroll into it.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
keep-open-on-submit set to false (its default value). If it is true, it keeps the dialog element but hide it. If the Child is created in relations tab, then we should scroll into this child.

This solution fixes the issue in Gantt view too.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
