### PR TITLE
Bug/60538 misplaced cursor in comments text editor on ios

### DIFF
--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -17,6 +17,8 @@
         .ck-content
             &.ck-focused
                 max-height: 30vh
+                @media screen and (max-width: $breakpoint-sm)
+                  height: 30vh
             &.ck-blurred
                 max-height: 10vh
         .ck-editor__preview

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -19,10 +19,5 @@
                 max-height: 30vh
             &.ck-blurred
                 max-height: 10vh
-            @media screen and (max-width: $breakpoint-sm)
-                &.ck-focused
-                    height: 30vh
-                &.ck-blurred
-                    height: 10vh
         .ck-editor__preview
             max-height: 30vh

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -17,9 +17,12 @@
         .ck-content
             &.ck-focused
                 max-height: 30vh
-                @media screen and (max-width: $breakpoint-sm)
-                  height: 30vh
             &.ck-blurred
                 max-height: 10vh
+            @media screen and (max-width: $breakpoint-sm)
+                &.ck-focused
+                    height: 30vh
+                &.ck-blurred
+                    height: 10vh
         .ck-editor__preview
             max-height: 30vh

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -15,9 +15,15 @@
         width: calc(100% - 40px)
         // specific ck editor adjustments
         .ck-content
-            &.ck-focused
-                max-height: 30vh
-            &.ck-blurred
-                max-height: 10vh
+            @media screen and (max-width: $breakpoint-sm)
+                &.ck-focused
+                    height: 30vh
+                &.ck-blurred
+                    height: 10vh
+            @media screen and (min-width: $breakpoint-md)
+              &.ck-focused
+                  max-height: 30vh
+              &.ck-blurred
+                  max-height: 10vh
         .ck-editor__preview
             max-height: 30vh

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -16,6 +16,7 @@
         // specific ck editor adjustments
         .ck-content
             @media screen and (max-width: $breakpoint-sm)
+                height: 30vh // set content-height before hand so there's no shift
                 &.ck-focused
                     height: 30vh
                 &.ck-blurred

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -600,6 +600,7 @@ export default class IndexController extends Controller {
     if (this.isMobile()) {
       void this.showFormMobile();
     } else if (this.sortingValue === 'asc' && journalsContainerAtBottom) {
+      // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form
       this.scrollJournalContainer(true);
       this.focusEditor();
     } else {
@@ -609,23 +610,24 @@ export default class IndexController extends Controller {
 
   private async showFormMobile() {
     // First scroll input container into view before focusing
-    this.scrollInputContainerIntoView(0);
+    // Use the original 100ms delay that was tested for best scrolling experience
+    this.scrollInputContainerIntoView(100);
 
-    // Wait a bit for the scroll to complete
+    // Wait for the initial scroll to complete
     await new Promise<void>((resolve) => {
       void window.setTimeout(resolve, 100);
     });
 
-    // Then focus editor to trigger keyboard
-    this.focusEditor(0);
+    // Then focus editor with the original 400ms delay that was tested to avoid interference
+    this.focusEditor(400);
 
     // Wait for virtual keyboard animation - iOS takes ~0.3s to show the keyboard
     await new Promise<void>((resolve) => {
       void window.setTimeout(resolve, 300);
     });
 
-    // Final scroll adjustment after keyboard is shown
-    this.scrollInputContainerIntoView(0);
+    // Final scroll adjustment after keyboard is shown, with original 100ms delay
+    this.scrollInputContainerIntoView(100);
   }
 
   focusEditor(timeout:number = 10) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -519,7 +519,7 @@ export default class IndexController extends Controller {
     this.onFocusEditorBound = () => {
       void this.onFocusEditor();
       if (this.isMobile()) {
-        void this.scrollInputContainerIntoView(0);
+        void this.scrollInputContainerIntoView(200);
       }
     };
 
@@ -596,8 +596,6 @@ export default class IndexController extends Controller {
     this.addEventListenersToCkEditorInstance();
 
     if (this.isMobile()) {
-      // first bring the input container fully into view (before focusing!)
-      this.scrollInputContainerIntoView(0);
       this.focusEditor(0);
     } else if (this.sortingValue === 'asc' && journalsContainerAtBottom) {
       // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -707,15 +707,11 @@ export default class IndexController extends Controller {
     if (ckEditorInstance && ckEditorInstance.getData({ trim: false }).length === 0) {
       this.hideEditor();
     } else {
-      // Store current scroll position before height adjustment
-      const scrollableContainer = this.getScrollableContainer();
-      const scrollPosition = scrollableContainer?.scrollTop || 0;
-
       this.adjustJournalContainerMargin();
 
-      // Restore scroll position after height adjustment
-      if (scrollableContainer) {
-        scrollableContainer.scrollTop = scrollPosition;
+      if (this.isMobile()) {
+        // wait for the keyboard to be fully down before adjusting scroll position
+        this.scrollInputContainerIntoView(400);
       }
     }
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -598,16 +598,26 @@ export default class IndexController extends Controller {
     this.addEventListenersToCkEditorInstance();
 
     if (this.isMobile()) {
-      // timeout amount tested on mobile devices for best possible user experience
-      this.scrollInputContainerIntoView(100); // first bring the input container fully into view (before focusing!)
-      this.focusEditor(400); // wait before focusing to avoid interference with the auto scroll
+      void this.showFormMobile();
     } else if (this.sortingValue === 'asc' && journalsContainerAtBottom) {
-      // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form
       this.scrollJournalContainer(true);
       this.focusEditor();
     } else {
       this.focusEditor();
     }
+  }
+
+  private async showFormMobile() {
+    // First focus to trigger keyboard
+    this.focusEditor(100);
+
+    // Wait for virtual keyboard animation - iOS takes ~0.3s to show the keyboard
+    await new Promise<void>((resolve) => {
+      void window.setTimeout(resolve, 300);
+    });
+
+    // Then scroll into position
+    this.scrollInputContainerIntoView(0);
   }
 
   focusEditor(timeout:number = 10) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -569,21 +569,14 @@ export default class IndexController extends Controller {
     }
   }
 
-  private scrollInputContainerIntoView(timeout:number = 0) {
+  private scrollInputContainerIntoView(timeout:number = 0, behavior:ScrollBehavior = 'smooth') {
     const inputContainer = this.getInputContainer() as HTMLElement;
     setTimeout(() => {
       if (inputContainer) {
-        if (this.sortingValue === 'desc') {
-          inputContainer.scrollIntoView({
-            behavior: 'smooth',
-            block: 'nearest',
-          });
-        } else {
-          inputContainer.scrollIntoView({
-            behavior: 'smooth',
-            block: 'start',
-          });
-        }
+        inputContainer.scrollIntoView({
+          behavior,
+          block: this.sortingValue === 'desc' ? 'nearest' : 'start',
+        });
       }
     }, timeout);
   }
@@ -598,7 +591,9 @@ export default class IndexController extends Controller {
     this.addEventListenersToCkEditorInstance();
 
     if (this.isMobile()) {
-      void this.showFormMobile();
+      // timeout amount tested on mobile devices for best possible user experience
+      this.scrollInputContainerIntoView(200, 'auto'); // first bring the input container fully into view (before focusing!)
+      this.focusEditor(400); // wait before focusing to avoid interference with the auto scroll
     } else if (this.sortingValue === 'asc' && journalsContainerAtBottom) {
       // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form
       this.scrollJournalContainer(true);
@@ -606,28 +601,6 @@ export default class IndexController extends Controller {
     } else {
       this.focusEditor();
     }
-  }
-
-  private async showFormMobile() {
-    // First scroll input container into view before focusing
-    // Use the original 100ms delay that was tested for best scrolling experience
-    this.scrollInputContainerIntoView(100);
-
-    // Wait for the initial scroll to complete
-    await new Promise<void>((resolve) => {
-      void window.setTimeout(resolve, 100);
-    });
-
-    // Then focus editor with the original 400ms delay that was tested to avoid interference
-    this.focusEditor(400);
-
-    // Wait for virtual keyboard animation - iOS takes ~0.3s to show the keyboard
-    await new Promise<void>((resolve) => {
-      void window.setTimeout(resolve, 300);
-    });
-
-    // Final scroll adjustment after keyboard is shown, with original 100ms delay
-    this.scrollInputContainerIntoView(100);
   }
 
   focusEditor(timeout:number = 10) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -516,7 +516,12 @@ export default class IndexController extends Controller {
     this.onSubmitBound = () => { void this.onSubmit(); };
     this.adjustMarginBound = () => { void this.adjustJournalContainerMargin(); };
     this.onBlurEditorBound = () => { void this.onBlurEditor(); };
-    this.onFocusEditorBound = () => { void this.onFocusEditor(); };
+    this.onFocusEditorBound = () => {
+      void this.onFocusEditor();
+      if (this.isMobile()) {
+        void this.scrollInputContainerIntoView(100, 'smooth');
+      }
+    };
 
     const editorElement = this.getCkEditorElement();
     if (editorElement) {
@@ -592,7 +597,7 @@ export default class IndexController extends Controller {
 
     if (this.isMobile()) {
       // timeout amount tested on mobile devices for best possible user experience
-      this.scrollInputContainerIntoView(200, 'auto'); // first bring the input container fully into view (before focusing!)
+      this.scrollInputContainerIntoView(100, 'auto'); // first bring the input container fully into view (before focusing!)
       this.focusEditor(400); // wait before focusing to avoid interference with the auto scroll
     } else if (this.sortingValue === 'asc' && journalsContainerAtBottom) {
       // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -608,15 +608,23 @@ export default class IndexController extends Controller {
   }
 
   private async showFormMobile() {
-    // First focus to trigger keyboard
-    this.focusEditor(100);
+    // First scroll input container into view before focusing
+    this.scrollInputContainerIntoView(0);
+
+    // Wait a bit for the scroll to complete
+    await new Promise<void>((resolve) => {
+      void window.setTimeout(resolve, 100);
+    });
+
+    // Then focus editor to trigger keyboard
+    this.focusEditor(0);
 
     // Wait for virtual keyboard animation - iOS takes ~0.3s to show the keyboard
     await new Promise<void>((resolve) => {
       void window.setTimeout(resolve, 300);
     });
 
-    // Then scroll into position
+    // Final scroll adjustment after keyboard is shown
     this.scrollInputContainerIntoView(0);
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -707,12 +707,26 @@ export default class IndexController extends Controller {
     if (ckEditorInstance && ckEditorInstance.getData({ trim: false }).length === 0) {
       this.hideEditor();
     } else {
+      // Store current scroll position before height adjustment
+      const scrollableContainer = this.getScrollableContainer();
+      const scrollPosition = scrollableContainer?.scrollTop || 0;
+
       this.adjustJournalContainerMargin();
+
+      // Restore scroll position after height adjustment
+      if (scrollableContainer) {
+        scrollableContainer.scrollTop = scrollPosition;
+      }
     }
   }
 
   onFocusEditor() {
     this.adjustJournalContainerMargin();
+
+    if (this.isMobile()) {
+      // Ensure editor is fully visible when focused
+      this.scrollInputContainerIntoView(0);
+    }
   }
 
   async onSubmit(event:Event | null = null) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -519,7 +519,7 @@ export default class IndexController extends Controller {
     this.onFocusEditorBound = () => {
       void this.onFocusEditor();
       if (this.isMobile()) {
-        void this.scrollInputContainerIntoView(100, 'smooth');
+        void this.scrollInputContainerIntoView(0);
       }
     };
 
@@ -596,9 +596,9 @@ export default class IndexController extends Controller {
     this.addEventListenersToCkEditorInstance();
 
     if (this.isMobile()) {
-      // timeout amount tested on mobile devices for best possible user experience
-      this.scrollInputContainerIntoView(100, 'auto'); // first bring the input container fully into view (before focusing!)
-      this.focusEditor(400); // wait before focusing to avoid interference with the auto scroll
+      // first bring the input container fully into view (before focusing!)
+      this.scrollInputContainerIntoView(0);
+      this.focusEditor(0);
     } else if (this.sortingValue === 'asc' && journalsContainerAtBottom) {
       // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before showing the form
       this.scrollJournalContainer(true);

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -708,21 +708,11 @@ export default class IndexController extends Controller {
       this.hideEditor();
     } else {
       this.adjustJournalContainerMargin();
-
-      if (this.isMobile()) {
-        // wait for the keyboard to be fully down before adjusting scroll position
-        this.scrollInputContainerIntoView(400);
-      }
     }
   }
 
   onFocusEditor() {
     this.adjustJournalContainerMargin();
-
-    if (this.isMobile()) {
-      // Ensure editor is fully visible when focused
-      this.scrollInputContainerIntoView(0);
-    }
   }
 
   async onSubmit(event:Event | null = null) {


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/60538

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

| WP Full View | WP Notification Centre |
|--------|--------|
|![work package in full view keeps input in view](https://github.com/user-attachments/assets/94b714b1-872a-4005-8296-3f4b0a7a722d) | ![work package in notification centre keeps input in view](https://github.com/user-attachments/assets/96588429-b140-44b2-b6fa-9b058b2218d0) | 


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

On mobile set the editor to a fixed height to reduce scrolling events and since the input is hidden initially hidden, bring it into view, focus it- and when CKEditor focuses, ensure it's in view again. There's a slight jitter as it's scrolled into view but this is the best I could achieve right now.

<img width="814" alt="Screenshot 2025-02-13 at 10 53 07 AM" src="https://github.com/user-attachments/assets/0af81f3e-24df-484c-b7bd-9107cb527128" />


# Merge checklist

- [ ] Added/updated tests (tests really tough on this one. Footprint is small enough)
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
