### PR TITLE
[60629] Display messed up after creating child from relations tab in split view

### DIFF
--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -181,6 +181,9 @@ export function initializeUiRouterListeners(injector:Injector) {
     // Re-find the current app-base
     openprojectBaseApp = document.querySelector(appBaseSelector);
     uiRouter.urlService.sync();
+
+    // Re-apply the body classes
+    bodyClass(_.get(uiRouter.globals.current, 'data.bodyClasses'), 'add');
   });
 
   // Uncomment to trace route changes

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -64,6 +64,34 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
       end
     end
 
+    context "when being on the split screen" do
+      let(:wp_split_page) { Pages::SplitWorkPackage.new(work_package, project) }
+
+      it "can render the page correctly after creation (regression #60629)" do
+        wp_split_page.visit_tab!("relations")
+        relations_tab.expect_add_relation_button
+        relations_tab.expect_new_relation_type("New child")
+        relations_tab.expect_new_relation_type("Existing child")
+
+        relations_tab.select_relation_type "New child"
+
+        create_dialog.select_type "Risk"
+        create_dialog.set_subject "Hello there"
+        create_dialog.set_custom_field(required_cf, "Custom value")
+
+        create_dialog.submit
+
+        wait_for_network_idle
+
+        page.within("#work-package-relations-tab-content") do
+          expect(page).to have_content("Hello there")
+          expect(page).to have_content("RISK")
+        end
+
+        expect(page).to have_css("body.router--work-packages-partitioned-split-view-details")
+      end
+    end
+
     context "when work package is a milestone and user does not have manage_work_package_relations permission" do
       let(:work_package) { create(:work_package, type: type_milestone, project:, subject: "Milestone") }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/60629/activity

# What are you trying to accomplish?
After creating a Child via the relations tab from split screen, the page layout was completely broken. This happened because we use `redirect_back` in the children creation controller to refresh the page that called the dialog. For whatever reason, this is however not a complete reload as the angular uiRouter is not triggered. Thus, the bodyClasses are missing and the page layout breaks. 
This PR adds the bodyClasses on `turbo:load` which is somehow circumventing the actual problem as it is not turbo related. However, the `turbo:load` event is fired when `redirect_back` is called.

