### PR TITLE
Show an error when logging time on a work package you did not have permission to log for

### DIFF
--- a/modules/costs/app/components/time_entries/work_package_form.rb
+++ b/modules/costs/app/components/time_entries/work_package_form.rb
@@ -84,7 +84,11 @@ module TimeEntries
     end
 
     def work_package_validation_error
-      model.errors[:project_id]&.first
+      if model.errors[:project_id].present?
+        model.errors[:project_id].first
+      else
+        model.errors[:work_package]&.first
+      end
     end
 
     def work_package_completer_filters

--- a/modules/costs/app/components/time_entries/work_package_form.rb
+++ b/modules/costs/app/components/time_entries/work_package_form.rb
@@ -49,6 +49,7 @@ module TimeEntries
                                        hiddenFieldAction: "change->time-entry#workPackageChanged",
                                        focusDirectly: false,
                                        append_to: "#time-entry-dialog",
+                                       relations: true, # allows using the custom url
                                        url: work_package_completer_url,
                                        filters: work_package_completer_filters
                                      }

--- a/modules/costs/app/contracts/time_entries/create_contract.rb
+++ b/modules/costs/app/contracts/time_entries/create_contract.rb
@@ -37,6 +37,7 @@ module TimeEntries
       return if allowed_to_log_for_others?
       return if allowed_to_log_to_himself?
 
+      errors.add :work_package, :cannot_log_for_this_work_package
       errors.add :base, :error_unauthorized
     end
 

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
       models:
         time_entry:
           invalid_time: "must be between 00:00 and 23:59."
+          cannot_log_for_this_work_package: "Cannot log time for this work package."
         work_package:
           is_not_a_valid_target_for_cost_entries: "Work package #%{id} is not a valid target for reassigning the cost entries."
           nullify_is_not_valid_for_cost_entries: "Cost entries can not be assigned to a project."

--- a/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe TimeEntries::CreateContract do
       let(:permissions) { [] }
 
       it "is invalid" do
-        expect_valid(false, base: %i(error_unauthorized))
+        expect_valid(false,
+                     work_package: %i(cannot_log_for_this_work_package),
+                     base: %i(error_unauthorized))
       end
     end
 
@@ -88,7 +90,9 @@ RSpec.describe TimeEntries::CreateContract do
         let(:changed_by_system) { {} }
 
         it "is invalid" do
-          expect_valid(false, base: %i(error_unauthorized))
+          expect_valid(false,
+                       work_package: %i(cannot_log_for_this_work_package),
+                       base: %i(error_unauthorized))
         end
       end
     end
@@ -105,7 +109,9 @@ RSpec.describe TimeEntries::CreateContract do
       end
 
       it "is invalid" do
-        expect_valid(false, base: %i(error_unauthorized))
+        expect_valid(false,
+                     work_package: %i(cannot_log_for_this_work_package),
+                     base: %i(error_unauthorized))
       end
     end
 
@@ -130,7 +136,9 @@ RSpec.describe TimeEntries::CreateContract do
       end
 
       it "is invalid" do
-        expect_valid(false, base: %i(error_unauthorized))
+        expect_valid(false,
+                     work_package: %i(cannot_log_for_this_work_package),
+                     base: %i(error_unauthorized))
       end
     end
 

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "filtering by user" do
+    context "when filtering by user" do
       let(:invisible_time_entry) do
         create(:time_entry, project: other_project, work_package: other_work_package, user: other_user)
       end
@@ -171,7 +171,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "filtering by work package" do
+    context "when filtering by work package" do
       let(:unwanted_work_package) do
         create(:work_package, project:, type: project.types.first)
       end
@@ -208,7 +208,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "filtering by project" do
+    context "when filtering by project" do
       let(:other_time_entry) do
         create(:time_entry, project: other_project, work_package: other_work_package, user: current_user)
       end
@@ -244,7 +244,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "filtering by global activity" do
+    context "when filtering by global activity" do
       let(:activity) do
         create(:time_entry_activity)
       end
@@ -305,7 +305,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "invalid filter" do
+    context "when adding an invalid filter" do
       let(:path) do
         filter = [{ "bogus" => {
           "operator" => "=",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61635

# What are you trying to accomplish?
For an admin, the autocompleter even lists work packages of projects that do not have the time&costs module enabled. When trying to log time for those work packages, the form submit returns an error but no error is shown. This PR adds a validation error to the work package that is presented to the user.

Additionally we also set the correct properties on the autocompleter so that we are using the custom URL that would prevent even selecting this work package

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
