### PR TITLE
[#61619] keep form values on submit failure

### DIFF
--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -52,14 +52,26 @@ module WorkPackages
       private
 
       def subject_form_object
-        subject_pattern = model.patterns.subject || ::Types::Pattern.new(blueprint: "", enabled: false)
+        values = subject_configuration_form_values
 
         ::Types::Forms::SubjectConfigurationFormModel.new(
-          subject_configuration: subject_pattern.enabled ? :generated : :manual,
-          pattern: subject_pattern.blueprint,
+          subject_configuration: values[:subject_configuration],
+          pattern: values[:pattern],
           suggestions: ::Types::Patterns::TokenPropertyMapper.new.tokens_for_type(model),
           validation_errors: model.errors
         )
+      end
+
+      def subject_configuration_form_values
+        if params[:types_forms_subject_configuration_form_model].present?
+          params[:types_forms_subject_configuration_form_model]
+        else
+          persisted_subject_pattern = model.patterns.subject || ::Types::Pattern.new(blueprint: "", enabled: false)
+          subject_configuration = persisted_subject_pattern.enabled ? :generated : :manual
+          pattern = persisted_subject_pattern.blueprint
+
+          { subject_configuration:, pattern: }
+        end
       end
     end
   end

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -34,6 +34,11 @@ module WorkPackages
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 
+      def initialize(model, subject_configuration_form_data: nil, **)
+        @subject_configuration_form_data = subject_configuration_form_data
+        super(model, **)
+      end
+
       def form_options
         form_model = subject_form_object
 
@@ -63,8 +68,8 @@ module WorkPackages
       end
 
       def subject_configuration_form_values
-        if params[:types_forms_subject_configuration_form_model].present?
-          params[:types_forms_subject_configuration_form_model]
+        if @subject_configuration_form_data.present?
+          @subject_configuration_form_data
         else
           persisted_subject_pattern = model.patterns.subject || ::Types::Pattern.new(blueprint: "", enabled: false)
           subject_configuration = persisted_subject_pattern.enabled ? :generated : :manual

--- a/app/views/types/edit.html.erb
+++ b/app/views/types/edit.html.erb
@@ -35,9 +35,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   selected_tab = selected_tab(tabs)
+  form_data = {
+    subject_configuration_form_data: params[:types_forms_subject_configuration_form_model]
+  }
 
   if selected_tab.key?(:view_component)
-    render selected_tab[:view_component].new(@type)
+    render selected_tab[:view_component].new(@type, **form_data)
   else
     form_for @type,
              url: update_tab_type_path(id: @type.id, tab: @tab),

--- a/spec/components/work_packages/types/subject_configuration_component_spec.rb
+++ b/spec/components/work_packages/types/subject_configuration_component_spec.rb
@@ -32,9 +32,10 @@ require "rails_helper"
 
 RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :component do
   let(:type) { create(:type) }
+  let(:subject_configuration_form_data) { nil }
 
   subject(:render_component) do
-    render_inline(described_class.new(type))
+    render_inline(described_class.new(type, subject_configuration_form_data:))
   end
 
   context "when enterprise edition is activated", with_ee: %i[work_package_subject_generation] do
@@ -75,13 +76,12 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
 
     context "if component is rendered with form values in parameters" do
       before do
-        allow_any_instance_of(described_class).to receive(:params).and_return(params)
         render_component
       end
 
       context "if work package type has subject pattern configured, but form params have option manual selected" do
         let(:type) { create(:type, patterns: { subject: { blueprint: "Created by {{assignee}}", enabled: true } }) }
-        let(:params) { { types_forms_subject_configuration_form_model: { subject_configuration: :manual } } }
+        let(:subject_configuration_form_data) { { subject_configuration: :manual } }
 
         it "must have manual option checked" do
           expect(page.find("input[type=radio][value=manual]")).to be_checked
@@ -89,11 +89,10 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
       end
 
       context "if work package type has no subject pattern configured, but form params have a pattern" do
-        let(:params) do
+        let(:subject_configuration_form_data) do
           {
-            types_forms_subject_configuration_form_model: {
-              subject_configuration: :generated, pattern: "Created by {{assignee}}"
-            }
+            subject_configuration: :generated,
+            pattern: "Created by {{assignee}}"
           }
         end
 


### PR DESCRIPTION
# Ticket
[OP#61619](https://community.openproject.org/wp/61619)

# What are you trying to accomplish?
- when submitting form but validation fails, form must keep the current state
- when form is reloaded, fill in values from database

