### PR TITLE
improve performance of wp mentionable users filter

### DIFF
--- a/app/models/queries/filters/strategies/huge_list.rb
+++ b/app/models/queries/filters/strategies/huge_list.rb
@@ -33,10 +33,18 @@ module Queries::Filters::Strategies
 
     def validate
       unique_values = values.uniq
-      allowed_and_desired_values = allowed_values_subset & unique_values
 
-      if allowed_and_desired_values.sort != unique_values.sort
-        errors.add(:values, :inclusion)
+      case allowed_values_subset
+      when ActiveRecord::Relation
+        unless allowed_values_subset.exists?(id: values)
+          errors.add(:values, :inclusion)
+        end
+      else
+        allowed_and_desired_values = allowed_values_subset & unique_values
+
+        if allowed_and_desired_values.sort != unique_values.sort
+          errors.add(:values, :inclusion)
+        end
       end
     end
 

--- a/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
@@ -31,8 +31,11 @@
 class Queries::Principals::Filters::MentionableOnWorkPackageFilter <
   Queries::Principals::Filters::PrincipalFilter
   def allowed_values
-    # We don't care for the first value as we do not display the values visibly
-    @allowed_values ||= ::WorkPackage.visible.pluck(:id).map { |id| [id, id.to_s] }
+    raise NotImplementedError, "There would be too many candidates"
+  end
+
+  def allowed_values_subset
+    @allowed_values_subset ||= ::WorkPackage.visible
   end
 
   def type
@@ -53,6 +56,10 @@ class Queries::Principals::Filters::MentionableOnWorkPackageFilter <
   end
 
   private
+
+  def type_strategy
+    @type_strategy ||= Queries::Filters::Strategies::HugeList.new(self)
+  end
 
   def principals_with_a_membership
     visible_scope.where(id: work_package_members.select(:user_id))


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61365

# What are you trying to accomplish?

Improve the performance of the `Queries::Principals::Filters::MentionableOnWorkPackageFilter` which is central for returning the users available when trying to mention somebody in a work package comment. On some SaaS instances, the `api/v3/principals` endpoint using this filter currently has an impact of 50%. 

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/ff858725-56db-4b47-9b1e-ecb4d121230d" />


This is caused in part by the filter, when checking for the allowed values fetching the ids of all work packages the requesting user can see. 

<img width="1647" alt="image" src="https://github.com/user-attachments/assets/90d7c0bd-2503-4bc0-9dcc-cdd38c67829d" />


This is done to validate that the filter is not used for probing for information. While this is necessary to be done, it can be done in a more performant way. Instead of fetching all the ids and then comparing those to the filter's values, the filter can check within the DB that the values are within the visible scope using ARs `exists?` functionality.    

This mechanism should be applied to other `HugeList` filters as well but this is out of scope for this drive by fix.
