### PR TITLE
allow custom url + custom function for loading work packages in autocompleter

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -294,7 +294,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   footerTemplate:TemplateRef<Element>;
 
-  readonly opAutocompleterService = new OpAutocompleterService(this.apiV3Service);
+  readonly opAutocompleterService = new OpAutocompleterService(this.apiV3Service, this.halResourceService);
 
   constructor(
     readonly injector:Injector,
@@ -480,16 +480,16 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
       tap(() => this.loading$.next(true)),
       debounceTime(this.debounceTimeForCurrentEnvironment),
       switchMap((queryString:string) => {
+        if (this.getOptionsFn) {
+          return this.getOptionsFn(queryString);
+        }
+
         if (this.relations && this.url) {
           return this.fetchFromUrl(queryString);
         }
 
         if (this.defaultData) {
           return this.opAutocompleterService.loadData(queryString, this.resource, this.filters, this.searchKey);
-        }
-
-        if (this.getOptionsFn) {
-          return this.getOptionsFn(queryString);
         }
 
         return NEVER;

--- a/frontend/src/app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter.component.ts
@@ -134,12 +134,15 @@ export class TimeEntriesWorkPackageAutocompleterComponent extends OpAutocomplete
   }
 
   protected loadWorkPackages(query:string):Observable<HalResource[]> {
-    return this
-      .opAutocompleterService
-      .loadData(query, this.resource, this.modeSpecificFilters, this.searchKey)
-      .pipe(
-        map((workPackages) => this.sortValues(workPackages)),
-      );
+    return this.opAutocompleterService
+      .loadFromUrl(
+        this.url,
+        query,
+        this.resource,
+        this.modeSpecificFilters,
+        this.searchKey,
+      )
+      .pipe(map((workPackages) => this.sortValues(workPackages)));
   }
 
   protected sortValues(availableValues:HalResource[]) {

--- a/modules/costs/app/components/time_entries/work_package_form.rb
+++ b/modules/costs/app/components/time_entries/work_package_form.rb
@@ -49,8 +49,8 @@ module TimeEntries
                                        hiddenFieldAction: "change->time-entry#workPackageChanged",
                                        focusDirectly: false,
                                        append_to: "#time-entry-dialog",
-                                       relations: true, # allows using the custom url
                                        url: work_package_completer_url,
+                                       searchKey: "subjectOrId",
                                        filters: work_package_completer_filters
                                      }
       else


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/61657

# What are you trying to accomplish?
Current implementation basically renders the autocompleter useless, because adding the URL will not make filter generation work properly. Instead we just add `query=foobar` query element. This would then need to be explicitly added in the API endpoint to be converted to a filter. We do that for WP completer in relation modal, but here we do not add this. Instead we allow the time entry autocompleter to correctly apply filters.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
