### PR TITLE
fix tmp folder permissions on helm

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -75,6 +75,15 @@ RUN cp Gemfile.lock.bak Gemfile.lock && rm Gemfile.lock.bak && \
 # -------------------------------------
 FROM base AS slim
 
+# install sudo so we can run the following single command as root on start-up
+# (see entrypoint-slim.sh)
+RUN apt-get update -qq && \
+    apt-get install -yq --no-install-recommends sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    truncate -s 0 /var/log/*log
+RUN echo "$APP_USER ALL=(ALL) NOPASSWD:$APP_PATH/docker/prod/fix-tmp-permissions" > /etc/sudoers
+
 USER $APP_USER
 EXPOSE 8080
 CMD ["./docker/prod/web"]

--- a/docker/prod/entrypoint-slim.sh
+++ b/docker/prod/entrypoint-slim.sh
@@ -8,4 +8,8 @@ if [ "$USE_JEMALLOC" = "true" ]; then
 	export LD_PRELOAD=libjemalloc.so.2
 fi
 
+# make sure tmp folders have the correct owners and permissions
+# so that Ruby can create temporary files
+sudo docker/prod/fix-tmp-permissions
+
 exec "$@"

--- a/docker/prod/fix-tmp-permissions
+++ b/docker/prod/fix-tmp-permissions
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+# needs to be executed as root
+
+APP_TMP_DIR=/app/tmp
+TMP_DIR=/tmp
+
+chmod 775 $APP_TMP_DIR
+chown app:app $APP_TMP_DIR
+
+chmod 1777 $TMP_DIR


### PR DESCRIPTION
this is mostly relevant when using the helm chart where the default is a read-only file system and mounted tmp volumes

https://community.openproject.org/projects/openproject/work_packages/61646/activity

For this to work one also needs to [enable privilege escalation](https://github.com/opf/helm-charts/blob/main/charts/openproject/values.yaml#L230) in the helm chart values.

The question is then, if there is any point to all of this. 

