### PR TITLE
do not panic if start time hour is nil

### DIFF
--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -132,7 +132,7 @@ module Meeting::VirtualStartTime
     return nil if @start_time_hour.nil?
 
     Time.strptime(@start_time_hour, "%H:%M")
-  rescue ArgumentError
+  rescue ArgumentError, TypeError
     nil
   end
 end


### PR DESCRIPTION
There is no bug report. I don't know how to reproduce it without using specific data where I ran into this issue.
But this is just a small improvement handling a nil value here which apparently can be the case.