### PR TITLE
Implementation/60979 add capability to create work package comments with restricted visibility (UI)

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -37,7 +37,7 @@
                     px: 2,
                     py: 3,
                     bg: :subtle,
-                    data: new_comment_wrapper_data_attributes
+                    data: add_comment_wrapper_data_attributes
                   ) do
                     render(
                       WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:)

--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -36,7 +36,8 @@
                     classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
                     px: 2,
                     py: 3,
-                    bg: :subtle
+                    bg: :subtle,
+                    data: new_comment_wrapper_data_attributes
                   ) do
                     render(
                       WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:)

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -50,7 +50,7 @@ module WorkPackages
       attr_reader :work_package, :filter, :last_server_timestamp, :deferred
 
       def wrapper_data_attributes
-        stimulus_controller = "work-packages--activities-tab--index"
+        stimulus_controller = activities_tab_index_stimulus_controller
 
         {
           test_selector: "op-wp-activity-tab",
@@ -75,7 +75,8 @@ module WorkPackages
           test_selector: "op-work-package-journal--new-comment-component",
           controller: stimulus_controller,
           "application-target": "dynamic",
-          "#{stimulus_controller}-target": "formContainer"
+          "#{stimulus_controller}-target": "formContainer",
+          action: "#{activities_tab_index_stimulus_controller}:onSubmit-end@window->#{stimulus_controller}#onSubmitEnd"
         }
       end
 
@@ -91,6 +92,8 @@ module WorkPackages
       def adding_comment_allowed?
         User.current.allowed_in_work_package?(:add_work_package_notes, @work_package)
       end
+
+      def activities_tab_index_stimulus_controller = "work-packages--activities-tab--index"
     end
   end
 end

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -50,29 +50,32 @@ module WorkPackages
       attr_reader :work_package, :filter, :last_server_timestamp, :deferred
 
       def wrapper_data_attributes
-        index_stimulus_controller = "work-packages--activities-tab--index"
-        restricted_comments_stimulus_controller = "work-packages--activities-tab--restricted-comment"
+        stimulus_controller = "work-packages--activities-tab--index"
 
         {
           test_selector: "op-wp-activity-tab",
-          controller: [index_stimulus_controller, restricted_comments_stimulus_controller].join(" "),
+          controller: stimulus_controller,
           "application-target": "dynamic",
-          "#{index_stimulus_controller}-update-streams-path-value": update_streams_work_package_activities_path(work_package),
-          "#{index_stimulus_controller}-sorting-value": journal_sorting,
-          "#{index_stimulus_controller}-filter-value": filter,
-          "#{index_stimulus_controller}-user-id-value": User.current.id,
-          "#{index_stimulus_controller}-work-package-id-value": work_package.id,
-          "#{index_stimulus_controller}-polling-interval-in-ms-value": polling_interval,
-          "#{index_stimulus_controller}-notification-center-path-name-value": notifications_path,
-          "#{index_stimulus_controller}-show-conflict-flash-message-url-value": show_conflict_flash_message_work_packages_path,
-          "#{index_stimulus_controller}-last-server-timestamp-value": last_server_timestamp
+          "#{stimulus_controller}-update-streams-path-value": update_streams_work_package_activities_path(work_package),
+          "#{stimulus_controller}-sorting-value": journal_sorting,
+          "#{stimulus_controller}-filter-value": filter,
+          "#{stimulus_controller}-user-id-value": User.current.id,
+          "#{stimulus_controller}-work-package-id-value": work_package.id,
+          "#{stimulus_controller}-polling-interval-in-ms-value": polling_interval,
+          "#{stimulus_controller}-notification-center-path-name-value": notifications_path,
+          "#{stimulus_controller}-show-conflict-flash-message-url-value": show_conflict_flash_message_work_packages_path,
+          "#{stimulus_controller}-last-server-timestamp-value": last_server_timestamp
         }
       end
 
-      def new_comment_wrapper_data_attributes
+      def add_comment_wrapper_data_attributes
+        stimulus_controller = "work-packages--activities-tab--restricted-comment"
+
         {
           test_selector: "op-work-package-journal--new-comment-component",
-          "work-packages--activities-tab--restricted-comment-target": "formContainer"
+          controller: stimulus_controller,
+          "application-target": "dynamic",
+          "#{stimulus_controller}-target": "formContainer"
         }
       end
 

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -76,7 +76,8 @@ module WorkPackages
           controller: stimulus_controller,
           "application-target": "dynamic",
           "#{stimulus_controller}-target": "formContainer",
-          action: "#{activities_tab_index_stimulus_controller}:onSubmit-end@window->#{stimulus_controller}#onSubmitEnd"
+          action: "#{activities_tab_index_stimulus_controller}:onSubmit-end@window->#{stimulus_controller}#onSubmitEnd",
+          "#{stimulus_controller}-highlight-class": "work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment" # rubocop:disable Layout/LineLength
         }
       end
 

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -50,21 +50,29 @@ module WorkPackages
       attr_reader :work_package, :filter, :last_server_timestamp, :deferred
 
       def wrapper_data_attributes
-        stimulus_controller = "work-packages--activities-tab--index"
+        index_stimulus_controller = "work-packages--activities-tab--index"
+        restricted_comments_stimulus_controller = "work-packages--activities-tab--restricted-comment"
 
         {
           test_selector: "op-wp-activity-tab",
-          controller: stimulus_controller,
+          controller: [index_stimulus_controller, restricted_comments_stimulus_controller].join(" "),
           "application-target": "dynamic",
-          "#{stimulus_controller}-update-streams-path-value": update_streams_work_package_activities_path(work_package),
-          "#{stimulus_controller}-sorting-value": journal_sorting,
-          "#{stimulus_controller}-filter-value": filter,
-          "#{stimulus_controller}-user-id-value": User.current.id,
-          "#{stimulus_controller}-work-package-id-value": work_package.id,
-          "#{stimulus_controller}-polling-interval-in-ms-value": polling_interval,
-          "#{stimulus_controller}-notification-center-path-name-value": notifications_path,
-          "#{stimulus_controller}-show-conflict-flash-message-url-value": show_conflict_flash_message_work_packages_path,
-          "#{stimulus_controller}-last-server-timestamp-value": last_server_timestamp
+          "#{index_stimulus_controller}-update-streams-path-value": update_streams_work_package_activities_path(work_package),
+          "#{index_stimulus_controller}-sorting-value": journal_sorting,
+          "#{index_stimulus_controller}-filter-value": filter,
+          "#{index_stimulus_controller}-user-id-value": User.current.id,
+          "#{index_stimulus_controller}-work-package-id-value": work_package.id,
+          "#{index_stimulus_controller}-polling-interval-in-ms-value": polling_interval,
+          "#{index_stimulus_controller}-notification-center-path-name-value": notifications_path,
+          "#{index_stimulus_controller}-show-conflict-flash-message-url-value": show_conflict_flash_message_work_packages_path,
+          "#{index_stimulus_controller}-last-server-timestamp-value": last_server_timestamp
+        }
+      end
+
+      def new_comment_wrapper_data_attributes
+        {
+          test_selector: "op-work-package-journal--new-comment-component",
+          "work-packages--activities-tab--restricted-comment-target": "formContainer"
         }
       end
 

--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -74,7 +74,7 @@
                         Primer::Beta::Octicon.new(
                           :"dot-fill", # color is set via CSS as requested by UI/UX Team
                           classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
-                          size: :small,
+                          size: (OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? ? :small : :medium),
                           data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
                         )
                       )

--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -67,12 +67,12 @@
                 end
                 header_container.with_column(flex_layout: true, align_items: :center) do |header_end_container|
                   if has_unread_notifications?
-                    header_end_container.with_column(mr: 2, pt: 1) do
+                    header_end_container.with_column(mr: 2) do
                       render(
                         Primer::Beta::Octicon.new(
                           :"dot-fill", # color is set via CSS as requested by UI/UX Team
                           classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
-                          size: :medium,
+                          size: :small,
                           data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
                         )
                       )

--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -14,13 +14,15 @@
               data: {
                 "anchor-activity-id": journal.sequence_version,
                 "anchor-comment-id": journal.id
-              }
+              },
+              border_color: container_border_color
             )
           ) do |border_box_component|
             border_box_component.with_header(
               px: 2, py: 1,
               data: { test_selector: "op-journal-notes-header" },
-              classes: comment_header_classes
+              classes: comment_header_classes,
+              border_color: container_border_color
             ) do
               flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
                 header_container.with_column(
@@ -87,7 +89,8 @@
                           classes: "work-packages-activities-tab-journals-item-component--restricted-icon",
                           size: :small,
                           aria: { label: I18n.t("activities.work_packages.activity_tab.restricted_journal") },
-                          data: { test_selector: "op-journal-restricted-icon" }
+                          data: { test_selector: "op-journal-restricted-icon" },
+                          color: (journal.restricted? ? :attention : :default)
                         )
                       )
                     end
@@ -119,7 +122,8 @@
             end
             border_box_component.with_body(
               classes: comment_body_classes,
-              data: { test_selector: "op-journal-notes-body" }
+              data: { test_selector: "op-journal-notes-body" },
+              border_color: container_border_color
             ) do
               if noop?
                 render(Primer::Beta::Text.new(font_style: :italic, color: :subtle, mt: 1)) do

--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -17,7 +17,11 @@
               }
             )
           ) do |border_box_component|
-            border_box_component.with_header(px: 2, py: 1, data: { test_selector: "op-journal-notes-header" }) do
+            border_box_component.with_header(
+              px: 2, py: 1,
+              data: { test_selector: "op-journal-notes-header" },
+              classes: comment_header_classes
+            ) do
               flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
                 header_container.with_column(
                   flex_layout: true,
@@ -75,6 +79,20 @@
                     end
                   end
 
+                  if journal.restricted?
+                    header_end_container.with_column(mr: 2) do
+                      render(
+                        Primer::Beta::Octicon.new(
+                          :lock,
+                          classes: "work-packages-activities-tab-journals-item-component--restricted-icon",
+                          size: :small,
+                          aria: { label: I18n.t("activities.work_packages.activity_tab.restricted_journal") },
+                          data: { test_selector: "op-journal-restricted-icon" }
+                        )
+                      )
+                    end
+                  end
+
                   unless OpenProject::FeatureDecisions.work_package_comment_id_url_active?
                     header_end_container.with_column do
                       activity_anchor_link(journal)
@@ -100,7 +118,7 @@
               end
             end
             border_box_component.with_body(
-              classes: "work-packages-activities-tab-journals-item-component--journal-notes-body",
+              classes: comment_body_classes,
               data: { test_selector: "op-journal-notes-body" }
             ) do
               if noop?

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -76,6 +76,10 @@ module WorkPackages
           end
         end
 
+        def container_border_color
+          journal.restricted? ? :attention_emphasis : :default
+        end
+
         def show_comment_container?
           (journal.notes.present? || noop?) && filter != :only_changes
         end

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -60,6 +60,22 @@ module WorkPackages
           }
         end
 
+        def comment_header_classes
+          [].tap do |classes|
+            if journal.restricted?
+              classes << "work-packages-activities-tab-journals-item-component__header--restricted-comment"
+            end
+          end
+        end
+
+        def comment_body_classes
+          ["work-packages-activities-tab-journals-item-component--journal-notes-body"].tap do |classes|
+            if journal.restricted?
+              classes << "work-packages-activities-tab-journals-item-component__journal-notes-body--restricted-comment"
+            end
+          end
+        end
+
         def show_comment_container?
           (journal.notes.present? || noop?) && filter != :only_changes
         end

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -63,7 +63,7 @@ module WorkPackages
         def comment_header_classes
           [].tap do |classes|
             if journal.restricted?
-              classes << "work-packages-activities-tab-journals-item-component__header--restricted-comment"
+              classes << "work-packages-activities-tab-journals-item-component--header__restricted-comment"
             end
           end
         end
@@ -71,7 +71,7 @@ module WorkPackages
         def comment_body_classes
           ["work-packages-activities-tab-journals-item-component--journal-notes-body"].tap do |classes|
             if journal.restricted?
-              classes << "work-packages-activities-tab-journals-item-component__journal-notes-body--restricted-comment"
+              classes << "work-packages-activities-tab-journals-item-component--journal-notes-body__restricted-comment"
             end
           end
         end

--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -12,7 +12,7 @@
     &--header-start-container
         flex-grow: 1
     &__header--restricted-comment
-        background-color: #ffd8b5 !important // base-color-orange-1 not defined in design tokens
+        background-color: var(--data-auburn-color-muted)
     &__journal-notes-body--restricted-comment
-        background-color: #ffe7d1 !important // base-color-orange-0 not defined in design tokens
+        background-color: var(--bgColor-severe-muted)
 

--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -11,8 +11,8 @@
         color: var(--bgColor-accent-emphasis)
     &--header-start-container
         flex-grow: 1
-    &__header--restricted-comment
+    &--header__restricted-comment
         background-color: var(--data-auburn-color-muted)
-    &__journal-notes-body--restricted-comment
+    &--journal-notes-body__restricted-comment
         background-color: var(--bgColor-severe-muted)
 

--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -11,5 +11,8 @@
         color: var(--bgColor-accent-emphasis)
     &--header-start-container
         flex-grow: 1
-
+    &__header--restricted-comment
+        background-color: #ffd8b5 !important // base-color-orange-1 not defined in design tokens
+    &__journal-notes-body--restricted-comment
+        background-color: #ffe7d1 !important // base-color-orange-0 not defined in design tokens
 

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -193,7 +193,7 @@ module WorkPackages
             render(Primer::Beta::Octicon.new(
                      :"dot-fill", # color is set via CSS as requested by UI/UX Team
                      classes: "work-packages-activities-tab-journals-item-component-details--notification-dot-icon",
-                     size: :medium,
+                     size: (OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? ? :small : :medium),
                      data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
                    ))
           end

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -57,18 +57,7 @@
             concat(
               flex_layout do |flex|
                 flex.with_row(mb: 3) do
-                  flex_layout(flex_wrap: :wrap) do |restricted_note_container|
-                    restricted_note_container.with_column(mr: 2) do
-                      render(WorkPackages::ActivitiesTab::Journals::RestrictedNoteForm.new(f))
-                    end
-
-                    restricted_note_container.with_column(
-                      display: :none,
-                      data: { "work-packages--activities-tab--restricted-comment-target": "visibilityExplainer" }
-                    ) do
-                      render(Primer::Beta::Text.new(color: :subtle)) { restricted_visibility_explainer }
-                    end
-                  end
+                  render(WorkPackages::ActivitiesTab::Journals::RestrictedNoteForm.new(f))
                 end
               end
             )

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -56,7 +56,7 @@
           if adding_restricted_comment_allowed?
             concat(
               flex_layout do |flex|
-                flex.with_row(mb: 3) do
+                flex.with_row(mb: 3, test_selector: "op-work-package-journal-restricted-comment-checkbox") do
                   render(WorkPackages::ActivitiesTab::Journals::RestrictedNoteForm.new(f))
                 end
               end

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -88,7 +88,6 @@
               end
             end
           )
-
         end
       end
     end

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -57,7 +57,18 @@
             concat(
               flex_layout do |flex|
                 flex.with_row(mb: 3) do
-                  render(WorkPackages::ActivitiesTab::Journals::RestrictedNoteForm.new(f))
+                  flex_layout(flex_wrap: :wrap) do |restricted_note_container|
+                    restricted_note_container.with_column(mr: 2) do
+                      render(WorkPackages::ActivitiesTab::Journals::RestrictedNoteForm.new(f))
+                    end
+
+                    restricted_note_container.with_column(
+                      display: :none,
+                      data: { "work-packages--activities-tab--restricted-comment-target": "visibilityExplainer" }
+                    ) do
+                      render(Primer::Beta::Text.new(color: :subtle)) { restricted_visibility_explainer }
+                    end
+                  end
                 end
               end
             )

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -53,28 +53,42 @@
           },
           url: work_package_activities_path(work_package_id: work_package.id)
         ) do |f|
-          flex_layout(justify_content: :space_between, align_items: :flex_end) do |form_container|
-            form_container.with_column(
-              classes: "work-packages-activities-tab-journals-new-component--ck-editor-column",
-              mr: 2
-            ) do
-              render(WorkPackages::ActivitiesTab::Journals::NotesForm.new(f))
-            end
-            form_container.with_column do
-              render(
-                Primer::Beta::IconButton.new(
-                  scheme: :default,
-                  icon: :"paper-airplane",
-                  "aria-label": t("activities.work_packages.activity_tab.label_submit_comment"),
-                  type: :submit,
-                  data: {
-                    test_selector: "op-submit-work-package-journal-form",
-                    "work-packages--activities-tab--index-target": "formSubmitButton"
-                  }
-                )
-              )
-            end
+          if adding_restricted_comment_allowed?
+            concat(
+              flex_layout do |flex|
+                flex.with_row(mb: 3) do
+                  render(WorkPackages::ActivitiesTab::Journals::RestrictedNoteForm.new(f))
+                end
+              end
+            )
           end
+
+          concat(
+            flex_layout(justify_content: :space_between, align_items: :flex_end) do |form_container|
+              form_container.with_column(
+                classes: "work-packages-activities-tab-journals-new-component--ck-editor-column",
+                mr: 2
+              ) do
+                render(WorkPackages::ActivitiesTab::Journals::NotesForm.new(f))
+              end
+
+              form_container.with_column do
+                render(
+                  Primer::Beta::IconButton.new(
+                    scheme: :default,
+                    icon: :"paper-airplane",
+                    "aria-label": t("activities.work_packages.activity_tab.label_submit_comment"),
+                    type: :submit,
+                    data: {
+                      test_selector: "op-submit-work-package-journal-form",
+                      "work-packages--activities-tab--index-target": "formSubmitButton"
+                    }
+                  )
+                )
+              end
+            end
+          )
+
         end
       end
     end

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -62,6 +62,14 @@ module WorkPackages
           # TODO: change to use permissions
           true
         end
+
+        def restricted_visibility_explainer
+          href = ::OpenProject::Static::Links.url_for(:user_guides_work_package_activity)
+          I18n.t("activities.work_packages.activity_tab.restricted_visibility_explainer",
+                 who_link_text: render(Primer::Beta::Link.new(href:, target: "_blank")) do
+                   I18n.t("activities.work_packages.activity_tab.label_who")
+                 end).html_safe
+        end
       end
     end
   end

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -60,7 +60,7 @@ module WorkPackages
 
         def adding_restricted_comment_allowed?
           OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
-            User.current.allowed_in_work_package?(:write_comments_with_restricted_visibility, work_package)
+            User.current.allowed_in_work_package?(:add_comments_with_restricted_visibility, work_package)
         end
       end
     end

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -59,8 +59,7 @@ module WorkPackages
         end
 
         def adding_restricted_comment_allowed?
-          # TODO: change to use permissions
-          true
+          User.current.allowed_in_work_package?(:write_comments_with_restricted_visibility, work_package)
         end
       end
     end

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -62,14 +62,6 @@ module WorkPackages
           # TODO: change to use permissions
           true
         end
-
-        def restricted_visibility_explainer
-          href = ::OpenProject::Static::Links.url_for(:user_guides_work_package_activity)
-          I18n.t("activities.work_packages.activity_tab.restricted_visibility_explainer",
-                 who_link_text: render(Primer::Beta::Link.new(href:, target: "_blank")) do
-                   I18n.t("activities.work_packages.activity_tab.label_who")
-                 end).html_safe
-        end
       end
     end
   end

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -59,7 +59,8 @@ module WorkPackages
         end
 
         def adding_restricted_comment_allowed?
-          User.current.allowed_in_work_package?(:write_comments_with_restricted_visibility, work_package)
+          OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
+            User.current.allowed_in_work_package?(:write_comments_with_restricted_visibility, work_package)
         end
       end
     end

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -29,4 +29,4 @@
         .ck-editor__preview
             max-height: 30vh
     &__journal-notes-body--restricted-comment
-        background-color: #ffe7d1 !important // base-color-orange-0 not defined in design tokens
+        background-color: var(--bgColor-severe-muted)

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -30,3 +30,4 @@
             max-height: 30vh
     &--journal-notes-body__restricted-comment
         background-color: var(--bgColor-severe-muted) !important
+        border-top: var(--borderWidth-thick) solid var(--data-auburn-color-muted)

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -28,3 +28,5 @@
                   max-height: 10vh
         .ck-editor__preview
             max-height: 30vh
+    &__journal-notes-body--restricted-comment
+        background-color: #ffe7d1 !important // base-color-orange-0 not defined in design tokens

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -28,5 +28,5 @@
                   max-height: 10vh
         .ck-editor__preview
             max-height: 30vh
-    &__journal-notes-body--restricted-comment
-        background-color: var(--bgColor-severe-muted)
+    &--journal-notes-body__restricted-comment
+        background-color: var(--bgColor-severe-muted) !important

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -222,7 +222,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def journal_params
-    params.require(:journal).permit(:notes)
+    params.require(:journal).permit(:notes, :restricted)
   end
 
   def handle_successful_create_call(call)

--- a/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
@@ -38,19 +38,8 @@ module WorkPackages::ActivitiesTab::Journals
         data: {
           "work-packages--activities-tab--restricted-comment-target": "visibilityCheckbox",
           action: "input->work-packages--activities-tab--restricted-comment#toggleVisibility"
-        },
-        caption:
+        }
       )
-    end
-
-    private
-
-    def caption
-      href = ::OpenProject::Static::Links.url_for(:user_guides_work_package_activity)
-      I18n.t("activities.work_packages.activity_tab.restricted_visibility_explainer",
-             who_link_text: render(Primer::Beta::Link.new(href:, target: "_blank")) do
-               I18n.t("activities.work_packages.activity_tab.label_who")
-             end).html_safe
     end
   end
 end

--- a/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) 2012-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -25,44 +27,19 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
-module WorkPackages
-  module ActivitiesTab
-    module Journals
-      class NewComponent < ApplicationComponent
-        include ApplicationHelper
-        include OpPrimer::ComponentHelpers
-        include OpTurbo::Streamable
-
-        def initialize(work_package:, journal: nil, form_hidden_initially: true)
-          super
-
-          @work_package = work_package
-          @journal = journal
-          @form_hidden_initially = form_hidden_initially
-        end
-
-        private
-
-        attr_reader :work_package, :form_hidden_initially
-
-        def journal
-          @journal || Journal.new(journable: work_package)
-        end
-
-        def button_row_display_value
-          form_hidden_initially ? :block : :none
-        end
-
-        def form_row_display_value
-          form_hidden_initially ? :none : :block
-        end
-
-        def adding_restricted_comment_allowed?
-          # TODO: change to use permissions
-          true
-        end
-      end
+module WorkPackages::ActivitiesTab::Journals
+  class RestrictedNoteForm < ApplicationForm
+    form do |notes_form|
+      notes_form.check_box(
+        name: :restricted,
+        label: I18n.t("activities.work_packages.activity_tab.restricted_visibility"),
+        checked: false,
+        label_arguments: { class: "no-wrap" },
+        data: {
+          "work-packages--activities-tab--restricted-comment-target": "checkbox",
+          action: "input->work-packages--activities-tab--restricted-comment#onCheckboxChange"
+        }
+      )
     end
   end
 end

--- a/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
@@ -38,8 +38,19 @@ module WorkPackages::ActivitiesTab::Journals
         data: {
           "work-packages--activities-tab--restricted-comment-target": "visibilityCheckbox",
           action: "input->work-packages--activities-tab--restricted-comment#toggleVisibility"
-        }
+        },
+        caption:
       )
+    end
+
+    private
+
+    def caption
+      href = ::OpenProject::Static::Links.url_for(:user_guides_work_package_activity)
+      I18n.t("activities.work_packages.activity_tab.restricted_visibility_explainer",
+             who_link_text: render(Primer::Beta::Link.new(href:, target: "_blank")) do
+               I18n.t("activities.work_packages.activity_tab.label_who")
+             end).html_safe
     end
   end
 end

--- a/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
@@ -36,8 +36,8 @@ module WorkPackages::ActivitiesTab::Journals
         checked: false,
         label_arguments: { class: "no-wrap" },
         data: {
-          "work-packages--activities-tab--restricted-comment-target": "visibilityCheckbox",
-          action: "input->work-packages--activities-tab--restricted-comment#toggleVisibility"
+          "work-packages--activities-tab--restricted-comment-target": "restrictedCheckbox",
+          action: "input->work-packages--activities-tab--restricted-comment#toggleBackgroundColor"
         },
         caption:
       )

--- a/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
@@ -38,8 +38,19 @@ module WorkPackages::ActivitiesTab::Journals
         data: {
           "work-packages--activities-tab--restricted-comment-target": "checkbox",
           action: "input->work-packages--activities-tab--restricted-comment#onCheckboxChange"
-        }
+        },
+        caption:
       )
+    end
+
+    private
+
+    def caption
+      href = ::OpenProject::Static::Links.url_for(:user_guides_work_package_activity)
+      I18n.t("activities.work_packages.activity_tab.restricted_visibility_explainer",
+             who_link_text: render(Primer::Beta::Link.new(href:, target: "_blank")) do
+               I18n.t("activities.work_packages.activity_tab.label_who")
+             end).html_safe
     end
   end
 end

--- a/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/restricted_note_form.rb
@@ -36,8 +36,8 @@ module WorkPackages::ActivitiesTab::Journals
         checked: false,
         label_arguments: { class: "no-wrap" },
         data: {
-          "work-packages--activities-tab--restricted-comment-target": "checkbox",
-          action: "input->work-packages--activities-tab--restricted-comment#onCheckboxChange"
+          "work-packages--activities-tab--restricted-comment-target": "visibilityCheckbox",
+          action: "input->work-packages--activities-tab--restricted-comment#toggleVisibility"
         },
         caption:
       )

--- a/app/models/activities/fetcher.rb
+++ b/app/models/activities/fetcher.rb
@@ -117,7 +117,11 @@ module Activities
 
     def filter_by_visibility(events)
       events.reject! do |event|
-        event.journal.restricted? && !@user.allowed_in_project?(:view_comments_with_restricted_visibility, event.project)
+        if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active?
+          event.journal.restricted? && !@user.allowed_in_project?(:view_comments_with_restricted_visibility, event.project)
+        else
+          event.journal.restricted?
+        end
       end
     end
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -114,7 +114,8 @@ class Journal < ApplicationRecord
   scope :for_work_package, -> { where(journable_type: "WorkPackage") }
   scope :for_meeting, -> { where(journable_type: "Meeting") }
   scope :restricted_visible, ->(work_package) {
-    if User.current.allowed_in_work_package?(:view_comments_with_restricted_visibility, work_package)
+    if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
+        User.current.allowed_in_work_package?(:view_comments_with_restricted_visibility, work_package)
       all
     else
       where(restricted: false)

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -320,21 +320,21 @@ Rails.application.reloader.to_prepare do
                      {},
                      permissible_on: %i[work_package project],
                      require: :loggedin,
-                     dependencies: :view_work_packages,
+                     dependencies: %i[view_work_packages view_comments_with_restricted_visibility],
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       wpt.permission :edit_own_comments_with_restricted_visibility,
                      {},
                      permissible_on: %i[work_package project],
                      require: :loggedin,
-                     dependencies: :view_work_packages,
+                     dependencies: %i[view_work_packages view_comments_with_restricted_visibility],
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       wpt.permission :edit_others_comments_with_restricted_visibility,
                      {},
                      permissible_on: %i[work_package project],
                      require: :loggedin,
-                     dependencies: :view_work_packages,
+                     dependencies: %i[view_work_packages view_comments_with_restricted_visibility],
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       # WP attachments can be added with :edit_work_packages, this permission allows it without Edit WP as well.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
         commented: "commented"
         restricted_visibility: Restricted visibility
         restricted_visibility_explainer: Only visible to a limited group of members. %{who_link_text}
-        restricted_journal: Only visible to a limited group of members.
+        restricted_journal: Restricted comments are visible to a limited group of members.
 
   admin:
     plugins:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
         changed: "changed"
         created: "created"
         commented: "commented"
+        restricted_journal: Only visible to a limited group of members.
 
   admin:
     plugins:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
         changed: "changed"
         created: "created"
         commented: "commented"
+        restricted_visibility: Restricted visibility
         restricted_journal: Only visible to a limited group of members.
 
   admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,12 +43,14 @@ en:
         label_sort_desc: "Newest on top"
         label_type_to_comment: "Add a comment. Type @ to notify people."
         label_submit_comment: "Submit comment"
+        label_who: Who?
         changed_on: "changed on"
         created_on: "created this on"
         changed: "changed"
         created: "created"
         commented: "commented"
         restricted_visibility: Restricted visibility
+        restricted_visibility_explainer: Only visible to a limited group of members. %{who_link_text}
         restricted_journal: Only visible to a limited group of members.
 
   admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
         commented: "commented"
         restricted_visibility: Restricted visibility
         restricted_visibility_explainer: Only visible to a limited group of members. %{who_link_text}
-        restricted_journal: Restricted comments are visible to a limited group of members.
+        restricted_journal: Only visible to a limited group of members.
 
   admin:
     plugins:

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -19,6 +19,9 @@ upsale_get_quote:
 user_guides:
   href: https://www.openproject.org/docs/user-guide/
   label: homescreen.links.user_guides
+user_guides_work_package_activity:
+  href: https://www.openproject.org/docs/user-guide/activity/#work-package-activity
+  label: noscript_learn_more
 installation_guides:
   href: https://www.openproject.org/docs/installation-and-operations/installation/
   label: :label_installation_guides

--- a/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.component.ts
@@ -303,8 +303,10 @@ export class OpCkeditorComponent extends UntilDestroyedMixin implements OnInit, 
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (!editor.ui.focusTracker.isFocused) {
             this.editorBlur.emit();
+            debugLog('CKEditor blurred');
           } else {
             this.editorFocus.emit();
+            debugLog('CKEditor focused');
           }
         }, 0);
       },

--- a/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/op-ckeditor.component.ts
@@ -303,10 +303,8 @@ export class OpCkeditorComponent extends UntilDestroyedMixin implements OnInit, 
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (!editor.ui.focusTracker.isFocused) {
             this.editorBlur.emit();
-            debugLog('CKEditor blurred');
           } else {
             this.editorFocus.emit();
-            debugLog('CKEditor focused');
           }
         }, 0);
       },

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -752,6 +752,7 @@ export default class IndexController extends Controller {
       })
       .finally(() => {
         this.setFormSubmitInProgress(false);
+        this.dispatch('onSubmit-end');
       });
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -745,6 +745,7 @@ export default class IndexController extends Controller {
     void this.submitForm(formData)
       .then(({ html, headers }) => {
         this.handleSuccessfulSubmission(html, headers);
+        this.formTarget.reset();
       })
       .catch((error) => {
         console.error('Error saving activity:', error);

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -1,3 +1,33 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
 import { Controller } from '@hotwired/stimulus';
 import {
   ICKEditorInstance,

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -37,17 +37,12 @@ export default class RestrictedCommentController extends Controller {
   declare readonly formContainerTarget:HTMLElement;
 
   toggleVisibility():void {
-    const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component__journal-notes-body--restricted-comment';
-    // FIXME: This is not ideal as primer can change class names. Awaiting redesign of the form...
-    // This should NOT make it to production.
-    const primerBgColorClass = 'color-bg-subtle';
+    const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment';
 
     if (this.visibilityCheckboxTarget.checked) {
-      this.formContainerTarget.classList.remove(primerBgColorClass);
       this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
     } else {
       this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
-      this.formContainerTarget.classList.add(primerBgColorClass);
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -31,10 +31,11 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
-  static targets = ['checkbox', 'formContainer'];
+  static targets = ['checkbox', 'formContainer', 'visibilityExplainer'];
 
   declare readonly checkboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
+  declare readonly visibilityExplainerTarget:HTMLElement;
 
   onCheckboxChange():void {
     const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component__journal-notes-body--restricted-comment';
@@ -45,9 +46,11 @@ export default class RestrictedCommentController extends Controller {
     if (this.checkboxTarget.checked) {
       this.formContainerTarget.classList.remove(primerBgColorClass);
       this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
+      this.visibilityExplainerTarget.classList.remove('d-none');
     } else {
       this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
       this.formContainerTarget.classList.add(primerBgColorClass);
+      this.visibilityExplainerTarget.classList.add('d-none');
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -31,18 +31,18 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
-  static targets = ['checkbox', 'formContainer'];
+  static targets = ['visibilityCheckbox', 'formContainer'];
 
-  declare readonly checkboxTarget:HTMLInputElement;
+  declare readonly visibilityCheckboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
 
-  onCheckboxChange():void {
+  toggleVisibility():void {
     const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component__journal-notes-body--restricted-comment';
     // FIXME: This is not ideal as primer can change class names. Awaiting redesign of the form...
     // This should NOT make it to production.
     const primerBgColorClass = 'color-bg-subtle';
 
-    if (this.checkboxTarget.checked) {
+    if (this.visibilityCheckboxTarget.checked) {
       this.formContainerTarget.classList.remove(primerBgColorClass);
       this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
     } else {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -31,11 +31,10 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
-  static targets = ['checkbox', 'formContainer', 'visibilityExplainer'];
+  static targets = ['checkbox', 'formContainer'];
 
   declare readonly checkboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
-  declare readonly visibilityExplainerTarget:HTMLElement;
 
   onCheckboxChange():void {
     const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component__journal-notes-body--restricted-comment';
@@ -46,11 +45,9 @@ export default class RestrictedCommentController extends Controller {
     if (this.checkboxTarget.checked) {
       this.formContainerTarget.classList.remove(primerBgColorClass);
       this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
-      this.visibilityExplainerTarget.classList.remove('d-none');
     } else {
       this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
       this.formContainerTarget.classList.add(primerBgColorClass);
-      this.visibilityExplainerTarget.classList.add('d-none');
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -31,18 +31,22 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
-  static targets = ['visibilityCheckbox', 'formContainer'];
+  static targets = ['restrictedCheckbox', 'formContainer'];
 
-  declare readonly visibilityCheckboxTarget:HTMLInputElement;
+  declare readonly restrictedCheckboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
 
-  toggleVisibility():void {
-    const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment';
+  private restrictedCommentBgColorClass:string = 'work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment';
 
-    if (this.visibilityCheckboxTarget.checked) {
-      this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
+  onSubmitEnd(_event:CustomEvent):void {
+    this.toggleBackgroundColor();
+  }
+
+  toggleBackgroundColor():void {
+    if (this.restrictedCheckboxTarget.checked) {
+      this.formContainerTarget.classList.add(this.restrictedCommentBgColorClass);
     } else {
-      this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
+      this.formContainerTarget.classList.remove(this.restrictedCommentBgColorClass);
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -31,21 +31,18 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
-  static targets = ['visibilityCheckbox', 'formContainer', 'visibilityExplainer'];
+  static targets = ['visibilityCheckbox', 'formContainer'];
 
   declare readonly visibilityCheckboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
-  declare readonly visibilityExplainerTarget:HTMLElement;
 
   toggleVisibility():void {
     const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment';
 
     if (this.visibilityCheckboxTarget.checked) {
       this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
-      this.visibilityExplainerTarget.classList.remove('d-none');
     } else {
       this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
-      this.visibilityExplainerTarget.classList.add('d-none');
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -31,18 +31,21 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
-  static targets = ['visibilityCheckbox', 'formContainer'];
+  static targets = ['visibilityCheckbox', 'formContainer', 'visibilityExplainer'];
 
   declare readonly visibilityCheckboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
+  declare readonly visibilityExplainerTarget:HTMLElement;
 
   toggleVisibility():void {
     const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment';
 
     if (this.visibilityCheckboxTarget.checked) {
       this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
+      this.visibilityExplainerTarget.classList.remove('d-none');
     } else {
       this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
+      this.visibilityExplainerTarget.classList.add('d-none');
     }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -43,6 +43,10 @@ export default class RestrictedCommentController extends Controller {
   }
 
   toggleBackgroundColor():void {
-    this.formContainerTarget.classList.toggle(this.highlightClass);
+    if (this.restrictedCheckboxTarget.checked) {
+      this.formContainerTarget.classList.add(this.highlightClass);
+    } else {
+      this.formContainerTarget.classList.remove(this.highlightClass);
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -1,0 +1,53 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class RestrictedCommentController extends Controller {
+  static targets = ['checkbox', 'formContainer'];
+
+  declare readonly checkboxTarget:HTMLInputElement;
+  declare readonly formContainerTarget:HTMLElement;
+
+  onCheckboxChange():void {
+    const restrictedCommentBgColorClass = 'work-packages-activities-tab-journals-new-component__journal-notes-body--restricted-comment';
+    // FIXME: This is not ideal as primer can change class names. Awaiting redesign of the form...
+    // This should NOT make it to production.
+    const primerBgColorClass = 'color-bg-subtle';
+
+    if (this.checkboxTarget.checked) {
+      this.formContainerTarget.classList.remove(primerBgColorClass);
+      this.formContainerTarget.classList.add(restrictedCommentBgColorClass);
+    } else {
+      this.formContainerTarget.classList.remove(restrictedCommentBgColorClass);
+      this.formContainerTarget.classList.add(primerBgColorClass);
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -43,10 +43,6 @@ export default class RestrictedCommentController extends Controller {
   }
 
   toggleBackgroundColor():void {
-    if (this.restrictedCheckboxTarget.checked) {
-      this.formContainerTarget.classList.add(this.highlightClass);
-    } else {
-      this.formContainerTarget.classList.remove(this.highlightClass);
-    }
+    this.formContainerTarget.classList.toggle(this.highlightClass);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -32,11 +32,11 @@ import { Controller } from '@hotwired/stimulus';
 
 export default class RestrictedCommentController extends Controller {
   static targets = ['restrictedCheckbox', 'formContainer'];
+  static classes = ['highlight'];
 
   declare readonly restrictedCheckboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
-
-  private restrictedCommentBgColorClass:string = 'work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment';
+  declare readonly highlightClass:string;
 
   onSubmitEnd(_event:CustomEvent):void {
     this.toggleBackgroundColor();
@@ -44,9 +44,9 @@ export default class RestrictedCommentController extends Controller {
 
   toggleBackgroundColor():void {
     if (this.restrictedCheckboxTarget.checked) {
-      this.formContainerTarget.classList.add(this.restrictedCommentBgColorClass);
+      this.formContainerTarget.classList.add(this.highlightClass);
     } else {
-      this.formContainerTarget.classList.remove(this.restrictedCommentBgColorClass);
+      this.formContainerTarget.classList.remove(this.highlightClass);
     }
   }
 }

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -235,7 +235,8 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
     end
 
-    context "when a user cannot see comments with restricted visibility" do
+    context "when a user cannot see comments with restricted visibility",
+            with_flag: { comments_with_restricted_visibility: true } do
       current_user { member }
 
       before do
@@ -255,7 +256,8 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
     end
 
-    context "when a user can see comments with restricted visibility" do
+    context "when a user can see comments with restricted visibility",
+            with_flag: { comments_with_restricted_visibility: true } do
       current_user { admin }
 
       before do

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -30,7 +30,10 @@
 
 require "spec_helper"
 
-RSpec.describe "Work package comments with restricted visibility", :js, :with_cuprite do
+RSpec.describe "Work package comments with restricted visibility",
+               :js,
+               :with_cuprite,
+               with_flag: { comments_with_restricted_visibility: true } do
   let(:project) { create(:project) }
   let(:admin) { create(:admin) }
   let(:viewer) { create_user_with_restricted_comments_view_permissions }

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package comments with restricted visibility", :js, :with_cuprite do
+  let(:project) { create(:project) }
+  let(:admin) { create(:admin) }
+  let(:viewer) { create_user_with_restricted_comments_view_permissions }
+  let(:viewer_with_commenting_permission) { create_user_with_restricted_comments_view_and_write_permissions }
+  let(:project_admin) { create_user_as_project_admin }
+
+  let(:work_package) { create(:work_package, project:, author: admin) }
+  let(:first_comment) do
+    create(:work_package_journal, user: admin, notes: "A (restricted) comment by admin",
+                                  journable: work_package, version: 2, restricted: true)
+  end
+
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+  let(:activity_tab) { Components::WorkPackages::Activities.new(work_package) }
+
+  context "with an admin user" do
+    current_user { admin }
+
+    before do
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "allows adding a comment with restricted visibility" do
+      activity_tab.expect_input_field
+
+      activity_tab.add_comment(text: "First (restricted) comment by admin", restricted: true)
+
+      activity_tab.expect_journal_notes(text: "First (restricted) comment by admin")
+    end
+  end
+
+  context "with a user that is only allowed to view comments with restricted visibility" do
+    current_user { viewer }
+
+    before do
+      first_comment
+
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "does show restricted comments but does NOT enable editing or quoting comments" do
+      activity_tab.expect_journal_notes(text: "A (restricted) comment by admin")
+
+      activity_tab.within_journal_entry(first_comment) do
+        page.find_test_selector("op-wp-journal-#{first_comment.id}-action-menu").click
+
+        expect(page).not_to have_test_selector("op-wp-journal-#{first_comment.id}-edit")
+        expect(page).not_to have_test_selector("op-wp-journal-#{first_comment.id}-quote")
+      end
+    end
+  end
+
+  context "with a user that is allowed to view, create and edit own comments" do
+    current_user { viewer_with_commenting_permission }
+
+    before do
+      first_comment
+
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "allows adding a comment with restricted visibility" do
+      activity_tab.expect_input_field
+
+      activity_tab.add_comment(text: "First (restricted) comment by member", restricted: true)
+
+      activity_tab.expect_journal_notes(text: "First (restricted) comment by member")
+
+      created_comment = work_package.journals.reload.last
+
+      activity_tab.within_journal_entry(created_comment) do
+        page.find_test_selector("op-wp-journal-#{created_comment.id}-action-menu").click
+
+        expect(page).to have_test_selector("op-wp-journal-#{created_comment.id}-edit")
+      end
+    end
+
+    it "does show restricted comments but does NOT enable editing other users comments" do
+      activity_tab.expect_journal_notes(text: "A (restricted) comment by admin")
+
+      activity_tab.within_journal_entry(first_comment) do
+        page.find_test_selector("op-wp-journal-#{first_comment.id}-action-menu").click
+
+        # not allowed to edit other user's restricted comments
+        expect(page).not_to have_test_selector("op-wp-journal-#{first_comment.id}-edit")
+        # allowed to quote other user's comments
+        expect(page).to have_test_selector("op-wp-journal-#{first_comment.id}-quote")
+      end
+    end
+  end
+
+  context "with a user that is allowed to view, create and edit all comments" do
+    current_user { project_admin }
+
+    before do
+      first_comment
+
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "allows editing and quoting restricted comments" do
+      activity_tab.expect_journal_notes(text: "A (restricted) comment by admin")
+
+      activity_tab.within_journal_entry(first_comment) do
+        page.find_test_selector("op-wp-journal-#{first_comment.id}-action-menu").click
+
+        expect(page).to have_test_selector("op-wp-journal-#{first_comment.id}-edit")
+        expect(page).to have_test_selector("op-wp-journal-#{first_comment.id}-quote")
+      end
+    end
+  end
+
+  def create_user_as_project_admin
+    member_role = create(:project_role,
+                         permissions: %i[view_work_packages add_work_package_notes
+                                         edit_own_work_package_notes
+                                         view_comments_with_restricted_visibility
+                                         write_comments_with_restricted_visibility
+                                         edit_own_comments_with_restricted_visibility
+                                         edit_others_comments_with_restricted_visibility])
+    create(:user, firstname: "Project", lastname: "Admin",
+                  member_with_roles: { project => member_role })
+  end
+
+  def create_user_with_restricted_comments_view_permissions
+    viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
+    create(:user,
+           firstname: "A",
+           lastname: "Viewer",
+           member_with_roles: { project => viewer_role })
+  end
+
+  def create_user_with_restricted_comments_view_and_write_permissions
+    viewer_role_with_commenting_permission = create(:project_role,
+                                                    permissions: %i[view_work_packages add_work_package_notes
+                                                                    edit_own_work_package_notes
+                                                                    view_comments_with_restricted_visibility
+                                                                    write_comments_with_restricted_visibility
+                                                                    edit_own_comments_with_restricted_visibility])
+    create(:user,
+           firstname: "A",
+           lastname: "Viewer",
+           member_with_roles: { project => viewer_role_with_commenting_permission })
+  end
+end

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -106,8 +106,15 @@ RSpec.describe "Work package comments with restricted visibility", :js, :with_cu
 
       activity_tab.within_journal_entry(created_comment) do
         page.find_test_selector("op-wp-journal-#{created_comment.id}-action-menu").click
+        page.find_test_selector("op-wp-journal-#{created_comment.id}-edit").click
 
-        expect(page).to have_test_selector("op-wp-journal-#{created_comment.id}-edit")
+        page.within_test_selector("op-work-package-journal-form-element") do
+          expect(page).not_to have_test_selector("op-work-package-journal-restricted-comment-checkbox")
+          activity_tab.get_editor_form_field_element.set_value("Edited comment by member")
+          page.find_test_selector("op-submit-work-package-journal-form").click
+        end
+
+        wait_for { page }.to have_test_selector("op-journal-notes-body", text: "Edited comment by member")
       end
     end
 

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "Work package comments with restricted visibility",
                          permissions: %i[view_work_packages add_work_package_notes
                                          edit_own_work_package_notes
                                          view_comments_with_restricted_visibility
-                                         write_comments_with_restricted_visibility
+                                         add_comments_with_restricted_visibility
                                          edit_own_comments_with_restricted_visibility
                                          edit_others_comments_with_restricted_visibility])
     create(:user, firstname: "Project", lastname: "Admin",
@@ -182,7 +182,7 @@ RSpec.describe "Work package comments with restricted visibility",
                                                     permissions: %i[view_work_packages add_work_package_notes
                                                                     edit_own_work_package_notes
                                                                     view_comments_with_restricted_visibility
-                                                                    write_comments_with_restricted_visibility
+                                                                    add_comments_with_restricted_visibility
                                                                     edit_own_comments_with_restricted_visibility])
     create(:user,
            firstname: "A",

--- a/spec/models/activities/fetcher_integration_spec.rb
+++ b/spec/models/activities/fetcher_integration_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Activities::Fetcher, "integration" do
       .not_to include("budgets")
   end
 
-  describe "#events" do
+  describe "#events", with_flag: { comments_with_restricted_visibility: true } do
     let(:event_user) { user }
     let(:work_package) { create(:work_package, project:, author: event_user) }
     let(:forum) { create(:forum, project:) }

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Journal do
     end
   end
 
-  describe ".restricted_visible scope" do
+  describe ".restricted_visible scope", with_flag: { comments_with_restricted_visibility: true } do
     let(:work_package) { create(:work_package) }
     let(:admin) { create(:admin) }
     let(:user) { create(:user) }

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do # rubocop:disa
       allow(User).to receive(:current).and_return(current_user)
     end
 
-    describe "GET /api/v3/work_packages/:id/activities" do
+    describe "GET /api/v3/work_packages/:id/activities", with_flag: { comments_with_restricted_visibility: true } do
       context "when activities do not include restricted journals" do
         before do
           get api_v3_paths.work_package_activities work_package.id

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -232,7 +232,7 @@ module Components
         page.find_test_selector("op-submit-work-package-journal-form").click
       end
 
-      def add_comment(text: nil, save: true)
+      def add_comment(text: nil, save: true, restricted: false)
         if page.find_test_selector("op-open-work-package-journal-form-trigger")
           open_new_comment_editor
         else
@@ -241,6 +241,7 @@ module Components
 
         page.within_test_selector("op-work-package-journal-form-element") do
           get_editor_form_field_element.set_value(text)
+          page.check("Restricted visibility") if restricted
           page.find_test_selector("op-submit-work-package-journal-form").click if save
         end
 

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -241,7 +241,12 @@ module Components
 
         page.within_test_selector("op-work-package-journal-form-element") do
           get_editor_form_field_element.set_value(text)
-          page.check("Restricted visibility") if restricted
+
+          if restricted
+            expect(page).to have_test_selector("op-work-package-journal-restricted-comment-checkbox")
+            page.check("Restricted visibility")
+          end
+
           page.find_test_selector("op-submit-work-package-journal-form").click if save
         end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/60979

#18091

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Introduce work package comments with restricted visibility- access controlled via dedicated permissions

> [!IMPORTANT]
> The UI is still undergoing refinements- this PR provides base functionality. OPEN POINTS exist for updating the UI and managing the odd [editor shrinking](https://community.openproject.org/projects/communicator-stream/work_packages/61953/github) behaviour

- [x] View restricted comments
   - [x] Color restricted comments
   - [ ] Distinguish associated comment restricted journals (such as attachments) https://community.openproject.org/wp/61874
   - [x] Filter out restricted comments via permissions
- [x] Edit restricted comments (cannot change restriction)
- [x] Add restricted comments
   - [x] Change background based on restriction
   - [ ] 🐛 primer color vars do not scale to dark mode (becomes invisible) https://community.openproject.org/wp/61949
   - [x] 🐛 on submit remove background color
   - [x] add border top color (restricted)
- [x] https://github.com/opf/openproject/pull/18245

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/629aac33-c0a9-4e48-98a5-8315ef379786

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
