### PR TITLE
Wait for cost entry to update after save before test assertion

### DIFF
--- a/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
@@ -149,7 +149,9 @@ RSpec.describe "Work Package cost fields", :js do
       fill_in "cost_entry_overridden_costs", with: "55.000,55"
       click_on I18n.t(:button_save)
 
-      expect(page).to have_css("#cost_entry_costs", text: "55.000,55 EUR")
+      # Add explicit wait for the updated cost value
+      wait_for { page }.to have_css("#cost_entry_costs", text: "55.000,55 EUR")
+
       entry.reload
       expect(entry.units).to eq(1.42)
       expect(entry.costs).to eq(2.84)


### PR DESCRIPTION
Allow the page to update after saving the cost entry. Avoid possible race condition where the test was checking the value before the page has finished updating

https://github.com/opf/openproject/actions/runs/13326139713/job/37219715506

```
modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb:110 # Work Package cost fields with german locale creates the budget including the given cost items with german locale
```