### PR TITLE
turn pagination_helper into frozen_string_literal file

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -73,7 +75,7 @@ module PaginationHelper
       content = will_paginate(paginator, options) || ""
 
       range = "(#{page_first} - #{page_last}/#{total})"
-      content << content_tag(:li, range, class: "op-pagination--range", title: range)
+      content += content_tag(:li, range, class: "op-pagination--range", title: range)
 
       content.html_safe
     end


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Remove warning:
```
/app/helpers/pagination_helper.rb:76:in 'block in PaginationHelper#pagination_entries': literal string will be frozen in the future (run with --debug-frozen-string-literal for more information) (StructuredWarnings::BuiltInWarning)
```


