### PR TITLE
Fix untranslated end_date label

### DIFF
--- a/modules/meeting/app/forms/recurring_meeting/specific_date.rb
+++ b/modules/meeting/app/forms/recurring_meeting/specific_date.rb
@@ -32,8 +32,7 @@ class RecurringMeeting::SpecificDate < ApplicationForm
       name: :end_date,
       type: "date",
       value: @value,
-      placeholder: Meeting.human_attribute_name(:end_date),
-      label: Meeting.human_attribute_name(:end_date),
+      label: I18n.t("activerecord.attributes.recurring_meeting.end_date"),
       required: false,
       autofocus: false
     )

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
         start_time: "Start time"
         start_time_hour: "Start time"
         end_after: "Meeting series ends"
+        end_date: "End date"
         iterations: "Occurrences"
     errors:
       messages:


### PR DESCRIPTION
Provide a key for `end_date`