### PR TITLE
Fix incorrect erb todo and disable comment indentation erb rule

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -15,6 +15,8 @@ linters:
     rubocop_config:
       inherit_from:
         - .rubocop.yml
+      Layout/CommentIndentation:
+        Enabled: false
       Layout/FirstArgumentIndentation:
         EnforcedStyle: consistent
       Layout/FirstMethodArgumentLineBreak:

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -110,7 +110,7 @@ See COPYRIGHT and LICENSE files for more details.
                     ) %>
               </div>
             </div>
-# TODO: allow editing versions when multiple projects %>
+            <%# TODO: allow editing versions when multiple projects %>
             <div class="form--field">
               <%= styled_label_tag :work_package_version_id, WorkPackage.human_attribute_name(:version) %>
               <div class="form--field-container">


### PR DESCRIPTION
# Ticket
Having the comment syntax cop and the erb indentation cop enabled together causes an incorrect code fix. See
https://github.com/Shopify/erb_lint/issues/306

# What are you trying to accomplish?
Disable the `Layout/CommentIndentation` cop. Fix the incorrect cop correction instances.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
