### PR TITLE
Use default loadFromUrl option in autocompleter, not relation mode

### DIFF
--- a/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_child_form_component.html.erb
@@ -29,7 +29,6 @@
                 resource: 'work_packages',
                 searchKey: 'subjectOrId',
                 url:,
-                relations: true, # Activates relations fetch mode in the autocomplete
                 openDirectly: false,
                 focusDirectly: true,
                 dropdownPosition: 'bottom',

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -44,12 +44,12 @@
                 required: true,
                 visually_hide_label: false,
                 autocomplete_options: {
-                  resource: 'work_packages',
+                  resource: "work_packages",
                   url:,
-                  relations: true, # Activates relations fetch mode in the autocomplete
+                  searchKey: "subjectOrId",
                   openDirectly: false,
                   focusDirectly: true,
-                  dropdownPosition: 'bottom',
+                  dropdownPosition: "bottom",
                   appendTo: "##{DIALOG_ID}",
                   data: { test_selector: TO_ID_FIELD_TEST_SELECTOR}
                 }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -20,11 +20,12 @@ import {
   TemplateRef,
   Type,
   ViewChild,
-  ViewContainerRef, ViewEncapsulation,
+  ViewContainerRef,
+  ViewEncapsulation,
 } from '@angular/core';
 import { DropdownPosition, NgSelectComponent } from '@ng-select/ng-select';
 import { BehaviorSubject, merge, NEVER, Observable, of, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
 import { AddTagFn, GroupValueFn } from '@ng-select/ng-select/lib/ng-select.component';
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -50,9 +51,6 @@ import { ID } from '@datorama/akita';
 import { HttpClient } from '@angular/common/http';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
-import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
-import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
-import { addFiltersToPath } from 'core-app/core/apiv3/helpers/add-filters-to-path';
 import {
   IAPIFilter,
   IOPAutocompleterOption,
@@ -235,8 +233,6 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
   @Input() public getOptionsFn:(searchTerm:string) => Observable<unknown>;
 
   @Input() public url:string;
-
-  @Input() public relations?:boolean = false;
 
   @Input() public debounceTimeMs:number = 250;
 
@@ -478,7 +474,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     }
 
     return this.typeahead.pipe(
-      filter(() => !!(this.defaultData || this.getOptionsFn)),
+      filter(() => !!(this.defaultData || this.url || this.getOptionsFn)),
       distinctUntilChanged(),
       tap(() => this.loading$.next(true)),
       debounceTime(this.debounceTimeForCurrentEnvironment),
@@ -487,8 +483,8 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
           return this.getOptionsFn(queryString);
         }
 
-        if (this.relations && this.url) {
-          return this.fetchFromUrl(queryString);
+        if (this.url) {
+          return this.opAutocompleterService.loadFromUrl(this.url, queryString, this.resource, this.filters, this.searchKey);
         }
 
         if (this.defaultData) {
@@ -502,39 +498,6 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
         error: () => this.loading$.next(false),
       }),
     );
-  }
-
-  private fetchFromUrl(queryString:string):Observable<unknown> {
-    // Exit early if the query string is empty as there is no typeahead
-    if (queryString === null || queryString.length === 0) {
-      return of([]);
-    }
-
-    // Build filters if provided
-    const finalFilters = new ApiV3FilterBuilder();
-    this.filters?.forEach((currentFilter) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      finalFilters.add(currentFilter.name, currentFilter.operator, currentFilter.values);
-    });
-
-    const urlWithFilters = addFiltersToPath(this.url, finalFilters);
-
-    // Add default sort parameters if resource is work packages
-    if (this.resource === 'work_packages') {
-      urlWithFilters.searchParams.set('sortBy', '[["updatedAt","desc"]]');
-    }
-
-    // Add query string to the url if provided
-    urlWithFilters.searchParams.set('query', queryString);
-
-    const stringifiedBuiltOutUrl = urlWithFilters.toString();
-
-    return this
-      .halResourceService
-      .get(stringifiedBuiltOutUrl)
-      .pipe(
-        map((collection:CollectionResource<T>) => collection.elements),
-      );
   }
 
   private get debounceTimeForCurrentEnvironment():number {

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
@@ -8,7 +8,7 @@ import { ApiV3WorkPackagePaths } from 'core-app/core/apiv3/endpoints/work_packag
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import {
   IAPIFilter,
@@ -87,7 +87,12 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
   // If you need to fetch our default date sources like work_packages or users,
   // you should use the default method (loadAvailable), otherwise you should implement a function for
   // your desired resource
-  public loadData(matching:string, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string) {
+  public loadData(matching:string|null, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string) {
+    // Exit early if the query string is empty as there is no typeahead
+    if (matching === null || matching.length === 0) {
+      return of([]);
+    }
+
     switch (resource) {
       // in this case we can add more functions for fetching usual resources
       default: {
@@ -98,7 +103,12 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
 
   // A method for returning data based on a custom URL (i.e. in time logging we have a special endpoint for retrieving
   // work packages)
-  public loadFromUrl(url:string, matching:string, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string) {
+  public loadFromUrl(url:string, matching:string|null, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string) {
+    // Exit early if the query string is empty as there is no typeahead
+    if (matching === null || matching.length === 0) {
+      return of([]);
+    }
+
     const finalFilters:ApiV3FilterBuilder = this.createFilters(filters ?? [], matching, searchKey);
     const params = this.createParams(resource);
 

--- a/lib/api/v3/work_packages/available_relation_candidates_api.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_api.rb
@@ -38,14 +38,18 @@ module API
 
           def filters_param
             JSON::parse(params[:filters] || "[]")
-              .concat([string_filter, type_filter])
+              .concat([string_filter, type_filter].compact)
           end
 
           def string_filter
+            return unless params.key?(:query)
+
             filter_param(:typeahead, "**", params[:query])
           end
 
           def type_filter
+            return unless params.key?(:type)
+
             filter_param(:relatable, params[:type], [@work_package.id.to_s])
           end
 
@@ -56,7 +60,7 @@ module API
 
         resources :available_relation_candidates do
           params do
-            requires :query, type: String # part of the WP ID and/or part of its subject and/or part of the projects name
+            optional :query, type: String # part of the WP ID and/or part of its subject and/or part of the projects name
             optional :type, type: String, default: ::Relation::TYPE_RELATES # relation type
             optional :pageSize, type: Integer, default: 10
           end


### PR DESCRIPTION
op-autocompleter used a weird input `relations` to switch to some specific loading from URL, which misled us to assume that URL inputs were supported generally. This PR ensures that it is, which is building on top of https://github.com/opf/openproject/pull/18035