### PR TITLE
Ensure meeting series are created in the future

### DIFF
--- a/modules/meeting/app/contracts/recurring_meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/create_contract.rb
@@ -30,6 +30,7 @@ module RecurringMeetings
   class CreateContract < BaseContract
     validate :user_allowed_to_add
     validate :project_is_present
+    validate :start_time_constraints
 
     private
 
@@ -44,6 +45,17 @@ module RecurringMeetings
 
       unless user.allowed_in_project?(:create_meetings, model.project)
         errors.add :base, :error_unauthorized
+      end
+    end
+
+    def start_time_constraints
+      return if model.start_time.nil?
+      return if model.start_time >= Time.zone.now
+
+      if model.start_time.today?
+        errors.add :start_time_hour, :after_today
+      else
+        errors.add :start_date, :after_today
       end
     end
   end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -65,6 +65,8 @@ en:
         frequency: "Frequency"
         interval: "Interval"
         start_date: "Starts on"
+        start_time: "Start time"
+        start_time_hour: "Start time"
         end_after: "Meeting series ends"
         iterations: "Occurrences"
     errors:

--- a/modules/meeting/spec/services/recurring_meetings/create_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/create_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -40,6 +42,19 @@ RSpec.describe RecurringMeetings::CreateService, "integration", type: :model do
 
   subject { instance.call(**params) }
 
+  shared_examples "creates the series" do
+    it "creates the series and template" do
+      expect(service_result).to be_success
+      expect(series).to be_persisted
+
+      expect(series.template).to be_a(StructuredMeeting)
+      expect(series.template).to be_template
+
+      expect(series.meetings.count).to eq(1)
+      expect(series.meetings.first).to be_template
+    end
+  end
+
   describe "project" do
     context "when not provided" do
       let(:params) { { title: "foo" } }
@@ -66,16 +81,7 @@ RSpec.describe RecurringMeetings::CreateService, "integration", type: :model do
       }
     end
 
-    it "creates the series and template" do
-      expect(service_result).to be_success
-      expect(series).to be_persisted
-
-      expect(series.template).to be_a(StructuredMeeting)
-      expect(series.template).to be_template
-
-      expect(series.meetings.count).to eq(1)
-      expect(series.meetings.first).to be_template
-    end
+    it_behaves_like "creates the series"
 
     context "when the template cannot be saved" do
       let(:template) { StructuredMeeting.new }
@@ -88,6 +94,51 @@ RSpec.describe RecurringMeetings::CreateService, "integration", type: :model do
       it "does not create the series" do
         expect { subject }.not_to have_enqueued_job(RecurringMeetings::InitNextOccurrenceJob)
         expect(service_result).not_to be_success
+        expect(series).to be_new_record
+      end
+    end
+  end
+
+  describe "start time constraints" do
+    let(:params) do
+      {
+        start_time:,
+        frequency: "daily",
+        interval: 1,
+        end_after: "never",
+        project:,
+        title: "My daily"
+      }
+    end
+
+    context "when start_time is today, but in the past" do
+      let(:start_time) { 1.hour.ago }
+
+      it "adds a validation error for start_time_hour" do
+        expect(service_result).not_to be_success
+        expect(service_result.errors[:start_time_hour]).to include "must be in the future."
+        expect(series).to be_new_record
+      end
+    end
+
+    context "when start_time is today, but in the future" do
+      let(:start_time) { 1.hour.from_now }
+
+      it_behaves_like "creates the series"
+    end
+
+    context "when start_time is tomorrow" do
+      let(:start_time) { 1.day.from_now }
+
+      it_behaves_like "creates the series"
+    end
+
+    context "when start_time is yesterday" do
+      let(:start_time) { 1.day.ago }
+
+      it "adds a validation error for start_date" do
+        expect(service_result).not_to be_success
+        expect(service_result.errors[:start_date]).to include "must be in the future."
         expect(series).to be_new_record
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61441

# What are you trying to accomplish?
Require meeting series to be created in the future, to prevent edge-cases where your first occurrences are never shown as they are already past.