### PR TITLE
fix double submit after refresh

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -706,11 +706,11 @@ export default class IndexController extends Controller {
   }
 
   async onSubmit(event:Event | null = null) {
+    event?.preventDefault();
+
     if (this.saveInProgress === true) return;
 
     this.setFormSubmitInProgress(true);
-
-    event?.preventDefault();
 
     const formData = this.prepareFormData();
     void this.submitForm(formData)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/60719

# What are you trying to accomplish?

Fix a behaviour where a comment would get submitted twice if, after a page refresh, the user clicked the submit button multiple times quickly

# What approach did you choose and why?

First thing we do in the form is prevent it to do it's default behaviour. This way if anything triggers the "submit" method, while it's already doing something else it will not trigger a double submit.