### PR TITLE
Meeting model scope fixes

### DIFF
--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -60,8 +62,8 @@ class Meeting < ApplicationRecord
   scope :not_recurring, -> { where(recurring_meeting_id: nil) }
   scope :recurring, -> { where.not(id: not_recurring) }
 
-  scope :from_tomorrow, -> { where(["start_time >= ?", Date.tomorrow.beginning_of_day]) }
-  scope :from_today, -> { where(["start_time >= ?", Time.zone.today.beginning_of_day]) }
+  scope :from_tomorrow, -> { where(start_time: Date.tomorrow.beginning_of_day..) }
+  scope :from_today, -> { where(start_time: Time.zone.today.beginning_of_day..) }
 
   scope :upcoming, -> { where("start_time + (interval '1 hour' * duration) >= ?", Time.current) }
   scope :past, -> { where("start_time + (interval '1 hour' * duration) < ?", Time.current) }

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -56,11 +56,10 @@ class Meeting < ApplicationRecord
   scope :templated, -> { where(template: true) }
   scope :not_templated, -> { where(template: false) }
 
-  scope :cancelled, -> { where(state: :cancelled) }
-  scope :not_cancelled, -> { where.not(id: cancelled) }
+  scope :not_cancelled, -> { where.not.cancelled }
 
   scope :not_recurring, -> { where(recurring_meeting_id: nil) }
-  scope :recurring, -> { where.not(id: not_recurring) }
+  scope :recurring, -> { where.not(recurring_meeting_id: nil) }
 
   scope :from_tomorrow, -> { where(start_time: Date.tomorrow.beginning_of_day..) }
   scope :from_today, -> { where(start_time: Time.zone.today.beginning_of_day..) }


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Fix a few issues with `Meeting` scopes that I came across while working on another PR.

- Fixes Rubocop `Rails/WhereRange` offenses _(ideally we would try to fix these offences everywhere)
- Removes extraneous scope definition for `cancelled`: the `enum` macro already generates scopes for each enum value.
- Changes `recurring` scope to avoid generating a SQL subquery:

```
    # before
    Meeting.recurring.to_sql
    => "SELECT \"meetings\".* FROM \"meetings\" WHERE \"meetings\".\"id\" NOT IN (SELECT \"meetings\".\"id\" FROM \"meetings\" WHERE \"meetings\".\"recurring_meeting_id\" IS NULL)"

    # after
    Meeting.recurring.to_sql
    => "SELECT \"meetings\".* FROM \"meetings\" WHERE \"meetings\".\"recurring_meeting_id\" IS NOT NULL"
```


I have no idea if our use of SQL subqueries has potential performance implications. Although I'm pasting the query plan, my development database only such a small number of rows that there's nothing really meaningful that can be gleaned from it.

<details><summary>Query Plan</summary>
<code><pre>
before

=> EXPLAIN (ANALYZE) SELECT "meetings".* FROM "meetings" WHERE "meetings"."id" NOT IN (SELECT "meetings"."id" FROM "meetings" WHERE "meetings"."recurring_meeting_id" IS NULL)
                                                     QUERY PLAN
---------------------------------------------------------------------------------------------------------------------
 Seq Scan on meetings  (cost=1.12..2.26 rows=6 width=125) (actual time=0.058..0.086 rows=36 loops=1)
   Filter: (NOT (hashed SubPlan 1))
   Rows Removed by Filter: 8
   SubPlan 1
     ->  Seq Scan on meetings meetings_1  (cost=0.00..1.11 rows=5 width=8) (actual time=0.008..0.020 rows=8 loops=1)
           Filter: (recurring_meeting_id IS NULL)
           Rows Removed by Filter: 36
 Planning Time: 0.179 ms
 Execution Time: 0.132 ms
(9 rows)

after

=> EXPLAIN (ANALYZE) SELECT "meetings".* FROM "meetings" WHERE "meetings"."recurring_meeting_id" IS NOT NULL
                                             QUERY PLAN
-----------------------------------------------------------------------------------------------------
 Seq Scan on meetings  (cost=0.00..1.11 rows=6 width=125) (actual time=0.025..0.063 rows=36 loops=1)
   Filter: (recurring_meeting_id IS NOT NULL)
   Rows Removed by Filter: 8
 Planning Time: 0.141 ms
 Execution Time: 0.091 ms
(5 rows)
</pre></code>
</details> 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
