### PR TITLE
[#61749] PDF Export: table cell border/background styles definition in yml file is ignored

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ gem "structured_warnings", "~> 0.4.0"
 gem "airbrake", "~> 13.0.0", require: false
 
 gem "markly", "~> 0.10" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "5a3938c7721f406af2adebe5ccab58d8f13aeb6b"
+gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "6d63db06beaa030e5c4529ffe274ca1c6fe309cb"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 5a3938c7721f406af2adebe5ccab58d8f13aeb6b
-  ref: 5a3938c7721f406af2adebe5ccab58d8f13aeb6b
+  revision: 6d63db06beaa030e5c4529ffe274ca1c6fe309cb
+  ref: 6d63db06beaa030e5c4529ffe274ca1c6fe309cb
   specs:
-    md_to_pdf (0.1.5)
+    md_to_pdf (0.1.6)
       color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.3)
@@ -1685,7 +1685,7 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   markly (0.12.1) sha256=fda3a53ec29e349e9c30e34cf9da322aa260d66627f75b2d3a8ad9633e5cbab9
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
-  md_to_pdf (0.1.5)
+  md_to_pdf (0.1.6)
   messagebird-rest (1.4.2) sha256=1501e16ad76c87558f20f3b26cb39d05f587b349b44b8bf8056b040e9b495301
   meta-tags (2.22.1) sha256=e5ae1febbd320d396c7226d7edb868e5d63466c14b9c8b06622a1a74e6dce354
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5

--- a/app/models/work_package/pdf_export/export/schema.json
+++ b/app/models/work_package/pdf_export/export/schema.json
@@ -1717,6 +1717,12 @@
       "allOf" : [
         {
           "$ref" : "#/$defs/font"
+        },
+        {
+          "$ref" : "#/$defs/padding"
+        },
+        {
+          "$ref" : "#/$defs/border"
         }
       ]
     },


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/61749

# What are you trying to achieve?
If an admin changes the default table cell border/background styles definition in yml file `app/models/work_package/pdf_export/export/standard.yml` the settings are not applied

# What approach did you choose and why?
Fix the bug in md_to_pdf & bump the version

# Merge checklist

- [x] Added/updated tests (in [md_to_pdf](https://github.com/opf/md-to-pdf/blob/main/spec/markdown_to_pdf/table_spec.rb#L245))
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
