### PR TITLE
[60746] Missing breadcrumb in Times & Cost Administration

### DIFF
--- a/modules/costs/app/views/cost_types/edit.html.erb
+++ b/modules/costs/app/views/cost_types/edit.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% title = @cost_type.name %>
 <% else %>
   <% html_title t(:label_administration), t(:label_cost_type_plural) %>
-  <% title = t(:label_new) + " " + I18n.t("activerecord.models.cost_type.one") %>
+  <% title = "#{t(:label_new)} #{I18n.t('activerecord.models.cost_type.one')}" %>
 <% end %>
 
 <%=
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { title }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: url_for({ controller: "/admin/settings", action: "show_plugin", id: :costs }), text: t(:project_module_costs) },
+       { href: admin_costs_settings_path, text: t(:project_module_costs) },
        { href: cost_types_path, text: t(:label_cost_type_plural) },
        title]
     )

--- a/modules/costs/app/views/cost_types/index.html.erb
+++ b/modules/costs/app/views/cost_types/index.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { I18n.t(:label_cost_type_plural) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: url_for({ controller: "/admin/settings", action: "show_plugin", id: :costs }), text: t(:project_module_costs) },
+       { href: admin_costs_settings_path, text: t(:project_module_costs) },
        I18n.t(:label_cost_type_plural)]
     )
   end

--- a/modules/costs/app/views/costs_settings/show.html.erb
+++ b/modules/costs/app/views/costs_settings/show.html.erb
@@ -31,10 +31,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t("plugin_costs.name") }
+    header.with_title { t(:label_setting_plural) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       t("plugin_costs.name")]
+       { href: admin_costs_settings_path, text: t(:project_module_costs) },
+       t(:label_setting_plural)]
     )
   end
 %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/60746/activity

# What are you trying to accomplish?
Fix PageHeader for Time&Costs module

## Screenshots
**After**
<img width="810" alt="Bildschirmfoto 2025-02-11 um 15 02 08" src="https://github.com/user-attachments/assets/5426ffe3-286d-4a7e-b0a5-799f6c2ed63e" />
