### PR TITLE
[#61315] fix tokens for work packages

### DIFF
--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -103,7 +103,7 @@ module Types
       end
 
       def work_package_cfs_for(type)
-        all_work_package_cfs.where(type: type)
+        all_work_package_cfs.merge(type.custom_fields)
       end
 
       def all_work_package_cfs


### PR DESCRIPTION
# Ticket
[OP#61315](https://community.openproject.org/wp/61315)

# What are you trying to accomplish?
- subject pattern input now provides all configured custom fields of the work package type

# What approach did you choose and why?
- fix relation for work package only cfs

