### PR TITLE
Toggle CKEditor readonly state onSubmit

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -713,6 +713,21 @@ export default class IndexController extends Controller {
     if (this.hasFormSubmitButtonTarget) {
       this.formSubmitButtonTarget.disabled = inProgress;
     }
+
+    this.setCKEditorReadonlyMode(inProgress);
+  }
+
+  private setCKEditorReadonlyMode(disabled:boolean) {
+    const ckEditorInstance = this.getCkEditorInstance();
+    const editorLockID = 'work-packages-activities-tab-index-component';
+
+    if (ckEditorInstance) {
+      if (disabled) {
+        ckEditorInstance.enableReadOnlyMode(editorLockID);
+      } else {
+        ckEditorInstance.disableReadOnlyMode(editorLockID);
+      }
+    }
   }
 
   private prepareFormData():FormData {


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/60719

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Continues #17696 Prevent possible repeat submissions that can arise from double clicking the comment submit button or multiple keyboard events

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_*Clicking the submit button twice (quickly)_

_After_

https://github.com/user-attachments/assets/7ddb1d52-cc7f-4152-8263-d29f968af697


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

In addition to disabling the submitter, further set ckeditor to readonly state to prevent
duplicate form submit events; arising from multiple clicks / keyboard events

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
