### PR TITLE
[#61398] Version autocompleter for filter values on the project list

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -82,13 +82,13 @@ module Filter
 
     def custom_field_list_autocomplete_options(filter)
       options = if filter.custom_field.version?
-                {
-                  items: filter.allowed_values.map { |name, id, project_name| { name:, id:, project_name: } },
-                  groupBy: "project_name"
-                }
-              else
-                { items: filter.allowed_values.map { |name, id| { name:, id: } } }
-              end
+                  {
+                    items: filter.allowed_values.map { |name, id, project_name| { name:, id:, project_name: } },
+                    groupBy: "project_name"
+                  }
+                else
+                  { items: filter.allowed_values.map { |name, id| { name:, id: } } }
+                end
 
       autocomplete_options.merge(options).merge(model: filter.values)
     end

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -81,13 +81,16 @@ module Filter
     end
 
     def custom_field_list_autocomplete_options(filter)
-      items = if filter.custom_field.version?
-                filter.allowed_values.map { |name, id, project_name| { name:, id:, project_name: } }
+      options = if filter.custom_field.version?
+                {
+                  items: filter.allowed_values.map { |name, id, project_name| { name:, id:, project_name: } },
+                  groupBy: "project_name"
+                }
               else
-                filter.allowed_values.map { |name, id| { name:, id: } }
+                { items: filter.allowed_values.map { |name, id| { name:, id: } } }
               end
 
-      autocomplete_options.merge(items:, model: filter.values)
+      autocomplete_options.merge(options).merge(model: filter.values)
     end
 
     def list_autocomplete_options(filter)

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -70,8 +70,9 @@ module Filter
         { autocomplete_options: project_autocomplete_options }
       when Queries::Filters::Shared::CustomFields::User
         { autocomplete_options: user_autocomplete_options }
-      when Queries::Filters::Shared::CustomFields::ListOptional,
-           Queries::Projects::Filters::ProjectStatusFilter,
+      when Queries::Filters::Shared::CustomFields::ListOptional
+        { autocomplete_options: custom_field_list_autocomplete_options(filter) }
+      when Queries::Projects::Filters::ProjectStatusFilter,
            Queries::Projects::Filters::TypeFilter
         { autocomplete_options: list_autocomplete_options(filter) }
       else
@@ -79,11 +80,26 @@ module Filter
       end
     end
 
+    def custom_field_list_autocomplete_options(filter)
+      items = if filter.custom_field.field_format == "version"
+                filter.allowed_values.map { |name, id, project_name| { name:, id:, project_name: } }
+              else
+                filter.allowed_values.map { |name, id| { name:, id: } }
+              end
+
+      autocomplete_options.merge(items:, model: filter.values)
+    end
+
     def list_autocomplete_options(filter)
+      autocomplete_options.merge(
+        items: filter.allowed_values.map { |name, id| { name:, id: } },
+        model: filter.values
+      )
+    end
+
+    def autocomplete_options
       {
         component: "opce-autocompleter",
-        items: filter.allowed_values.map { |name, id| { name:, id: } },
-        model: filter.values,
         bindValue: "id",
         bindLabel: "name",
         hideSelected: true

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -81,7 +81,7 @@ module Filter
     end
 
     def custom_field_list_autocomplete_options(filter)
-      items = if filter.custom_field.field_format == "version"
+      items = if filter.custom_field.version?
                 filter.allowed_values.map { |name, id, project_name| { name:, id:, project_name: } }
               else
                 filter.allowed_values.map { |name, id| { name:, id: } }

--- a/app/forms/custom_fields/inputs/multi_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_version_select_list.rb
@@ -48,6 +48,7 @@ class CustomFields::Inputs::MultiVersionSelectList < CustomFields::Inputs::Base:
         list.option(
           label: version.name,
           value: version.id,
+          group_by: version.project.name,
           selected: selected?(version)
         )
       end

--- a/app/forms/custom_fields/inputs/multi_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_version_select_list.rb
@@ -48,7 +48,7 @@ class CustomFields::Inputs::MultiVersionSelectList < CustomFields::Inputs::Base:
         list.option(
           label: version.name,
           value: version.id,
-          group_by: version.project.name,
+          group_by: group_key(version.project),
           selected: selected?(version)
         )
       end
@@ -63,5 +63,9 @@ class CustomFields::Inputs::MultiVersionSelectList < CustomFields::Inputs::Base:
 
   def selected?(version)
     @custom_values.pluck(:value).map { |value| value&.to_i }.include?(version.id)
+  end
+
+  def group_key(project)
+    project.visible?(User.current) ? project.name : I18n.t(:"project.not_available")
   end
 end

--- a/app/forms/custom_fields/inputs/single_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/single_version_select_list.rb
@@ -41,7 +41,9 @@ class CustomFields::Inputs::SingleVersionSelectList < CustomFields::Inputs::Base
     custom_value_form.autocompleter(**version_input_attributes) do |list|
       assignable_custom_field_values(@custom_field).each do |version|
         list.option(
-          label: version.name, value: version.id,
+          label: version.name,
+          value: version.id,
+          group_by: version.project.name,
           selected: selected?(version)
         )
       end

--- a/app/forms/custom_fields/inputs/single_version_select_list.rb
+++ b/app/forms/custom_fields/inputs/single_version_select_list.rb
@@ -43,7 +43,7 @@ class CustomFields::Inputs::SingleVersionSelectList < CustomFields::Inputs::Base
         list.option(
           label: version.name,
           value: version.id,
-          group_by: version.project.name,
+          group_by: group_key(version.project),
           selected: selected?(version)
         )
       end
@@ -58,5 +58,9 @@ class CustomFields::Inputs::SingleVersionSelectList < CustomFields::Inputs::Base
 
   def selected?(version)
     version.id == @custom_value.value&.to_i
+  end
+
+  def group_key(project)
+    project.visible?(User.current) ? project.name : I18n.t(:"project.not_available")
   end
 end

--- a/app/forms/custom_fields/inputs/version_select.rb
+++ b/app/forms/custom_fields/inputs/version_select.rb
@@ -38,23 +38,21 @@ module CustomFields
       end
 
       def additional_attributes
+        autocomplete_options = { groupBy: "group_by" }
+
         if @object.blank? || (@object.respond_to?(:project) && @object.project.blank?)
-          {
-            autocomplete_options: {
-              disabled: true,
-              placeholder: I18n.t("custom_fields.placeholder_version_select")
-            }
-          }
-        else
-          {}
+          autocomplete_options[:disabled] = true
+          autocomplete_options[:placeholder] = I18n.t("custom_fields.placeholder_version_select")
         end
+
+        { autocomplete_options: }
       end
 
       def assignable_versions(only_open:)
         if @object.is_a?(Project)
-          @object.assignable_versions(only_open: only_open)
+          @object.assignable_versions(only_open:)
         elsif @object.respond_to?(:project) && @object.project.present?
-          @object.project.assignable_versions(only_open: only_open)
+          @object.project.assignable_versions(only_open:)
         else
           Version.none
         end

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -93,21 +93,8 @@ module CustomFieldsHelper
                         id: field_id,
                         include_blank: I18n.t(:label_no_change_option))
     when "list"
-      base_options = []
-      unless custom_field.required?
-        unset_label = custom_field.field_format == "user" ? :label_nobody : :label_none
-        base_options << [I18n.t(unset_label), "none"]
-      end
-
-      possible_values = custom_field.possible_values_options(project)
-      options = if custom_field.version?
-                  grouped_options_for_select(possible_values.group_by(&:last).to_a)
-                else
-                  options_for_select(possible_values)
-                end
-
       styled_select_tag(field_name,
-                        options_for_select(base_options) + options,
+                        options_for_list(custom_field, project),
                         id: field_id,
                         multiple: custom_field.multi_value?,
                         include_blank: I18n.t(:label_no_change_option))
@@ -163,5 +150,22 @@ module CustomFieldsHelper
     suffix = show_enterprise_text ? " (#{I18n.t(:"ee.upsale.title")})" : ""
 
     "#{label}#{suffix}"
+  end
+
+  def options_for_list(custom_field, project)
+    base_options = []
+    unless custom_field.required?
+      unset_label = custom_field.field_format == "user" ? :label_nobody : :label_none
+      base_options << [I18n.t(unset_label), "none"]
+    end
+
+    possible_values = custom_field.possible_values_options(project)
+    options = if custom_field.version?
+                grouped_options_for_select(possible_values.group_by(&:last).to_a)
+              else
+                options_for_select(possible_values)
+              end
+
+    options_for_select(base_options) + options
   end
 end

--- a/app/models/projects/versions.rb
+++ b/app/models/projects/versions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -51,7 +53,7 @@ module Projects::Versions
       Version.shared_with(self)
     end
 
-    # Returns all versions a work package can be assigned to.  Opposed to
+    # Returns all versions a work package can be assigned to. Opposed to
     # #shared_versions this returns an array of Versions, not a scope.
     #
     # The main benefit is in scenarios where work packages' projects are eager

--- a/app/models/queries/filters/strategies/boolean_list.rb
+++ b/app/models/queries/filters/strategies/boolean_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -37,7 +39,7 @@ module Queries::Filters::Strategies
     end
 
     def valid_values!
-      filter.values &= allowed_values.map { |v| v.last.to_s }
+      filter.values &= allowed_values.map { |_, v| v.to_s }
     end
 
     private

--- a/app/models/queries/filters/strategies/list.rb
+++ b/app/models/queries/filters/strategies/list.rb
@@ -52,11 +52,11 @@ module Queries::Filters::Strategies
     end
 
     def valid_values!
-      filter.values &= (allowed_values.map(&:last).map(&:to_s) + ["-1"])
+      filter.values &= (allowed_values.map(&:second).map(&:to_s) + ["-1"])
     end
 
     def non_valid_values?
-      (values.reject(&:blank?) & (allowed_values.map(&:last).map(&:to_s) + ["-1"])) != values.reject(&:blank?)
+      (values.reject(&:blank?) & (allowed_values.map(&:second).map(&:to_s) + ["-1"])) != values.reject(&:blank?)
     end
   end
 end

--- a/app/models/queries/filters/strategies/list.rb
+++ b/app/models/queries/filters/strategies/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,9 +30,6 @@
 
 module Queries::Filters::Strategies
   class List < BaseStrategy
-    delegate :allowed_values,
-             to: :filter
-
     self.supported_operators = ["=", "!"]
     self.default_operator = "="
 
@@ -51,12 +50,16 @@ module Queries::Filters::Strategies
       end
     end
 
+    def allowed_values
+      filter.allowed_values.map { |_, v| v.to_s }
+    end
+
     def valid_values!
-      filter.values &= (allowed_values.map(&:second).map(&:to_s) + ["-1"])
+      filter.values &= (allowed_values + ["-1"])
     end
 
     def non_valid_values?
-      (values.reject(&:blank?) & (allowed_values.map(&:second).map(&:to_s) + ["-1"])) != values.reject(&:blank?)
+      (values.compact_blank & (allowed_values + ["-1"])) != values.compact_blank
     end
   end
 end

--- a/app/models/queries/filters/strategies/list.rb
+++ b/app/models/queries/filters/strategies/list.rb
@@ -30,6 +30,9 @@
 
 module Queries::Filters::Strategies
   class List < BaseStrategy
+    delegate :allowed_values,
+             to: :filter
+
     self.supported_operators = ["=", "!"]
     self.default_operator = "="
 
@@ -50,16 +53,12 @@ module Queries::Filters::Strategies
       end
     end
 
-    def allowed_values
-      filter.allowed_values.map { |_, v| v.to_s }
-    end
-
     def valid_values!
-      filter.values &= (allowed_values + ["-1"])
+      filter.values &= (allowed_values.map { |_, v| v.to_s } + ["-1"])
     end
 
     def non_valid_values?
-      (values.compact_blank & (allowed_values + ["-1"])) != values.compact_blank
+      (values.compact_blank & (allowed_values.map { |_, v| v.to_s } + ["-1"])) != values.compact_blank
     end
   end
 end

--- a/app/models/queries/filters/strategies/relation.rb
+++ b/app/models/queries/filters/strategies/relation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -48,7 +50,7 @@ module Queries::Filters::Strategies
     end
 
     def valid_values!
-      filter.values &= allowed_values.map { |v| v.last.to_s }
+      filter.values &= allowed_values.map { |_, v| v.to_s }
     end
 
     private

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -55,14 +55,22 @@ See COPYRIGHT and LICENSE files for more details.
           <div class="form--field">
             <%= styled_label_tag :work_package_type_id, WorkPackage.human_attribute_name(:type) %>
             <div class="form--field-container">
-              <%= styled_select_tag("work_package[type_id]", "<option value=\"\">#{t(:label_no_change_option)}</option>".html_safe + options_from_collection_for_select(@types, :id, :name)) %>
+              <%= styled_select_tag(
+                    "work_package[type_id]",
+                    options_from_collection_for_select(@types, :id, :name),
+                    include_blank: t(:label_no_change_option)
+                  ) %>
             </div>
           </div>
           <% if @available_statuses.any? %>
             <div class="form--field">
               <%= styled_label_tag :work_package_status_id, WorkPackage.human_attribute_name(:status) %>
               <div class="form--field-container">
-                <%= styled_select_tag("work_package[status_id]", "<option value=\"\">#{t(:label_no_change_option)}</option>".html_safe + options_from_collection_for_select(@available_statuses, :id, :name)) %>
+                <%= styled_select_tag(
+                      "work_package[status_id]",
+                      options_from_collection_for_select(@available_statuses, :id, :name),
+                      include_blank: t(:label_no_change_option)
+                    ) %>
               </div>
             </div>
           <% else %>
@@ -76,16 +84,21 @@ See COPYRIGHT and LICENSE files for more details.
           <div class="form--field">
             <%= styled_label_tag :work_package_priority_id, WorkPackage.human_attribute_name(:priority) %>
             <div class="form--field-container">
-              <%= styled_select_tag("work_package[priority_id]", "<option value=\"\">#{t(:label_no_change_option)}</option>".html_safe + options_from_collection_for_select(IssuePriority.active, :id, :name)) %>
+              <%= styled_select_tag(
+                    "work_package[priority_id]",
+                    options_from_collection_for_select(IssuePriority.active, :id, :name),
+                    include_blank: t(:label_no_change_option)
+                  ) %>
             </div>
           </div>
           <div class="form--field">
             <%= styled_label_tag :work_package_assigned_to_id, WorkPackage.human_attribute_name(:assigned_to) %>
             <div class="form--field-container">
               <%= styled_select_tag(
-                    "work_package[assigned_to_id]", content_tag("option", t(:label_no_change_option), value: "") +
-                                     content_tag("option", t(:label_nobody), value: "none") +
-                                     options_from_collection_for_select(@assignables, :id, :name)
+                    "work_package[assigned_to_id]",
+                    content_tag("option", t(:label_nobody), value: "none") +
+                    options_from_collection_for_select(@assignables, :id, :name),
+                    include_blank: t(:label_no_change_option)
                   ) %>
             </div>
           </div>
@@ -93,9 +106,10 @@ See COPYRIGHT and LICENSE files for more details.
             <%= styled_label_tag :work_package_responsible_id, WorkPackage.human_attribute_name(:responsible) %>
             <div class="form--field-container">
               <%= styled_select_tag(
-                    "work_package[responsible_id]", content_tag("option", t(:label_no_change_option), value: "") +
-                                     content_tag("option", t(:label_nobody), value: "none") +
-                                     options_from_collection_for_select(@responsibles, :id, :name)
+                    "work_package[responsible_id]",
+                    content_tag("option", t(:label_nobody), value: "none") +
+                    options_from_collection_for_select(@responsibles, :id, :name),
+                    include_blank: t(:label_no_change_option)
                   ) %>
             </div>
           </div>
@@ -104,9 +118,10 @@ See COPYRIGHT and LICENSE files for more details.
               <%= styled_label_tag :work_package_category_id, WorkPackage.human_attribute_name(:category) %>
               <div class="form--field-container">
                 <%= styled_select_tag(
-                      "work_package[category_id]", content_tag("option", t(:label_no_change_option), value: "") +
-                                    content_tag("option", t(:label_none), value: "none") +
-                                    options_from_collection_for_select(@project.categories, :id, :name)
+                      "work_package[category_id]",
+                      content_tag("option", t(:label_none), value: "none") +
+                      options_from_collection_for_select(@project.categories, :id, :name),
+                      include_blank: t(:label_no_change_option)
                     ) %>
               </div>
             </div>
@@ -115,9 +130,10 @@ See COPYRIGHT and LICENSE files for more details.
               <%= styled_label_tag :work_package_version_id, WorkPackage.human_attribute_name(:version) %>
               <div class="form--field-container">
                 <%= styled_select_tag(
-                      "work_package[version_id]", content_tag("option", t(:label_no_change_option), value: "") +
-                                       content_tag("option", t(:label_none), value: "none") +
-                                       version_options_for_select(@project.shared_versions.with_status_open.order_by_semver_name)
+                      "work_package[version_id]",
+                      content_tag("option", t(:label_none), value: "none") +
+                      version_options_for_select(@project.shared_versions.with_status_open.order_by_semver_name),
+                      include_blank: t(:label_no_change_option)
                     ) %>
               </div>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -995,6 +995,8 @@ en:
         active_value:
           true: "unarchived"
           false: "archived"
+        description: "Description"
+        enabled_modules: "Enabled modules"
         identifier: "Identifier"
         latest_activity_at: "Latest activity at"
         parent: "Subproject of"
@@ -1003,9 +1005,7 @@ en:
           true: "public"
           false: "private"
         queries: "Queries"
-        enabled_modules: "Enabled modules"
         status_code: "Project status"
-        description: "Description"
         status_explanation: "Project status description"
         status_codes:
           not_started: "Not started"
@@ -3482,6 +3482,13 @@ en:
     default: "-"
 
   project:
+    archive:
+      are_you_sure: "Are you sure you want to archive the project '%{name}'?"
+      archived: "Archived"
+    count:
+      zero: "0 projects"
+      one: "1 project"
+      other: "%{count} projects"
     destroy:
       confirmation: "If you continue, the project %{identifier} will be permanently destroyed. To confirm this action please introduce the project name in the field below, this will:"
       project_delete_result_1: "Delete all related data."
@@ -3494,6 +3501,7 @@ en:
       warning_one: Members of the project will have to relocate the project's repositories.
       warning_two: Existing links to the project will no longer work.
       title: Change the project's identifier
+    not_available: "Project N/A"
     template:
       copying: >
         Your project is being created from the selected template project.
@@ -3501,13 +3509,6 @@ en:
       use_template: "Use template"
       make_template: "Set as template"
       remove_from_templates: "Remove from templates"
-    archive:
-      are_you_sure: "Are you sure you want to archive the project '%{name}'?"
-      archived: "Archived"
-    count:
-      zero: "0 projects"
-      one: "1 project"
-      other: "%{count} projects"
 
   project_module_activity: "Activity"
   project_module_forums: "Forums"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -777,19 +777,19 @@ en:
       relation_description: "Click to add description for this relation"
 
     project:
+      autocompleter:
+        label: "Project autocompletion"
+      click_to_switch_to_project: "Project: %{projectname}"
+      confirm_template_load: "Switching the template will reload the page and you will lose all input to this form. Continue?"
+      context: "Project context"
+      copy:
+        copy_options: "Copy options"
+      not_available: "Project N/A"
+      no_template_selected: "(None)"
       required_outside_context: >
         Please choose a project to create the work package in to see all attributes.
         You can only select projects which have the type above activated.
-      context: "Project context"
-      click_to_switch_to_project: "Project: %{projectname}"
-      confirm_template_load: "Switching the template will reload the page and you will lose all input to this form. Continue?"
       use_template: "Use template"
-      no_template_selected: "(None)"
-      copy:
-        copy_options: "Copy options"
-
-      autocompleter:
-        label: "Project autocompletion"
 
     reminders:
       settings:

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.html
@@ -6,6 +6,7 @@
     class="advanced-filters--ng-select -multi-select"
     [id]="'values-' + filter.id"
     [getOptionsFn]="autocompleterFn"
+    [groupBy]="groupByFn"
     [classes]="{'-required-highlighting' : value.length === 0}"
     [virtualScroll]
     [closeOnSelect]="false"

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -67,7 +67,7 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   groupByFn = (item:HalResource):string|null => {
     if (!this.isVersionResource) return null;
     const project = item.definingProject as HalResource | undefined;
-    return project?.name ?? null;
+    return project?.name ?? this.I18n.t('js.project.not_available');
   };
 
   compareByHref = compareByHref;

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -64,6 +64,12 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
 
   itemTracker = (item:HalResource):string => item.href || item.id || item.name;
 
+  groupByFn = (item:HalResource):string|null => {
+    if (!this.isVersionResource) return null;
+    const project = item.definingProject as HalResource | undefined;
+    return project?.name ?? null;
+  };
+
   compareByHref = compareByHref;
 
   resourceType:string|null = null;
@@ -209,5 +215,10 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   private get isUserResource() {
     const type = _.get(this.filter.currentSchema, 'values.type', null) as string;
     return type && type.indexOf('User') > 0;
+  }
+
+  private get isVersionResource() {
+    const type = _.get(this.filter.currentSchema, 'values.type', null) as string;
+    return type && type.indexOf('Version') > 0;
   }
 }

--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.html
@@ -2,6 +2,7 @@
            [(ngModel)]="model"
            [items]="availableValues"
            [ngClass]="classes"
+           [groupBy]="groupByFn"
            [addTag]="createAllowed"
            [virtualScroll]="true"
            [required]="required"

--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
@@ -28,6 +28,7 @@
 
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -38,7 +39,6 @@ import {
 } from '@angular/core';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { OpInviteUserModalService } from 'core-app/features/invite-user-modal/invite-user-modal.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -46,9 +46,7 @@ import { AddTagFn } from '@ng-select/ng-select/lib/ng-select.component';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { Subject } from 'rxjs';
-import { typeFromHref } from 'core-app/shared/components/principal/principal-helper';
 import { compareByHref } from 'core-app/shared/helpers/angular/tracking-functions';
-import { filter } from 'rxjs/operators';
 import { repositionDropdownBugfix } from 'core-app/shared/components/autocompleter/op-autocompleter/autocompleter.helper';
 
 export interface CreateAutocompleterValueOption {
@@ -59,6 +57,7 @@ export interface CreateAutocompleterValueOption {
 @Component({
   templateUrl: './create-autocompleter.component.html',
   selector: 'create-autocompleter',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./create-autocompleter.component.sass'],
 })
 export class CreateAutocompleterComponent extends UntilDestroyedMixin implements AfterViewInit {
@@ -107,6 +106,8 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
   @InjectField() readonly pathHelper:PathHelperService;
 
   public compareByHref = compareByHref;
+
+  public groupByFn = (_item:HalResource):string | null => null;
 
   public text:{ [key:string]:string } = {};
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -217,10 +217,6 @@
       class="op-autocompleter__option-principal-email"
       *ngIf="item.email"
       [ngOptionHighlight]="search">{{ item.email }}</span>
-    <span
-      class="op-autocompleter__option-project-name"
-      *ngIf="item.project_name"
-      [ngOptionHighlight]="search">({{ item.project_name }})</span>
   </ng-container>
 </ng-template>
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -183,7 +183,6 @@
           [ngClass]="highlighting('status',item.status?.id)"
           class="op-autocompleter--wp-status"
         ></span>
-
       </div>
     </div>
   </ng-container>
@@ -218,6 +217,10 @@
       class="op-autocompleter__option-principal-email"
       *ngIf="item.email"
       [ngOptionHighlight]="search">{{ item.email }}</span>
+    <span
+      class="op-autocompleter__option-project-name"
+      *ngIf="item.project_name"
+      [ngOptionHighlight]="search">({{ item.project_name }})</span>
   </ng-container>
 </ng-template>
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
@@ -50,14 +50,12 @@
     text-overflow: ellipsis
 
   &__option-principal-email
-  &__option-project-name
     color: var(--fgColor-muted)
     font-size: var(--font-size-small)
     margin-left: var(--stack-gap-condensed)
 
   @media screen and (max-width: $breakpoint-sm)
     &__option-principal-email
-    &__option-project-name
       display: block
       margin-left: 0
       margin-top: var(--control-xsmall-gap)

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.sass
@@ -50,12 +50,14 @@
     text-overflow: ellipsis
 
   &__option-principal-email
+  &__option-project-name
     color: var(--fgColor-muted)
     font-size: var(--font-size-small)
     margin-left: var(--stack-gap-condensed)
 
   @media screen and (max-width: $breakpoint-sm)
     &__option-principal-email
+    &__option-project-name
       display: block
       margin-left: 0
       margin-top: var(--control-xsmall-gap)

--- a/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
@@ -28,6 +28,7 @@
 
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -39,6 +40,7 @@ import { CreateAutocompleterComponent } from 'core-app/shared/components/autocom
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { VersionResource } from 'core-app/features/hal/resources/version-resource';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { firstValueFrom } from 'rxjs';
@@ -46,9 +48,15 @@ import { firstValueFrom } from 'rxjs';
 @Component({
   templateUrl: '../create-autocompleter/create-autocompleter.component.html',
   selector: 'version-autocompleter',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VersionAutocompleterComponent extends CreateAutocompleterComponent implements AfterViewInit {
   @Output() public onCreate = new EventEmitter<VersionResource>();
+
+  groupByFn = (item:HalResource):string|null => {
+    const project = item.definingProject as HalResource | undefined;
+    return project?.name ?? null;
+  };
 
   constructor(
     readonly injector:Injector,
@@ -65,7 +73,7 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
   ngAfterViewInit() {
     super.ngAfterViewInit();
 
-    this.canCreateNewActionElements().then((val) => {
+    void this.canCreateNewActionElements().then((val) => {
       if (val) {
         this.createAllowed = (input:string) => this.createNewVersion(input);
         this.cdRef.detectChanges();

--- a/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
@@ -54,8 +54,9 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
   @Output() public onCreate = new EventEmitter<VersionResource>();
 
   groupByFn = (item:HalResource):string|null => {
+    if (!item.id) return null; // Do not group non version options
     const project = item.definingProject as HalResource | undefined;
-    return project?.name ?? null;
+    return project?.name ?? this.I18n.t('js.project.not_available');
   };
 
   constructor(

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.html
@@ -16,6 +16,7 @@
            [multiple]="true"
            [closeOnSelect]="false"
            [appendTo]="appendTo"
+           [groupBy]="groupByFn"
            [dropdownPosition]="'top'"
            [hideSelected]="true">
   <ng-template ng-option-tmp let-item="item">

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -29,7 +29,7 @@
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, OnInit, ViewChild } from '@angular/core';
 import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-field.component';
 import { ValueOption } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component';
 import { NgSelectComponent } from '@ng-select/ng-select';
@@ -38,6 +38,7 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 
 @Component({
   templateUrl: './multi-select-edit-field.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MultiSelectEditFieldComponent extends EditFieldComponent implements OnInit {
   @ViewChild(NgSelectComponent, { static: true }) public ngSelectComponent:NgSelectComponent;
@@ -45,6 +46,12 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   @InjectField() I18n!:I18nService;
 
   @InjectField() pathHelperService:PathHelperService;
+
+  groupByFn = (item:HalResource):string|null => {
+    if (!this.isVersionResource) return null;
+    const project = item.definingProject as HalResource | undefined;
+    return project?.name ?? null;
+  };
 
   public availableOptions:any[] = [];
 
@@ -151,9 +158,8 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   private openAutocompleteSelectField() {
     // The timeout takes care that the opening is added to the end of the current call stack.
     // Thus we can be sure that the autocompleter is rendered and ready to be opened.
-    const that = this;
     window.setTimeout(() => {
-      that.ngSelectComponent.open();
+      this.ngSelectComponent.open();
     }, 0);
   }
 
@@ -232,7 +238,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
    * dropdown. For this to happen we must register a trigger target.
    */
   protected getHoverCardTriggerTarget() {
-    if (this.schema?.type === '[]User') {
+    if (this.isUserResource) {
       return 'trigger';
     }
 
@@ -252,4 +258,14 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   }
 
   protected readonly getComputedStyle = getComputedStyle;
+
+  private get isUserResource() {
+    const type = this.schema?.type;
+    return type && type.indexOf('User') > 0;
+  }
+
+  private get isVersionResource() {
+    const type = this.schema?.type;
+    return type && type.indexOf('Version') > 0;
+  }
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -50,7 +50,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   groupByFn = (item:HalResource):string|null => {
     if (!this.isVersionResource) return null;
     const project = item.definingProject as HalResource | undefined;
-    return project?.name ?? null;
+    return project?.name ?? this.I18n.t('js.project.not_available');
   };
 
   public availableOptions:any[] = [];

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -96,7 +96,11 @@ class CustomFieldFormBuilder < TabularFormBuilder
     selected_options = Array(selected).map(&:value)
 
     if custom_field.version?
-      template.grouped_options_for_select(options.group_by(&:last).to_a, selected_options)
+      grouped_options = Hash.new { |hsh, key| hsh[key] = [] }
+      options.each do |label, value, group_key|
+        grouped_options[group_key] << [label, value]
+      end
+      template.grouped_options_for_select(grouped_options, selected_options)
     else
       template.options_for_select(options, selected_options)
     end

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -83,17 +83,23 @@ class CustomFieldFormBuilder < TabularFormBuilder
     end
   end
 
-  # rubocop:enable Metrics/AbcSize
-
   def custom_field_input_list(field, input_options)
     customized = Array(custom_value).first&.customized
-    possible_options = custom_field.possible_values_options(customized)
-    select_options = custom_field_select_options_for_object
-    selected_options = Array(custom_value).map(&:value)
-    selectable_options = template.options_for_select(possible_options, selected_options)
+    selectable_options = custom_field_input_list_options(customized, custom_value)
     input_options[:multiple] = custom_field.multi_value?
 
-    select(field, selectable_options, select_options, input_options).html_safe
+    select(field, selectable_options, custom_field_select_options_for_object, input_options)
+  end
+
+  def custom_field_input_list_options(customized, selected)
+    options = custom_field.possible_values_options(customized)
+    selected_options = Array(selected).map(&:value)
+
+    if custom_field.version?
+      template.grouped_options_for_select(options.group_by(&:last).to_a, selected_options)
+    else
+      template.options_for_select(options, selected_options)
+    end
   end
 
   def custom_field_select_options_for_object

--- a/lib/primer/open_project/forms/autocompleter.rb
+++ b/lib/primer/open_project/forms/autocompleter.rb
@@ -39,7 +39,6 @@ module Primer
           inputs[:inputName] ||= builder.field_name(@input.name)
           inputs[:labelForId] ||= builder.field_id(@input.name)
           inputs[:defaultData] = true unless inputs.key?(:defaultData)
-          inputs[:hideSelected] = true
           inputs
         end
 

--- a/lib/primer/open_project/forms/autocompleter.rb
+++ b/lib/primer/open_project/forms/autocompleter.rb
@@ -20,24 +20,41 @@ module Primer
           @wrapper_data_attributes = wrapper_data_attributes
         end
 
-        def extend_autocomplete_inputs(inputs) # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
-          inputs[:classes] = "ng-select--primerized #{@input.invalid? ? '-error' : ''}"
-          inputs[:inputName] ||= builder.field_name(@input.name)
-          inputs[:labelForId] ||= builder.field_id(@input.name)
-          inputs[:defaultData] = true unless inputs.key?(:defaultData)
+        def extend_autocomplete_inputs(inputs)
+          inputs = autocomplete_input_defaults(inputs)
 
           if inputs.delete(:decorated)
-            inputs[:items] = @input.select_options.map(&:to_h)
-            selected = @input.select_options.filter_map { |option| option.to_h if option.selected }
-            inputs[:model] = inputs[:multiple] ? selected : selected.first
-            inputs[:defaultData] = false
-            inputs[:additionalClassProperty] = "classes"
-            inputs[:bindLabel] = "name"
+            inputs = autocomplete_input_decorated(inputs)
           elsif builder.object
             inputs[:inputValue] ||= builder.object.send(@input.name)
           end
 
           inputs
+        end
+
+        private
+
+        def autocomplete_input_defaults(inputs)
+          inputs[:classes] = "ng-select--primerized #{@input.invalid? ? '-error' : ''}"
+          inputs[:inputName] ||= builder.field_name(@input.name)
+          inputs[:labelForId] ||= builder.field_id(@input.name)
+          inputs[:defaultData] = true unless inputs.key?(:defaultData)
+          inputs[:hideSelected] = true
+          inputs
+        end
+
+        def autocomplete_input_decorated(inputs)
+          selected = @input.select_options.filter_map { |option| option.to_h if option.selected }
+          model = inputs[:multiple] ? selected : selected.first
+
+          inputs.merge(
+            items: @input.select_options.map(&:to_h),
+            model:,
+            defaultData: false,
+            additionalClassProperty: "classes",
+            bindLabel: "name",
+            bindValue: "id"
+          )
         end
       end
     end

--- a/lib/primer/open_project/forms/dsl/autocompleter_input.rb
+++ b/lib/primer/open_project/forms/dsl/autocompleter_input.rb
@@ -8,19 +8,21 @@ module Primer
           attr_reader :name, :label, :autocomplete_options, :select_options, :wrapper_data_attributes
 
           class Option
-            attr_reader :label, :value, :selected, :classes
+            attr_reader :label, :value, :selected, :classes, :group_by
 
-            def initialize(label:, value:, classes: nil, selected: false)
+            def initialize(label:, value:, classes: nil, selected: false, group_by: nil)
               @label = label
               @value = value
               @selected = selected
               @classes = classes
+              @group_by = group_by
             end
 
             def to_h
               {
                 id: value,
                 name: label,
+                group_by:,
                 classes:
               }.compact
             end

--- a/spec/features/custom_fields/multi_version_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_version_custom_field_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
 RSpec.describe "multi version custom field", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
   shared_let(:admin) { create(:admin) }
   let(:current_user) { admin }
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
@@ -98,8 +100,12 @@ RSpec.describe "multi version custom field", :js do
       expect(page).to have_text "Version Current"
 
       page.find(".inline-edit--display-field", text: "Version Old").click
-
       cf_edit_field.unset_value "Version Old", multi: true
+
+      expect_ng_option(cf_edit_field, version_old, grouping: project.name, results_selector: "body")
+      expect_no_ng_option(cf_edit_field, version_current, results_selector: "body")
+      expect_ng_option(cf_edit_field, version_future, grouping: project.name, results_selector: "body")
+
       cf_edit_field.set_value "Version Future"
 
       click_on "Fix version: Save"

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -499,11 +499,12 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
     it "displays the visible project members as available options" do
       load_and_open_filters admin
 
-      projects_page.expect_autocomplete_options_for(
-        user_cf,
-        [{ name: some_user.name, email: some_user.mail },
-         { name: manager.name, email: manager.mail }]
-      )
+      expected_options = [
+        { name: some_user.name, email: some_user.mail },
+        { name: manager.name, email: manager.mail }
+      ]
+
+      projects_page.expect_user_autocomplete_options_for(user_cf, expected_options)
     end
   end
 

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
@@ -318,8 +318,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
               overview_page.open_edit_dialog_for_section(section)
 
               field.search("Version 1")
-
-              field.expect_option(first_version.name)
+              field.expect_option(first_version.name, grouping: project.name)
               field.expect_no_option(version_in_other_project.name)
             end
           end
@@ -549,7 +548,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
               field.search("Version 1")
 
-              field.expect_option(first_version.name)
+              field.expect_option(first_version.name, grouping: project.name)
               field.expect_no_option(version_in_other_project.name)
             end
           end

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe "subject inplace editor", :js, :selenium do
 
       # Expect the order to be descending by version date
       labels = page.all(".ng-option-label").map { |el| el.text.strip }
-      expect(labels).to eq ["-", version.name, version2.name, version3.name]
+      expect(labels)
+        .to eq ["-", project.name, version.name, "Project N/A", version2.name, version3.name]
 
       page.find(".ng-option-label", text: version3.name).select_option
       field.expect_state_text(version3.name)

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -29,6 +29,8 @@
 require "spec_helper"
 
 RSpec.describe "filter work packages", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
   shared_let(:user) { create(:admin, preferences: { time_zone: "Etc/UTC" }) }
   shared_let(:watcher) { create(:user) }
   shared_let(:role) { create(:existing_project_role, permissions: [:view_work_packages]) }
@@ -84,6 +86,18 @@ RSpec.describe "filter work packages", :js do
 
     it "allows filtering, saving, retrieving and altering the saved filter" do
       filters.open
+
+      # Expect filters to be grouped by project name
+      filters.add_filter("Version")
+
+      expect_ng_option(
+        page.find_by_id("values-version"),
+        version,
+        grouping: project.name,
+        results_selector: "body"
+      )
+
+      filters.remove_filter "version"
 
       filters.add_filter_by("Version", "is (OR)", version.name)
 

--- a/spec/features/work_packages/table/queries/version_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/version_cf_filter_spec.rb
@@ -30,6 +30,8 @@ require "spec_helper"
 
 # This is not strictly version CF specific, but targets regression #53198.
 RSpec.describe "Work package filtering by version custom field", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
   let!(:project) { create(:project) }
   let!(:type) { project.types.first }
   let!(:version_cf1) do
@@ -91,6 +93,27 @@ RSpec.describe "Work package filtering by version custom field", :js do
 
   current_user do
     create(:user, member_with_roles: { project => role })
+  end
+
+  it "displays the available versions grouped by their corresponding project" do
+    wp_table.visit!
+    filters.open
+
+    filters.add_filter(version_cf1.name)
+
+    expect_ng_option(
+      page.find("#values-#{version_cf1.attribute_name(:camel_case)}"),
+      version_1,
+      grouping: project.name,
+      results_selector: "body"
+    )
+
+    expect_ng_option(
+      page.find("#values-#{version_cf1.attribute_name(:camel_case)}"),
+      version_2,
+      grouping: project.name,
+      results_selector: "body"
+    )
   end
 
   it 'shows the work package matching the version CF "is (AND)" filter' do

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -56,6 +58,8 @@ RSpec.describe CustomFieldFormBuilder do
     let(:resource) do
       build_stubbed(:user)
     end
+
+    let(:scope) { instance_double(ActiveRecord::Relation) }
 
     before do
       without_partial_double_verification do
@@ -255,7 +259,6 @@ RSpec.describe CustomFieldFormBuilder do
       let(:project) { build_stubbed(:project) }
       let(:user1) { build_stubbed(:user) }
       let(:user2) { build_stubbed(:user) }
-      let(:scope) { instance_double(ActiveRecord::Relation) }
 
       let(:resource) { project }
 
@@ -273,8 +276,10 @@ RSpec.describe CustomFieldFormBuilder do
                 .and_return(scope)
 
         allow(scope)
-          .to receive(:select)
-                .and_return([user1, user2])
+          .to receive_messages(
+            select: [user1, user2],
+            includes: scope
+          )
       end
 
       it_behaves_like "wrapped in container", "select-container" do
@@ -331,6 +336,10 @@ RSpec.describe CustomFieldFormBuilder do
 
           allow(project)
             .to receive(:shared_versions)
+                  .and_return(scope)
+
+          allow(scope)
+            .to receive(:includes)
                   .and_return([version1, version2])
         end
       end

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe CustomFieldFormBuilder do
                   .and_return(scope)
 
           allow(scope)
-            .to receive(:includes)
+            .to receive(:references)
                   .and_return([version1, version2])
         end
       end
@@ -355,8 +355,12 @@ RSpec.describe CustomFieldFormBuilder do
                   name="user[#{custom_field.id}]"
                   no_label="true">
             <option value="" label=" "></option>
-            <option value="#{version1.id}">#{version1.name}</option>
-            <option value="#{version2.id}">#{version2.name}</option>
+            <optgroup label="#{version1.project.name}">
+              <option value="#{version1.id}">#{version1.name}</option>
+            </optgroup>
+            <optgroup label="#{version2.project.name}">
+              <option value="#{version2.id}">#{version2.name}</option>
+            </optgroup>
           </select>
         }).at_path("select")
       end
@@ -373,8 +377,12 @@ RSpec.describe CustomFieldFormBuilder do
                     name="user[#{custom_field.id}]"
                     no_label="true">
               <option value="">--- Please select ---</option>
-              <option value="#{version1.id}">#{version1.name}</option>
-              <option value="#{version2.id}">#{version2.name}</option>
+              <optgroup label="#{version1.project.name}">
+                <option value="#{version1.id}">#{version1.name}</option>
+              </optgroup>
+              <optgroup label="#{version2.project.name}">
+                <option value="#{version2.id}">#{version2.name}</option>
+              </optgroup>
             </select>
           }).at_path("select")
         end

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -110,7 +112,7 @@ RSpec.describe CustomActions::Actions::CustomField do
       expect(described_class.all.map(&:custom_field))
         .to match_array(custom_fields)
 
-      described_class.all.each do |subclass|
+      described_class.find_each do |subclass|
         expect(subclass.ancestors).to include(described_class)
       end
     end
@@ -408,7 +410,8 @@ RSpec.describe CustomActions::Actions::CustomField do
 
       before do
         allow(scope)
-          .to receive(:includes)
+          .to receive(:references)
+                .with(:project)
                 .and_return(versions)
 
         allow(Version)
@@ -555,7 +558,8 @@ RSpec.describe CustomActions::Actions::CustomField do
 
       before do
         allow(scope)
-          .to receive(:includes)
+          .to receive(:references)
+                .with(:project)
                 .and_return(versions)
 
         allow(Version)
@@ -577,8 +581,8 @@ RSpec.describe CustomActions::Actions::CustomField do
       it_behaves_like "bool custom action validations" do
         let(:allowed_values) do
           [
-            { true: OpenProject::Database::DB_VALUE_TRUE },
-            { false: OpenProject::Database::DB_VALUE_FALSE }
+            { true => OpenProject::Database::DB_VALUE_TRUE },
+            { false => OpenProject::Database::DB_VALUE_FALSE }
           ]
         end
       end

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe CustomActions::Actions::CustomField do
       expect(described_class.all.map(&:custom_field))
         .to match_array(custom_fields)
 
-      described_class.find_each do |subclass|
+      described_class.all.each do |subclass|
         expect(subclass.ancestors).to include(described_class)
       end
     end

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -29,6 +29,7 @@ require "spec_helper"
 require_relative "../shared_expectations"
 
 RSpec.describe CustomActions::Actions::CustomField do
+  let(:scope) { instance_double(ActiveRecord::Relation) }
   let(:list_custom_field) do
     build_stubbed(:list_wp_custom_field,
                   custom_options: [build_stubbed(:custom_option, value: "A"),
@@ -406,9 +407,13 @@ RSpec.describe CustomActions::Actions::CustomField do
       let(:versions) { [z_version, a_version, m_version] }
 
       before do
+        allow(scope)
+          .to receive(:includes)
+                .and_return(versions)
+
         allow(Version)
           .to receive(:systemwide)
-          .and_return(versions)
+          .and_return(scope)
       end
 
       context "for a non required field" do
@@ -441,7 +446,6 @@ RSpec.describe CustomActions::Actions::CustomField do
          build_stubbed(:user),
          build_stubbed(:user)]
       end
-      let(:scope) { instance_double(ActiveRecord::Relation) }
 
       before do
         allow(Principal)
@@ -520,7 +524,6 @@ RSpec.describe CustomActions::Actions::CustomField do
          build_stubbed(:user),
          build_stubbed(:user)]
       end
-      let(:scope) { instance_double(ActiveRecord::Relation) }
 
       before do
         allow(Principal)
@@ -551,9 +554,13 @@ RSpec.describe CustomActions::Actions::CustomField do
       end
 
       before do
+        allow(scope)
+          .to receive(:includes)
+                .and_return(versions)
+
         allow(Version)
           .to receive(:systemwide)
-          .and_return(versions)
+          .and_return(scope)
       end
 
       it_behaves_like "associated custom action validations" do

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -156,7 +158,7 @@ RSpec.describe CustomField do
 
       it "is not valid" do
         expect(field)
-          .to be_invalid
+          .not_to be_valid
       end
     end
 
@@ -295,7 +297,7 @@ RSpec.describe CustomField do
       before do
         field.field_format = "version"
         allow(shared_versions_scope)
-          .to receive(:includes)
+          .to receive(:references)
           .with(:project)
           .and_return(versions)
       end

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -289,20 +289,25 @@ RSpec.describe CustomField do
     end
 
     context "for a version custom field" do
-      let(:versions) { [build_stubbed(:version), build_stubbed(:version)] }
+      let(:versions) { [build_stubbed(:version, project:), build_stubbed(:version, project:)] }
+      let(:shared_versions_scope) { instance_double(ActiveRecord::Relation) }
 
       before do
         field.field_format = "version"
+        allow(shared_versions_scope)
+          .to receive(:includes)
+          .with(:project)
+          .and_return(versions)
       end
 
       context "with a project provided" do
         it "returns the project's shared_versions" do
           allow(project)
             .to receive(:shared_versions)
-            .and_return(versions)
+            .and_return(shared_versions_scope)
 
           expect(field.possible_values_options(project))
-            .to eql(versions.sort.map { |u| [u.name, u.id.to_s] })
+            .to eql(versions.sort.map { |u| [u.name, u.id.to_s, project.name] })
         end
       end
 
@@ -312,10 +317,10 @@ RSpec.describe CustomField do
         it "returns the project's shared_versions" do
           allow(project)
             .to receive(:shared_versions)
-            .and_return(versions)
+            .and_return(shared_versions_scope)
 
           expect(field.possible_values_options(project))
-            .to eql(versions.sort.map { |u| [u.name, u.id.to_s] })
+            .to eql(versions.sort.map { |u| [u.name, u.id.to_s, project.name] })
         end
       end
 
@@ -323,10 +328,10 @@ RSpec.describe CustomField do
         it "returns the systemwide versions" do
           allow(Version)
             .to receive(:systemwide)
-            .and_return(versions)
+            .and_return(shared_versions_scope)
 
           expect(field.possible_values_options)
-            .to eql(versions.sort.map { |u| [u.name, u.id.to_s] })
+            .to eql(versions.sort.map { |u| [u.name, u.id.to_s, project.name] })
         end
       end
     end

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components::Autocompleter
   module NgSelectAutocompleteHelpers
     def search_autocomplete(element, query:, results_selector: nil, wait_dropdown_open: true, wait_for_fetched_options: true)
@@ -55,9 +57,19 @@ module Components::Autocompleter
           # Make sure the option is displayed under correct grouping title.
           option_group = find(".ng-optgroup", text: grouping)
           option = find(".ng-option.ng-option-child", text: option, visible: :visible)
-          expect(option_group).to eq(
-            option.find(:xpath, "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]")
-          )
+
+          expected_group = begin
+            option.find(:xpath,
+                        "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]",
+                        wait: false)
+          rescue Capybara::ElementNotFound
+            raise "Unable to find the '.ng-optgroup' grouping for option '#{option.text}'"
+          end
+
+          expect(option_group).to eq(expected_group), <<~MSG
+            Expected the option '#{option.text}' to be under the group '#{option_group.text}',
+            but it was under '#{expected_group.text}' instead.
+          MSG
         else
           expect(page).to have_conditional_selector(present, ".ng-option", text: option)
         end
@@ -75,6 +87,7 @@ module Components::Autocompleter
         expect(page).to have_css("##{field_id} .ng-value-label", text:)
       end
     end
+
     ##
     # Insert the query, typing
     def ng_enter_query(element, query, wait_for_fetched_options: true)

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -49,9 +49,18 @@ module Components::Autocompleter
       end
     end
 
-    def expect_ng_option(element, option, results_selector: nil, present: true)
+    def expect_ng_option(element, option, grouping: nil, results_selector: nil, present: true)
       within(ng_find_dropdown(element, results_selector:)) do
-        expect(page).to have_conditional_selector(present, ".ng-option", text: option)
+        if grouping && present
+          # Make sure the option is displayed under correct grouping title.
+          option_group = find(".ng-optgroup", text: grouping)
+          option = find(".ng-option.ng-option-child", text: option, visible: :visible)
+          expect(option_group).to eq(
+            option.find(:xpath, "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]")
+          )
+        else
+          expect(page).to have_conditional_selector(present, ".ng-option", text: option)
+        end
       end
     end
 

--- a/spec/support/form_fields/primerized/autocomplete_field.rb
+++ b/spec/support/form_fields/primerized/autocomplete_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "form_field"
 
 module FormFields
@@ -82,9 +84,19 @@ module FormFields
           # Make sure the option is displayed under correct grouping title.
           option_group = find(".ng-optgroup", text: grouping)
           option = find(".ng-option.ng-option-child", text: option, visible: :visible)
-          expect(option_group).to eq(
-            option.find(:xpath, "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]")
-          )
+
+          expected_group = begin
+            option.find(:xpath,
+                        "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]",
+                        wait: false)
+          rescue Capybara::ElementNotFound
+            raise "Unable to find the '.ng-optgroup' grouping for option '#{option.text}'"
+          end
+
+          expect(option_group).to eq(expected_group), <<~MSG
+            Expected the option '#{option.text}' to be under the group '#{option_group.text}',
+            but it was under '#{expected_group.text}' instead.
+          MSG
         else
           expect(page)
             .to have_css(".ng-option", text: option, visible: :visible)

--- a/spec/support/form_fields/primerized/autocomplete_field.rb
+++ b/spec/support/form_fields/primerized/autocomplete_field.rb
@@ -77,9 +77,16 @@ module FormFields
           .to have_no_css(".ng-option", text: option, visible: :all, wait: 1)
       end
 
-      def expect_option(option)
-        expect(page)
-          .to have_css(".ng-option", text: option, visible: :visible)
+      def expect_option(option, grouping: nil)
+        if grouping
+          # Make sure the option is displayed under correct grouping title.
+          option_group = find(".ng-optgroup", text: grouping)
+          option = find(".ng-option.ng-option-child", text: option, visible: :visible)
+          expect(option_group).to eq option.find(:xpath, "preceding-sibling::*[1]")
+        else
+          expect(page)
+            .to have_css(".ng-option", text: option, visible: :visible)
+        end
       end
 
       def expect_visible

--- a/spec/support/form_fields/primerized/autocomplete_field.rb
+++ b/spec/support/form_fields/primerized/autocomplete_field.rb
@@ -82,7 +82,9 @@ module FormFields
           # Make sure the option is displayed under correct grouping title.
           option_group = find(".ng-optgroup", text: grouping)
           option = find(".ng-option.ng-option-child", text: option, visible: :visible)
-          expect(option_group).to eq option.find(:xpath, "preceding-sibling::*[1]")
+          expect(option_group).to eq(
+            option.find(:xpath, "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]")
+          )
         else
           expect(page)
             .to have_css(".ng-option", text: option, visible: :visible)

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -287,6 +287,18 @@ module Pages
         end
       end
 
+      def expect_autocomplete_options_for(custom_field, options, grouping: nil, results_selector: "body")
+        selected_filter = select_filter(custom_field.column_name, custom_field.name)
+
+        within(selected_filter) do
+          find('[data-filter-autocomplete="true"]').click
+        end
+
+        Array(options).each do |option|
+          expect_ng_option(selected_filter, option, grouping:, results_selector:)
+        end
+      end
+
       def autocomplete_options_for(custom_field)
         selected_filter = select_filter(custom_field.column_name, custom_field.name)
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -299,13 +299,15 @@ module Pages
         end
       end
 
-      def autocomplete_options_for(custom_field)
+      def expect_user_autocomplete_options_for(custom_field, expected_options)
         selected_filter = select_filter(custom_field.column_name, custom_field.name)
 
         within(selected_filter) do
           find('[data-filter-autocomplete="true"]').click
         end
-        visible_user_auto_completer_options
+        options = visible_user_auto_completer_options
+
+        expect(options).to eq(expected_options)
       end
 
       def apply_operator(name, human_operator)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61398

# What are you trying to accomplish?
Add project names as secondary information to the version select values on the project filter page. This is important, because the demo data has ie a Bug Backlog version for each project apart, and without the project name, they are not differentiable.

## Screenshots
<details><summary>Specified version autocompleter.</summary>
<p>

![Group 360](https://github.com/user-attachments/assets/66d8bb0d-74bd-4395-8536-d3c610508bcc)

</p>
</details> 

# Todo list

- Project list page changes:
  - [X] Version Custom field filter to be grouped by Project
- Project attributes dialog changes:
  - [X] Single select Version Custom field to be grouped by Project
  - [X] Multi select Version Custom field to be grouped by Project
- [X] Update Primer autocomplete component to accept grouping of options
- Work Package bulk edit/move page changes:
  - [X] Single select Version Custom field to be grouped by Project
  - [X] Multi select Version Custom field to be grouped by Project
- Work Packages list page changes:
  - [x] Version filter to be grouped by Project
  - [x] Version Custom Field filter to be grouped by Project
  - [x] Single select Version Custom field for inline editing to be grouped by Project
  - [x] Multi select Version Custom field for inline editing to be grouped by Project
- Work Package show page changes:
  - [x] Single select, Version Custom field to be grouped by Project
  - [x] Multi select, Version Custom field to be grouped by Project
- Provide all the versions the user has access to (Deferred to https://community.openproject.org/wp/61967):
  - ~On the Project list Version Custom field filter~
  - ~On the Global WorkPackage list Version Custom field filter~
  - ~On the Global WorkPackage list Version filter~

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
