### PR TITLE
[chore] add container for admin settings form

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -1,3 +1,4 @@
+@import "admin_settings_form_component"
 @import "work_packages/activities_tab/index_component"
 @import "work_packages/activities_tab/journals/new_component"
 @import "work_packages/activities_tab/journals/index_component"

--- a/app/components/admin_settings_form_component.rb
+++ b/app/components/admin_settings_form_component.rb
@@ -28,36 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
-  module Types
-    class SettingsComponent < AdminSettingsFormComponent
-      include OpPrimer::ComponentHelpers
-      include OpTurbo::Streamable
-
-      def initialize(model, copy_workflow_from: nil, **)
-        @copy_workflow_from = copy_workflow_from
-        super(model, **)
-      end
-
-      def form_options
-        if model.new_record?
-          create_form_options
-        else
-          update_form_options
-        end
-      end
-
-      private
-
-      attr_reader :copy_workflow_from
-
-      def create_form_options
-        { url: types_path, method: :post, model:, copy_workflow_from: }
-      end
-
-      def update_form_options
-        { url: update_tab_type_path(id: model.id, tab: :settings), method: :patch, model: }
-      end
+class AdminSettingsFormComponent < ApplicationComponent
+  def render_in(view_context, &)
+    tag.div(class: "op-admin-settings-form-wrapper") do
+      super
     end
   end
 end

--- a/app/components/admin_settings_form_component.sass
+++ b/app/components/admin_settings_form_component.sass
@@ -1,3 +1,3 @@
 .op-admin-settings-form-wrapper
-  max-width: 480px
+  max-width: 680px
   margin: 0 auto 0 0

--- a/app/components/admin_settings_form_component.sass
+++ b/app/components/admin_settings_form_component.sass
@@ -1,0 +1,3 @@
+.op-admin-settings-form-wrapper
+  max-width: 480px
+  margin: 0 auto 0 0

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -30,7 +30,7 @@
 
 module WorkPackages
   module Types
-    class SubjectConfigurationComponent < ApplicationComponent
+    class SubjectConfigurationComponent < AdminSettingsFormComponent
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 

--- a/app/forms/work_packages/types/settings_form.rb
+++ b/app/forms/work_packages/types/settings_form.rb
@@ -43,12 +43,14 @@ module WorkPackages
         settings_form.color_select_list(
           name: :color_id,
           label: Color.model_name.human,
+          input_width: :medium,
           caption: I18n.t("types.edit.settings.type_color_text")
         )
 
         if show_work_flow_copy?
           settings_form.select_list(
             name: :copy_workflow_from,
+            input_width: :medium,
             label: I18n.t(:label_copy_workflow_from),
             include_blank: true
           ) do |other_types|

--- a/app/forms/work_packages/types/settings_form.rb
+++ b/app/forms/work_packages/types/settings_form.rb
@@ -36,7 +36,6 @@ module WorkPackages
           name: :name,
           label: label(:name),
           placeholder: I18n.t(:label_name),
-          input_width: :large,
           required: true,
           disabled: model.is_standard?
         )
@@ -44,16 +43,14 @@ module WorkPackages
         settings_form.color_select_list(
           name: :color_id,
           label: Color.model_name.human,
-          caption: I18n.t("types.edit.settings.type_color_text"),
-          input_width: :large
+          caption: I18n.t("types.edit.settings.type_color_text")
         )
 
         if show_work_flow_copy?
           settings_form.select_list(
             name: :copy_workflow_from,
             label: I18n.t(:label_copy_workflow_from),
-            include_blank: true,
-            input_width: :large
+            include_blank: true
           ) do |other_types|
             work_package_types.each do |type|
               other_types.option(
@@ -68,7 +65,6 @@ module WorkPackages
         settings_form.rich_text_area(
           name: :description,
           label: label(:description),
-          input_width: :large,
           rich_text_options: { showAttachments: false }
         )
 

--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -54,7 +54,6 @@ module WorkPackages
           toggleable_group.pattern_input(
             name: :pattern,
             value: model.pattern,
-            input_width: :large,
             suggestions: model.suggestions,
             label: I18n.t("types.edit.subject_configuration.pattern.label"),
             caption: I18n.t("types.edit.subject_configuration.pattern.caption"),

--- a/lookbook/docs/patterns/02-forms.md.erb
+++ b/lookbook/docs/patterns/02-forms.md.erb
@@ -30,9 +30,19 @@ If a form does not use Subhead sections, then there should be a single 'Save' (u
 
 ## Form width
 
-In Primer, form elements automatically take the width of the container. In certain cases (especially Settings pages), full-width input fields will look strange. In this case, form inputs will need to have a smaller width. A good rule of thumb is to fit the size of the fields to the expected length of the user input. Date fields can for example be rather small, as they are limited in length. The name of an object on the other hand can be quite long, so the field is expected to be larger.
+In Primer, form elements automatically take the width of the container. In certain cases (especially Settings pages),
+full-width input fields will look strange. For those wide settings pages, the component rendering the form in its
+template should inherit from the base component `AdminSettingsFormComponent`. This component ensures a wrapping
+container, limiting the max-width of the form to `480px`.
 
-In OpenProject, each form element has its own container. It is thus possible to define the container width for each input with the `:input_width` parameter. This width will define both the visual width of the field but also the max width of the caption field (where the line breaks).
+In any container though the form elements can still limit its own width. A good rule of thumb is to fit the size of the
+fields to the expected length of the user input. Date fields can for example be rather small, as they are limited in
+length. The name of an object on the other hand can be quite long, so the field is expected to be larger. While the
+input field can be limited in width, the caption and validation messages will always extend to the full width of the
+form.
+
+In OpenProject, each form element has its own container. It is thus possible to define the container width for each
+input with the `:input_width` parameter.
 
 The options are:
 

--- a/lookbook/docs/patterns/02-forms.md.erb
+++ b/lookbook/docs/patterns/02-forms.md.erb
@@ -31,9 +31,8 @@ If a form does not use Subhead sections, then there should be a single 'Save' (u
 ## Form width
 
 In Primer, form elements automatically take the width of the container. In certain cases (especially Settings pages),
-full-width input fields will look strange. For those wide settings pages, the component rendering the form in its
-template should inherit from the base component `AdminSettingsFormComponent`. This component ensures a wrapping
-container, limiting the max-width of the form to `480px`.
+full-width input fields will look strange. For those wide settings pages, we introduced [a pattern](./settings_pages)
+that wraps the form into a container with limited width.
 
 In any container though the form elements can still limit its own width. A good rule of thumb is to fit the size of the
 fields to the expected length of the user input. Date fields can for example be rather small, as they are limited in

--- a/lookbook/docs/patterns/02-forms.md.erb
+++ b/lookbook/docs/patterns/02-forms.md.erb
@@ -31,16 +31,14 @@ If a form does not use Subhead sections, then there should be a single 'Save' (u
 ## Form width
 
 In Primer, form elements automatically take the width of the container. In certain cases (especially Settings pages),
-full-width input fields will look strange. For those wide settings pages, we introduced [a pattern](./settings_pages)
-that wraps the form into a container with limited width.
+full-width input fields will look strange. For these wide settings pages, we introduced [a pattern](./settings_pages)
+that wraps the form inside container that limits the width of the form.
 
-In any container though the form elements can still limit its own width. A good rule of thumb is to fit the size of the
-fields to the expected length of the user input. Date fields can for example be rather small, as they are limited in
-length. The name of an object on the other hand can be quite long, so the field is expected to be larger. While the
-input field can be limited in width, the caption and validation messages will always extend to the full width of the
-form.
+Individual form elements can however be sized to be smaller than the width the container. A good rule of thumb is to choose a width for a
+field based on the expected length of the user input: date fields can for example be rather short but a name field has the potential to be quite long. While the
+input field can be limited in width, the caption and validation messages will always extend to the full width of the form (or the container, if one is used).
 
-In OpenProject, each form element has its own container. It is thus possible to define the container width for each
+In OpenProject, each form element also has its own container. It is thus possible to define the container width for each
 input with the `:input_width` parameter.
 
 The options are:

--- a/lookbook/docs/patterns/17-settings-pages.md.erb
+++ b/lookbook/docs/patterns/17-settings-pages.md.erb
@@ -1,14 +1,12 @@
-Settings pages usually have content space that stretches to the full width of the viewport, as there is no other element
-horizontally positioned, except the left side menu.
+Settings pages usually stretch to the full width of the viewport as they tend not to have addition horizontally-positioned elements.
 
 ## Settings page base component
 
-According to the [form width specification](./forms), we avoid forms to stretch without limit. Because of the default
-behaviour of form elements to use the full width of the container, we use a base component that embeds the form inside
-such a wrapping container.
+As specified in the documentation for [forms](./forms), we prefer limiting the width of a form for legibility. Because the default
+behaviour of form elements to fill the full width of the container, we wrap forms in a container that limits its available width.
 
 Any view component rendering a form should inherit from `AdminSettingsFormComponent`. The template stays unchanged. This
-way, the rendered form is wrapped into a container with `480px` max-width.
+way, the rendered form is wrapped into a container with `680px` max-width.
 
 ```ruby
 module WorkPackages

--- a/lookbook/docs/patterns/17-settings-pages.md.erb
+++ b/lookbook/docs/patterns/17-settings-pages.md.erb
@@ -1,1 +1,29 @@
-When working on Settings pages, please refer to the Forms pattern for information on how to implement form elements.
+Settings pages usually have content space that stretches to the full width of the viewport, as there is no other element
+horizontally positioned, except the left side menu.
+
+## Settings page base component
+
+According to the [form width specification](./forms), we avoid forms to stretch without limit. Because of the default
+behaviour of form elements to use the full width of the container, we use a base component that embeds the form inside
+such a wrapping container.
+
+Any view component rendering a form should inherit from `AdminSettingsFormComponent`. The template stays unchanged. This
+way, the rendered form is wrapped into a container with `480px` max-width.
+
+```ruby
+module WorkPackages
+  module Types
+    class SettingsComponent < AdminSettingsFormComponent
+      # component logic goes here
+    end
+  end
+end
+```
+
+```erb
+<%%=
+  primer_form_with(**form_options) do |f|
+    render(WorkPackages::Types::SettingsForm.new(f))
+  end
+%>
+```

--- a/lookbook/previews/patterns/forms_preview/default.html.erb
+++ b/lookbook/previews/patterns/forms_preview/default.html.erb
@@ -13,6 +13,7 @@
         name: :ultimate_answer,
         label: "Small",
         required: true,
+        caption: "Small fields cannot contain a much longer caption. It will overflow until it reaches the form width.",
         input_width: :small
       )
 


### PR DESCRIPTION
# Ticket
Reference implementation for [OP#61755](https://community.openproject.org/wp/61755)

# What are you trying to accomplish?
- harmonize visuals of admin setting pages

# What approach did you choose and why?
- admin setting forms can use as base component `AdminSettingsFormComponent` and will benefit from the general approved form container for admin setting pages
- applied for wp types general settings and wp types subject generation