### PR TITLE
[43665] Missing space for no-results box on mobile

### DIFF
--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -34,6 +34,8 @@
     display: flex
     overflow: auto
     @include styled-scroll-bar
+    :has(.generic-table--no-results-container)
+      padding: 0 1rem 0 1rem
 
   .work-packages-partitioned-page--content-left,
   .work-packages-partitioned-page--content-right

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -34,8 +34,6 @@
     display: flex
     overflow: auto
     @include styled-scroll-bar
-    :has(.generic-table--no-results-container)
-      padding: 0 1rem 0 1rem
 
   .work-packages-partitioned-page--content-left,
   .work-packages-partitioned-page--content-right

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.sass
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.sass
@@ -22,6 +22,7 @@
       min-width: calc(100vw + 10px)
       &:has(.generic-table--no-results-container)
         min-width: auto
+        padding: 0 1rem 0 1rem
 
 .work-packages-split-view--tabletimeline-container
   display: flex

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.sass
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.sass
@@ -20,6 +20,8 @@
       // Ensure the WP cards span the complete width on mobile
       // --> Move scrollbar out of visible area
       min-width: calc(100vw + 10px)
+      &:has(.generic-table--no-results-container)
+        min-width: auto
 
 .work-packages-split-view--tabletimeline-container
   display: flex


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/43665

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add some space to the no-result box in work packages page

## Screenshots
Before:
![Screenshot 2025-02-13 at 15 41 17](https://github.com/user-attachments/assets/e4ee3b8b-eebb-49f7-864f-659d4f0c5cce)

After:
![Screenshot 2025-02-13 at 15 30 37](https://github.com/user-attachments/assets/41360e74-23ea-4a76-bebc-6135d97ebb0e)

# What approach did you choose and why?
When there is result, there will be no scroll then we shouldn't change the width, and we need to add some padding around the no-result box, since we don't want it to span the whole width.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
