### PR TITLE
Do not display time entry comment unsanitized in My Spent Time widget

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -640,7 +640,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
           </li>
           <li class="tooltip--map--item">
             <span class="tooltip--map--key">${schema.comment.name}:</span>
-            <span class="tooltip--map--value">${entry.comment.raw || this.i18n.t('js.placeholders.default')}</span>
+            <span class="tooltip--map--value">${this.sanitizedValue(entry.comment.raw || this.i18n.t('js.placeholders.default'))}</span>
           </li>
         `;
   }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/security/work_packages/61605

# What are you trying to accomplish?
Fix a persisted XSS on the my page via the My Spent Time widget when entering a maliciously crafted comment 