### PR TITLE
Fix/61049 activity tab scroll to bottom

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -393,7 +393,7 @@ export default class IndexController extends Controller {
     this.tryScroll(activityAnchorName, activityId, 0, maxAttempts);
   }
 
-  private tryScrollToBottom(attempts:number = 0, maxAttempts:number = 20) {
+  private tryScrollToBottom(attempts:number = 0, maxAttempts:number = 20, behavior:ScrollBehavior = 'smooth') {
     const scrollableContainer = this.getScrollableContainer();
 
     if (!scrollableContainer) {
@@ -415,7 +415,7 @@ export default class IndexController extends Controller {
         observer.disconnect();
         scrollableContainer.scrollTo({
           top: scrollableContainer.scrollHeight,
-          behavior: 'smooth',
+          behavior,
         });
       }, 100);
     });
@@ -428,7 +428,7 @@ export default class IndexController extends Controller {
   }
 
   private scrollToBottom() {
-    this.tryScrollToBottom();
+    this.tryScrollToBottom(0, 20, 'auto');
   }
 
   setFilterToOnlyComments() { this.filterValue = 'only_comments'; }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/61049
https://community.openproject.org/projects/communicator-stream/work_packages/61074

# What are you trying to accomplish?
Make "scrolling to the end" of the activity tab when there are more than 30 comments more consistent.

The reason the scrolling ends up on the wrong place seems to be that we do the turbo frame DOM update simultaneously with the scrolling behaviour, thus putting the user in the wrong position.

## Screenshots

https://github.com/user-attachments/assets/8c325774-bb3c-42bc-aeb5-b31e8c9ef51b

# What approach did you choose and why?
Tried to rely on [Turbo Frame's autoscroll properties](https://turbo.hotwired.dev/reference/frames#html-attributes) but we have too much dependency on javascript custom behaviour, checking the viewport and handling custom events, that in the end just "forcing" auto scroll seems to be a way simpler approach.

# Merge checklist

- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
