### PR TITLE
Storage Health Check: OIDC Provisioned Current User 

### DIFF
--- a/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
@@ -58,7 +58,7 @@ module Storages
       def sso_misconfigured
         return None() unless @storage.authenticate_via_idp?
 
-        audience_missing.or { non_provisioned_user }
+        audience_missing.or { non_provisioned_user }.or { oidc_provisioned_user }
       end
 
       def audience_missing
@@ -71,12 +71,21 @@ module Storages
       end
 
       def non_provisioned_user
-        return None() if @user.authentication_provider.present?
+        return None() if @user.identity_url.present?
 
         Some(ConnectionValidation.new(type: :warning,
                                       error_code: :oidc_non_provisioned_user,
                                       timestamp: Time.current,
                                       description: I18n.t("storages.health.connection_validation.oidc_non_provisioned_user")))
+      end
+
+      def oidc_provisioned_user
+        return None() if @user.authentication_provider.is_a?(OpenIDConnect::Provider)
+
+        Some(ConnectionValidation.new(type: :warning,
+                                      error_code: :oidc_non_oidc_user,
+                                      timestamp: Time.current,
+                                      description: I18n.t("storages.health.connection_validation.oidc_non_oidc_user")))
       end
 
       def has_base_configuration_error?

--- a/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_connection_validator.rb
@@ -58,7 +58,7 @@ module Storages
       def sso_misconfigured
         return None() unless @storage.authenticate_via_idp?
 
-        audience_missing.or { non_provisioned_user }.or { oidc_provisioned_user }
+        audience_missing.or { non_provisioned_user }.or { non_oidc_provisioned_user }
       end
 
       def audience_missing
@@ -79,7 +79,7 @@ module Storages
                                       description: I18n.t("storages.health.connection_validation.oidc_non_provisioned_user")))
       end
 
-      def oidc_provisioned_user
+      def non_oidc_provisioned_user
         return None() if @user.authentication_provider.is_a?(OpenIDConnect::Provider)
 
         Some(ConnectionValidation.new(type: :warning,

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -224,6 +224,7 @@ en:
         missing_dependencies: 'A required dependency is missing on the file storage. Please add the following dependency: %{dependency}.'
         not_configured: The connection could not be validated. Please finish configuration first.
         oidc_audience_missing: The storage has no audience defined. This is necessary for OpenID Connect integration.
+        oidc_non_oidc_user: The current user, while provisioned, wasn't provisioned by an OpenID Connect (OIDC) Identity Provider. Please re-run the check with an OIDC provisioned user.
         oidc_non_provisioned_user: The current user isn't provided by an OpenID Connect Identity Provider. Please re-run the check with a provided user.
         placeholder: Check your connection against the server.
         subtitle: Connection validation

--- a/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
@@ -267,6 +267,14 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
       expect(subject.error_code).to eq(:oidc_non_provisioned_user)
       expect(subject.description).to eq(I18n.t("storages.health.connection_validation.oidc_non_provisioned_user"))
     end
+
+    it "returns a warning if the user is not provided by an oidc provider" do
+      user.update(identity_url: "ldap-provider:this-will-trigger-a-warning")
+
+      expect(subject.type).to eq(:warning)
+      expect(subject.error_code).to eq(:oidc_non_oidc_user)
+      expect(subject.description).to eq(I18n.t("storages.health.connection_validation.oidc_non_oidc_user"))
+    end
   end
 
   private


### PR DESCRIPTION
### Related Work Package: [OP#61477](https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61477)

Adds the check if the current user is provisioned by OIDC IdP.