### PR TITLE
Feature/60521 autocompleters for filter values on the project list

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -70,9 +70,24 @@ module Filter
         { autocomplete_options: project_autocomplete_options }
       when Queries::Filters::Shared::CustomFields::User
         { autocomplete_options: user_autocomplete_options }
+      when Queries::Filters::Shared::CustomFields::ListOptional,
+           Queries::Projects::Filters::ProjectStatusFilter,
+           Queries::Projects::Filters::TypeFilter
+        { autocomplete_options: list_autocomplete_options(filter) }
       else
         {}
       end
+    end
+
+    def list_autocomplete_options(filter)
+      {
+        component: "opce-autocompleter",
+        items: filter.allowed_values.map { |name, id| { name:, id: } },
+        model: filter.values,
+        bindValue: "id",
+        bindLabel: "name",
+        hideSelected: true
+      }
     end
 
     def project_autocomplete_options

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -6,6 +6,7 @@
                               multipleAsSeparateInputs: false,
                               inputValue: filter.values,
                               appendTo: "body",
+                              id: "#{filter.name}_value",
                               hiddenFieldAction: "change->filter--filters-form#autocompleteSendForm"
                               # Set on the template as there is a timing issue where the
                               # angular component is not yet ready in the DOM and hence
@@ -13,11 +14,9 @@
                               # of the #connect lifecycle hook of the filter--filters-form
                               # Stimulus controller.
                             }.merge(autocomplete_options.except(:component)),
-                            id: "#{filter.name}_value",
                             data: {
                               "filter-autocomplete": true,
                               "filter--filters-form-target": "filterValueContainer",
                               "filter-name": filter.name
-                            }
-  %>
+                            } %>
 </div>

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -1,10 +1,11 @@
 <div class="advanced-filters--filter-value <%= value_visibility %>">
   <%= angular_component_tag autocomplete_options[:component],
                             inputs: {
-                              inputName: 'value',
+                              inputName: "value",
                               multiple: true,
                               multipleAsSeparateInputs: false,
                               inputValue: filter.values,
+                              appendTo: "body",
                               hiddenFieldAction: "change->filter--filters-form#autocompleteSendForm"
                               # Set on the template as there is a timing issue where the
                               # angular component is not yet ready in the DOM and hence
@@ -14,9 +15,9 @@
                             }.merge(autocomplete_options.except(:component)),
                             id: "#{filter.name}_value",
                             data: {
-                              'filter-autocomplete': true,
-                              'filter--filters-form-target': 'filterValueContainer',
-                              'filter-name': filter.name
+                              "filter-autocomplete": true,
+                              "filter--filters-form-target": "filterValueContainer",
+                              "filter-name": filter.name
                             }
   %>
 </div>

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -613,7 +613,13 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     return null;
   }
 
-  protected defaultCompareWithFunction():(a:unknown, b:unknown) => boolean {
-    return (a, b) => a === b;
+  protected defaultCompareWithFunction():null|((a:unknown, b:unknown) => boolean) {
+    return (a, b) => {
+      if (this.bindValue) {
+        return (a as Record<string, unknown>)[this.bindValue] === b;
+      }
+
+      return a === b;
+    };
   }
 }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -615,7 +615,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   protected defaultCompareWithFunction():null|((a:unknown, b:unknown) => boolean) {
     return (a, b) => {
-      if (this.bindValue) {
+      if (this.bindValue && !_.isObject(b)) {
         return (a as Record<string, unknown>)[this.bindValue] === b;
       }
 

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH
@@ -454,41 +456,17 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
           select_value_id = "#{list_custom_field.column_name}_value"
 
           within(cf_filter) do
-            # Initial filter is a 'single select'
-            expect(cf_filter.find(:select, select_value_id)).not_to be_multiple
-            click_on "Toggle multiselect"
-            # switching to multiselect keeps the current selection
-            expect(cf_filter.find(:select, select_value_id)).to be_multiple
-            expect(cf_filter).to have_select(select_value_id, selected: list_custom_field.possible_values[2].value)
-
-            select list_custom_field.possible_values[3].value, from: select_value_id
+            projects_page.expect_ng_value_label(select_value_id, list_custom_field.possible_values[2].value)
+            projects_page.set_autocomplete_filter list_custom_field.possible_values[3].value, clear: false
           end
           wait_for_reload
 
           cf_filter = page.find("li[data-filter-name='#{list_custom_field.column_name}']")
           within(cf_filter) do
-            # Query has two values for that filter, so it should show a 'multi select'.
-            expect(cf_filter.find(:select, select_value_id)).to be_multiple
-            expect(cf_filter)
-              .to have_select(select_value_id,
-                              selected: [list_custom_field.possible_values[2].value,
-                                         list_custom_field.possible_values[3].value])
-
-            # switching to single select keeps the first selection
-            select list_custom_field.possible_values[1].value, from: select_value_id
-            unselect list_custom_field.possible_values[2].value, from: select_value_id
-
-            click_on "Toggle multiselect"
-            expect(cf_filter.find(:select, select_value_id)).not_to be_multiple
-            expect(cf_filter).to have_select(select_value_id, selected: list_custom_field.possible_values[1].value)
-            expect(cf_filter).to have_no_select(select_value_id, selected: list_custom_field.possible_values[3].value)
-          end
-          wait_for_reload
-
-          cf_filter = page.find("li[data-filter-name='#{list_custom_field.column_name}']")
-          within(cf_filter) do
-            # Query has one value for that filter, so it should show a 'single select'.
-            expect(cf_filter.find(:select, select_value_id)).not_to be_multiple
+            # Query has two values for that filter.
+            projects_page.expect_ng_value_label(select_value_id,
+                                                [list_custom_field.possible_values[2].value,
+                                                 list_custom_field.possible_values[3].value])
           end
 
           # CF date filter work (at least for one operator)

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -35,7 +35,9 @@ module Components::Autocompleter
       retry_block do
         if results_selector
           results_selector = "#{results_selector} .ng-dropdown-panel" if results_selector == "body"
-          page.find(results_selector, wait: 5)
+          within_window(current_window) do
+            page.find(results_selector, wait: 5)
+          end
         else
           within(element) do
             page.find("ng-select .ng-dropdown-panel", wait: 5)
@@ -59,6 +61,11 @@ module Components::Autocompleter
       end
     end
 
+    def expect_ng_value_label(field_id, labels)
+      Array(labels).each do |text|
+        expect(page).to have_css("##{field_id} .ng-value-label", text:)
+      end
+    end
     ##
     # Insert the query, typing
     def ng_enter_query(element, query, wait_for_fetched_options: true)
@@ -96,8 +103,10 @@ module Components::Autocompleter
 
     ##
     # clear the ng select field
-    def ng_select_clear(from_element)
-      from_element.find(".ng-clear-wrapper", visible: :all).click
+    def ng_select_clear(from_element, raise_on_missing: true)
+      if raise_on_missing || from_element.has_css?(".ng-clear-wrapper", visible: :all, wait: 1)
+        from_element.find(".ng-clear-wrapper", visible: :all).click
+      end
     end
 
     def select_autocomplete(element,

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -266,7 +268,7 @@ module Pages
 
       def set_advanced_filter(name, human_name, human_operator = nil, values = [], send_keys: false)
         selected_filter = select_filter(name, human_name)
-        select(human_operator, from: "operator") unless boolean_filter?(name)
+        apply_operator(name, human_operator)
 
         within(selected_filter) do
           return unless values.any?
@@ -274,12 +276,12 @@ module Pages
           if boolean_filter?(name)
             set_toggle_filter(values)
           elsif autocomplete_filter?(selected_filter)
+            select(human_operator, from: "operator")
             set_autocomplete_filter(values)
           elsif name == "created_at"
             select(human_operator, from: "operator")
             set_created_at_filter(human_operator, values, send_keys:)
           elsif date_filter?(selected_filter) && human_operator == "on"
-            select(human_operator, from: "operator")
             set_date_filter(values, send_keys)
           end
         end
@@ -292,6 +294,10 @@ module Pages
           find('[data-filter-autocomplete="true"]').click
         end
         visible_user_auto_completer_options
+      end
+
+      def apply_operator(name, human_operator)
+        select(human_operator, from: "operator") unless boolean_filter?(name)
       end
 
       def select_filter(name, human_name)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60521

# What are you trying to accomplish?
Move all filter selects to use autocomplete selects.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
