### PR TITLE
Rescheduled series creates invalid open meetings

### DIFF
--- a/modules/meeting/app/components/recurring_meetings/show_page_sub_header_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_sub_header_component.html.erb
@@ -1,12 +1,4 @@
-<%= render(
-      Primer::OpenProject::SubHeader.new(
-        data: {
-          controller: "filter--filters-form",
-          "application-target": "dynamic",
-          "filter--filters-form-output-format-value": "json"
-        }
-      )
-    ) do |subheader|
+<%= render(Primer::OpenProject::SubHeader.new) do |subheader|
       subheader.with_filter_component do
         render(Primer::Alpha::SegmentedControl.new("aria-label": I18n.t(:label_filter_plural))) do |control|
           control.with_item(

--- a/modules/meeting/app/contracts/recurring_meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/update_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -33,6 +34,7 @@ module RecurringMeetings
 
     validate :user_allowed_to_edit
     validate :not_before_scheduled_time
+    validate :all_instantiated_meetings_covered
 
     def user_allowed_to_edit
       unless user.allowed_in_project?(:edit_meetings, model.project)
@@ -49,6 +51,26 @@ module RecurringMeetings
         else
           errors.add :start_time_hour, :datetime_must_be_in_future
         end
+      end
+    end
+
+    def all_instantiated_meetings_covered
+      return if model.end_after_never?
+      return unless model.reschedule_required?
+
+      validate_meeting_coverage
+    end
+
+    private
+
+    def validate_meeting_coverage
+      upcoming_count = model.scheduled_instances.not_cancelled.count
+      remaining_count = model.remaining_occurrences.count
+
+      if remaining_count < upcoming_count
+        errors.add :base,
+                   :must_cover_existing_meetings,
+                   count: upcoming_count - remaining_count
       end
     end
   end

--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -133,7 +133,7 @@ module Meeting::VirtualStartTime
     return nil if @start_time_hour.nil?
 
     Time.strptime(@start_time_hour, "%H:%M")
-  rescue ArgumentError
+  rescue ArgumentError, TypeError
     nil
   end
 end

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -56,6 +56,10 @@ class RecurringMeeting < ApplicationRecord
            if: -> { end_after_specific_date? }
 
   after_initialize :set_defaults
+
+  # Unset any previously set schedule before running validations
+  before_validation :unset_schedule
+
   after_save :unset_schedule
   before_destroy :remove_jobs
 
@@ -174,6 +178,12 @@ class RecurringMeeting < ApplicationRecord
     I18n.t("recurring_meeting.in_words.frequency",
            base: base_schedule,
            time: format_time(start_time, include_date: false))
+  end
+
+  def reschedule_required?(previous: false)
+    (previous ? previous_changes : changes)
+      .keys
+      .intersect?(%w[frequency start_date start_time start_time_hour iterations interval end_after end_date])
   end
 
   def scheduled_occurrences(limit:)

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -100,6 +100,7 @@ module RecurringMeetings
       # Get all future scheduled meetings that have been instantiated, ordered by start time
       future_meetings = recurring_meeting
         .scheduled_instances
+        .instantiated
         .not_cancelled
 
       # Get the next occurrences from the schedule matching the number of future meetings
@@ -156,10 +157,7 @@ module RecurringMeetings
     def should_reschedule?(recurring_meeting)
       return false if recurring_meeting.next_occurrence.nil?
 
-      recurring_meeting
-        .previous_changes
-        .keys
-        .intersect?(%w[frequency start_date start_time start_time_hour iterations interval end_after end_date])
+      recurring_meeting.reschedule_required?(previous: true)
     end
   end
 end

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -43,7 +43,6 @@ module RecurringMeetings
       return call unless call.success?
 
       recurring_meeting = call.result
-      cleanup_cancelled_schedules(recurring_meeting)
 
       if should_reschedule?(recurring_meeting)
         reschedule_future_occurrences(recurring_meeting)
@@ -51,6 +50,7 @@ module RecurringMeetings
         send_rescheduled_mail(recurring_meeting)
       end
 
+      cleanup_cancelled_schedules(recurring_meeting)
       update_template(call)
     end
 
@@ -80,7 +80,7 @@ module RecurringMeetings
     end
 
     def update_time_of_day(recurring_meeting)
-      schedule_meetings = recurring_meeting.scheduled_instances
+      schedule_meetings = recurring_meeting.scheduled_meetings
 
       schedule_meetings.each do |scheduled|
         new_time = scheduled.start_time.change(

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -107,11 +107,12 @@ module RecurringMeetings
       next_occurrences = recurring_meeting.scheduled_occurrences(limit: future_meetings.count)
 
       # Update each meeting's timing to match the new schedule
-      future_meetings.each_with_index do |scheduled, index|
-        next_time = next_occurrences[index]&.to_time
+      # Wrap in transaction to allow deferrable unique constraint to work
+      Meeting.transaction do
+        future_meetings.each_with_index do |scheduled, index|
+          next_time = next_occurrences[index]&.to_time
 
-        if next_time
-          Meeting.transaction do
+          if next_time
             scheduled.update_column(:start_time, next_time)
             scheduled.meeting.update_column(:start_time, next_time)
           end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -75,7 +75,7 @@ en:
         recurring_meeting:
           must_cover_existing_meetings:
             one: "There is one open meeting in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."
-            other: "There are %{count} open meetings in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."
+            other: "There are %{count} open meetings in the series that are not covered by the new schedule. Adjust the schedule to include all existing meetings."
             format: "%{message}"
 
       messages:

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -71,6 +71,13 @@ en:
         end_date: "End date"
         iterations: "Occurrences"
     errors:
+      models:
+        recurring_meeting:
+          must_cover_existing_meetings:
+            one: "There is one open meeting in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."
+            other: "There are %{count} open meetings in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."
+            format: "%{message}"
+
       messages:
         invalid_time_format: "is not a valid time. Required format: HH:MM"
     models:

--- a/modules/meeting/db/migrate/20250227140619_change_unique_constraint_on_scheduled_meetings.rb
+++ b/modules/meeting/db/migrate/20250227140619_change_unique_constraint_on_scheduled_meetings.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+class ChangeUniqueConstraintOnScheduledMeetings < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :scheduled_meetings,
+                 %i[recurring_meeting_id start_time],
+                 unique: true
+
+    execute <<~SQL.squish
+      ALTER TABLE scheduled_meetings
+      ADD CONSTRAINT unique_recurring_meeting_start_time
+      UNIQUE (recurring_meeting_id, start_time) DEFERRABLE INITIALLY DEFERRED;
+    SQL
+  end
+
+  def down
+    execute <<~SQL.squish
+      ALTER TABLE scheduled_meetings
+      DROP CONSTRAINT unique_recurring_meeting_start_time;
+    SQL
+
+    add_index :scheduled_meetings,
+              %i[recurring_meeting_id start_time],
+              unique: true
+  end
+end

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -230,6 +230,24 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
       end
     end
 
+    context "when changing interval to 2, so that previous occurrences overlap" do
+      let(:params) do
+        {
+          interval: 2
+        }
+      end
+
+      it "succeeds" do
+        expect(service_result).to be_success
+
+        # Verify each scheduled meeting is moved to weekly intervals
+        scheduled_meetings.each_with_index do |meeting, index|
+          meeting.reload
+          expect(meeting.start_time).to eq(Time.zone.today + ((index + 1) * 2).days + 10.hours)
+        end
+      end
+    end
+
     context "when changing end_date to before the last scheduled meeting" do
       let(:params) do
         {

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
       end
     end
 
+    context "when updating only the start time hour" do
+      let(:params) do
+        { start_time_hour: "09:00" }
+      end
+
+      it "updates the cancelled occurrence" do
+        expect(service_result).to be_success
+
+        scheduled_meeting.reload
+        expect(scheduled_meeting.start_time).to eq(Time.zone.today + 1.day + 9.hours)
+      end
+    end
+
     context "when updating the start_date to further in the future" do
       let(:params) do
         { start_date: Time.zone.today + 2.days }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61729/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Move instantiated meetings around when the schedule changes

- All n open meetings in the future will be rescheduled:
-  [x] If only the start time (hours) changed: simply update the start time hour of the instantiated meeting to match the new time
 - [x] If the date/frequency/interval, etc has changed: according ot the next n planned meetings according to the new series schedule. Even if moving from daily to monthly, or weekly to daily.
 - [x] If the user changes the # occurences so that it's fewer than actual open occurences, then you get an inline validation in the meeting details dialog.

# Merge checklist

- [x] Added/updated tests
