### PR TITLE
Ensure to select auth strategy via storage registry

### DIFF
--- a/modules/storages/app/controllers/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/project_storages_controller.rb
@@ -71,9 +71,7 @@ class Storages::ProjectStoragesController < ApplicationController
   private
 
   def auth_strategy
-    Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-      .strategy
-      .with_user(current_user)
+    Storages::Peripherals::Registry.resolve("#{@storage}.authentication.user_bound").call(user: current_user, storage: @storage)
   end
 
   def user_can_read_project_folder

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -82,9 +82,7 @@ module Storages
     end
 
     def open(user)
-      auth_strategy = Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-                        .strategy
-                        .with_user(user)
+      auth_strategy = Peripherals::Registry.resolve("#{storage}.authentication.user_bound").call(user:, storage:)
 
       if project_folder_not_accessible?(user)
         Peripherals::Registry

--- a/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
@@ -34,16 +34,15 @@ class API::V3::FileLinks::FileLinksDownloadAPI < API::OpenProjectAPI
 
   helpers do
     def auth_strategy
-      Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-        .strategy
-        .with_user(User.current)
+      storage = @file_link.storage
+      Storages::Peripherals::Registry.resolve("#{storage}.authentication.user_bound").call(user: User.current, storage:)
     end
   end
 
   resources :download do
     get do
       Storages::Peripherals::Registry
-        .resolve("#{@file_link.storage.short_provider_type}.queries.download_link")
+        .resolve("#{@file_link.storage}.queries.download_link")
         .call(storage: @file_link.storage, auth_strategy:, file_link: @file_link)
         .match(
           on_success: ->(url) do

--- a/modules/storages/lib/api/v3/file_links/file_links_open_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_open_api.rb
@@ -31,14 +31,17 @@ class API::V3::FileLinks::FileLinksOpenAPI < API::OpenProjectAPI
 
   using Storages::Peripherals::ServiceResultRefinements
 
+  helpers do
+    def auth_strategy
+      storage = @file_link.storage
+      Storages::Peripherals::Registry.resolve("#{storage}.authentication.user_bound").call(user: current_user, storage:)
+    end
+  end
+
   resources :open do
     get do
-      auth_strategy = Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-                        .strategy
-                        .with_user(current_user)
-
       Storages::Peripherals::Registry
-        .resolve("#{@file_link.storage.short_provider_type}.queries.open_file_link")
+        .resolve("#{@file_link.storage}.queries.open_file_link")
         .call(
           storage: @file_link.storage,
           auth_strategy:,

--- a/modules/storages/lib/api/v3/storages/storage_open_api.rb
+++ b/modules/storages/lib/api/v3/storages/storage_open_api.rb
@@ -33,12 +33,14 @@ class API::V3::Storages::StorageOpenAPI < API::OpenProjectAPI
 
   using Storages::Peripherals::ServiceResultRefinements
 
+  helpers do
+    def auth_strategy
+      Storages::Peripherals::Registry.resolve("#{@storage}.authentication.user_bound").call(user: current_user, storage: @storage)
+    end
+  end
+
   resources :open do
     get do
-      auth_strategy = Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-                        .strategy
-                        .with_user(current_user)
-
       Storages::Peripherals::Registry
         .resolve("#{@storage}.queries.open_storage")
         .call(storage: @storage, auth_strategy:)


### PR DESCRIPTION
There were a few places left that hardcoded the userbound strategy to OAuthUserToken, which used to be the only strategy for userbound authentcation. However, by now there is also SSO-based authentication which requires the use of a different strategy.

# Ticket

https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61804

# Merge checklist

- [x] Tested manually
