### PR TITLE
Stream the SQL dump file when backing up

### DIFF
--- a/app/workers/backup_job.rb
+++ b/app/workers/backup_job.rb
@@ -167,8 +167,7 @@ class BackupJob < ApplicationJob
 
         paths_to_clean << get_cache_folder_path(attachment) if clean_up && attachment.file.cached?
       end
-
-      zipfile.get_output_stream("openproject.sql") { |f| f.write File.read(db_dump_file_name) }
+      zipfile.add "openproject.sql", db_dump_file_name
     end
 
     remove_paths! paths_to_clean # delete locally cached files that were downloaded just for the backup

--- a/spec/workers/backup_job_spec.rb
+++ b/spec/workers/backup_job_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe BackupJob, type: :model do
 
     let(:user) { create(:admin) }
 
+    let(:openproject_sql) do
+      Tempfile.new(["openproject", ".sql"]).tap do |f|
+        f.write("SOME SQL")
+      end
+    end
+
     before do
       previous_backup
       backup
@@ -70,11 +76,6 @@ RSpec.describe BackupJob, type: :model do
       allow(job).to receive(:job_id).and_return job_id
 
       allow(Open3).to receive(:capture3).and_return [nil, "Dump failed", db_dump_process_status]
-
-      openproject_sql = Tempfile.new(["openproject", ".sql"]).tap do |f|
-        f.write("SOME SQL")
-        f.rewind
-      end
 
       allow_any_instance_of(BackupJob)
         .to receive(:tmp_file_name).with("openproject", ".sql").and_return(openproject_sql.path)
@@ -218,20 +219,18 @@ RSpec.describe BackupJob, type: :model do
       }
     }
   ) do
-    let(:dummy_path) { "#{LocalFileUploader.cache_dir}/1639754082-3468-0002-0911/file.ext" }
+    let(:dummy_file) { Pathname("#{LocalFileUploader.cache_dir}/1639754082-3468-0002-0911/file.ext") }
 
     before do
-      FileUtils.mkdir_p Pathname(dummy_path).parent.to_s
-      File.open(dummy_path, "w") { |f| f.puts "dummy" }
+      dummy_file.parent.mkpath
+      dummy_file.write("dummy")
 
       allow_any_instance_of(LocalFileUploader).to receive(:cached?).and_return(true)
-      allow_any_instance_of(LocalFileUploader)
-        .to receive(:local_file)
-              .and_return(File.new(dummy_path))
+      allow_any_instance_of(LocalFileUploader).to receive(:local_file).and_return(File.new(dummy_file))
     end
 
     after do
-      FileUtils.rm_rf dummy_path
+      dummy_file.unlink
     end
 
     it_behaves_like "it creates a backup", remote_storage: true

--- a/spec/workers/backup_job_spec.rb
+++ b/spec/workers/backup_job_spec.rb
@@ -71,14 +71,18 @@ RSpec.describe BackupJob, type: :model do
 
       allow(Open3).to receive(:capture3).and_return [nil, "Dump failed", db_dump_process_status]
 
+      openproject_sql = Tempfile.new(["openproject", ".sql"]).tap do |f|
+        f.write("SOME SQL")
+        f.rewind
+      end
+
       allow_any_instance_of(BackupJob)
-        .to receive(:tmp_file_name).with("openproject", ".sql").and_return("/tmp/openproject.sql")
+        .to receive(:tmp_file_name).with("openproject", ".sql").and_return(openproject_sql.path)
 
       allow_any_instance_of(BackupJob)
         .to receive(:tmp_file_name).with("openproject-backup", ".zip").and_return("/tmp/openproject.zip")
 
       allow(File).to receive(:read).and_call_original
-      allow(File).to receive(:read).with("/tmp/openproject.sql").and_return "SOME SQL"
     end
 
     def perform


### PR DESCRIPTION
Previously this was loading the entire dump file in memory before adding to the zip, potentially leading to memory exhaustion.

https://community.openproject.org/work_packages/50637/activity