### PR TITLE
Group AWS gems into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
     target-branch: "dev"
     open-pull-requests-limit: 3
     versioning-strategy: lockfile-only
+    groups:
+      aws-gems:
+        patterns:
+          - "aws-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Ticket
n/a

# What are you trying to accomplish?
AWS gems are always released in bulk so this change groups their updates together in one PR and thus reduces the number of PRs we will see for AWS gems