### PR TITLE
Always open meetings in project scope

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -345,7 +345,7 @@ class ApplicationController < ActionController::Base
     params[:back_url] || request.env["HTTP_REFERER"]
   end
 
-  def redirect_back_or_default(default, use_escaped = true)
+  def redirect_back_or_default(default, use_escaped: true, status: :found)
     policy = RedirectPolicy.new(
       params[:back_url],
       hostname: request.host,
@@ -353,7 +353,7 @@ class ApplicationController < ActionController::Base
       return_escaped: use_escaped
     )
 
-    redirect_to policy.redirect_url
+    redirect_to(policy.redirect_url, status:)
   end
 
   # Picks which layout to use based on the request

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -148,17 +150,17 @@ class UsersController < ApplicationController
     render_400 unless %i(activate lock unlock).include? @status_change
   end
 
-  def change_status
+  def change_status # rubocop:disable Metrics/AbcSize
     if @user.id == current_user.id
       # user is not allowed to change own status
-      redirect_back_or_default(action: "edit", id: @user)
+      redirect_back_or_default({ action: "edit", id: @user })
       return
     end
 
     if (params[:unlock] || params[:activate]) && user_limit_reached?
       show_user_limit_error!
 
-      return redirect_back_or_default(action: "edit", id: @user)
+      return redirect_back_or_default({ action: "edit", id: @user })
     end
 
     if params[:unlock]
@@ -184,7 +186,7 @@ class UsersController < ApplicationController
       flash[:error] = I18n.t("user.error_status_change_failed",
                              errors: @user.errors.full_messages.join(", "))
     end
-    redirect_back_or_default(action: "edit", id: @user)
+    redirect_back_or_default({ action: "edit", id: @user })
   end
 
   def resend_invitation

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -101,7 +101,7 @@ class WikiMenuItemsController < ApplicationController
         flash[:notice] = t(:notice_successful_update)
       end
 
-      redirect_back_or_default(action: "edit", id: @page)
+      redirect_back_or_default({ action: "edit", id: @page })
     else
       respond_to do |format|
         format.html do

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -48,7 +48,7 @@ class WorkPackages::BulkController < ApplicationController
 
     if @call.success?
       flash[:notice] = t(:notice_successful_update)
-      redirect_back_or_default(controller: "/work_packages", action: :index, project_id: @project)
+      redirect_back_or_default({ controller: "/work_packages", action: :index, project_id: @project })
     else
       flash[:error] = bulk_error_message(@work_packages, @call)
       setup_edit

--- a/modules/costs/app/controllers/cost_types_controller.rb
+++ b/modules/costs/app/controllers/cost_types_controller.rb
@@ -70,7 +70,7 @@ class CostTypesController < ApplicationController
 
     if @cost_type.save
       flash[:notice] = t(:notice_successful_update)
-      redirect_back_or_default(action: "index")
+      redirect_back_or_default({ action: "index" })
     else
       render action: :edit, status: :unprocessable_entity, layout: !request.xhr?
     end
@@ -92,7 +92,7 @@ class CostTypesController < ApplicationController
 
     if @cost_type.save
       flash[:notice] = t(:notice_successful_update)
-      redirect_back_or_default(action: "index")
+      redirect_back_or_default({ action: "index" })
     else
       @cost_type.rates.build(valid_from: Date.today) if @cost_type.rates.empty?
       render action: :edit, status: :unprocessable_entity, layout: !request.xhr?
@@ -109,7 +109,7 @@ class CostTypesController < ApplicationController
     if @cost_type.save
       flash[:notice] = t(:notice_successful_lock)
 
-      redirect_back_or_default(action: "index")
+      redirect_back_or_default({ action: "index" })
     end
   end
 
@@ -120,7 +120,7 @@ class CostTypesController < ApplicationController
     if @cost_type.save
       flash[:notice] = t(:notice_successful_restore)
 
-      redirect_back_or_default(action: "index")
+      redirect_back_or_default({ action: "index" })
     end
   end
 

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -108,9 +108,9 @@ class HourlyRatesController < ApplicationController
     if @user.save
       flash[:notice] = t(:notice_successful_update)
       if @project.nil?
-        redirect_back_or_default(controller: "users", action: "edit", id: @user)
+        redirect_back_or_default({ controller: "users", action: "edit", id: @user })
       else
-        redirect_back_or_default(action: "show", id: @user, project_id: @project)
+        redirect_back_or_default({ action: "show", id: @user, project_id: @project })
       end
     else
       if @project.nil?

--- a/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
@@ -8,7 +8,7 @@
                                            dismiss_scheme: :none) do
             t("recurring_meeting.template.banner_html",
               link: link_to(@meeting.recurring_meeting.title,
-                            recurring_meeting_path(@meeting.recurring_meeting)))
+                            project_recurring_meeting_path(@meeting.project, @meeting.recurring_meeting)))
           end
         end
       end

--- a/modules/meeting/app/components/meetings/delete_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     id:,
     title:,
     form_arguments: {
-      action: project_meeting_path(@project, @meeting),
+      action: project_meeting_path(@project, @meeting, back_url: @back_url),
       method: :delete,
       data: { turbo: true }
     }

--- a/modules/meeting/app/components/meetings/delete_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.html.erb
@@ -27,12 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= 
+<%=
   render(Primer::OpenProject::DangerDialog.new(
     id:,
     title:,
     form_arguments: {
-      action: polymorphic_path([@project, @meeting.becomes(Meeting)]),
+      action: project_meeting_path(@project, @meeting),
       method: :delete,
       data: { turbo: true }
     }

--- a/modules/meeting/app/components/meetings/delete_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.rb
@@ -33,11 +33,12 @@ module Meetings
     include ApplicationHelper
     include OpTurbo::Streamable
 
-    def initialize(meeting:, project:)
+    def initialize(meeting:, back_url: nil)
       super
 
       @meeting = meeting
-      @project = project
+      @project = meeting.project
+      @back_url = back_url
     end
 
     delegate :recurring_meeting, to: :@meeting

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   helpers.content_controller "poll-for-changes keep-scroll-position",
-                     poll_for_changes_url_value: check_for_updates_meeting_path(@meeting),
+                     poll_for_changes_url_value: check_for_updates_project_meeting_path(@meeting.project, @meeting),
                      poll_for_changes_interval_value: check_for_updates_interval,
                      keep_scroll_position_url_value: meeting_path(@meeting)
 
@@ -15,8 +15,8 @@
     )) do |header|
       header.with_title do |title|
         title.with_editable_form(model: @meeting,
-                                 update_path: update_title_meeting_path(@meeting),
-                                 cancel_path: cancel_edit_meeting_path(@meeting),
+                                 update_path: update_title_project_meeting_path(@project, @meeting),
+                                 cancel_path: cancel_edit_project_meeting_path(@project, @meeting),
                                  label: Meeting.human_attribute_name(:title),
                                  placeholder: Meeting.human_attribute_name(:title),)
         if @meeting.template?
@@ -38,7 +38,7 @@
           mobile_icon: :check,
           size: :medium,
           data: { "turbo-method": :post },
-          href: template_completed_recurring_meeting_path(@meeting.recurring_meeting),
+          href: template_completed_project_recurring_meeting_path(@project, @meeting.recurring_meeting),
         ) do |button|
           button.with_leading_visual_icon(icon: :check)
           I18n.t("recurring_meeting.template.button_finalize")
@@ -51,7 +51,7 @@
                                                   classes: "hide-when-print",
                                                   test_selector: 'op-meetings-header-action-trigger'}) do |menu|
         menu.with_item(label: t("label_meeting_edit_title"),
-                       href: edit_meeting_path(@meeting),
+                       href: edit_project_meeting_path(@project, @meeting),
                        content_arguments: {
                          data: { 'turbo-stream': true }
                        }) do |item|
@@ -75,7 +75,7 @@
             if @meeting.open? &&User.current.allowed_in_project?(:send_meeting_agendas_notification, @meeting.project
             )
               menu.with_item(label: t('meeting.label_mail_all_participants'),
-                             href: notify_meeting_path(@meeting),
+                             href: notify_project_meeting_path(@project, @meeting),
                              form_arguments: { method: :post, data: { turbo: 'false' } }) do |item|
                 item.with_leading_visual_icon(icon: :mail)
               end
@@ -84,7 +84,7 @@
 
         menu.with_item(label: t(:label_history),
                        tag: :a,
-                       href: history_meeting_path(@meeting),
+                       href: history_project_meeting_path(@project, @meeting),
                        content_arguments: {
                          "data-controller": "async-dialog",
                        },
@@ -95,7 +95,7 @@
 
         menu.with_item(label: delete_label,
                        scheme: :danger,
-                       href: polymorphic_path([:delete_dialog, @project, @meeting.becomes(Meeting)]),
+                       href: delete_dialog_project_meeting_path(@project, @meeting),
                        tag: :a,
                        content_arguments: {
                          data: { controller: "async-dialog" }

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -1,24 +1,24 @@
 <%=
   helpers.content_controller "poll-for-changes keep-scroll-position",
-                     poll_for_changes_url_value: check_for_updates_project_meeting_path(@meeting.project, @meeting),
-                     poll_for_changes_interval_value: check_for_updates_interval,
-                     keep_scroll_position_url_value: meeting_path(@meeting)
+                             poll_for_changes_url_value: check_for_updates_project_meeting_path(@meeting.project, @meeting),
+                             poll_for_changes_interval_value: check_for_updates_interval,
+                             keep_scroll_position_url_value: meeting_path(@meeting)
 
   component_wrapper do
     render(Primer::OpenProject::PageHeader.new(
-      test_selector: "meeting-page-header",
-      state: @state,
-      data: {
-        poll_for_changes_target: "reference",
-        reference_value: @meeting.changed_hash
-      }
-    )) do |header|
+             test_selector: "meeting-page-header",
+             state: @state,
+             data: {
+               poll_for_changes_target: "reference",
+               reference_value: @meeting.changed_hash
+             }
+           )) do |header|
       header.with_title do |title|
         title.with_editable_form(model: @meeting,
                                  update_path: update_title_project_meeting_path(@project, @meeting),
                                  cancel_path: cancel_edit_project_meeting_path(@project, @meeting),
                                  label: Meeting.human_attribute_name(:title),
-                                 placeholder: Meeting.human_attribute_name(:title),)
+                                 placeholder: Meeting.human_attribute_name(:title))
         if @meeting.template?
           "#{@meeting.title} (#{I18n.t(:label_template)})"
         elsif @series.present?
@@ -38,7 +38,7 @@
           mobile_icon: :check,
           size: :medium,
           data: { "turbo-method": :post },
-          href: template_completed_project_recurring_meeting_path(@project, @meeting.recurring_meeting),
+          href: template_completed_project_recurring_meeting_path(@project, @meeting.recurring_meeting)
         ) do |button|
           button.with_leading_visual_icon(icon: :check)
           I18n.t("recurring_meeting.template.button_finalize")
@@ -49,59 +49,61 @@
                               button_arguments: { icon: "kebab-horizontal",
                                                   "aria-label": t("label_meeting_actions"),
                                                   classes: "hide-when-print",
-                                                  test_selector: 'op-meetings-header-action-trigger'}) do |menu|
-        menu.with_item(label: t("label_meeting_edit_title"),
-                       href: edit_project_meeting_path(@project, @meeting),
-                       content_arguments: {
-                         data: { 'turbo-stream': true }
-                       }) do |item|
-          item.with_leading_visual_icon(icon: :pencil)
-        end if @meeting.editable? && !@series
+                                                  test_selector: "op-meetings-header-action-trigger" }) do |menu|
+        if @meeting.editable? && !@series
+          menu.with_item(label: t("label_meeting_edit_title"),
+                         href: edit_project_meeting_path(@project, @meeting),
+                         content_arguments: {
+                           data: { "turbo-stream": true }
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :pencil)
+          end
+        end
 
         unless @meeting.template?
-            menu.with_item(label: copy_label,
-                           href: copy_meeting_path(@meeting),
-                           content_arguments: {
-                             data: { turbo_stream: true }
-                           }) do |item|
-              item.with_leading_visual_icon(icon: :copy)
-            end
+          menu.with_item(label: copy_label,
+                         href: copy_meeting_path(@meeting),
+                         content_arguments: {
+                           data: { turbo_stream: true }
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :copy)
+          end
 
-            menu.with_item(label: t(:label_icalendar_download),
-                           href: ics_download_path) do |item|
-              item.with_leading_visual_icon(icon: :download)
-            end
+          menu.with_item(label: t(:label_icalendar_download),
+                         href: ics_download_path) do |item|
+            item.with_leading_visual_icon(icon: :download)
+          end
 
-            if @meeting.open? &&User.current.allowed_in_project?(:send_meeting_agendas_notification, @meeting.project
-            )
-              menu.with_item(label: t('meeting.label_mail_all_participants'),
-                             href: notify_project_meeting_path(@project, @meeting),
-                             form_arguments: { method: :post, data: { turbo: 'false' } }) do |item|
-                item.with_leading_visual_icon(icon: :mail)
-              end
+          if @meeting.open? && User.current.allowed_in_project?(:send_meeting_agendas_notification, @meeting.project)
+            menu.with_item(label: t("meeting.label_mail_all_participants"),
+                           href: notify_project_meeting_path(@project, @meeting),
+                           form_arguments: { method: :post, data: { turbo: "false" } }) do |item|
+              item.with_leading_visual_icon(icon: :mail)
             end
           end
+        end
 
         menu.with_item(label: t(:label_history),
                        tag: :a,
                        href: history_project_meeting_path(@project, @meeting),
                        content_arguments: {
-                         "data-controller": "async-dialog",
+                         "data-controller": "async-dialog"
                        },
-                       value: ""
-        ) do |item|
+                       value: "") do |item|
           item.with_leading_visual_icon(icon: :clock) # or :check TBD
         end
 
-        menu.with_item(label: delete_label,
-                       scheme: :danger,
-                       href: delete_dialog_project_meeting_path(@project, @meeting),
-                       tag: :a,
-                       content_arguments: {
-                         data: { controller: "async-dialog" }
-                       }) do |item|
-          item.with_leading_visual_icon(icon: :trash)
-        end if delete_enabled?
+        if delete_enabled?
+          menu.with_item(label: delete_label,
+                         scheme: :danger,
+                         href: delete_dialog_project_meeting_path(@project, @meeting),
+                         tag: :a,
+                         content_arguments: {
+                           data: { controller: "async-dialog" }
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :trash)
+          end
+        end
       end
     end
   end

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -62,7 +62,7 @@
 
         unless @meeting.template?
           menu.with_item(label: copy_label,
-                         href: copy_meeting_path(@meeting),
+                         href: copy_project_meeting_path(@project, @meeting),
                          content_arguments: {
                            data: { turbo_stream: true }
                          }) do |item|

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -38,12 +38,12 @@ module Meetings
     STATE_EDIT = :edit
     STATE_OPTIONS = [STATE_DEFAULT, STATE_EDIT].freeze
 
-    def initialize(meeting:, project: nil, state: STATE_DEFAULT)
+    def initialize(meeting:, state: STATE_DEFAULT)
       super
 
       @meeting = meeting
       @series = meeting.recurring_meeting
-      @project = project
+      @project = meeting.project
       @state = fetch_or_fallback(STATE_OPTIONS, state)
     end
 
@@ -54,9 +54,9 @@ module Meetings
 
     def ics_download_path
       if @series
-        download_ics_recurring_meeting_path(@series, occurrence_id: @meeting.id)
+        download_ics_project_recurring_meeting_path(@series.project, @series, occurrence_id: @meeting.id)
       else
-        download_ics_meeting_path(@meeting)
+        download_ics_project_meeting_path(@meeting.project, @meeting)
       end
     end
 
@@ -94,7 +94,7 @@ module Meetings
 
     def meeting_series_element
       if @series.present?
-        { href: recurring_meeting_path(@series), text: @series.title }
+        { href: project_recurring_meeting_path(@series.project, @series), text: @series.title }
       end
     end
 

--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -25,7 +25,7 @@
 
         menu.with_item(label: I18n.t("meeting.types.one_time"),
                        tag: :a,
-                       href: new_dialog_meetings_path(project_id: @project&.id, type: :structured),
+                       href: polymorphic_path([:new_dialog, @project, :meetings], type: :structured),
                        content_arguments: { data: { controller: "async-dialog" } }
         ) do |item|
           item.with_description.with_content(t("meeting.types.structured_text"))
@@ -33,7 +33,7 @@
 
         menu.with_item(label: I18n.t("meeting.types.recurring"),
                        tag: :a,
-                       href: new_dialog_meetings_path(project_id: @project&.id, type: :recurring),
+                       href: polymorphic_path([:new_dialog, @project, :meetings], type: :recurring),
                        content_arguments: { data: { controller: "async-dialog" } }
         ) do |item|
           item.with_description.with_content(t("meeting.types.recurring_text"))

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -143,9 +143,10 @@ module Meetings
     def delete_action(menu)
       return unless delete_allowed?
 
+      back_url = current_project ? nil : meetings_path
       menu.with_item(label: recurring_meeting.present? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_meeting_delete),
                      scheme: :danger,
-                     href: delete_dialog_project_meeting_path(project, model),
+                     href: delete_dialog_project_meeting_path(project, model, back_url:),
                      tag: :a,
                      content_arguments: {
                        data: { controller: "async-dialog" }

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -31,25 +31,26 @@
 module Meetings
   class RowComponent < ::OpPrimer::BorderBoxRowComponent
     delegate :current_project, to: :table
+    delegate :project, to: :model
 
     def project_name
-      helpers.link_to_project model.project, {}, {}, false
+      helpers.link_to_project project, {}, {}, false
     end
 
     def title
       if recurring?
-        link_to model.title, recurring_meeting_path(model)
+        link_to model.title, project_recurring_meeting_path(project, model)
       elsif recurring_meeting.present?
         occurrence_title
       else
-        link_to model.title, project_meeting_path(model.project, model)
+        link_to model.title, project_meeting_path(project, model)
       end
     end
 
     def occurrence_title
       safe_join(
-        [(link_to model.title, project_meeting_path(model.project, model)),
-         (link_to recurring_label, recurring_meeting_path(recurring_meeting))], "  "
+        [(link_to model.title, project_meeting_path(project, model)),
+         (link_to recurring_label, project_recurring_meeting_path(project, recurring_meeting))], "  "
       )
     end
 
@@ -109,7 +110,7 @@ module Meetings
 
     def view_meeting_series(menu)
       menu.with_item(label: I18n.t(:label_recurring_meeting_view),
-                     href: recurring_meeting_path(recurring_meeting)) do |item|
+                     href: project_recurring_meeting_path(project, recurring_meeting)) do |item|
         item.with_leading_visual_icon(icon: :iterations)
       end
     end
@@ -131,7 +132,7 @@ module Meetings
 
     def ical_action(menu)
       menu.with_item(label: I18n.t(:label_icalendar_download),
-                     href: download_ics_meeting_path(model),
+                     href: download_ics_project_meeting_path(project, model),
                      content_arguments: {
                        data: { turbo: false }
                      }) do |item|
@@ -144,7 +145,7 @@ module Meetings
 
       menu.with_item(label: recurring_meeting.present? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_meeting_delete),
                      scheme: :danger,
-                     href: polymorphic_path([:delete_dialog, current_project, model.becomes(Meeting)]),
+                     href: delete_dialog_project_meeting_path(project, model),
                      tag: :a,
                      content_arguments: {
                        data: { controller: "async-dialog" }
@@ -161,11 +162,11 @@ module Meetings
     end
 
     def delete_allowed?
-      User.current.allowed_in_project?(:delete_meetings, model.project)
+      User.current.allowed_in_project?(:delete_meetings, project)
     end
 
     def copy_allowed?
-      User.current.allowed_in_project?(:create_meetings, model.project)
+      User.current.allowed_in_project?(:create_meetings, project)
     end
 
     def recurring?

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -119,7 +119,7 @@ module Meetings
       return unless copy_allowed?
 
       menu.with_item(label: I18n.t(:label_meeting_copy),
-                     href: copy_meeting_path(model),
+                     href: copy_project_meeting_path(project, model),
                      content_arguments: {
                        data: {
                          turbo: model.is_a?(StructuredMeeting),

--- a/modules/meeting/app/components/meetings/show_component.html.erb
+++ b/modules/meeting/app/components/meetings/show_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   flex_layout(data: { turbo: true }) do |show_page|
     show_page.with_row do
-      render(Meetings::HeaderComponent.new(meeting: @meeting, project: @project))
+      render(Meetings::HeaderComponent.new(meeting: @meeting))
     end
 
     show_page.with_row do

--- a/modules/meeting/app/components/meetings/show_component.rb
+++ b/modules/meeting/app/components/meetings/show_component.rb
@@ -31,11 +31,11 @@ module Meetings
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting:, project:)
+    def initialize(meeting:)
       super
 
       @meeting = meeting
-      @project = project
+      @project = meeting.project
     end
   end
 end

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -10,9 +10,9 @@
       if @meeting.editable?
         href =
           if @meeting.template?
-            details_dialog_recurring_meeting_path(@meeting.recurring_meeting)
+            details_dialog_project_recurring_meeting_path(@project, @meeting.recurring_meeting)
           else
-            details_dialog_meeting_path(@meeting)
+            details_dialog_project_meeting_path(@project, @meeting)
           end
 
         section.with_action_icon(
@@ -40,7 +40,7 @@
           if @series.present?
             details.with_row(mb: 2) do
               render_meeting_attribute_row(:iterations) do
-                render(Primer::Beta::Link.new(href: recurring_meeting_path(@series))) do
+                render(Primer::Beta::Link.new(href: project_recurring_meeting_path(@project, @series))) do
                   @series.title
                 end
               end
@@ -128,7 +128,7 @@
                   scheme: :link,
                   underline: false,
                   tag: :a,
-                  href: participants_dialog_meeting_path(@meeting),
+                  href: participants_dialog_project_meeting_path(@project, @meeting),
                   classes: "hide-when-print",
                   data: { controller: 'async-dialog' }
                 )) do

--- a/modules/meeting/app/components/meetings/side_panel/details_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.rb
@@ -36,6 +36,7 @@ module Meetings
       super
 
       @meeting = meeting
+      @project = @meeting.project
       @series = meeting.recurring_meeting
     end
 

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.html.erb
@@ -4,7 +4,7 @@
       model: @meeting,
       method: :put,
       data: { turbo: true, turbo_stream: true },
-      url: update_details_meeting_path(@meeting)
+      url: update_details_project_meeting_path(@project, @meeting)
     ) do |f|
       component_collection do |collection|
         collection.with_component(Primer::Alpha::Dialog::Body.new) do

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
@@ -36,10 +36,11 @@ module Meetings
       super
 
       @meeting = meeting
+      @project = meeting.project
     end
 
     def render?
-      User.current.allowed_in_project?(:edit_meetings, @meeting.project)
+      User.current.allowed_in_project?(:edit_meetings, @project)
     end
 
     private

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
@@ -13,7 +13,7 @@
           icon: :gear,
           scheme: :invisible,
           tag: :a,
-          href: participants_dialog_meeting_path(@meeting),
+          href: participants_dialog_project_meeting_path(@project, @meeting),
           classes: "hide-when-print",
           data: { controller: 'async-dialog' },
           'aria-label': t("label_meeting_manage_participants"),
@@ -39,7 +39,7 @@
                 underline: false,
                 font_weight: :bold,
                 tag: :a,
-                href: participants_dialog_meeting_path(@meeting),
+                href: participants_dialog_project_meeting_path(@project, @meeting),
                 classes: "hide-when-print",
                 data: { controller: 'async-dialog' }
               )) do |button|

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.rb
@@ -45,6 +45,7 @@ module Meetings
       super
 
       @meeting = meeting
+      @project = meeting.project
     end
 
     def elements

--- a/modules/meeting/app/components/meetings/side_panel/participants_dialog.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_dialog.html.erb
@@ -12,7 +12,7 @@
           id: "edit_participants_form",
           model: @meeting,
           method: :put,
-          url: update_participants_meeting_path(@meeting),
+          url: update_participants_project_meeting_path(@project, @meeting),
           data: { turbo: true, turbo_stream: true },
           class: 'Overlay-form'
         ) do |f|

--- a/modules/meeting/app/components/meetings/side_panel/participants_dialog.rb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_dialog.rb
@@ -37,10 +37,11 @@ module Meetings
       super
 
       @meeting = meeting
+      @project = meeting.project
     end
 
     def render?
-      User.current.allowed_in_project?(:view_meetings, @meeting.project)
+      User.current.allowed_in_project?(:view_meetings, @project)
     end
   end
 end

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -24,7 +24,7 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_meeting_path(@meeting, state: 'closed'),
+              href: change_state_project_meeting_path(@project, @meeting, state: 'closed'),
               classes: "hide-when-print",
               data: { 'turbo-stream': true, 'turbo-method': 'put' },
               test_selector: "close-meeting-button"
@@ -55,7 +55,7 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_meeting_path(@meeting, state: 'open'),
+              href: change_state_project_meeting_path(@project, @meeting, state: 'open'),
               classes: "hide-when-print",
               data: { 'turbo-stream': true, 'turbo-method': 'put' }
             ) do |button|

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -6,7 +6,7 @@
       case @meeting.state
       when "open"
         section.with_description(display: [:none, nil, :block]) { t("text_meeting_open_description") }
-        flex_layout(classes: 'op-meeting-sidebar-state') do |open_state|
+        flex_layout(classes: "op-meeting-sidebar-state") do |open_state|
           open_state.with_row do
             render(Primer::Beta::State.new(title: "state", scheme: :open)) do
               flex_layout do |open_state_label|
@@ -24,9 +24,9 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_project_meeting_path(@project, @meeting, state: 'closed'),
+              href: change_state_project_meeting_path(@project, @meeting, state: "closed"),
               classes: "hide-when-print",
-              data: { 'turbo-stream': true, 'turbo-method': 'put' },
+              data: { "turbo-stream": true, "turbo-method": "put" },
               test_selector: "close-meeting-button"
             ) do |button|
               button.with_leading_visual_icon(icon: :unlock)
@@ -37,7 +37,7 @@
       when "closed"
         section.with_description(display: [:none, nil, :block]) { t("text_meeting_closed_description") }
 
-        flex_layout(classes: 'op-meeting-sidebar-state') do |closed_state|
+        flex_layout(classes: "op-meeting-sidebar-state") do |closed_state|
           closed_state.with_row do
             render(Primer::Beta::State.new(title: "state", scheme: :default)) do
               flex_layout do |closed_state_label|
@@ -55,9 +55,9 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_project_meeting_path(@project, @meeting, state: 'open'),
+              href: change_state_project_meeting_path(@project, @meeting, state: "open"),
               classes: "hide-when-print",
-              data: { 'turbo-stream': true, 'turbo-method': 'put' }
+              data: { "turbo-stream": true, "turbo-method": "put" }
             ) do |button|
               button.with_leading_visual_icon(icon: :unlock)
               t("label_meeting_reopen_action")

--- a/modules/meeting/app/components/meetings/side_panel/state_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.rb
@@ -36,12 +36,13 @@ module Meetings
       super
 
       @meeting = meeting
+      @project = meeting.project
     end
 
     private
 
     def edit_enabled?
-      User.current.allowed_in_project?(:close_meeting_agendas, @meeting.project)
+      User.current.allowed_in_project?(:close_meeting_agendas, @project)
     end
   end
 end

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -31,6 +31,7 @@ module Meetings
     include OpTurbo::Streamable
 
     alias_method :meeting, :model
+    delegate :project, to: :meeting
 
     def call
       render(
@@ -42,7 +43,7 @@ module Meetings
       ) do |banner|
         banner.with_action_button(
           tag: :a,
-          href: helpers.meeting_path(meeting),
+          href: helpers.project_meeting_path(project, meeting),
           size: :medium,
           data: {
             keep_scroll_position_target: "triggerButton"

--- a/modules/meeting/app/components/recurring_meetings/delete_dialog_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/delete_dialog_component.html.erb
@@ -27,12 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= 
+<%=
   render(Primer::OpenProject::DangerDialog.new(
     id:,
     title:,
     form_arguments: {
-      action: polymorphic_path([@project, @recurring_meeting]),
+      action: project_recurring_meeting_path(@project, @recurring_meeting),
       method: :delete,
       data: { turbo: true }
     }

--- a/modules/meeting/app/components/recurring_meetings/delete_dialog_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/delete_dialog_component.rb
@@ -33,11 +33,11 @@ module RecurringMeetings
     include ApplicationHelper
     include OpTurbo::Streamable
 
-    def initialize(recurring_meeting:, project:)
+    def initialize(recurring_meeting:)
       super
 
       @recurring_meeting = recurring_meeting
-      @project = project
+      @project = recurring_meeting.project
     end
 
     private

--- a/modules/meeting/app/components/recurring_meetings/delete_scheduled_dialog_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/delete_scheduled_dialog_component.html.erb
@@ -34,8 +34,9 @@ See COPYRIGHT and LICENSE files for more details.
     confirm_button_text:,
     cancel_button_text:,
     form_arguments: {
-      action: polymorphic_path(
-        [:destroy_scheduled, @project, @scheduled_meeting.recurring_meeting],
+      action: destroy_scheduled_project_recurring_meeting_path(
+        @project,
+        @series,
         start_time: @scheduled_meeting.start_time.iso8601
       ),
       method: :delete,

--- a/modules/meeting/app/components/recurring_meetings/delete_scheduled_dialog_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/delete_scheduled_dialog_component.rb
@@ -33,11 +33,12 @@ module RecurringMeetings
     include ApplicationHelper
     include OpTurbo::Streamable
 
-    def initialize(scheduled_meeting:, project:)
+    def initialize(scheduled_meeting:)
       super
 
       @scheduled_meeting = scheduled_meeting
-      @project = project
+      @series = scheduled_meeting.recurring_meeting
+      @project = @series.project
     end
 
     private

--- a/modules/meeting/app/components/recurring_meetings/end_series_dialog_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/end_series_dialog_component.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
     confirm_button_text: I18n.t(:label_recurring_meeting_series_end_now),
     title: I18n.t("recurring_meeting.end_series_dialog.title"),
     form_arguments: {
-      action: end_series_recurring_meeting_path(@series),
+      action: end_series_project_recurring_meeting_path(@project, @series),
       method: :post
     }
   )) do |dialog|

--- a/modules/meeting/app/components/recurring_meetings/end_series_dialog_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/end_series_dialog_component.rb
@@ -35,7 +35,9 @@ module RecurringMeetings
 
     def initialize(series)
       super
+
       @series = series
+      @project = series.project
     end
   end
 end

--- a/modules/meeting/app/components/recurring_meetings/row_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/row_component.rb
@@ -35,7 +35,6 @@ module RecurringMeetings
     delegate :recurring_meeting, to: :model
     delegate :project, to: :recurring_meeting
     delegate :schedule, to: :meeting
-    delegate :current_project, to: :table
 
     def instantiated?
       meeting.present?
@@ -51,17 +50,9 @@ module RecurringMeetings
 
     def start_time
       if instantiated?
-        link_to start_time_title, current_project_meeting_path(meeting)
+        link_to start_time_title, project_meeting_path(project, meeting)
       else
         start_time_title
-      end
-    end
-
-    def current_project_meeting_path(meeting)
-      if current_project
-        project_meeting_path(current_project, meeting)
-      else
-        meeting_path(meeting)
       end
     end
 
@@ -130,7 +121,7 @@ module RecurringMeetings
           size: :medium,
           tag: :a,
           data: { "turbo-method": "post" },
-          href: init_recurring_meeting_path(model.recurring_meeting.id, start_time: model.start_time.iso8601)
+          href: init_project_recurring_meeting_path(project, model.recurring_meeting.id, start_time: model.start_time.iso8601)
         )
       ) do |_c|
         I18n.t(:label_recurring_meeting_create)
@@ -163,7 +154,9 @@ module RecurringMeetings
       return unless instantiated? && !cancelled?
 
       menu.with_item(label: I18n.t(:label_icalendar_download),
-                     href: download_ics_recurring_meeting_path(model.recurring_meeting, occurrence_id: model.id),
+                     href: download_ics_project_recurring_meeting_path(project,
+                                                                       model.recurring_meeting,
+                                                                       occurrence_id: model.id),
                      content_arguments: {
                        data: { turbo: false }
                      }) do |item|
@@ -177,7 +170,7 @@ module RecurringMeetings
       menu.with_item(
         label: past? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_recurring_meeting_cancel),
         scheme: :danger,
-        href: polymorphic_path([:delete_dialog, current_project, meeting.becomes(Meeting)]),
+        href: delete_dialog_project_meeting_path(project, meeting),
         tag: :a,
         content_arguments: {
           data: { controller: "async-dialog" }
@@ -193,8 +186,9 @@ module RecurringMeetings
       menu.with_item(
         label: I18n.t(:label_recurring_meeting_cancel),
         scheme: :danger,
-        href: polymorphic_path([:delete_scheduled_dialog, current_project, model.recurring_meeting],
-                               start_time: model.start_time.iso8601),
+        href: delete_scheduled_dialog_project_recurring_meeting_path(project,
+                                                                     model.recurring_meeting,
+                                                                     start_time: model.start_time.iso8601),
         tag: :a,
         content_arguments: {
           data: { controller: "async-dialog" }
@@ -209,7 +203,7 @@ module RecurringMeetings
 
       menu.with_item(
         label: I18n.t(:label_recurring_meeting_restore),
-        href: init_recurring_meeting_path(recurring_meeting, start_time: model.start_time.iso8601),
+        href: init_project_recurring_meeting_path(project, recurring_meeting, start_time: model.start_time.iso8601),
         form_arguments: {
           method: :post
         }

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.html.erb
@@ -20,7 +20,7 @@
           menu.with_item(
             label: I18n.t(:label_recurring_meeting_series_edit),
             icon: :gear,
-            href: details_dialog_recurring_meeting_path(@meeting),
+            href: details_dialog_project_recurring_meeting_path(@project, @meeting),
             tag: :a,
             content_arguments: {
               data: { controller: 'async-dialog' },
@@ -33,14 +33,14 @@
 
           menu.with_item(
             label: t(:label_icalendar_download),
-            href: download_ics_recurring_meeting_path(@meeting)
+            href: download_ics_project_recurring_meeting_path(@project, @meeting)
           ) do |item|
             item.with_leading_visual_icon(icon: :calendar)
           end
 
           menu.with_item(
             label: t('meeting.label_mail_all_participants'),
-            href: notify_recurring_meeting_path(@meeting),
+            href: notify_project_recurring_meeting_path(@project, @meeting),
             form_arguments: { method: :post }
           ) do |item|
             item.with_leading_visual_icon(icon: :mail)
@@ -49,7 +49,7 @@
           if !@meeting.has_ended? && @meeting.start_time.to_date < Time.zone.today
             menu.with_item(
               label: t(:label_recurring_meeting_series_end),
-              href: end_series_dialog_recurring_meeting_path(@meeting),
+              href: end_series_dialog_project_recurring_meeting_path(@project, @meeting),
               tag: :a,
               content_arguments: {
                 data: { controller: 'async-dialog' },
@@ -61,7 +61,7 @@
 
           menu.with_item(
             label: I18n.t(:label_recurring_meeting_series_delete),
-            href: polymorphic_path([:delete_dialog, @project, @meeting]),
+            href: delete_dialog_project_recurring_meeting_path(@project, @meeting),
             scheme: :danger,
             tag: :a,
             content_arguments: {

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
@@ -34,11 +34,11 @@ module RecurringMeetings
     include OpPrimer::ComponentHelpers
     include ApplicationHelper
 
-    def initialize(project: nil, meeting: nil)
+    def initialize(meeting: nil)
       super
 
-      @project = project
       @meeting = meeting
+      @project = meeting.project
     end
 
     def render_create_button?

--- a/modules/meeting/app/components/recurring_meetings/show_page_sub_header_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_sub_header_component.html.erb
@@ -7,13 +7,13 @@
     render(Primer::Alpha::SegmentedControl.new("aria-label": I18n.t(:label_filter_plural))) do |control|
       control.with_item(tag: :a,
                         icon: :"arrow-right",
-                        href: recurring_meeting_path(@meeting),
+                        href: project_recurring_meeting_path(@meeting.project, @meeting),
                         label: t(:label_upcoming_meetings_short),
                         title: t(:label_upcoming_meetings),
                         selected: @params[:direction] != "past")
       control.with_item(tag: :a,
                         icon: :history,
-                        href: recurring_meeting_path(@meeting, direction: :past),
+                        href: project_recurring_meeting_path(@meeting.project, @meeting, direction: :past),
                         label: t(:label_past_meetings_short),
                         title: t(:label_past_meetings),
                         selected: @params[:direction] == "past")

--- a/modules/meeting/app/components/recurring_meetings/show_page_sub_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_sub_header_component.rb
@@ -34,11 +34,11 @@ module RecurringMeetings
     # rubocop:enable OpenProject/AddPreviewForViewComponent
     include ApplicationHelper
 
-    def initialize(meeting:, params:, project: nil)
+    def initialize(meeting:, params:)
       super
 
       @meeting = meeting
-      @project = project
+      @project = meeting.project
       @params = params
     end
 

--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -31,11 +31,10 @@ module Meetings
     extend ActiveSupport::Concern
 
     included do
-      def update_header_component_via_turbo_stream(project: @project, meeting: @meeting, state: :show)
+      def update_header_component_via_turbo_stream(meeting: @meeting, state: :show)
         update_via_turbo_stream(
           component: Meetings::HeaderComponent.new(
             meeting:,
-            project:,
             state:
           )
         )

--- a/modules/meeting/app/controllers/meeting_agendas_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agendas_controller.rb
@@ -32,12 +32,12 @@ class MeetingAgendasController < MeetingContentsController
   def close
     @meeting.close_agenda_and_copy_to_minutes!
 
-    redirect_back_or_default controller: "/meetings", action: "show", id: @meeting
+    redirect_back_or_default({ controller: "/meetings", action: "show", id: @meeting })
   end
 
   def open
     @content.unlock!
-    redirect_back_or_default controller: "/meetings", action: "show", id: @meeting
+    redirect_back_or_default({ controller: "/meetings", action: "show", id: @meeting })
   end
 
   private

--- a/modules/meeting/app/controllers/meeting_contents_controller.rb
+++ b/modules/meeting/app/controllers/meeting_contents_controller.rb
@@ -39,8 +39,8 @@ class MeetingContentsController < ApplicationController
   helper :watchers
   helper :meetings
 
+  before_action :load_and_authorize_in_optional_project
   before_action :find_meeting, :find_content
-  before_action :authorize
 
   def show
     if params[:id].present? && @content.last_journal.version == params[:id].to_i
@@ -99,7 +99,6 @@ class MeetingContentsController < ApplicationController
   def find_meeting
     @meeting = Meeting.includes(:project, :author, :participants, :agenda, :minutes)
                       .find(params[:meeting_id])
-    @project = @meeting.project
     @author = User.current
   rescue ActiveRecord::RecordNotFound
     render_404

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -168,6 +168,7 @@ class MeetingsController < ApplicationController
       format.turbo_stream do
         respond_with_dialog Meetings::Index::DialogComponent.new(
           meeting: @meeting,
+          project: @project,
           copy_from:
         )
       end

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -29,7 +29,6 @@
 class MeetingsController < ApplicationController
   before_action :load_and_authorize_in_optional_project
 
-  before_action :verify_activities_module_activated, only: %i[history]
   before_action :determine_date_range, only: %i[history]
   before_action :determine_author, only: %i[history]
   before_action :build_meeting, only: %i[new new_dialog]
@@ -468,10 +467,6 @@ class MeetingsController < ApplicationController
         .require(:structured_meeting)
         .permit(:title, :location, :start_time_hour, :duration, :start_date, :state, :lock_version)
     end
-  end
-
-  def verify_activities_module_activated
-    render_403 if @project && !@project.module_enabled?("activity")
   end
 
   def set_activity

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -33,6 +33,7 @@ class MeetingsController < ApplicationController
   before_action :determine_author, only: %i[history]
   before_action :build_meeting, only: %i[new new_dialog]
   before_action :find_meeting, except: %i[index new create new_dialog]
+  before_action :redirect_to_project, only: %i[show]
   before_action :set_activity, only: %i[history]
   before_action :find_copy_from_meeting, only: %i[create]
   before_action :convert_params, only: %i[create update update_participants]
@@ -525,5 +526,11 @@ class MeetingsController < ApplicationController
 
   def prevent_template_destruction
     render_400 if @meeting.templated?
+  end
+
+  def redirect_to_project
+    return if @project
+
+    redirect_to project_meeting_path(@meeting.project, @meeting, tab: params[:tab]), status: :see_other
   end
 end

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -168,7 +168,6 @@ class MeetingsController < ApplicationController
       format.turbo_stream do
         respond_with_dialog Meetings::Index::DialogComponent.new(
           meeting: @meeting,
-          project: @project,
           copy_from:
         )
       end
@@ -178,7 +177,7 @@ class MeetingsController < ApplicationController
   def delete_dialog
     respond_with_dialog Meetings::DeleteDialogComponent.new(
       meeting: @meeting,
-      project: @project
+      back_url: params[:back_url]
     )
   end
 
@@ -196,7 +195,7 @@ class MeetingsController < ApplicationController
     if recurring
       redirect_to project_recurring_meeting_path(@project, recurring), status: :see_other
     else
-      redirect_to project_meetings_path(@project), status: :see_other
+      redirect_back_or_default project_meetings_path(@project), status: :see_other
     end
   end
 

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -7,17 +7,11 @@ class RecurringMeetingsController < ApplicationController
   include OpTurbo::FlashStreamHelper
   include OpTurbo::DialogStreamHelper
 
-  before_action :find_meeting,
-                only: %i[show update details_dialog delete_dialog destroy edit init
-                         delete_scheduled_dialog destroy_scheduled template_completed download_ics notify end_series
-                         end_series_dialog]
-  before_action :find_optional_project,
-                only: %i[index show new create update details_dialog delete_dialog destroy edit delete_scheduled_dialog
-                         destroy_scheduled notify]
-  before_action :authorize_global, only: %i[index new create]
-  before_action :authorize, except: %i[index new create]
-  before_action :get_scheduled_meeting, only: %i[delete_scheduled_dialog destroy_scheduled]
+  before_action :load_and_authorize_in_optional_project
+  before_action :find_meeting, except: %i[index new create]
 
+  before_action :get_scheduled_meeting, only: %i[delete_scheduled_dialog destroy_scheduled]
+  before_action :redirect_to_project, only: %i[show]
   before_action :set_direction, only: %i[show]
   before_action :convert_params, only: %i[create update]
   before_action :check_template_completable, only: %i[template_completed]
@@ -46,7 +40,7 @@ class RecurringMeetingsController < ApplicationController
     @recurring_meeting = RecurringMeeting.new(project: @project)
   end
 
-  def show # rubocop:disable Metrics/AbcSize
+  def show
     if @direction == "past"
       @meetings = @recurring_meeting.scheduled_instances(upcoming: false).limit(@count)
     else
@@ -85,16 +79,18 @@ class RecurringMeetingsController < ApplicationController
       .new(user: current_user)
       .call(@converted_params)
 
+    @recurring_meeting = call.result
+
     if call.success?
       flash[:notice] = I18n.t(:notice_successful_create).html_safe
-      redirect_to polymorphic_path([@project, :meeting], { id: call.result.template.id }),
+      redirect_to project_meeting_path(@recurring_meeting.project, @recurring_meeting.template),
                   status: :see_other
     else
       respond_to do |format|
         format.turbo_stream do
           update_via_turbo_stream(
             component: Meetings::Index::FormComponent.new(
-              meeting: call.result,
+              meeting: @recurring_meeting,
               project: @project,
               copy_from: @copy_from
             ),
@@ -117,7 +113,8 @@ class RecurringMeetingsController < ApplicationController
       .call(@converted_params)
 
     if call.success?
-      redirect_back(fallback_location: recurring_meeting_path(call.result), status: :see_other, turbo: false)
+      fallback_location = project_recurring_meeting_path(@project, call.result)
+      redirect_back(fallback_location:, status: :see_other, turbo: false)
     else
       respond_to do |format|
         format.turbo_stream do
@@ -154,8 +151,7 @@ class RecurringMeetingsController < ApplicationController
 
   def delete_dialog
     respond_with_dialog RecurringMeetings::DeleteDialogComponent.new(
-      recurring_meeting: @recurring_meeting,
-      project: @project
+      recurring_meeting: @recurring_meeting
     )
   end
 
@@ -170,7 +166,7 @@ class RecurringMeetingsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        redirect_to polymorphic_path([@project, :meetings])
+        redirect_to project_meetings_path(@project), status: :see_other
       end
     end
   end
@@ -194,8 +190,7 @@ class RecurringMeetingsController < ApplicationController
 
   def delete_scheduled_dialog
     respond_with_dialog RecurringMeetings::DeleteScheduledDialogComponent.new(
-      scheduled_meeting: @scheduled_meeting,
-      project: @project
+      scheduled_meeting: @scheduled_meeting
     )
   end
 
@@ -206,7 +201,7 @@ class RecurringMeetingsController < ApplicationController
       flash[:error] = I18n.t(:error_failed_to_delete_entry)
     end
 
-    redirect_to polymorphic_path([@project, @recurring_meeting]), status: :see_other
+    redirect_to project_recurring_meeting_path(@project, @recurring_meeting), status: :see_other
   end
 
   def download_ics # rubocop:disable Metrics/AbcSize
@@ -234,6 +229,12 @@ class RecurringMeetingsController < ApplicationController
   end
 
   private
+
+  def redirect_to_project
+    return if @project
+
+    redirect_to project_recurring_meeting_path(@recurring_meeting.project, @recurring_meeting), status: :see_other
+  end
 
   def init_next_occurrence_job(from_time)
     # Now we can schedule the job to create the next occurrence

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -76,9 +76,9 @@ module Meetings
       current_href = params[:current_href]
       current_recurring_meeting_id = extracted_id(current_href)
 
-      series.pluck(:id, :title)
-            .map do |id, title|
-        href = polymorphic_path([project, :recurring_meeting], { id: })
+      series.pluck(:id, :project_id, :title)
+            .map do |id, project_id, title|
+        href = project_recurring_meeting_path(project_id, id:)
         OpenProject::Menu::MenuItem.new(title:,
                                         selected: select_status(href, current_href, current_recurring_meeting_id),
                                         href:)

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -64,9 +64,10 @@ module Meetings
                 query_params: { filters: all_filter })
     end
 
-    def meeting_series_menu_items
+    def meeting_series_menu_items # rubocop:disable Metrics/AbcSize
       series = RecurringMeeting
         .visible
+        .includes(:project)
         .reorder("LOWER(title)")
 
       if project
@@ -76,10 +77,9 @@ module Meetings
       current_href = params[:current_href]
       current_recurring_meeting_id = extracted_id(current_href)
 
-      series.pluck(:id, :project_id, :title)
-            .map do |id, project_id, title|
-        href = project_recurring_meeting_path(project_id, id:)
-        OpenProject::Menu::MenuItem.new(title:,
+      series.all.map do |series|
+        href = project_recurring_meeting_path(series.project, series)
+        OpenProject::Menu::MenuItem.new(title: series.title,
                                         selected: select_status(href, current_href, current_recurring_meeting_id),
                                         href:)
       end

--- a/modules/meeting/app/views/meetings/menus/_menu.html.erb
+++ b/modules/meeting/app/views/meetings/menus/_menu.html.erb
@@ -3,7 +3,7 @@
   .merge(current_href: request.path)
 %>
 <%= turbo_frame_tag "meeting_sidemenu",
-                      src: @project.present? ? menu_project_meetings_path(@project, **request_params) : meetings_menu_path(**request_params),
+                      src: @project.present? ? menu_project_meetings_path(@project, **request_params) : menu_meetings_path(**request_params),
                       target: '_top',
                       data: { turbo: false },
                       loading: :lazy %>

--- a/modules/meeting/app/views/meetings/menus/_menu.html.erb
+++ b/modules/meeting/app/views/meetings/menus/_menu.html.erb
@@ -1,9 +1,8 @@
 <% request_params = params
   .permit(:filters, :sort)
-  .merge(current_href: request.path)
-%>
+  .merge(current_href: request.path) %>
 <%= turbo_frame_tag "meeting_sidemenu",
-                      src: @project.present? ? menu_project_meetings_path(@project, **request_params) : menu_meetings_path(**request_params),
-                      target: '_top',
-                      data: { turbo: false },
-                      loading: :lazy %>
+                    src: @project.present? ? menu_project_meetings_path(@project, **request_params) : menu_meetings_path(**request_params),
+                    target: "_top",
+                    data: { turbo: false },
+                    loading: :lazy %>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if authorize_for(:meetings, :notify) %>
         <li>
           <%= link_to t('meeting.label_mail_all_participants'),
-                      notify_meeting_path(@meeting),
+                      notify_project_meeting_path(@project, @meeting),
                       class: 'icon-context icon-mail1',
                       method: :post %>
         </li>
@@ -68,7 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if authorize_for(:meetings, :icalendar) %>
         <li>
           <%= link_to t(:label_icalendar_download),
-                      download_ics_meeting_path(@meeting),
+                      download_ics_project_meeting_path(@project, @meeting),
                       class: 'icon-context icon-calendar2' %>
         </li>
       <% end %>
@@ -82,7 +82,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if authorize_for(:meetings, :destroy) %>
         <li>
           <%= link_to(t(:button_delete),
-                      polymorphic_path([@project, @meeting]),
+                      project_meeting_path(@project, @meeting),
                       class: 'icon-context icon-delete',
                       method: :delete,
                       data: { confirm: t(:text_are_you_sure) }) %>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
   <% if authorize_for(:meetings, :edit) %>
     <li class="toolbar-item">
-      <%= link_to({ :controller => '/meetings', :action => 'edit', :id => @meeting }, class: 'button', :accesskey => accesskey(:edit)) do %>
+      <%= link_to(edit_project_meeting_path(@project, @meeting), class: 'button', :accesskey => accesskey(:edit)) do %>
         <%= op_icon('button--icon icon-edit') %>
         <span class="button--text"><%= t(:button_edit) %></span>
       <% end %>
@@ -121,8 +121,26 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 </div>
 
-<%= render_tabs [{ :name => 'agenda', :action => :create_meeting_agendas, :partial => 'meeting_contents/show', :path => meeting_agenda_path(@meeting), :label => :label_meeting_agenda, :content => @meeting.agenda || @meeting.build_agenda, :content_type => "meeting_agenda" },
-                 { :name => 'minutes', :action => :create_meeting_minutes, :partial => 'meeting_contents/show', :path => meeting_minutes_path(@meeting), :label => :label_meeting_minutes, :content => @meeting.minutes || @meeting.build_minutes, :content_type => "meeting_minutes" }] %>
+<%= render_tabs(
+      [
+        { name: 'agenda',
+          action: :create_meeting_agendas,
+          partial: 'meeting_contents/show',
+          path: meeting_agenda_path(@meeting),
+          label: :label_meeting_agenda,
+          content: @meeting.agenda || @meeting.build_agenda,
+          content_type: "meeting_agenda"
+        },
+        {
+          name: 'minutes',
+          action: :create_meeting_minutes,
+          partial: 'meeting_contents/show',
+          path: meeting_minutes_path(@meeting),
+          label: :label_meeting_minutes, content: @meeting.minutes || @meeting.build_minutes,
+          content_type: "meeting_minutes"
+        }
+      ]
+    ) %>
 
 <% if @meeting.journals.changing.present? %>
   <div id="history">

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= toolbar title: t(:label_meeting),
             link_to: link_to(@meeting),
-            html: { class: 'meeting--main-toolbar -with-dropdown' } do %>
+            html: { class: "meeting--main-toolbar -with-dropdown" } do %>
   <% unless User.current.anonymous? %>
     <li class="toolbar-item hidden-for-tablet">
       <div class="button">
@@ -39,8 +39,8 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
   <% if authorize_for(:meetings, :edit) %>
     <li class="toolbar-item">
-      <%= link_to(edit_project_meeting_path(@project, @meeting), class: 'button', :accesskey => accesskey(:edit)) do %>
-        <%= op_icon('button--icon icon-edit') %>
+      <%= link_to(edit_project_meeting_path(@project, @meeting), class: "button", accesskey: accesskey(:edit)) do %>
+        <%= op_icon("button--icon icon-edit") %>
         <span class="button--text"><%= t(:button_edit) %></span>
       <% end %>
     </li>
@@ -52,16 +52,15 @@ See COPYRIGHT and LICENSE files for more details.
       aria-haspopup="true"
       title="<%= t(:label_more) %>"
       class="button"
-      data-test-selector="meetings-more-dropdown-menu"
-    >
-      <%= op_icon('button--icon icon-show-more') %>
+      data-test-selector="meetings-more-dropdown-menu">
+      <%= op_icon("button--icon icon-show-more") %>
     </a>
     <ul style="display:none;" class="menu-drop-down-container">
       <% if authorize_for(:meetings, :notify) %>
         <li>
-          <%= link_to t('meeting.label_mail_all_participants'),
+          <%= link_to t("meeting.label_mail_all_participants"),
                       notify_project_meeting_path(@project, @meeting),
-                      class: 'icon-context icon-mail1',
+                      class: "icon-context icon-mail1",
                       method: :post %>
         </li>
       <% end %>
@@ -69,21 +68,21 @@ See COPYRIGHT and LICENSE files for more details.
         <li>
           <%= link_to t(:label_icalendar_download),
                       download_ics_project_meeting_path(@project, @meeting),
-                      class: 'icon-context icon-calendar2' %>
+                      class: "icon-context icon-calendar2" %>
         </li>
       <% end %>
       <% if authorize_for(:meetings, :copy) %>
         <li>
           <%= link_to(t(:button_copy),
                       copy_meeting_path(@meeting),
-                      class: 'icon-context icon-copy') %>
+                      class: "icon-context icon-copy") %>
         </li>
       <% end %>
       <% if authorize_for(:meetings, :destroy) %>
         <li>
           <%= link_to(t(:button_delete),
                       project_meeting_path(@project, @meeting),
-                      class: 'icon-context icon-delete',
+                      class: "icon-context icon-delete",
                       method: :delete,
                       data: { confirm: t(:text_are_you_sure) }) %>
         </li>
@@ -105,7 +104,7 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
     <div class="grid-content small-6">
       <p>
-        <strong><%= Meeting.human_attribute_name(:location) %></strong>: <%= auto_link(h(@meeting.location), link: :all, html: { target: '_blank' }) %>
+        <strong><%= Meeting.human_attribute_name(:location) %></strong>: <%= auto_link(h(@meeting.location), link: :all, html: { target: "_blank" }) %>
       </p>
     </div>
     <div class="grid-content small-12">
@@ -123,18 +122,17 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render_tabs(
       [
-        { name: 'agenda',
+        { name: "agenda",
           action: :create_meeting_agendas,
-          partial: 'meeting_contents/show',
+          partial: "meeting_contents/show",
           path: meeting_agenda_path(@meeting),
           label: :label_meeting_agenda,
           content: @meeting.agenda || @meeting.build_agenda,
-          content_type: "meeting_agenda"
-        },
+          content_type: "meeting_agenda" },
         {
-          name: 'minutes',
+          name: "minutes",
           action: :create_meeting_minutes,
-          partial: 'meeting_contents/show',
+          partial: "meeting_contents/show",
           path: meeting_minutes_path(@meeting),
           label: :label_meeting_minutes, content: @meeting.minutes || @meeting.build_minutes,
           content_type: "meeting_minutes"

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -74,7 +74,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% if authorize_for(:meetings, :copy) %>
         <li>
           <%= link_to(t(:button_copy),
-                      copy_meeting_path(@meeting),
+                      copy_project_meeting_path(@project, @meeting),
                       class: "icon-context icon-copy") %>
         </li>
       <% end %>

--- a/modules/meeting/app/views/recurring_meetings/show.html.erb
+++ b/modules/meeting/app/views/recurring_meetings/show.html.erb
@@ -29,8 +29,8 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_recurring_meeting_plural) %>
 
-<%= render(RecurringMeetings::ShowPageHeaderComponent.new(project: @project, meeting: @recurring_meeting)) %>
-<%= render(RecurringMeetings::ShowPageSubHeaderComponent.new(project: @project, meeting: @recurring_meeting, params:)) %>
+<%= render(RecurringMeetings::ShowPageHeaderComponent.new(meeting: @recurring_meeting)) %>
+<%= render(RecurringMeetings::ShowPageSubHeaderComponent.new(meeting: @recurring_meeting, params:)) %>
 
 <% if @recurring_meeting.nil? -%>
   <%= no_results_box %>

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       end
 
       member do
+        get :copy
         get :check_for_updates
         get :cancel_edit
         get :download_ics
@@ -149,7 +150,6 @@ Rails.application.routes.draw do
     end
 
     member do
-      get :copy
       match "/:tab" => "meetings#show", :constraints => { tab: /(agenda|minutes)/ },
             :via => :get,
             :as => "tab"

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -28,19 +28,40 @@
 
 Rails.application.routes.draw do
   resources :projects, only: %i[] do
-    resources :meetings, only: %i[index new create show destroy] do
+    resources :meetings do
       collection do
+        get :new_dialog
         get "menu" => "meetings/menus#show"
       end
+
       member do
+        get :check_for_updates
+        get :cancel_edit
+        get :download_ics
+        put :update_title
+        get :details_dialog
+        put :update_details
+        get :participants_dialog
+        put :update_participants
+        put :change_state
+        post :notify
+        get :history
         get :delete_dialog
       end
     end
-    resources :recurring_meetings, only: %i[index new create show destroy] do
+
+    resources :recurring_meetings do
       member do
+        get :details_dialog
+        get :download_ics
         get :delete_dialog
         get :delete_scheduled_dialog
+        post :init
         delete :destroy_scheduled
+        post :template_completed
+        post :notify
+        post :end_series
+        get :end_series_dialog
       end
     end
   end
@@ -61,44 +82,18 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :meetings do
-    resource :menu, only: %[show]
-  end
-
-  resources :recurring_meetings do
-    member do
-      get :details_dialog
-      get :download_ics
-      get :delete_dialog
-      get :delete_scheduled_dialog
-      post :init
-      delete :destroy_scheduled
-      post :template_completed
-      post :notify
-      post :end_series
-      get :end_series_dialog
-    end
+  resources :recurring_meetings, only: %i[index show new create] do
     collection do
       get :humanize_schedule, controller: "recurring_meetings/schedule", action: :humanize_schedule
     end
   end
 
-  resources :meetings do
-    get :new_dialog, on: :collection
-    member do
-      get :check_for_updates
-      get :cancel_edit
-      get :download_ics
-      put :update_title
-      get :details_dialog
-      put :update_details
-      get :participants_dialog
-      put :update_participants
-      put :change_state
-      post :notify
-      get :history
-      get :delete_dialog
+  resources :meetings, only: %i[index show new create] do
+    collection do
+      get :new_dialog
+      get "menu" => "meetings/menus#show"
     end
+
     resources :agenda_items, controller: "meeting_agenda_items" do
       collection do
         get :new, action: :new, as: :new

--- a/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Meetings::DeleteDialogComponent, type: :component do
   let(:user) { build_stubbed(:user) }
 
   subject do
-    render_inline(described_class.new(meeting:, project:))
+    render_inline(described_class.new(meeting:))
     page
   end
 

--- a/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/delete_dialog_component_spec.rb
@@ -48,20 +48,10 @@ RSpec.describe Meetings::DeleteDialogComponent, type: :component do
   describe "dialog form" do
     let(:meeting) { build_stubbed(:meeting, project:) }
 
-    context "without a current project" do
-      let(:project) { nil }
+    let(:project) { build_stubbed(:project) }
 
-      it "renders the correct form action" do
-        expect(subject).to have_element "form", action: meeting_path(meeting)
-      end
-    end
-
-    context "with a current project" do
-      let(:project) { build_stubbed(:project) }
-
-      it "renders the correct form action" do
-        expect(subject).to have_element "form", action: project_meeting_path(project, meeting)
-      end
+    it "renders the correct form action" do
+      expect(subject).to have_element "form", action: project_meeting_path(project, meeting)
     end
   end
 

--- a/modules/meeting/spec/components/meetings/header_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/header_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Meetings::HeaderComponent, type: :component do
   let(:user) { build_stubbed(:user) }
 
   subject do
-    render_inline(described_class.new(meeting:, project:))
+    render_inline(described_class.new(meeting:))
     page
   end
 

--- a/modules/meeting/spec/components/meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/row_component_spec.rb
@@ -81,8 +81,10 @@ RSpec.describe Meetings::RowComponent, type: :component do
         let(:meeting) { build_stubbed(:meeting, project:) }
 
         context "without a current project" do
-          it "shows delete menu item" do
-            expect(subject).to have_link "Delete meeting", href: delete_dialog_project_meeting_path(project, meeting)
+          it "shows delete menu item with a back url" do
+            back_url = meetings_path
+            expect(subject).to have_link "Delete meeting",
+                                         href: delete_dialog_project_meeting_path(project, meeting, back_url:)
           end
         end
 
@@ -100,8 +102,10 @@ RSpec.describe Meetings::RowComponent, type: :component do
         let(:meeting) { build_stubbed(:structured_meeting_template, recurring_meeting: series, project:) }
 
         context "without a current project" do
-          it "shows delete menu item" do
-            expect(subject).to have_link "Delete occurrence", href: delete_dialog_project_meeting_path(project, meeting)
+          it "shows delete menu item with a back url" do
+            back_url = meetings_path
+            expect(subject).to have_link "Delete occurrence",
+                                         href: delete_dialog_project_meeting_path(project, meeting, back_url:)
           end
         end
 

--- a/modules/meeting/spec/components/meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/row_component_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Meetings::RowComponent, type: :component do
 
         context "without a current project" do
           it "shows delete menu item" do
-            expect(subject).to have_link "Delete meeting", href: delete_dialog_meeting_path(meeting)
+            expect(subject).to have_link "Delete meeting", href: delete_dialog_project_meeting_path(project, meeting)
           end
         end
 
@@ -101,7 +101,7 @@ RSpec.describe Meetings::RowComponent, type: :component do
 
         context "without a current project" do
           it "shows delete menu item" do
-            expect(subject).to have_link "Delete occurrence", href: delete_dialog_meeting_path(meeting)
+            expect(subject).to have_link "Delete occurrence", href: delete_dialog_project_meeting_path(project, meeting)
           end
         end
 

--- a/modules/meeting/spec/components/recurring_meetings/delete_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/recurring_meetings/delete_dialog_component_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RecurringMeetings::DeleteDialogComponent, type: :component do
   let(:user) { build_stubbed(:user) }
 
   subject do
-    render_inline(described_class.new(recurring_meeting:, project:))
+    render_inline(described_class.new(recurring_meeting:))
     page
   end
 
@@ -48,14 +48,6 @@ RSpec.describe RecurringMeetings::DeleteDialogComponent, type: :component do
   end
 
   describe "dialog form" do
-    context "without a current project" do
-      let(:project) { nil }
-
-      it "renders the correct form action" do
-        expect(subject).to have_element "form", action: recurring_meeting_path(recurring_meeting)
-      end
-    end
-
     context "with a current project" do
       let(:project) { build_stubbed(:project) }
 

--- a/modules/meeting/spec/components/recurring_meetings/delete_scheduled_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/recurring_meetings/delete_scheduled_dialog_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RecurringMeetings::DeleteScheduledDialogComponent, type: :compone
   let(:user) { build_stubbed(:user) }
 
   subject do
-    render_inline(described_class.new(scheduled_meeting:, project:))
+    render_inline(described_class.new(scheduled_meeting:))
     page
   end
 
@@ -50,24 +50,12 @@ RSpec.describe RecurringMeetings::DeleteScheduledDialogComponent, type: :compone
   end
 
   describe "dialog form" do
-    context "without a current project" do
-      let(:project) { nil }
+    let(:project) { build_stubbed(:project) }
 
-      it "renders the correct form action" do
-        expect(subject).to have_element "form", action: destroy_scheduled_recurring_meeting_path(
-          recurring_meeting, start_time: start_time.iso8601
-        )
-      end
-    end
-
-    context "with a current project" do
-      let(:project) { build_stubbed(:project) }
-
-      it "renders the correct form action" do
-        expect(subject).to have_element "form", action: destroy_scheduled_project_recurring_meeting_path(
-          project, recurring_meeting, start_time: start_time.iso8601
-        )
-      end
+    it "renders the correct form action" do
+      expect(subject).to have_element "form", action: destroy_scheduled_project_recurring_meeting_path(
+        project, recurring_meeting, start_time: start_time.iso8601
+      )
     end
   end
 

--- a/modules/meeting/spec/components/recurring_meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/recurring_meetings/row_component_spec.rb
@@ -65,8 +65,10 @@ RSpec.describe RecurringMeetings::RowComponent, type: :component do
         context "without a current project" do
           it "shows cancel menu item" do
             expect(subject).to have_link "Cancel this occurrence",
-                                         href: delete_scheduled_dialog_recurring_meeting_path(
-                                           recurring_meeting, start_time: scheduled_meeting.start_time.iso8601
+                                         href: delete_scheduled_dialog_project_recurring_meeting_path(
+                                           project,
+                                           recurring_meeting,
+                                           start_time: scheduled_meeting.start_time.iso8601
                                          )
           end
         end
@@ -90,7 +92,7 @@ RSpec.describe RecurringMeetings::RowComponent, type: :component do
         context "without a current project" do
           it "shows cancel menu item" do
             expect(subject).to have_link "Cancel this occurrence",
-                                         href: delete_dialog_meeting_path(scheduled_meeting.meeting)
+                                         href: delete_dialog_project_meeting_path(project, scheduled_meeting.meeting)
           end
         end
 

--- a/modules/meeting/spec/controllers/meetings_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meetings_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe MeetingsController do
 
       describe "html" do
         before do
-          get "edit", params: { id: meeting.id }
+          get "edit", params: { project_id: meeting.project_id, id: meeting.id }
         end
 
         it { expect(response).to be_successful }
@@ -195,7 +195,7 @@ RSpec.describe MeetingsController do
     let!(:participant) { create(:meeting_participant, meeting:, attended: true) }
 
     it "produces a background job for notification" do
-      post :notify, params: { id: meeting.id }
+      post :notify, params: { project_id: meeting.project_id, id: meeting.id }
 
       perform_enqueued_jobs
       expect(ActionMailer::Base.deliveries.count).to eq(1)
@@ -207,7 +207,7 @@ RSpec.describe MeetingsController do
       end
 
       it "produces a flash message containing the mail addresses raising the error" do
-        expect { post :notify, params: { id: meeting.id } }.not_to raise_error
+        expect { post :notify, params: { project_id: meeting.project_id, id: meeting.id } }.not_to raise_error
         meeting.participants.each do |participant|
           expect(flash[:error]).to include(participant.name)
         end

--- a/modules/meeting/spec/controllers/meetings_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meetings_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe MeetingsController do
           get "show", params: { id: meeting.id }
         end
 
-        it { expect(response).to be_successful }
+        it { expect(response).to redirect_to(project_meeting_path(project, meeting)) }
         it { expect(assigns(:meeting)).to eql meeting }
       end
     end

--- a/modules/meeting/spec/features/meetings_close_spec.rb
+++ b/modules/meeting/spec/features/meetings_close_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Meetings close" do
     let(:permissions) { %i[view_meetings close_meeting_agendas] }
 
     it "can delete own and other`s meetings" do
-      visit meetings_path(project)
+      visit project_meetings_path(project)
 
       click_on meeting.title
 
@@ -87,7 +87,7 @@ RSpec.describe "Meetings close" do
     let(:permissions) { %i[view_meetings] }
 
     it "cannot delete own and other`s meetings" do
-      visit meetings_path(project)
+      visit project_meetings_path(project)
 
       expect(page)
         .to have_no_link "Close"

--- a/modules/meeting/spec/features/meetings_locking_spec.rb
+++ b/modules/meeting/spec/features/meetings_locking_spec.rb
@@ -31,7 +31,7 @@ require "spec_helper"
 RSpec.describe "Meetings locking", :js do
   let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   let(:user) { create(:admin) }
-  let!(:meeting) { create(:meeting) }
+  let!(:meeting) { create(:meeting, project:) }
   let!(:agenda) { create(:meeting_agenda, meeting:) }
   let(:agenda_field) do
     TextEditorField.new(page,

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Recurring meetings CRUD",
   end
 
   let(:current_user) { user }
-  let(:show_page) { Pages::RecurringMeeting::Show.new(meeting, project:) }
+  let(:show_page) { Pages::RecurringMeeting::Show.new(meeting) }
   let(:meetings_page) { Pages::Meetings::Index.new(project:) }
 
   before do

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Recurring meetings end series", :js do
       click_on "End series now"
     end
 
-    expect(page).to have_current_path recurring_meeting_path(meeting)
+    expect(page).to have_current_path project_recurring_meeting_path(project, meeting)
     expect(page).to have_text("Meeting series ended")
   end
 

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Recurring meetings global creation",
       meetings_page.click_create
       wait_for_network_idle
 
-      expect(page).to have_css("h1", text: "Some title")
+      expect(page).to have_css("h1", text: "Some title (Template)")
       meeting = Meeting.last
       expect(meeting.title).to eq "Some title"
       expect(meeting.project).to eq project

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Recurring meetings global CRUD", :js do
   end
 
   let(:current_user) { user }
-  let(:show_page) { Pages::RecurringMeeting::Show.new(meeting, project: nil) }
+  let(:show_page) { Pages::RecurringMeeting::Show.new(meeting) }
   let(:meetings_page) { Pages::Meetings::Index.new(project: nil) }
 
   before do
@@ -97,7 +97,7 @@ RSpec.describe "Recurring meetings global CRUD", :js do
       end
     end
 
-    expect(page).to have_current_path meetings_path
+    expect(page).to have_current_path project_meetings_path(project)
 
     expect_flash(type: :success, message: "Successful deletion.")
     show_page.expect_no_meeting date: "12/31/2024 01:30 PM"

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -339,14 +339,17 @@ RSpec.describe "history",
     end
 
     history_page.open_history_modal
-    within("li.op-activity-list--item", match: :first) do
-      expect(page).to have_css("li", text: "Notes set")
-      click_link_or_button "Details"
-    end
 
-    wait_for_network_idle
-    expect(page).to have_current_path /\/journals\/\d+\/diff\/agenda_items_\d+_notes/
-    expect(page).to have_css("ins.diffmod", text: "# Hello there")
+    retry_block do
+      within("li.op-activity-list--item", match: :first) do
+        expect(page).to have_css("li", text: "Notes set")
+        click_link_or_button "Details"
+      end
+
+      wait_for_network_idle
+      expect(page).to have_current_path /\/journals\/\d+\/diff\/agenda_items_\d+_notes/
+      expect(page).to have_css("ins.diffmod", text: "# Hello there")
+    end
   end
 
   it "for a user with no permissions, renders an error", with_settings: { journal_aggregation_time_minutes: 0 } do

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe "history",
   include Components::Autocompleter::NgSelectAutocompleteHelpers
   include Redmine::I18n
 
-  shared_let(:project) { create(:project, enabled_module_names: %w[meetings work_package_tracking]) }
-  shared_let(:other_project) { create(:project, enabled_module_names: %w[work_package_tracking]) }
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings work_package_tracking activities]) }
+  shared_let(:other_project) { create(:project, enabled_module_names: %w[work_package_tracking activites]) }
   shared_let(:user) do
     create(:user,
            lastname: "First",
@@ -344,6 +344,7 @@ RSpec.describe "history",
       click_link_or_button "Details"
     end
 
+    wait_for_network_idle
     expect(page).to have_current_path /\/journals\/\d+\/diff\/agenda_items_\d+_notes/
     expect(page).to have_css("ins.diffmod", text: "# Hello there")
   end
@@ -351,7 +352,7 @@ RSpec.describe "history",
   it "for a user with no permissions, renders an error", with_settings: { journal_aggregation_time_minutes: 0 } do
     login_as no_member_user
 
-    visit history_meeting_path(meeting)
+    visit history_project_meeting_path(project, meeting)
 
     expected = "[Error 403] You are not authorized to access this page."
     expect_flash(type: :error, message: expected)

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -293,9 +293,8 @@ RSpec.describe "Structured meetings CRUD",
     end
 
     wait_for_network_idle
-    click_on("op-meetings-header-action-trigger")
-
     retry_block do
+      click_on("op-meetings-header-action-trigger")
       click_on "Copy"
       # dynamically wait for the modal to be loaded
       expect(page).to have_text("Copy meeting")

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_delete_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_delete_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_delete_spec.rb
@@ -1,0 +1,76 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+require_relative "../../support/pages/meetings/new"
+require_relative "../../support/pages/structured_meeting/show"
+require_relative "../../support/pages/meetings/index"
+
+RSpec.describe "Structured meetings deletion",
+               :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings work_package_tracking]) }
+  shared_let(:user) do
+    create(:user,
+           lastname: "First",
+           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings] }).tap do |u|
+      u.pref[:time_zone] = "Etc/UTC"
+
+      u.save!
+    end
+  end
+
+  shared_let(:meeting) { create(:meeting, project:, author: user) }
+
+  let(:current_user) { user }
+  let(:meetings_page) { Pages::Meetings::Index.new(project: nil) }
+
+  before do
+    login_as current_user
+    meetings_page.visit!
+  end
+
+  it "can delete globally, redirecting back to global" do
+    expect(page).to have_current_path(meetings_page.path)
+    expect(page).to have_text meeting.title
+
+    within("li", text: meeting.title) do
+      click_on "more-button"
+      click_on "Delete meeting"
+    end
+
+    within("#delete-meeting-dialog") do
+      expect(page).to have_text "Delete this meeting?"
+      click_on "Delete"
+    end
+
+    expect(page).to have_current_path(meetings_page.path)
+  end
+end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_global_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_global_crud_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Structured meetings global CRUD", :js do
       click_on "Delete"
     end
 
-    expect(page).to have_current_path meetings_path
+    expect(page).to have_current_path project_meetings_path(project)
 
     expect_flash(type: :success, message: "Successful deletion.")
   end

--- a/modules/meeting/spec/features/structured_meetings/turbo_links_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/turbo_links_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Structured meetings links caught by turbo",
 
   it "can link to the other meeting" do
     click_link_or_button "Meeting link"
-    expect(page).to have_current_path meeting_path(meeting2)
+    expect(page).to have_current_path project_meeting_path(project, meeting2)
     expect(page).to have_css("#content", text: "Other meeting", visible: :visible)
   end
 end

--- a/modules/meeting/spec/requests/meetings_delete_spec.rb
+++ b/modules/meeting/spec/requests/meetings_delete_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "DELETE /meetings/:id",
   end
 
   let(:current_user) { user }
-  let(:request) { delete meeting_path(meeting) }
+  let(:request) { delete project_meeting_path(project, meeting) }
 
   subject do
     request
@@ -79,11 +79,6 @@ RSpec.describe "DELETE /meetings/:id",
 
   context "when user has no permissions to access" do
     let(:current_user) { create(:user) }
-
-    it "does not delete the meeting" do
-      delete meeting_path(meeting)
-      expect(response).to have_http_status(:forbidden)
-    end
 
     it "does not delete project meeting" do
       delete project_meeting_path(project, meeting)

--- a/modules/meeting/spec/requests/meetings_spec.rb
+++ b/modules/meeting/spec/requests/meetings_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Meeting requests",
       let(:send_notifications) { "1" }
 
       it "sends an invitation mail to the invited users" do
-        patch(meeting_path(meeting), params:)
+        patch(project_meeting_path(project, meeting), params:)
 
         expect(subject.participants.count).to eq(2)
 
@@ -88,7 +88,7 @@ RSpec.describe "Meeting requests",
       let(:send_notifications) { "0" }
 
       it "sends an invitation mail to the invited users" do
-        patch(meeting_path(meeting), params:)
+        patch(project_meeting_path(project, meeting), params:)
 
         expect(subject.participants.count).to eq(2)
 

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_delete_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_delete_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "DELETE /recurring_meetings/:id",
 
   let(:current_user) { user }
   let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting).with_capybara_page(page) }
-  let(:request) { delete recurring_meeting_path(recurring_meeting) }
+  let(:request) { delete project_recurring_meeting_path(project, recurring_meeting) }
 
   subject do
     request
@@ -71,7 +71,7 @@ RSpec.describe "DELETE /recurring_meetings/:id",
   context "when user has permissions to access" do
     it "deletes the series" do
       title = recurring_meeting.title
-      expect(subject).to have_http_status(:found)
+      expect(subject).to have_http_status(:see_other)
 
       expect { recurring_meeting.reload }.to raise_error(ActiveRecord::RecordNotFound)
 
@@ -83,7 +83,7 @@ RSpec.describe "DELETE /recurring_meetings/:id",
     end
 
     context "when deleting an occurrence" do
-      let(:request) { delete meeting_path(recurring_meeting.meetings.not_templated.last) }
+      let(:request) { delete project_meeting_path(project, recurring_meeting.meetings.not_templated.last) }
 
       it "deletes the occurrence" do
         title = recurring_meeting.template.title
@@ -102,14 +102,9 @@ RSpec.describe "DELETE /recurring_meetings/:id",
   context "when user has no permissions to access" do
     let(:current_user) { create(:user) }
 
-    it "does not show the recurring meetings" do
-      delete recurring_meeting_path(recurring_meeting)
-      expect(response).to have_http_status(:not_found)
-    end
-
     it "does not show project recurring meetings" do
       delete project_recurring_meeting_path(project, recurring_meeting)
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_end_series_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_end_series_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Recurring meetings complete template",
   let(:current_user) { user }
   let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting).with_capybara_page(page) }
   let(:request) do
-    post end_series_recurring_meeting_path(recurring_meeting)
+    post end_series_project_recurring_meeting_path(project, recurring_meeting)
   end
 
   subject do
@@ -189,7 +189,7 @@ RSpec.describe "Recurring meetings complete template",
 
     it "does not authorize" do
       subject
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Recurring meetings show",
 
   let(:current_user) { user }
   let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting).with_capybara_page(page) }
-  let(:request) { get recurring_meeting_path(recurring_meeting) }
+  let(:request) { get project_recurring_meeting_path(project, recurring_meeting) }
 
   before do
     login_as(current_user)
@@ -57,7 +57,8 @@ RSpec.describe "Recurring meetings show",
   context "when user has permissions to access" do
     it "shows the recurring meetings" do
       get recurring_meeting_path(recurring_meeting)
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(project_recurring_meeting_path(project, recurring_meeting))
     end
 
     it "shows project recurring meetings" do
@@ -109,7 +110,7 @@ RSpec.describe "Recurring meetings show",
     end
 
     it "does not show the cancelled meeting" do
-      get recurring_meeting_path(recurring_meeting, direction: "past")
+      get project_recurring_meeting_path(project, recurring_meeting, direction: "past")
 
       expect(page).to have_text format_time(past_instance.start_time)
       expect(page).to have_no_text format_time(past_schedule_cancelled.start_time)
@@ -122,7 +123,7 @@ RSpec.describe "Recurring meetings show",
       end
 
       it "still shows the one past meeting (Regression #61280)" do
-        get recurring_meeting_path(recurring_meeting, direction: "past")
+        get project_recurring_meeting_path(project, recurring_meeting, direction: "past")
         expect(page).to have_text format_time(past_instance.start_time)
       end
     end
@@ -147,7 +148,7 @@ RSpec.describe "Recurring meetings show",
     end
 
     it "sorts meetings into two tables based on state" do
-      get recurring_meeting_path(recurring_meeting)
+      get project_recurring_meeting_path(project, recurring_meeting)
 
       content = page.find_by_id("content")
       expect(content).to have_text "Open"
@@ -189,7 +190,7 @@ RSpec.describe "Recurring meetings show",
 
     it "does not show the meeting ended blankslate" do
       travel_to(Time.zone.today + 9.hours) do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
       end
 
       expect(page).to have_text format_time(ongoing_meeting.start_time)
@@ -197,7 +198,7 @@ RSpec.describe "Recurring meetings show",
       expect(page).to have_no_text "Meeting series ended"
 
       travel_to(Time.zone.today + 10.hours + 5.minutes) do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
       end
 
       expect(page).to have_text format_time(ongoing_meeting.start_time)
@@ -221,7 +222,7 @@ RSpec.describe "Recurring meetings show",
       end
 
       it "shows rescheduled occurrences" do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
 
         old_date = format_time(rescheduled.start_time)
         new_date = format_time(rescheduled_instance.start_time)
@@ -270,7 +271,7 @@ RSpec.describe "Recurring meetings show",
       end
 
       it "shows all open meetings in 'Open', even if they no longer match the schedule (Regression #61301)" do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
 
         first_date = format_time(first.start_time)
         second_date = format_time(second.start_time)
@@ -290,7 +291,7 @@ RSpec.describe "Recurring meetings show",
       end
 
       it "shows the cancelled occurrences" do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
 
         expect(page).to have_css("li", text: format_time(rescheduled.start_time))
         expect(page).to have_css("li", text: "Cancelled")
@@ -301,7 +302,7 @@ RSpec.describe "Recurring meetings show",
       it "shows the next five occurrences" do
         # Assuming we're past today's occurrence
         Timecop.freeze(Time.zone.today + 11.hours) do
-          get recurring_meeting_path(recurring_meeting)
+          get project_recurring_meeting_path(project, recurring_meeting)
         end
 
         (1..5).each do |date|
@@ -336,7 +337,7 @@ RSpec.describe "Recurring meetings show",
     it "shows the correct number of next occurrences (Regression #61194)" do
       # While today's meeting is ongoing, but no longer in remaining_occurrences
       Timecop.freeze(Time.zone.today + 10.hours + 1.minute) do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
       end
 
       (1..4).each do |date|
@@ -350,19 +351,19 @@ RSpec.describe "Recurring meetings show",
 
     it "does not show the recurring meetings" do
       get recurring_meeting_path(recurring_meeting)
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "does not show project recurring meetings" do
       get project_recurring_meeting_path(project, recurring_meeting)
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
   describe "Show more" do
     context "when there are more than 5 scheduled instances" do
       it "shows the footer" do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
 
         expect(page).to have_css("#recurring-meetings-footer-component")
       end
@@ -380,7 +381,7 @@ RSpec.describe "Recurring meetings show",
       end
 
       it "shows no footer" do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
 
         expect(page).to have_no_css("#recurring-meetings-footer-component")
       end
@@ -397,7 +398,7 @@ RSpec.describe "Recurring meetings show",
       end
 
       it "shows footer, but no counts" do
-        get recurring_meeting_path(recurring_meeting)
+        get project_recurring_meeting_path(project, recurring_meeting)
 
         expect(page).to have_text "There are more scheduled meetings"
       end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Recurring meetings complete template",
   let(:current_user) { user }
   let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting).with_capybara_page(page) }
   let(:request) do
-    post template_completed_recurring_meeting_path(recurring_meeting)
+    post template_completed_project_recurring_meeting_path(project, recurring_meeting)
   end
 
   subject do
@@ -122,7 +122,7 @@ RSpec.describe "Recurring meetings complete template",
 
     it "does not authorize" do
       subject
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/modules/meeting/spec/support/pages/meetings/edit.rb
+++ b/modules/meeting/spec/support/pages/meetings/edit.rb
@@ -34,6 +34,7 @@ module Pages::Meetings
     attr_accessor :meeting
 
     def initialize(meeting)
+      super(meeting.project)
       self.meeting = meeting
     end
 
@@ -62,7 +63,7 @@ module Pages::Meetings
     end
 
     def path
-      edit_meeting_path(meeting)
+      edit_project_meeting_path(project, meeting)
     end
   end
 end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -93,7 +93,7 @@ module Pages::Meetings
     end
 
     def path
-      meeting_path(meeting)
+      project_meeting_path(meeting.project, meeting)
     end
   end
 end

--- a/modules/meeting/spec/support/pages/recurring_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/recurring_meeting/show.rb
@@ -32,18 +32,14 @@ module Pages::RecurringMeeting
   class Show < ::Pages::Meetings::Base
     attr_accessor :meeting
 
-    def initialize(meeting, project: nil)
-      super(project)
+    def initialize(meeting)
+      super(meeting.project)
 
       self.meeting = meeting
     end
 
     def path
-      if project
-        project_recurring_meeting_path(project, meeting)
-      else
-        recurring_meeting_path(meeting)
-      end
+      project_recurring_meeting_path(project, meeting)
     end
 
     def expect_planned_meeting(date:)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61422
https://community.openproject.org/wp/61397

# What are you trying to accomplish?

Provide a consistent behavior of the application by moving all meeting related routes apart from global index, show (redirect to project), new, and create to the project level.