### PR TITLE
chore: bump md_to_pdf to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ gem "structured_warnings", "~> 0.4.0"
 gem "airbrake", "~> 13.0.0", require: false
 
 gem "markly", "~> 0.10" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "965034bdd4b119c7233ea4ecd62d3964d3dec11d"
+gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "66893683b94a5fe8f1dc9a60600773307209cdd2"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,12 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 965034bdd4b119c7233ea4ecd62d3964d3dec11d
-  ref: 965034bdd4b119c7233ea4ecd62d3964d3dec11d
+  revision: 66893683b94a5fe8f1dc9a60600773307209cdd2
+  ref: 66893683b94a5fe8f1dc9a60600773307209cdd2
   specs:
-    md_to_pdf (0.1.5)
+    md_to_pdf (0.2.0)
+      base64 (~> 0.2)
+      bigdecimal (~> 3.1)
       color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.3)

--- a/app/models/work_package/pdf_export/export/schema.json
+++ b/app/models/work_package/pdf_export/export/schema.json
@@ -1717,6 +1717,12 @@
       "allOf" : [
         {
           "$ref" : "#/$defs/font"
+        },
+        {
+          "$ref" : "#/$defs/padding"
+        },
+        {
+          "$ref" : "#/$defs/border"
         }
       ]
     },


### PR DESCRIPTION
This is bumping md_to_pdf to v0.2.0 which has the proper gems requirements for ruby >= 3.4.

This does not need to wait for a 15.4 release as it cannot be reviewed by QA and also fixes the bug in [61749](https://community.openproject.org/projects/openproject/work_packages/61749/activity) which enables a workaround for admins with PDF styling. So it would be nice to have in a patch level release (if there is one at all after 15.3.1)

# Merge checklist

- [x] Added/updated tests (in [md_to_pdf](https://github.com/opf/md-to-pdf/blob/main/spec/markdown_to_pdf/table_spec.rb#L245))
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

