### PR TITLE
[61091] Show datepicker as dialog instead of drop-modal

### DIFF
--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -1,85 +1,94 @@
 <%=
-  content_tag("turbo-frame", id: "wp-datepicker-dialog--content") do
-    component_wrapper(
-      data: { "application-target": "dynamic",
-              controller: "work-packages--date-picker--preview",
-              "work-packages--date-picker--preview-date-mode-value": date_mode,
-              test_selector: "op-datepicker-modal" },
-      class: "wp-datepicker-dialog--content"
-    ) do
-      component_collection do |collection|
-        if show_banner?
-          collection.with_component(WorkPackages::DatePicker::BannerComponent.new(work_package:, manually_scheduled: schedule_manually))
-        end
-
-        collection.with_component(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
-          render(
-            Primer::Alpha::UnderlinePanels.new(
-              'aria-label': I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
-              label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
-              classes: "wp-datepicker-dialog--UnderlineNav",
-              px: 3
-            )
-          ) do |component|
-            component.with_tab(selected: true, id: "wp-datepicker-dialog--content-tab--dates") do |tab|
-              tab.with_text { I18n.t("work_packages.datepicker_modal.tabs.dates") }
-              tab.with_panel(m: 3) do
-                render(
-                  WorkPackages::DatePicker::FormComponent.new(
-                    form_id: DIALOG_FORM_ID,
-                    show_date_form: can_set_dates?,
-                    work_package:,
-                    schedule_manually:,
-                    focused_field:,
-                    touched_field_map:,
-                    date_mode:
-                  )
-                )
+  content_tag("turbo-frame", id: "wp-datepicker-dialog--frame") do
+    render(
+      Primer::Alpha::Dialog.new(
+        open: true,
+        id: "wp-datepicker-dialog",
+        title: nil,
+        classes: "Overlay--size-datepicker",
+        data: { "application-target": "dynamic",
+                controller: "work-packages--date-picker--preview",
+                "work-packages--date-picker--preview-date-mode-value": date_mode,
+                test_selector: "op-datepicker-modal" }
+      )
+    ) do |dialog|
+      dialog.with_header(display: :none)
+      dialog.with_body(p: 0) do
+        component_wrapper(class: "wp-datepicker-dialog--content") do
+          render(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
+            component_collection do |collection|
+              if show_banner?
+                collection.with_component(WorkPackages::DatePicker::BannerComponent.new(work_package:, manually_scheduled: schedule_manually))
               end
-            end
+              collection.with_component(
+                Primer::Alpha::UnderlinePanels.new(
+                  'aria-label': I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
+                  label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
+                  classes: "wp-datepicker-dialog--UnderlineNav",
+                  px: 3
+                )
+              ) do |component|
+                component.with_tab(selected: true, id: "wp-datepicker-dialog--content-tab--dates") do |tab|
+                  tab.with_text { I18n.t("work_packages.datepicker_modal.tabs.dates") }
+                  tab.with_panel(m: 3) do
+                    render(
+                      WorkPackages::DatePicker::FormComponent.new(
+                        form_id: DIALOG_FORM_ID,
+                        show_date_form: can_set_dates?,
+                        work_package:,
+                        schedule_manually:,
+                        focused_field:,
+                        touched_field_map:,
+                        date_mode:
+                      )
+                    )
+                  end
+                end
 
-            additional_tabs.each do |tab|
-              component.with_tab(id: "wp-datepicker-dialog--content-tab--#{tab.key}") do |tab_content|
-                relation_group = tab.relation_group
-                tab_content.with_text { I18n.t("work_packages.datepicker_modal.tabs.#{tab.key}") }
-                tab_content.with_counter(count: relation_group.count)
-                tab_content.with_panel(m: 3) do
-                  if relation_group.any?
-                    render(border_box_container(padding: :condensed)) do |box|
-                      relation_group.visible_relations.each do |relation|
-                        box.with_row(scheme: :default) do
-                          render(
-                            WorkPackageRelationsTab::RelationComponent.new(
-                              work_package:,
-                              relation: (relation unless relation_group.type.children?),
-                              visibility: :visible,
-                              child: (relation if relation_group.type.children?),
-                              editable: false,
-                              closest: relation_group.closest_relation?(relation)
-                            )
-                          )
+                additional_tabs.each do |tab|
+                  component.with_tab(id: "wp-datepicker-dialog--content-tab--#{tab.key}") do |tab_content|
+                    relation_group = tab.relation_group
+                    tab_content.with_text { I18n.t("work_packages.datepicker_modal.tabs.#{tab.key}") }
+                    tab_content.with_counter(count: relation_group.count)
+                    tab_content.with_panel(m: 3) do
+                      if relation_group.any?
+                        render(border_box_container(padding: :condensed)) do |box|
+                          relation_group.visible_relations.each do |relation|
+                            box.with_row(scheme: :default) do
+                              render(
+                                WorkPackageRelationsTab::RelationComponent.new(
+                                  work_package:,
+                                  relation: (relation unless relation_group.type.children?),
+                                  visibility: :visible,
+                                  child: (relation if relation_group.type.children?),
+                                  editable: false,
+                                  closest: relation_group.closest_relation?(relation)
+                                )
+                              )
+                            end
+                          end
+                          relation_group.ghost_relations.each do |relation|
+                            box.with_row(scheme: :default) do
+                              render(
+                                WorkPackageRelationsTab::RelationComponent.new(
+                                  work_package:,
+                                  relation: (relation unless relation_group.type.children?),
+                                  visibility: :ghost,
+                                  child: (relation if relation_group.type.children?),
+                                  editable: false,
+                                  closest: relation_group.closest_relation?(relation)
+                                )
+                              )
+                            end
+                          end
+                        end
+                      else
+                        render(Primer::Beta::Blankslate.new(border: true)) do |component|
+                          component.with_visual_icon(icon: :book, size: :medium)
+                          component.with_heading(tag: :h2) { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.title") }
+                          component.with_description { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.description") }
                         end
                       end
-                      relation_group.ghost_relations.each do |relation|
-                        box.with_row(scheme: :default) do
-                          render(
-                            WorkPackageRelationsTab::RelationComponent.new(
-                              work_package:,
-                              relation: (relation unless relation_group.type.children?),
-                              visibility: :ghost,
-                              child: (relation if relation_group.type.children?),
-                              editable: false,
-                              closest: relation_group.closest_relation?(relation)
-                            )
-                          )
-                        end
-                      end
-                    end
-                  else
-                    render(Primer::Beta::Blankslate.new(border: true)) do |component|
-                      component.with_visual_icon(icon: :book, size: :medium)
-                      component.with_heading(tag: :h2) { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.title") }
-                      component.with_description { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.description") }
                     end
                   end
                 end
@@ -87,29 +96,31 @@
             end
           end
         end
+      end
+      dialog.with_footer do
+        component_collection do |footer|
+          footer.with_component(
+            Primer::ButtonComponent.new(
+              data: {
+                action: "work-packages--date-picker--preview#cancel",
+                "close-dialog-id": "wp-datepicker-dialog"
+              },
+              test_selector: "op-datepicker-modal--action"
+            )
+          ) do
+            I18n.t("button_cancel")
+          end
 
-        collection.with_component(Primer::Alpha::Dialog::Footer.new) do
-          component_collection do |footer|
-            footer.with_component(
-              Primer::ButtonComponent.new(
-                data: { action: "work-packages--date-picker--preview#cancel" },
-                test_selector: "op-datepicker-modal--action"
-              )
-            ) do
-              I18n.t("button_cancel")
-            end
-
-            footer.with_component(
-              Primer::ButtonComponent.new(
-                scheme: :primary,
-                type: :submit,
-                form: DIALOG_FORM_ID,
-                test_selector: "op-datepicker-modal--action",
-                disabled: !can_set_dates?
-              )
-            ) do
-              I18n.t("button_save")
-            end
+          footer.with_component(
+            Primer::ButtonComponent.new(
+              scheme: :primary,
+              type: :submit,
+              form: DIALOG_FORM_ID,
+              test_selector: "op-datepicker-modal--action",
+              disabled: !can_set_dates?
+            )
+          ) do
+            I18n.t("button_save")
           end
         end
       end

--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -2,15 +2,15 @@
   .wp-datepicker-dialog
     &--body
       // We set a fixed height for this dialog zo avoid that it jumps around when the tabs are switched or errors shown
-      min-height: 490px
+      min-height: 555px
       width: 600px
 
 @media screen and (max-width: $breakpoint-sm)
   .wp-datepicker-dialog
     &--UnderlineNav
       display: none !important
+
     &--body
-      padding-top: var(--stack-padding-normal)
       min-height: unset
       width: auto
 
@@ -18,13 +18,3 @@
       flex-direction: column !important
       align-items: flex-start !important
       row-gap: 1rem
-
-  // re-implement the scrolling behaviour. Due to the turbo-frame element in between the default Dialog body scrolling does not work
-  .wp-datepicker-dialog--content
-    display: flex
-    flex-direction: column
-    overflow: auto
-
-  .wp-datepicker-dialog--content,
-  #wp-datepicker-dialog--content
-    height: inherit

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -99,7 +99,7 @@ class WorkPackages::DatePickerController < ApplicationController
           # the request in order to fetch the new set of Work Package
           # attributes in the ancestry solely on success.
           render turbo_stream: [
-            turbo_stream.morph("wp-datepicker-dialog--content", datepicker_modal_component)
+            turbo_stream.morph("wp-datepicker-dialog--frame", datepicker_modal_component)
           ], status: :unprocessable_entity
         end
       end
@@ -139,7 +139,7 @@ class WorkPackages::DatePickerController < ApplicationController
           # the request in order to fetch the new set of Work Package
           # attributes in the ancestry solely on success.
           render turbo_stream: [
-            turbo_stream.morph("wp-datepicker-dialog--content", datepicker_modal_component)
+            turbo_stream.morph("wp-datepicker-dialog--frame", datepicker_modal_component)
           ], status: :unprocessable_entity
         end
       end

--- a/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.html
@@ -1,36 +1,18 @@
-<spot-drop-modal
-  [opened]="opened"
-  (closed)="onModalClosed()"
-  alignment="bottom-center"
->
-  <input
-    slot="trigger"
-    type="text"
-    class="spot-input"
-    (click)="onInputClick($event)"
-    [value]="dates"
-    (focus)="showDatePickerModal()"
-  />
+<input
+  type="text"
+  class="spot-input"
+  (click)="onInputClick($event)"
+  [value]="dates"
+  (focus)="showDatePickerModal()"
+/>
 
-  <ng-container slot="body">
-    <turbo-frame *ngIf="turboFrameSrc && opened"
-                 [src]="turboFrameSrc"
-                 opModalWithTurboContent
-                 [change]="change"
-                 [resource]="resource"
-                 (successfulCreate)="handleSuccessfulCreate($event)"
-                 (successfulUpdate)="handleSuccessfulUpdate()"
-                 (cancel)="cancel()"
-                 id="wp-datepicker-dialog--content">
-      <op-content-loader viewBox="0 0 100 100">
-        <svg:rect x="5" y="5" width="70" height="5" rx="1"/>
-
-        <svg:rect x="80" y="5" width="15" height="5" rx="1"/>
-
-        <svg:rect x="5" y="15" width="90" height="8" rx="1"/>
-
-        <svg:rect x="5" y="30" width="90" height="12" rx="1"/>
-      </op-content-loader>
-    </turbo-frame>
-  </ng-container>
-</spot-drop-modal>
+<turbo-frame *ngIf="turboFrameSrc && opened"
+             [src]="turboFrameSrc"
+             opModalWithTurboContent
+             [change]="change"
+             [resource]="resource"
+             (successfulCreate)="handleSuccessfulCreate($event)"
+             (successfulUpdate)="handleSuccessfulUpdate()"
+             (cancel)="cancel()"
+             id="wp-datepicker-dialog--frame">
+</turbo-frame>

--- a/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.component.html
@@ -1,36 +1,18 @@
-<spot-drop-modal
-  [opened]="opened"
-  (closed)="cancel()"
-  alignment="bottom-center"
->
-  <input
-    type="number"
-    slot="trigger"
-    class="inline-edit--field op-input"
-    [ngModel]="formattedValue"
-    (click)="onInputClick($event)"
-    (focus)="showDatePickerModal()"
-    [id]="handler.htmlId"
-  />
-  <ng-container slot="body">
-    <turbo-frame *ngIf="turboFrameSrc && opened"
-                 [src]="turboFrameSrc"
-                 opModalWithTurboContent
-                 [change]="change"
-                 [resource]="resource"
-                 (successfulCreate)="handleSuccessfulCreate($event)"
-                 (successfulUpdate)="handleSuccessfulUpdate()"
-                 (cancel)="cancel()"
-                 id="wp-datepicker-dialog--content">
-      <op-content-loader viewBox="0 0 100 100">
-        <svg:rect x="5" y="5" width="70" height="5" rx="1"/>
+<input
+  class="inline-edit--field op-input"
+  [ngModel]="formattedValue"
+  (click)="onInputClick($event)"
+  (focus)="showDatePickerModal()"
+  [id]="handler.htmlId"
+/>
 
-        <svg:rect x="80" y="5" width="15" height="5" rx="1"/>
-
-        <svg:rect x="5" y="15" width="90" height="8" rx="1"/>
-
-        <svg:rect x="5" y="30" width="90" height="12" rx="1"/>
-      </op-content-loader>
-    </turbo-frame>
-  </ng-container>
-</spot-drop-modal>
+<turbo-frame *ngIf="turboFrameSrc && opened"
+             [src]="turboFrameSrc"
+             opModalWithTurboContent
+             [change]="change"
+             [resource]="resource"
+             (successfulCreate)="handleSuccessfulCreate($event)"
+             (successfulUpdate)="handleSuccessfulUpdate()"
+             (cancel)="cancel()"
+             id="wp-datepicker-dialog--frame">
+</turbo-frame>

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
@@ -12,13 +12,13 @@
   // Style actual edit inputs
   // Checkboxes need to be excluded because the width
   // causes an ugly increase of the box
-  &:not(.subject) input:not([type='checkbox']):not(.spot-text-field--input):not(.spot-input)
+  &:not(.subject) input:not([type='checkbox']):not(.spot-text-field--input):not(.spot-input):not(.FormControl-input)
     // Full width to inline-edit inputs
     width: 100%
     line-height: 24px
     border-radius: 2px
 
-  input:not([type='checkbox'])
+  input:not([type='checkbox']):not(.FormControl-input)
     // Same height as the row - padding
     height: 24px
     padding: 2px
@@ -44,4 +44,3 @@
   .inline-edit--display-field
     display: block
     padding: 5px 0 5px 5px
-

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -116,3 +116,7 @@ ul.SegmentedControl,
 .generic-table
   .generic-table--action-menu-button
     min-width: max-content !important
+
+.Overlay.Overlay--size-datepicker
+  --overlay-height: 610px
+  --overlay-width: 600px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61091/activity

# What are you trying to accomplish?
* The datepicker should not be rendereed outside the screen limit and create artifical white space

Known issues:

* The turboFrame update causes a second dialog to be rendered inside of the first one
* There is a visible flicker when switching between the modes
* The duration field can only be opened once

## Screenshots
<img width="2074" alt="Bildschirmfoto 2025-03-03 um 12 54 49" src="https://github.com/user-attachments/assets/3eca637b-690f-46d2-9719-76fb54b17a0a" />


# What approach did you choose and why?
* Use a Primer::Dialog instead of the spot drop-modal to avoid that the datepicker is weirdly positioned

