### PR TITLE
Fix/59543 quote when editor open

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -623,7 +623,13 @@ export default class IndexController extends Controller {
     const userName = target.dataset.userNameParam as string;
     const content = target.dataset.contentParam as string;
 
-    this.openEditorWithInitialData(this.quotedText(content, userName));
+    const quotedText = this.quotedText(content, userName);
+    const formVisible = !this.formRowTarget.classList.contains('d-none');
+    if (formVisible) {
+      this.insertQuoteOnExistingEditor(quotedText);
+    } else {
+      this.openEditorWithInitialData(quotedText);
+    }
   }
 
   private quotedText(rawComment:string, userName:string) {
@@ -632,6 +638,18 @@ export default class IndexController extends Controller {
       .join('');
 
     return `${userName}\n${quoted}`;
+  }
+
+  insertQuoteOnExistingEditor(quotedText:string) {
+    const ckEditorInstance = this.getCkEditorInstance();
+    if (ckEditorInstance) {
+      const editorData = ckEditorInstance.getData({ trim: false });
+      if (editorData.endsWith('<br>') || editorData.endsWith('\n')) {
+        ckEditorInstance.setData(`${editorData}${quotedText}`);
+      } else {
+        ckEditorInstance.setData(`${editorData}\n\n${quotedText}`);
+      }
+    }
   }
 
   openEditorWithInitialData(quotedText:string) {

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -776,7 +776,27 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         activity_tab.quote_comment(first_comment_by_member)
 
         # expect the quoted comment to be shown
-        activity_tab.expect_journal_notes(text: "A Member wrote:\nFirst comment by member")
+        activity_tab.ckeditor.expect_value("A Member wrote:\nFirst comment by member")
+      end
+    end
+
+    context "when writing a comment" do
+      current_user { admin }
+
+      before do
+        wp_page.visit!
+        wp_page.wait_for_activity_tab
+      end
+
+      it "can quote other user's comments", :aggregate_failures do
+        # open the editor and type something
+        activity_tab.type_comment("Partial message:")
+
+        # quote other user's comment
+        activity_tab.quote_comment(first_comment_by_member)
+
+        # expect the original comment and quote are shown
+        activity_tab.ckeditor.expect_value("Partial message:\nA Member wrote:\nFirst comment by member")
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/59543/activity

# What are you trying to accomplish?
Fix behaviour when trying to insert a quote, in case a editor is already open.

## Screenshots
Comming soon~

# What approach did you choose and why?
Implemented the behaviour. It was not accounted for.

# Merge checklist

- [x] Added/updated tests
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
