### PR TITLE
Bug/60538 misplaced cursor in comments text editor on ios (no fixed height)

### DIFF
--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -17,6 +17,8 @@
         .ck-content
             &.ck-focused
                 max-height: 30vh
+                @media screen and (max-width: $breakpoint-sm)
+                  height: 30vh
             &.ck-blurred
                 max-height: 10vh
         .ck-editor__preview

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -17,8 +17,6 @@
         .ck-content
             &.ck-focused
                 max-height: 30vh
-                @media screen and (max-width: $breakpoint-sm)
-                  height: 30vh
             &.ck-blurred
                 max-height: 10vh
         .ck-editor__preview

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -608,16 +608,14 @@ export default class IndexController extends Controller {
   }
 
   private async showFormMobile() {
-    // First focus to trigger keyboard
-    this.focusEditor(100);
-
-    // Wait for virtual keyboard animation - iOS takes ~0.3s to show the keyboard
+    // Let the DOM update and CKEditor initialize before scrolling into view and focusing the editor
+    // This is necessary to honor iOS requirement for user interaction to trigger the virtual keyboard
     await new Promise<void>((resolve) => {
-      void window.setTimeout(resolve, 300);
+      void window.setTimeout(resolve, 50);
     });
 
-    // Then scroll into position
     this.scrollInputContainerIntoView(0);
+    this.focusEditor(0);
   }
 
   focusEditor(timeout:number = 10) {


### PR DESCRIPTION
It looks too "thin" and off as the submit button takes up a sizeable portion on the right side. If we go with this approach, we should probably relocate the submit button