### PR TITLE
[61551] Fix: make child creation from relations tab work in status-based progress calculation mode

### DIFF
--- a/app/forms/work_packages/dialogs/create_form.rb
+++ b/app/forms/work_packages/dialogs/create_form.rb
@@ -94,7 +94,10 @@ module WorkPackages::Dialogs
       render_custom_fields(form: f)
 
       # Keep hidden fields for relevant changes
-      work_package.changes.except(:description, :subject, :type_id).each do |attribute, value|
+      work_package.changes
+                  .slice(*writable_attributes)
+                  .except(:description, :subject, :type_id)
+                  .each do |attribute, value|
         f.hidden(name: attribute, value:)
       end
     end
@@ -111,6 +114,11 @@ module WorkPackages::Dialogs
 
     def custom_fields
       @custom_fields ||= work_package.available_custom_fields.select(&:required?)
+    end
+
+    def writable_attributes
+      contract = WorkPackages::CreateContract.new(work_package, User.current)
+      contract.writable_attributes
     end
   end
 end

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -118,6 +118,25 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
         relations_tab.expect_no_new_relation_type("New child")
       end
     end
+
+    context "in status-based progress calculation mode (bug #61551)",
+            with_settings: { work_package_done_ratio: "status" } do
+      it "can add a new child" do
+        wp_page.visit_tab!("relations")
+        relations_tab.select_relation_type "New child"
+
+        create_dialog.select_type "Task"
+        create_dialog.set_subject "Hello there"
+        create_dialog.submit
+
+        wait_for_network_idle
+
+        page.within("#work-package-relations-tab-content") do
+          expect(page).to have_content("Hello there")
+          expect(page).to have_content("TASK")
+        end
+      end
+    end
   end
 
   context "without permissions to add children" do


### PR DESCRIPTION
In status-based mode, the done_ratio is automatically added to the work package, and it's read-only too. It should not be submitted as a hidden field in the create child dialog form.

Excluding all read-only attributes from being submitted as hidden fields fixes the issue.

# Ticket

https://community.openproject.org/wp/61551

# What are you trying to accomplish?

In status-based mode, it's not possible to create child work package from the relations tab.

It's because hidden parameters are added to the form based on the work package default values, and in status based mode, the % complete value gets a default value, but it's also read-only so submitting the form sends a 400 error.

# What approach did you choose and why?

Excluding all read-only attributes from being added to the create form as hidden fields, so it fixes this issue, and it could fix potential similar issues.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
