### PR TITLE
limit time entry comment to the current database value with a rails validation

### DIFF
--- a/modules/costs/app/components/time_entries/comments_form.rb
+++ b/modules/costs/app/components/time_entries/comments_form.rb
@@ -31,7 +31,7 @@
 module TimeEntries
   class CommentsForm < ApplicationForm
     form do |f|
-      f.text_area name: :comments, label: TimeEntry.human_attribute_name(:comments)
+      f.text_area name: :comments, label: TimeEntry.human_attribute_name(:comments), maxlength: 255
     end
   end
 end

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -59,6 +59,10 @@ class TimeEntry < ApplicationRecord
             },
             allow_nil: true
 
+  validates :comments,
+            length: { maximum: 255 },
+            allow_blank: true
+
   validates :start_time,
             presence: true,
             if: -> { TimeEntry.must_track_start_and_end_time? }

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -484,6 +484,23 @@ RSpec.describe TimeEntry do
         end
       end
     end
+
+    describe "comments" do
+      it "allows blank values" do
+        time_entry.comments = ""
+        expect(time_entry).to be_valid
+      end
+
+      it "allows values with a length of 255 characters" do
+        time_entry.comments = "a" * 255
+        expect(time_entry).to be_valid
+      end
+
+      it "does not allow values with a length of >255 characters" do
+        time_entry.comments = "a" * 256
+        expect(time_entry).not_to be_valid
+      end
+    end
   end
 
   describe "#start_timestamp" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61602

# What are you trying to accomplish?
Currently we have a DB limit of 255 characters for the comment field. When entering more than 255 characters, the DB insert fails. Instead we add a validation error. For 15.4 we will increase the limit

## Screenshots
![Bildschirmfoto 2025-02-19 um 10 26 53](https://github.com/user-attachments/assets/0fe13cb7-f742-443a-93bc-ceb0a8774fef)

# What approach did you choose and why?
Added a rails migration

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
