### PR TITLE
Use @-mention of user when quote replying to a comment

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -119,7 +119,9 @@ module WorkPackages
                            data: {
                              action: "click->work-packages--activities-tab--index#quote",
                              "content-param": journal.notes,
-                             "user-name-param": I18n.t(:text_user_wrote, value: ERB::Util.html_escape(journal.user)),
+                             "user-id-param": journal.user_id,
+                             "user-name-param": journal.user.name,
+                             "text-wrote-param": t(:text_wrote),
                              test_selector: "op-wp-journal-#{journal.id}-quote"
                            }
                          }) do |item|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3977,6 +3977,7 @@ en:
   text_unallowed_characters: "Unallowed characters"
   text_user_invited: The user has been invited and is pending registration.
   text_user_wrote: "%{value} wrote:"
+  text_wrote: "wrote"
   text_warn_on_leaving_unsaved: "The work package contains unsaved text that will be lost if you leave this page."
   text_what_did_you_change_click_to_add_comment: "What did you change? Click to add comment"
   text_wiki_destroy_confirmation: "Are you sure you want to delete this wiki and all its content?"

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -620,10 +620,12 @@ export default class IndexController extends Controller {
   quote(event:Event) {
     event.preventDefault();
     const target = event.currentTarget as HTMLElement;
+    const userId = target.dataset.userIdParam as string;
     const userName = target.dataset.userNameParam as string;
+    const textWrote = target.dataset.textWroteParam as string;
     const content = target.dataset.contentParam as string;
 
-    const quotedText = this.quotedText(content, userName);
+    const quotedText = this.quotedText(content, userId, userName, textWrote);
     const formVisible = !this.formRowTarget.classList.contains('d-none');
     if (formVisible) {
       this.insertQuoteOnExistingEditor(quotedText);
@@ -632,12 +634,13 @@ export default class IndexController extends Controller {
     }
   }
 
-  private quotedText(rawComment:string, userName:string) {
+  private quotedText(rawComment:string, userId:string, userName:string, textWrote:string) {
     const quoted = rawComment.split('\n')
       .map((line:string) => `\n> ${line}`)
       .join('');
 
-    return `${userName}\n${quoted}`;
+    // if we ever change CKEditor or how @mentions work this will break
+    return `<mention class="mention" data-id="${userId}" data-type="user" data-text="@${userName}">@${userName}</mention> ${textWrote}:\n\n${quoted}`;
   }
 
   insertQuoteOnExistingEditor(quotedText:string) {

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -793,11 +793,11 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
 
       it "can quote other user's comments", :aggregate_failures do
         # quote other user's comment
-        # not adding additional text in this spec to the spec as I didn't find a way to add text the editor component
         activity_tab.quote_comment(first_comment_by_member)
 
         # expect the quoted comment to be shown
-        activity_tab.ckeditor.expect_value("A Member wrote:\nFirst comment by member")
+        # include value because ckeditor is returning a bunch of invisible characters and breaking the check
+        activity_tab.ckeditor.expect_include_value("@A Member wrote:\nFirst comment by member")
       end
     end
 
@@ -817,7 +817,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         activity_tab.quote_comment(first_comment_by_member)
 
         # expect the original comment and quote are shown
-        activity_tab.ckeditor.expect_value("Partial message:\nA Member wrote:\nFirst comment by member")
+        activity_tab.ckeditor.expect_value("Partial message:\n@A Member wrote:\nFirst comment by member")
       end
     end
   end

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -67,6 +67,10 @@ module Components
       expect(editor_element.text).to eq(value)
     end
 
+    def expect_include_value(value)
+      expect(editor_element.text).to include(value)
+    end
+
     def expect_supports_macros
       expect(container)
           .to have_css(".ck-button", visible: :all, text: "Macros")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/37093/activity

# What are you trying to accomplish?

Make it so that quoting a message from a user, actually mentions them

## Screenshots

https://github.com/user-attachments/assets/366a5660-73c4-4185-b424-c0eb8c217dfc

# What approach did you choose and why?

I found out what text the CodeMirror would produce and manually inject the same text into the editor. It seems to translate accurately into a mention and even persists it correctly.

# Merge checklist

- [X] Added/updated tests
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
