### PR TITLE
Fix openapi: time entry comments are plain strings

### DIFF
--- a/docs/api/apiv3/components/schemas/time_entry_model.yml
+++ b/docs/api/apiv3/components/schemas/time_entry_model.yml
@@ -7,9 +7,8 @@ properties:
     description: The id of the time entry
     minimum: 1
   comment:
-    allOf:
-      - $ref: "./formattable.yml"
-      - description: A comment to the time entry
+    type: string
+    description: A comment to the time entry
   spentOn:
     type: string
     format: date


### PR DESCRIPTION
Comments for time entries are not formatable string, but plain text 