### PR TITLE
Fix flaky spec

### DIFF
--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Recurring meetings end series", :js do
     end
 
     expect(page).to have_current_path recurring_meeting_path(meeting)
-    expect(page).to have_text("No open meetings at the moment")
+    expect(page).to have_text("Meeting series ended")
   end
 
   context "when meeting start time is in the future" do


### PR DESCRIPTION
- Noticed by @myabc in https://github.com/opf/openproject/actions/runs/13155332981/job/36711077536?pr=17820
- Introduced in https://github.com/opf/openproject/pull/17812
- Ran green ~75% of the time via `bulk_run_rspec`, but only because the page wasn't fully loaded  