### PR TITLE
[60858] In add relation dialog, selecting a WP that user doesn't have permission to edit raises an error

### DIFF
--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -48,6 +48,10 @@ module WorkPackages
     default_attribute_permission :edit_work_packages
     attribute_permission :project_id, :move_work_packages
 
+    def can_set_parent?
+      @can.allowed?(model, :edit)
+    end
+
     private
 
     def user_allowed_to_edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1410,6 +1410,7 @@ en:
               must_be_empty_when_work_is_empty_and_percent_complete_is_100p: >-
                 must be empty when Work is empty and % Complete is 100%.
           readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
+          lack_of_permission: "Cannot add child because work package is read-only."
         type:
           attributes:
             attribute_groups:


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60858

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Before adding a child, we check if the user has permission to edit the selected WP and set a parent for it.

## Screenshots

![Screenshot 2025-02-17 at 16 51 35](https://github.com/user-attachments/assets/d8a1869c-aec5-4e37-947d-e61704c01284)

# What approach did you choose and why?
Create a method in update contract of Workpackages to check if the user has permission to edit the WP and then call this method before setting a WP as Child in relations tab.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
