### PR TITLE
bug/61708 Cannot delete users who used emoji reactions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,7 @@ class User < Principal
            inverse_of: :user,
            dependent: :destroy
 
+  has_many :emoji_reactions, dependent: :destroy
   has_many :remote_identities, dependent: :destroy
 
   # Users blocked via brute force prevention

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe User do
           status:)
   end
 
+  describe "Associations" do
+    it { is_expected.to have_many(:emoji_reactions).dependent(:destroy) }
+  end
+
   describe "with long but allowed attributes" do
     it "is valid" do
       user.firstname = "a" * 256


### PR DESCRIPTION
https://community.openproject.org/work_packages/61708

Add missing active record user association with dependent destroy