### PR TITLE
Task/61607 allow more characters for time entry comment

### DIFF
--- a/modules/costs/app/components/time_entries/comments_form.rb
+++ b/modules/costs/app/components/time_entries/comments_form.rb
@@ -31,7 +31,7 @@
 module TimeEntries
   class CommentsForm < ApplicationForm
     form do |f|
-      f.text_area name: :comments, label: TimeEntry.human_attribute_name(:comments), maxlength: 255
+      f.text_area name: :comments, label: TimeEntry.human_attribute_name(:comments), maxlength: 1_000
     end
   end
 end

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -60,7 +60,7 @@ class TimeEntry < ApplicationRecord
             allow_nil: true
 
   validates :comments,
-            length: { maximum: 255 },
+            length: { maximum: 1_000 },
             allow_blank: true
 
   validates :start_time,

--- a/modules/costs/db/migrate/20180323133404_to_v710_aggregated_costs_migrations.rb
+++ b/modules/costs/db/migrate/20180323133404_to_v710_aggregated_costs_migrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/costs/db/migrate/20200327074416_rename_fixed_version_in_cost_query.rb
+++ b/modules/costs/db/migrate/20200327074416_rename_fixed_version_in_cost_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/costs/db/migrate/20200807083952_rename_time_and_cost_module.rb
+++ b/modules/costs/db/migrate/20200807083952_rename_time_and_cost_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,8 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require Rails.root.to_s + "/db/migrate/migration_utils/module_renamer"
-require Rails.root.to_s + "/db/migrate/migration_utils/setting_renamer"
+require Rails.root.join("db/migrate/migration_utils/module_renamer").to_s
+require Rails.root.join("db/migrate/migration_utils/setting_renamer").to_s
 
 class RenameTimeAndCostModule < ActiveRecord::Migration[6.0]
   def up

--- a/modules/costs/db/migrate/20210726065912_rename_cost_object_type.rb
+++ b/modules/costs/db/migrate/20210726065912_rename_cost_object_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/costs/db/migrate/20230622074222_add_ongoing_to_time_entry.rb
+++ b/modules/costs/db/migrate/20230622074222_add_ongoing_to_time_entry.rb
@@ -1,3 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 class AddOngoingToTimeEntry < ActiveRecord::Migration[7.0]
   def change
     change_table :time_entries do |t|

--- a/modules/costs/db/migrate/20250219103939_make_time_entry_comment_text_field.rb
+++ b/modules/costs/db/migrate/20250219103939_make_time_entry_comment_text_field.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class MakeTimeEntryCommentTextField < ActiveRecord::Migration[7.1]
+  def up
+    change_column :time_entries, :comments, :text
+    change_column :time_entry_journals, :comments, :text
+  end
+end

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -491,13 +491,13 @@ RSpec.describe TimeEntry do
         expect(time_entry).to be_valid
       end
 
-      it "allows values with a length of 255 characters" do
-        time_entry.comments = "a" * 255
+      it "allows values with a length of 1000 characters" do
+        time_entry.comments = "a" * 1000
         expect(time_entry).to be_valid
       end
 
-      it "does not allow values with a length of >255 characters" do
-        time_entry.comments = "a" * 256
+      it "does not allow values with a length of >1000 characters" do
+        time_entry.comments = "a" * 1001
         expect(time_entry).not_to be_valid
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61607

# What are you trying to accomplish?
Allow comments up to 1000 characters for time entries. We do want to increase the limit from the 255 we have right now. But we also do not want to allow arbitrary lengths of text. So we limit to 1000 characters on the model. DB is uncapped

## Screenshots
![grafik](https://github.com/user-attachments/assets/3768f262-3680-4c23-bdf5-3d5f46ecdc5c)
![grafik](https://github.com/user-attachments/assets/4af02971-7d08-4842-b62c-474526b4272a)
![grafik](https://github.com/user-attachments/assets/c632b518-96ea-41de-9031-fcf48c7d30f2)

# What approach did you choose and why?
DB column is text, limit comes from rails

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
