### PR TITLE
Bug/61134 no error message when user tries to save time log without work packages

### DIFF
--- a/modules/costs/app/components/time_entries/work_package_form.rb
+++ b/modules/costs/app/components/time_entries/work_package_form.rb
@@ -41,7 +41,8 @@ module TimeEntries
       if show_work_package_field?
         f.work_package_autocompleter name: :work_package_id,
                                      label: TimeEntry.human_attribute_name(:work_package),
-                                     required: true,
+                                     required: work_package_required?,
+                                     validation_message: work_package_validation_error,
                                      autocomplete_options: {
                                        defaultData: false,
                                        component: "opce-time-entries-work-package-autocompleter",
@@ -70,6 +71,20 @@ module TimeEntries
       else
         ::API::V3::Utilities::PathHelper::ApiV3Path.time_entries_available_work_packages_on_create
       end
+    end
+
+    # When logging time from a project page or the work package page, the project id field is set in the background.
+    # When logging from the my page the project is only settable via the work package so in this case we need to make
+    # the WP field mandatory and get the error message from the project_id field and move it to the work_package_id field.
+    #
+    # We're still discussing if we make the work package mandatory, then this will become obsolete and
+    # probably be removed.
+    def work_package_required?
+      model.project.blank?
+    end
+
+    def work_package_validation_error
+      model.errors[:project_id]&.first
     end
 
     def work_package_completer_filters

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -48,6 +48,7 @@ class TimeEntry < ApplicationRecord
 
   validates :user_id, :project_id, :spent_on,
             presence: true
+
   validates :hours,
             presence: true,
             if: -> { !ongoing? }

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -349,4 +349,22 @@ RSpec.describe "My page time entries current user widget spec", :js, :selenium d
         .to have_css(".grid--widget-add")
     end
   end
+
+  it "validates that a work package is set" do
+    my_page.add_widget(1, 1, :within, "My spent time")
+    entries_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(1)")
+    my_page.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)
+
+    within entries_area.area do
+      find("td.fc-timegrid-col:nth-of-type(5) .te-calendar--add-entry", visible: false).click
+    end
+
+    time_logging_modal.is_visible true
+    time_logging_modal.update_field "hours", 6
+
+    time_logging_modal.submit
+
+    time_logging_modal.is_visible true
+    time_logging_modal.field_has_error "work_package_id", "can't be blank."
+  end
 end

--- a/spec/features/support/components/time_logging_modal.rb
+++ b/spec/features/support/components/time_logging_modal.rb
@@ -118,6 +118,12 @@ module Components
       end
     end
 
+    def field_has_error(field, error)
+      within modal_container do
+        expect(page).to have_css(".FormControl:has(label[for=time_entry_#{field}]) > .FormControl-inlineValidation", text: error)
+      end
+    end
+
     def update_time_field(field_name, hour:, minute:)
       built_time = browser_timezone.local(2025, 1, 1, hour, minute, 0)
       page.fill_in "time_entry_#{field_name}", with: built_time.iso8601


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61134

# What are you trying to accomplish?
We have 3 cases how we can log time
- from the work package
- from the spent time widget in a project
- from the my spent time widget on the my page

> [!NOTE]  
> Currently on the `TimeEntry` only the project is a mandatory field, it is not required to be linked with a work package. We might want to change this in the future. See [WP #61136](https://community.openproject.org/projects/stream-time-and-costs/work_packages/61136/)

We do not offer selecting the project itself on the modal (not the old one and not the new one), so in the case when we log time entries from the my page, we do not know the project and thus the WP becomes mandatory in the dialog because we need it to set the project through the WP. But since the validation is run on the `project_id` field, we do not show it anywhere in the dialog. So we need to display the error from the `project_id` field on the `work_package_id` autocompleter.

## Screenshots
![Bildschirmfoto 2025-02-03 um 15 28 38](https://github.com/user-attachments/assets/632cf0aa-100b-415f-a4c1-47bf10e5734b)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
