### PR TITLE
[#58135] principal renderer will not open a new window for links

### DIFF
--- a/frontend/src/app/shared/components/principal/principal-renderer.service.ts
+++ b/frontend/src/app/shared/components/principal/principal-renderer.service.ts
@@ -207,7 +207,6 @@ export class PrincipalRendererService {
       const link = document.createElement('a');
       link.textContent = principal.name;
       link.href = this.principalURL(principal, type);
-      link.target = '_blank';
       link.classList.add('op-principal--name');
       link.title = title;
 


### PR DESCRIPTION
We have hover cards now, there is no reason to force open a new tab. Users can decide themselves whether or not they want to stay in the current tab or not. Power to the people!

https://community.openproject.org/wp/58135 