### PR TITLE
[#61466] show hover cards in WP multi select CFs

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -56,7 +56,6 @@ import { addFiltersToPath } from 'core-app/core/apiv3/helpers/add-filters-to-pat
 import { UserAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component';
 import { IUser } from 'core-app/core/state/principals/user.model';
 import { compareByAttribute } from 'core-app/shared/helpers/angular/tracking-functions';
-import { SHOW_USER_HOVER_CARD } from 'core-app/shared/components/time_entries/create/create.modal';
 
 export const usersAutocompleterSelector = 'op-user-autocompleter';
 
@@ -96,17 +95,11 @@ export class UserAutocompleterComponent extends OpAutocompleterComponent<IUserAu
   @Output() public userInvited = new EventEmitter<HalResource>();
 
   @InjectField(OpInviteUserModalService) opInviteUserModalService:OpInviteUserModalService;
-  @InjectField(SHOW_USER_HOVER_CARD, true) showUserHoverCard:boolean;
 
   getOptionsFn = this.getAvailableUsers.bind(this);
 
   ngOnInit():void {
     super.ngOnInit();
-
-    // Disabling hover cards by injection takes precedence over the input setting
-    if (!this.showUserHoverCard) {
-      this.hoverCards = false;
-    }
 
     this.applyTemplates(UserAutocompleterTemplateComponent, {
       inviteUserToProject: this.inviteUserToProject,

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.html
@@ -21,6 +21,8 @@
   <ng-template ng-option-tmp let-item="item">
     <span
       class="ng-option-label ellipsis"
+      [attr.data-hover-card-trigger-target]="getHoverCardTriggerTarget()"
+      [attr.data-hover-card-url]="getHoverCardUrl(item)"
       [textContent]="item.name"
       [ngStyle]="{'padding-left.px': item.depth * 16}"
     ></span>

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -243,7 +243,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
    * For multi-select fields that are of type User, we want to show a hover card when hovering over users in the
    * dropdown. For this to happen we must define a URL for the hover card.
    */
-  protected getHoverCardUrl(item:any) {
+  protected getHoverCardUrl(item:{ id?:string }) {
     if (item && item.id) {
       return this.pathHelperService.userHoverCardPath(item.id);
     }

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -34,6 +34,7 @@ import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-
 import { ValueOption } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Component({
   templateUrl: './multi-select-edit-field.component.html',
@@ -42,6 +43,8 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   @ViewChild(NgSelectComponent, { static: true }) public ngSelectComponent:NgSelectComponent;
 
   @InjectField() I18n!:I18nService;
+
+  @InjectField() pathHelperService:PathHelperService;
 
   public availableOptions:any[] = [];
 
@@ -223,4 +226,30 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
       this.currentValueInvalid = !!this.schema.required;
     }
   }
+
+  /**
+   * For multi-select fields that are of type User, we want to show a hover card when hovering over users in the
+   * dropdown. For this to happen we must register a trigger target.
+   */
+  protected getHoverCardTriggerTarget() {
+    if (this.schema?.type === '[]User') {
+      return 'trigger';
+    } else {
+      return '';
+    }
+  }
+
+  /**
+   * For multi-select fields that are of type User, we want to show a hover card when hovering over users in the
+   * dropdown. For this to happen we must define a URL for the hover card.
+   */
+  protected getHoverCardUrl(item:any) {
+    if (item && item.id) {
+      return this.pathHelperService.userHoverCardPath(item.id);
+    }
+
+    return '';
+  }
+
+  protected readonly getComputedStyle = getComputedStyle;
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -234,9 +234,9 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   protected getHoverCardTriggerTarget() {
     if (this.schema?.type === '[]User') {
       return 'trigger';
-    } else {
-      return '';
     }
+
+    return '';
   }
 
   /**

--- a/frontend/src/app/shared/components/principal/principal-renderer.service.ts
+++ b/frontend/src/app/shared/components/principal/principal-renderer.service.ts
@@ -6,13 +6,11 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { IPrincipal } from 'core-app/core/state/principals/principal.model';
 import { PrincipalLike } from './principal-types';
 import { hrefFromPrincipal, PrincipalType, typeFromHref } from './principal-helper';
-import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outlet-target.enum';
 
 export type AvatarSize = 'default'|'medium'|'mini';
 
 export interface HoverCardOptions {
   url?:string;
-  modalTarget?:PortalOutletTarget;
 }
 
 export interface AvatarOptions {
@@ -255,13 +253,13 @@ export class PrincipalRendererService {
   }
 
   private setHoverCardAttributes(element:HTMLElement, options:AvatarOptions, principal:PrincipalLike|IPrincipal):void {
-    const hoverCard = options.hoverCard;
+    const hoverCard = options.hoverCard || {};
 
     if (!hoverCard?.url) {
       // In some cases, there is no URL given although a hover card is expected. For example when the principle
       // is rendered from an angular template. We try to infer the URL here.
       const url = this.userHoverCardUrl(principal);
-      if (hoverCard && url) {
+      if (url) {
         hoverCard.url = url;
       } else {
         return;

--- a/frontend/src/app/shared/components/time_entries/create/create.modal.ts
+++ b/frontend/src/app/shared/components/time_entries/create/create.modal.ts
@@ -1,10 +1,8 @@
-import { ChangeDetectionStrategy, Component, InjectionToken } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { TimeEntryBaseModal } from '../shared/modal/base.modal';
-
-export const SHOW_USER_HOVER_CARD = new InjectionToken('SHOW_USER_HOVER_CARD');
 
 @Component({
   templateUrl: '../shared/modal/base.modal.html',


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61466

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show the hover card for multi user CF within work packages.

I did not find an easy way to display the popover for the tagged selections while the dropdown is open. See attached GIF. Since you can get the popover when the dropdown is not visible, there is an easy workaround for our users.

## Screenshots

![multiuser_cf](https://github.com/user-attachments/assets/22f53631-df3d-49e5-ae75-ee2405f8f978)


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
