### PR TITLE
Fix destroy of meetings with attachments

### DIFF
--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -129,6 +129,8 @@ module Meeting::VirtualStartTime
   ##
   # Enforce HH::MM time parsing for the given input string
   def parsed_start_time_hour
+    return nil if @start_time_hour.nil?
+
     Time.strptime(@start_time_hour, "%H:%M")
   rescue ArgumentError
     nil

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -230,4 +230,16 @@ RSpec.describe Meeting do
       expect(meeting.formatted_duration).to be_nil
     end
   end
+
+  describe "#destroy" do
+    context "with an attachment" do
+      let!(:meeting) { create(:meeting, project: project) }
+      let!(:attachment) { create(:attachment, container: meeting) }
+
+      it "does not raise an exception (Regression #61632)" do
+        expect { meeting.destroy! }.not_to raise_error
+        expect { meeting.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/61632

# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Destroying an attachment on the meeting validates it, resulting in a change from start_time_hour value -> nil, resulting in a the changed being picked up, but not parsed correctly.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
