### PR TITLE
Use primerized editor for meeting agenda items

### DIFF
--- a/modules/meeting/app/forms/meeting_agenda_item/notes.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/notes.rb
@@ -34,6 +34,7 @@ class MeetingAgendaItem::Notes < ApplicationForm
       name: :notes,
       label: MeetingAgendaItem.human_attribute_name(:notes),
       disabled: @disabled,
+      classes: "ck-editor-primer-adjusted",
       rich_text_options: {
         resource:,
         showAttachments: false


### PR DESCRIPTION
<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Before
<img width="858" alt="image" src="https://github.com/user-attachments/assets/4e1899da-f13c-4e91-b8ee-cf0b5237be3e" />

### After
<img width="860" alt="image" src="https://github.com/user-attachments/assets/2cf3557e-a625-480f-83c9-7b6d6998841e" />


# What approach did you choose and why?
Use the rounded rich text editor as it matches the rest of the components. Was there a reason for not doing this before?