### PR TITLE
Fix mail handler attributes when translated, and provide stable default

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -355,7 +355,10 @@ class MailHandler < ActionMailer::Base
   end
 
   def human_attr_translations(attr)
-    keys = [attr.to_s.humanize]
+    keys = [
+      attr.to_s,
+      attr.to_s.humanize
+    ]
 
     [user&.language, Setting.default_language].compact_blank.each do |lang|
       keys << all_attribute_translations(lang)[attr]

--- a/docs/installation-and-operations/configuration/incoming-emails/README.md
+++ b/docs/installation-and-operations/configuration/incoming-emails/README.md
@@ -180,21 +180,22 @@ OR set it as fixed variable with `project=identifier`.
 
 The subject of the work package that shall be created is derived from the subject of the email. The body of the email gets parsed and all lines that contain recognized keys are removed. What is left will become the description.
 
-Other available keys for the email are:
+Other available keys for the email are as follows. You can always use the internal **Key** or the **Name** of the attribute. The name will depend on the system's default language or the selected language of the user identified through the email address.
 
-| Key             | Description                                           | Example                          |
-|-----------------|-------------------------------------------------------|----------------------------------|
-| Project         | sets the project. Use the project identifier          | Project:test\_project            |
-| Accountable     | sets the accountable, via user email or login         | Accountable:user@example.org     |
-| Assignee        | sets the assignee. Use the email or login of the user | Assignee:test.nutzer@example.org |
-| Type            | sets the type                                         | type:Milestone                   |
-| Version         | sets the version                                      | version:v4.1.0                   |
-| Start date      | sets the start date                                   | start date:2015-02-28            |
-| Due date        | sets the finish date                                  |                                  |
-| Estimated hours | sets the estimated hours. Use a number                | Estimated hours:10.5             |
-| Remaining hours | sets the remaining hours. Use a number                | Remaining hours:2.5              |
-| Status          | sets the status                                       | Status:closed                    |
-| priority        | sets the priority                                     | priority:High                    |
+| Key             | Name (EN)       | Description                                           | Example                          |
+| --------------- | --------------- | ----------------------------------------------------- | -------------------------------- |
+| project         | Project         | sets the project. Use the project identifier          | project:test\_project            |
+| responsible     | Accountable     | sets the accountable, via user email or login         | responsible:user@example.org     |
+| assigned_to     | Assignee        | sets the assignee. Use the email or login of the user | assignee:test.nutzer@example.org |
+| type            | Type            | sets the type                                         | type:Milestone                   |
+| version         | Version         | sets the version                                      | version:v4.1.0                   |
+| start_date      | Start date      | sets the start date                                   | start_date:2015-02-28            |
+| due_date        | Due date        | sets the finish date                                  | due:_date:2015-02-28             |
+| estimated_hours | Estimated hours | sets the estimated hours. Use a number                | estimated_hours:10.5             |
+| remaining_hours | Remaining hours | sets the remaining hours. Use a number                | remaining_hours:2.5              |
+| status          | Status          | sets the status                                       | status:closed                    |
+| priority        | Priority        | sets the priority                                     | priority:High                    |
+| category        | Category        | sets the category from the project's categories       | category:Testing                 |
 
 If you want to set a custom field just use the name as it is displayed in your browser, e.g. `Custom field:new value`
 

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -245,7 +245,7 @@ module Redmine
         general_attributes = ::I18n.t("attributes", locale:)
         ::I18n.t("activerecord.attributes",
                  locale:).inject(general_attributes) do |attr_t, model_t|
-          attr_t.merge(model_t.last || {})
+          attr_t.reverse_merge(model_t.last || {})
         end
       end
       @cached_attribute_translations[locale]

--- a/spec/fixtures/mail_handler/wp_with_attribute_keys.eml
+++ b/spec/fixtures/mail_handler/wp_with_attribute_keys.eml
@@ -1,0 +1,31 @@
+Return-Path: <jsmith@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "John Smith" <jsmith@somenet.foo>
+To: <openproject@somenet.foo>
+Subject: New ticket with full attributes
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Priority: 3
+X-MSMail-Priority: Normal
+X-Mailer: Microsoft Outlook Express 6.00.2900.2869
+X-MimeOLE: Produced By Microsoft MimeOLE V6.00.2900.2869
+
+project: onlinestore
+type: Feature request
+status: Resolved
+category: Stock management
+version: alpha
+priority: Urgent
+assigned_to: jsmith@somenet.foo
+responsible: jsmith@somenet.foo
+start_date: 2025-01-01
+due_date: 2025-12-31
+estimated_hours: 20
+remaining_hours: 10.5
+
+Some description here

--- a/spec/fixtures/mail_handler/wp_with_attributes_i18n_de.eml
+++ b/spec/fixtures/mail_handler/wp_with_attributes_i18n_de.eml
@@ -1,0 +1,31 @@
+Return-Path: <jsmith@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "John Smith" <jsmith@somenet.foo>
+To: <openproject@somenet.foo>
+Subject: Neues Arbeitspaket
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Priority: 3
+X-MSMail-Priority: Normal
+X-Mailer: Microsoft Outlook Express 6.00.2900.2869
+X-MimeOLE: Produced By Microsoft MimeOLE V6.00.2900.2869
+
+Project: onlinestore
+Typ: Feature request
+Status: Resolved
+Kategorie: Stock management
+Version: alpha
+Priorität: Urgent
+Zugewiesen an: jsmith@somenet.foo
+Verantwortlich: jsmith@somenet.foo
+Anfangstermin: 2025-01-01
+Endtermin: 2025-12-31
+Aufwand: 20
+Verbleibender Aufwand: 10.5
+
+Beschreibung würde hier stehen.


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61482

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Translations for incoming mails were overridden by other attributes of the same key (for example meetings.type would be used as the german translation for "Type", as it merges keys). The German translation was never fully tested.

On top of that, add a stable attribute key that people can use regardless of the available language.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
