### PR TITLE
Code maintenance/61471 Migration Utils Permission adder crashes when supplied with a permission that no longer exists

### DIFF
--- a/db/migrate/migration_utils/permission_adder.rb
+++ b/db/migrate/migration_utils/permission_adder.rb
@@ -31,8 +31,13 @@ module Migration
     module PermissionAdder
       module_function
 
-      def add(having, add)
+      def add(having, add) # rubocop:disable Metrics/AbcSize
         added_permission = OpenProject::AccessControl.permission(add)
+
+        if added_permission.blank?
+          OpenProject.logger.warn("Permission #{add} is not a valid permission in use. Skipping...")
+          return
+        end
 
         role_scope = Role
           .joins(:role_permissions)

--- a/spec/migrations/permission_adder_spec.rb
+++ b/spec/migrations/permission_adder_spec.rb
@@ -85,4 +85,18 @@ RSpec.describe Migration::MigrationUtils::PermissionAdder, type: :model do # rub
       expect(anonymous_role.permissions).not_to include(:archive_project)
     end
   end
+
+  context "with a permission that does not exist" do
+    it "results in a no-op" do
+      result = nil
+      expect { result = described_class.add(:view_project, :non_existent_permission) }.not_to raise_error
+      expect(result).to be_nil
+
+      roles.each(&:reload)
+
+      expect(role.permissions).not_to include(:non_existent_permission)
+      expect(non_member_role.permissions).not_to include(:non_existent_permission)
+      expect(anonymous_role.permissions).not_to include(:non_existent_permission)
+    end
+  end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/61471

```ruby
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

undefined method 'require_member?' for nil
/home/dev/openproject/db/migrate/migration_utils/permission_adder.rb:47:in 'block in Migration::MigrationUtils::PermissionAdder.add'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:82:in 'Array#each'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:82:in 'block in ActiveRecord::Batches#find_each'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:158:in 'block in ActiveRecord::Batches#find_in_batches'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:396:in 'block in ActiveRecord::Batches#batch_on_unloaded_relation'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:372:in 'ActiveRecord::Batches#batch_on_unloaded_relation'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:269:in 'ActiveRecord::Batches#in_batches'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:157:in 'ActiveRecord::Batches#find_in_batches'
/usr/local/bundle/gems/activerecord-7.1.5.1/lib/active_record/relation/batches.rb:81:in 'ActiveRecord::Batches#find_each'
/home/dev/openproject/db/migrate/migration_utils/permission_adder.rb:42:in 'Migration::MigrationUtils::PermissionAdder.add'
/home/dev/openproject/db/migrate/20241129135602_populate_manage_own_reminders_permission.rb:34:in 'PopulateManageOwnRemindersPermission#up'

```
