### PR TITLE
Allow to create missing OAuth application

### DIFF
--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -196,7 +196,7 @@ class Storages::Admin::StoragesController < ApplicationController
   end
 
   def replace_oauth_application
-    @storage.oauth_application.destroy
+    @storage.oauth_application&.destroy
     service_result = ::Storages::OAuthApplications::CreateService.new(storage: @storage, user: current_user).call
 
     if service_result.success?


### PR DESCRIPTION
If the user got into a state where the storage had no OAuth Application configured, it was impossible to add one.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61939