### PR TITLE
Fix Nextcloud capitalization in I18n strings, docs

### DIFF
--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/nextcloud/create_folder_command_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::Nextcloud::CreateFolde
   end
 
   # For the VCR tests in this block it's necessary to
-  # create a user in NextCloud with the account name `member@example1`
+  # create a user in Nextcloud with the account name `member@example1`
   # and use its oauth access & refresh tokens on .env.test.local
   describe "user with custom origin name" do
     let(:user) { create(:user) }


### PR DESCRIPTION
⚠️ ~~**This PR is based off #17903. Please review/merge that PR first** (GitHub will automatically update this PR's base when #17903 is merged).~~

# Ticket

N/A


# What are you trying to accomplish?

Ensures we [respect Nextcloud's branding guidelines](https://nextcloud.com/brand/) throughout our codebase.

## Screenshots

![image](https://github.com/user-attachments/assets/317945ef-5966-416a-9501-0c34c4105527)

# What approach did you choose and why?

N/A

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
