### PR TITLE
remove maxlength for comment field, is validated via rails validation (dev edition)

### DIFF
--- a/modules/costs/app/components/time_entries/comments_form.rb
+++ b/modules/costs/app/components/time_entries/comments_form.rb
@@ -31,7 +31,7 @@
 module TimeEntries
   class CommentsForm < ApplicationForm
     form do |f|
-      f.text_area name: :comments, label: TimeEntry.human_attribute_name(:comments), maxlength: 1_000
+      f.text_area name: :comments, label: TimeEntry.human_attribute_name(:comments)
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61607

# What are you trying to accomplish?
Remove maxlength as it's weird behavior for the user and rely on the rails validation