### PR TITLE
Ensure project stays selected on error in global meeting form

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -56,6 +56,7 @@ import {
   ProjectAutocompleterTemplateComponent,
 } from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component';
 import { addFiltersToPath } from 'core-app/core/apiv3/helpers/add-filters-to-path';
+import { TOpAutocompleterResource } from 'core-app/shared/components/autocompleter/op-autocompleter/typings';
 
 export const projectsAutocompleterSelector = 'op-project-autocompleter';
 
@@ -108,6 +109,8 @@ export class ProjectAutocompleterComponent extends OpAutocompleterComponent<IPro
   getOptionsFn = this.getAvailableProjects.bind(this);
 
   dataLoaded = false;
+
+  resource:TOpAutocompleterResource = 'projects';
 
   projects:IProjectAutocompleteItem[];
 

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -441,7 +441,7 @@ class MeetingsController < ApplicationController
     # instance variable.
     @converted_params = meeting_params.to_h
 
-    @converted_params[:project] = @project
+    @converted_params[:project] = @project if @project.present?
     @converted_params[:duration] = @converted_params[:duration].to_hours if @converted_params[:duration].present?
     @converted_params[:send_notifications] = params[:send_notifications] == "1"
 
@@ -459,9 +459,11 @@ class MeetingsController < ApplicationController
 
   def meeting_params
     if params[:meeting].present?
-      params.require(:meeting).permit(:title, :location, :start_time,
-                                      :duration, :start_date, :start_time_hour, :type,
-                                      participants_attributes: %i[email name invited attended user user_id meeting id])
+      params
+        .require(:meeting)
+        .permit(:title, :location, :start_time, :project_id,
+                :duration, :start_date, :start_time_hour, :type,
+                participants_attributes: %i[email name invited attended user user_id meeting id])
     end
   end
 

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -317,14 +317,14 @@ class RecurringMeetingsController < ApplicationController
     # instance variable.
     @converted_params = recurring_meeting_params.to_h
 
-    @converted_params[:project] = @project
+    @converted_params[:project] = @project if @project.present?
     @converted_params[:duration] = @converted_params[:duration].to_hours if @converted_params[:duration].present?
   end
 
   def recurring_meeting_params
     params
       .require(:meeting)
-      .permit(:title, :location, :start_time_hour, :duration, :start_date,
+      .permit(:project_id, :title, :location, :start_time_hour, :duration, :start_date,
               :interval, :frequency, :end_after, :end_date, :iterations)
   end
 

--- a/modules/meeting/app/forms/meeting/project_autocompleter.rb
+++ b/modules/meeting/app/forms/meeting/project_autocompleter.rb
@@ -38,8 +38,6 @@ class Meeting::ProjectAutocompleter < ApplicationForm
         openDirectly: false,
         focusDirectly: false,
         dropdownPosition: "bottom",
-        inputName: "project_id",
-        inputValue: @project&.id,
         appendTo: "#new-meeting-dialog",
         filters: [{ name: "user_action", operator: "=", values: ["meetings/create"] }],
         data: {

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
@@ -1,0 +1,87 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+require_relative "../../support/pages/meetings/new"
+require_relative "../../support/pages/structured_meeting/show"
+require_relative "../../support/pages/recurring_meeting/show"
+require_relative "../../support/pages/meetings/index"
+
+RSpec.describe "Recurring meetings global creation",
+               :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  shared_let(:user) do
+    create(:user,
+           lastname: "First",
+           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings] }).tap do |u|
+      u.pref[:time_zone] = "Etc/UTC"
+
+      u.save!
+    end
+  end
+
+  let(:meetings_page) { Pages::Meetings::Index.new(project: nil) }
+
+  context "with a user with permissions" do
+    before do
+      login_as(user)
+      meetings_page.visit!
+    end
+
+    it "keeps the current selected project when hitting a validation error (Regression #59972)" do
+      expect(page).to have_current_path(meetings_page.path)
+      meetings_page.click_on "add-meeting-button"
+
+      page.within("action-list") do
+        meetings_page.click_on "Recurring"
+      end
+
+      meetings_page.set_project project
+      meetings_page.click_create
+      wait_for_network_idle
+
+      expect(page).to have_text "Title can't be blank."
+
+      within("[data-test-selector='project_id']") do
+        expect(page).to have_text project.name
+      end
+
+      meetings_page.set_title "Some title"
+      meetings_page.click_create
+      wait_for_network_idle
+
+      expect(page).to have_css("h1", text: "Some title")
+      meeting = Meeting.last
+      expect(meeting.title).to eq "Some title"
+      expect(meeting.project).to eq project
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/59972

The project autocompleter set a global `project_id` instead of setting it on the meeting directly, which behaves really weirdly. Instead, make it a regular param of the meeting