### PR TITLE
Replace with_merged_former_errors by validate_and_merge_errors

### DIFF
--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -144,9 +144,7 @@ module Projects
       contract_klass = model.being_archived? ? ArchiveContract : UnarchiveContract
       contract = contract_klass.new(model, user)
 
-      with_merged_former_errors do
-        contract.validate
-      end
+      validate_and_merge_errors(contract)
     end
   end
 end

--- a/app/contracts/views/base_contract.rb
+++ b/app/contracts/views/base_contract.rb
@@ -42,9 +42,7 @@ module Views
       if (strategy_class = Constants::Views.contract_strategy(model.type))
         strategy = strategy_class.new(model, user)
 
-        with_merged_former_errors do
-          strategy.valid?
-        end
+        validate_and_merge_errors(strategy)
       end
 
       errors.empty?

--- a/modules/storages/app/contracts/storages/storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/base_contract.rb
@@ -61,11 +61,7 @@ module Storages::Storages
       # Otherwise, we get :readonly validation errors.
       contract.writable_attributes.append(*writable_attributes)
 
-      # Validating the contract will clear the errors
-      # of this contract so we save them for later.
-      with_merged_former_errors do
-        contract.validate
-      end
+      validate_and_merge_errors(contract)
     end
 
     def require_ee_token_for_one_drive


### PR DESCRIPTION
The main problem with the previous method was that it only worked if the contract being validated inside the block was sharing the same `errors` object as the contract calling it. The old implementation was incapable of incorporating errors from a contract that had its own `errors` object. Sharing of the `errors` object is pretty common among our contracts, because most of them just delegate the `errors` method (among others) to the model being validated.

In my opinion it's a code smell that our contracts use the `errors` of the model they are validating as the place to store their validation result, however I didn't dare touching this yet, because changing that would certainly be a huge change (e.g. because it means that validating the contract will change the model being inspected). I can also imagine that some places rely on it for historic reasons (because using "classic" validations also puts the errors on the model). However, I think that no two contracts should RELY on using the SAME errors object, just because the way we implemented them happens to cause them to share the same object.

# What are you trying to accomplish?
This PR was coupled out from #17838 to be able to discuss and test this change separately. In #17838 I want to add a `ComposedContract` which is essentially a way of combining multiple contracts into one.

That class is not reusing the errors object of the model under test, because that would introduce an unintended coupling between the contracts that I'd need to work around.