### PR TITLE
Fix/avoid sending OIDC data to appsignal

### DIFF
--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -23,6 +23,11 @@ if OpenProject::Appsignal.enabled?
       ],
       ignore_logs: [
         "GET /health_check"
+      ],
+      filter_session_data: %w[
+        _csrf_token
+        omniauth.oidc_access_token
+        omniauth.oidc_sid
       ]
     }
 

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -9,17 +9,17 @@ if OpenProject::Appsignal.enabled?
       name: ENV.fetch("APPSIGNAL_NAME"),
       push_api_key: ENV.fetch("APPSIGNAL_KEY"),
       revision: OpenProject::VERSION.to_s,
-      ignore_actions: [
-        "OkComputer::OkComputerController#show",
-        "OkComputer::OkComputerController#index",
-        "GET::API::V3::Notifications::NotificationsAPI",
-        "GET::API::V3::Notifications::NotificationsAPI#/notifications/"
+      ignore_actions: %w[
+        OkComputer::OkComputerController#show
+        OkComputer::OkComputerController#index
+        GET::API::V3::Notifications::NotificationsAPI
+        GET::API::V3::Notifications::NotificationsAPI#/notifications/
       ],
-      ignore_errors: [
-        "Grape::Exceptions::MethodNotAllowed",
-        "ActionController::UnknownFormat",
-        "ActiveJob::DeserializationError",
-        "Net::SMTPServerBusy"
+      ignore_errors: %w[
+        Grape::Exceptions::MethodNotAllowed
+        ActionController::UnknownFormat
+        ActiveJob::DeserializationError
+        Net::SMTPServerBusy
       ],
       ignore_logs: [
         "GET /health_check"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61691

# What are you trying to accomplish?

AppSignal should not receive sensitive oidc data that is part of the session.

# What approach did you choose and why?

Using the [config option to filter session data](https://docs.appsignal.com/ruby/configuration/options.html#option-filter_session_data), the information should be removed.

⚠️ I have no setup for AppSignal so I couldn't test the change.

