### PR TITLE
[61906] focus on the banner while opening the date pickr

### DIFF
--- a/app/components/work_packages/date_picker/banner_component.html.erb
+++ b/app/components/work_packages/date_picker/banner_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   render(Primer::Alpha::Banner.new(description:,
-                                   classes: "wp-datepicker--banner_desktop rounded-top-2",
+                                   classes: "wp-datepicker--banner wp-datepicker--banner_desktop rounded-top-2",
                                    **banner_options)) do |banner|
     banner.with_action_button(tag: :a, href: link, target: "_blank") { I18n.t("work_packages.datepicker_modal.show_relations") }
     title
@@ -8,7 +8,7 @@
 %>
 <%=
   render(Primer::Alpha::Banner.new(description: mobile_description,
-                                   classes: "wp-datepicker--banner_mobile rounded-top-2",
+                                   classes: "wp-datepicker--banner wp-datepicker--banner_mobile rounded-top-2",
                                    **banner_options)) do
     mobile_title
   end

--- a/app/components/work_packages/date_picker/banner_component.sass
+++ b/app/components/work_packages/date_picker/banner_component.sass
@@ -1,4 +1,7 @@
 .wp-datepicker--banner
+  &:focus
+    border-color: var(--fgColor-accent)
+    box-shadow: 0 0 0 1px var(--fgColor-accent)
 
   @media screen and (min-width: $breakpoint-sm)
     &_mobile

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -21,7 +21,7 @@
           render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: I18n.t("attributes.start_date"))))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
-          today(name: :start_date,)
+          today(name: :start_date)
         end
       end
     end

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -21,7 +21,7 @@
           render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: I18n.t("attributes.start_date"))))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
-          today(name: :start_date)
+          render_today_link(name: :start_date)
         end
       end
     end
@@ -48,7 +48,7 @@
             render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))))
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
-            today(name: :due_date)
+            render_today_link(name: :due_date)
           end
         end
       end

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -20,6 +20,9 @@
         start_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
           render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: I18n.t("attributes.start_date"))))
         end
+        start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
+          today(name: :start_date,)
+        end
       end
     end
 
@@ -43,6 +46,9 @@
 
           due_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
             render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))))
+          end
+          due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
+            today(name: :due_date,)
           end
         end
       end

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -48,7 +48,7 @@
             render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))))
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
-            today(name: :due_date,)
+            today(name: :due_date)
           end
         end
       end

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -98,6 +98,7 @@ module WorkPackages
         return text if @disabled
 
         render(Primer::Beta::Link.new(href: "",
+                                      "aria-label": name == :start_date ? I18n.t(:label_today_as_start_date): I18n.t(:label_today_as_finish_date),
                                       data: {
                                         action: "work-packages--date-picker--preview#setTodayForField",
                                         "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -90,7 +90,7 @@ module WorkPackages
         text_field_options
       end
 
-      def today(name:)
+      def render_today_link(name:)
         return if duration_field?(name)
 
         text = I18n.t(:label_today).capitalize
@@ -98,7 +98,7 @@ module WorkPackages
         return text if @disabled
 
         render(Primer::Beta::Link.new(href: "",
-                                      "aria-label":  I18n.t(:label_today_as_"#{name.to_s}")
+                                      "aria-label":  I18n.t("label_today_as_#{name.to_s}"),
                                       data: {
                                         action: "work-packages--date-picker--preview#setTodayForField",
                                         "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -97,13 +97,17 @@ module WorkPackages
 
         return text if @disabled
 
-        render(Primer::Beta::Link.new(href: "",
-                                      "aria-label":  I18n.t("label_today_as_#{name.to_s}"),
-                                      data: {
-                                        action: "work-packages--date-picker--preview#setTodayForField",
-                                        "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",
-                                        test_selector: "op-datepicker-modal--#{name.to_s.dasherize}-field--today"
-                                      })) { text }
+        render(
+          Primer::Beta::Link.new(
+            href: "",
+            "aria-label": I18n.t("label_today_as_#{name}"),
+            data: {
+              action: "work-packages--date-picker--preview#setTodayForField",
+              "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",
+              test_selector: "op-datepicker-modal--#{name.to_s.dasherize}-field--today"
+            }
+          )
+        ) { text }
       end
 
       def duration_field?(name)

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -98,11 +98,7 @@ module WorkPackages
         return text if @disabled
 
         render(Primer::Beta::Link.new(href: "",
-                                      "aria-label": if name == :start_date
-                                                      I18n.t(:label_today_as_start_date)
-                                                    else
-                                                      I18n.t(:label_today_as_finish_date)
-                                                    end,
+                                      "aria-label":  I18n.t(:label_today_as_"#{name.to_s}")
                                       data: {
                                         action: "work-packages--date-picker--preview#setTodayForField",
                                         "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -98,7 +98,11 @@ module WorkPackages
         return text if @disabled
 
         render(Primer::Beta::Link.new(href: "",
-                                      "aria-label": name == :start_date ? I18n.t(:label_today_as_start_date): I18n.t(:label_today_as_finish_date),
+                                      "aria-label": if name == :start_date
+                                                      I18n.t(:label_today_as_start_date)
+                                                    else
+                                                      I18n.t(:label_today_as_finish_date)
+                                                    end,
                                       data: {
                                         action: "work-packages--date-picker--preview#setTodayForField",
                                         "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -75,7 +75,6 @@ module WorkPackages
           value: field_value(name),
           disabled: disabled?(name),
           label:,
-          caption: caption(name),
           show_clear_button: !disabled?(name) && !duration_field?(name),
           classes: "op-datepicker-modal--date-field #{'op-datepicker-modal--date-field_current' if @focused_field == name}",
           validation_message: validation_message(name),
@@ -91,7 +90,7 @@ module WorkPackages
         text_field_options
       end
 
-      def caption(name)
+      def today(name:)
         return if duration_field?(name)
 
         text = I18n.t(:label_today).capitalize

--- a/app/components/work_packages/date_picker/date_form_component.sass
+++ b/app/components/work_packages/date_picker/date_form_component.sass
@@ -20,6 +20,8 @@
     &_visible
       + .wp-datepicker-dialog-date-form--text-field-container
         display: none
+      ~ .wp-datepicker-dialog-set-today-link
+        display: none
 
 @media screen and (max-width: $breakpoint-sm)
   .wp-datepicker-dialog-date-form

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -15,6 +15,7 @@
         collection.with_component(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
           render(
             Primer::Alpha::UnderlinePanels.new(
+              'aria-label': I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
               label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
               classes: "wp-datepicker-dialog--UnderlineNav",
               px: 3

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -93,7 +93,7 @@
           )
         end
 
-        body.with_row do
+        body.with_row("aria-hidden": true) do
           helpers.angular_component_tag "opce-wp-modal-date-picker",
                                         inputs: {
                                           start_date: work_package.start_date,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2982,6 +2982,8 @@ en:
   label_projects_menu: "Projects"
   label_today: "today"
   label_token_version: "Token Version"
+  label_today_as_start_date: "Select today as start date."
+  label_today_as_finish_date: "Select today as finish date."
   label_top_menu: "Top Menu"
   label_topic_plural: "Topics"
   label_total: "Total"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2983,7 +2983,7 @@ en:
   label_today: "today"
   label_token_version: "Token Version"
   label_today_as_start_date: "Select today as start date."
-  label_today_as_finish_date: "Select today as finish date."
+  label_today_as_due_date: "Select today as finish date."
   label_top_menu: "Top Menu"
   label_topic_plural: "Topics"
   label_total: "Total"

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -75,6 +75,7 @@ export default class PreviewController extends DialogPreviewController {
     this.timezoneService = context.services.timezone;
 
     document.addEventListener('date-picker:flatpickr-dates-changed', this.handleFlatpickrDatesChangedBound);
+    this.focusOnOpen();
   }
 
   disconnect() {
@@ -497,6 +498,18 @@ export default class PreviewController extends DialogPreviewController {
         this.markUntouched('due_date');
         this.markTouched('start_date');
       }
+    }
+  }
+
+  private focusOnOpen() {
+    const banner = document.querySelector('.wp-datepicker--banner') as HTMLElement;
+    if (banner) {
+      banner.setAttribute('tabindex', '-1');
+      banner.focus();
+    } else {
+      const tabs = document.querySelector('.wp-datepicker-dialog--UnderlineNav') as HTMLElement;
+      tabs.setAttribute('tabindex', '-1');
+      tabs.focus();
     }
   }
 }

--- a/spec/features/work_packages/table/duration_field_spec.rb
+++ b/spec/features/work_packages/table/duration_field_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe "Duration field in the work package table", :js do
     wait_for_network_idle
 
     date_field.expect_duration_highlighted
-    expect(page).to have_focus_on(test_selector("op-datepicker-modal--duration-field").to_s)
     expect(page).to have_field("work_package[duration]", with: "4", wait: 10)
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61906

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix focus issues in new primerized datepickr
Focus on the first element when it is open
Navigate correctly through date pickr fields using keyboard

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
