### PR TITLE
Fix cost log edit form field updater

### DIFF
--- a/frontend/src/app/shared/components/remote-field-updater/remote-field-updater.component.ts
+++ b/frontend/src/app/shared/components/remote-field-updater/remote-field-updater.component.ts
@@ -61,6 +61,14 @@ export class RemoteFieldUpdaterComponent implements OnInit {
     this.htmlMode = element.dataset.mode === 'html';
 
     const debouncedEvent = _.debounce((event:InputEvent) => {
+      // Do not handle the change event on input fields, because they can trigger the
+      // debouncedEvent after a form submission which will lead to a broken UI update.
+      // This can happen if the form submission is clicked when an input field is still focused.
+      const target = event.target as HTMLElement | null;
+      if (event.type === 'change' && target instanceof HTMLInputElement) {
+        return;
+      }
+
       // This prevents an update of the result list when
       // tabbing to the result list (9),
       // pressing enter (13)
@@ -112,12 +120,12 @@ export class RemoteFieldUpdaterComponent implements OnInit {
 
     this
       .request(params)
-      .subscribe((response:any) => {
+      .subscribe((response:string|object) => {
         if (this.htmlMode) {
           // Replace the given target
           this.target.innerHTML = response as string;
         } else {
-          _.each(response, (val:string, selector:string) => {
+          _.each(response as object, (val:string, selector:string) => {
             const element = document.getElementById(selector) as HTMLElement|HTMLInputElement;
 
             if (element instanceof HTMLInputElement) {

--- a/modules/costs/app/views/admin/cost_types/edit.html.erb
+++ b/modules/costs/app/views/admin/cost_types/edit.html.erb
@@ -121,7 +121,7 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
   </div>
   <div class="wp-inline-create-button">
-    <label class="hidden-for-sighted" for="add_rate_date" <%= t(:description_date_for_new_rate) %>>
+    <label class="hidden-for-sighted" for="add_rate_date"> <%= t(:description_date_for_new_rate) %></label>
     <a id="add_rate_date"
        href="#"
        class="add-row-button wp-inline-create--add-link"

--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -152,7 +152,6 @@ See COPYRIGHT and LICENSE files for more details.
 
   <%= styled_button_tag t(:button_save), class: "-with-icon icon-checkmark" %>
 
-  <opce-remote-field-updater data-url="<%= url_for(controller: :budgets, action: :update_material_budget_item, project_id: @cost_entry.project) %>"
-                             data-mode="json">
+  <opce-remote-field-updater data-url="<%= url_for(controller: :budgets, action: :update_material_budget_item, project_id: @cost_entry.project) %>">
   </opce-remote-field-updater>
 <% end %>

--- a/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
@@ -68,17 +68,24 @@ RSpec.describe "Work Package cost fields", :js do
     login_as user
   end
 
+  # It is necessary to use send keys, because some UI events are triggered on keyboard input.
+  def fill_in_with_send_keys(field_name, with:)
+    fill_in(field_name, with:)
+    find_field(field_name).send_keys(:right)
+  end
+
   it "does not show read-only fields" do
     full_view.visit!
     full_view.select_log_unit_costs_action
 
     # Set single value, should update suffix
     select "A", from: "cost_entry_cost_type_id"
-    fill_in "cost_entry_units", with: "1"
+    fill_in_with_send_keys "cost_entry_units", with: "1"
+
     expect(page).to have_css("#cost_entry_unit_name", text: "A single")
     expect(page).to have_css("#cost_entry_costs", text: "1.00 EUR")
 
-    fill_in "cost_entry_units", with: "2"
+    fill_in_with_send_keys "cost_entry_units", with: "2"
     expect(page).to have_css("#cost_entry_unit_name", text: "A plural")
     expect(page).to have_css("#cost_entry_costs", text: "2.00 EUR")
 
@@ -90,8 +97,7 @@ RSpec.describe "Work Package cost fields", :js do
     # Override costs
     find_by_id("cost_entry_costs").click
     SeleniumHubWaiter.wait
-    fill_in "cost_entry_overridden_costs", with: "15.52"
-
+    fill_in_with_send_keys "cost_entry_overridden_costs", with: "15.52"
     click_on "Save"
 
     # Expect correct costs
@@ -114,7 +120,7 @@ RSpec.describe "Work Package cost fields", :js do
       full_view.visit!
       full_view.select_log_unit_costs_action
 
-      fill_in CostEntry.human_attribute_name(:units), with: "1,42"
+      fill_in_with_send_keys CostEntry.human_attribute_name(:units), with: "1,42"
       expect(page).to have_css("#cost_entry_costs", text: "1,42 EUR")
 
       select "B", from: CostEntry.human_attribute_name(:cost_type)
@@ -124,7 +130,7 @@ RSpec.describe "Work Package cost fields", :js do
       # Override costs
       find_by_id("cost_entry_costs").click
       SeleniumHubWaiter.wait
-      fill_in "cost_entry_overridden_costs", with: "1.350,25"
+      fill_in_with_send_keys "cost_entry_overridden_costs", with: "1.350,25"
 
       click_on I18n.t(:button_save)
 
@@ -146,7 +152,7 @@ RSpec.describe "Work Package cost fields", :js do
 
       # Update the costs in german locale
       SeleniumHubWaiter.wait
-      fill_in "cost_entry_overridden_costs", with: "55.000,55"
+      fill_in_with_send_keys "cost_entry_overridden_costs", with: "55.000,55"
       click_on I18n.t(:button_save)
 
       # Add explicit wait for the updated cost value

--- a/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
@@ -68,24 +68,18 @@ RSpec.describe "Work Package cost fields", :js do
     login_as user
   end
 
-  # It is necessary to use send keys, because some UI events are triggered on keyboard input.
-  def fill_in_with_send_keys(field_name, with:)
-    fill_in(field_name, with:)
-    find_field(field_name).send_keys(:right)
-  end
-
   it "does not show read-only fields" do
     full_view.visit!
     full_view.select_log_unit_costs_action
 
     # Set single value, should update suffix
     select "A", from: "cost_entry_cost_type_id"
-    fill_in_with_send_keys "cost_entry_units", with: "1"
+    fill_in "cost_entry_units", with: "1"
 
     expect(page).to have_css("#cost_entry_unit_name", text: "A single")
     expect(page).to have_css("#cost_entry_costs", text: "1.00 EUR")
 
-    fill_in_with_send_keys "cost_entry_units", with: "2"
+    fill_in "cost_entry_units", with: "2"
     expect(page).to have_css("#cost_entry_unit_name", text: "A plural")
     expect(page).to have_css("#cost_entry_costs", text: "2.00 EUR")
 
@@ -97,7 +91,8 @@ RSpec.describe "Work Package cost fields", :js do
     # Override costs
     find_by_id("cost_entry_costs").click
     SeleniumHubWaiter.wait
-    fill_in_with_send_keys "cost_entry_overridden_costs", with: "15.52"
+    fill_in "cost_entry_overridden_costs", with: "15.52"
+
     click_on "Save"
 
     # Expect correct costs
@@ -120,7 +115,7 @@ RSpec.describe "Work Package cost fields", :js do
       full_view.visit!
       full_view.select_log_unit_costs_action
 
-      fill_in_with_send_keys CostEntry.human_attribute_name(:units), with: "1,42"
+      fill_in CostEntry.human_attribute_name(:units), with: "1,42"
       expect(page).to have_css("#cost_entry_costs", text: "1,42 EUR")
 
       select "B", from: CostEntry.human_attribute_name(:cost_type)
@@ -130,7 +125,7 @@ RSpec.describe "Work Package cost fields", :js do
       # Override costs
       find_by_id("cost_entry_costs").click
       SeleniumHubWaiter.wait
-      fill_in_with_send_keys "cost_entry_overridden_costs", with: "1.350,25"
+      fill_in "cost_entry_overridden_costs", with: "1.350,25"
 
       click_on I18n.t(:button_save)
 
@@ -152,7 +147,7 @@ RSpec.describe "Work Package cost fields", :js do
 
       # Update the costs in german locale
       SeleniumHubWaiter.wait
-      fill_in_with_send_keys "cost_entry_overridden_costs", with: "55.000,55"
+      fill_in "cost_entry_overridden_costs", with: "55.000,55"
       click_on I18n.t(:button_save)
 
       # Add explicit wait for the updated cost value


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61689

# What are you trying to accomplish?
The Costs field display an invalid value, when the form is submitted while still focusing the cost field. This happens because the cost field updater logic runs after the form is submitted, overwriting the correctly rendered form content.
## Screenshots
<details><summary>Before</summary>
<p>

[updating costs then saving does not work.webm](https://github.com/user-attachments/assets/3ba5cf31-afb1-4b89-a608-96d2ec951766)

</p>
</details> 

<details><summary>After</summary>
<p>

![fix](https://github.com/user-attachments/assets/827bf532-e948-49e7-87f2-17a9fa856bc6)

</p>
</details> 

# What approach did you choose and why?
Use a `post` request instead of a `get` so the updater script's stale response values are not cached. 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
