### PR TITLE
Bug/53451 always show ckeditor tool bar on screen when scrolling

### DIFF
--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -92,7 +92,7 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
 
   .document-editor__toolbar
     position: sticky
-    top: 0px
+    top: 0
     z-index: 2
 
     // Reset these styles explicitly when the editor is opened inside a Dialog, as position: sticky opens a separate stacking context.

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -48,7 +48,7 @@
   &--split-left
     border-right: 1px solid var(--borderColor-default)
     overflow-y: auto
-    overflow-x: hidden
+    overflow-x: clip
     flex: 2
     position: relative
     @include styled-scroll-bar

--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -50,6 +50,13 @@
           margin: 0
           width: initial
           border: none
+          // Set overflow to clip so that the editor toolbar can stick, see WP#53451
+          overflow-y: clip
+
+          // We need to cancel out the padding of the page content.
+          // Otherwise, the scrolled content will be visible above the toolbar
+          .document-editor__toolbar
+            top: -10px
 
           .work-packages--panel-inner
             padding: 5px 0 20px 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/53451

# What are you trying to accomplish?
When you shrink your browser window (aka you are in "moblie mode"), the editor toolbar should stick to the top of the scroll container when you edit a work package description.

## Screenshots
<img width="991" alt="image" src="https://github.com/user-attachments/assets/402bcd69-73e0-4f7d-a196-43cfc3ad7a41" />


# What approach did you choose and why?
TIL that when any parent of a sticky-element has an overflow that is set to `auto` , `hidden` or `scroll`, the stickiness does not take effect. There seem to be further issues with parents defining a set height, etc.

In our case, the stickiness could be restored by using `overflow: clip` instead of `overflow: hidden`. Clip does the same as hidden, but does not open up a new formatting context, preserving the functionality of `sticky`.

https://benfrain.com/yes-you-can-use-position-sticky-and-overflow-together/

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
