### PR TITLE
Fix js error when time entry has no activity

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -632,7 +632,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
           </li>
           <li class="tooltip--map--item">
             <span class="tooltip--map--key">${schema.activity.name}:</span>
-            <span class="tooltip--map--value">${this.sanitizedValue(entry.activity.name)}</span>
+            <span class="tooltip--map--value">${this.sanitizedValue(entry.activity?.name || '')}</span>
           </li>
           <li class="tooltip--map--item">
             <span class="tooltip--map--key">${schema.hours.name}:</span>

--- a/frontend/src/app/features/hal/resources/time-entry-resource.ts
+++ b/frontend/src/app/features/hal/resources/time-entry-resource.ts
@@ -35,7 +35,7 @@ import Formattable = api.v3.Formattable;
 export class TimeEntryResource extends HalResource {
   project:ProjectResource;
 
-  activity:HalResource;
+  activity:HalResource|null;
 
   comment:Formattable;
 


### PR DESCRIPTION
Noticed while logging time on community on the "My spent time" widget in "My page".

![image](https://github.com/user-attachments/assets/086293ef-aee0-4a40-b620-0ec1dc4c5ca6)

This happens for each logged time entry which does not link to an activity. Not harmful, but creates noise, and lead me in the wrong direction while looking for another issue.