### PR TITLE
[#61422,61397] Meeting global or project-scope lost on performing various actions

### DIFF
--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,8 +1,8 @@
 <%=
   helpers.content_controller "poll-for-changes keep-scroll-position",
-                     poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
-                     poll_for_changes_interval_value: check_for_updates_interval,
-                     keep_scroll_position_url_value: meeting_path(@meeting)
+                             poll_for_changes_url_value: polymorphic_path([:check_for_updates, @project, @meeting.becomes(Meeting)]),
+                             poll_for_changes_interval_value: check_for_updates_interval,
+                             keep_scroll_position_url_value: meeting_path(@meeting)
 
   component_wrapper do
     render(Primer::OpenProject::PageHeader.new(

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -94,7 +94,8 @@ module Meetings
 
     def meeting_series_element
       if @series.present?
-        { href: recurring_meeting_path(@series), text: @series.title }
+        { href: @project.present? ? project_recurring_meeting_path(@project, @series) : recurring_meeting_path(@series),
+          text: @series.title }
       end
     end
 

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -42,14 +42,14 @@ module Meetings
       elsif recurring_meeting.present?
         occurrence_title
       else
-        link_to model.title, project_meeting_path(model.project, model)
+        link_to model.title, polymorphic_path([current_project, model.becomes(Meeting)])
       end
     end
 
     def occurrence_title
       safe_join(
-        [(link_to model.title, project_meeting_path(model.project, model)),
-         (link_to recurring_label, recurring_meeting_path(recurring_meeting))], "  "
+        [(link_to model.title, polymorphic_path([current_project, model.becomes(Meeting)])),
+         (link_to recurring_label, polymorphic_path([current_project, recurring_meeting]))], "  "
       )
     end
 
@@ -109,7 +109,7 @@ module Meetings
 
     def view_meeting_series(menu)
       menu.with_item(label: I18n.t(:label_recurring_meeting_view),
-                     href: recurring_meeting_path(recurring_meeting)) do |item|
+                     href: polymorphic_path([current_project, recurring_meeting])) do |item|
         item.with_leading_visual_icon(icon: :iterations)
       end
     end

--- a/modules/meeting/app/components/recurring_meetings/row_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/row_component.rb
@@ -130,7 +130,7 @@ module RecurringMeetings
           size: :medium,
           tag: :a,
           data: { "turbo-method": "post" },
-          href: init_recurring_meeting_path(model.recurring_meeting.id, start_time: model.start_time.iso8601)
+          href: polymorphic_path([:init, current_project, recurring_meeting], start_time: model.start_time.iso8601)
         )
       ) do |_c|
         I18n.t(:label_recurring_meeting_create)
@@ -209,7 +209,7 @@ module RecurringMeetings
 
       menu.with_item(
         label: I18n.t(:label_recurring_meeting_restore),
-        href: init_recurring_meeting_path(recurring_meeting, start_time: model.start_time.iso8601),
+        href: polymorphic_path([:init, current_project, recurring_meeting], start_time: model.start_time.iso8601),
         form_arguments: {
           method: :post
         }

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -27,7 +27,8 @@
 #++
 
 class MeetingsController < ApplicationController
-  before_action :load_and_authorize_in_optional_project, only: %i[index new new_dialog show create delete_dialog destroy]
+  before_action :load_and_authorize_in_optional_project,
+                only: %i[index new new_dialog show check_for_updates create delete_dialog destroy]
   before_action :verify_activities_module_activated, only: %i[history]
   before_action :determine_date_range, only: %i[history]
   before_action :determine_author, only: %i[history]
@@ -91,7 +92,7 @@ class MeetingsController < ApplicationController
     if params[:reference] == @meeting.changed_hash
       head :no_content
     else
-      respond_with_flash(Meetings::UpdateFlashComponent.new(@meeting))
+      respond_with_flash(Meetings::UpdateFlashComponent.new(meeting: @meeting, project: @project))
     end
   end
 

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -458,7 +458,7 @@ class MeetingsController < ApplicationController
       force_defaults
     end
 
-    # Recurring meeting occurrences can only be copied as one-off meetings
+    # Recurring meeting occurrences can only be copied as one-time meetings
     @converted_params[:recurring_meeting_id] = nil
   end
 

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -12,7 +12,7 @@ class RecurringMeetingsController < ApplicationController
                          delete_scheduled_dialog destroy_scheduled template_completed download_ics notify end_series
                          end_series_dialog]
   before_action :find_optional_project,
-                only: %i[index show new create update details_dialog delete_dialog destroy edit delete_scheduled_dialog
+                only: %i[index show new init create update details_dialog delete_dialog destroy edit delete_scheduled_dialog
                          destroy_scheduled notify]
   before_action :authorize_global, only: %i[index new create]
   before_action :authorize, except: %i[index new create]
@@ -66,7 +66,7 @@ class RecurringMeetingsController < ApplicationController
       .call(start_time: DateTime.iso8601(params[:start_time]))
 
     if call.success?
-      redirect_to project_meeting_path(call.result.project, call.result), status: :see_other
+      redirect_to polymorphic_path([@project, call.result.becomes(Meeting)]), status: :see_other
     else
       flash[:error] = call.message
       redirect_to action: :show, id: @recurring_meeting

--- a/modules/meeting/config/locales/crowdin/af.yml
+++ b/modules/meeting/config/locales/crowdin/af.yml
@@ -117,7 +117,7 @@ af:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ar.yml
+++ b/modules/meeting/config/locales/crowdin/ar.yml
@@ -121,7 +121,7 @@ ar:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/az.yml
+++ b/modules/meeting/config/locales/crowdin/az.yml
@@ -117,7 +117,7 @@ az:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/be.yml
+++ b/modules/meeting/config/locales/crowdin/be.yml
@@ -119,7 +119,7 @@ be:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/bg.yml
+++ b/modules/meeting/config/locales/crowdin/bg.yml
@@ -117,7 +117,7 @@ bg:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ca.yml
+++ b/modules/meeting/config/locales/crowdin/ca.yml
@@ -117,7 +117,7 @@ ca:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ckb-IR.yml
+++ b/modules/meeting/config/locales/crowdin/ckb-IR.yml
@@ -117,7 +117,7 @@ ckb-IR:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/da.yml
+++ b/modules/meeting/config/locales/crowdin/da.yml
@@ -117,7 +117,7 @@ da:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/el.yml
+++ b/modules/meeting/config/locales/crowdin/el.yml
@@ -117,7 +117,7 @@ el:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/eo.yml
+++ b/modules/meeting/config/locales/crowdin/eo.yml
@@ -117,7 +117,7 @@ eo:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/et.yml
+++ b/modules/meeting/config/locales/crowdin/et.yml
@@ -117,7 +117,7 @@ et:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/eu.yml
+++ b/modules/meeting/config/locales/crowdin/eu.yml
@@ -117,7 +117,7 @@ eu:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/fa.yml
+++ b/modules/meeting/config/locales/crowdin/fa.yml
@@ -117,7 +117,7 @@ fa:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/fi.yml
+++ b/modules/meeting/config/locales/crowdin/fi.yml
@@ -117,7 +117,7 @@ fi:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/fil.yml
+++ b/modules/meeting/config/locales/crowdin/fil.yml
@@ -117,7 +117,7 @@ fil:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/he.yml
+++ b/modules/meeting/config/locales/crowdin/he.yml
@@ -119,7 +119,7 @@ he:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/hi.yml
+++ b/modules/meeting/config/locales/crowdin/hi.yml
@@ -117,7 +117,7 @@ hi:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/hr.yml
+++ b/modules/meeting/config/locales/crowdin/hr.yml
@@ -118,7 +118,7 @@ hr:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/hu.yml
+++ b/modules/meeting/config/locales/crowdin/hu.yml
@@ -117,7 +117,7 @@ hu:
   label_template: "Sablon"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/id.yml
+++ b/modules/meeting/config/locales/crowdin/id.yml
@@ -116,7 +116,7 @@ id:
   label_template: "Templat"
   label_recurring_meeting_view: "Lihat jajaran rapat"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ja.yml
+++ b/modules/meeting/config/locales/crowdin/ja.yml
@@ -116,7 +116,7 @@ ja:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ka.yml
+++ b/modules/meeting/config/locales/crowdin/ka.yml
@@ -117,7 +117,7 @@ ka:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/kk.yml
+++ b/modules/meeting/config/locales/crowdin/kk.yml
@@ -117,7 +117,7 @@ kk:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/lt.yml
+++ b/modules/meeting/config/locales/crowdin/lt.yml
@@ -119,7 +119,7 @@ lt:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/lv.yml
+++ b/modules/meeting/config/locales/crowdin/lv.yml
@@ -118,7 +118,7 @@ lv:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/mn.yml
+++ b/modules/meeting/config/locales/crowdin/mn.yml
@@ -117,7 +117,7 @@ mn:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ms.yml
+++ b/modules/meeting/config/locales/crowdin/ms.yml
@@ -116,7 +116,7 @@ ms:
   label_template: "templat"
   label_recurring_meeting_view: "Lihat siri mesyuarat"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Salin sebagai one-off"
+  label_recurring_meeting_copy: "Salin sebagai one-time"
   label_recurring_meeting_cancel: "Batalkan kejadian ini"
   label_recurring_meeting_delete: "Padam kejadian"
   label_recurring_meeting_restore: "Pulihkan kejadian ini"

--- a/modules/meeting/config/locales/crowdin/ne.yml
+++ b/modules/meeting/config/locales/crowdin/ne.yml
@@ -117,7 +117,7 @@ ne:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/no.yml
+++ b/modules/meeting/config/locales/crowdin/no.yml
@@ -117,7 +117,7 @@
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/ro.yml
+++ b/modules/meeting/config/locales/crowdin/ro.yml
@@ -118,7 +118,7 @@ ro:
   label_template: "Șablon"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/rw.yml
+++ b/modules/meeting/config/locales/crowdin/rw.yml
@@ -117,7 +117,7 @@ rw:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/si.yml
+++ b/modules/meeting/config/locales/crowdin/si.yml
@@ -117,7 +117,7 @@ si:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/sk.yml
+++ b/modules/meeting/config/locales/crowdin/sk.yml
@@ -119,7 +119,7 @@ sk:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/sl.yml
+++ b/modules/meeting/config/locales/crowdin/sl.yml
@@ -119,7 +119,7 @@ sl:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/sr.yml
+++ b/modules/meeting/config/locales/crowdin/sr.yml
@@ -118,7 +118,7 @@ sr:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/sv.yml
+++ b/modules/meeting/config/locales/crowdin/sv.yml
@@ -117,7 +117,7 @@ sv:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/th.yml
+++ b/modules/meeting/config/locales/crowdin/th.yml
@@ -116,7 +116,7 @@ th:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/crowdin/uz.yml
+++ b/modules/meeting/config/locales/crowdin/uz.yml
@@ -117,7 +117,7 @@ uz:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
   label_template: "Template"
   label_recurring_meeting_view: "View meeting series"
   label_recurring_meeting_create: "Open"
-  label_recurring_meeting_copy: "Copy as one-off"
+  label_recurring_meeting_copy: "Copy as one-time"
   label_recurring_meeting_cancel: "Cancel this occurrence"
   label_recurring_meeting_delete: "Delete occurrence"
   label_recurring_meeting_restore: "Restore this occurrence"

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     end
     resources :recurring_meetings, only: %i[index new create show destroy] do
       member do
+        post :init
         get :delete_dialog
         get :delete_scheduled_dialog
         delete :destroy_scheduled

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
         get "menu" => "meetings/menus#show"
       end
       member do
+        get :check_for_updates
         get :delete_dialog
       end
     end

--- a/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Meetings::DeleteDialogComponent, type: :component do
     end
   end
 
-  describe "with a one-off meeting" do
+  describe "with a one-time meeting" do
     let(:meeting) { build_stubbed(:meeting, project:) }
 
     it "shows a heading" do

--- a/modules/meeting/spec/components/meetings/header_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/header_component_spec.rb
@@ -31,12 +31,13 @@
 require "rails_helper"
 
 RSpec.describe Meetings::HeaderComponent, type: :component do
-  let(:project) { build_stubbed(:project) }
-  let(:meeting) { build_stubbed(:meeting, project:) }
+  let(:project) { build_stubbed(:project, name: "Top SECRET Project") }
+  let(:meeting) { build_stubbed(:meeting, project:, title: "All Hands and All 🦶") }
+  let(:current_project) { nil }
   let(:user) { build_stubbed(:user) }
 
   subject do
-    render_inline(described_class.new(meeting:, project:))
+    render_inline(described_class.new(meeting:, project: current_project))
     page
   end
 
@@ -44,7 +45,80 @@ RSpec.describe Meetings::HeaderComponent, type: :component do
     login_as(user)
   end
 
+  describe "breadcrumbs" do
+    it "renders breadcrumb navigation" do
+      expect(subject).to have_navigation "Breadcrumb"
+    end
+
+    context "with a one-off meeting" do
+      context "without a current project" do
+        it "renders global breadcrumbs" do
+          expect(subject).to have_css ".breadcrumb-item", count: 3
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(1)", text: "OpenProject"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(2)", text: "Meetings"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(3)", text: "All Hands and All 🦶"
+        end
+
+        it "renders global links" do
+          expect(subject).to have_no_link href: /\/projects\//
+        end
+      end
+
+      context "with a current project" do
+        let(:current_project) { project }
+
+        it "renders project breadcrumbs" do
+          expect(subject).to have_css ".breadcrumb-item", count: 3
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(1)", text: "Top SECRET Project"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(2)", text: "Meetings"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(3)", text: "All Hands and All 🦶"
+        end
+
+        it "renders project links" do
+          expect(subject).to have_link href: /\/projects\//
+        end
+      end
+    end
+
+    context "with an associated recurring/templated meeting" do
+      let(:series) { build_stubbed(:recurring_meeting, project:, title: "Coffee Chat") }
+      let(:meeting) { build_stubbed(:structured_meeting_template, recurring_meeting: series, project:) }
+
+      context "without a current project" do
+        it "renders global breadcrumbs" do
+          expect(subject).to have_css ".breadcrumb-item", count: 4
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(1)", text: "OpenProject"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(2)", text: "Meetings"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(3)", text: "Coffee Chat"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(4)", text: "Template"
+        end
+
+        it "renders global links" do
+          expect(subject).to have_no_link href: /\/projects\//
+        end
+      end
+
+      context "with a current project" do
+        let(:current_project) { project }
+
+        it "renders project breadcrumbs" do
+          expect(subject).to have_css ".breadcrumb-item", count: 4
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(1)", text: "Top SECRET Project"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(2)", text: "Meetings"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(3)", text: "Coffee Chat"
+          expect(subject).to have_css ".breadcrumb-item:nth-of-type(4)", text: "Template"
+        end
+
+        it "renders project links" do
+          expect(subject).to have_link href: /\/projects\//
+        end
+      end
+    end
+  end
+
   describe "send mail invitation" do
+    let(:current_project) { project }
+
     context "when allowed" do
       before do
         mock_permissions_for(user) do |mock|

--- a/modules/meeting/spec/components/meetings/header_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/header_component_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Meetings::HeaderComponent, type: :component do
       expect(subject).to have_navigation "Breadcrumb"
     end
 
-    context "with a one-off meeting" do
+    context "with a one-time meeting" do
       context "without a current project" do
         it "renders global breadcrumbs" do
           expect(subject).to have_css ".breadcrumb-item", count: 3

--- a/modules/meeting/spec/components/meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/row_component_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Meetings::RowComponent, type: :component do
   end
 
   describe "title column" do
-    context "with a one-off meeting" do
+    context "with a one-time meeting" do
       let(:meeting) { build_stubbed(:structured_meeting, project:, title: "One-time fun!") }
 
       it "is shows the meeting title" do
@@ -112,7 +112,7 @@ RSpec.describe Meetings::RowComponent, type: :component do
 
   describe "actions" do
     context "with default permissions" do
-      context "with a one-off meeting" do
+      context "with a one-time meeting" do
         let(:meeting) { build_stubbed(:structured_meeting, project:) }
 
         it "shows default menu items" do
@@ -151,7 +151,7 @@ RSpec.describe Meetings::RowComponent, type: :component do
         end
       end
 
-      context "with a one-off meeting" do
+      context "with a one-time meeting" do
         let(:meeting) { build_stubbed(:structured_meeting, project:) }
 
         context "without a current project" do
@@ -196,7 +196,7 @@ RSpec.describe Meetings::RowComponent, type: :component do
         end
       end
 
-      context "with a one-off meeting" do
+      context "with a one-time meeting" do
         let(:meeting) { build_stubbed(:structured_meeting, project:) }
 
         it "shows copy menu item" do

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe "Recurring meetings global CRUD", :js do
     show_page.expect_no_meeting date: "12/31/2024 01:30 PM"
   end
 
+  it "can use the 'Open' button" do
+    show_page.visit!
+
+    show_page.open date: "01/07/2025 01:30 PM"
+    wait_for_reload
+
+    expect(page).to have_current_path meeting_path(Meeting.last)
+
+    show_page.visit!
+
+    show_page.expect_no_planned_meeting date: "01/07/2025 01:30 PM"
+    show_page.expect_open_meeting date: "01/07/2025 01:30 PM"
+  end
+
   it "can cancel an occurrence from the show page" do
     show_page.visit!
 

--- a/modules/meeting/spec/requests/meetings_delete_spec.rb
+++ b/modules/meeting/spec/requests/meetings_delete_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "DELETE /meetings/:id",
   shared_let(:meeting) do
     create :meeting,
            project:,
-           title: "My one-off meeting",
+           title: "My one-time meeting",
            author: user,
            start_time: Time.zone.today - 10.days + 10.hours
   end
@@ -73,7 +73,7 @@ RSpec.describe "DELETE /meetings/:id",
       expect(ActionMailer::Base.deliveries.size).to eq(1)
       mail = ActionMailer::Base.deliveries.first
       expect(mail.body.parts.first.parts.first.body.to_s)
-        .to include "'My one-off meeting' has been cancelled by #{user.name}"
+        .to include "'My one-time meeting' has been cancelled by #{user.name}"
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61422
https://community.openproject.org/wp/61397

# What are you trying to accomplish?

Improve the user experience for users of the meetings module.

To fix:

- [x] From the **global meetings page**
  - [x] Clicking on a one-time meeting or an occurrence of a meeting series in the list takes you to the project-scoped meeting show page
  - [x] Clicking a classic meeting in the list takes you to the project-scoped meeting show page
- [x] From the global meetings show page `/meetings/73`
  - [x] Copying the meeting via the header menu redirects to the project-scoped meeting show page
- [x] From the **global recurring meetings show page** `/recurring_meetings/14`
  - [x] Clicking Restore this occurrence via the row menu for a Planned meeting redirects you to the project-scoped meeting show page.
  - [x] Clicking Open for a Planned meeting redirects you to the project-scoped meeting show page.
- [x] From the **project-scoped meetings page** `/projects/brand-new-project/meetings`
  - [x] Clicking on the meeting series via "Every working day"/"Daily"/"Weekly" text takes you to the global meeting series show page `/recurring_meetings/7`
  - [x] Viewing a meeting series via row menu > "View meeting series" takes you to the global meeting series show page `/recurring_meetings/7`
- [ ] From the project-scoped meetings show page `/projects/brand-new-project/meetings/86`
  - [x] Editing the meeting title via the header menu shows the global breadcrumbs
  - [ ] Closing the meeting updates the page with global breadcrumbs!
  - [ ] Reopening the meeting updates the page with global breadcrumbs!
  - [ ] Clicking Open first meeting (if the meeting is a template) redirects to global recurring meeting show page
- [ ] From the project-scoped recurring meetings show page `/projects/brand-new-project/recurring_meetings/15`
  - [ ] Clicking Edit template next to the Planned meeting header takes you to the global meeting show page. `/meetings/7`

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Similar to #17569, my approach has been to:
1. configure **both global and project-scoped routes** for applicable Controller actions. _We should probably do this for all Controller actions that may involve a redirect or render components that need to be aware of whether they are in a project context or not._
2. use `polymorphic_path` to generate correct URL routes.
3. sanity check with component tests.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
