### PR TITLE
[#56694] transform Markdown to HTML in search results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -76,7 +76,9 @@ module SearchHelper
       doc.traverse do |node|
         next unless node.text?
 
-        highlighted_text = node.content.gsub(/(#{Regexp.escape(token)})/i, '<span class="search-highlight">\1</span>')
+        t = (tokens.index(node.content.downcase) || 0) % 4
+        highlighted_text = node.content.gsub(/(#{Regexp.escape(token)})/i,
+                                             "<span class='search-highlight token-#{t}'>\\1</span>")
         node.replace(Nokogiri::HTML::DocumentFragment.parse(highlighted_text))
       end
     end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -73,12 +73,18 @@ module SearchHelper
     doc = Nokogiri::HTML::DocumentFragment.parse(html)
 
     tokens.each do |token|
+      escaped_token = Regexp.escape(token)
+
       doc.traverse do |node|
         next unless node.text?
 
+        escaped_text = CGI.escapeHTML(node.content)
+
         t = (tokens.index(node.content.downcase) || 0) % 4
-        highlighted_text = node.content.gsub(/(#{Regexp.escape(token)})/i,
-                                             "<span class='search-highlight token-#{t}'>\\1</span>")
+        highlighted_text = escaped_text.gsub(/(#{escaped_token})/i) do
+          %{<span class="search-highlight token-#{t}">#{$1}</span>}
+        end
+
         node.replace(Nokogiri::HTML::DocumentFragment.parse(highlighted_text))
       end
     end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -231,12 +231,11 @@ module SearchHelper
 
     truncated_text = truncate_formatted_text(content, length: 100)
 
-    if current_length + truncated_text.length > max_length
-      t = truncated_text[0..(max_length - current_length - 1)]
-      truncated_text = "#{t}..."
+    if current_length + content.length > max_length
+      truncated_text.truncate(max_length - current_length - 1)
+    else
+      truncated_text
     end
-
-    truncated_text
   end
 
   def preserve_spaces(original_text, modified_text)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe "search/index" do
     context "with the token in the description" do
       let(:tokens) { %w(description) }
 
-      it "shows the text in the description" do
+      it "shows the formatted text in the description" do
         expect(helper.highlight_tokens_in_event(event, tokens))
-          .to eql 'The <span class="search-highlight token-0">description</span> of the event'
+          .to eql '<p class="op-uc-p">The <span class="search-highlight token-0">description</span> of the event</p>'
       end
     end
 
@@ -140,9 +140,28 @@ RSpec.describe "search/index" do
       let(:tokens) { %w(description) }
       let(:journal_notes) { "" }
 
-      it "shows the text in the description" do
+      it "shows the formatted text in the description" do
         expect(helper.highlight_tokens_in_event(event, tokens))
-          .to eql 'The <span class="search-highlight token-0">description</span> of the event'
+          .to eql '<p class="op-uc-p">The <span class="search-highlight token-0">description</span> of the event</p>'
+      end
+
+      context "with elaborate markdown formatting in the description" do
+        let(:event_description) do
+          <<~MARKDOWN
+            This is a paragraph with **bold** and *italic* text #{'hello ' * 100}.
+          MARKDOWN
+        end
+        let(:tokens) { %w(bold) }
+
+        it "formats it to abbreviated HTML" do
+          expectation = <<~HTML.squish
+            <p class="op-uc-p">This is a paragraph with
+            <strong><span class="search-highlight token-0">bold</span></strong>
+            and <em>italic</em> text #{'hello ' * 15} hello...</p>
+          HTML
+
+          expect(helper.highlight_tokens_in_event(event, tokens)).to eql(expectation)
+        end
       end
     end
 
@@ -179,9 +198,9 @@ RSpec.describe "search/index" do
     context "with the token in neither" do
       let(:tokens) { %w(bogus) }
 
-      it "shows the description (without highlight)" do
+      it "shows the formatted description (without highlight)" do
         expect(helper.highlight_tokens_in_event(event, tokens))
-          .to eql "The description of the event"
+          .to eql '<p class="op-uc-p">The description of the event</p>'
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/56694 

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The search results should display proper markdown where applicable. This is more of a feature than a mere bugfix, I suppose.

I have used our text formatter to transform the event description from markdown to HTML. The previous plaintext implementation offered text abbreviation and search result highlighting. I preserved this behavior by carefully modifying the generated HTML DOM.

## Screenshots
![image](https://github.com/user-attachments/assets/400df93a-506b-4fba-a15e-b35a7e305ebe)

# Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
