### PR TITLE
[#61316] subject field gets readonly on type change

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-edit/work-package-changeset.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit/work-package-changeset.ts
@@ -26,14 +26,27 @@ export class WorkPackageChangeset extends ResourceChangeset<WorkPackageResource>
     // Otherwise, the backend will set it for us.
     delete payload.description;
 
+    // Explicitly not send the subject, if the subject was not editable.
+    // In this case a generated template is rendered in the subject and
+    // must not get submitted.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    if (!this.schema.isAttributeEditable('subject')) {
+      delete (payload as { subject?:string }).subject;
+    }
+
     return super.applyChanges(payload);
   }
 
   protected setNewDefaultFor(key:string, val:unknown) {
-    // Special handling for taking over the description
-    // to the pristine resource
+    // Special handling for taking over the description and
+    // the subject to the pristine resource.
     if (key === 'description' && isNewResource(this.pristineResource)) {
       this.pristineResource.description = val;
+      return;
+    }
+
+    if (key === 'subject' && isNewResource(this.pristineResource)) {
+      this.pristineResource.subject = val as string;
       return;
     }
 

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -488,7 +488,7 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
   protected setNewDefaults(form:FormResource) {
     _.each(form.payload, (val:unknown, key:string) => {
       const fieldSchema:IFieldSchema|null = this.schema.ofProperty(key);
-      if (!fieldSchema?.writable) {
+      if (!fieldSchema?.writable && !fieldSchema?.required) {
         return;
       }
 

--- a/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
@@ -126,7 +126,11 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
       )
       .subscribe((resource) => {
         this.resource = resource;
-        this.render();
+        if (this.isEditable) {
+          this.render();
+        } else {
+          this.reset();
+        }
       });
   }
 


### PR DESCRIPTION
# Ticket
[OP#61316](https://community.openproject.org/wp/61316)

# What are you trying to accomplish?
- in wp new form, switching type to one with a generated subject must make subject input readonly and update it to template string - if subject input is still pristine

# What approach did you choose and why?
- editable form field renders or resets now on change, depending on writability
- subject value is ignored, if subject is readonly in wp changeset
- subject value is updated, if subject is pristine - e.g. if it is set to readonly but has a template string from schema

