### PR TITLE
Make some files ready for frozen string literals

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -124,7 +126,7 @@ module ApplicationHelper
   end
 
   def project_nested_ul(projects, &)
-    s = ""
+    s = +""
     if projects.any?
       ancestors = []
       Project.project_tree(projects) do |project, _level|
@@ -428,8 +430,8 @@ module ApplicationHelper
 
   def initial_menu_classes(side_displayed, show_decoration)
     classes = "can-hide-navigation"
-    classes << " nosidebar" unless side_displayed
-    classes << " nomenus" unless show_decoration
+    classes += " nosidebar" unless side_displayed
+    classes += " nomenus" unless show_decoration
 
     classes
   end

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -253,7 +255,7 @@ class Notifications::CreateFromModelService
   # * only lines added
   # * excluding quoted lines
   def text_for_mentions
-    potential_text = ""
+    potential_text = +""
     potential_text << journal.notes if journal.try(:notes)
 
     %i[description subject].each do |field|

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -124,7 +126,7 @@ class CustomFieldFormBuilder < TabularFormBuilder
   # Return custom field label tag
   def custom_field_label_tag(options)
     classes = "form--label"
-    classes << " error" unless Array(custom_value).flat_map(&:errors).empty?
+    classes += " error" unless Array(custom_value).flat_map(&:errors).empty?
 
     content_tag "label",
                 for: custom_field_field_id,

--- a/lib/open_project/form_tag_helper.rb
+++ b/lib/open_project/form_tag_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -165,9 +167,7 @@ module OpenProject
                   "form--#{selector.tr('_', '-')}-container"
                 end
 
-      classes << (" " + options.fetch(:container_class, ""))
-
-      classes.strip
+      "#{classes} #{options[:container_class]}".strip
     end
   end
 end

--- a/spec/contracts/shared/model_contract_shared_context.rb
+++ b/spec/contracts/shared/model_contract_shared_context.rb
@@ -1,3 +1,33 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
 RSpec.shared_context "ModelContract shared context" do # rubocop:disable RSpec/ContextWording
   def expect_contract_valid
     expect(contract.validate)
@@ -30,7 +60,7 @@ RSpec.shared_context "ModelContract shared context" do # rubocop:disable RSpec/C
 
   shared_examples "contract is invalid" do |error_symbols = {}|
     example_title = "contract is invalid"
-    example_title << " with #{error_symbols.inspect}" if error_symbols.any?
+    example_title += " with #{error_symbols.inspect}" if error_symbols.any?
 
     it example_title do
       expect_contract_invalid error_symbols


### PR DESCRIPTION
During a previous test (https://github.com/opf/openproject/pull/18039), I added the frozen string literal comment to all Ruby files, to see how our codebase would react to that.

The test run uncovered ~~a few~~ _many_ files that were trying to modify strings that originate from string literals. This commit changes some of them to be safe under frozen string literals and freezes literals in the affected files.