### PR TITLE
[61395] Spacing issues in log time dialog

### DIFF
--- a/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
@@ -1,46 +1,46 @@
-<%= render(Primer::Alpha::Dialog.new(title: t('caption_log_time_dialog'), size: :medium_portrait, id: MODAL_ID, data: { "controller" => "time-entry",  "application-target" => "dynamic", "time-entry-id" => time_entry.id, "ongoing" => time_entry.ongoing? })) do |d| %>
-  <% d.with_header(variant: :large, mb: 3) %>
+<%= render(Primer::Alpha::Dialog.new(title: t("caption_log_time_dialog"), size: :medium_portrait, id: MODAL_ID, data: { "controller" => "time-entry", "application-target" => "dynamic", "time-entry-id" => time_entry.id, "ongoing" => time_entry.ongoing? })) do |d| %>
+  <% d.with_header(variant: :large) %>
   <% d.with_body do %>
     <%= render(
-      TimeEntries::TimeEntryFormComponent.new(
-        time_entry: time_entry,
-        show_user: show_user,
-        show_work_package: show_work_package,
-      ),
-    ) %>
+          TimeEntries::TimeEntryFormComponent.new(
+            time_entry: time_entry,
+            show_user: show_user,
+            show_work_package: show_work_package
+          )
+        ) %>
   <% end %>
   <% d.with_footer(variant: :large) do %>
-    <% flex_layout(justify_content: :flex_end, classes: 'time-entry-dialog-footer-buttons') do |flex| %>
+    <% flex_layout(justify_content: :flex_end, classes: "time-entry-dialog-footer-buttons") do |flex| %>
       <% if time_entry.persisted? %>
         <% flex.with_column do %>
           <%= render(
-            Primer::ButtonComponent.new(
-              scheme: :danger,
-              test_selector: "destroy-time-entry-button",
-              data: {
-                "turbo" => true,
-                "turbo-method" => :delete,
-                "turbo-confirm" => t("js.text_are_you_sure"),
-              },
-              href: time_entry_path(time_entry),
-              tag: :a,
-            ),
-          ) { t("button_delete") } %>
+                Primer::ButtonComponent.new(
+                  scheme: :danger,
+                  test_selector: "destroy-time-entry-button",
+                  data: {
+                    "turbo" => true,
+                    "turbo-method" => :delete,
+                    "turbo-confirm" => t("js.text_are_you_sure")
+                  },
+                  href: time_entry_path(time_entry),
+                  tag: :a
+                )
+              ) { t("button_delete") } %>
         <% end %>
       <% end %>
       <% flex.with_column(classes: "time-entry-button-push") %>
       <% flex.with_column do %>
         <%= render(
-          Primer::ButtonComponent.new(data: { "close-dialog-id": "time-entry-dialog" }),
-        ) { I18n.t("button_cancel") } %>
+              Primer::ButtonComponent.new(data: { "close-dialog-id": "time-entry-dialog" })
+            ) { I18n.t("button_cancel") } %>
         <%= render(
-          Primer::ButtonComponent.new(
-            scheme: :primary,
-            type: :submit,
-            test_selector: "create-time-entry-button",
-            form: "time-entry-form",
-          ),
-        ) { t("button_log_time") } %>
+              Primer::ButtonComponent.new(
+                scheme: :primary,
+                type: :submit,
+                test_selector: "create-time-entry-button",
+                form: "time-entry-form"
+              )
+            ) { t("button_log_time") } %>
       <% end %>
     <% end %>
   <% end %>

--- a/modules/costs/app/components/time_entries/time_entry_form_component.html.erb
+++ b/modules/costs/app/components/time_entries/time_entry_form_component.html.erb
@@ -28,20 +28,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   ++# %>
 
   <%= component_wrapper do
-    primer_form_with(**form_options) do |form|
-      flex_layout(classes: "time-entry-dialog-form-spacing") do |body|
-        body.with_row do
-          render(TimeEntries::UserForm.new(form, visible: show_user))
+        primer_form_with(**form_options) do |form|
+          flex_layout(classes: "time-entry-dialog-form-spacing") do |body|
+            body.with_row do
+              render(TimeEntries::UserForm.new(form, visible: show_user))
+            end
+            body.with_row { render(TimeEntries::DaysAndHoursForm.new(form)) }
+            body.with_row(display: show_work_package ? :block : :none) do
+              render(
+                TimeEntries::WorkPackageForm.new(form, visible: show_work_package)
+              )
+            end
+            body.with_row { render(TimeEntries::ActivityForm.new(form)) }
+            body.with_row { render(TimeEntries::CommentsForm.new(form)) }
+            body.with_row { render(TimeEntries::CustomFieldsForm.new(form)) }
+          end
         end
-        body.with_row { render(TimeEntries::DaysAndHoursForm.new(form)) }
-        body.with_row do
-          render(
-            TimeEntries::WorkPackageForm.new(form, visible: show_work_package),
-          )
-        end
-        body.with_row { render(TimeEntries::ActivityForm.new(form)) }
-        body.with_row { render(TimeEntries::CommentsForm.new(form)) }
-        body.with_row { render(TimeEntries::CustomFieldsForm.new(form)) }
-      end
-    end
-  end %>
+      end %>

--- a/modules/costs/app/components/time_entries/time_entry_form_component.html.erb
+++ b/modules/costs/app/components/time_entries/time_entry_form_component.html.erb
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <%= component_wrapper do
         primer_form_with(**form_options) do |form|
           flex_layout(classes: "time-entry-dialog-form-spacing") do |body|
-            body.with_row do
+            body.with_row(display: show_user ? :block : :none) do
               render(TimeEntries::UserForm.new(form, visible: show_user))
             end
             body.with_row { render(TimeEntries::DaysAndHoursForm.new(form)) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61395/activity

# What are you trying to accomplish?
Fix spacings issues on the "Log time" dialog

## Screenshots
**Before**
<img width="499" alt="Bildschirmfoto 2025-02-11 um 10 44 11" src="https://github.com/user-attachments/assets/f812d202-7735-4126-a472-ea38da4c1e9f" />


**After**
<img width="493" alt="Bildschirmfoto 2025-02-11 um 10 39 50" src="https://github.com/user-attachments/assets/28fd655d-b6ae-4305-b4fd-9b01836b5fa4" />
