### PR TITLE
Use stable sort and name groups consistently

### DIFF
--- a/app/components/users/hover_card_component.rb
+++ b/app/components/users/hover_card_component.rb
@@ -48,7 +48,7 @@ class Users::HoverCardComponent < ApplicationComponent
   # "Member of group1, group2 and 3 more"
   # The latter string is cut off since the complete list of group names would exceed the allowed `max_length`.
   def group_membership_summary(max_length = 40)
-    groups = @user.groups.visible
+    groups = @user.groups.visible.order(:lastname)
     return no_group_text if groups.empty?
 
     group_links = linked_group_names(groups)

--- a/spec/components/users/hover_card_component_spec.rb
+++ b/spec/components/users/hover_card_component_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Users::HoverCardComponent, type: :component do
 
     context "with the user being member of many groups" do
       let(:groups) do
-        Array.new(8) { create(:group, members: user) }
+        ("A".."H").map { |char| create(:group, lastname: "Group #{char}", members: user) }
       end
 
       it "lists some group names with truncation" do


### PR DESCRIPTION
Fixes spec

```
  1) Users::HoverCardComponent when showing the group summary with the user being member of many groups lists some group names with truncation
     Failure/Error: expect(g).to have_text("Member of #{groups.slice(0, 4).map(&:lastname).join(', ')} and 4 more.")
       expected to find text "Member of Group 137, Group 138, Group 139, Group 140 and 4 more." in "Member of Group 137, Group 138, Group 139 and 5 more."
     # ./spec/components/users/hover_card_component_spec.rb:116:in 'block (4 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:204:in 'block (2 levels) in <top (required)>'

Finished in 2 minutes 32.2 seconds (files took 33.51 seconds to load)
31501 examples, 1 failure, 24 pending, 1 error occurred outside of examples

'./spec/components/users/hover_card_component_spec.rb:113'
```

The flickering pattern is quite interesting. Text is cut off at a specific character limit here, and the spec expects four groups to be visible before cutoff. If the spec is run late in the test suite run, the group sequence is already in the 100s, so that only three groups are visible before character cutoff.