### PR TITLE
Fix npm version

### DIFF
--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y chromium
 
 ENV CHROME_BIN=/usr/bin/chromium
 
-RUN npm i -g npm
+RUN npm i -g npm@10.1.0
 
 RUN groupadd $USER || true
 RUN groupmod -g $DEV_GID $USER || true


### PR DESCRIPTION
# Ticket
[#61943](https://community.openproject.org/projects/openproject/work_packages/61943) 

# What are you trying to accomplish?
Fix building frontend in dev environment. Just download stable/15 with clean docker volumes/containers/images and go through [manual](https://www.openproject.org/docs/development/development-environment/docker/).

## Screenshots
```
 => [frontend 2/9] RUN apt-get update && apt-get install -y chromium                                                                                                                                                   90.1s
 => ERROR [frontend 3/9] RUN npm i -g npm                                                                                                                                                                               1.6s
------
 > [frontend 3/9] RUN npm i -g npm:
1.618 npm ERR! code EBADENGINE
1.618 npm ERR! engine Unsupported engine
1.618 npm ERR! engine Not compatible with your version of node/npm: npm@11.1.0
1.618 npm ERR! notsup Not compatible with your version of node/npm: npm@11.1.0
1.619 npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
1.619 npm ERR! notsup Actual:   {"npm":"10.1.0","node":"v20.9.0"}

```
# What approach did you choose and why?
I'm not sure I do it in correct way. So may be more experienced people will correct my solution.

Whole story: somehow I got this error while frontend container is building. Just regular run from manual `docker compose run --rm frontend npm install`. 
I suppose before there was docker cache playing and npm wasn't updated and now, after cleaning volumes and images it became a problem. I even tried reinstall docker with /var/lib/docker wipe — not the case. 
I choose 10.1 because it shows inside backend container and  npm installs all the packages with it. 

Production Dockerfile isn't relay on system's packages but installs npm manually and I see there exact 10.1.0.