### PR TITLE
[#59966] Main recurring meeting index doesn't show updated empty state

### DIFF
--- a/modules/meeting/app/components/meetings/table_component.rb
+++ b/modules/meeting/app/components/meetings/table_component.rb
@@ -88,5 +88,13 @@ module Meetings
     def recurring?
       model.first.is_a?(RecurringMeeting)
     end
+
+    def blank_title
+      I18n.t("meeting.blankslate.title")
+    end
+
+    def blank_description
+      I18n.t("meeting.blankslate.desc")
+    end
   end
 end

--- a/modules/meeting/app/views/meetings/_grouped_meetings.html.erb
+++ b/modules/meeting/app/views/meetings/_grouped_meetings.html.erb
@@ -27,22 +27,24 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-
 <% if @grouped_meetings.empty? || @grouped_meetings.values.all?(&:empty?) -%>
-  <%= no_results_box %>
+  <%= render Meetings::TableComponent.new(
+        rows: [],
+        current_project: @project
+      ) %>
 <% end %>
 <% %i[today tomorrow this_week later].each_with_index do |key, i| %>
   <% group = @grouped_meetings[key] %>
   <% if group.present? %>
     <%= render(Primer::Beta::Heading.new(
-      tag: :h3,
-      mb: 3,
-      mt: i == 0 ? 0 : 3
-    )) { I18n.t("label_meeting_index_#{key}") } %>
+                 tag: :h3,
+                 mb: 3,
+                 mt: i == 0 ? 0 : 3
+               )) { I18n.t("label_meeting_index_#{key}") } %>
     <%= render Meetings::TableComponent.new(
-      rows: group,
-      current_project: @project,
-      test_selector: "meetings-table-#{key}"
-    ) %>
+          rows: group,
+          current_project: @project,
+          test_selector: "meetings-table-#{key}"
+        ) %>
   <% end %>
 <% end %>

--- a/modules/meeting/app/views/meetings/index.html.erb
+++ b/modules/meeting/app/views/meetings/index.html.erb
@@ -34,11 +34,14 @@ See COPYRIGHT and LICENSE files for more details.
 <% if @grouped_meetings -%>
   <%= render partial: "grouped_meetings" %>
 <% elsif @meetings.empty? -%>
-  <%= no_results_box %>
+  <%= render Meetings::TableComponent.new(
+        rows: [],
+        current_project: @project
+      ) %>
 <% else %>
   <%= render Meetings::TableComponent.new(
-    rows: @meetings,
-    current_project: @project,
-    upcoming: params[:upcoming],
-    ) %>
+        rows: @meetings,
+        current_project: @project,
+        upcoming: params[:upcoming]
+      ) %>
 <% end -%>

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -231,6 +231,9 @@ en:
           This meeting is part of a series called <strong>%{title}</strong>.
           This will only delete this particular occurrence and not the entire series.
           Do you want to continue?
+    blankslate:
+      title: "No meetings to display"
+      desc: "There are no meetings that meet the active filter criteria."
 
   meeting_section:
     untitled_title: "Untitled section"

--- a/modules/meeting/spec/features/meetings_delete_spec.rb
+++ b/modules/meeting/spec/features/meetings_delete_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Meetings deletion" do
       end
 
       expect(page)
-        .to have_content(I18n.t(".no_results_title_text", cascade: true))
+        .to have_content(I18n.t("meeting.blankslate.title"))
 
       expect(page)
         .to have_current_path index_path

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe "Meetings", "Index", :js do
     context "when showing all meetings without invitations" do
       it "does not show under My meetings, but in All meetings" do
         meetings_page.visit!
-        expect(page).to have_content "There is currently nothing to display."
+        # expect(page).to have_content "No meetings to display"
+        meetings_page.expect_no_meetings_listed
 
         meetings_page.set_sidebar_filter "All meetings"
 

--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -165,7 +165,7 @@ module Pages::Meetings
     def expect_no_meetings_listed
       within "#content-wrapper" do
         expect(page)
-          .to have_content I18n.t(:no_results_title_text)
+          .to have_content I18n.t("meeting.blankslate.title")
       end
     end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/59966

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Replace `no_results_box` with an empty `TableComponent` for meetings pages

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
