### PR TITLE
[60618] Replace project list deletion dialog with new DangerDialog

### DIFF
--- a/app/components/projects/delete_list_modal_component.html.erb
+++ b/app/components/projects/delete_list_modal_component.html.erb
@@ -1,25 +1,14 @@
-<%= render(
-      Primer::Alpha::Dialog.new(
-        title: t(:"projects.lists.delete_modal.title"),
-        size: :large,
-        id: MODAL_ID,
-        data: { "test-selector": MODAL_ID }
-      )
-    ) do |d| %>
-  <% d.with_header(variant: :large) %>
-  <% d.with_body { t(:"projects.lists.delete_modal.text") } %>
-  <% d.with_footer do %>
-    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": MODAL_ID })) { I18n.t(:button_cancel) } %>
-    <%= form_with(
-          url: project_query_path(query),
-          method: :delete
-        ) do %>
-      <%= render(
-            Primer::Beta::Button.new(
-              scheme: :danger,
-              type: :submit
-            )
-          ) { I18n.t(:button_delete) } %>
-    <% end %>
-  <% end %>
-<% end %>
+<%=
+  render(Primer::OpenProject::DangerDialog.new(title: t(:"projects.lists.delete_modal.title"),
+                                               form_arguments: {
+                                                 action: project_query_path(query),
+                                                 method: :delete
+                                               },
+                                               id: MODAL_ID,
+                                               test_selector: MODAL_ID)) do |d|
+    d.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { t(:"projects.lists.delete_modal.title") }
+      message.with_description_content(t(:"projects.lists.delete_modal.text"))
+    end
+  end
+%>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/60618/activity

# What are you trying to accomplish?
Replace custom component with standardized DangerDialog

## Screenshots
**Before**
<img width="687" alt="Bildschirmfoto 2025-02-18 um 11 41 35" src="https://github.com/user-attachments/assets/a83ca849-318a-47be-9373-175fa33b20eb" />

**After**
<img width="515" alt="Bildschirmfoto 2025-02-18 um 11 41 03" src="https://github.com/user-attachments/assets/459c08ea-aa9c-40b6-bfd2-900d9800c4e1" />
