### PR TITLE
fix label overflow

### DIFF
--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -1,7 +1,10 @@
 .work-packages-activities-tab-journals-new-component
     &--input-trigger-column
+        min-width: 0
+        overflow: hidden
         width: 100%
         button
+            min-width: 0
             background: var(--bgColor-default)
             cursor: text
             .Button-content

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -1,14 +1,16 @@
+@import "helpers"
+
 .work-packages-activities-tab-journals-new-component
     &--input-trigger-column
-        min-width: 0
-        overflow: hidden
         width: 100%
+        overflow: hidden
         button
             min-width: 0
             background: var(--bgColor-default)
             cursor: text
-            .Button-content
+            span
                 display: block
+                @include text-shortener
     &--ck-editor-column
         width: calc(100% - 40px)
         // specific ck editor adjustments


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/61088

# What are you trying to accomplish?

Fix an issue with overflowing layout where the submit button for the comment input would be outside the visible area.

## Screenshots (Screencast)

https://github.com/user-attachments/assets/4ca77d08-16b2-4f5d-b77b-1dcbbdc52e7d

# What approach did you choose and why?

Using `min-width: 0` seems to be the way to go - https://dfmcphee.com/flex-items-and-min-width-0/

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
