### PR TITLE
[#61619] unclear error message upon save on empty subject patterns

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -39,3 +39,5 @@ linters:
         Enabled: true
       Style/FrozenStringLiteralComment:
         Enabled: false
+      Style/RedundantConstantBase:
+        Enabled: false

--- a/app/components/work_packages/types/settings_component.rb
+++ b/app/components/work_packages/types/settings_component.rb
@@ -56,7 +56,7 @@ module WorkPackages
       end
 
       def update_form_options
-        { url: type_path(id: model.id), method: :patch, model: }
+        { url: update_tab_type_path(id: model.id, tab: :settings), method: :patch, model: }
       end
     end
   end

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -53,11 +53,7 @@ class TypesController < ApplicationController
     if params[:tab].blank?
       redirect_to tab: :settings
     else
-      type = ::Type
-             .includes(:projects,
-                       :custom_fields)
-             .find(params[:id])
-
+      type = ::Type.includes(:projects, :custom_fields).find(params[:id])
       render_edit_tab(type)
     end
   end
@@ -82,14 +78,8 @@ class TypesController < ApplicationController
     UpdateTypeService
       .new(@type, current_user)
       .call(permitted_type_params) do |call|
-      call.on_success do
-        redirect_to_type_tab_path(@type, t(:notice_successful_update))
-      end
-
-      call.on_failure do |result|
-        flash[:error] = result.errors.full_messages.join("\n")
-        render_edit_tab(@type, status: :unprocessable_entity)
-      end
+      call.on_success { redirect_to_type_tab_path(@type, t(:notice_successful_update)) }
+      call.on_failure { render_edit_tab(@type, status: :unprocessable_entity) }
     end
   end
 

--- a/app/controllers/work_packages/types/subject_configuration_controller.rb
+++ b/app/controllers/work_packages/types/subject_configuration_controller.rb
@@ -48,7 +48,7 @@ module WorkPackages
           end
 
           call.on_failure do
-            @default_tab = "subject_configuration"
+            params[:tab] = "subject_configuration"
             render template: "types/edit", status: :unprocessable_entity
           end
         end

--- a/app/controllers/work_packages/types/subject_configuration_tab_controller.rb
+++ b/app/controllers/work_packages/types/subject_configuration_tab_controller.rb
@@ -30,7 +30,7 @@
 
 module WorkPackages
   module Types
-    class SubjectConfigurationController < ApplicationController
+    class SubjectConfigurationTabController < ApplicationController
       layout "admin"
 
       before_action :require_admin

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -39,10 +39,8 @@ module TabsHelper
     end
   end
 
-  def selected_tab(tabs, default_tab = nil)
-    tabs.detect { |t| t[:name] == params[:tab] } ||
-      tabs.detect { |t| t[:name] == default_tab } ||
-      tabs.first
+  def selected_tab(tabs)
+    tabs.detect { |t| t[:name] == params[:tab] } || tabs.first
   end
 
   def tabs_for_key(key, params = {})

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -31,10 +31,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% tabs = types_tabs %>
 
-<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: tabs) %>
+<%= render Types::EditPageHeaderComponent.new(type: @type, tabs:) %>
 
 <%=
-  selected_tab = selected_tab(tabs, @default_tab)
+  selected_tab = selected_tab(tabs)
 
   if selected_tab.key?(:view_component)
     render selected_tab[:view_component].new(@type)
@@ -47,6 +47,3 @@ See COPYRIGHT and LICENSE files for more details.
     end
   end
 %>
-
-<!-- Remove those once all tab contents are using view components -->
-<%= error_messages_for "type" %>

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% tabs = types_tabs %>
 
-<%= render Types::EditPageHeaderComponent.new(type: @type, tabs:) %>
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs:) %>
 
 <%=
   selected_tab = selected_tab(tabs)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,7 @@ Rails.application.routes.draw do
       get "edit/:tab" => "types#edit", as: "edit_tab"
       match "update/:tab" => "types#update", as: "update_tab", via: %i[post patch]
       put :subject_configuration,
-          controller: "work_packages/types/subject_configuration",
+          controller: "work_packages/types/subject_configuration_tab",
           action: "update_subject_configuration"
     end
 

--- a/spec/controllers/work_packages/types/subject_configuration_tab_controller_spec.rb
+++ b/spec/controllers/work_packages/types/subject_configuration_tab_controller_spec.rb
@@ -31,7 +31,7 @@
 
 require "spec_helper"
 
-RSpec.describe WorkPackages::Types::SubjectConfigurationController do
+RSpec.describe WorkPackages::Types::SubjectConfigurationTabController do
   let(:user) { create(:admin) }
   let(:wp_type) { create(:type) }
 


### PR DESCRIPTION
# Ticket
[OP#61619](https://community.openproject.org/wp/61619)

# What are you trying to accomplish?
- removed error message banners
- fixed controller and params when calling updates
- renamed subject configuration controller to emphasize usage in tab

