### PR TITLE
Fix WP status button preview

### DIFF
--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -29,6 +29,9 @@ See COPYRIGHT and LICENSE files for more details.
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <%= include_frontend_assets %>
+  <%= stylesheet_link_tag "/highlighting/styles/#{Time.current.iso8601}",
+                          media: :all,
+                          skip_pipeline: true %>
 </head>
 <%
   styles = []

--- a/lookbook/previews/open_project/work_packages/status_button_component_preview.rb
+++ b/lookbook/previews/open_project/work_packages/status_button_component_preview.rb
@@ -9,7 +9,8 @@ module OpenProject::WorkPackages
     # @param size [Symbol] select [small, medium, large]
     def playground(readonly: true, size: :medium)
       user = FactoryBot.build_stubbed(:admin)
-      render(WorkPackages::StatusButtonComponent.new(work_package: WorkPackage.visible.first,
+      work_package = FactoryBot.build_stubbed(:work_package, status: Status.first)
+      render(WorkPackages::StatusButtonComponent.new(work_package:,
                                                      user:,
                                                      readonly:,
                                                      button_arguments: { size: }))


### PR DESCRIPTION
Loads the highlighting assets and use a work package that can be shown