### PR TITLE
Fix autocompleter is cut off inside the filter header

### DIFF
--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -1,10 +1,11 @@
 <div class="advanced-filters--filter-value <%= value_visibility %>">
   <%= angular_component_tag autocomplete_options[:component],
                             inputs: {
-                              inputName: 'value',
+                              inputName: "value",
                               multiple: true,
                               multipleAsSeparateInputs: false,
                               inputValue: filter.values,
+                              appendTo: "body",
                               hiddenFieldAction: "change->filter--filters-form#autocompleteSendForm"
                               # Set on the template as there is a timing issue where the
                               # angular component is not yet ready in the DOM and hence
@@ -14,9 +15,9 @@
                             }.merge(autocomplete_options.except(:component)),
                             id: "#{filter.name}_value",
                             data: {
-                              'filter-autocomplete': true,
-                              'filter--filters-form-target': 'filterValueContainer',
-                              'filter-name': filter.name
+                              "filter-autocomplete": true,
+                              "filter--filters-form-target": "filterValueContainer",
+                              "filter-name": filter.name
                             }
   %>
 </div>

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -35,7 +35,9 @@ module Components::Autocompleter
       retry_block do
         if results_selector
           results_selector = "#{results_selector} .ng-dropdown-panel" if results_selector == "body"
-          page.find(results_selector, wait: 5)
+          within_window(current_window) do
+            page.find(results_selector, wait: 5)
+          end
         else
           within(element) do
             page.find("ng-select .ng-dropdown-panel", wait: 5)

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -288,8 +288,8 @@ module Pages
 
         within(selected_filter) do
           find('[data-filter-autocomplete="true"]').click
-          visible_user_auto_completer_options
         end
+        visible_user_auto_completer_options
       end
 
       def select_filter(name, human_name)


### PR DESCRIPTION
# Ticket
Just a cherry pick from the dev branch from the PR #17846 .

# What are you trying to accomplish?
Fix the cut off autocompleter on the filter header.

## Screenshots

<details><summary>Before</summary>
<p>

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/42f12e0d-7965-4bd3-8b58-6dc37f9a4d85" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/47591696-fac3-4f54-80be-338164122b99" />


</p>
</details> 

# What approach did you choose and why?

Append the autocompleter to the document body so it won't get cut off.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
