### PR TITLE
Remove CSP strict-dynamic in favor of `self` again

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,3 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 # rubocop:disable Lint/PercentStringArray
 Rails.application.config.after_initialize do
   SecureHeaders::Configuration.default do |config|
@@ -16,7 +46,7 @@ Rails.application.config.after_initialize do
     config.referrer_policy = "origin-when-cross-origin"
 
     # Valid for assets
-    assets_src = []
+    assets_src = ["'self'"]
     asset_host = OpenProject::Configuration.rails_asset_host
     assets_src << asset_host if asset_host.present?
 
@@ -64,6 +94,8 @@ Rails.application.config.after_initialize do
 
     config.csp = {
       preserve_schemes: true,
+      # Don't append unsafe-inline in CSP as a fallback
+      disable_nonce_backwards_compatibility: true,
 
       # Fallback when no value is defined
       default_src:,
@@ -80,9 +112,10 @@ Rails.application.config.after_initialize do
       # Allow images from anywhere including data urls and blobs (used in resizing)
       img_src: %w(* data: blob:),
       # Allow scripts from self
-      script_src: script_src + %w('strict-dynamic'),
+      script_src:,
+      script_src_attr: %w('none'),
       # Allow unsafe-inline styles
-      style_src: assets_src + %w('unsafe-inline' 'self'),
+      style_src: assets_src + %w('unsafe-inline'),
       # Allow object-src from Release API
       object_src: [OpenProject::Configuration[:security_badge_url]],
 

--- a/lib/open_project/patches/secure_headers_turbo_aware_nonce.rb
+++ b/lib/open_project/patches/secure_headers_turbo_aware_nonce.rb
@@ -30,10 +30,10 @@
 module OpenProject::Patches::SecureHeadersTurboAwareNonce
   def content_security_policy_script_nonce(request)
     if request.env["HTTP_TURBO_REFERRER"].present?
-      request.env["HTTP_X_TURBO_NONCE"]
-    else
-      super
+      request.env[SecureHeaders::NONCE_KEY] ||= request.env["HTTP_X_TURBO_NONCE"]
     end
+
+    super
   end
 end
 


### PR DESCRIPTION
We introduced strict-dynamic in https://github.com/opf/openproject/pull/15639 to avoid user-uploaded content from being used as JS with the appropriate content-type. 

But strict-dynamic has other, more drastic implications. The frontend code is now marked as trusted, so it can arbitrarily add new scripts and execute them without nonces.

Since we overwrite the content-type by now already (https://github.com/opf/openproject/blob/12ee9e6b8355f2f0daba5954d0aab6c17a95eb78/lib/api/helpers/attachment_renderer.rb#L100-L109) , the original reason for moving to strict-dynamic does no longer apply, and the previous mode of operation results in better security.

https://community.openproject.org/work_packages/61784

