### PR TITLE
[#61364] Saving changes to the meetings series details saves the template even though template is not yet saved

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   component_wrapper(data: wrapper_data_attributes) do
     flex_layout(mb: 3) do |flex|
-      if @meeting.template? && !empty?
+      if @meeting.template?
         flex.with_row(mb: 3) do
           render Primer::Alpha::Banner.new(scheme: :default,
                                            icon: :info,

--- a/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
@@ -7,12 +7,12 @@
                                            icon: :info,
                                            dismiss_scheme: :none) do
             t("recurring_meeting.template.banner_html",
-                   link: link_to(@meeting.recurring_meeting.title,
-                                 recurring_meeting_path(@meeting.recurring_meeting)))
+              link: link_to(@meeting.recurring_meeting.title,
+                            recurring_meeting_path(@meeting.recurring_meeting)))
           end
         end
       end
-      flex.with_row(classes: 'dragula-container', id: insert_target_modifier_id, data: { 'allowed-drop-type': 'section' }.merge(drop_target_config) ) do
+      flex.with_row(classes: "dragula-container", id: insert_target_modifier_id, data: { "allowed-drop-type": "section" }.merge(drop_target_config)) do
         first_and_last = [@meeting.sections.first, @meeting.sections.last]
         render(
           MeetingSections::ShowComponent.with_collection(

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -254,7 +254,7 @@ en:
         The first meeting has been successfuly created from template.
         All future meetings will be created automatically at the time of the previous occurrence.
     template:
-      button_finalize: "Finish template"
+      button_finalize: "Open first meeting"
       blank_title: "Your meeting series template is empty"
       description: >
         This template will be used whenever new meetings in the series get created.

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -118,9 +118,9 @@ RSpec.describe "Recurring meetings creation",
 
       expect(page).to have_css("#meetings-side-panel-participants-component", text: 2)
 
-      expect(page).to have_link("Finish template")
+      expect(page).to have_link("Open first meeting")
 
-      click_link_or_button "Finish template"
+      click_link_or_button "Open first meeting"
       wait_for_network_idle
 
       # Sends out an invitation to the series


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/61364

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
