### PR TITLE
[#61604] harden default function of property mapper

### DIFF
--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -31,7 +31,11 @@
 module Types
   module Patterns
     class TokenPropertyMapper
-      DEFAULT_FUNCTION = ->(key, context) { context.public_send(key.to_sym) }.curry
+      DEFAULT_FUNCTION = ->(key, context) do
+        return nil if context.nil?
+
+        context.public_send(key.to_sym)
+      end.curry
 
       TOKEN_PROPERTY_MAP = IceNine.deep_freeze(
         {


### PR DESCRIPTION
# Ticket
[OP#61604](https://community.openproject.org/wp/61604)

# What are you trying to accomplish?
- generated subject of wp without parent, while pattern contains parent custom field, should not render error

# What approach did you choose and why?
- context can be `nil` - e.g. if no parent exists - in this case `nil` must be returned
