### PR TITLE
[#61726] Internal Server Error when export with open overview screen panel

### DIFF
--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -183,6 +183,10 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger {
     params['columns[]'] = this.wpTableColumns.getColumns().map((column) => column.id);
     params.title = this.queryTitle(query);
     const url = new URL(window.location.href);
+    if (url.pathname.includes('/details')) {
+      // we are in a split screen, but need a work package list or gantt view or wherever the export menu item is
+      url.pathname = url.pathname.split('/details')[0];
+    }
     const queryId = url.searchParams.get('query_id');
     if (queryId) {
       params.query_id = queryId;

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -127,10 +127,10 @@ RSpec.describe "work package export", :js, :selenium do
       let(:query) do
         create(
           :query, id: 1234, user: current_user, project:,
-          display_sums: true,
-          include_subprojects: true,
-          show_hierarchies: true,
-          name: "My custom query title"
+                  display_sums: true,
+                  include_subprojects: true,
+                  show_hierarchies: true,
+                  name: "My custom query title"
         )
       end
       let(:expected_params) do

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -127,10 +127,10 @@ RSpec.describe "work package export", :js, :selenium do
       let(:query) do
         create(
           :query, id: 1234, user: current_user, project:,
-                  display_sums: true,
-                  include_subprojects: true,
-                  show_hierarchies: true,
-                  name: "My custom query title"
+          display_sums: true,
+          include_subprojects: true,
+          show_hierarchies: true,
+          name: "My custom query title"
         )
       end
       let(:expected_params) do
@@ -154,6 +154,20 @@ RSpec.describe "work package export", :js, :selenium do
       it "starts an export grouped" do
         export!
       end
+    end
+  end
+
+  context "in a split view" do
+    before do
+      wp_table.visit_query query
+      work_packages_page.ensure_loaded
+      wp_table.open_split_view(wp1)
+    end
+
+    it "opens the dialog and exports" do
+      settings_menu.open_and_choose I18n.t("js.toolbar.settings.export")
+      click_on export_type
+      export!
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/61726

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to achieve?
The export dialog is called in several views like wp_table and gantt, the split view changes these URLs, so the dialog URL is constructed wrong. 

# What approach did you choose and why?
Instead of adding several sub routes for the turbo dialog in split screens, strip the split view part in the Angular controller. The Angular code will be replaced soon℗, so IMO no need to dive deeper.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
