### PR TITLE
Use the plugin declaration for rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,14 @@
 require:
   - rubocop-openproject
-  - rubocop-rspec
   - rubocop-rspec_rails
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
   - ./config/initializers/inflections.rb
 
-plugins: rubocop-rails
+plugins:
+  - rubocop-rails
+  - rubocop-rspec
 
 # A rubocop-local.yml file can be added to customized the styles
 inherit_from:


### PR DESCRIPTION
# Ticket

N/A

# WAT ?

Avoid notification of:

```
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /Users/jensulferts/Documents/b/reddev/openproject/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```

last time, while a similar warning for rails was shown, the cops for it were in fact broken.
