### PR TITLE
[61543] Big space below the comment box on mobile 

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -1,7 +1,11 @@
 <%=
-  unless deferred
+  if deferred
+    render(
+      WorkPackages::ActivitiesTab::Journals::IndexComponent.new(work_package:, filter:, deferred:)
+    )
+  else
     content_tag("turbo-frame", id: "work-package-activities-tab-content") do
-      flex_layout(classes: "work-packages-activities-tab-index-component", mb: [5, 5, 5, 5, 0]) do |activties_tab_wrapper_container|
+      flex_layout(classes: "work-packages-activities-tab-index-component") do |activties_tab_wrapper_container|
         activties_tab_wrapper_container.with_row(classes: "work-packages-activities-tab-index-component--errors") do
           render(
             WorkPackages::ActivitiesTab::ErrorStreamComponent.new
@@ -18,7 +22,7 @@
                   )
                 )
               end
-              activties_tab_container.with_row(flex_layout: true, mt: 3) do |journals_wrapper_container|
+              activties_tab_container.with_row(flex_layout: true, classes: "work-packages-activities-tab-index-component--content-container", mt: 3) do |journals_wrapper_container|
                 journals_wrapper_container.with_row(
                   classes: "work-packages-activities-tab-index-component--journals-container work-packages-activities-tab-index-component--journals-container_with-initial-input-compensation",
                   data: { "work-packages--activities-tab--index-target": "journalsContainer" }
@@ -30,10 +34,8 @@
                 if adding_comment_allowed?
                   journals_wrapper_container.with_row(
                     classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
-                    mt: 3,
-                    pt: 2,
-                    pb: 2,
-                    pl: 3,
+                    px: 2,
+                    py: 3,
                     bg: :subtle
                   ) do
                     render(
@@ -47,9 +49,5 @@
         end
       end
     end
-  else
-    render(
-      WorkPackages::ActivitiesTab::Journals::IndexComponent.new(work_package:, filter:, deferred:)
-    )
   end
 %>

--- a/app/components/work_packages/activities_tab/index_component.sass
+++ b/app/components/work_packages/activities_tab/index_component.sass
@@ -1,5 +1,8 @@
-@mixin activities-tab-component($breakpoint, $input-container-padding-right: 10px, $input-container-margin-bottom: 20px)
+@mixin activities-tab-component($breakpoint, $input-container-padding-right: 10px)
     overflow-y: hidden
+    &--content-container
+        row-gap: var(--Layout-row-gap)
+
     &--errors
         position: absolute
         width: calc(100% - 22px)
@@ -22,13 +25,12 @@
             margin-bottom: 180px
             @media screen and (max-width: $breakpoint)
                 margin-bottom: -16px
-                
+
     &--input-container
         z-index: 10
         border-radius: var(--borderRadius-medium)
         border: none
-        padding-right: 16px
-        margin-bottom: $input-container-margin-bottom
+        margin-bottom: 16px
         @media screen and (min-width: $breakpoint)
             position: absolute
             min-height: 60px
@@ -37,12 +39,13 @@
             right: 0
             border-radius: 0px
             border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
-            padding-right: $input-container-padding-right
-            margin-bottom: 0px
+            padding-right: $input-container-padding-right !important
+            margin-bottom: 0 !important
 
         &_sort-desc
             @media screen and (max-width: $breakpoint)
                 order: -1
+                margin-bottom: 0
 
 .work-packages-activities-tab-index-component
     @include activities-tab-component($breakpoint-xl)
@@ -53,4 +56,4 @@
 
 .work-packages-activities-tab-index-component--within-split-screen
     .work-packages-activities-tab-index-component
-        @include activities-tab-component($breakpoint-sm, 10px, 10px)
+        @include activities-tab-component($breakpoint-sm)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/61543/activity

# What are you trying to accomplish?
reduce spacing around the comment box

## Screenshots
**Before**
<img width="500" alt="Bildschirmfoto 2025-02-17 um 14 34 00" src="https://github.com/user-attachments/assets/460d923e-bfa9-43a8-b7f4-23e7cbb7fa2e" />
<img width="500" alt="Bildschirmfoto 2025-02-17 um 14 33 50" src="https://github.com/user-attachments/assets/5a371ff5-a3cf-4f04-b8bb-e0344bae37f4" />


**After**
<img width="500" alt="Bildschirmfoto 2025-02-17 um 14 54 12" src="https://github.com/user-attachments/assets/db447e47-1c68-4e94-9792-6b2a4a409db6" />

<img width="500" alt="Bildschirmfoto 2025-02-17 um 14 54 20" src="https://github.com/user-attachments/assets/c9130633-fd00-4b34-b9bd-5589571ffec9" />
