### PR TITLE
Fix encoding issue with client id and secret

### DIFF
--- a/modules/openid_connect/app/services/openid_connect/user_tokens/refresh_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/refresh_service.rb
@@ -70,17 +70,7 @@ module OpenIDConnect
       end
 
       def refresh_token_request(refresh_token)
-        response = OpenProject.httpx
-                              .basic_auth(provider.client_id, provider.client_secret)
-                              .post(provider.token_endpoint, form: {
-                                      grant_type: :refresh_token,
-                                      refresh_token:
-                                    })
-        response.raise_for_status
-
-        Success(response.json)
-      rescue HTTPX::Error => e
-        Failure(e)
+        TokenRequest.new(provider:).refresh(refresh_token)
       end
 
       def provider

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/token_request.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/token_request.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenIDConnect
+  module UserTokens
+    class TokenRequest
+      include Dry::Monads[:result]
+
+      attr_reader :provider
+
+      def initialize(provider:)
+        @provider = provider
+      end
+
+      def refresh(refresh_token)
+        request_token(form: { grant_type: :refresh_token, refresh_token: })
+      end
+
+      def exchange(access_token, audience)
+        request_token(form: {
+                        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+                        subject_token: access_token,
+                        audience:
+                      })
+      end
+
+      private
+
+      def request_token(form:)
+        response = authenticated_request.post(provider.token_endpoint, form:)
+        response.raise_for_status
+
+        Success(response.json)
+      rescue HTTPX::Error => e
+        Failure(e)
+      end
+
+      def authenticated_request
+        # According to https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1
+        # Client ID and Client Secret must be form-encoded. Otherwise characters such as colon (:)
+        # would not be allowed in the Client ID, since HTTP Basic Auth does not support it
+        # as per https://datatracker.ietf.org/doc/html/rfc7617#section-2
+        OpenProject.httpx.basic_auth(CGI.escape(provider.client_id), CGI.escape(provider.client_secret))
+      end
+    end
+  end
+end

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/token_request_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/token_request_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "spec_helper"
+
+RSpec.describe OpenIDConnect::UserTokens::TokenRequest, :webmock do
+  let(:service) { described_class.new(provider:) }
+  let(:provider) { create(:oidc_provider, client_id:, client_secret:) }
+  let(:client_id) { "openproject" }
+  let(:client_secret) { "a-secret" }
+
+  let(:response) do
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: { access_token: "an-access-token" }.to_json
+    }
+  end
+
+  before do
+    stub_request(:post, provider.token_endpoint).to_return(**response)
+  end
+
+  describe "#refresh" do
+    subject { service.refresh(token) }
+
+    let(:token) { "a-refresh-token" }
+
+    it { is_expected.to be_success }
+
+    it "returns the decoded JSON response" do
+      expect(subject.value!).to eq({ "access_token" => "an-access-token" })
+    end
+
+    it "uses a properly formatted request body" do
+      subject
+      expect(WebMock).to have_requested(:post, provider.token_endpoint)
+        .with(body: { grant_type: "refresh_token", refresh_token: token })
+    end
+
+    it "authenticates the request via HTTP Basic auth using Client ID and Client Secret" do
+      subject
+      expect(WebMock).to(have_requested(:post, provider.token_endpoint).with do |request|
+        auth_header = request.headers["Authorization"]
+        type, credentials = auth_header.split
+        expect(type).to eq "Basic"
+        expect(Base64.decode64(credentials)).to eq "#{client_id}:#{client_secret}"
+      end)
+    end
+
+    context "when the Client ID and Client Secret contain special characters" do
+      let(:client_id) { "https://openproject.local" }
+      let(:client_secret) { "a-secret/with:special-characters" }
+
+      it "escapes Basic Auth credentials" do
+        subject
+        expect(WebMock).to(have_requested(:post, provider.token_endpoint).with do |request|
+          auth_header = request.headers["Authorization"]
+          _, credentials = auth_header.split
+          expect(Base64.decode64(credentials)).to eq "https%3A%2F%2Fopenproject.local:a-secret%2Fwith%3Aspecial-characters"
+        end)
+      end
+    end
+
+    context "when the request fails" do
+      let(:response) do
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+          body: { error: "invalid_client" }.to_json
+        }
+      end
+
+      it { is_expected.not_to be_success }
+
+      it "returns the error response" do
+        expect(subject.failure).to be_a(HTTPX::HTTPError)
+      end
+    end
+  end
+
+  describe "#exchange" do
+    subject { service.exchange(token, audience) }
+
+    let(:token) { "a-refresh-token" }
+    let(:audience) { "target-audience" }
+
+    it { is_expected.to be_success }
+
+    it "returns the decoded JSON response" do
+      expect(subject.value!).to eq({ "access_token" => "an-access-token" })
+    end
+
+    it "uses a properly formatted request body" do
+      subject
+      expect(WebMock).to have_requested(:post, provider.token_endpoint)
+        .with(body: { grant_type: "urn:ietf:params:oauth:grant-type:token-exchange", subject_token: token, audience: })
+    end
+
+    it "authenticates the request via HTTP Basic auth using Client ID and Client Secret" do
+      subject
+      expect(WebMock).to(have_requested(:post, provider.token_endpoint).with do |request|
+        auth_header = request.headers["Authorization"]
+        type, credentials = auth_header.split
+        expect(type).to eq "Basic"
+        expect(Base64.decode64(credentials)).to eq "#{client_id}:#{client_secret}"
+      end)
+    end
+
+    context "when the Client ID and Client Secret contain special characters" do
+      let(:client_id) { "https://openproject.local" }
+      let(:client_secret) { "a-secret/with:special-characters" }
+
+      it "escapes Basic Auth credentials" do
+        subject
+        expect(WebMock).to(have_requested(:post, provider.token_endpoint).with do |request|
+          auth_header = request.headers["Authorization"]
+          _, credentials = auth_header.split
+          expect(Base64.decode64(credentials)).to eq "https%3A%2F%2Fopenproject.local:a-secret%2Fwith%3Aspecial-characters"
+        end)
+      end
+    end
+
+    context "when the request fails" do
+      let(:response) do
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+          body: { error: "invalid_client" }.to_json
+        }
+      end
+
+      it { is_expected.not_to be_success }
+
+      it "returns the error response" do
+        expect(subject.failure).to be_a(HTTPX::HTTPError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We errorneously did not encode the client id and secret. According to the HTTP Basic Auth spec, certain characters such as colon (:) are simply not allowed as part of the username.

The OAuth 2.0 spec already considered this, by requiring client id and secret to be URL form-encoded, but we forgot to do that.

Since this would have required changes in two places that already looked very similar, the requests to the token endpoint have been extracted into a service class, where they can share the basic code to construct the request and we can centrally test behaviours, such as authentication.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61694/activity

# Merge checklist

- [x] Added/updated tests
- [x] Tested changes manually
