### PR TITLE
Revert "Make recurring meeting specs work reliably"

### DIFF
--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe RecurringMeetings::UpdateService, "integration", freeze_time: Time.zone.today + 12.hours, type: :model do
+RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
   shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
   shared_let(:user) do
     create(:user, member_with_permissions: { project => %i(view_meetings edit_meetings) })


### PR DESCRIPTION
This reverts commit 66a8d0fba3aea0de540c59ef1389cb2ff6bb9faf.

That commit tried to make tests more stable by freezing the time, however the freezing just led to tests failing _after_ the frozen time, because real time leaked into the tests via the database (e.g. updated_at of ActiveRecord is set by the database), which didn't know that time was frozen to an imaginary value. This caused different errors (e.g. making SQL queries with time ranges that ended before they started).

This revert will cause tests to fail tomorrow **before 10:00** again.