### PR TITLE
Ensure human_attribute_name is present on ServiceResult

### DIFF
--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -223,6 +223,13 @@ class ServiceResult
     @state ||= ::Shared::ServiceState.build
   end
 
+  ##
+  # Required as we create an errors object bound to this ServiceResult.
+  # calling `errors#full_messages` will call `human_attribute_name` here.
+  def self.human_attribute_name(*)
+    ApplicationRecord.human_attribute_name(*)
+  end
+
   private
 
   def initialize_errors(errors)

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -151,6 +151,16 @@ RSpec.describe ServiceResult, type: :model do
         expect(instance.errors).not_to eq result.errors
       end
     end
+
+    context "when using default errors" do
+      it "uses the default human_attribute_name from ServiceResult (Regression #61483)" do
+        instance = described_class.new
+        instance.errors.add(:base, "some error")
+        instance.errors.add(:foo, "an error for foo")
+
+        expect { instance.errors.full_messages }.not_to raise_error
+      end
+    end
   end
 
   describe "result" do


### PR DESCRIPTION
Stopgap for, should probably fix by not allowing ServiceResult as base. https://community.openproject.org/work_packages/61483
