### PR TITLE
Explicitly store expiration time of access tokens

### DIFF
--- a/modules/openid_connect/app/services/openid_connect/user_tokens/refresh_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/refresh_service.rb
@@ -48,9 +48,10 @@ module OpenIDConnect
 
         access_token = json["access_token"]
         refresh_token = json["refresh_token"]
+        expires_in = json["expires_in"]
         return Failure("Refresh token response invalid") if access_token.blank?
 
-        token.update!(access_token:, refresh_token:)
+        token.update!(access_token:, refresh_token:, expires_at: expires_in&.seconds&.from_now)
 
         Success(token)
       end

--- a/modules/openid_connect/db/migrate/20250218133700_add_expires_at_to_oidc_user_tokens.rb
+++ b/modules/openid_connect/db/migrate/20250218133700_add_expires_at_to_oidc_user_tokens.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddExpiresAtToOidcUserTokens < ActiveRecord::Migration[7.1]
+  def change
+    add_column :oidc_user_tokens, :expires_at, :datetime, null: true, precision: 0
+  end
+end

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -55,6 +55,7 @@ module OpenProject::OpenIDConnect
             omniauth.oidc_sid
             omniauth.oidc_access_token
             omniauth.oidc_refresh_token
+            omniauth.oidc_expires_in
           ]
 
           h[:backchannel_logout_callback] = ->(logout_token) do

--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -44,10 +44,10 @@ module OpenProject::OpenIDConnect
         OpenIDConnect::UserTokens::CreateService.new(user).call(
           access_token: session["omniauth.oidc_access_token"],
           refresh_token: session["omniauth.oidc_refresh_token"],
+          expires_in: session["omniauth.oidc_expires_in"],
           known_audiences: [OpenIDConnect::UserToken::IDP_AUDIENCE],
           clear_previous: true
         )
-
       end
 
       ##
@@ -58,6 +58,7 @@ module OpenProject::OpenIDConnect
 
         session["omniauth.oidc_access_token"] = context.dig(:auth_hash, :credentials, :token)
         session["omniauth.oidc_refresh_token"] = context.dig(:auth_hash, :credentials, :refresh_token)
+        session["omniauth.oidc_expires_in"] = context.dig(:auth_hash, :credentials, :expires_in)
 
         nil
       end

--- a/modules/openid_connect/spec/requests/openid_connect_spec.rb
+++ b/modules/openid_connect/spec/requests/openid_connect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -48,6 +50,7 @@ RSpec.describe "OpenID Connect", :skip_2fa_stage, # Prevent redirects to 2FA sta
   end
   let(:access_token) { "foo-bar-baz" }
   let(:refresh_token) { "refreshing-foo-bar-baz" }
+  let(:expires_in) { 60 }
   let(:oidc_sid) { "oidc-session-id-42" }
 
   before do
@@ -57,6 +60,7 @@ RSpec.describe "OpenID Connect", :skip_2fa_stage, # Prevent redirects to 2FA sta
       instance_double(OpenIDConnect::AccessToken,
                       access_token:,
                       refresh_token:,
+                      expires_in:,
                       userinfo!: OpenIDConnect::ResponseObject::UserInfo.new(user_info),
                       id_token: "not-nil").as_null_object
     end
@@ -72,7 +76,7 @@ RSpec.describe "OpenID Connect", :skip_2fa_stage, # Prevent redirects to 2FA sta
     let(:limit_self_registration) { false }
     let!(:provider) { create(:oidc_provider, slug: "keycloak", limit_self_registration:) }
 
-    it "signs up and logs in the user" do
+    it "signs up and logs in the user", :freeze_time do
       ##
       # it should redirect to the provider's openid connect authentication endpoint
       click_on_signin("keycloak")
@@ -106,9 +110,12 @@ RSpec.describe "OpenID Connect", :skip_2fa_stage, # Prevent redirects to 2FA sta
 
       token = user.oidc_user_tokens.first
       expect(token).not_to be_nil
-      expect(token.access_token).to eq access_token
-      expect(token.refresh_token).to eq refresh_token
-      expect(token.audiences).to eq ["__op-idp__"]
+      aggregate_failures "OIDC user token details" do
+        expect(token.access_token).to eq access_token
+        expect(token.refresh_token).to eq refresh_token
+        expect(token.expires_at).to eq 60.seconds.from_now.change(usec: 0)
+        expect(token.audiences).to eq ["__op-idp__"]
+      end
     end
 
     context "when the user is already registered" do

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/create_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/create_service_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe OpenIDConnect::UserTokens::CreateService do
     expect(token.access_token).to eq access_token
     expect(token.refresh_token).to eq refresh_token
     expect(token.audiences).to contain_exactly("io", "aud1", "aud2")
+    expect(token.expires_at).to be_nil
   end
 
   it "logs no error" do
@@ -224,6 +225,18 @@ RSpec.describe OpenIDConnect::UserTokens::CreateService do
 
       token = OpenIDConnect::UserToken.last
       expect(token.audiences).to contain_exactly("io", "aud2")
+    end
+  end
+
+  context "when passing expires_in", :freeze_time do
+    let(:args) { { access_token:, refresh_token:, known_audiences: ["io"], expires_in: } }
+    let(:expires_in) { 120 }
+
+    it "creates a user token with correct expires_at", :aggregate_failures do
+      expect { subject }.to change(OpenIDConnect::UserToken, :count).by(1)
+
+      token = OpenIDConnect::UserToken.last
+      expect(token.expires_at).to eq expires_in.seconds.from_now.change(usec: 0)
     end
   end
 end

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
@@ -44,9 +44,14 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
     {
       status: 200,
       headers: { "Content-Type": "application/json" },
-      body: { access_token: "#{access_token}-exchanged", refresh_token: "#{refresh_token}-exchanged" }.to_json
+      body: {
+        access_token: "#{access_token}-exchanged",
+        refresh_token: "#{refresh_token}-exchanged",
+        expires_in: 45
+      }.to_json
     }
   end
+  let(:expected_expires_at) { 45.seconds.from_now.change(usec: 0) }
 
   before do
     user.oidc_user_tokens.create!(access_token: idp_access_token, audiences: [OpenIDConnect::UserToken::IDP_AUDIENCE])
@@ -63,10 +68,11 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
 
     it { is_expected.to be_success }
 
-    it "creates a new user token", :aggregate_failures do
+    it "creates a new user token", :aggregate_failures, :freeze_time do
       expect { subject }.to change(user.oidc_user_tokens, :count).from(2).to(3)
       expect(user.oidc_user_tokens.last.access_token).to eq("the-access-token-exchanged")
       expect(user.oidc_user_tokens.last.refresh_token).to be_nil
+      expect(user.oidc_user_tokens.last.expires_at).to eq(expected_expires_at)
     end
 
     it "returns the new user token" do
@@ -79,19 +85,56 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
         .with(body: hash_including(subject_token: idp_access_token))
     end
 
+    context "when the response has no expires_in" do
+      let(:exchange_response) do
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: {
+            access_token: "#{access_token}-exchanged",
+            refresh_token: "#{refresh_token}-exchanged"
+          }.to_json
+        }
+      end
+
+      it "creates a new user token without expiration", :aggregate_failures do
+        expect { subject }.to change(user.oidc_user_tokens, :count).from(2).to(3)
+        expect(user.oidc_user_tokens.last.expires_at).to be_nil
+      end
+    end
+
     context "when exchanging token for an existing user token" do
       let(:audience) { existing_audience }
 
       it { is_expected.to be_success }
 
-      it "creates a new user token", :aggregate_failures do
+      it "updates the existing user token", :aggregate_failures, :freeze_time do
         expect { subject }.not_to change(user.oidc_user_tokens, :count)
         expect(user.oidc_user_tokens.last.access_token).to eq("the-access-token-exchanged")
         expect(user.oidc_user_tokens.last.refresh_token).to be_nil
+        expect(user.oidc_user_tokens.last.expires_at).to eq(expected_expires_at)
       end
 
       it "returns the updated user token" do
         expect(result.value!).to eq(user.oidc_user_tokens.last)
+      end
+
+      context "and when the response has no expires_in" do
+        let(:exchange_response) do
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: {
+              access_token: "#{access_token}-exchanged",
+              refresh_token: "#{refresh_token}-exchanged"
+            }.to_json
+          }
+        end
+
+        it "updates the existing user token without expiration", :aggregate_failures do
+          expect { subject }.not_to change(user.oidc_user_tokens, :count)
+          expect(user.oidc_user_tokens.last.expires_at).to be_nil
+        end
       end
     end
 

--- a/spec/support/shared/timecop.rb
+++ b/spec/support/shared/timecop.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.configure do |config|
+  config.around(:example, :freeze_time) do |example|
+    time = example.metadata[:freeze_time] == true ? Time.zone.now : example.metadata[:freeze_time]
+    Timecop.freeze(time) { example.run }
+  end
+end


### PR DESCRIPTION
Previously we didn't consider the `expires_in` from the token endpoint response, thus being unable to know whether a token was expired or not before using it. While we worked around that by inspecting tokens that seemed readable as JWTs, the better approach is to memoize the information returned by the server, as that also allows to know the expiration time of opaque access tokens.

We'll keep the JWT extraction around as a fallback mechanism, but prefer reading the info from the token endpoint, if it's present.

# Ticket
https://community.openproject.org/projects/openproject/work_packages/61344

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Firefox)
