### PR TITLE
Compare with beginning_of_day for meeting index groups

### DIFF
--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -369,7 +369,10 @@ class MeetingsController < ApplicationController
   end
 
   def group_meetings(all_meetings) # rubocop:disable Metrics/AbcSize
-    next_week = Time.current.next_occurring(Redmine::I18n.start_of_week)
+    next_week = Time
+      .current
+      .next_occurring(Redmine::I18n.start_of_week)
+      .beginning_of_day
     groups = Hash.new { |h, k| h[k] = [] }
     groups[:later] = show_more_pagination(all_meetings
                                             .where(start_time: next_week..)


### PR DESCRIPTION


# Ticket
https://community.openproject.org/work_packages/61486

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
We compared with next_week datetime _at the current_ time. Which means if you compare at e.g., 11AM, you would include Monday 10AM into earlier groups.

# Merge checklist

- [x] Added/updated tests
