### PR TITLE
Fix quote flaky test

### DIFF
--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -796,7 +796,6 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         activity_tab.quote_comment(first_comment_by_member)
 
         # expect the quoted comment to be shown
-        # include value because ckeditor is returning a bunch of invisible characters and breaking the check
         activity_tab.ckeditor.expect_include_value("@A Member wrote:\nFirst comment by member")
       end
     end
@@ -817,7 +816,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         activity_tab.quote_comment(first_comment_by_member)
 
         # expect the original comment and quote are shown
-        activity_tab.ckeditor.expect_value("Partial message:\n@A Member wrote:\nFirst comment by member")
+        activity_tab.ckeditor.expect_include_value("Partial message:\n@A Member wrote:\nFirst comment by member")
       end
     end
   end

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -287,10 +287,6 @@ module Components
         end
 
         expect(page).to have_test_selector("op-work-package-journal-form-element")
-
-        page.within_test_selector("op-work-package-journal-form-element") do
-          page.find_test_selector("op-submit-work-package-journal-form").click
-        end
       end
 
       def get_all_comments_as_array


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61488

# What are you trying to accomplish?
Fix flaky spec

# What approach did you choose and why?
`quote_comment` was submitting the comment as well. So there was a window where the ckeditor would still have the expected text. Now I removed the submit, so it should be more consistently finding the expected value inside the editor.