### PR TITLE
SSO error handling

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4577,6 +4577,7 @@ en:
       connected: "Connected"
       error: "Error"
       failed_authorization: "Authorization failed"
+      not_connected: "Not connected"
     labels:
       label_oauth_integration: "OAuth2 integration"
       label_redirect_uri: "Redirect URI"

--- a/frontend/src/app/shared/components/storages/storages-constants.const.ts
+++ b/frontend/src/app/shared/components/storages/storages-constants.const.ts
@@ -4,6 +4,7 @@ export const oneDrive = 'urn:openproject-org:api:v3:storages:OneDrive';
 
 // Storage authorization state
 export const storageConnected = 'urn:openproject-org:api:v3:storages:authorization:Connected';
+export const storageNotConnected = 'urn:openproject-org:api:v3:storages:authorization:NotConnected';
 export const storageFailedAuthorization = 'urn:openproject-org:api:v3:storages:authorization:FailedAuthorization';
 export const storageAuthorizationError = 'urn:openproject-org:api:v3:storages:authorization:Error';
 

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
+RSpec.describe RecurringMeetings::UpdateService, "integration", freeze_time: Time.zone.today + 12.hours, type: :model do
   shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
   shared_let(:user) do
     create(:user, member_with_permissions: { project => %i(view_meetings edit_meetings) })

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_method_selector.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_method_selector.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal:true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages
+  module Peripherals
+    module StorageInteraction
+      class AuthenticationMethodSelector
+        attr_reader :storage, :user
+
+        def initialize(storage:, user:)
+          @storage = storage
+          @user = user
+        end
+
+        def authentication_method
+          sso_preferred = storage.authenticate_via_idp? && oidc_provider_for(user)
+
+          if sso_preferred
+            :sso
+          elsif storage.authenticate_via_storage?
+            :storage_oauth
+          end
+        end
+
+        def sso?
+          authentication_method == :sso
+        end
+
+        def storage_oauth?
+          authentication_method == :storage_oauth
+        end
+
+        private
+
+        def oidc_provider_for(user)
+          user.authentication_provider.is_a?(OpenIDConnect::Provider)
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/nextcloud_strategies.rb
@@ -47,13 +47,14 @@ module Storages
 
               def call(user:, storage:)
                 with_tagged_logger do
-                  sso_preferred = storage.authenticate_via_idp? && oidc_provider_for(user)
+                  selector = AuthenticationMethodSelector.new(user:, storage:)
 
-                  if sso_preferred
+                  case selector.authentication_method
+                  when :sso
                     ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::SsoUserToken
                       .strategy
                       .with_user(user)
-                  elsif storage.authenticate_via_storage?
+                  when :storage_oauth
                     ::Storages::Peripherals::StorageInteraction::AuthenticationStrategies::OAuthUserToken
                       .strategy
                       .with_user(user)

--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -51,19 +51,16 @@ module Storages::ProjectStorages::Members
 
     def status
       connection_result = storage_connection_status
-
-      if connection_result == :not_connected
-        ensure_connection_url = oauth_clients_ensure_connection_url(
-          oauth_client_id: storage.oauth_client.client_id,
-          storage_id: storage.id
-        )
+      case connection_result
+      when :not_connected
         helpers.op_icon("icon-warning -warning") +
           content_tag(
             :span,
             I18n.t("storages.member_connection_status.not_connected",
-                   link: link_to(I18n.t("link"), ensure_connection_url),
-                   class: "pl-2").html_safe
+                   link: link_to(I18n.t("link"), ensure_connection_url)).html_safe
           )
+      when :not_connected_sso
+        content_tag(:span, I18n.t("storages.member_connection_status.not_connected_sso"))
       else
         I18n.t("storages.member_connection_status.#{connection_result}")
       end
@@ -89,22 +86,31 @@ module Storages::ProjectStorages::Members
     end
 
     def storage_connection_status
-      return :not_connected unless oauth_client_connected?
+      if storage_connected?
+        return :connected if can_read_files?
 
-      if can_read_files?
-        :connected
-      else
-        :connected_no_permissions
+        return :connected_no_permissions
       end
+
+      selector = Storages::Peripherals::StorageInteraction::AuthenticationMethodSelector.new(user: member.principal, storage:)
+      return :not_connected_sso if selector.sso?
+
+      :not_connected
     end
 
-    def oauth_client_connected?
-      storage.oauth_client.present? &&
-        member.principal.remote_identities.exists?(auth_source: storage.oauth_client)
+    def storage_connected?
+      member.principal.remote_identities.exists?(integration: storage)
     end
 
     def can_read_files?
       member.principal.admin? || member.roles.any? { |role| role.has_permission?(:read_files) }
+    end
+
+    def ensure_connection_url
+      oauth_clients_ensure_connection_url(
+        oauth_client_id: storage.oauth_client.client_id,
+        storage_id: storage.id
+      )
     end
   end
 end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -349,6 +349,7 @@ en:
       connected: Connected
       connected_no_permissions: User role has no storages permissions
       not_connected: Not connected. The user should login to the storage via the following %{link}.
+      not_connected_sso: Not yet connected, SSO should automatically connect them, once looking at files.
     members_no_results: No members to display.
     no_results: No storages set up yet.
     oauth_access_granted_modal:

--- a/modules/storages/config/locales/js-en.yml
+++ b/modules/storages/config/locales/js-en.yml
@@ -2,6 +2,7 @@
 en:
   js:
     storages:
+      authentication_error: "Authentication with %{storageType} failed"
       link_files_in_storage: "Link files in %{storageType}"
       link_existing_files: "Link existing files"
       upload_files: "Upload files"
@@ -21,6 +22,7 @@ en:
         default: "Storage"
 
       information:
+        authentication_error: "The request to %{storageType} could not be authenticated, that's an error."
         connection_error: >
           Some %{storageType} settings are not working. Please contact your %{storageType} administrator.
         live_data_error: "Error fetching file details"
@@ -30,6 +32,8 @@ en:
         no_file_links: "In order to link files to this work package please do it via %{storageType}."
         not_logged_in: >
           To add a link, see or upload files related to this work package, please login to %{storageType}.
+        suggest_logout: You can try whether logging out and back in fixes this problem.
+        suggest_relink: You can try whether re-linking your account via the login button below fixes this problem.
 
       files:
         already_existing_header: "This file already exists"

--- a/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_method_selector_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/storage_interaction/authentication_method_selector_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Storages::Peripherals::StorageInteraction::AuthenticationMethodSelector do
+  subject { described_class.new(storage:, user:) }
+
+  context "if user is provisioned by an IDP" do
+    let(:provider) { create(:oidc_provider) }
+    let(:user) { create(:user, identity_url: "#{provider.slug}:me") }
+
+    context "if file storage is configured for sso only" do
+      let(:storage) { create(:nextcloud_storage, :oidc_sso_enabled) }
+
+      it { is_expected.to be_sso }
+      it { is_expected.not_to be_storage_oauth }
+
+      it "indicates an authentication method of :sso" do
+        expect(subject.authentication_method).to eq(:sso)
+      end
+    end
+
+    context "if file storage is configured for sso and oauth" do
+      let(:storage) { create(:nextcloud_storage_configured, :oidc_sso_with_fallback) }
+
+      it { is_expected.to be_sso }
+      it { is_expected.not_to be_storage_oauth }
+
+      it "indicates an authentication method of :sso" do
+        expect(subject.authentication_method).to eq(:sso)
+      end
+    end
+
+    context "if file storage is configured for oauth only" do
+      let(:storage) { create(:nextcloud_storage_configured) }
+
+      it { is_expected.not_to be_sso }
+      it { is_expected.to be_storage_oauth }
+
+      it "indicates an authentication method of :storage_oauth" do
+        expect(subject.authentication_method).to eq(:storage_oauth)
+      end
+    end
+  end
+
+  context "if user is local" do
+    let(:user) { create(:user) }
+
+    context "if file storage is configured for sso only" do
+      let(:storage) { create(:nextcloud_storage, :oidc_sso_enabled) }
+
+      it { is_expected.not_to be_sso }
+      it { is_expected.not_to be_storage_oauth }
+
+      it "indicates an authentication method of :sso" do
+        expect(subject.authentication_method).to be_nil
+      end
+    end
+
+    context "if file storage is configured for sso and oauth" do
+      let(:storage) { create(:nextcloud_storage_configured, :oidc_sso_with_fallback) }
+
+      it { is_expected.not_to be_sso }
+      it { is_expected.to be_storage_oauth }
+
+      it "indicates an authentication method of :storage_oauth" do
+        expect(subject.authentication_method).to eq(:storage_oauth)
+      end
+    end
+
+    context "if file storage is configured for oauth only" do
+      let(:storage) { create(:nextcloud_storage_configured) }
+
+      it { is_expected.not_to be_sso }
+      it { is_expected.to be_storage_oauth }
+
+      it "indicates an authentication method of :storage_oauth" do
+        expect(subject.authentication_method).to eq(:storage_oauth)
+      end
+    end
+
+    context "if file storage is configured for oauth only, but client and app not fully configured" do
+      let(:storage) { create(:nextcloud_storage) }
+
+      it { is_expected.not_to be_sso }
+      it { is_expected.to be_storage_oauth }
+
+      it "indicates an authentication method of :storage_oauth" do
+        expect(subject.authentication_method).to eq(:storage_oauth)
+      end
+    end
+  end
+end

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -33,7 +33,7 @@ require_module_spec_helper
 
 RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
   let(:oauth_client_credentials) { build_stubbed(:oauth_client) }
-  let(:user) { build_stubbed(:user) }
+  let(:user) { create(:user) }
   let(:auth_check_result) { ServiceResult.success }
   let(:representer) { described_class.new(storage, current_user: user, embed_links: true) }
 
@@ -73,6 +73,12 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
   end
 
   shared_examples_for "common file storage links" do
+    let(:remote_identity) { create :remote_identity, user:, integration: storage }
+
+    before do
+      remote_identity
+    end
+
     describe "self" do
       it_behaves_like "has a titled link" do
         let(:link) { "self" }
@@ -105,6 +111,16 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
           let(:link) { "authorizationState" }
           let(:href) { "urn:openproject-org:api:v3:storages:authorization:Error" }
           let(:title) { "Error" }
+        end
+      end
+
+      context "if there is no remote identity for the user at the storage" do
+        let(:remote_identity) { nil }
+
+        it_behaves_like "has a titled link" do
+          let(:link) { "authorizationState" }
+          let(:href) { "urn:openproject-org:api:v3:storages:authorization:NotConnected" }
+          let(:title) { "Not connected" }
         end
       end
     end
@@ -173,7 +189,7 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
       end
 
       context "as admin" do
-        let(:user) { build_stubbed(:admin) }
+        let(:user) { create(:admin) }
 
         it_behaves_like "has an untitled link" do
           let(:link) { "oauthClientCredentials" }
@@ -182,7 +198,7 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
       end
 
       context "as admin without oauth client credentials set" do
-        let(:user) { build_stubbed(:admin) }
+        let(:user) { create(:admin) }
         let(:oauth_client_credentials) { nil }
 
         it_behaves_like "has an untitled link" do
@@ -198,13 +214,13 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
       it { is_expected.not_to have_json_path("_embedded/oauthClientCredentials") }
 
       context "as admin" do
-        let(:user) { build_stubbed(:admin) }
+        let(:user) { create(:admin) }
 
         it { is_expected.to be_json_eql(oauth_client_credentials.id).at_path("_embedded/oauthClientCredentials/id") }
       end
 
       context "as admin without oauth client credentials set" do
-        let(:user) { build_stubbed(:admin) }
+        let(:user) { create(:admin) }
         let(:oauth_client_credentials) { nil }
 
         it { is_expected.not_to have_json_path("_embedded/oauthClientCredentials") }
@@ -260,7 +276,7 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
         end
 
         context "as admin" do
-          let(:user) { build_stubbed(:admin) }
+          let(:user) { create(:admin) }
 
           it_behaves_like "has a titled link" do
             let(:link) { "oauthApplication" }
@@ -287,7 +303,7 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
         it { is_expected.not_to have_json_path("_embedded/oauthApplication") }
 
         context "as admin" do
-          let(:user) { build_stubbed(:admin) }
+          let(:user) { create(:admin) }
 
           it { is_expected.to be_json_eql(oauth_application.id).at_path("_embedded/oauthApplication/id") }
         end

--- a/modules/storages/spec/requests/api/v3/storages/storages_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storages_api_spec.rb
@@ -244,28 +244,40 @@ RSpec.describe "API v3 storages resource", :storage_server_helpers, :webmock, co
         end
       end
 
-      context "when authorization succeeds and storage is connected" do
-        let(:auth_check_result) { ServiceResult.success }
+      context "when user has a remote identity for the storage" do
+        before do
+          create :remote_identity, user: current_user, integration: storage
+        end
 
-        include_examples "a storage authorization result",
-                         expected: API::V3::Storages::URN_CONNECTION_CONNECTED,
-                         has_authorize_link: false
+        context "when authorization succeeds and storage is connected" do
+          let(:auth_check_result) { ServiceResult.success }
+
+          include_examples "a storage authorization result",
+                           expected: API::V3::Storages::URN_CONNECTION_CONNECTED,
+                           has_authorize_link: false
+        end
+
+        context "when authorization fails" do
+          let(:auth_check_result) { ServiceResult.failure(errors: Storages::StorageError.new(code: :unauthorized)) }
+
+          include_examples "a storage authorization result",
+                           expected: API::V3::Storages::URN_CONNECTION_AUTH_FAILED,
+                           has_authorize_link: true
+        end
+
+        context "when authorization fails with an error" do
+          let(:auth_check_result) { ServiceResult.failure(errors: Storages::StorageError.new(code: :error)) }
+
+          include_examples "a storage authorization result",
+                           expected: API::V3::Storages::URN_CONNECTION_ERROR,
+                           has_authorize_link: false
+        end
       end
 
-      context "when authorization fails" do
-        let(:auth_check_result) { ServiceResult.failure(errors: Storages::StorageError.new(code: :unauthorized)) }
-
+      context "when user has no remote identity for the storage" do
         include_examples "a storage authorization result",
-                         expected: API::V3::Storages::URN_CONNECTION_AUTH_FAILED,
+                         expected: API::V3::Storages::URN_CONNECTION_NOT_CONNECTED,
                          has_authorize_link: true
-      end
-
-      context "when authorization fails with an error" do
-        let(:auth_check_result) { ServiceResult.failure(errors: Storages::StorageError.new(code: :error)) }
-
-        include_examples "a storage authorization result",
-                         expected: API::V3::Storages::URN_CONNECTION_ERROR,
-                         has_authorize_link: false
       end
     end
   end

--- a/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
+++ b/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_ac
 
       before do
         Storages::Peripherals::Registry.stub("nextcloud.queries.user", ->(_) { ServiceResult.success })
+        create(:remote_identity, user:, integration: storage)
       end
 
       it "redirects to destination_url" do

--- a/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
+++ b/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
           let!(:oauth_client_token) do
             create(:oauth_client_token, oauth_client:, user:)
           end
+          let!(:remote_identity) { create(:remote_identity, user:, integration: storage) }
 
           before do
             stub_request(:get, "#{storage.host}ocs/v1.php/cloud/user")


### PR DESCRIPTION
# Ticket
* https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61612
* https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61880

# What are you trying to accomplish?
Fixing errors related to showing the connection status of SSO users to their storage.

In the files tab, the following cases should now be indicated correctly:

* A "classic" (OAuth) user is not yet linked to the storage (existed before)
* A "classic" (OAuth) user could not successfully authenticate at the storage (new: indicated as an error)
* An SSO user could not successfully authenticate at the storage (indicated as an error)

In the project storages member overview (e.g. `/projects/:name/settings/project_storages/:id/members`):

* SSO members are now indicated as connected, once they obtained a remote identity
* SSO members have a specific not-connected message, when there is no remote identity yet

# Which approach did you choose and why?
It occured to me, that the question of which authentication method will really be used for a user at a storage has to be asked in many different places. Thus I extracted the relevant code into a helper called `AuthenticationMethodSelector`.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
