### PR TITLE
Bump rubocop_performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,12 +3,12 @@ require:
   - rubocop-rspec_rails
   - rubocop-capybara
   - rubocop-factory_bot
-  - rubocop-performance
   - ./config/initializers/inflections.rb
 
 plugins:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-performance
 
 # A rubocop-local.yml file can be added to customized the styles
 inherit_from:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1077,9 +1077,10 @@ GEM
       rubocop (~> 1.61)
     rubocop-openproject (0.2.0)
       rubocop
-    rubocop-performance (1.23.1)
-      rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-performance (1.24.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-rails (2.30.1)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
@@ -1836,7 +1837,7 @@ CHECKSUMS
   rubocop-capybara (2.21.0) sha256=5d264efdd8b6c7081a3d4889decf1451a1cfaaec204d81534e236bc825b280ab
   rubocop-factory_bot (2.26.1) sha256=8de13cd4edcee5ca800f255188167ecef8dbfc3d1fae9f15734e9d2e755392aa
   rubocop-openproject (0.2.0) sha256=2300ed6b638a34a9368b458dc5fb618ae396da6a27670b50519ad1e3cea65ccb
-  rubocop-performance (1.23.1) sha256=f22f86a795f5e6a6180aac2c6fc172534b173a068d6ed3396d6460523e051b82
+  rubocop-performance (1.24.0) sha256=e5bd39ff3e368395b9af886927cc37f5892f43db4bd6c8526594352d5b4440b5
   rubocop-rails (2.30.1) sha256=5eb39fbfce4e63fb0d79d48ba9a3fbc23d33dd9fa4585b8f9c811056fe156c10
   rubocop-rspec (3.5.0) sha256=710c942fe1af884ba8eea75cbb8bdbb051929a2208880a6fc2e2dce1eed5304c
   rubocop-rspec_rails (2.30.0) sha256=888112e83f9d7ef7ad2397e9d69a0b9614a4bae24f072c399804a180f80c4c46


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Bump rubocop-performance and liste it as a rubocop plugin. This avoids the problem we faced e.g. with rubocop-rails
