### PR TITLE
[60705] Regression: If WP title is long without spaces, it overflows outside of the split screen

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -20,6 +20,7 @@
 @import "op_primer/border_box_table_component"
 @import "work_packages/exports/modal_dialog_component"
 @import "work_package_relations_tab/index_component"
+@import "work_package_relations_tab/relation_component"
 @import "users/hover_card_component"
 @import "enterprise_edition/banner_component"
 @import "work_packages/types/pattern_input"

--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -44,7 +44,7 @@
         end
       end
 
-      flex.with_row(mb: 2) do
+      flex.with_row(mb: 2, classes: "relation-row--subject") do
         render(Primer::Beta::Link.new(href: work_package_path(related_work_package),
                                       color: :default,
                                       underline: false,

--- a/app/components/work_package_relations_tab/relation_component.sass
+++ b/app/components/work_package_relations_tab/relation_component.sass
@@ -1,0 +1,2 @@
+.relation-row--subject
+  @include text-shortener(false)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/60705/activity

# What are you trying to accomplish?
Truncate long words in WP subjects. This only affects long individual words, long subjects which contain multiple words are wrapped in multiple 
