### PR TITLE
no need for tests when only docker (except CI) files change

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'help/**'
+      - 'docker/prod/**'
+      - 'docker/dev/**'
+      - 'docker/pullpreview/**'
   pull_request:
     types: [opened, reopened, synchronize]
     paths-ignore:
@@ -16,6 +19,9 @@ on:
       - 'help/**'
       - 'packaging/**'
       - '.pkgr.yml'
+      - 'docker/prod/**'
+      - 'docker/dev/**'
+      - 'docker/pullpreview/**'
 
 permissions:
   contents: read

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -21,7 +21,7 @@ ENV NEXT_PGVERSION="15"
 ENV PGBIN="/usr/lib/postgresql/$PGVERSION/bin"
 ENV BUNDLE_WITHOUT="development:test"
 
-# RAILS
+# RAILS!!
 # Set a default key base, ensure to provide a secure value in production environments!
 ENV SECRET_KEY_BASE=OVERWRITE_ME
 ENV RAILS_ENV=production


### PR DESCRIPTION
Mini change just preventing us from wasting time and resources running tests for code that doesn't affect them. In this case, docker files.