### PR TITLE
[#61358] User cannot see the upcoming tab of a meeting series if it consists of only one ongoing meeting

### DIFF
--- a/modules/meeting/app/views/recurring_meetings/_show_upcoming.html.erb
+++ b/modules/meeting/app/views/recurring_meetings/_show_upcoming.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% if @recurring_meeting.has_ended? -%>
+<% if @recurring_meeting.has_ended? && @recurring_meeting.ongoing_meetings.empty? -%>
   <%=
     render(Primer::Beta::Blankslate.new(border: true)) do |component|
       component.with_visual_icon(icon: :book)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61358

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Don't just check for ended meetings, also see if any meetings are still ongoing

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
