### PR TITLE
Fix condition for checking if draft

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   version-check:
-    if: !github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Failed with following error in https://github.com/opf/openproject/actions/runs/13110986768:
> The workflow is not valid. .github/workflows/version-check.yml: Unexpected tag '!github.event.pull_request.draft'

In GitHub actions, `!` is not supported in `if` conditions. Replacing with `== false` instead.
