### PR TITLE
[61185] Replace storage deletion dialog with new DangerDialog

### DIFF
--- a/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
+++ b/modules/storages/app/components/storages/project_storages/destroy_confirmation_dialog_component.html.erb
@@ -28,54 +28,25 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  component_wrapper do
-    primer_form_with(
-      model: @project_storage,
-      url: admin_settings_storage_project_storage_path(id: @project_storage, page: current_page),
-      data: {
-        turbo: true,
-        controller: 'disable-when-checked',
-        'disable-when-checked-reversed-value': true
-      },
-      method: :delete
-    ) do |form|
-      render(Primer::OpenProject::FeedbackDialog.new(
-               id:,
-               title:,
-               test_selector: id,
-               size: :large
-             )) do |dialog|
-        dialog.with_feedback_message(icon_arguments: { icon: :alert, color: :danger }) do |message|
-          message.with_heading(tag: :h2) { heading }
-          message.with_description { text }
-        end
-
-        dialog.with_additional_details do
-          render(Primer::Alpha::CheckBox.new(
-            name: "confirm_delete",
-            label: confirmation_text,
-            data: { 'disable-when-checked-target': 'cause' }
-          ))
-        end
-
-        dialog.with_footer do
-          component_collection do |footer|
-            footer.with_component(Primer::ButtonComponent.new(data: { "close-dialog-id": id })) do
-              I18n.t("button_close")
-            end
-
-            footer.with_component(
-              Primer::ButtonComponent.new(scheme: :danger, type: :submit,
-                                          test_selector: "remove-project-storage-button",
-                                          disabled: true,
-                                          data: {
-                                            "disable-when-checked-target": "effect",
-                                            "close-dialog-id": id
-                                          })
-            ) { I18n.t("button_remove") }
-          end
-        end
-      end
+  render(Primer::OpenProject::DangerDialog.new(
+           id:,
+           title:,
+           test_selector: id,
+           size: :large,
+           form_arguments: {
+             model: @project_storage,
+             action: admin_settings_storage_project_storage_path(id: @project_storage, page: current_page),
+             data: {
+               turbo: true
+             },
+             method: :delete
+           },
+           confirm_button_text: I18n.t("button_remove")
+         )) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { heading }
+      message.with_description_content(text)
     end
+    dialog.with_confirmation_check_box_content(confirmation_text)
   end
 %>

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         page.within("dialog") do
           expect(page).to have_text("Remove project from #{storage.name}")
           expect(page).to have_text("this storage has an automatically managed project folder")
-          click_on "Close"
+          click_on "Cancel"
         end
 
         expect(page).to have_text(project.name)
@@ -393,7 +393,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         page.within("dialog") do
           expect(page).to have_button("Remove", disabled: true)
           Retryable.repeat_until_success do
-            check "Please, confirm you understand and want to remove this file storage from this project"
+            check "Please, confirm you understand and want to remove this file storage from this project", allow_label_click: true
             expect(page).to have_button("Remove", disabled: false) # ensure button is clickable
             click_on "Remove"
           end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/nextcloud-integration/work_packages/61185/activity

# What are you trying to accomplish?
Use Primer::DangerDialog instead of FeedbackDialog for destructive actions

