### PR TITLE
Adds the preliminar check for an existing token

### DIFF
--- a/modules/openid_connect/app/models/openid_connect/user_token.rb
+++ b/modules/openid_connect/app/models/openid_connect/user_token.rb
@@ -37,5 +37,6 @@ module OpenIDConnect
     belongs_to :user
 
     scope :idp, -> { where(audience: IDP_AUDIENCE) }
+    scope :with_audience, ->(audience) { where("audiences ? :aud", aud: audience) }
   end
 end

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/fetch_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/fetch_service.rb
@@ -85,7 +85,7 @@ module OpenIDConnect
       private
 
       def token_with_audience(aud)
-        token = @user.oidc_user_tokens.where("audiences ? :aud", aud:).first
+        token = @user.oidc_user_tokens.with_audience(aud).first
         return Success(token) if token
 
         return @token_exchange.call(aud) if @token_exchange.supported?

--- a/modules/openid_connect/spec/factories/oidc_user_token_factory.rb
+++ b/modules/openid_connect/spec/factories/oidc_user_token_factory.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     user
     access_token { "INVALID_TOKEN" }
     refresh_token { "COOL_AID_TOKEN" }
-    audiences { ["__op-idp__"] + Array(extra_audiences) }
+    audiences { [OpenIDConnect::UserToken::IDP_AUDIENCE] + Array(extra_audiences) }
   end
 end

--- a/modules/openid_connect/spec/factories/oidc_user_token_factory.rb
+++ b/modules/openid_connect/spec/factories/oidc_user_token_factory.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :oidc_user_token, class: "OpenIDConnect::UserToken" do
+    transient do
+      extra_audiences { nil }
+    end
+
+    user
+    access_token { "INVALID_TOKEN" }
+    refresh_token { "COOL_AID_TOKEN" }
+    audiences { ["__op-idp__"] + Array(extra_audiences) }
+  end
+end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -233,6 +233,7 @@ en:
         host_not_found: No Nextcloud server found at the configured host url. Please check the configuration.
         missing_dependencies: 'A required dependency is missing on the file storage. Please add the following dependency: %{dependency}.'
         not_configured: The connection could not be validated. Please finish configuration first.
+        oidc_no_token_with_required_audience: There's no OpenID Connect token with the required %{audience} audience.
         oidc_non_oidc_user: The current user, while provisioned, wasn't provisioned by an OpenID Connect (OIDC) Identity Provider. Please re-run the check with an OIDC provisioned user.
         oidc_non_provisioned_user: The current user isn't provided by an OpenID Connect Identity Provider. Please re-run the check with a provided user.
         placeholder: Check your connection against the server.

--- a/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/nextcloud_connection_validator_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
 
     it "returns a success" do
       create(:oidc_user_token, user:, extra_audiences: storage.audience)
-      user.update(identity_url: "#{oidc_provider.slug}:UNIVERSALLY-DUPLICATED-IDENTIFIER")
+      user.update!(identity_url: "#{oidc_provider.slug}:UNIVERSALLY-DUPLICATED-IDENTIFIER")
 
       expect(subject.type).to eq(:healthy)
       expect(subject.error_code).to eq(:none)
@@ -270,7 +270,7 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
     end
 
     it "returns a warning if the user is not provided by an oidc provider" do
-      user.update(identity_url: "ldap-provider:this-will-trigger-a-warning")
+      user.update!(identity_url: "ldap-provider:this-will-trigger-a-warning")
 
       expect(subject.type).to eq(:warning)
       expect(subject.error_code).to eq(:oidc_non_oidc_user)
@@ -278,7 +278,7 @@ RSpec.describe Storages::Peripherals::NextcloudConnectionValidator do
     end
 
     it "returns an error if the user does not have a usable token" do
-      user.update(identity_url: "#{oidc_provider.slug}:UNIVERSALLY-DUPLICATED-IDENTIFIER")
+      user.update!(identity_url: "#{oidc_provider.slug}:UNIVERSALLY-DUPLICATED-IDENTIFIER")
 
       expect(subject.type).to eq(:error)
       expect(subject.error_code).to eq(:oidc_no_token_with_required_audience)


### PR DESCRIPTION
### Related WP: [OP#61608](https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61608)

Implements the first step for checking the actual OIDC tokens. This is a preliminary check verifying if the current user already has a token with the required audiences.

The next step is to validate the token with a request and also try to grab a new one (or refresh... whatever FetchService wants to do). 