### PR TITLE
Fix setting direction for past meetings count

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -18,6 +18,7 @@ class RecurringMeetingsController < ApplicationController
   before_action :authorize, except: %i[index new create]
   before_action :get_scheduled_meeting, only: %i[delete_scheduled_dialog destroy_scheduled]
 
+  before_action :set_direction, only: %i[show]
   before_action :convert_params, only: %i[create update]
   before_action :check_template_completable, only: %i[template_completed]
   before_action :build_meeting_limits, only: %i[show]
@@ -46,8 +47,6 @@ class RecurringMeetingsController < ApplicationController
   end
 
   def show # rubocop:disable Metrics/AbcSize
-    @direction = params[:direction]
-
     if @direction == "past"
       @meetings = @recurring_meeting.scheduled_instances(upcoming: false).limit(@count)
     else
@@ -276,6 +275,10 @@ class RecurringMeetingsController < ApplicationController
       .first(count)
 
     [opened.values.sort_by(&:start_time), planned]
+  end
+
+  def set_direction
+    @direction = params[:direction]
   end
 
   def build_meeting_limits

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
@@ -115,6 +115,17 @@ RSpec.describe "Recurring meetings show",
       expect(page).to have_no_text format_time(past_schedule_cancelled.start_time)
       expect(page).to have_no_css("li", text: "Cancelled")
     end
+
+    context "when meeting has ended and no upcoming meetings remain" do
+      before do
+        recurring_meeting.update_columns(end_date: Time.zone.yesterday)
+      end
+
+      it "still shows the one past meeting (Regression #61280)" do
+        get recurring_meeting_path(recurring_meeting, direction: "past")
+        expect(page).to have_text format_time(past_instance.start_time)
+      end
+    end
   end
 
   describe "upcoming tab" do


### PR DESCRIPTION
The @direction instance variable was not set correctly, always resulting in upcoming counts

https://community.openproject.org/work_packages/61280
