### PR TITLE
Make sure redirect URI does not show as completed prematurely

### DIFF
--- a/modules/storages/app/components/storages/admin/redirect_uri_component.html.erb
+++ b/modules/storages/app/components/storages/admin/redirect_uri_component.html.erb
@@ -7,7 +7,7 @@
             Primer::Beta::Text.new(font_weight: :bold, mr: 1, test_selector: 'storage-redirect-uri-label')
           ) { I18n.t('storages.file_storage_view.redirect_uri') }
         )
-        concat(configuration_check_label_for(:storage_oauth_client_configured))
+        concat(configuration_check_label_for(:storage_redirect_uri_configured))
       end
 
       grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-redirect-uri-description') do

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -42,6 +42,7 @@ module Storages
     def configuration_checks
       {
         storage_oauth_client_configured: oauth_client.present?,
+        storage_redirect_uri_configured: oauth_client&.persisted?,
         storage_tenant_drive_configured: tenant_id.present? && drive_id.present?,
         access_management_configured: !automatic_management_unspecified?,
         name_configured: name.present?

--- a/modules/storages/spec/models/storages/one_drive_storage_spec.rb
+++ b/modules/storages/spec/models/storages/one_drive_storage_spec.rb
@@ -43,16 +43,17 @@ RSpec.describe Storages::OneDriveStorage do
 
   describe "#configured?" do
     context "with a complete configuration" do
-      let(:storage) { build(:one_drive_storage, :as_not_automatically_managed, oauth_client: build(:oauth_client)) }
+      let(:storage) { create(:one_drive_storage, :as_not_automatically_managed, oauth_client: build(:oauth_client)) }
 
       it "returns true" do
-        expect(storage.configured?).to be(true)
+        expect(storage).to be_configured
 
         aggregate_failures "configuration_checks" do
           expect(storage.configuration_checks)
             .to eq(name_configured: true,
                    storage_oauth_client_configured: true,
                    access_management_configured: true,
+                   storage_redirect_uri_configured: true,
                    storage_tenant_drive_configured: true)
         end
       end
@@ -62,10 +63,11 @@ RSpec.describe Storages::OneDriveStorage do
       let(:storage) { build(:one_drive_storage) }
 
       it "returns false" do
-        expect(storage.configured?).to be(false)
+        expect(storage).not_to be_configured
 
         aggregate_failures "configuration_checks" do
-          expect(storage.configuration_checks[:storage_oauth_client_configured]).to be(false)
+          expect(storage.configuration_checks[:storage_oauth_client_configured]).to be_falsey
+          expect(storage.configuration_checks[:storage_redirect_uri_configured]).to be_falsey
         end
       end
     end


### PR DESCRIPTION
Since we are now refreshing the entire form from step to step, future steps show as incompleted usually. However, redirect_uri has nothing to do itself, so it previously checked the same thing that the oauth_client checked. This would show it as completed a bit too early.

For consistency it now got its own configuration check.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61744/activity