### PR TITLE
Disable ActionFilter cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -181,6 +181,10 @@ Rails/HttpPositionalArguments:
 Rails/RequireDependency:
   Enabled: true
 
+# Disable deprecated actionfilter
+Rails/ActionFilter:
+  Enabled: false
+
 # For feature specs, we tend to have longer specs that cover a larger part of the functionality.
 # This is done for multiple reasons:
 # * performance, as setting up integration tests is costly


### PR DESCRIPTION
this cop causes issues in the recent version of rubocop. The cop itself is deprecated: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactionfilter
