### PR TITLE
Fix wrong comments/descriptions

### DIFF
--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -159,9 +159,7 @@ module Authentication
     end
 
     ##
-    # Allow to map existing users with an Omniauth source if the login
-    # already exists, and no existing auth source or omniauth provider is
-    # linked
+    # Allow to map existing users with an Omniauth source if the login already exists
     def remap_existing_user
       return unless Setting.oauth_allow_remapping_of_existing_users?
 

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -701,8 +701,8 @@ module Settings
         default: 60000
       },
       oauth_allow_remapping_of_existing_users: {
-        description: "When set to false, prevent users from other identity providers to take over accounts connected " \
-                     "to another identity provider.",
+        description: "When set to false, prevent users from other identity providers to take over accounts " \
+                     "that exist in OpenProject.",
         default: true
       },
       omniauth_direct_login_provider: {


### PR DESCRIPTION
The comments did not describe the actual code behaviour anymore. Rough history:

* The code comment I added was originally introduced in commit 629c73c, with a behavioural change
* Then the corresponding code was moved into a service, where the previous comment was reinstated, but the new behaviour remained

The change in behaviour was apparently due to https://community.openproject.org/projects/openproject/work_packages/33620, which hints at the possibility that this setting affects not only oauth (as in "The OAuth 2.0 Authorization Framework"), but most likely all SSO-like solutions we have (e.g. LDAP). So maybe oauth is intended to be short for "omniauth".

This commit only rectifies the descriptions. Considering whether we should change to a safer default and/or rename the setting is something for the future.