### PR TITLE
Use default scopes as default value, not as placeholder

### DIFF
--- a/modules/openid_connect/app/components/openid_connect/providers/client_details_form.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/client_details_form.rb
@@ -53,7 +53,6 @@ module OpenIDConnect
         f.text_field(
           name: :scope,
           label: I18n.t("activemodel.attributes.openid_connect/provider.scope"),
-          placeholder: "openid email profile",
           caption: link_translate(
             "openid_connect.instructions.scope",
             links: {

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -33,7 +33,7 @@ module OpenIDConnect
     store_attribute :options, :scheme, :string
     store_attribute :options, :port, :string
 
-    store_attribute :options, :scope, :string
+    store_attribute :options, :scope, :string, default: "openid email profile"
     store_attribute :options, :claims, :string
     store_attribute :options, :acr_values, :string
 


### PR DESCRIPTION
The scopes defined as placeholders were not set by OpenProject directly, but by one of the OIDC-related gems. By defining them explicitly here, we can be sure that those are the scopes really requested.

UX-wise this also makes it easier to change the scopes from the default value. For example adding a scope now consists of adding the scope instead of typing out all the default scopes before adding your scope.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61470