### PR TITLE
[61894] Fix disappearing fields in date picker when in automatic mode

### DIFF
--- a/app/components/work_packages/date_picker/form_content_component.rb
+++ b/app/components/work_packages/date_picker/form_content_component.rb
@@ -69,11 +69,11 @@ module WorkPackages
       def milestone?
         # Either the work package is a milestone OR in the create form, the angular 'date' field was triggered OR
         # in the WorkPackage create form, the datepicker dialog was already updated via Turbo
-        # in which case the field param is overwritten and we have to check whether there is a due date field
+        # in which case the field param is overwritten and we have to check whether the duration field is absent
         @milestone ||=
           @work_package.milestone? ||
           params[:field] == "date" ||
-          (params[:work_package].present? && params[:work_package][:due_date].nil?)
+          (params[:work_package].present? && params[:work_package][:duration].nil?)
       end
 
       def disabled_checkbox?

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -158,6 +158,10 @@ module Components
       find("label", text: "Working days only").click
     end
 
+    def uncheck_working_days_only
+      page.find(:checkbox, "Working days only").uncheck
+    end
+
     def clear_duration
       set_duration("")
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61894

# What are you trying to accomplish?

In the backend, the date picker component assumes that the work package is a milestone if the frontend did not send any `work_package[due_date]` value ("Finish date" field).

Problem is, when in automatic scheduling mode, the "Finish date" field is disabled, so it's not sent to the backend. The backend then misleadingly thinks that it's a milestone being edited, and displays only the "Date" field, as a milestone work package would do. The "Finish date" and "Duration" fields disappear.

## Screenshots

[working days only with single date.webm](https://github.com/user-attachments/assets/cc7450a2-27fc-43b4-89d5-00c656637e07)

# What approach did you choose and why?

As the "Duration" field is always enabled, the fix is rely on it instead of the "Finish date" field.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
