### PR TITLE
[#61306] Dialog text should use "Cancel occurrence"

### DIFF
--- a/modules/meeting/app/components/meetings/delete_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.html.erb
@@ -31,6 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::DangerDialog.new(
     id:,
     title:,
+    confirm_button_text:,
+    cancel_button_text:,
     form_arguments: {
       action: polymorphic_path([@project, @meeting.becomes(Meeting)]),
       method: :delete,

--- a/modules/meeting/app/components/meetings/delete_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.rb
@@ -64,9 +64,25 @@ module Meetings
 
     def confirmation_message
       if recurring_meeting.present?
-        t("meeting.delete_dialog.occurrence.confirmation_message_html", title: recurring_meeting.title)
+        t("meeting.delete_dialog.occurrence.confirmation_message_html")
       else
         t("meeting.delete_dialog.one_time.confirmation_message_html")
+      end
+    end
+
+    def confirm_button_text
+      if recurring_meeting.present?
+        I18n.t("meeting.delete_dialog.occurrence.confirm_button")
+      else
+        I18n.t("button_delete")
+      end
+    end
+
+    def cancel_button_text
+      if recurring_meeting.present?
+        I18n.t("button_close")
+      else
+        I18n.t("button_cancel")
       end
     end
   end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -239,12 +239,13 @@ en:
         confirmation_message_html: >
           This action is not reversible. Please proceed with caution.
       occurrence:
-        title: "Delete meeting occurrence"
-        heading: "Delete this meeting occurrence?"
+        title: "Cancel meeting occurrence"
+        heading: "Cancel this meeting occurrence?"
         confirmation_message_html: >
-          This meeting is part of a series called <strong>%{title}</strong>.
-          This will only delete this particular occurrence and not the entire series.
+          Any meeting information not in the template will be lost.
+
           Do you want to continue?
+        confirm_button: "Cancel occurrence"
     blankslate:
       title: "No meetings to display"
       desc: "There are no meetings that meet the active filter criteria."

--- a/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe Meetings::DeleteDialogComponent, type: :component do
     let(:meeting) { build_stubbed(:structured_meeting_template, recurring_meeting: series) }
 
     it "shows a heading" do
-      expect(subject).to have_text "Delete this meeting occurrence?"
+      expect(subject).to have_text "Cancel this meeting occurrence?"
     end
 
-    it "shows a message that the meeting is part of a series" do
-      expect(subject).to have_text "meeting is part of a series"
+    it "shows a warning about potential information loss" do
+      expect(subject).to have_text "Any meeting information not in the template will be lost."
     end
   end
 end

--- a/modules/meeting/spec/components/recurring_meetings/delete_scheduled_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/recurring_meetings/delete_scheduled_dialog_component_spec.rb
@@ -74,4 +74,8 @@ RSpec.describe RecurringMeetings::DeleteScheduledDialogComponent, type: :compone
   it "shows a heading" do
     expect(subject).to have_text "Cancel this meeting occurrence?"
   end
+
+  it "shows a warning about potential information loss" do
+    expect(subject).to have_text "Any meeting information not in the template will be lost."
+  end
 end

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe "Recurring meetings CRUD",
     show_page.visit!
 
     show_page.cancel_occurrence date: "12/31/2024 01:30 PM"
-    show_page.within_modal "Delete meeting occurrence" do
-      click_on "Delete"
+    show_page.within_modal "Cancel meeting occurrence" do
+      click_on "Cancel occurrence"
     end
 
     expect_flash(type: :success, message: "Successful cancellation.")
@@ -134,7 +134,7 @@ RSpec.describe "Recurring meetings CRUD",
   it "can cancel a planned occurrence from the show page" do
     show_page.visit!
 
-    show_page.cancel_planned_occurrence date: "01/07/2025 01:30 PM"
+    show_page.cancel_occurrence date: "01/07/2025 01:30 PM"
     show_page.within_modal "Cancel meeting occurrence" do
       click_on "Cancel occurrence"
     end
@@ -175,8 +175,8 @@ RSpec.describe "Recurring meetings CRUD",
     show_page.expect_planned_actions date: "01/07/2025 01:30 PM"
 
     show_page.cancel_occurrence date: "12/31/2024 01:30 PM"
-    show_page.within_modal "Delete meeting occurrence" do
-      click_on "Delete"
+    show_page.within_modal "Cancel meeting occurrence" do
+      click_on "Cancel occurrence"
     end
 
     expect_flash(type: :success, message: "Successful cancellation.")

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe "Recurring meetings global CRUD", :js do
     show_page.visit!
 
     show_page.cancel_occurrence date: "12/31/2024 01:30 PM"
-    show_page.within_modal "Delete meeting occurrence" do
-      click_on "Delete"
+    show_page.within_modal "Cancel meeting occurrence" do
+      click_on "Cancel occurrence"
     end
 
     expect_flash(type: :success, message: "Successful cancellation.")
@@ -122,7 +122,7 @@ RSpec.describe "Recurring meetings global CRUD", :js do
   it "can cancel a planned occurrence from the show page" do
     show_page.visit!
 
-    show_page.cancel_planned_occurrence date: "01/07/2025 01:30 PM"
+    show_page.cancel_occurrence date: "01/07/2025 01:30 PM"
     show_page.within_modal "Cancel meeting occurrence" do
       click_on "Cancel occurrence"
     end

--- a/modules/meeting/spec/support/pages/recurring_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/recurring_meeting/show.rb
@@ -101,15 +101,6 @@ module Pages::RecurringMeeting
         click_on "Cancel this occurrence"
       end
 
-      expect_modal("Delete meeting occurrence")
-    end
-
-    def cancel_planned_occurrence(date:)
-      within("li", text: date) do
-        click_on "more-button"
-        click_on "Cancel this occurrence"
-      end
-
       expect_modal("Cancel meeting occurrence")
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61306

# What are you trying to accomplish?

Updates the title, description and confirmation button text of `Meetings::DeleteDialogComponent` to use the term "cancel" rather than "delete" for removing occurrences.

**Danger Dialogs for cancelling open/instantiated occurrences and planned/scheduled occurrences should now be visually identical.**

## Screenshots

| Scenario                      | Before | After |
|-------------------------------|--------|--------|
| open/instantiated occurrences | <img width="519" alt="Screenshot 2025-02-12 at 11 54 21" src="https://github.com/user-attachments/assets/20ef4cf1-93e1-433b-9f21-bad441e83a98" /> | <img width="507" alt="Screenshot 2025-02-12 at 11 54 54" src="https://github.com/user-attachments/assets/70ff1ce5-1e1c-476d-b3b9-faa0e69aee57" /> |
| planned/scheduled occurrences | <img width="502" alt="Screenshot 2025-02-12 at 11 54 30" src="https://github.com/user-attachments/assets/2cc7333b-9818-40cc-9010-ba3ea3a62521" /> | <img width="495" alt="Screenshot 2025-02-12 at 11 55 04" src="https://github.com/user-attachments/assets/b3c071aa-c04b-4bda-8cc1-f0f6b4d98d48" /> | 

# What approach did you choose and why?

I stuck with the 1-to-1 controller action to dialog approach introduced in #17569. It is not the DRY-est approach, but it reduces complexity. It might be possible to make `Meetings::DeleteDialogComponent` polymorphic in the future - thereby allowing us to drop `RecurringMeetings::ScheduledDeleteDialogComponent`.

Additionally, I've kept the I18n string keys separate for now. Although we are making the UI for cancelling open/instantiated occurrences and planned/scheduled occurrences visually identical for moment, I could envisage us making adjustments to the copy in the future.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
