### PR TITLE
Let bundler take the version from the Gemfile.lock

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -17,10 +17,6 @@ m = Module.new do
     File.expand_path($0) == File.expand_path(__FILE__)
   end
 
-  def env_var_version
-    ENV["BUNDLER_VERSION"]
-  end
-
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
     return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
@@ -66,8 +62,7 @@ m = Module.new do
 
   def bundler_version
     @bundler_version ||= begin
-      env_var_version || cli_arg_version ||
-        lockfile_version || "#{Gem::Requirement.default}.a"
+      cli_arg_version || lockfile_version || "#{Gem::Requirement.default}.a"
     end
   end
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -3,7 +3,6 @@ ARG RUBY_VERSION
 FROM ruby:${RUBY_VERSION}-bookworm
 
 ENV NODE_VERSION="20.9.0"
-ENV BUNDLER_VERSION="2.6.3"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV BUNDLE_WITHOUT="development:production:docker"
 
@@ -18,7 +17,7 @@ RUN --mount=type=cache,target=/var/cache/apt export f="/tmp/chrome.deb" && wget 
 
 RUN curl -L https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz -o - | tar xJf - -C /usr/local --strip=1 && node --version
 
-RUN rm -rf /usr/local/bundle && gem install bundler --version "$BUNDLER_VERSION" --no-document
+RUN rm -rf /usr/local/bundle && gem install bundler --no-document
 
 ENV APP_USER=dev
 ENV APP_PATH=/app

--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -107,7 +107,7 @@ setup_tests() {
 	execute_quiet "cp docker/ci/database.yml config/"
 	create_db_cluster
 
-  execute "gem install bundler --version '${BUNDLER_VERSION}' --no-document"
+  execute "gem install bundler --no-document"
 
   run_background execute "BUNDLE_JOBS=8 bundle install --quiet && bundle clean --force && echo BUNDLE DONE"
 	run_background execute "JOBS=8 time npm install --quiet && npm prune --quiet && echo NPM DONE"

--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -8,8 +8,6 @@ ENV USER=dev
 ENV RAILS_ENV=development
 ENV NODE_MAJOR=20
 
-ENV BUNDLER_VERSION "2.6.3"
-
 # `--no-log-init` is required as a workaround to avoid disk exhaustion.
 #
 # Read more at:
@@ -52,7 +50,7 @@ WORKDIR /home/$USER/openproject
 
 USER $USER
 
-RUN gem install bundler --version "${BUNDLER_VERSION}" --no-document
+RUN gem install bundler --no-document
 
 ####### Testing image below #########
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -2,7 +2,6 @@ ARG RUBY_VERSION="3.4.1"
 FROM ruby:${RUBY_VERSION}-bookworm AS base
 LABEL maintainer="operations@openproject.com"
 
-ARG BUNDLER_VERSION="2.6.3"
 ARG NODE_VERSION="20.9.0"
 ARG BIM_SUPPORT=true
 ENV USE_JEMALLOC=false
@@ -44,7 +43,7 @@ RUN useradd -d /home/$APP_USER -m $APP_USER && \
 WORKDIR $APP_PATH
 
 # upgrade bundler
-RUN gem install bundler --version "$BUNDLER_VERSION" --no-document
+RUN gem install bundler --no-document
 
 # system dependencies, nodejs
 COPY ./docker/prod/setup/preinstall-common.sh ./docker/prod/setup/preinstall-common.sh


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Remove redundant bundler version definitions for docker and let bundler figure out the required version from the `Gemfile.lock`. `BUNDLED WITH` section.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
