### PR TITLE
SSO error handling

### DIFF
--- a/app/models/oauth_client.rb
+++ b/app/models/oauth_client.rb
@@ -30,7 +30,7 @@
 
 class OAuthClient < ApplicationRecord
   belongs_to :integration, polymorphic: true
-  has_many :remote_identities, dependent: :destroy
+  has_many :remote_identities, as: :auth_source, dependent: :destroy
   has_many :oauth_client_tokens, dependent: :destroy
 
   def redirect_uri

--- a/app/models/oauth_client_token.rb
+++ b/app/models/oauth_client_token.rb
@@ -28,13 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# OAuthClientToken stores the OAuth2 Bearer+Refresh tokens that
-# an OAuth2 server (Nextcloud or similar) provides after a user
-# has granted access.
 class OAuthClientToken < ApplicationRecord
-  # OAuthClientToken sits between User and OAuthClient
   belongs_to :user, optional: false
   belongs_to :oauth_client, optional: false
+  alias_method :auth_source, :oauth_client
 
   validates :user, uniqueness: { scope: :oauth_client }
 

--- a/app/models/remote_identity.rb
+++ b/app/models/remote_identity.rb
@@ -30,8 +30,9 @@
 
 class RemoteIdentity < ApplicationRecord
   belongs_to :user
-  belongs_to :oauth_client, class_name: "OAuthClient"
+  belongs_to :auth_source, polymorphic: true
+  belongs_to :integration, polymorphic: true
 
-  validates :user, uniqueness: { scope: :oauth_client }
-  validates :origin_user_id, :user, :oauth_client, presence: true
+  validates :user, uniqueness: { scope: %i[auth_source integration] }
+  validates :origin_user_id, :user, :auth_source, :integration, presence: true
 end

--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -115,7 +115,7 @@ module OAuthClients
           oauth_client_token.save!
 
           RemoteIdentities::CreateService
-            .call(user: @user, oauth_config: @config, oauth_client_token:)
+            .call(user: @user, integration: @oauth_client.integration, token: oauth_client_token)
             .on_failure { raise ActiveRecord::Rollback }
         end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4518,6 +4518,7 @@ en:
       connected: "Connected"
       error: "Error"
       failed_authorization: "Authorization failed"
+      not_connected: "Not connected"
     labels:
       label_oauth_integration: "OAuth2 integration"
       label_redirect_uri: "Redirect URI"

--- a/db/migrate/20250220123358_add_polymorphic_auth_source_and_integration_to_remote_identities.rb
+++ b/db/migrate/20250220123358_add_polymorphic_auth_source_and_integration_to_remote_identities.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddPolymorphicAuthSourceAndIntegrationToRemoteIdentities < ActiveRecord::Migration[7.1]
+  def up
+    remove_foreign_key :remote_identities, :oauth_clients
+
+    rename_column :remote_identities, :oauth_client_id, :auth_source_id
+    add_column :remote_identities, :auth_source_type, :string
+    remove_index :remote_identities, :auth_source_id, if_exists: true
+    add_index :remote_identities, %i[auth_source_type auth_source_id]
+
+    add_column :remote_identities, :integration_type, :string
+    add_column :remote_identities, :integration_id, :bigint
+    add_index :remote_identities, %i[integration_type integration_id]
+
+    execute <<~SQL.squish
+      UPDATE remote_identities
+      SET auth_source_type = 'OAuthClient',
+          integration_id = oauth_clients.integration_id,
+          integration_type = oauth_clients.integration_type
+      FROM oauth_clients
+      WHERE remote_identities.auth_source_id = oauth_clients.id;
+    SQL
+
+    change_column_null(:remote_identities, :integration_id, false)
+    change_column_null(:remote_identities, :integration_type, false)
+    change_column_null(:remote_identities, :auth_source_type, false)
+
+    add_index(:remote_identities,
+              %i[user_id auth_source_type auth_source_id integration_id integration_type],
+              unique: true)
+  end
+
+  def down
+    remove_index(:remote_identities,
+                 %i[user_id auth_source_type auth_source_id integration_id integration_type])
+    rename_column :remote_identities, :auth_source_id, :oauth_client_id
+    add_foreign_key :remote_identities, :oauth_clients
+    add_index :remote_identities, :oauth_client_id
+    remove_column :remote_identities, :auth_source_type
+
+    remove_column :remote_identities, :integration_id
+    remove_column :remote_identities, :integration_type
+  end
+end

--- a/frontend/src/app/shared/components/storages/storage-information/storage-information.service.ts
+++ b/frontend/src/app/shared/components/storages/storage-information/storage-information.service.ts
@@ -40,6 +40,7 @@ import {
   fileLinkStatusError,
   storageAuthorizationError,
   storageConnected,
+  storageNotConnected,
   storageFailedAuthorization,
 } from 'core-app/shared/components/storages/storages-constants.const';
 
@@ -48,11 +49,15 @@ export class StorageInformationService {
   private text = {
     fileLinkErrorHeader: this.i18n.t('js.storages.information.live_data_error'),
     fileLinkErrorContent: (storageType:string):string => this.i18n.t('js.storages.information.live_data_error_description', { storageType }),
+    authenticationErrorHeader: (storageType:string):string => this.i18n.t('js.storages.authentication_error', { storageType }),
+    authenticationErrorContent: (storageType:string):string => this.i18n.t('js.storages.information.authentication_error', { storageType }),
     connectionErrorHeader: (storageType:string):string => this.i18n.t('js.storages.no_connection', { storageType }),
     connectionErrorContent: (storageType:string):string => this.i18n.t('js.storages.information.connection_error', { storageType }),
-    authorizationFailureHeader: (storageType:string):string => this.i18n.t('js.storages.login_to', { storageType }),
-    authorizationFailureContent: (storageType:string):string => this.i18n.t('js.storages.information.not_logged_in', { storageType }),
+    notConnectedHeader: (storageType:string):string => this.i18n.t('js.storages.login_to', { storageType }),
+    notConnectedContent: (storageType:string):string => this.i18n.t('js.storages.information.not_logged_in', { storageType }),
     loginButton: (storageType:string):string => this.i18n.t('js.storages.login', { storageType }),
+    suggestLogout: this.i18n.t('js.storages.information.suggest_logout'),
+    suggestRelink: this.i18n.t('js.storages.information.suggest_relink'),
   };
 
   constructor(
@@ -73,6 +78,8 @@ export class StorageInformationService {
           switch (storage._links.authorizationState.href) {
             case storageFailedAuthorization:
               return [this.failedAuthorizationInformation(storage, storageType)];
+            case storageNotConnected:
+              return [this.notConnectedInformation(storage, storageType)];
             case storageAuthorizationError:
               return [this.authorizationErrorInformation(storageType)];
             case storageConnected:
@@ -87,16 +94,31 @@ export class StorageInformationService {
       );
   }
 
-  private failedAuthorizationInformation(storage:IStorage, storageType:string):StorageInformationBox {
-    if (!storage._links.authorize) {
-      throw new Error('Authorize link is missing!');
+  private notConnectedInformation(storage:IStorage, storageType:string):StorageInformationBox {
+    if(!storage._links.authorize) {
+      // user should authenticate through SSO, but is not yet linked, that's an error
+      return this.failedAuthorizationInformation(storage, storageType);
     }
 
     return new StorageInformationBox(
       'import',
-      this.text.authorizationFailureHeader(storageType),
-      this.text.authorizationFailureContent(storageType),
+      this.text.notConnectedHeader(storageType),
+      this.text.notConnectedContent(storageType),
       {
+        storageId: storage.id,
+        storageType: storage._links.type.href,
+        authorizationLink: storage._links.authorize,
+      },
+    );
+  }
+
+  private failedAuthorizationInformation(storage:IStorage, storageType:string):StorageInformationBox {
+    const suggestion = storage._links.authorize ? this.text.suggestRelink : this.text.suggestLogout;
+    return new StorageInformationBox(
+      'error',
+      this.text.authenticationErrorHeader(storageType),
+      `${this.text.authenticationErrorContent(storageType)} ${suggestion}`,
+      storage._links.authorize && {
         storageId: storage.id,
         storageType: storage._links.type.href,
         authorizationLink: storage._links.authorize,

--- a/frontend/src/app/shared/components/storages/storages-constants.const.ts
+++ b/frontend/src/app/shared/components/storages/storages-constants.const.ts
@@ -4,6 +4,7 @@ export const oneDrive = 'urn:openproject-org:api:v3:storages:OneDrive';
 
 // Storage authorization state
 export const storageConnected = 'urn:openproject-org:api:v3:storages:authorization:Connected';
+export const storageNotConnected = 'urn:openproject-org:api:v3:storages:authorization:NotConnected';
 export const storageFailedAuthorization = 'urn:openproject-org:api:v3:storages:authorization:FailedAuthorization';
 export const storageAuthorizationError = 'urn:openproject-org:api:v3:storages:authorization:Error';
 

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 module OpenIDConnect
   class Provider < AuthProvider
     include HashBuilder
+
+    has_many :remote_identities, as: :auth_source, dependent: :destroy
 
     OIDC_PROVIDERS = %w[google microsoft_entra custom].freeze
     DISCOVERABLE_STRING_ATTRIBUTES_MANDATORY = %i[authorization_endpoint

--- a/modules/openid_connect/app/models/openid_connect/user_token.rb
+++ b/modules/openid_connect/app/models/openid_connect/user_token.rb
@@ -38,5 +38,9 @@ module OpenIDConnect
 
     scope :idp, -> { where(audience: IDP_AUDIENCE) }
     scope :with_audience, ->(audience) { where("audiences ? :aud", aud: audience) }
+
+    def auth_source
+      user.authentication_provider
+    end
   end
 end

--- a/modules/storages/app/common/storages/peripherals/nextcloud_registry.rb
+++ b/modules/storages/app/common/storages/peripherals/nextcloud_registry.rb
@@ -88,6 +88,7 @@ module Storages
       namespace("authentication") do
         register(:userless, StorageInteraction::AuthenticationStrategies::NextcloudStrategies::UserLess, call: false)
         register(:user_bound, StorageInteraction::AuthenticationStrategies::NextcloudStrategies::UserBound)
+        register(:bearer_token, StorageInteraction::AuthenticationStrategies::NextcloudStrategies::BearerToken)
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/oauth_configurations/configuration_interface.rb
+++ b/modules/storages/app/common/storages/peripherals/oauth_configurations/configuration_interface.rb
@@ -43,19 +43,6 @@ module Storages
         def authorization_uri(state: nil)
           basic_rack_oauth_client.authorization_uri(scope:, state:)
         end
-
-        def extract_origin_user_id(oauth_client_token)
-          auth_strategy = Registry
-                            .resolve("#{@storage}.authentication.user_bound")
-                            .call(user: oauth_client_token.user, storage: @storage)
-          Registry
-            .resolve("#{@storage}.queries.user")
-            .call(auth_strategy:, storage: @storage)
-            .match(
-              on_success: ->(user) { user[:id] },
-              on_failure: ->(error) { raise "UserQuery responed with #{error}" }
-            )
-        end
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/one_drive_registry.rb
+++ b/modules/storages/app/common/storages/peripherals/one_drive_registry.rb
@@ -79,6 +79,7 @@ module Storages
       namespace("authentication") do
         register(:userless, StorageInteraction::AuthenticationStrategies::OneDriveStrategies::UserLess, call: false)
         register(:user_bound, StorageInteraction::AuthenticationStrategies::OneDriveStrategies::UserBound)
+        register(:bearer_token, StorageInteraction::AuthenticationStrategies::OneDriveStrategies::BearerToken)
       end
     end
   end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication.rb
@@ -57,10 +57,14 @@ module Storages
 
         # Checks for the current authorization state of a user on a specific file storage.
         # Returns one of three results:
-        # - :connected If a valid user token is available
-        # - :failed_authorization If a user token is available, which is invalid and not refreshable
+        # - :connected If requests can be made to the storage in the user's name
+        # - :failed_authorization If the token to request the storage in the user's name was rejected
+        # - :not_connected if the user still needs to establish a connection to the storage
         # - :error If an unexpected error occurred
         def self.authorization_state(storage:, user:)
+          selector = AuthenticationMethodSelector.new(storage:, user:)
+          return :not_connected if RemoteIdentity.where(integration: storage, user:).none? && selector.storage_oauth?
+
           auth_strategy = Registry.resolve("#{storage}.authentication.user_bound").call(user:, storage:)
 
           Registry
@@ -68,6 +72,8 @@ module Storages
             .call(storage:, auth_strategy:)
             .match(
               on_success: ->(*) { :connected },
+              # TODO: what happens if the error is not an HTTPX error?
+              # TODO cont.: what happens if the expired IDP token has NO refresh token
               on_failure: ->(error) { error.code == :unauthorized ? :failed_authorization : :error }
             )
         end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication.rb
@@ -42,6 +42,8 @@ module Storages
             AuthenticationStrategies::Failure.new
           when :basic_auth
             AuthenticationStrategies::BasicAuth.new
+          when :bearer_token
+            AuthenticationStrategies::BearerToken.new(strategy.token)
           when :sso_user_token
             AuthenticationStrategies::SsoUserToken.new(strategy.user)
           when :oauth_user_token

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_method_selector.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_method_selector.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal:true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages
+  module Peripherals
+    module StorageInteraction
+      class AuthenticationMethodSelector
+        attr_reader :storage, :user
+
+        def initialize(storage:, user:)
+          @storage = storage
+          @user = user
+        end
+
+        def authentication_method
+          sso_preferred = storage.authenticate_via_idp? && oidc_provider_for(user)
+
+          if sso_preferred
+            :sso
+          elsif storage.authenticate_via_storage?
+            :storage_oauth
+          else
+            nil
+          end
+        end
+
+        def sso?
+          authentication_method == :sso
+        end
+
+        def storage_oauth?
+          authentication_method == :storage_oauth
+        end
+
+        private
+
+        def oidc_provider_for(user)
+          user.authentication_provider.is_a?(OpenIDConnect::Provider)
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/bearer_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/bearer_token.rb
@@ -32,20 +32,22 @@ module Storages
   module Peripherals
     module StorageInteraction
       module AuthenticationStrategies
-        module OneDriveStrategies
-          BearerToken = -> do
-            ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::BearerToken.strategy
+        class BearerToken
+          def self.strategy
+            Strategy.new(:bearer_token)
           end
 
-          UserLess = -> do
-            ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthClientCredentials.strategy
+          attr_reader :bearer_token
+
+          def initialize(bearer_token)
+            @bearer_token = bearer_token
           end
 
-          UserBound = ->(user:, storage:) do # rubocop:disable Lint/UnusedBlockArgument
-            ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
-              .strategy
-              .with_user(user)
+          # rubocop:disable Lint/UnusedMethodArgument
+          def call(storage:, http_options: {})
+            yield OpenProject.httpx.bearer_auth(bearer_token).with(http_options)
           end
+          # rubocop:enable Lint/UnusedMethodArgument
         end
       end
     end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
@@ -33,6 +33,10 @@ module Storages
     module StorageInteraction
       module AuthenticationStrategies
         module NextcloudStrategies
+          BearerToken = -> do
+            ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::BearerToken.strategy
+          end
+
           UserLess = -> do
             ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::BasicAuth.strategy
           end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
@@ -47,13 +47,14 @@ module Storages
 
               def call(user:, storage:)
                 with_tagged_logger do
-                  sso_preferred = storage.authenticate_via_idp? && oidc_provider_for(user)
+                  selector = AuthenticationMethodSelector.new(user:, storage:)
 
-                  if sso_preferred
+                  case selector.authentication_method
+                  when :sso
                     ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::SsoUserToken
                       .strategy
                       .with_user(user)
-                  elsif storage.authenticate_via_storage?
+                  when :storage_oauth
                     ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
                       .strategy
                       .with_user(user)

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/strategy.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/strategy.rb
@@ -33,7 +33,7 @@ module Storages
     module StorageInteraction
       module AuthenticationStrategies
         class Strategy
-          attr_reader :key, :user, :use_cache
+          attr_reader :key, :user, :use_cache, :token
 
           def initialize(key)
             @key = key
@@ -49,6 +49,11 @@ module Storages
 
           def with_cache(use_cache)
             @use_cache = use_cache
+            self
+          end
+
+          def with_token(token)
+            @token = token
             self
           end
         end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/nextcloud/util.rb
@@ -71,7 +71,8 @@ module Storages
               when :basic_auth
                 ServiceResult.success(result: storage.username)
               when :oauth_user_token, :sso_user_token
-                origin_user_id = RemoteIdentity.where(user_id: auth_strategy.user, oauth_client: storage.oauth_client)
+                origin_user_id = RemoteIdentity.where(user_id: auth_strategy.user, auth_source: storage.oauth_client,
+                                                      integration: storage)
                                                .pick(:origin_user_id)
                 if origin_user_id.present?
                   ServiceResult.success(result: origin_user_id)

--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -100,7 +100,7 @@ module Storages::ProjectStorages::Members
 
     def oauth_client_connected?
       storage.oauth_client.present? &&
-        member.principal.remote_identities.exists?(oauth_client: storage.oauth_client)
+        member.principal.remote_identities.exists?(auth_source: storage.oauth_client)
     end
 
     def can_read_files?

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -40,6 +40,8 @@
 # db/migrate/20220113144323_create_storage.rb "migration".
 module Storages
   class Storage < ApplicationRecord
+    using Peripherals::ServiceResultRefinements
+
     PROVIDER_TYPES = [
       PROVIDER_TYPE_NEXTCLOUD = "Storages::NextcloudStorage",
       PROVIDER_TYPE_ONE_DRIVE = "Storages::OneDriveStorage"
@@ -61,6 +63,7 @@ module Storages
     has_many :projects, through: :project_storages
     has_one :oauth_client, as: :integration, dependent: :destroy
     has_one :oauth_application, class_name: "::Doorkeeper::Application", as: :integration, dependent: :destroy
+    has_many :remote_identities, as: :integration, dependent: :destroy
 
     validates_uniqueness_of :host, allow_nil: true
     validates_uniqueness_of :name
@@ -219,6 +222,19 @@ module Storages
 
     def health_reason_description
       @health_reason_description ||= self.class.extract_part_from_piped_string(health_reason, 1)
+    end
+
+    def extract_origin_user_id(token)
+      auth_strategy = ::Storages::Peripherals::Registry
+                        .resolve("#{self}.authentication.bearer_token")
+                        .with_token(token.access_token)
+      ::Storages::Peripherals::Registry
+        .resolve("#{self}.queries.user")
+        .call(auth_strategy:, storage: self)
+        .match(
+          on_success: ->(user) { user[:id] },
+          on_failure: ->(error) { raise "UserQuery responed with #{error}" }
+        )
     end
   end
 end

--- a/modules/storages/app/services/storages/nextcloud_managed_folder_sync_service.rb
+++ b/modules/storages/app/services/storages/nextcloud_managed_folder_sync_service.rb
@@ -318,7 +318,7 @@ module Storages
     end
 
     def remote_identities_scope
-      RemoteIdentity.includes(:user).where(oauth_client: @storage.oauth_client)
+      RemoteIdentity.includes(:user).where(integration: @storage, auth_source: @storage.oauth_client)
     end
 
     def auth_strategy
@@ -326,7 +326,7 @@ module Storages
     end
 
     def admin_remote_identities_scope
-      RemoteIdentity.includes(:user).where(oauth_client: @storage.oauth_client, user: User.admin.active)
+      RemoteIdentity.includes(:user).where(integration: @storage, auth_source: @storage.oauth_client, user: User.admin.active)
     end
   end
 end

--- a/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
+++ b/modules/storages/app/services/storages/one_drive_managed_folder_sync_service.rb
@@ -223,11 +223,11 @@ module Storages
     end
 
     def client_remote_identities_scope
-      RemoteIdentity.includes(:user).where(oauth_client: @storage.oauth_client)
+      RemoteIdentity.includes(:user).where(integration: @storage, auth_source: @storage.oauth_client)
     end
 
     def admin_remote_identities_scope
-      RemoteIdentity.includes(:user).where(oauth_client: @storage.oauth_client, user: User.admin.active)
+      RemoteIdentity.includes(:user).where(integration: @storage, auth_source: @storage.oauth_client, user: User.admin.active)
     end
 
     def root_folder = Peripherals::ParentFolder.new("/")

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -349,6 +349,7 @@ en:
       connected: Connected
       connected_no_permissions: User role has no storages permissions
       not_connected: Not connected. The user should login to the storage via the following %{link}.
+      not_connected_sso: Not yet connected, SSO should automatically connect them, once looking at files.
     members_no_results: No members to display.
     no_results: No storages set up yet.
     oauth_access_granted_modal:

--- a/modules/storages/config/locales/js-en.yml
+++ b/modules/storages/config/locales/js-en.yml
@@ -2,6 +2,7 @@
 en:
   js:
     storages:
+      authentication_error: "Authentication with %{storageType} failed"
       link_files_in_storage: "Link files in %{storageType}"
       link_existing_files: "Link existing files"
       upload_files: "Upload files"
@@ -21,6 +22,7 @@ en:
         default: "Storage"
 
       information:
+        authentication_error: "The request to %{storageType} could not be authenticated, that's an error."
         connection_error: >
           Some %{storageType} settings are not working. Please contact your %{storageType} administrator.
         live_data_error: "Error fetching file details"
@@ -30,6 +32,8 @@ en:
         no_file_links: "In order to link files to this work package please do it via %{storageType}."
         not_logged_in: >
           To add a link, see or upload files related to this work package, please login to %{storageType}.
+        suggest_logout: You can try whether logging out and back in fixes this problem.
+        suggest_relink: You can try whether re-linking your account via the login button below fixes this problem.
 
       files:
         already_existing_header: "This file already exists"

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -34,6 +34,7 @@
 # Reference: Roar-Rails integration: https://github.com/apotonick/roar-rails
 module API::V3::Storages
   URN_CONNECTION_CONNECTED = "#{::API::V3::URN_PREFIX}storages:authorization:Connected".freeze
+  URN_CONNECTION_NOT_CONNECTED = "#{::API::V3::URN_PREFIX}storages:authorization:NotConnected".freeze
   URN_CONNECTION_AUTH_FAILED = "#{::API::V3::URN_PREFIX}storages:authorization:FailedAuthorization".freeze
   URN_CONNECTION_ERROR = "#{::API::V3::URN_PREFIX}storages:authorization:Error".freeze
 
@@ -166,6 +167,8 @@ module API::V3::Storages
       urn = case auth_state
             when :connected
               URN_CONNECTION_CONNECTED
+            when :not_connected
+              URN_CONNECTION_NOT_CONNECTED
             when :failed_authorization
               URN_CONNECTION_AUTH_FAILED
             else
@@ -177,7 +180,7 @@ module API::V3::Storages
     end
 
     link :authorize do
-      next if hide_authorize_link?
+      next unless show_authorize_link?
 
       { href: represented.oauth_configuration.authorization_uri, title: "Authorize" }
     end
@@ -227,8 +230,12 @@ module API::V3::Storages
       current_user.admin? && represented.provider_type_nextcloud?
     end
 
-    def hide_authorize_link?
-      represented.oauth_client.blank? || authorization_state != :failed_authorization
+    def show_authorize_link?
+      selector = Storages::Peripherals::StorageInteraction::AuthenticationMethodSelector.new(
+        user: current_user, storage: represented
+      )
+
+      selector.storage_oauth? && (authorization_state == :not_connected || authorization_state == :failed_authorization)
     end
 
     def storage_projects(storage)

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -135,6 +135,21 @@ module OpenProject::Storages
         ) do |payload|
           ::Storages::HealthService.new(storage: payload[:storage]).healthy
         end
+
+        OpenProject::Notifications.subscribe(
+          ::OpenIDConnect::UserTokens::FetchService::TOKEN_OBTAINED
+        ) do |payload|
+          audience = payload[:audience]
+          token = payload[:token]
+          storage = Storages::Storage.all.find { |s| s.audience == audience }
+          if storage
+            RemoteIdentities::CreateService
+              .call(user: token.user, integration: storage, token:)
+              .on_failure { raise "RemoteIdentity creation failed" }
+          else
+            puts "WARNING: no integration was found for audience: #{audience}"
+          end
+        end
       end
     end
 

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -157,7 +157,8 @@ FactoryBot.define do
              token_type: "bearer")
 
       create(:remote_identity,
-             oauth_client: storage.oauth_client,
+             auth_source: storage.oauth_client,
+             integration: storage,
              user: evaluator.oauth_client_token_user,
              origin_user_id: evaluator.origin_user_id)
     end
@@ -221,8 +222,11 @@ FactoryBot.define do
              refresh_token: ENV.fetch("ONE_DRIVE_TEST_OAUTH_CLIENT_REFRESH_TOKEN",
                                       "MISSING_ONE_DRIVE_TEST_OAUTH_CLIENT_REFRESH_TOKEN"),
              token_type: "bearer")
-      create(:remote_identity, oauth_client: storage.oauth_client, user: evaluator.oauth_client_token_user,
-                               origin_user_id: "33db2c84-275d-46af-afb0-c26eb786b194")
+      create(:remote_identity,
+             auth_source: storage.oauth_client,
+             user: evaluator.oauth_client_token_user,
+             integration: storage,
+             origin_user_id: "33db2c84-275d-46af-afb0-c26eb786b194")
     end
   end
 end

--- a/modules/storages/spec/features/create_file_links_spec.rb
+++ b/modules/storages/spec/features/create_file_links_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe "Managing file links in work package", :js, :webmock do
   let(:storage) { create(:nextcloud_storage, name: "My Storage", oauth_application:) }
   let(:oauth_client) { create(:oauth_client, integration: storage) }
   let(:oauth_client_token) { create(:oauth_client_token, oauth_client:, user: current_user) }
-  let(:remote_identity) { create(:remote_identity, oauth_client:, user: current_user, origin_user_id: "admin") }
+  let(:remote_identity) do
+    create(:remote_identity, auth_source: oauth_client, integration: storage, user: current_user, origin_user_id: "admin")
+  end
   let(:project_storage) { create(:project_storage, project:, storage:, project_folder_id: nil, project_folder_mode: "inactive") }
   let(:file_link) { create(:file_link, container: work_package, storage:, origin_id: "22", origin_name: "jingle.ogg") }
 

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe("Activation of storages in projects",
 
   let(:oauth_client) { create(:oauth_client, integration: storage) }
   let(:oauth_client_token) { create(:oauth_client_token, oauth_client:, user:) }
-  let(:remote_identity) { create(:remote_identity, user:, oauth_client:, origin_user_id: "admin") }
+  let(:remote_identity) do
+    create(:remote_identity, user:, auth_source: oauth_client, integration: storage, origin_user_id: "admin")
+  end
 
   let(:location_picker) { Components::FilePickerDialog.new }
 

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Admin lists project mappings for a storage",
   shared_let(:oauth_client_token) { create(:oauth_client_token, oauth_client: storage.oauth_client, user: admin) }
 
   shared_let(:remote_identity) do
-    create(:remote_identity, oauth_client: storage.oauth_client, user: admin, origin_user_id: "admin")
+    create(:remote_identity, auth_source: storage.oauth_client, integration: storage, user: admin, origin_user_id: "admin")
   end
 
   shared_let(:archived_project_project_storage) do

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -134,7 +134,8 @@ RSpec.describe "Project storage members connection status view", :js do
 
   def create_remote_identities_for_users(oauth_client:, users:)
     users.each do |user|
-      create(:remote_identity, oauth_client:, user:, origin_user_id: "origin-user-id-#{user.id}")
+      create(:remote_identity, auth_source: oauth_client, integration: oauth_client.integration, user:,
+                               origin_user_id: "origin-user-id-#{user.id}")
     end
   end
 end

--- a/modules/storages/spec/services/storages/nextcloud_managed_folder_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/nextcloud_managed_folder_sync_service_spec.rb
@@ -54,14 +54,20 @@ module Storages
       shared_let(:storage) { create(:nextcloud_storage_with_complete_configuration, :as_automatically_managed) }
 
       shared_let(:remote_identities) do
-        [create(:remote_identity, user: admin, oauth_client: storage.oauth_client, origin_user_id: "admin"),
+        [create(:remote_identity,
+                user: admin,
+                auth_source: storage.oauth_client,
+                integration: storage,
+                origin_user_id: "admin"),
          create(:remote_identity,
                 user: multiple_projects_user,
-                oauth_client: storage.oauth_client,
+                auth_source: storage.oauth_client,
+                integration: storage,
                 origin_user_id: "multiple_projects_user"),
          create(:remote_identity,
                 user: single_project_user,
-                oauth_client: storage.oauth_client,
+                auth_source: storage.oauth_client,
+                integration: storage,
                 origin_user_id: "single_project_user")]
       end
 

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_sync_service_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
   shared_let(:single_project_user_token) do
     create(:remote_identity,
            user: single_project_user,
-           oauth_client: storage.oauth_client,
+           auth_source: storage.oauth_client,
+           integration: storage,
            origin_user_id: "2ff33b8f-2843-40c1-9a17-d786bca17fba")
   end
 
@@ -56,7 +57,8 @@ RSpec.describe Storages::OneDriveManagedFolderSyncService, :webmock do
   shared_let(:multiple_project_user_token) do
     create(:remote_identity,
            user: multiple_projects_user,
-           oauth_client: storage.oauth_client,
+           auth_source: storage.oauth_client,
+           integration: storage,
            origin_user_id: "248aeb72-b231-4e71-a466-67fa7df2a285")
   end
 

--- a/spec/factories/remote_identity_factory.rb
+++ b/spec/factories/remote_identity_factory.rb
@@ -30,8 +30,10 @@
 
 FactoryBot.define do
   factory :remote_identity do
-    user
-    oauth_client
+    user factory: %i[user]
+
+    auth_source factory: %i[oauth_client]
+    integration factory: %i[nextcloud_storage]
 
     sequence(:origin_user_id) { |n| "remote-user-identifier-#{n}" }
   end

--- a/spec/models/remote_identity_spec.rb
+++ b/spec/models/remote_identity_spec.rb
@@ -32,20 +32,21 @@ require "spec_helper"
 
 RSpec.describe RemoteIdentity do
   let(:user) { create(:user) }
-  let(:oauth_client) { create(:oauth_client) }
+  let(:integration) { create(:nextcloud_storage) }
+  let(:auth_source) { create(:oauth_client) }
 
   it "a user can have multiple identities in different oauth clients" do
     other_client = create(:oauth_client)
-    create(:remote_identity, user:, oauth_client:)
-    second_identity = build(:remote_identity, user:, oauth_client: other_client)
+    create(:remote_identity, user:, auth_source:)
+    second_identity = build(:remote_identity, user:, auth_source: other_client)
 
     expect(second_identity).to be_valid
   end
 
-  it "a user can only have one identity per oauth client" do
-    create(:remote_identity, user:, oauth_client:)
+  it "a user can only have one identity per oauth client and integration" do
+    create(:remote_identity, user:, auth_source:, integration:)
 
-    invalid = build(:remote_identity, user:, oauth_client:)
+    invalid = build(:remote_identity, user:, auth_source:, integration:)
 
     expect(invalid).not_to be_valid
     p invalid.errors
@@ -59,8 +60,8 @@ RSpec.describe RemoteIdentity do
   end
 
   it "is destroyed when the related oauth client is destroyed" do
-    create(:remote_identity, oauth_client:)
+    create(:remote_identity, auth_source:)
 
-    expect { oauth_client.destroy }.to change(described_class, :count).by(-1)
+    expect { auth_source.destroy }.to change(described_class, :count).by(-1)
   end
 end

--- a/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe OAuthClients::ConnectionManager, :oauth_connection_helpers, :webm
     it "fills in the origin_user_id" do
       expect { subject.code_to_token(code) }.to change(OAuthClientToken, :count).by(1).and(change(RemoteIdentity, :count).by(1))
 
-      last_token = RemoteIdentity.find_by!(user:, oauth_client: storage.oauth_client)
+      last_token = RemoteIdentity.find_by!(user:, auth_source: storage.oauth_client)
       expect(last_token.origin_user_id).to eq("87d349ed-44d7-43e1-9a83-5f2406dee5bd")
     end
 

--- a/spec/services/oauth_clients/connection_manager_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe OAuthClients::ConnectionManager, :webmock, type: :model do
 
       it "fills in the origin_user_id" do
         expect { subject }.to change(OAuthClientToken, :count).by(1).and(change(RemoteIdentity, :count).by(1))
-        last_token = RemoteIdentity.find_by!(user:, oauth_client:)
+        last_token = RemoteIdentity.find_by!(user:, auth_source: oauth_client)
 
         expect(last_token.origin_user_id).to eq("admin")
       end

--- a/spec/services/remote_identities/create_service_spec.rb
+++ b/spec/services/remote_identities/create_service_spec.rb
@@ -6,27 +6,28 @@ require "services/base_services/behaves_like_create_service"
 
 RSpec.describe RemoteIdentities::CreateService, :storage_server_helpers, :webmock, type: :model do
   let(:user) { create(:user) }
-  let(:storage) { create(:nextcloud_storage_configured) }
-  let(:oauth_config) { storage.oauth_configuration }
+  let(:integration) { create(:nextcloud_storage_configured) }
+  let(:oauth_config) { integration.oauth_configuration }
+  let(:auth_source) { oauth_config.oauth_client }
   let(:oauth_client_token) do
     create(:oauth_client_token,
            user:,
            oauth_client: oauth_config.oauth_client)
   end
 
-  subject(:service) { described_class.new(user:, oauth_config:, oauth_client_token:) }
+  subject(:service) { described_class.new(user:, token: oauth_client_token, integration:) }
 
-  before { stub_nextcloud_user_query(storage.host) }
+  before { stub_nextcloud_user_query(integration.host) }
 
   describe ".call" do
     it "requires a user, a oauth configuration and a rack token" do
       method = described_class.method :call
 
-      expect(method.parameters).to contain_exactly(%i[keyreq user], %i[keyreq oauth_config], %i[keyreq oauth_client_token])
+      expect(method.parameters).to contain_exactly(%i[keyreq user], %i[keyreq token], %i[keyreq integration])
     end
 
     it "succeeds", :webmock do
-      expect(described_class.call(user:, oauth_config:, oauth_client_token:)).to be_success
+      expect(described_class.call(user:, token: oauth_client_token, integration:)).to be_success
     end
   end
 


### PR DESCRIPTION
# Ticket
* https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61612
* https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61880

# What are you trying to accomplish?
Fixing errors related to showing the connection status of SSO users to their storage.

In the files tab, the following cases should now be indicated correctly:

* A "classic" (OAuth) user is not yet linked to the storage (existed before)
* A "classic" (OAuth) user could not successfully authenticate at the storage (new: indicated as an error)
* An SSO user could not successfully authenticate at the storage (indicated as an error)

In the project storages member overview (e.g. `/projects/:name/settings/project_storages/:id/members`):

* SSO members are now indicated as connected, once they obtained a remote identity
* SSO members have a specific not-connected message, when there is no remote identity yet

# Which approach did you choose and why?
It occured to me, that the question of which authentication method will really be used for a user at a storage has to be asked in many different places. Thus I extracted the relevant code into a helper called `AuthenticationMethodSelector`.

# Merge checklist

- [ ] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
