### PR TITLE
Replace custom activities tab onSubmit action with default turbo:submit

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -37,7 +37,7 @@
                     bg: :subtle
                   ) do
                     render(
-                      WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:)
+                      WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:, filter:, last_server_timestamp:)
                     )
                   end
                 end

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -36,14 +36,13 @@
         data: { "work-packages--activities-tab--index-target": "formRow" }
       ) do
         primer_form_with(
-          id: "work-package-journal-form-element", # required for specs
+          id: "work-package-journal-form-element",
           model: journal,
           method: :post,
           data: {
             turbo: true,
             turbo_stream: true,
             "work-packages--activities-tab--index-target": "form",
-            action: "submit->work-packages--activities-tab--index#onSubmit",
             "test_selector": "op-work-package-journal-form-element"
           },
           url: work_package_activities_path(work_package_id: work_package.id),
@@ -53,8 +52,14 @@
               classes: "work-packages-activities-tab-journals-new-component--ck-editor-column",
               mr: 2
             ) do
-              render(WorkPackages::ActivitiesTab::Journals::NotesForm.new(f))
+              render(
+                Primer::Forms::FormList.new(
+                  WorkPackages::ActivitiesTab::Journals::HiddenForm.new(f, filter:, last_server_timestamp:),
+                  WorkPackages::ActivitiesTab::Journals::NotesForm.new(f)
+                )
+              )
             end
+
             form_container.with_column do
               render(Primer::Beta::IconButton.new(
                 scheme: :default,

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -214,7 +214,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def set_filter
-    @filter = params[:filter]&.to_sym || :all
+    @filter = (params[:filter] || params.dig(:journal, :filter))&.to_sym || :all
   end
 
   def journal_sorting
@@ -249,7 +249,9 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def perform_update_streams_from_last_update_timestamp
-    if params[:last_update_timestamp].present? && (last_updated_at = Time.zone.parse(params[:last_update_timestamp]))
+    last_update_timestamp = params[:last_update_timestamp] || params.dig(:journal, :last_update_timestamp)
+
+    if last_update_timestamp.present? && (last_updated_at = Time.zone.parse(last_update_timestamp))
       generate_time_based_update_streams(last_updated_at)
       generate_work_package_journals_emoji_reactions_update_streams
     else

--- a/app/forms/work_packages/activities_tab/journals/hidden_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/hidden_form.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
+#
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,40 +29,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
-  module ActivitiesTab
-    module Journals
-      class NewComponent < ApplicationComponent
-        include ApplicationHelper
-        include OpPrimer::ComponentHelpers
-        include OpTurbo::Streamable
+module WorkPackages::ActivitiesTab::Journals
+  class HiddenForm < ApplicationForm
+    form do |journals_form|
+      journals_form.hidden(name: :last_update_timestamp, value: @last_server_timestamp)
+      journals_form.hidden(name: :filter, value: @filter)
+    end
 
-        def initialize(work_package:, filter:, last_server_timestamp:, journal: nil, form_hidden_initially: true)
-          super
-
-          @work_package = work_package
-          @filter = filter
-          @last_server_timestamp = last_server_timestamp
-          @journal = journal
-          @form_hidden_initially = form_hidden_initially
-        end
-
-        private
-
-        attr_reader :work_package, :filter, :last_server_timestamp, :form_hidden_initially
-
-        def journal
-          @journal || Journal.new(journable: work_package)
-        end
-
-        def button_row_display_value
-          form_hidden_initially ? :block : :none
-        end
-
-        def form_row_display_value
-          form_hidden_initially ? :none : :block
-        end
-      end
+    def initialize(last_server_timestamp:, filter: :all)
+      super()
+      @last_server_timestamp = last_server_timestamp
+      @filter = filter
     end
   end
 end

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -730,12 +730,13 @@ export default class IndexController extends Controller {
 
   private setCKEditorReadonlyMode(disabled:boolean) {
     const ckEditorInstance = this.getCkEditorInstance();
+    const editorLockID = 'work-packages-activities-tab-index-component';
 
     if (ckEditorInstance) {
       if (disabled) {
-        ckEditorInstance.enableReadOnlyMode('work-packages-activities-tab-index-component');
+        ckEditorInstance.enableReadOnlyMode(editorLockID);
       } else {
-        ckEditorInstance.disableReadOnlyMode('work-packages-activities-tab-index-component');
+        ckEditorInstance.disableReadOnlyMode(editorLockID);
       }
     }
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -724,7 +724,7 @@ export default class IndexController extends Controller {
           );
         }
         this.handleStemVisibility();
-      }, 10);
+      }, 100);
     }
   }
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/60719

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

* Reduce complexity
* Fix double submit scenario- turbo already includes submitter disable - we sync this up with CKEditor as well

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
