### PR TITLE
make comments journable

### DIFF
--- a/app/models/journal/comment_journal.rb
+++ b/app/models/journal/comment_journal.rb
@@ -28,29 +28,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Comment < ApplicationRecord
-  belongs_to :commented, polymorphic: true, counter_cache: true
-  belongs_to :author, class_name: "User"
-
-  validates :commented, :author, :comments, presence: true
-
-  after_create :send_news_comment_added_mail
-
-  acts_as_journalized
-
-  def text
-    comments
-  end
-
-  def post!
-    save!
-  end
-
-  private
-
-  def send_news_comment_added_mail
-    OpenProject::Notifications.send(OpenProject::Events::NEWS_COMMENT_CREATED,
-                                    comment: self,
-                                    send_notification: true)
-  end
+class Journal::CommentJournal < Journal::BaseJournal
+  self.table_name = "comment_journals"
 end

--- a/db/migrate/20250225120139_create_comment_journals.rb
+++ b/db/migrate/20250225120139_create_comment_journals.rb
@@ -28,29 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Comment < ApplicationRecord
-  belongs_to :commented, polymorphic: true, counter_cache: true
-  belongs_to :author, class_name: "User"
-
-  validates :commented, :author, :comments, presence: true
-
-  after_create :send_news_comment_added_mail
-
-  acts_as_journalized
-
-  def text
-    comments
-  end
-
-  def post!
-    save!
-  end
-
-  private
-
-  def send_news_comment_added_mail
-    OpenProject::Notifications.send(OpenProject::Events::NEWS_COMMENT_CREATED,
-                                    comment: self,
-                                    send_notification: true)
+class CreateCommentJournals < ActiveRecord::Migration[7.1]
+  def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :comment_journals do |t|
+      t.text :comments
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -73,4 +73,20 @@ RSpec.describe Comment do
         .not_to be_valid
     end
   end
+
+  describe "acts_as_journalized" do
+    let(:work_package) { create(:work_package) }
+    # using work package association as it was introduced along with journalized
+    let(:comment) { described_class.new(author: user, comments: "some important words", commented: work_package) }
+
+    it "creates a journal with the correct journable" do
+      comment.save
+      expect(Journal.last.journable).to eq(comment)
+    end
+
+    it "creates a journal with the correct notes" do
+      comment.save
+      expect(Journal.last.notes).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
# What are you trying to accomplish?

Checking how this would look like. Making comments into journable is good as an event ledger thing, but it's overkill as a snapshot changes tracker.

- I could not figure out a way of handling the user. Journals end up with a associated user and I don't know where it comes from, but the comments themselves have an associated user already. So we have some weird duplication here.