### PR TITLE
[#61776] Configure `active_record_doctor` to detect mismatched fk constraints and association `dependent` option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -363,6 +363,9 @@ group :development, :test do
 
   # i18n-tasks helps find and manage missing and unused translations.
   gem "i18n-tasks", "~> 1.0.13", require: false
+
+  # Active Record Doctor helps to keep the database in good shape.
+  gem "active_record_doctor", "~> 1.15.0"
 end
 
 gem "bootsnap", "~> 1.18.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_record_doctor (1.15.0)
+      activerecord (>= 4.2.0)
     activejob (7.1.5.1)
       activesupport (= 7.1.5.1)
       globalid (>= 0.3.6)
@@ -1267,6 +1269,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-xml_parser (~> 2.0.0)
+  active_record_doctor (~> 1.15.0)
   activemodel-serializers-xml (~> 1.0.1)
   activerecord-import (~> 2.1.0)
   activerecord-nulldb-adapter (~> 1.1.0)
@@ -1486,6 +1489,7 @@ CHECKSUMS
   actionpack-xml_parser (2.0.1) sha256=40cb461ee99445314ab580a783fb7413580deb8b28113c9e70ecd7c1b334d5e6
   actiontext (7.1.5.1) sha256=b8e261cfad5bc6a78b3f15be5e7c7f32190041b3dc6f027a3a353b4392d2f7ec
   actionview (7.1.5.1) sha256=8c559a213501798e29b50b5341a643a70bbf6fa0aa2abaf571d0efc59dc4f6aa
+  active_record_doctor (1.15.0) sha256=614a49e259a679d17cbc62dead9217acaf7191a371115606132473123b426b13
   activejob (7.1.5.1) sha256=7633376c857f4c491d06b5a7f5d86d9f07afc595398354a3f1abe80eb7e35767
   activemodel (7.1.5.1) sha256=74727466854a7fbdfe8f2702ca3112b23877500d4926bf7e02e921ad542191f1
   activemodel-serializers-xml (1.0.3) sha256=fa1b16305e7254cc58a59c68833e3c0a593a59c8ab95d3be5aaea7cd9416c397

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < Principal
   belongs_to :ldap_auth_source, optional: true
 
   # Authorized OAuth grants
-  has_many :oauth_grants,
+  has_many :oauth_grants, # rubocop:disable Rails/InverseOf
            class_name: "Doorkeeper::AccessGrant",
            foreign_key: "resource_owner_id",
            dependent: :delete_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,12 +70,14 @@ class User < Principal
   # Authorized OAuth grants
   has_many :oauth_grants,
            class_name: "Doorkeeper::AccessGrant",
-           foreign_key: "resource_owner_id"
+           foreign_key: "resource_owner_id",
+           dependent: :delete_all
 
   # User-defined oauth applications
   has_many :oauth_applications,
            class_name: "Doorkeeper::Application",
-           as: :owner
+           as: :owner,
+           dependent: :destroy
 
   # Meeting memberships
   has_many :meeting_participants,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe User do
   describe "Associations" do
     it { is_expected.to have_many(:emoji_reactions).dependent(:destroy) }
     it { is_expected.to have_many(:reminders).with_foreign_key(:creator_id).dependent(:destroy).inverse_of(:creator) }
+    it { is_expected.to have_many(:oauth_grants).with_foreign_key(:resource_owner_id).dependent(:delete_all) }
+    it { is_expected.to have_many(:oauth_applications).dependent(:destroy) }
   end
 
   describe "with long but allowed attributes" do


### PR DESCRIPTION
⚠️ ~~**This PR includes a commit from #18077**. Please review/merge that PR first!~~

# Ticket

https://community.openproject.org/wp/61776

also relates to bug https://community.openproject.org/wp/61708

# What are you trying to accomplish?

- Adds [Active Record Doctor](https://github.com/gregnavis/active_record_doctor) as a dependency to help us establish where there may be a mismatch between foreign keys and model association `dependent` option.
- This PR also fixes missing `dependent` option on two `User` `has_many` associations.
- ⚠️ This PR doesn't (yet) fix incorrect `dependent` option on `User` (or any other model) associations - _this is open to discussion_.

## Results

```
bundle exec rake active_record_doctor:incorrect_dependent_option
```

<details><summary>Details</summary>
<pre><code>
use `dependent: :delete_all` or similar on Budget.material_budget_items - associated model MaterialBudgetItem has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on Budget.labor_budget_items - associated model LaborBudgetItem has no callbacks and can be deleted in bulk
use `dependent: :destroy` or similar on CustomField.custom_options - associated model CustomOption has callbacks that are currently skipped
use `dependent: :delete_all` or similar on DeployTarget.deploy_status_checks - associated model DeployStatusCheck has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on GithubPullRequest.deploy_status_checks - associated model DeployStatusCheck has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on Journal.emoji_reactions - associated model EmojiReaction has no callbacks and can be deleted in bulk
use `dependent: :destroy` or similar on Journal.agenda_item_journals - associated model Journal::MeetingAgendaItemJournal has callbacks that are currently skipped
use `dependent: :delete_all` or similar on Meeting.participants - associated model MeetingParticipant has no callbacks and can be deleted in bulk
use `dependent: :delete` or similar on Migrations::Attachments::CurrentWikiPage.content - associated model Migrations::Attachments::CurrentWikiContent has no callbacks and can be deleted without loading
use `dependent: :delete_all` or similar on OAuthClient.remote_identities - associated model RemoteIdentity has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on OAuthClient.oauth_client_tokens - associated model OAuthClientToken has no callbacks and can be deleted in bulk
use `dependent: :destroy` or similar on OpenIDConnect::UserSessionLink.session - associated model Sessions::UserSession has callbacks that are currently skipped
use `dependent: :destroy` or similar on Principal.work_package_shares - associated model Member has callbacks that are currently skipped
use `dependent: :delete` or similar on Principal.preference - associated model UserPreference has no callbacks and can be deleted without loading
use `dependent: :delete_all` or similar on Project.project_custom_field_project_mappings - associated model ProjectCustomFieldProjectMapping has no callbacks and can be deleted in bulk
use `dependent: :destroy` or similar on Project.time_entries - associated model TimeEntry has callbacks that are currently skipped
use `dependent: :destroy` or similar on Project.categories - associated model Category has callbacks that are currently skipped
use `dependent: :delete_all` or similar on Project.notification_settings - associated model NotificationSetting has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on ProjectCustomField.project_custom_field_project_mappings - associated model ProjectCustomFieldProjectMapping has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on Query.views - associated model View has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on Role.role_permissions - associated model RolePermission has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on Storages::ProjectStorage.last_project_folders - associated model Storages::LastProjectFolder has no callbacks and can be deleted in bulk
use `dependent: :delete` or similar on Token::ICal.ical_token_query_assignment - associated model ICalTokenQueryAssignment has no callbacks and can be deleted without loading
use `dependent: :delete_all` or similar on User.passwords - associated model UserPassword has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.oauth_client_tokens - associated model OAuthClientToken has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.meeting_participants - associated model MeetingParticipant has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.notification_settings - associated model NotificationSetting has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.emoji_reactions - associated model EmojiReaction has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.remote_identities - associated model RemoteIdentity has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.otp_devices - associated model TwoFactorAuthentication::Device has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on User.ldap_groups_memberships - associated model LdapGroups::Membership has no callbacks and can be deleted in bulk
use `dependent: :delete_all` or similar on Version.version_settings - associated model VersionSetting has no callbacks and can be deleted in bulk
use `dependent: :destroy` or similar on Webhooks::Webhook.deliveries - associated model Webhooks::Log has callbacks that are currently skipped
use `dependent: :destroy` or similar on Wiki.wiki_menu_items - associated model MenuItems::WikiMenuItem has callbacks that are currently skipped
use `dependent: :destroy` or similar on WorkPackage.cost_entries - associated model CostEntry has callbacks that are currently skipped
use `dependent: :delete_all` or similar on WorkPackage.relations - associated model Relation has no callbacks and can be deleted in bulk
use `dependent: :destroy` or similar on WorkPackage.time_entries - associated model TimeEntry has callbacks that are currently skipped
</code></pre>
</details> 

```
bundle exec rake active_record_doctor:missing_foreign_keys
```

<details><summary>Details</summary>
<pre><code>
create a foreign key on reminders.job_id - looks like an association without a foreign key constraint
create a foreign key on group_users.group_id - looks like an association without a foreign key constraint
create a foreign key on group_users.user_id - looks like an association without a foreign key constraint
create a foreign key on categories.project_id - looks like an association without a foreign key constraint
create a foreign key on categories.assigned_to_id - looks like an association without a foreign key constraint
create a foreign key on projects.parent_id - looks like an association without a foreign key constraint
create a foreign key on sessions.session_id - looks like an association without a foreign key constraint
create a foreign key on sessions.user_id - looks like an association without a foreign key constraint
create a foreign key on changesets_work_packages.changeset_id - looks like an association without a foreign key constraint
create a foreign key on changesets_work_packages.work_package_id - looks like an association without a foreign key constraint
create a foreign key on custom_fields_types.custom_field_id - looks like an association without a foreign key constraint
create a foreign key on custom_fields_types.type_id - looks like an association without a foreign key constraint
create a foreign key on custom_values.custom_field_id - looks like an association without a foreign key constraint
create a foreign key on custom_fields.custom_field_section_id - looks like an association without a foreign key constraint
create a foreign key on message_journals.forum_id - looks like an association without a foreign key constraint
create a foreign key on message_journals.parent_id - looks like an association without a foreign key constraint
create a foreign key on message_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on changeset_journals.repository_id - looks like an association without a foreign key constraint
create a foreign key on changeset_journals.user_id - looks like an association without a foreign key constraint
create a foreign key on news_journals.project_id - looks like an association without a foreign key constraint
create a foreign key on news_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on attachable_journals.journal_id - looks like an association without a foreign key constraint
create a foreign key on attachable_journals.attachment_id - looks like an association without a foreign key constraint
create a foreign key on attachment_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on enumerations.project_id - looks like an association without a foreign key constraint
create a foreign key on enumerations.parent_id - looks like an association without a foreign key constraint
create a foreign key on enumerations.color_id - looks like an association without a foreign key constraint
create a foreign key on member_roles.member_id - looks like an association without a foreign key constraint
create a foreign key on member_roles.role_id - looks like an association without a foreign key constraint
create a foreign key on role_permissions.role_id - looks like an association without a foreign key constraint
create a foreign key on user_preferences.user_id - looks like an association without a foreign key constraint
create a foreign key on watchers.user_id - looks like an association without a foreign key constraint
create a foreign key on wiki_redirects.wiki_id - looks like an association without a foreign key constraint
create a foreign key on wiki_pages.wiki_id - looks like an association without a foreign key constraint
create a foreign key on wiki_pages.parent_id - looks like an association without a foreign key constraint
create a foreign key on menu_items.parent_id - looks like an association without a foreign key constraint
create a foreign key on menu_items.navigatable_id - looks like an association without a foreign key constraint
create a foreign key on wikis.project_id - looks like an association without a foreign key constraint
create a foreign key on enabled_modules.project_id - looks like an association without a foreign key constraint
create a foreign key on relations.from_id - looks like an association without a foreign key constraint
create a foreign key on relations.to_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_roles.role_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_roles.custom_action_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_statuses.status_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_statuses.custom_action_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_projects.project_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_projects.custom_action_id - looks like an association without a foreign key constraint
create a foreign key on budget_journals.project_id - looks like an association without a foreign key constraint
create a foreign key on budget_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on labor_budget_items.budget_id - looks like an association without a foreign key constraint
create a foreign key on labor_budget_items.user_id - looks like an association without a foreign key constraint
create a foreign key on material_budget_items.budget_id - looks like an association without a foreign key constraint
create a foreign key on material_budget_items.cost_type_id - looks like an association without a foreign key constraint
create a foreign key on document_journals.project_id - looks like an association without a foreign key constraint
create a foreign key on document_journals.category_id - looks like an association without a foreign key constraint
create a foreign key on done_statuses_for_project.project_id - looks like an association without a foreign key constraint
create a foreign key on done_statuses_for_project.status_id - looks like an association without a foreign key constraint
create a foreign key on meeting_content_journals.meeting_id - looks like an association without a foreign key constraint
create a foreign key on meeting_content_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on grid_widgets.grid_id - looks like an association without a foreign key constraint
create a foreign key on oauth_access_grants.resource_owner_id - looks like an association without a foreign key constraint
create a foreign key on bcf_comments.journal_id - looks like an association without a foreign key constraint
create a foreign key on forums.project_id - looks like an association without a foreign key constraint
create a foreign key on forums.last_message_id - looks like an association without a foreign key constraint
create a foreign key on ifc_models.uploader_id - looks like an association without a foreign key constraint
create a foreign key on github_pull_requests_work_packages.github_pull_request_id - looks like an association without a foreign key constraint
create a foreign key on github_pull_requests_work_packages.work_package_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_merge_requests_work_packages.gitlab_merge_request_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_merge_requests_work_packages.work_package_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_issues.gitlab_user_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_issues.gitlab_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_issues_work_packages.gitlab_issue_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_issues_work_packages.work_package_id - looks like an association without a foreign key constraint
create a foreign key on work_package_hierarchies.ancestor_id - looks like an association without a foreign key constraint
create a foreign key on work_package_hierarchies.descendant_id - looks like an association without a foreign key constraint
create a foreign key on messages.forum_id - looks like an association without a foreign key constraint
create a foreign key on messages.parent_id - looks like an association without a foreign key constraint
create a foreign key on messages.author_id - looks like an association without a foreign key constraint
create a foreign key on messages.last_reply_id - looks like an association without a foreign key constraint
create a foreign key on changesets.repository_id - looks like an association without a foreign key constraint
create a foreign key on changesets.user_id - looks like an association without a foreign key constraint
create a foreign key on custom_options.custom_field_id - looks like an association without a foreign key constraint
create a foreign key on user_passwords.user_id - looks like an association without a foreign key constraint
create a foreign key on versions.project_id - looks like an association without a foreign key constraint
create a foreign key on two_factor_authentication_devices.webauthn_external_id - looks like an association without a foreign key constraint
create a foreign key on ldap_groups_memberships.user_id - looks like an association without a foreign key constraint
create a foreign key on ldap_groups_memberships.group_id - looks like an association without a foreign key constraint
create a foreign key on meeting_contents.meeting_id - looks like an association without a foreign key constraint
create a foreign key on meeting_contents.author_id - looks like an association without a foreign key constraint
create a foreign key on meetings.author_id - looks like an association without a foreign key constraint
create a foreign key on meetings.project_id - looks like an association without a foreign key constraint
create a foreign key on meetings.recurring_meeting_id - looks like an association without a foreign key constraint
create a foreign key on meeting_participants.user_id - looks like an association without a foreign key constraint
create a foreign key on meeting_participants.meeting_id - looks like an association without a foreign key constraint
create a foreign key on version_settings.project_id - looks like an association without a foreign key constraint
create a foreign key on version_settings.version_id - looks like an association without a foreign key constraint
create a foreign key on attachments.author_id - looks like an association without a foreign key constraint
create a foreign key on meeting_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on meeting_journals.project_id - looks like an association without a foreign key constraint
create a foreign key on users.ldap_auth_source_id - looks like an association without a foreign key constraint
create a foreign key on users.webauthn_id - looks like an association without a foreign key constraint
create a foreign key on oauth_access_tokens.resource_owner_id - looks like an association without a foreign key constraint
create a foreign key on grids.user_id - looks like an association without a foreign key constraint
create a foreign key on grids.project_id - looks like an association without a foreign key constraint
create a foreign key on queries.project_id - looks like an association without a foreign key constraint
create a foreign key on queries.user_id - looks like an association without a foreign key constraint
create a foreign key on documents.project_id - looks like an association without a foreign key constraint
create a foreign key on documents.category_id - looks like an association without a foreign key constraint
create a foreign key on news.project_id - looks like an association without a foreign key constraint
create a foreign key on news.author_id - looks like an association without a foreign key constraint
create a foreign key on ldap_groups_synchronized_groups.group_id - looks like an association without a foreign key constraint
create a foreign key on ldap_groups_synchronized_groups.ldap_auth_source_id - looks like an association without a foreign key constraint
create a foreign key on ldap_groups_synchronized_filters.ldap_auth_source_id - looks like an association without a foreign key constraint
create a foreign key on job_statuses.user_id - looks like an association without a foreign key constraint
create a foreign key on job_statuses.job_id - looks like an association without a foreign key constraint
create a foreign key on budgets.project_id - looks like an association without a foreign key constraint
create a foreign key on budgets.author_id - looks like an association without a foreign key constraint
create a foreign key on cost_entries.user_id - looks like an association without a foreign key constraint
create a foreign key on cost_entries.project_id - looks like an association without a foreign key constraint
create a foreign key on cost_entries.work_package_id - looks like an association without a foreign key constraint
create a foreign key on cost_entries.cost_type_id - looks like an association without a foreign key constraint
create a foreign key on cost_entries.rate_id - looks like an association without a foreign key constraint
create a foreign key on members.user_id - looks like an association without a foreign key constraint
create a foreign key on members.project_id - looks like an association without a foreign key constraint
create a foreign key on journals.user_id - looks like an association without a foreign key constraint
create a foreign key on cost_queries.user_id - looks like an association without a foreign key constraint
create a foreign key on cost_queries.project_id - looks like an association without a foreign key constraint
create a foreign key on github_pull_requests.github_user_id - looks like an association without a foreign key constraint
create a foreign key on github_pull_requests.merged_by_id - looks like an association without a foreign key constraint
create a foreign key on github_pull_requests.github_id - looks like an association without a foreign key constraint
create a foreign key on github_users.github_id - looks like an association without a foreign key constraint
create a foreign key on github_check_runs.github_pull_request_id - looks like an association without a foreign key constraint
create a foreign key on github_check_runs.github_id - looks like an association without a foreign key constraint
create a foreign key on github_check_runs.app_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_merge_requests.gitlab_user_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_merge_requests.merged_by_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_merge_requests.gitlab_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_users.gitlab_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_pipelines.gitlab_merge_request_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_pipelines.gitlab_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_pipelines.project_id - looks like an association without a foreign key constraint
create a foreign key on gitlab_pipelines.commit_id - looks like an association without a foreign key constraint
create a foreign key on file_links.origin_id - looks like an association without a foreign key constraint
create a foreign key on oauth_clients.client_id - looks like an association without a foreign key constraint
create a foreign key on project_storages.project_folder_id - looks like an association without a foreign key constraint
create a foreign key on changes.changeset_id - looks like an association without a foreign key constraint
create a foreign key on comments.author_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_types.type_id - looks like an association without a foreign key constraint
create a foreign key on custom_actions_types.custom_action_id - looks like an association without a foreign key constraint
create a foreign key on customizable_journals.journal_id - looks like an association without a foreign key constraint
create a foreign key on customizable_journals.custom_field_id - looks like an association without a foreign key constraint
create a foreign key on rates.project_id - looks like an association without a foreign key constraint
create a foreign key on rates.user_id - looks like an association without a foreign key constraint
create a foreign key on rates.cost_type_id - looks like an association without a foreign key constraint
create a foreign key on repositories.project_id - looks like an association without a foreign key constraint
create a foreign key on statuses.color_id - looks like an association without a foreign key constraint
create a foreign key on time_entries.project_id - looks like an association without a foreign key constraint
create a foreign key on time_entries.user_id - looks like an association without a foreign key constraint
create a foreign key on time_entries.work_package_id - looks like an association without a foreign key constraint
create a foreign key on time_entries.activity_id - looks like an association without a foreign key constraint
create a foreign key on time_entries.rate_id - looks like an association without a foreign key constraint
create a foreign key on time_entry_journals.project_id - looks like an association without a foreign key constraint
create a foreign key on time_entry_journals.user_id - looks like an association without a foreign key constraint
create a foreign key on time_entry_journals.work_package_id - looks like an association without a foreign key constraint
create a foreign key on time_entry_journals.activity_id - looks like an association without a foreign key constraint
create a foreign key on time_entry_journals.rate_id - looks like an association without a foreign key constraint
create a foreign key on wiki_page_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.type_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.project_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.category_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.status_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.assigned_to_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.priority_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.version_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.parent_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.responsible_id - looks like an association without a foreign key constraint
create a foreign key on work_package_journals.budget_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.category_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.assigned_to_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.priority_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.version_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.author_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.responsible_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.budget_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.parent_id - looks like an association without a foreign key constraint
create a foreign key on work_packages.project_life_cycle_step_id - looks like an association without a foreign key constraint
create a foreign key on project_journals.parent_id - looks like an association without a foreign key constraint
create a foreign key on storages_file_links_journals.file_link_id - looks like an association without a foreign key constraint
create a foreign key on meeting_agenda_items.work_package_id - looks like an association without a foreign key constraint
create a foreign key on meeting_agenda_items.meeting_section_id - looks like an association without a foreign key constraint
create a foreign key on project_queries.user_id - looks like an association without a foreign key constraint
create a foreign key on meeting_agenda_item_journals.journal_id - looks like an association without a foreign key constraint
create a foreign key on meeting_agenda_item_journals.agenda_item_id - looks like an association without a foreign key constraint
create a foreign key on meeting_agenda_item_journals.author_id - looks like an association without a foreign key constraint
create a foreign key on meeting_agenda_item_journals.work_package_id - looks like an association without a foreign key constraint
create a foreign key on last_project_folders.origin_folder_id - looks like an association without a foreign key constraint
create a foreign key on good_jobs.active_job_id - looks like an association without a foreign key constraint
create a foreign key on good_jobs.retried_good_job_id - looks like an association without a foreign key constraint
create a foreign key on good_jobs.batch_id - looks like an association without a foreign key constraint
create a foreign key on good_jobs.batch_callback_id - looks like an association without a foreign key constraint
create a foreign key on good_jobs.locked_by_id - looks like an association without a foreign key constraint
create a foreign key on good_job_executions.active_job_id - looks like an association without a foreign key constraint
create a foreign key on good_job_executions.process_id - looks like an association without a foreign key constraint
create a foreign key on deploy_status_checks.deploy_target_id - looks like an association without a foreign key constraint
create a foreign key on deploy_status_checks.github_pull_request_id - looks like an association without a foreign key constraint
create a foreign key on hierarchical_item_hierarchies.ancestor_id - looks like an association without a foreign key constraint
create a foreign key on hierarchical_item_hierarchies.descendant_id - looks like an association without a foreign key constraint
create a foreign key on remote_identities.origin_user_id - looks like an association without a foreign key constraint
create a foreign key on hierarchical_items.parent_id - looks like an association without a foreign key constraint
</code></pre>
</details> 

# What approach did you choose and why?

I've looked at Active Record Doctor while working on a previous project and I've found it to provide quite useful information with regards to the health of the database schema.

Unfortunately AR Doctor's `rake active_record_doctor:incorrect_dependent_option` task only checks for cases when `dependent:` is defined but not incorrect (because of the presence or absence of callbacks on the associated model). However used in conjunction with Rubocop's `HasManyOrHasOneDependent` cop, I still think this is a useful tool.

⚠️ This PR does not attempt to integrate AR Doctor with existing CI or developer workflows (e.g. hooks).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
