### PR TITLE
Use relative path instead of url for activities refresh

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -56,7 +56,7 @@ module WorkPackages
           test_selector: "op-wp-activity-tab",
           controller: stimulus_controller,
           "application-target": "dynamic",
-          "#{stimulus_controller}-update-streams-url-value": update_streams_work_package_activities_url(work_package),
+          "#{stimulus_controller}-update-streams-path-value": update_streams_work_package_activities_path(work_package),
           "#{stimulus_controller}-sorting-value": journal_sorting,
           "#{stimulus_controller}-filter-value": filter,
           "#{stimulus_controller}-user-id-value": User.current.id,

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -19,7 +19,7 @@ interface CustomEventWithIdParam extends Event {
 
 export default class IndexController extends Controller {
   static values = {
-    updateStreamsUrl: String,
+    updateStreamsPath: String,
     sorting: String,
     pollingIntervalInMs: Number,
     filter: String,
@@ -41,7 +41,7 @@ export default class IndexController extends Controller {
 
   declare readonly hasFormSubmitButtonTarget:boolean;
 
-  declare updateStreamsUrlValue:string;
+  declare updateStreamsPathValue:string;
   declare sortingValue:string;
   declare lastServerTimestampValue:string;
   declare intervallId:number;
@@ -204,7 +204,8 @@ export default class IndexController extends Controller {
   }
 
   private prepareUpdateStreamsUrl():string {
-    const url = new URL(this.updateStreamsUrlValue);
+    const baseUrl = window.location.origin;
+    const url = new URL(this.updateStreamsPathValue, baseUrl);
     url.searchParams.set('sortBy', this.sortingValue);
     url.searchParams.set('filter', this.filterValue);
     url.searchParams.set('last_update_timestamp', this.lastServerTimestampValue);


### PR DESCRIPTION
When using accessing the instance using the wrong host name (different from `Setting.host_name` configured in the administration or through env vars), the app should still work.

The activities tab component is using a url to know where the activities should be fetched from. This will trigger a CORS error when using the wrong host name, and the activities will not be updated. By using a relative path, the request will be relative to the current host, and thus work correctly even when using the wrong host name.

I detected that during local development while using port 4200 instead of 3000 as we usually do.
