### PR TITLE
flaky test - wait for network requests to complete on wp update in activities spec

### DIFF
--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -341,6 +341,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
 
       wp_page.update_attributes(subject: "A new subject") # rubocop:disable Rails/ActiveRecordAliases
+      wait_for_network_idle
       wp_page.expect_and_dismiss_toaster(message: "Successful update.")
 
       second_journal = work_package.journals.second
@@ -363,6 +364,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       # the journals will not be merged due to the time difference
 
       wp_page.update_attributes(subject: "A new subject!!!") # rubocop:disable Rails/ActiveRecordAliases
+      wait_for_network_idle
 
       third_journal = work_package.journals.third
 


### PR DESCRIPTION
On wp update, activities are updated async. Wait for that request to complete

https://community.openproject.org/wp/61390