### PR TITLE
Make recurring meeting specs work reliably

### DIFF
--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
+RSpec.describe RecurringMeetings::UpdateService, "integration", freeze_time: Time.zone.today + 12.hours, type: :model do
   shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
   shared_let(:user) do
     create(:user, member_with_permissions: { project => %i(view_meetings edit_meetings) })


### PR DESCRIPTION
The way those specs were written they would not bbe able to succeed before 10 AM in the morning, because meeting were scheduled for 10:00, but the specs did not expect a meeting to be scheduled today.

This fix is a workaround that makes sure we always run the specs "after 10". A better fix would be to ALSO have specs running before 10, and expecting the behaviour that's currently seen as errorneous.
