### PR TITLE
Fix meeting DST behavior by storing time zone

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1018,7 +1018,6 @@ en:
       user_preference:
         comments_sorting: "Display comments"
         impaired: "Accessibility mode"
-        time_zone: "Time zone"
         auto_hide_popups: "Auto-hide success notifications"
         warn_on_leaving_unsaved: "Warn me when leaving a work package with unsaved changes"
         theme: "Mode"
@@ -1607,6 +1606,7 @@ en:
     status: "Status"
     subject: "Subject"
     summary: "Summary"
+    time_zone: "Time zone"
     title: "Title"
     type: "Type"
     updated_at: "Updated on"

--- a/modules/meeting/app/contracts/recurring_meetings/base_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/base_contract.rb
@@ -43,6 +43,7 @@ module RecurringMeetings
     attribute :end_date
     attribute :iterations
     attribute :interval
+    attribute :time_zone
 
     # Virtual attributes for the form
     attribute :duration

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -39,7 +39,7 @@ class RecurringMeeting < ApplicationRecord
   belongs_to :project
   belongs_to :author, class_name: "User"
 
-  validates_presence_of :start_time, :title, :frequency, :end_after
+  validates_presence_of :start_time, :title, :frequency, :end_after, :time_zone
   validates_presence_of :end_date, if: -> { end_after_specific_date? }
   validates_numericality_of :iterations,
                             only_integer: true,
@@ -119,6 +119,10 @@ class RecurringMeeting < ApplicationRecord
 
   def date
     start_time.day.ordinalize
+  end
+
+  def start_time
+    super&.in_time_zone(time_zone)
   end
 
   def schedule

--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_series_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_series_seeder.rb
@@ -67,6 +67,7 @@ module Meetings
           start_time: Time.current.next_weekday + 10.hours,
           frequency: meeting_data["frequency"],
           interval: meeting_data["interval"],
+          time_zone: meeting_data["time_zone"],
           project:
         }
       end

--- a/modules/meeting/app/seeders/standard.yml
+++ b/modules/meeting/app/seeders/standard.yml
@@ -34,6 +34,7 @@ projects:
         duration: 60
         interval: 1
         frequency: :weekly
+        time_zone: "Europe/Berlin"
         author: :openproject_admin
     meeting_agenda_items:
       - t_title: Good news

--- a/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
@@ -42,6 +42,7 @@ module RecurringMeetings
 
     def set_default_attributes(_params)
       model.change_by_system do
+        model.time_zone = user.time_zone.name
         model.author = user
         model.duration ||= 1
       end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_dst_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_dst_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/recurring_meeting/show"
+
+RSpec.describe "Recurring meetings show DST",
+               :skip_csrf,
+               freeze_time: DateTime.parse("2025-03-04T9:00:00Z"),
+               type: :rails_request do
+  include Redmine::I18n
+
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  shared_let(:berlin_user) do
+    create(:user,
+           preferences: { time_zone: "Europe/Berlin" },
+           member_with_permissions: { project => %i[view_meetings] })
+  end
+  shared_let(:tokyo_user) do
+    create(:user,
+           preferences: { time_zone: "Asia/Tokyo" },
+           member_with_permissions: { project => %i[view_meetings] })
+  end
+
+  shared_let(:recurring_meeting) do
+    create :recurring_meeting,
+           project:,
+           author: berlin_user,
+           time_zone: "Europe/Berlin",
+           start_time: Time.zone.tomorrow.in_time_zone("Europe/Berlin") + 10.hours, # March 5th, 10AM CET
+           frequency: "weekly",
+           end_after: "iterations",
+           iterations: 10
+  end
+
+  let(:current_user) { user }
+  let(:request) { get project_recurring_meeting_path(project, recurring_meeting) }
+  let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting) }
+
+  before do
+    login_as(current_user)
+  end
+
+  context "with berlin user and DST approaching" do
+    let(:current_user) { berlin_user }
+
+    it "shows a stable 10AM schedule time" do
+      request
+
+      expect(page).to have_text "Every week on Wednesday at 10:00 AM, ends on 05/07/2025"
+      expect(page).to have_text "March 5, 2025 10:00"
+      expect(page).to have_text "March 12, 2025 10:00"
+      expect(page).to have_text "March 19, 2025 10:00"
+      expect(page).to have_text "March 26, 2025 10:00"
+      expect(page).to have_text "April 2, 2025 10:00"
+    end
+  end
+
+  context "with tokyo user that doesn't have DST" do
+    let(:current_user) { tokyo_user }
+
+    it "changes times according to the CET DST" do
+      request
+
+      expect(page).to have_text "Every week on Wednesday at 06:00 PM, ends on 05/07/2025"
+      expect(page).to have_text "March 5, 2025 18:00"
+      expect(page).to have_text "March 12, 2025 18:00"
+      expect(page).to have_text "March 19, 2025 18:00"
+      expect(page).to have_text "March 26, 2025 18:00"
+      expect(page).to have_text "April 2, 2025 17:00"
+    end
+  end
+end

--- a/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe DemoData::ProjectSeeder do
           frequency: :weekly
           interval: 1
           author: :openproject_user
+          time_zone: "Etc/UTC"
       meeting_agenda_items:
         - title: First topic
           meeting: :weekly_meeting_template


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61933

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Deal with DST changes by not storing the timezone offset, but the time zone of the user creating the series

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
- Create a migration to store the time zone in the series
- Migrate existing series to store that time
- Compute the schedule based on that time

# Merge checklist

- [x] Added/updated tests