### PR TITLE
Grammar fixes in code, docs: possessive its/it's

### DIFF
--- a/app/components/projects/concerns/table_component/streamable_pagination_links_constraints.rb
+++ b/app/components/projects/concerns/table_component/streamable_pagination_links_constraints.rb
@@ -37,7 +37,7 @@ module Projects
         # generated in the context of the component index action, instead of any turbo stream actions performing
         # partial updates on the page.
         #
-        # params[:url_for_action] is passed to the pagination_options making it's way down to any pagination links
+        # params[:url_for_action] is passed to the pagination_options making its way down to any pagination links
         # that are generated via link_to which calls url_for which uses the params[:url_for_action] to specify
         # the controller action that link_to should use.
         #

--- a/app/components/users/hover_card_component.sass
+++ b/app/components/users/hover_card_component.sass
@@ -3,7 +3,7 @@
   z-index: 9600
 
 // On the project list page, there is a bug when a hover card is invoked within the share dialog. The global spot
-// modal overlay will darken the background while the hover card is active, since its semi-transparent bg shading is
+// modal overlay will darken the background while the hover card is active, since it's semi-transparent bg shading is
 // added on top of the other dialog background shaders. We don't want an additional spot modal background here,
 // so we disable it for this edge case.
 .controller-projects.action-index, .controller-meetings.action-show

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -113,7 +113,7 @@ module PaginationHelper
   #  * page
   #  parameters.
   #  Prefers page over the other two and
-  #  calculates page in it's absence based on limit and offset.
+  #  calculates page in its absence based on limit and offset.
   #  Return 1 if all else fails.
   def page_param(options = params)
     page = if options[:page]

--- a/app/helpers/wiki_pages/at_version.rb
+++ b/app/helpers/wiki_pages/at_version.rb
@@ -29,7 +29,7 @@
 # The class represents a wiki page at a specific version.
 # It is implemented as somewhat of a mix between a decorator and a view model. It simplifies
 # both the controller as well as the view. The controller will only have to provide a single object
-# to the view and the view can serve all it's data needs from that one object.
+# to the view and the view can serve all its data needs from that one object.
 #
 # In case more objects like this are generated, a separate folder under e.g. app/view_models or app/decorators
 # should be introduced.

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -187,7 +187,7 @@ class Changeset < ApplicationRecord
     @next ||= Changeset.where(["id > ? AND repository_id = ?", id, repository_id]).order(Arel.sql("id ASC")).first
   end
 
-  # Creates a new Change from it's common parameters
+  # Creates a new Change from its common parameters
   def create_change(change)
     Change.create(changeset: self,
                   action: change[:action],

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -305,7 +305,7 @@ class CustomField < ApplicationRecord
 
   ##
   # Overrides cache key so that a custom field's representation
-  # is updated correctly when it's mutli_value attribute changes.
+  # is updated correctly when its multi_value attribute changes.
   def cache_key
     tag = multi_value? ? "mv" : "sv"
 

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -48,7 +48,7 @@ class Enumeration < ApplicationRecord
   scope :shared, -> { where(project_id: nil) }
   scope :active, -> { where(active: true) }
 
-  # let all child classes have Enumeration as it's model name
+  # let all child classes have Enumeration as its model name
   # used to not having to create another route for every subclass of Enumeration
   def self.inherited(child)
     child.instance_eval do
@@ -65,7 +65,7 @@ class Enumeration < ApplicationRecord
 
   def self.default
     # Creates a fake default scope so Enumeration.default will check
-    # it's type.  STI subclasses will automatically add their own
+    # its type.  STI subclasses will automatically add their own
     # types to the finder.
     if descends_from_active_record?
       where(is_default: true, type: "Enumeration").first

--- a/app/models/work_packages/scopes/for_scheduling.rb
+++ b/app/models/work_packages/scopes/for_scheduling.rb
@@ -43,7 +43,7 @@ module WorkPackages::Scopes
       # stop on that path if the work package evaluated to be added is either:
       #
       #   * itself scheduled manually
-      #   * having all of it's children scheduled manually
+      #   * having all of its children scheduled manually
       #
       # The children themselves are scheduled manually if all of their children
       # are scheduled manually which repeats itself down to the leaf work

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -28,7 +28,7 @@
 
 # = OpenProject configuration file
 #
-# Each environment has it's own configuration options.  If you are only
+# Each environment has its own configuration options.  If you are only
 # running in production, only the production block needs to be configured.
 # Environment specific configuration options override the default ones.
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -468,10 +468,10 @@ Rails.application.routes.draw do
 
     resources :groups, except: %i[show] do
       member do
-        # this should be put into it's own resource
+        # this should be put into its own resource
         post "/members" => "groups#add_users", as: "members_of"
         delete "/members/:user_id" => "groups#remove_user", as: "member_of"
-        # this should be put into it's own resource
+        # this should be put into its own resource
         patch "/memberships/:membership_id" => "groups#edit_membership", as: "membership_of"
         put "/memberships/:membership_id" => "groups#edit_membership"
         delete "/memberships/:membership_id" => "groups#destroy_membership"

--- a/db/migrate/20231020154219_add_trgm_index_to_meeting_agenda_item_notes.rb
+++ b/db/migrate/20231020154219_add_trgm_index_to_meeting_agenda_item_notes.rb
@@ -2,7 +2,7 @@ class AddTrgmIndexToMeetingAgendaItemNotes < ActiveRecord::Migration[7.0]
   def change
     # A previous migration 20230328154645_add_gin_trgm_index_on_journals_and_custom_values
     # already enabled on the extension. Hence we do not attempt to enable it here, just
-    # to use it if it's available.
+    # to use it if its available.
 
     if extensions.include?("pg_trgm")
       add_index(:meeting_agenda_items, :notes, using: "gin", opclass: :gin_trgm_ops)

--- a/db/migrate/20240715183144_add_indexes_to_custom_options.rb
+++ b/db/migrate/20240715183144_add_indexes_to_custom_options.rb
@@ -2,7 +2,7 @@ class AddIndexesToCustomOptions < ActiveRecord::Migration[7.1]
   def change
     # A previous migration 20230328154645_add_gin_trgm_index_on_journals_and_custom_values
     # already enabled on the extension. Hence we do not attempt to enable it here, just
-    # to use it if it's available.
+    # to use it if its available.
 
     if extensions.include?("pg_trgm")
       add_index(:custom_options, :value, using: "gin", opclass: :gin_trgm_ops)

--- a/docs/api/apiv3/paths/meeting_attachments.yml
+++ b/docs/api/apiv3/paths/meeting_attachments.yml
@@ -254,7 +254,7 @@ post:
   tags:
   - Attachments
   description: |-
-    Adds an attachment with the meeting as it's container.
+    Adds an attachment with the meeting as its container.
 
   operationId: Add_attachment_to_meeting
   summary: Add attachment to meeting

--- a/docs/api/apiv3/paths/post_attachments.yml
+++ b/docs/api/apiv3/paths/post_attachments.yml
@@ -254,7 +254,7 @@ post:
   tags:
   - Attachments
   description: |-
-    Adds an attachment with the post as it's container.
+    Adds an attachment with the post as its container.
 
   operationId: Add_attachment_to_post
   summary: Add attachment to post

--- a/docs/api/apiv3/paths/projects.yml
+++ b/docs/api/apiv3/paths/projects.yml
@@ -21,7 +21,7 @@ get:
         Currently supported filters are:
 
         + active: based on the active property of the project
-        + ancestor: filters projects by their ancestor. A project is not considered to be it's own ancestor.
+        + ancestor: filters projects by their ancestor. A project is not considered to be its own ancestor.
         + available_project_attributes: filters projects based on the activated project project attributes.
         + created_at: based on the time the project was created
         + latest_activity_at: based on the time the last activity was registered on a project.

--- a/docs/api/apiv3/paths/projects_available_parent_projects.yml
+++ b/docs/api/apiv3/paths/projects_available_parent_projects.yml
@@ -133,7 +133,7 @@ get:
   - Projects
   description: |-
     Lists projects which can become parent to another project. Only sound candidates are returned.
-    For instance a project cannot become parent of itself or it's children.
+    For instance a project cannot become parent of itself or its children.
 
     To specify the project for which a parent is queried for, the `of` parameter can be provided. If no `of`
     parameter is provided, a new project is assumed. Then, the check for the hierarchy is omitted as a new project cannot be

--- a/docs/api/apiv3/paths/wiki_page_attachments.yml
+++ b/docs/api/apiv3/paths/wiki_page_attachments.yml
@@ -254,7 +254,7 @@ post:
   tags:
   - Attachments
   description: |-
-    Adds an attachment with the wiki page as it's container.
+    Adds an attachment with the wiki page as its container.
 
   operationId: Add_attachment_to_wiki_page
   summary: Add attachment to wiki page

--- a/docs/api/apiv3/tags/grids.yml
+++ b/docs/api/apiv3/tags/grids.yml
@@ -2,7 +2,7 @@
 description: |-
   A grid is a layout for a page or a part of the page of the OpenProject application. It defines the structure (number of rows and number of columns) as well as the contents of the page.
 
-  The contents is defined by `GridWidget`s. While a `GridWidget` is it's own type, it is not a resource in it's own right as it is an intrinsic part of a `Grid`.
+  The contents is defined by `GridWidget`s. While a `GridWidget` is its own type, it is not a resource in its own right as it is an intrinsic part of a `Grid`.
 
   Depending on what page a grid is defined for, different widgets may be eligible to be placed on the grid. The page might also define the permissions needed for accessing, creating or modifying the grid.
 

--- a/docs/development/git-workflow/README.md
+++ b/docs/development/git-workflow/README.md
@@ -81,7 +81,7 @@ git push origin <your feature branch>
 
 Create a pull request against a branch of of the `opf/openproject` repository, containing a **clear description** of what the pull request attempts to change and/or fix.
 
-If your pull request **does not contain a description** for what it does and what it's intentions are, we will reject it. If you are working on a specific work package from the [list](https://community.openproject.org/projects/openproject/work_packages), please include a link to that work package in the description, so we can track your work.
+If your pull request **does not contain a description** for what it does and what its intentions are, we will reject it. If you are working on a specific work package from the [list](https://community.openproject.org/projects/openproject/work_packages), please include a link to that work package in the description, so we can track your work.
 
 The core contributor team will then review your pull request according to our [code review guideline](../code-review-guidelines/). Please note that you can add commits after the pull request has been created by pushing to the branch in your fork.
 

--- a/docs/release-notes/13/13-4-0/README.md
+++ b/docs/release-notes/13/13-4-0/README.md
@@ -122,7 +122,7 @@ Thanks to our great Community we can continuously offer more languages for OpenP
 - Bugfix: Automatic download of exports do not start. Download link also shows up late. \[[#40163](https://community.openproject.org/wp/40163)\]
 - Bugfix: Number of displayed assignees in team planner wrongly restricted by "objects per page" \[[#46490](https://community.openproject.org/wp/46490)\]
 - Bugfix: Baseline change columns display grey color dot for priority but not for status \[[#51379](https://community.openproject.org/wp/51379)\]
-- Bugfix: Search bar doesn't stretches back if blank, has it's inside text matching the bar color (white)  \[[#51682](https://community.openproject.org/wp/51682)\]
+- Bugfix: Search bar doesn't stretches back if blank, has its inside text matching the bar color (white)  \[[#51682](https://community.openproject.org/wp/51682)\]
 - Bugfix: Add to meeting button on Meetings tab overflows \[[#51747](https://community.openproject.org/wp/51747)\]
 - Bugfix: Announcement box and create new account button are not responsive \[[#51949](https://community.openproject.org/wp/51949)\]
 - Bugfix: Can't specify project key for incoming email \[[#52524](https://community.openproject.org/wp/52524)\]

--- a/frontend/src/app/core/setup/globals/onboarding/tours/work_package_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/work_package_tour.ts
@@ -32,7 +32,7 @@ export function wpOnboardingTourSteps():OnboardingStep[] {
       shape: 'circle',
       timeout: () => new Promise((resolve) => {
         // We are waiting here for the badge to appear,
-        // because its the last that appears and it shifts the WP create button to the left.
+        // because it's the last that appears and it shifts the WP create button to the left.
         // Thus it is important that the tour rendering starts after the badge is visible
         waitForElement('#work-packages-filter-toggle-button .badge', '#content', () => {
           resolve(undefined);

--- a/frontend/src/app/features/homescreen/blocks/new-features.component.ts
+++ b/frontend/src/app/features/homescreen/blocks/new-features.component.ts
@@ -70,7 +70,7 @@ const featureTeaserImage = `${OpVersionI18n}_features.svg`;
 export class HomescreenNewFeaturesBlockComponent {
   public isStandardEdition:boolean;
 
-  /** Set to true if BIM has it's own changes */
+  /** Set to true if BIM has its own changes */
   hasBimChanges = false;
 
   /** Update the feature image appropriately */

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
@@ -35,7 +35,7 @@ export class InAppNotificationBellComponent implements OnInit {
 
   // enable other parts of the application to trigger an immediate update
   // e.g. a stimulus controller
-  // currently used by the new activities tab which does it's own polling
+  // currently used by the new activities tab which does its own polling
   // and receives updates from the backend earlier than the polling in the bell component
   @HostListener('document:ian-update-immediate')
   triggerImmediateUpdate() {

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
@@ -83,7 +83,7 @@ export class GroupedRenderPass extends PlainRenderPass {
         return this.matchesMultiValue(property as HalResource[], group);
       }
 
-      /// / If its a linked resource, compare the href,
+      /// / If it's a linked resource, compare the href,
       /// / which is an array of links the resource offers
       if (property && property.href) {
         return !!_.find(group._links.valueLink, (l:any):any => property.href === l.href);

--- a/frontend/src/app/features/work-packages/components/wp-table/drag-and-drop/actions/hierarchy-drag-action.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/drag-and-drop/actions/hierarchy-drag-action.service.ts
@@ -65,7 +65,7 @@ export class HierarchyDragActionService extends TableDragActionService {
         // If the sibling is a hierarchy root, return that sibling as new parent.
         parent = previousWpId;
       } else {
-        // If the sibling is no hierarchy root, return it's parent.
+        // If the sibling is no hierarchy root, return its parent.
         // Thus, the dropped element will get the same hierarchy level as the sibling
         parent = this.loadParentOfWP(previousWpId);
       }

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -92,7 +92,7 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
 
   // enable other parts of the application to trigger an immediate update
   // e.g. a stimulus controller
-  // currently used by the new activities tab which does it's own polling
+  // currently used by the new activities tab which does its own polling
   @HostListener('document:ian-update-immediate')
   triggerImmediateUpdate() {
     this.storeService.reload();

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -93,7 +93,7 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
 
     // enable other parts of the application to trigger an immediate update
   // e.g. a stimulus controller
-  // currently used by the new activities tab which does it's own polling
+  // currently used by the new activities tab which does its own polling
   @HostListener('document:ian-update-immediate')
   triggerImmediateUpdate() {
     this.storeService.reload();

--- a/frontend/src/app/shared/components/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/drag-and-drop.service.ts
@@ -55,7 +55,7 @@ export class GridDragAndDropService implements OnDestroy {
 
     // Set the draggedArea's startRow/startColumn properties
     // to the drop zone ones.
-    // The dragged Area should keep it's height and width normally but will
+    // The dragged Area should keep its height and width normally but will
     // shrink if the area would otherwise end outside the grid.
     // we cannot use the widget's original area as moving it while dragging confuses cdkDrag
     this.copyPositionButRestrict(dropArea, this.placeholderArea);

--- a/frontend/src/global_styles/content/work_packages/timelines/elements/_labels.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/elements/_labels.sass
@@ -57,7 +57,7 @@
     margin-left: 15px
 
   // label hover right needs different position
-  // since its not part of containerRight
+  // since it's not part of containerRight
   .labelHoverRight
     pointer-events: none
     display: none

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -106,7 +106,7 @@ module OpenProject
         end
 
         ##
-        # Checks if the repository is up-to-date. It is not it's updated.
+        # Checks if the repository is up-to-date. If it is not, it's updated.
         # Checks out the repository if necessary.
         def refresh_repository!
           if checkout?

--- a/lib/open_project/text_formatting/filters/sanitization_filter.rb
+++ b/lib/open_project/text_formatting/filters/sanitization_filter.rb
@@ -99,7 +99,7 @@ module OpenProject::TextFormatting
             # both Foo and Bar are contained by labels
             if checkbox.nil?
               # In case we don't have a checkbox, add the content of the label
-              # or it's parent in case of links directly to the node
+              # or its parent in case of links directly to the node
               to_add = li_node == parent ? label.children : parent
               li_node.add_child to_add
             else

--- a/lib/open_project/text_formatting/filters/sanitization_filter.rb
+++ b/lib/open_project/text_formatting/filters/sanitization_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -75,7 +77,7 @@ module OpenProject::TextFormatting
 
       # Transformer to fix task lists in sanitization
       # Replace to do lists in tables with their markdown equivalent
-      def todo_list_transformer
+      def todo_list_transformer # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
         lambda { |env|
           name = env[:node_name]
           table = env[:node]

--- a/lib/redmine/menu_manager/tree_node.rb
+++ b/lib/redmine/menu_manager/tree_node.rb
@@ -91,7 +91,7 @@ class Redmine::MenuManager::TreeNode < Tree::TreeNode
   end
 
   # Will return the position (zero-based) of the current child in
-  # it's parent
+  # its parent
   def position
     parent.children.index(self)
   end

--- a/lookbook/previews/patterns/danger_dialog_preview/default.html.erb
+++ b/lookbook/previews/patterns/danger_dialog_preview/default.html.erb
@@ -6,7 +6,7 @@
   ) do |dialog|
     dialog.with_confirmation_message do |message|
       message.with_heading(tag: :h2) { "Are you sure?" }
-      message.with_description_content("You are going to delete the whole project and all it's WorkPackages!")
+      message.with_description_content("You are going to delete the whole project and all its WorkPackages!")
     end
     dialog.with_confirmation_check_box_content("I understand that this deletion cannot be reversed")
   end

--- a/modules/auth_saml/config/locales/crowdin/af.yml
+++ b/modules/auth_saml/config/locales/crowdin/af.yml
@@ -138,7 +138,7 @@ af:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ar.yml
+++ b/modules/auth_saml/config/locales/crowdin/ar.yml
@@ -138,7 +138,7 @@ ar:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/az.yml
+++ b/modules/auth_saml/config/locales/crowdin/az.yml
@@ -138,7 +138,7 @@ az:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/be.yml
+++ b/modules/auth_saml/config/locales/crowdin/be.yml
@@ -138,7 +138,7 @@ be:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/bg.yml
+++ b/modules/auth_saml/config/locales/crowdin/bg.yml
@@ -138,7 +138,7 @@ bg:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ca.yml
+++ b/modules/auth_saml/config/locales/crowdin/ca.yml
@@ -138,7 +138,7 @@ ca:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ckb-IR.yml
+++ b/modules/auth_saml/config/locales/crowdin/ckb-IR.yml
@@ -138,7 +138,7 @@ ckb-IR:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/cs.yml
+++ b/modules/auth_saml/config/locales/crowdin/cs.yml
@@ -138,7 +138,7 @@ cs:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/da.yml
+++ b/modules/auth_saml/config/locales/crowdin/da.yml
@@ -138,7 +138,7 @@ da:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/el.yml
+++ b/modules/auth_saml/config/locales/crowdin/el.yml
@@ -138,7 +138,7 @@ el:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/eo.yml
+++ b/modules/auth_saml/config/locales/crowdin/eo.yml
@@ -138,7 +138,7 @@ eo:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/et.yml
+++ b/modules/auth_saml/config/locales/crowdin/et.yml
@@ -138,7 +138,7 @@ et:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/eu.yml
+++ b/modules/auth_saml/config/locales/crowdin/eu.yml
@@ -138,7 +138,7 @@ eu:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/fi.yml
+++ b/modules/auth_saml/config/locales/crowdin/fi.yml
@@ -138,7 +138,7 @@ fi:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/fil.yml
+++ b/modules/auth_saml/config/locales/crowdin/fil.yml
@@ -138,7 +138,7 @@ fil:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/he.yml
+++ b/modules/auth_saml/config/locales/crowdin/he.yml
@@ -138,7 +138,7 @@ he:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/hi.yml
+++ b/modules/auth_saml/config/locales/crowdin/hi.yml
@@ -138,7 +138,7 @@ hi:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/hr.yml
+++ b/modules/auth_saml/config/locales/crowdin/hr.yml
@@ -138,7 +138,7 @@ hr:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/hu.yml
+++ b/modules/auth_saml/config/locales/crowdin/hu.yml
@@ -138,7 +138,7 @@ hu:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/id.yml
+++ b/modules/auth_saml/config/locales/crowdin/id.yml
@@ -138,7 +138,7 @@ id:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ja.yml
+++ b/modules/auth_saml/config/locales/crowdin/ja.yml
@@ -138,7 +138,7 @@ ja:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ka.yml
+++ b/modules/auth_saml/config/locales/crowdin/ka.yml
@@ -138,7 +138,7 @@ ka:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/kk.yml
+++ b/modules/auth_saml/config/locales/crowdin/kk.yml
@@ -138,7 +138,7 @@ kk:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/lt.yml
+++ b/modules/auth_saml/config/locales/crowdin/lt.yml
@@ -138,7 +138,7 @@ lt:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/lv.yml
+++ b/modules/auth_saml/config/locales/crowdin/lv.yml
@@ -138,7 +138,7 @@ lv:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/mn.yml
+++ b/modules/auth_saml/config/locales/crowdin/mn.yml
@@ -138,7 +138,7 @@ mn:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ne.yml
+++ b/modules/auth_saml/config/locales/crowdin/ne.yml
@@ -138,7 +138,7 @@ ne:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/nl.yml
+++ b/modules/auth_saml/config/locales/crowdin/nl.yml
@@ -138,7 +138,7 @@ nl:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/no.yml
+++ b/modules/auth_saml/config/locales/crowdin/no.yml
@@ -138,7 +138,7 @@
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/ro.yml
+++ b/modules/auth_saml/config/locales/crowdin/ro.yml
@@ -138,7 +138,7 @@ ro:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/rw.yml
+++ b/modules/auth_saml/config/locales/crowdin/rw.yml
@@ -138,7 +138,7 @@ rw:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/si.yml
+++ b/modules/auth_saml/config/locales/crowdin/si.yml
@@ -138,7 +138,7 @@ si:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/sk.yml
+++ b/modules/auth_saml/config/locales/crowdin/sk.yml
@@ -138,7 +138,7 @@ sk:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/sl.yml
+++ b/modules/auth_saml/config/locales/crowdin/sl.yml
@@ -138,7 +138,7 @@ sl:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/sr.yml
+++ b/modules/auth_saml/config/locales/crowdin/sr.yml
@@ -138,7 +138,7 @@ sr:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/sv.yml
+++ b/modules/auth_saml/config/locales/crowdin/sv.yml
@@ -138,7 +138,7 @@ sv:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/th.yml
+++ b/modules/auth_saml/config/locales/crowdin/th.yml
@@ -138,7 +138,7 @@ th:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/tr.yml
+++ b/modules/auth_saml/config/locales/crowdin/tr.yml
@@ -138,7 +138,7 @@ tr:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/uz.yml
+++ b/modules/auth_saml/config/locales/crowdin/uz.yml
@@ -138,7 +138,7 @@ uz:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/crowdin/vi.yml
+++ b/modules/auth_saml/config/locales/crowdin/vi.yml
@@ -138,7 +138,7 @@ vi:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair. OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       certificate: >

--- a/modules/auth_saml/config/locales/en.yml
+++ b/modules/auth_saml/config/locales/en.yml
@@ -146,7 +146,7 @@ en:
       authn_requests_signed: >
         If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
       want_assertions_signed: >
-        If checked, OpenProject will required signed responses from the identity provider using it's own certificate keypair.
+        If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair.
         OpenProject will verify the signature against the certificate from the basic configuration section.
       want_assertions_encrypted: >
         If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.

--- a/modules/costs/app/helpers/hourly_rates_helper.rb
+++ b/modules/costs/app/helpers/hourly_rates_helper.rb
@@ -30,7 +30,7 @@ module HourlyRatesHelper
   include CostlogHelper
 
   # Returns the rate that is the closest at the specified date and that is
-  # defined in the specified projects or it's ancestors. The ancestor chain
+  # defined in the specified projects or its ancestors. The ancestor chain
   # is traversed from the specified project upwards.
   #
   # Expects all_rates to be all the rates that the user possibly has

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe API::V3::TimeEntries::TimeEntriesActivityRepresenter, "rendering"
       let(:title) { activity.name }
     end
 
-    # returns the projects where it (and it's children) is active
+    # returns the projects where it (and its children) is active
     it_behaves_like "has a link collection" do
       let(:project1) { build_stubbed(:project) }
       let(:project2) { build_stubbed(:project) }

--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -231,7 +231,7 @@ module ReportingHelper
   end
 
   ##
-  # For a given row, determine how to render it's contents according to usability and
+  # For a given row, determine how to render its contents according to usability and
   # localization rules
   def show_row(row)
     row.render { |k, v| show_field(k, v) }

--- a/modules/reporting/spec/models/cost_query/chaining_spec.rb
+++ b/modules/reporting/spec/models/cost_query/chaining_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe CostQuery, :reporting_query_helper do
       expect(query.chain.top).not_to be_a(CostQuery::Filter::NoFilter)
     end
 
-    it "remembers it's correct parent" do
+    it "remembers its correct parent" do
       query.group_by :project_id
       query.filter :project_id
       expect(query.chain.top.child.child.parent).to eq(query.chain.top.child)
@@ -271,7 +271,7 @@ RSpec.describe CostQuery, :reporting_query_helper do
         Object.send(:remove_const, :TestFilter)
       end
 
-      it "gives display? == true when a filter doesn't specify it's visibility" do
+      it "gives display? == true when a filter doesn't specify its visibility" do
         class TestFilter < Report::Filter::Base
         end
         expect(TestFilter.display?).to be true
@@ -296,7 +296,7 @@ RSpec.describe CostQuery, :reporting_query_helper do
         Object.send(:remove_const, :TestFilter)
       end
 
-      it "gives selectable? == true when a filter doesn't specify it's selectability" do
+      it "gives selectable? == true when a filter doesn't specify its selectability" do
         class TestFilter < Report::Filter::Base
         end
         expect(TestFilter.selectable?).to be true

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::CreateFolde
 
   # For the VCR tests in this block it's necessary to
   # create a user in NextCloud with the account name `member@example1`
-  # and use it's oauth access & refresh tokens on .env.test.local
+  # and use its oauth access & refresh tokens on .env.test.local
   describe "user with custom origin name" do
     let(:user) { create(:user) }
     let(:storage) do

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
@@ -40,7 +40,7 @@ module ::TwoFactorAuthentication
     end
 
     ##
-    # Destroy the given device if its not the default
+    # Destroy the given device if it's not the default
     def destroy
       if @device.default && strategy_manager.enforced?
         render_400 message: t("two_factor_authentication.devices.is_default_cannot_delete")

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
@@ -61,7 +61,7 @@ module ::TwoFactorAuthentication
       end
 
       ##
-      # Destroy the given device if its not the default
+      # Destroy the given device if it's not the default
       def destroy
         if @device.default && strategy_manager.enforced?
           render_400 message: t("two_factor_authentication.devices.is_default_cannot_delete")

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe TwoFactorAuthentication::AuthenticationController, with_settings:
         get :request_otp
       end
 
-      # User can login without 2FA, since its not enforced
+      # User can login without 2FA, since it's not enforced
       it_behaves_like "immediate success login"
     end
 
@@ -73,7 +73,7 @@ RSpec.describe TwoFactorAuthentication::AuthenticationController, with_settings:
         get :request_otp
       end
 
-      # User can login without 2FA, since its not enforced
+      # User can login without 2FA, since it's not enforced
       it_behaves_like "immediate success login"
     end
 

--- a/modules/xls_export/lib/open_project/xls_export/spreadsheet_builder.rb
+++ b/modules/xls_export/lib/open_project/xls_export/spreadsheet_builder.rb
@@ -5,7 +5,7 @@ require "spreadsheet"
 # by adding row after row, but can be used for random access to the
 # rows as well
 #
-# Multiple Worksheets are possible, the currently active worksheet and it's
+# Multiple Worksheets are possible, the currently active worksheet and its
 # associated column widths are always accessible through the @sheet and @column_widths
 # instance variables, the other worksheets are accessible through the #worksheet method.
 # If a worksheet with an index larger than the number of worksheets is requested,

--- a/spec/controllers/work_packages/auto_completes_controller_spec.rb
+++ b/spec/controllers/work_packages/auto_completes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -41,19 +43,19 @@ RSpec.describe WorkPackages::AutoCompletesController do
            principal: user,
            roles: [role])
   end
-  let(:work_package_1) do
+  let(:work_package1) do
     create(:work_package,
            subject: "Can't print recipes",
            project:)
   end
 
-  let(:work_package_2) do
+  let(:work_package2) do
     create(:work_package,
            subject: "Error when updating a recipe",
            project:)
   end
 
-  let(:work_package_3) do
+  let(:work_package3) do
     create(:work_package,
            subject: "Lorem ipsum",
            project:)
@@ -64,9 +66,9 @@ RSpec.describe WorkPackages::AutoCompletesController do
 
     allow(User).to receive(:current).and_return user
 
-    work_package_1
-    work_package_2
-    work_package_3
+    work_package1
+    work_package2
+    work_package3
   end
 
   shared_examples_for "successful response" do
@@ -83,7 +85,7 @@ RSpec.describe WorkPackages::AutoCompletesController do
 
   describe "#work_packages" do
     describe "search is case insensitive" do
-      let(:expected_values) { [work_package_1, work_package_2] }
+      let(:expected_values) { [work_package1, work_package2] }
 
       before do
         get :index,
@@ -100,13 +102,13 @@ RSpec.describe WorkPackages::AutoCompletesController do
     end
 
     describe "returns work package for given id" do
-      let(:expected_values) { work_package_1 }
+      let(:expected_values) { work_package1 }
 
       before do
         get :index,
             params: {
               project_id: project.id,
-              q: work_package_1.id
+              q: work_package1.id
             },
             format: :json
       end
@@ -116,16 +118,16 @@ RSpec.describe WorkPackages::AutoCompletesController do
       it_behaves_like "contains expected values"
     end
 
-    describe "returns work package for given id" do
+    describe "returns work package for given ids" do
       # this relies on all expected work packages to have ids that contain the given string
-      # we do not want to have work_package_3 so we take its id + 1 to create a string
-      # we are sure to not be part of work_package_3's id.
+      # we do not want to have work_package3 so we take its id + 1 to create a string
+      # we are sure to not be part of work_package3's id.
       let(:ids) do
         taken_ids = WorkPackage.pluck(:id).map(&:to_s)
 
-        id = work_package_3.id + 1
+        id = work_package3.id + 1
 
-        while taken_ids.include?(id.to_s) || work_package_3.id.to_s.include?(id.to_s)
+        while taken_ids.include?(id.to_s) || work_package3.id.to_s.include?(id.to_s)
           id = id + 1
         end
 
@@ -133,7 +135,7 @@ RSpec.describe WorkPackages::AutoCompletesController do
       end
 
       let!(:expected_values) do
-        expected = [work_package_1, work_package_2]
+        expected = [work_package1, work_package2]
 
         WorkPackage.pluck(:id)
 
@@ -160,7 +162,7 @@ RSpec.describe WorkPackages::AutoCompletesController do
 
       it_behaves_like "contains expected values"
 
-      context "uniq" do
+      context "when unique" do
         let(:assigned) { assigns(:work_packages) }
 
         subject { assigned.size }
@@ -169,20 +171,20 @@ RSpec.describe WorkPackages::AutoCompletesController do
       end
     end
 
-    describe "returns work package for given id" do
+    describe "returns work package for given id, escaping html" do
       render_views
-      let(:work_package_4) do
+      let(:work_package3) do
         create(:work_package,
                subject: "<script>alert('danger!');</script>",
                project:)
       end
-      let(:expected_values) { work_package_4 }
+      let(:expected_values) { work_package3 }
 
       before do
         get :index,
             params: {
               project_id: project.id,
-              q: work_package_4.id
+              q: work_package3.id
             },
             format: :json
       end
@@ -196,32 +198,32 @@ RSpec.describe WorkPackages::AutoCompletesController do
     end
 
     describe "in different projects" do
-      let(:project_2) do
+      let(:project2) do
         create(:project,
                parent: project)
       end
-      let(:expected_values) { work_package_4 }
-      let(:member_2) do
+      let(:expected_values) { work_package3 }
+      let(:member2) do
         create(:member,
-               project: project_2,
+               project: project2,
                principal: user,
                roles: [role])
       end
-      let(:work_package_4) do
+      let(:work_package3) do
         create(:work_package,
                subject: "Foo Bar Baz",
-               project: project_2)
+               project: project2)
       end
 
       before do
-        member_2
+        member2
 
-        work_package_4
+        work_package3
 
         get :index,
             params: {
               project_id: project.id,
-              q: work_package_4.id
+              q: work_package3.id
             },
             format: :json
       end

--- a/spec/controllers/work_packages/auto_completes_controller_spec.rb
+++ b/spec/controllers/work_packages/auto_completes_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe WorkPackages::AutoCompletesController do
 
     describe "returns work package for given id" do
       # this relies on all expected work packages to have ids that contain the given string
-      # we do not want to have work_package_3 so we take it's id + 1 to create a string
+      # we do not want to have work_package_3 so we take its id + 1 to create a string
       # we are sure to not be part of work_package_3's id.
       let(:ids) do
         taken_ids = WorkPackage.pluck(:id).map(&:to_s)

--- a/spec/migrations/add_validity_period_to_journals_spec.rb
+++ b/spec/migrations/add_validity_period_to_journals_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe AddValidityPeriodToJournals, type: :model do
     expect(seventh_journal.created_at).to be_x_ms_earlier_than seventh_journal_time, 0
     expect(seventh_journal.updated_at).to be_x_ms_earlier_than seventh_journal_time, 0
     expect(seventh_journal.validity_period.begin).to be_x_ms_earlier_than seventh_journal_time, 0
-    # Since it is the currently last journal, it's range is open-ended.
+    # Since it is the currently last journal, its range is open-ended.
     expect(seventh_journal.validity_period.end).to be_nil
   end
 end

--- a/spec/models/capabilities/scopes/default_spec.rb
+++ b/spec/models/capabilities/scopes/default_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Capabilities::Scopes::Default do
             # This complicated and programmatic way is chosen so that the test can deal with additional actions being defined
             item = ->(namespace, action, global, module_name) {
               # We only expect contract actions for project modules that are enabled by default. In the
-              # default edition the Bim module is not enabled by default for instance and thus it's contract
+              # default edition the Bim module is not enabled by default for instance and thus its contract
               # actions are not expected to be part of the default capabilities.
               return if module_name.present? && project.enabled_module_names.exclude?(module_name.to_s)
 

--- a/spec/models/token/ical_token_spec.rb
+++ b/spec/models/token/ical_token_spec.rb
@@ -245,8 +245,8 @@ RSpec.describe Token::ICal do
     end
 
     # TODO: following code is copy pasted from hashed_token_spec
-    # in order to make sure the token behaves in the same way in it's basics
-    # cheching for inheritance does not safely check if the basic behaviour is the same
+    # in order to make sure the token behaves in the same way in its basic
+    # checking for inheritance does not safely check if the basic behaviour is the same
     # is there a better way of reusing the specs from hashed_token_spec?
     describe "token value" do
       it "is generated on a new instance" do

--- a/spec/workers/principals/delete_job_integration_spec.rb
+++ b/spec/workers/principals/delete_job_integration_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe Principals::DeleteJob, type: :model do
       shared_examples_for "public query rewriting" do
         let(:filter_symbol) { filter.to_s.demodulize.underscore.to_sym }
 
-        describe "with the filter has the deleted user as it's value" do
+        describe "with the filter has the deleted user as its value" do
           before do
             query.filter(filter_symbol, values: [principal.id.to_s], operator: "=")
             query.save!
@@ -360,7 +360,7 @@ RSpec.describe Principals::DeleteJob, type: :model do
           end
         end
 
-        describe "with the filter has another user as it's value" do
+        describe "with the filter has another user as its value" do
           before do
             query.filter(filter_symbol, values: [other_user.id.to_s], operator: "=")
             query.save!
@@ -380,7 +380,7 @@ RSpec.describe Principals::DeleteJob, type: :model do
           end
         end
 
-        describe "with the filter has the deleted user and another user as it's value" do
+        describe "with the filter has the deleted user and another user as its value" do
           before do
             query.filter(filter_symbol, values: [principal.id.to_s, other_user.id.to_s], operator: "=")
             query.save!


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Grammar fixes in code, docs: possessive its/it's 

- **it's** is a contraction of _it is_ or _it has_. It requires an apostrophe.
- **its** is the posssive form of _it_, denoting ownership. It should not use an apostrophe.

More: https://www.merriam-webster.com/grammar/when-to-use-its-vs-its

## Screenshots


# What approach did you choose and why?

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
