### PR TITLE
Use model + bindValue + bindLabel

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -613,7 +613,13 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     return null;
   }
 
-  protected defaultCompareWithFunction():(a:unknown, b:unknown) => boolean {
-    return (a, b) => a === b;
+  protected defaultCompareWithFunction():null|((a:unknown, b:unknown) => boolean) {
+    return (a, b) => {
+      if (this.bindValue) {
+        return (a as Record<string, unknown>)[this.bindValue] === b;
+      }
+
+      return a === b;
+    };
   }
 }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -615,7 +615,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   protected defaultCompareWithFunction():null|((a:unknown, b:unknown) => boolean) {
     return (a, b) => {
-      if (this.bindValue) {
+      if (this.bindValue && !_.isObject(b)) {
         return (a as Record<string, unknown>)[this.bindValue] === b;
       }
 


### PR DESCRIPTION
Don't use a default compareWith for opce-autocompleter, as this breaks comparison for bindValue objects:

https://github.com/ng-select/ng-select/pull/586/files