### PR TITLE
[#61194] Last planned meeting is not showing when current meeting is in both 'Upcoming' and 'Past' tab

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -287,7 +287,8 @@ class RecurringMeetingsController < ApplicationController
         @recurring_meeting.scheduled_instances(upcoming: false).count
       elsif @recurring_meeting.will_end?
         open = @recurring_meeting.upcoming_instantiated_meetings
-        @recurring_meeting.remaining_occurrences.count - open.count
+        ongoing = @recurring_meeting.ongoing_meetings
+        @recurring_meeting.remaining_occurrences.count - open.count + ongoing.count
       end
 
     @count = [show_more_limit_param, @max_count].compact.min

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -210,11 +210,18 @@ class RecurringMeeting < ApplicationRecord
   end
 
   def upcoming_instantiated_meetings
-    scheduled_meetings
+    @upcoming_instantiated_meetings ||= scheduled_meetings
       .includes(:meeting)
       .not_cancelled
       .joins(:meeting)
       .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.current)
+      .order(start_time: :asc)
+  end
+
+  def ongoing_meetings
+    upcoming_instantiated_meetings
+      .includes(:meeting)
+      .where(meetings: { start_time: ..Time.current })
       .order(start_time: :asc)
   end
 

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe "Meetings", "Index", :js do
     context "when showing all meetings without invitations" do
       it "does not show under My meetings, but in All meetings" do
         meetings_page.visit!
-        # expect(page).to have_content "No meetings to display"
         meetings_page.expect_no_meetings_listed
 
         meetings_page.set_sidebar_filter "All meetings"

--- a/modules/meeting/spec/support/pages/recurring_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/recurring_meeting/show.rb
@@ -188,9 +188,5 @@ module Pages::RecurringMeeting
         click_on "more-button"
       end
     end
-
-    # def for_meeting(date:, &)
-    #   within("li", text: date, &)
-    # end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/61194 & potentially https://community.openproject.org/wp/61356 as well

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
