### PR TITLE
Updated docu link to PDF export styling yml

### DIFF
--- a/docs/system-admin-guide/design/pdf-export-styles/README.md
+++ b/docs/system-admin-guide/design/pdf-export-styles/README.md
@@ -1,7 +1,7 @@
 
 # PDF Export Styling yml
 
-This document describes the style settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/standard.yml)
+This document describes the style settings format for the [PDF Export styling file](https://github.com/opf/openproject/blob/dev/app/models/work_package/pdf_export/export/standard.yml)
 
 | Key | Description | Data type |
 | - | - | - |


### PR DESCRIPTION
<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The PDF Export styling yml - file has been moved. There is a link in the docs to this file which delivered a 404 error.
I updated this link so that it leads to the correct file again.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
