### PR TITLE
remove unnecessary spring startup from rubocop

### DIFF
--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,4 +1,3 @@
 #!/usr/bin/env ruby
-load File.expand_path("spring", __dir__)
 require 'bundler/setup'
 load Gem.bin_path('rubocop', 'rubocop')


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Allow rubocop to run stable in my IDE.

# What approach did you choose and why?

The rubocop binstub included starting a spring server. Spring is notoriously unstable at least on my mac. From time to time, it just hangs. Additionally, its startup sometimes crashes because of it not finding a database connection (not sure why).

But moreover, starting a spring server should just not be necessary here. Rubocop does not need a running OpenProject application as it does static code analysis. 

