### PR TITLE
Do not accept refresh token in token exchange

### DIFF
--- a/modules/openid_connect/app/services/openid_connect/user_tokens/exchange_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/exchange_service.rb
@@ -57,10 +57,13 @@ module OpenIDConnect
         json = yield exchange_token_request(idp_token, audience)
 
         access_token = json["access_token"]
-        refresh_token = json["refresh_token"]
         return Failure("Token exchange response invalid") if access_token.blank?
 
-        token = store_exchanged_token(audience:, access_token:, refresh_token:)
+        # We are explicitly opting to not store the refresh token for exchanged tokens
+        # For one there is no need to store one, we can simply exchange a new token once the old expired.
+        # A second reason is that at least Keycloak (an IDP we implement against), offers broken
+        # refresh tokens after token exchange (see https://github.com/keycloak/keycloak/issues/37016)
+        token = store_exchanged_token(audience:, access_token:, refresh_token: nil)
         Success(token)
       end
 

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
     it "creates a new user token", :aggregate_failures do
       expect { subject }.to change(user.oidc_user_tokens, :count).from(2).to(3)
       expect(user.oidc_user_tokens.last.access_token).to eq("the-access-token-exchanged")
-      expect(user.oidc_user_tokens.last.refresh_token).to eq("the-refresh-token-exchanged")
+      expect(user.oidc_user_tokens.last.refresh_token).to be_nil
     end
 
     it "returns the new user token" do
@@ -87,7 +87,7 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
       it "creates a new user token", :aggregate_failures do
         expect { subject }.not_to change(user.oidc_user_tokens, :count)
         expect(user.oidc_user_tokens.last.access_token).to eq("the-access-token-exchanged")
-        expect(user.oidc_user_tokens.last.refresh_token).to eq("the-refresh-token-exchanged")
+        expect(user.oidc_user_tokens.last.refresh_token).to be_nil
       end
 
       it "returns the updated user token" do


### PR DESCRIPTION
There is no need to store one, we can simply exchange a new token once the old token expired.

A second reason is that at least Keycloak (an IDP we implement against), offers broken refresh tokens after token exchange.

Also see https://github.com/keycloak/keycloak/issues/37016

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61140

# What are you trying to accomplish?
Ensure that exchanged tokens remain valid for the audience that we exchanged them for.

# Merge checklist

- [x] Added/updated tests