### PR TITLE
Bump Keycloak to latest version

### DIFF
--- a/docker/dev/keycloak/docker-compose.yml
+++ b/docker/dev/keycloak/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - POSTGRES_PASSWORD=keycloak
 
   keycloak:
-    image: quay.io/keycloak/keycloak:21.1
-    command: ["start-dev", "--proxy edge", "--spi-connections-http-client-default-disable-trust-manager=true"]
+    image: quay.io/keycloak/keycloak:26.1
+    command: ["start-dev", "--proxy-headers", "xforwarded", "--spi-connections-http-client-default-disable-trust-manager=true"]
     restart: unless-stopped
     networks:
       - external


### PR DESCRIPTION
The version we've been using was outdated by 5 major releases.

A quick smoke check looks like everything is still working as intended with the new version and it helps in creation of bug reports when you use the latest version of a software ;-)
