### PR TITLE
[#59540] highlight closest predecessor in relations tab

### DIFF
--- a/app/components/work_package_relations_tab/closest_relation.rb
+++ b/app/components/work_package_relations_tab/closest_relation.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module WorkPackageRelationsTab
+  class ClosestRelation
+    include Comparable
+
+    attr :relation
+
+    delegate :predecessor, to: :relation
+
+    def <=>(other)
+      comparison = compare_nilable_dates(soonest_start, other.soonest_start)
+      comparison = -compare_nilable_dates(predecessor.created_at, other.predecessor.created_at) if comparison.zero?
+      comparison
+    end
+
+    def initialize(relation)
+      @relation = relation
+    end
+
+    def soonest_start
+      return @soonest_start if defined?(@soonest_start)
+
+      @soonest_start = relation.successor_soonest_start(gap: 0.days)
+    end
+
+    def inspect
+      "#<#{self.class.name} soonest_start: #{soonest_start} relation: #{relation.inspect}>"
+    end
+
+    private
+
+    def compare_nilable_dates(date1, date2)
+      return -1 if date1.nil? && !date2.nil?
+      return 1 if !date1.nil? && date2.nil?
+      return 0 if date1.nil? && date2.nil?
+
+      date1 <=> date2
+    end
+  end
+end

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -69,7 +69,8 @@
                 WorkPackageRelationsTab::RelationComponent.new(
                   work_package: work_package,
                   relation: relation,
-                  visibility: visibility
+                  visibility: visibility,
+                  closest: relation_group.closest_relation?(relation)
                 )
               )
             end

--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -87,9 +87,14 @@
           render(Primer::Beta::Text.new) { helpers.work_package_formatted_dates(related_work_package) }
         end
 
-        if follows? && lag_present?
-          dates_row.with_column(ml: 2, mr: 1) { render(Primer::Beta::Octicon.new(icon: "arrow-both")) }
-          dates_row.with_column(mr: 1) { render(Primer::Beta::Text.new) { lag_as_text(relation.lag) } }
+        if follows?
+          if lag_present?
+            dates_row.with_column(ml: 2, mr: 1) { render(Primer::Beta::Octicon.new(icon: "arrow-both")) }
+            dates_row.with_column(mr: 1) { render(Primer::Beta::Text.new) { lag_as_text(relation.lag) } }
+          end
+          if closest?
+            dates_row.with_column(ml: 2, mr: 1) { render(Primer::Beta::Label.new(scheme: :primary, inline: true)) { I18n.t("work_package_relations_tab.relations.label_closest") } }
+          end
         end
       end
     end

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -11,11 +11,13 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   # @param visibility [Symbol] The visibility status of the relation (:visible or :ghost)
   # @param child [WorkPackage, nil] The child work package, if this is a parent-child relationship
   # @param editable [Boolean] Whether the relation can be edited
+  # @param closest [Boolean] Whether the follows relation is the closest
   def initialize(work_package:,
                  relation:,
                  visibility:,
                  child: nil,
-                 editable: true)
+                 editable: true,
+                 closest: false)
     super()
 
     @work_package = work_package
@@ -23,6 +25,7 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
     @visibility = visibility
     @child = child
     @editable = editable
+    @closest = closest
   end
 
   def related_work_package
@@ -96,6 +99,10 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
     return false if parent_child_relationship?
 
     relation.relation_type_for(work_package) == Relation::TYPE_PRECEDES
+  end
+
+  def closest?
+    @closest
   end
 
   def edit_path

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -38,8 +38,28 @@ class WorkPackageRelationsTab::RelationsMediator
       visible_relations.any? || ghost_relations.any?
     end
 
+    def all_relations
+      visible_relations + ghost_relations
+    end
+
+    def closest_relation?(relation) = closest_relation == relation
+
+    def closest_relation = closest_relations.first
+
+    def closest_relations
+      return [] unless follows_type?
+
+      all_relations
+        .sort_by { WorkPackageRelationsTab::ClosestRelation.new(it) }
+        .reverse
+    end
+
     def children_type?
       type == "children"
+    end
+
+    def follows_type?
+      type == "follows"
     end
   end
 

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -48,18 +48,15 @@ class WorkPackageRelationsTab::RelationsMediator
 
     def closest_relation?(relation) = closest_relation == relation
 
-    def closest_relation = closest_relations.first
-
-    def closest_relations
-      return [] unless type.follows?
+    def closest_relation
+      return nil unless type.follows?
 
       all_relations
         .lazy
         .map { WorkPackageRelationsTab::ClosestRelation.new(it) }
         .select(&:soonest_start)
-        .sort
-        .reverse
-        .map(&:relation)
+        .max
+        &.relation
     end
   end
 

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -30,6 +30,10 @@
 
 class WorkPackageRelationsTab::RelationsMediator
   RelationGroup = Data.define(:type, :visible_relations, :ghost_relations) do
+    def initialize(type:, visible_relations:, ghost_relations:)
+      super(type: ActiveSupport::StringInquirer.new(type), visible_relations:, ghost_relations:)
+    end
+
     def count
       visible_relations.count + ghost_relations.count
     end
@@ -47,7 +51,7 @@ class WorkPackageRelationsTab::RelationsMediator
     def closest_relation = closest_relations.first
 
     def closest_relations
-      return [] unless follows_type?
+      return [] unless type.follows?
 
       all_relations
         .lazy
@@ -56,14 +60,6 @@ class WorkPackageRelationsTab::RelationsMediator
         .sort
         .reverse
         .map(&:relation)
-    end
-
-    def children_type?
-      type == "children"
-    end
-
-    def follows_type?
-      type == "follows"
     end
   end
 

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -50,8 +50,12 @@ class WorkPackageRelationsTab::RelationsMediator
       return [] unless follows_type?
 
       all_relations
-        .sort_by { WorkPackageRelationsTab::ClosestRelation.new(it) }
+        .lazy
+        .map { WorkPackageRelationsTab::ClosestRelation.new(it) }
+        .select(&:soonest_start)
+        .sort
         .reverse
+        .map(&:relation)
     end
 
     def children_type?

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -50,9 +50,9 @@
                           render(
                             WorkPackageRelationsTab::RelationComponent.new(
                               work_package:,
-                              relation: (relation unless relation_group.children_type?),
+                              relation: (relation unless relation_group.type.children?),
                               visibility: :visible,
-                              child: (relation if relation_group.children_type?),
+                              child: (relation if relation_group.type.children?),
                               editable: false,
                               closest: relation_group.closest_relation?(relation)
                             )
@@ -64,9 +64,9 @@
                           render(
                             WorkPackageRelationsTab::RelationComponent.new(
                               work_package:,
-                              relation: (relation unless relation_group.children_type?),
+                              relation: (relation unless relation_group.type.children?),
                               visibility: :ghost,
-                              child: (relation if relation_group.children_type?),
+                              child: (relation if relation_group.type.children?),
                               editable: false,
                               closest: relation_group.closest_relation?(relation)
                             )

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -53,7 +53,8 @@
                               relation: (relation unless relation_group.children_type?),
                               visibility: :visible,
                               child: (relation if relation_group.children_type?),
-                              editable: false
+                              editable: false,
+                              closest: relation_group.closest_relation?(relation)
                             )
                           )
                         end
@@ -66,7 +67,8 @@
                               relation: (relation unless relation_group.children_type?),
                               visibility: :ghost,
                               child: (relation if relation_group.children_type?),
-                              editable: false
+                              editable: false,
+                              closest: relation_group.closest_relation?(relation)
                             )
                           )
                         end

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -165,10 +165,10 @@ class Relation < ApplicationRecord
     successor.start_date || successor.due_date
   end
 
-  def successor_soonest_start
+  def successor_soonest_start(gap: 1.day)
     if follows? && predecessor_date
       days = WorkPackages::Shared::Days.for(from)
-      relation_start_date = predecessor_date + 1.day
+      relation_start_date = predecessor_date + gap
       days.soonest_working_day(relation_start_date, lag:)
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -825,6 +825,7 @@ en:
       new_child_text: "Creates a related work package as a sub-item of the current (parent) work package"
       existing_child: "Existing child"
       child_description: "Makes the related work package a sub-item of the current (parent) work package"
+      label_closest: "Closest"
       label_blocks_singular: "blocks"
       label_blocks_plural: "blocks"
       blocks_description: "The related work package cannot be closed until this one is closed first"

--- a/spec/components/work_package_relations_tab/closest_relation_spec.rb
+++ b/spec/components/work_package_relations_tab/closest_relation_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageRelationsTab::ClosestRelation do
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:today) { Time.zone.today }
+
+  def closest_relation(lag: 0, **wp_attributes)
+    predecessor = build_stubbed(:work_package, **wp_attributes)
+    relation = build_stubbed(:follows_relation, from: work_package, to: predecessor, lag:)
+    described_class.new(relation)
+  end
+
+  describe "#<=>" do
+    context "without a lag" do
+      context "when comparing two instances with different due dates" do
+        it "compares with the respective due dates" do
+          expect(closest_relation(due_date: 1.day.from_now)).to be < closest_relation(due_date: 2.days.from_now)
+          expect(closest_relation(due_date: today)).to be > closest_relation(due_date: 2.days.ago)
+          expect(closest_relation(due_date: today)).to be > closest_relation(due_date: nil)
+          expect(closest_relation(due_date: nil)).to be < closest_relation(due_date: 1.day.ago)
+        end
+      end
+
+      context "when comparing two instances with different start dates" do
+        it "compares with the respective start dates" do
+          expect(closest_relation(start_date: 1.day.from_now)).to be < closest_relation(start_date: 2.days.from_now)
+          expect(closest_relation(start_date: today)).to be > closest_relation(start_date: 2.days.ago)
+          expect(closest_relation(start_date: today)).to be > closest_relation(start_date: nil)
+          expect(closest_relation(start_date: nil)).to be < closest_relation(start_date: 1.day.ago)
+        end
+      end
+
+      context "when comparing two instances with same due dates" do
+        it "compares with the respective created at dates, oldest > newest" do
+          expect(closest_relation(due_date: 1.day.from_now)).to be > closest_relation(due_date: 1.day.from_now)
+          expect(closest_relation(due_date: 2.days.ago)).to be > closest_relation(due_date: 2.days.ago)
+          expect(closest_relation(due_date: nil)).to be > closest_relation(due_date: nil)
+        end
+      end
+
+      context "when comparing two instances with same start dates" do
+        it "compares with the respective created at dates, oldest > newest" do
+          expect(closest_relation(start_date: 1.day.from_now)).to be > closest_relation(start_date: 1.day.from_now)
+          expect(closest_relation(start_date: 2.days.ago)).to be > closest_relation(start_date: 2.days.ago)
+          expect(closest_relation(start_date: nil)).to be > closest_relation(start_date: nil)
+        end
+      end
+
+      context "when comparing two instances with both due and start dates set" do
+        it "compares with the respective due dates, ignoring start dates" do
+          expect(closest_relation(due_date: 10.days.from_now, start_date: today))
+            .to be < closest_relation(due_date: 12.days.from_now, start_date: 2.days.ago)
+          expect(closest_relation(due_date: 14.days.from_now, start_date: today))
+            .to be > closest_relation(due_date: 12.days.from_now, start_date: 2.days.ago)
+        end
+      end
+    end
+
+    context "with a lag" do
+      context "when comparing two instances with same soonest starts (due date and lag)" do
+        it "compares with the respective created at dates, oldest > newest" do
+          expect(closest_relation(lag: 3, due_date: 3.days.from_now))
+            .to be > closest_relation(lag: 4, due_date: 2.days.from_now)
+          expect(closest_relation(lag: 2, due_date: 3.days.ago))
+            .to be > closest_relation(lag: 1, due_date: 4.days.ago)
+          expect(closest_relation(lag: 2, due_date: nil))
+            .to be > closest_relation(lag: 2, due_date: nil)
+        end
+      end
+
+      context "when comparing two instances with same soonest starts (start date and lag)" do
+        it "compares with the respective created at dates, oldest > newest" do
+          expect(closest_relation(lag: 3, start_date: 3.days.from_now))
+            .to be > closest_relation(lag: 4, start_date: 2.days.from_now)
+          expect(closest_relation(lag: 2, start_date: 3.days.ago))
+            .to be > closest_relation(lag: 1, start_date: 4.days.ago)
+          expect(closest_relation(lag: 2, start_date: nil))
+            .to be > closest_relation(lag: 2, start_date: nil)
+        end
+      end
+
+      context "when comparing two instances with different soonest starts (due date and lag)" do
+        it "compares with the combined due dates and lag" do
+          expect(closest_relation(lag: 4, due_date: 3.days.from_now))
+            .to be > closest_relation(lag: 4, due_date: 2.days.from_now)
+          expect(closest_relation(lag: 1, due_date: 3.days.ago))
+            .to be < closest_relation(lag: 4, due_date: 3.days.ago)
+          expect(closest_relation(lag: 4, due_date: nil))
+            .to be < closest_relation(lag: 4, due_date: 2.days.from_now)
+          expect(closest_relation(lag: 1, due_date: 3.days.ago))
+            .to be > closest_relation(lag: 4, due_date: nil)
+        end
+      end
+
+      context "when comparing two instances with different soonest starts (start date and lag)" do
+        it "compares with the combined start dates and lag" do
+          expect(closest_relation(lag: 4, start_date: 3.days.from_now))
+            .to be > closest_relation(lag: 4, start_date: 2.days.from_now)
+          expect(closest_relation(lag: 1, start_date: 3.days.ago))
+            .to be < closest_relation(lag: 4, start_date: 3.days.ago)
+          expect(closest_relation(lag: 4, start_date: nil))
+            .to be < closest_relation(lag: 4, start_date: 2.days.from_now)
+          expect(closest_relation(lag: 1, start_date: 3.days.ago))
+            .to be > closest_relation(lag: 4, start_date: nil)
+        end
+      end
+    end
+  end
+
+  describe "#soonest_start" do
+    context "with a nil due and start date" do
+      it "returns nil" do
+        expect(closest_relation(due_date: nil, start_date: nil).soonest_start).to be_nil
+        expect(closest_relation(lag: 1, due_date: nil, start_date: nil).soonest_start).to be_nil
+      end
+    end
+
+    context "with a due date set" do
+      let(:due_date) { Date.new(2020, 7, 14) }
+
+      context "without a lag" do
+        it "returns the due date" do
+          expect(closest_relation(due_date:).soonest_start).to eq(Date.new(2020, 7, 14))
+        end
+      end
+
+      context "with a positive lag" do
+        it "returns the combined due date and lag" do
+          expect(closest_relation(lag: 11, due_date:).soonest_start).to eq(Date.new(2020, 7, 25))
+        end
+      end
+
+      context "with a negative lag" do
+        it "returns the combined due date and lag" do
+          pending "negative lags are not yet implemented"
+          expect(closest_relation(lag: -2, due_date:).soonest_start).to eq(Date.new(2020, 7, 12))
+        end
+      end
+    end
+
+    context "with a start date set" do
+      let(:start_date) { Date.new(2020, 7, 14) }
+
+      context "with a zero lag" do
+        it "returns the start date" do
+          expect(closest_relation(start_date:).soonest_start).to eq(Date.new(2020, 7, 14))
+        end
+      end
+
+      context "with a positive lag" do
+        it "returns the combined start date and lag" do
+          expect(closest_relation(lag: 11, start_date:).soonest_start).to eq(Date.new(2020, 7, 25))
+        end
+      end
+
+      context "with a negative lag" do
+        it "returns the combined start date and lag" do
+          pending "negative lags are not yet implemented (Feature OP#38606)"
+          expect(closest_relation(lag: -2, start_date:).soonest_start).to eq(Date.new(2020, 7, 12))
+        end
+      end
+    end
+  end
+
+  describe "#inspect" do
+    subject { closest_relation(lag: 3, due_date: Date.new(2022, 7, 4)) }
+
+    it "outputs object for debugging" do
+      expect(subject.inspect)
+        .to start_with("#<WorkPackageRelationsTab::ClosestRelation soonest_start: 2022-07-07")
+        .and include(subject.relation.inspect)
+    end
+  end
+end

--- a/spec/components/work_package_relations_tab/relations_mediator_spec.rb
+++ b/spec/components/work_package_relations_tab/relations_mediator_spec.rb
@@ -64,13 +64,16 @@ RSpec.describe WorkPackageRelationsTab::RelationsMediator do
     end
 
     describe "#closest_relations" do
-      it "returns all follows relations with the closest first" do
+      it "returns all follows relations with dates set, with the closest first" do
         expect(group.closest_relations).to eq [
           _table.relation(predecessor: predecessor2),
           _table.relation(predecessor: predecessor3),
-          _table.relation(predecessor: predecessor1),
-          _table.relation(predecessor: predecessor4)
+          _table.relation(predecessor: predecessor1)
         ]
+      end
+
+      it "does not return any follows relations without dates set" do
+        expect(group.closest_relations).not_to include(_table.relation(predecessor: predecessor4))
       end
     end
   end

--- a/spec/components/work_package_relations_tab/relations_mediator_spec.rb
+++ b/spec/components/work_package_relations_tab/relations_mediator_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe WorkPackageRelationsTab::RelationsMediator do
   describe "RelationGroup" do
     let(:group) { mediator.relation_group("follows") }
 
+    describe "#type" do
+      it "returns the type as String" do
+        expect(group.type).to eq "follows"
+      end
+
+      it "defines a predicate method for the type" do
+        expect(group.type).to be_follows
+      end
+    end
+
     describe "#closest_relation" do
       it "returns the closest follows relation" do
         expect(group.closest_relation).to eq _table.relation(predecessor: predecessor2)

--- a/spec/components/work_package_relations_tab/relations_mediator_spec.rb
+++ b/spec/components/work_package_relations_tab/relations_mediator_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageRelationsTab::RelationsMediator do
+  shared_let(:user) { create(:admin) }
+  shared_let(:work_package) { create(:work_package) }
+
+  current_user { user }
+
+  subject(:mediator) { described_class.new(work_package:) }
+
+  shared_let_work_packages(<<~TABLE)
+    hierarchy    | MTWTFSS    | scheduling mode | predecessors
+    predecessor1 | XXX        | manual          |
+    predecessor2 | XX         | manual          |
+    predecessor3 | XX         | manual          |
+    predecessor4 |            | manual          |
+    work_package |          X | automatic       | predecessor1 with lag 2, predecessor2 with lag 7, predecessor3 with lag 7, predecessor4 with lag 10
+  TABLE
+
+  describe "RelationGroup" do
+    let(:group) { mediator.relation_group("follows") }
+
+    describe "#closest_relation" do
+      it "returns the closest follows relation" do
+        expect(group.closest_relation).to eq _table.relation(predecessor: predecessor2)
+      end
+    end
+
+    describe "#closest_relation?(relation)" do
+      it "returns true if the given relation is the closest one, false otherwise" do
+        expect(group.closest_relation?(_table.relation(predecessor: predecessor2))).to be true
+        expect(group.closest_relation?(_table.relation(predecessor: predecessor1))).to be false
+      end
+    end
+
+    describe "#closest_relations" do
+      it "returns all follows relations with the closest first" do
+        expect(group.closest_relations).to eq [
+          _table.relation(predecessor: predecessor2),
+          _table.relation(predecessor: predecessor3),
+          _table.relation(predecessor: predecessor1),
+          _table.relation(predecessor: predecessor4)
+        ]
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Primerized work package relations tab",
 
       tabs.expect_counter("relations", 6)
 
-      relations_tab.expect_relation(relation_follows)
+      relations_tab.expect_closest_relation(relation_follows)
       relations_tab.expect_relation(relation_relates)
       relations_tab.expect_relation(relation_blocked)
 

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -54,17 +54,27 @@ RSpec.describe "Primerized work package relations tab",
   shared_let(:type1) { create(:type) }
   shared_let(:type2) { create(:type) }
 
-  shared_let(:wp_predecessor) do
-    create(:work_package, type: type1, subject: "wp_predecessor",
+  shared_let(:wp_predecessor1) do
+    create(:work_package, type: type1, subject: "wp_predecessor1",
                           start_date: Date.current, due_date: Date.current + 1.week)
+  end
+  shared_let(:wp_predecessor2) do
+    create(:work_package, type: type1, subject: "wp_predecessor2",
+                          start_date: Date.current, due_date: Date.current + 2.weeks)
   end
   shared_let(:wp_related) { create(:work_package, type: type2, subject: "wp_related") }
   shared_let(:wp_blocker) { create(:work_package, type: type1, subject: "wp_blocker") }
 
-  shared_let(:relation_follows) do
+  shared_let(:relation_follows1) do
     create(:relation,
            from: work_package,
-           to: wp_predecessor,
+           to: wp_predecessor1,
+           relation_type: Relation::TYPE_FOLLOWS)
+  end
+  shared_let(:relation_follows2) do
+    create(:relation,
+           from: work_package,
+           to: wp_predecessor2,
            relation_type: Relation::TYPE_FOLLOWS)
   end
   shared_let(:relation_relates) do
@@ -146,9 +156,10 @@ RSpec.describe "Primerized work package relations tab",
 
       expect(page).to have_css(relations_panel_selector)
 
-      tabs.expect_counter("relations", 6)
+      tabs.expect_counter("relations", 7)
 
-      relations_tab.expect_closest_relation(relation_follows)
+      relations_tab.expect_not_closest_relation(relation_follows1)
+      relations_tab.expect_closest_relation(relation_follows2)
       relations_tab.expect_relation(relation_relates)
       relations_tab.expect_relation(relation_blocked)
 
@@ -182,11 +193,11 @@ RSpec.describe "Primerized work package relations tab",
 
       wait_for_network_idle
 
-      relations_tab.remove_relation(relation_follows)
+      relations_tab.remove_relation(relation_follows1)
 
-      expect { relation_follows.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { relation_follows1.reload }.to raise_error(ActiveRecord::RecordNotFound)
 
-      tabs.expect_counter("relations", 5)
+      tabs.expect_counter("relations", 6)
 
       # Relations not visible due to lack of permissions on the project
       relations_tab.expect_ghost_relation(restricted_relation_relates)
@@ -201,7 +212,7 @@ RSpec.describe "Primerized work package relations tab",
       relations_tab.remove_child(child_wp)
       expect(child_wp.reload.parent).to be_nil
 
-      tabs.expect_counter("relations", 5)
+      tabs.expect_counter("relations", 6)
 
       # Relations not visible due to lack of permissions on the project
       relations_tab.expect_ghost_relation(restricted_relation_relates)
@@ -215,29 +226,29 @@ RSpec.describe "Primerized work package relations tab",
 
       wait_for_network_idle
 
-      relation_row = relations_tab.expect_relation(relation_follows)
+      relation_row = relations_tab.expect_relation(relation_follows1)
 
-      relations_tab.edit_relation_description(relation_follows, "Discovered relations have descriptions!")
+      relations_tab.edit_relation_description(relation_follows1, "Discovered relations have descriptions!")
 
-      relations_tab.edit_lag_of_relation(relation_follows, 5)
+      relations_tab.edit_lag_of_relation(relation_follows1, 5)
 
       # Reflects new description and lag
       expect(relation_row).to have_text("Discovered relations have descriptions!")
       expect(relation_row).to have_text("5 days")
 
       # Unchanged
-      tabs.expect_counter("relations", 6)
+      tabs.expect_counter("relations", 7)
       relations_tab.expect_ghost_relation(restricted_relation_relates)
       relations_tab.expect_ghost_relation(restricted_child_work_package)
 
       # Edit again
-      relations_tab.edit_relation_description(relation_follows, "And they can be edited!")
+      relations_tab.edit_relation_description(relation_follows1, "And they can be edited!")
 
       # Reflects new description
       expect(relation_row).to have_text("And they can be edited!")
 
       # Unchanged
-      tabs.expect_counter("relations", 6)
+      tabs.expect_counter("relations", 7)
 
       # Relations not visible due to lack of permissions on the project
       relations_tab.expect_ghost_relation(restricted_relation_relates)
@@ -313,7 +324,7 @@ RSpec.describe "Primerized work package relations tab",
       relations_tab.expect_relation(wp_successor)
 
       # Bumped by one
-      tabs.expect_counter("relations", 7)
+      tabs.expect_counter("relations", 8)
       # Relation is created
       expect(Relation.follows.where(from: wp_successor, to: work_package)).to exist
 
@@ -344,13 +355,13 @@ RSpec.describe "Primerized work package relations tab",
       relations_tab.expect_relation(wp_blocks)
 
       # Bumped by one
-      tabs.expect_counter("relations", 7)
+      tabs.expect_counter("relations", 8)
       # Relation is created
       expect(Relation.blocks.where(from: wp_blocks, to: work_package)).to exist
     end
 
     it "does not autocomplete unrelatable work packages" do
-      # wp_predecessor is already related to work_package as relation_follows
+      # wp_predecessor1 is already related to work_package as relation_follows
       # in a predecessor relation, so it should not be autocompleteable anymore
       # under the "Predecessor (before)" type
       relations_tab.select_relation_type "Predecessor (before)"
@@ -362,10 +373,10 @@ RSpec.describe "Primerized work package relations tab",
 
         autocomplete_field = page.find("[data-test-selector='work-package-relation-form-to-id']")
         search_autocomplete(autocomplete_field,
-                            query: wp_predecessor.subject,
+                            query: wp_predecessor1.subject,
                             results_selector: "body")
         expect_no_ng_option(autocomplete_field,
-                            wp_predecessor.subject,
+                            wp_predecessor1.subject,
                             results_selector: "body")
       end
     end
@@ -377,13 +388,13 @@ RSpec.describe "Primerized work package relations tab",
 
       wait_for_network_idle
 
-      tabs.expect_counter("relations", 6)
+      tabs.expect_counter("relations", 7)
 
       relations_tab.add_existing_child(not_child_yet_wp)
       relations_tab.expect_child(not_child_yet_wp)
 
       # Bumped by one
-      tabs.expect_counter("relations", 7)
+      tabs.expect_counter("relations", 8)
 
       # Child relation is created
       expect(not_child_yet_wp.reload.parent).to eq work_package
@@ -444,7 +455,7 @@ RSpec.describe "Primerized work package relations tab",
 
       wait_for_network_idle
 
-      tabs.expect_counter("relations", 6)
+      tabs.expect_counter("relations", 7)
 
       relations_tab.expect_no_add_relation_button
       relations_tab.expect_no_relatable_action_menu(wp_related)
@@ -461,7 +472,7 @@ RSpec.describe "Primerized work package relations tab",
 
         wait_for_network_idle
 
-        tabs.expect_counter("relations", 6)
+        tabs.expect_counter("relations", 7)
 
         # The menu is shown as the user can add a relation
         relations_tab.expect_add_relation_button
@@ -484,7 +495,7 @@ RSpec.describe "Primerized work package relations tab",
 
         wait_for_network_idle
 
-        tabs.expect_counter("relations", 6)
+        tabs.expect_counter("relations", 7)
 
         # The menu is shown as the user can add a child
         relations_tab.expect_add_relation_button

--- a/spec/support/capybara/primer_component_selectors.rb
+++ b/spec/support/capybara/primer_component_selectors.rb
@@ -45,6 +45,14 @@ Capybara.add_selector :primer_label, locator_type: [String, Symbol] do
            end
     text.public_send(exact ? :eql? : :include?, locator.to_s)
   end
+
+  expression_filter :scheme do |expr, scheme|
+    builder(expr).add_attribute_conditions(class: "Label--#{scheme.downcase}")
+  end
+
+  describe_expression_filters do |scheme: nil, **|
+    " with scheme #{scheme.inspect}" if scheme
+  end
 end
 
 module Capybara

--- a/spec/support/capybara/primer_component_selectors.rb
+++ b/spec/support/capybara/primer_component_selectors.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+Capybara.add_selector :primer_label, locator_type: [String, Symbol] do
+  label "Primer Label"
+
+  css do |*|
+    ".Label"
+  end
+
+  locator_filter skip_if: nil do |node, locator, exact:, **|
+    text = if node[:"aria-labelledby"]
+             CapybaraAccessibleSelectors::Helpers.element_labelledby(node)
+           elsif node[:"aria-label"]
+             node[:"aria-label"]
+           else
+             node.text
+           end
+    text.public_send(exact ? :eql? : :include?, locator.to_s)
+  end
+end
+
+module Capybara
+  module RSpecMatchers
+    def have_primer_label(locator = nil, **, &)
+      Matchers::HaveSelector.new(:primer_label, locator, **, &)
+    end
+
+    def have_no_primer_label(...)
+      Matchers::NegatedMatcher.new(have_primer_label(...))
+    end
+  end
+end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -257,12 +257,11 @@ module Components
       end
 
       def expect_closest_relation(relatable)
-        actual_relatable = find_relatable(relatable)
-        relation_row = find_row(actual_relatable)
+        expect(find_row(relatable)).to have_css(".Label", text: "Closest")
+      end
 
-        within relation_row do
-          expect(it).to have_css(".Label", text: "Closest")
-        end
+      def expect_not_closest_relation(relatable)
+        expect(find_row(relatable)).not_to have_css(".Label", text: "Closest")
       end
 
       def expect_ghost_relation(relatable)

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -257,11 +257,11 @@ module Components
       end
 
       def expect_closest_relation(relatable)
-        expect(find_row(relatable)).to have_css(".Label", text: "Closest")
+        expect(find_row(relatable)).to have_primer_label("Closest")
       end
 
       def expect_not_closest_relation(relatable)
-        expect(find_row(relatable)).not_to have_css(".Label", text: "Closest")
+        expect(find_row(relatable)).to have_no_primer_label("Closest")
       end
 
       def expect_ghost_relation(relatable)

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -256,6 +256,15 @@ module Components
         find_row(relatable)
       end
 
+      def expect_closest_relation(relatable)
+        actual_relatable = find_relatable(relatable)
+        relation_row = find_row(actual_relatable)
+
+        within relation_row do
+          expect(it).to have_css(".Label", text: "Closest")
+        end
+      end
+
       def expect_ghost_relation(relatable)
         find_ghost_row(relatable)
       end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -257,11 +257,11 @@ module Components
       end
 
       def expect_closest_relation(relatable)
-        expect(find_row(relatable)).to have_primer_label("Closest")
+        expect(find_row(relatable)).to have_primer_label("Closest", scheme: :primary)
       end
 
       def expect_not_closest_relation(relatable)
-        expect(find_row(relatable)).to have_no_primer_label("Closest")
+        expect(find_row(relatable)).to have_no_primer_label("Closest", scheme: :primary)
       end
 
       def expect_ghost_relation(relatable)


### PR DESCRIPTION
⚠️ **This PR is based off of #17806** - please review/merge that work first.

# Ticket

https://community.openproject.org/wp/59540

# What are you trying to accomplish?

Provide a visual indication of the closest predecessor in the Relations tab and Work Package date picker.

## Screenshots

| Relations tab | Date picker |
|---------------|-------------|
| ![Screenshot 2025-02-26 at 11 47 28](https://github.com/user-attachments/assets/b956fba2-b559-46af-b567-7e498cfee10a) | ![Screenshot 2025-02-26 at 11 52 05](https://github.com/user-attachments/assets/2a634cea-8cdd-481c-8772-b3f806cee596) | 

https://github.com/user-attachments/assets/f01adfec-4f5f-4637-aaae-f58019bb0aaa

# What approach did you choose and why?

The logic to determine the closest relation is in UI (component) code rather than the model. Based on the requirements, I think this is UI logic rather than business logic.

`WorkPackageRelationsTab::ClosestRelation` is a custom comparator that does "the heavy lifting" by encapsulate the sorting logic.

**For discussion: a few ideas for possible improvements**

1. subclass `WorkPackageRelationsTab::RelationComponent`, creating `ChildRelationComponent` and `PredecessorRelationComponent` that accept only the necessary parameters. It would enable us to remove a bunch of branch logic (i.e. `if parent_child_relationship?`) in the base class.
2. We could also consider using the decorator/presenter pattern and making `ClosestRelation` delegate all missing methods to `relation`. `ClosestRelation` would take on some UI logic responsibility, rather than just comparison. (I prefer the first idea for improvement though).
3. Optimise iterating over relations and relation groups - there is scope for this, but it doesn't need to be done now (_premature optimisation and all that 😄_ )
4. Component specs for `WorkPackageRelationsTab::RelationComponent` itself.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
