### PR TITLE
Allow to configure SSO with fallback to two-way OAuth 2.0

### DIFF
--- a/modules/storages/app/common/storages/peripherals/nextcloud_storage_wizard.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_storage_wizard.rb
@@ -44,13 +44,13 @@ module Storages
 
       step :oauth_application,
            section: :oauth_configuration,
-           if: ->(storage) { !storage.authenticate_via_idp? },
+           if: ->(storage) { storage.authenticate_via_storage? },
            completed_if: ->(storage) { storage.oauth_application.present? },
            preparation: :prepare_oauth_application
 
       step :oauth_client,
            section: :oauth_configuration,
-           if: ->(storage) { !storage.authenticate_via_idp? },
+           if: ->(storage) { storage.authenticate_via_storage? },
            completed_if: ->(storage) { storage.oauth_client.present? },
            preparation: ->(storage) { storage.build_oauth_client }
 

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
@@ -43,13 +43,13 @@ module Storages
 
               def call(user:, storage:)
                 with_tagged_logger do
-                  sso_preferred = storage.audience.present? && oidc_provider_for(user)
+                  sso_preferred = storage.authenticate_via_idp? && oidc_provider_for(user)
 
                   if sso_preferred
                     ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::SsoUserToken
                       .strategy
                       .with_user(user)
-                  elsif storage.oauth_client.present?
+                  elsif storage.authenticate_via_storage?
                     ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
                       .strategy
                       .with_user(user)

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -35,7 +35,7 @@ module Storages
       username: "OpenProject"
     }.freeze
 
-    AUTHENTICATION_METHODS = %w[two_way_oauth2 oauth2_sso].freeze
+    AUTHENTICATION_METHODS = %w[two_way_oauth2 oauth2_sso oauth2_sso_with_two_way_oauth2_fallback].freeze
 
     store_attribute :provider_fields, :automatically_managed, :boolean
     store_attribute :provider_fields, :username, :string
@@ -71,7 +71,11 @@ module Storages
     end
 
     def authenticate_via_idp?
-      authentication_method == "oauth2_sso"
+      %w[oauth2_sso oauth2_sso_with_two_way_oauth2_fallback].include?(authentication_method)
+    end
+
+    def authenticate_via_storage?
+      %w[two_way_oauth2 oauth2_sso_with_two_way_oauth2_fallback].include?(authentication_method)
     end
 
     def configuration_checks

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -80,8 +80,8 @@ module Storages
 
     def configuration_checks
       {
-        storage_oauth_client_configured: oauth_client.present?,
-        openproject_oauth_application_configured: oauth_application.present?,
+        storage_oauth_client_configured: !authenticate_via_storage? || oauth_client.present?,
+        openproject_oauth_application_configured: !authenticate_via_storage? || oauth_application.present?,
         host_name_configured: host.present? && name.present?,
         nextcloud_audience_configured: !authenticate_via_idp? || nextcloud_audience.present?
       }

--- a/modules/storages/app/services/storages/storages/create_service.rb
+++ b/modules/storages/app/services/storages/storages/create_service.rb
@@ -48,8 +48,6 @@ module Storages::Storages
       return service_call unless create_oauth_app?
 
       storage = service_call.result
-      # Automatically create an OAuthApplication object for the Nextcloud storage
-      # using values from storage (particularly :host) as defaults
       if storage.provider_type_nextcloud? && !storage.authenticate_via_idp?
         persist_service_result = ::Storages::OAuthApplications::CreateService.new(storage:, user:).call
         storage.oauth_application = persist_service_result.result if persist_service_result.success?

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       storages/nextcloud_storage:
         authentication_methods:
           oauth2_sso: Single-Sign-On through OpenID Connect Identity Provider
+          oauth2_sso_with_two_way_oauth2_fallback: Single-Sign-On with Two-Way OAuth 2.0 as fallback
           two_way_oauth2: Two-way OAuth 2.0 authorization code flow
         nextcloud_audience: Nextcloud Audience
       storages/project_storage:

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies/user_bound_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies/user_bound_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::AuthenticationStrategi
     end
 
     context "if file storage is configured for sso and oauth" do
-      let(:storage) { create(:nextcloud_storage_configured, :oidc_sso_enabled) }
+      let(:storage) { create(:nextcloud_storage_configured, :oidc_sso_with_fallback) }
 
       it "must use an SsoUserToken strategy" do
         strategy = described_class.call(user:, storage:)
@@ -77,7 +77,7 @@ RSpec.describe Storages::Peripherals::StorageInteraction::AuthenticationStrategi
     end
 
     context "if file storage is configured for sso and oauth" do
-      let(:storage) { create(:nextcloud_storage_configured, :oidc_sso_enabled) }
+      let(:storage) { create(:nextcloud_storage_configured, :oidc_sso_with_fallback) }
 
       it "must use an OAuthUserToken strategy" do
         strategy = described_class.call(user:, storage:)
@@ -93,15 +93,14 @@ RSpec.describe Storages::Peripherals::StorageInteraction::AuthenticationStrategi
         expect(strategy.key).to eq(:oauth_user_token)
       end
     end
-  end
 
-  context "if file storage is not fully configured" do
-    let(:user) { create(:user) }
-    let(:storage) { create(:nextcloud_storage) }
+    context "if file storage is configured for oauth only, but client and app not fully configured" do
+      let(:storage) { create(:nextcloud_storage) }
 
-    it "must return the failure strategy" do
-      strategy = described_class.call(user:, storage:)
-      expect(strategy.key).to eq(:failure)
+      it "returns the configured strategy" do
+        strategy = described_class.call(user:, storage:)
+        expect(strategy.key).to eq(:oauth_user_token)
+      end
     end
   end
 end

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -99,6 +99,11 @@ FactoryBot.define do
       authentication_method { "oauth2_sso" }
     end
 
+    trait :oidc_sso_with_fallback do
+      nextcloud_audience { "nextcloud" }
+      authentication_method { "oauth2_sso_with_two_way_oauth2_fallback" }
+    end
+
     trait :as_automatically_managed do
       automatic_management_enabled { true }
       username { "OpenProject" }

--- a/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
+++ b/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
@@ -133,6 +133,23 @@ RSpec.describe Storages::NextcloudStorage do
           expect(storage.configuration_checks[:storage_oauth_client_configured]).to be(false)
         end
       end
+
+      context "when storage authenticates through IDP" do
+        let(:storage) do
+          build(:nextcloud_storage,
+                authentication_method: "oauth2_sso",
+                nextcloud_audience: "some")
+        end
+
+        it "returns true" do
+          expect(storage.configured?).to be(true)
+
+          aggregate_failures "configuration_checks" do
+            expect(storage.configuration_checks[:openproject_oauth_application_configured]).to be(true)
+            expect(storage.configuration_checks[:storage_oauth_client_configured]).to be(true)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Our code to select how we authenticate mostly accounted for this already, so it was just a matter of allowing admins to configure it.

We now focus on what's been explicitly configured, so that it is not necessary to clear the audience or the oauth client/application just when changing the settings. Otherwise stale configuration could lead to the wrong authentication to happen contrary to the configuration.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61532

# Merge checklist

- [x] Added/updated tests
- [x] Tested Firefox
