### PR TITLE
[#62523] Work package datepicker incorrectly renders turbo frame response

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -32,6 +32,9 @@ module WorkPackages
   module DatePicker
     class DateFormComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
+
+      FOCUSED_CLASS = "op-datepicker-modal--date-field_current"
+
       attr_reader :work_package
 
       def initialize(work_package:,
@@ -78,7 +81,7 @@ module WorkPackages
           disabled: disabled?(name),
           label:,
           show_clear_button: show_clear_button?(name),
-          classes: "op-datepicker-modal--date-field #{'op-datepicker-modal--date-field_current' if @focused_field == name}",
+          classes: "op-datepicker-modal--date-field #{FOCUSED_CLASS if focused?(name)}",
           validation_message: validation_message(name),
           type: field_type(name),
           placeholder: placeholder(name)
@@ -165,6 +168,10 @@ module WorkPackages
         @disabled
       end
 
+      def focused?(name)
+        @focused_field == name && !disabled?(name)
+      end
+
       def field_value(name)
         errors = @work_package.errors.where(name)
         if (user_value = errors.map { |error| error.options[:value] }.find { !it.nil? })
@@ -206,7 +213,7 @@ module WorkPackages
                          "focus->work-packages--date-picker--preview#onHighlightField",
                  test_selector: "op-datepicker-modal--#{name.to_s.dasherize}-field" }
 
-        if @focused_field == name && !disabled?(name)
+        if focused?(name)
           data[:qa_highlighted] = "true"
           data[:focus] = "true"
         end

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -217,7 +217,7 @@ module WorkPackages
       def single_date_field_button_link(focused_field)
         permitted_params = params.merge(date_mode: "range", focused_field:).permit!
 
-        if params[:action] == "new"
+        if params[:action].in?(["new", "create"])
           new_date_picker_path(permitted_params)
         else
           work_package_date_picker_path(permitted_params)

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -224,10 +224,10 @@ module WorkPackages
       def single_date_field_button_link(focused_field)
         permitted_params = params.merge(date_mode: "range", focused_field:).permit!
 
-        if params[:action].in?(["new", "create"])
-          new_date_picker_path(permitted_params)
+        if work_package.new_record?
+          preview_date_picker_path(permitted_params)
         else
-          work_package_date_picker_path(permitted_params)
+          preview_work_package_date_picker_path(work_package, permitted_params)
         end
       end
 

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -1,6 +1,6 @@
 <live-region></live-region>
-<% if @live_region_message %>
-  <%= render OpTurbo::StreamComponent.new(action: :liveRegion, message: @live_region_message, politeness: "polite", delay: "500", target: nil) %>
+<% if live_region_message %>
+  <%= render OpTurbo::StreamComponent.new(action: :liveRegion, message: live_region_message, politeness: "polite", delay: "500", target: nil) %>
 <% end %>
 <%=
   component_wrapper(

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -1,108 +1,104 @@
+<live-region></live-region>
+<% if @live_region_message %>
+  <%= render OpTurbo::StreamComponent.new(action: :liveRegion, message: @live_region_message, politeness: "polite", delay: "500", target: nil) %>
+<% end %>
 <%=
-  content_tag("turbo-frame", id: "wp-datepicker-dialog--content") do
-%>
-  <live-region></live-region>
-  <% if @live_region_message %>
-    <%= render OpTurbo::StreamComponent.new(action: :liveRegion, message: @live_region_message, politeness: "polite", delay: "500", target: nil) %>
-  <% end %>
-  <%=
-    component_wrapper(
-      data: { controller: "work-packages--date-picker--preview",
-              "work-packages--date-picker--preview-date-mode-value": date_mode,
-              "work-packages--date-picker--preview-triggering-field-value": triggering_field,
-              "work-packages--date-picker--preview-schedule-manually-value": schedule_manually,
-              test_selector: "op-datepicker-modal" },
-      class: "wp-datepicker-dialog--content"
-    ) do
-      component_collection do |collection|
-        if show_banner?
-          collection.with_component(WorkPackages::DatePicker::BannerComponent.new(work_package:, manually_scheduled: schedule_manually))
-        end
+  component_wrapper(
+    data: { controller: "work-packages--date-picker--preview",
+            "work-packages--date-picker--preview-date-mode-value": date_mode,
+            "work-packages--date-picker--preview-triggering-field-value": triggering_field,
+            "work-packages--date-picker--preview-schedule-manually-value": schedule_manually,
+            test_selector: "op-datepicker-modal" },
+    class: "wp-datepicker-dialog--content"
+  ) do
+    component_collection do |collection|
+      if show_banner?
+        collection.with_component(WorkPackages::DatePicker::BannerComponent.new(work_package:, manually_scheduled: schedule_manually))
+      end
 
-        collection.with_component(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
-          render(
-            Primer::Alpha::UnderlinePanels.new(
-              "aria-label": I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
-              label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
-              classes: "wp-datepicker-dialog--UnderlineNav",
-              px: 3
-            )
-          ) do |component|
-            component.with_tab(selected: true, id: "wp-datepicker-dialog--content-tab--dates") do |tab|
-              tab.with_text { I18n.t("work_packages.datepicker_modal.tabs.dates") }
-              tab.with_panel(m: 3) do
-                render(
-                  WorkPackages::DatePicker::FormComponent.new(
-                    form_id: DIALOG_FORM_ID,
-                    show_date_form: can_set_dates?,
-                    work_package:,
-                    schedule_manually:,
-                    focused_field:,
-                    triggering_field:,
-                    touched_field_map:,
-                    date_mode:
-                  )
+      collection.with_component(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
+        render(
+          Primer::Alpha::UnderlinePanels.new(
+            "aria-label": I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
+            label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
+            classes: "wp-datepicker-dialog--UnderlineNav",
+            px: 3
+          )
+        ) do |component|
+          component.with_tab(selected: true, id: "wp-datepicker-dialog--content-tab--dates") do |tab|
+            tab.with_text { I18n.t("work_packages.datepicker_modal.tabs.dates") }
+            tab.with_panel(m: 3) do
+              render(
+                WorkPackages::DatePicker::FormComponent.new(
+                  form_id: DIALOG_FORM_ID,
+                  show_date_form: can_set_dates?,
+                  work_package:,
+                  schedule_manually:,
+                  focused_field:,
+                  triggering_field:,
+                  touched_field_map:,
+                  date_mode:
                 )
-              end
+              )
             end
+          end
 
-            additional_tabs.each do |tab|
-              component.with_tab(id: "wp-datepicker-dialog--content-tab--#{tab.key}") do |tab_content|
-                relation_group = tab.relation_group
-                tab_content.with_text { I18n.t("work_packages.datepicker_modal.tabs.#{tab.key}") }
-                tab_content.with_counter(count: relation_group.count)
-                tab_content.with_panel(m: 3, classes: "wp-datepicker-dialog--content-tab--relation-tab") do
-                  if relation_group.any?
-                    render(border_box_container(padding: :condensed)) do |box|
-                      relation_group.all_relation_items.each do |relation_item|
-                        box.with_row(scheme: :default) do
-                          render(
-                            WorkPackageRelationsTab::RelationComponent.new(
-                              relation_item:,
-                              editable: false
-                            )
+          additional_tabs.each do |tab|
+            component.with_tab(id: "wp-datepicker-dialog--content-tab--#{tab.key}") do |tab_content|
+              relation_group = tab.relation_group
+              tab_content.with_text { I18n.t("work_packages.datepicker_modal.tabs.#{tab.key}") }
+              tab_content.with_counter(count: relation_group.count)
+              tab_content.with_panel(m: 3, classes: "wp-datepicker-dialog--content-tab--relation-tab") do
+                if relation_group.any?
+                  render(border_box_container(padding: :condensed)) do |box|
+                    relation_group.all_relation_items.each do |relation_item|
+                      box.with_row(scheme: :default) do
+                        render(
+                          WorkPackageRelationsTab::RelationComponent.new(
+                            relation_item:,
+                            editable: false
                           )
-                        end
+                        )
                       end
                     end
-                  else
-                    render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
-                      blankslate.with_visual_icon(icon: :book, size: :medium)
-                      blankslate.with_heading(tag: :h2) { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.title") }
-                      blankslate.with_description { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.description") }
-                    end
+                  end
+                else
+                  render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
+                    blankslate.with_visual_icon(icon: :book, size: :medium)
+                    blankslate.with_heading(tag: :h2) { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.title") }
+                    blankslate.with_description { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.description") }
                   end
                 end
               end
             end
           end
         end
+      end
 
-        collection.with_component(Primer::Alpha::Dialog::Footer.new) do
-          component_collection do |footer|
-            footer.with_component(
-              Primer::Beta::Button.new(
-                data: { action: "work-packages--date-picker--preview#cancel" },
-                test_selector: "op-datepicker-modal--action"
-              )
-            ) do
-              I18n.t("button_cancel")
-            end
+      collection.with_component(Primer::Alpha::Dialog::Footer.new) do
+        component_collection do |footer|
+          footer.with_component(
+            Primer::Beta::Button.new(
+              data: { action: "work-packages--date-picker--preview#cancel" },
+              test_selector: "op-datepicker-modal--action"
+            )
+          ) do
+            I18n.t("button_cancel")
+          end
 
-            footer.with_component(
-              Primer::Beta::Button.new(
-                scheme: :primary,
-                type: :submit,
-                form: DIALOG_FORM_ID,
-                test_selector: "op-datepicker-modal--action",
-                disabled: !can_set_dates?
-              )
-            ) do
-              I18n.t("button_save")
-            end
+          footer.with_component(
+            Primer::Beta::Button.new(
+              scheme: :primary,
+              type: :submit,
+              form: DIALOG_FORM_ID,
+              test_selector: "op-datepicker-modal--action",
+              disabled: !can_set_dates?
+            )
+          ) do
+            I18n.t("button_save")
           end
         end
       end
     end
-  %>
-<% end %>
+  end
+%>

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -1,5 +1,5 @@
 <live-region></live-region>
-<% if live_region_message %>
+<% if preview && live_region_message %>
   <%= render OpTurbo::StreamComponent.new(action: :liveRegion, message: live_region_message, politeness: "polite", delay: "500", target: nil) %>
 <% end %>
 <%=

--- a/app/components/work_packages/date_picker/dialog_content_component.rb
+++ b/app/components/work_packages/date_picker/dialog_content_component.rb
@@ -39,14 +39,15 @@ module WorkPackages
       # Used for the three tabs for predecessors, successors and children in the date picker modal.
       Tab = Data.define(:key, :relation_group)
 
-      attr_reader :work_package, :schedule_manually, :focused_field, :triggering_field, :touched_field_map, :date_mode
+      attr_reader :work_package, :schedule_manually, :focused_field, :triggering_field, :touched_field_map, :date_mode, :preview
 
       def initialize(work_package:,
                      schedule_manually: true,
                      focused_field: :start_date,
                      triggering_field: nil,
                      touched_field_map: {},
-                     date_mode: nil)
+                     date_mode: nil,
+                     preview: false)
         super
 
         @work_package = work_package
@@ -55,6 +56,7 @@ module WorkPackages
         @triggering_field = triggering_field
         @touched_field_map = touched_field_map
         @date_mode = date_mode
+        @preview = preview
       end
 
       private

--- a/app/components/work_packages/date_picker/dialog_content_component.rb
+++ b/app/components/work_packages/date_picker/dialog_content_component.rb
@@ -46,7 +46,6 @@ module WorkPackages
                      focused_field: :start_date,
                      triggering_field: nil,
                      touched_field_map: {},
-                     live_region_message: "",
                      date_mode: nil)
         super
 
@@ -56,10 +55,56 @@ module WorkPackages
         @triggering_field = triggering_field
         @touched_field_map = touched_field_map
         @date_mode = date_mode
-        @live_region_message = live_region_message
       end
 
       private
+
+      def live_region_message
+        message_parts = [
+          scheduling_mode_message,
+          working_days_message,
+          *date_message_parts
+        ]
+
+        I18n.t(
+          "work_packages.datepicker_modal.update_inputs_aria_live_message",
+          message: message_parts.join(", ")
+        )
+      end
+
+      def scheduling_mode_message
+        mode_key = work_package.schedule_manually ? "manual" : "automatic"
+        mode = I18n.t("work_packages.datepicker_modal.mode.#{mode_key}")
+        "#{I18n.t('work_packages.datepicker_modal.mode.title')}: #{mode}"
+      end
+
+      def working_days_message
+        include_non_working = !!work_package.ignore_non_working_days
+        I18n.t("activerecord.attributes.work_package.include_non_working_days.#{include_non_working}")
+      end
+
+      def date_message_parts
+        [].tap do |parts|
+          parts << start_date_message if work_package.start_date.present?
+          parts << finish_date_message if work_package.due_date.present?
+          parts << duration_message if work_package.duration.present?
+        end
+      end
+
+      def start_date_message
+        "#{WorkPackage.human_attribute_name(:start_date)}: #{work_package.start_date}"
+      end
+
+      def finish_date_message
+        "#{WorkPackage.human_attribute_name(:due_date)}: #{work_package.due_date}"
+      end
+
+      def duration_message
+        [
+          WorkPackage.human_attribute_name(:duration),
+          I18n.t("datetime.distance_in_words.x_days", count: work_package.duration)
+        ].join(": ")
+      end
 
       def schedule_manually?
         @schedule_manually

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -23,7 +23,6 @@
                     icon: :pin,
                     href: dialog_content_with(schedule_manually: true),
                     data: {
-                      turbo_stream: true,
                       qa_selected: schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_manual",
@@ -35,7 +34,6 @@
                     icon: "op-auto-date",
                     href: dialog_content_with(schedule_manually: false),
                     data: {
-                      turbo_stream: true,
                       qa_selected: !schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_automatic",

--- a/app/components/work_packages/date_picker/form_component.rb
+++ b/app/components/work_packages/date_picker/form_component.rb
@@ -74,9 +74,9 @@ module WorkPackages
                               .merge(schedule_manually:)
                               .permit!
         if work_package.new_record?
-          new_date_picker_path(dialog_params)
+          preview_date_picker_path(dialog_params)
         else
-          work_package_date_picker_path(work_package, dialog_params)
+          preview_work_package_date_picker_path(work_package, dialog_params)
         end
       end
 

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -29,8 +29,6 @@
 # ++
 
 class WorkPackages::DatePickerController < ApplicationController
-  include OpTurbo::ComponentStream
-
   ERROR_PRONE_ATTRIBUTES = %i[start_date
                               due_date
                               duration].freeze

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -45,20 +45,9 @@ class WorkPackages::DatePickerController < ApplicationController
   def show
     set_date_attributes_to_work_package
 
-    respond_to do |format|
-      format.html do
-        render :show,
-               locals: { work_package:, schedule_manually:, focused_field:, params: params.merge(date_mode: date_mode).permit! },
-               layout: false
-      end
-
-      format.turbo_stream do
-        replace_via_turbo_stream(
-          component: datepicker_modal_component
-        )
-        render turbo_stream: turbo_streams
-      end
-    end
+    render :show,
+           locals: { work_package:, schedule_manually:, focused_field:, params: params.merge(date_mode: date_mode).permit! },
+           layout: false
   end
 
   def new
@@ -80,21 +69,8 @@ class WorkPackages::DatePickerController < ApplicationController
 
   def edit
     set_date_attributes_to_work_package
-
-    respond_to do |format|
-      format.turbo_stream do
-        replace_via_turbo_stream(
-          component: datepicker_modal_component
-        )
-        render turbo_stream: turbo_streams
-      end
-      # TODO: preserve context for selecting start and end date on the datepicker.
-      format.html do
-        render :show,
-               locals: { work_package:, schedule_manually:, focused_field:, params: params.merge(date_mode: date_mode).permit! },
-               layout: false
-      end
-    end
+    render :show,
+           locals: { work_package:, schedule_manually:, focused_field:, params: params.merge(date_mode: date_mode).permit! }
   end
 
   def create
@@ -104,17 +80,7 @@ class WorkPackages::DatePickerController < ApplicationController
     if service_call.errors
                    .map(&:attribute)
                    .intersect?(ERROR_PRONE_ATTRIBUTES)
-      respond_to do |format|
-        format.turbo_stream do
-          # Bundle 422 status code into stream response so
-          # Angular has context as to the success or failure of
-          # the request in order to fetch the new set of Work Package
-          # attributes in the ancestry solely on success.
-          render turbo_stream: [
-            turbo_stream.morph("wp-datepicker-dialog--content", datepicker_modal_component)
-          ], status: :unprocessable_entity
-        end
-      end
+      render datepicker_modal_component, status: :unprocessable_entity
     else
       render json: {
         startDate: @work_package.start_date,

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -108,8 +108,7 @@ class WorkPackages::DatePickerController < ApplicationController
              touched_field_map:,
              date_mode:
            },
-           status:,
-           layout: false
+           status:
   end
 
   def focused_field

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -106,36 +106,10 @@ class WorkPackages::DatePickerController < ApplicationController
              schedule_manually:,
              focused_field:,
              touched_field_map:,
-             date_mode:,
-             live_region_message:
+             date_mode:
            },
            status:,
            layout: false
-  end
-
-  def live_region_message
-    message_parts = [
-      "Scheduling mode: #{scheduling_label}",
-      working_days_label
-    ]
-
-    message_parts << "Start date: #{@work_package.start_date}" if @work_package.start_date.present?
-    message_parts << "Finish date: #{@work_package.due_date}" if @work_package.due_date.present?
-    message_parts << "Duration: #{@work_package.duration} days" if @work_package.duration.present?
-
-    I18n.t(
-      "work_packages.datepicker_modal.update_inputs_aria_live_message",
-      message: message_parts.join(", ")
-    )
-  end
-
-  def working_days_label
-    I18n.t("activerecord.attributes.work_package.include_non_working_days.#{@work_package.ignore_non_working_days || false}")
-  end
-
-  def scheduling_label
-    mode = @work_package.schedule_manually ? "manual" : "automatic"
-    I18n.t("work_packages.datepicker_modal.mode.#{mode}")
   end
 
   def focused_field

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -35,8 +35,8 @@ class WorkPackages::DatePickerController < ApplicationController
 
   layout false
 
-  before_action :find_work_package, except: %i[new create]
-  authorization_checked! :show, :update, :edit, :new, :create
+  before_action :find_work_package, except: %i[new create preview]
+  authorization_checked! :show, :preview, :update, :edit, :new, :create
 
   attr_accessor :work_package
 
@@ -54,6 +54,17 @@ class WorkPackages::DatePickerController < ApplicationController
   def edit
     set_date_attributes_to_work_package
     render_form
+  end
+
+  def preview
+    if params[:work_package_id]
+      find_work_package
+    else
+      make_fake_initial_work_package
+    end
+
+    set_date_attributes_to_work_package
+    render_form(preview: true)
   end
 
   def create
@@ -97,14 +108,15 @@ class WorkPackages::DatePickerController < ApplicationController
 
   private
 
-  def render_form(status: :ok)
+  def render_form(status: :ok, preview: false)
     render :show,
            locals: {
              work_package:,
              schedule_manually:,
              focused_field:,
              touched_field_map:,
-             date_mode:
+             date_mode:,
+             preview:
            },
            status:
   end

--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -35,7 +35,7 @@ class WorkPackages::ProgressController < ApplicationController
                               done_ratio].freeze
 
   layout false
-  authorization_checked! :new, :edit, :create, :update
+  authorization_checked! :new, :edit, :preview, :create, :update
 
   def new
     make_fake_initial_work_package
@@ -48,6 +48,17 @@ class WorkPackages::ProgressController < ApplicationController
     find_work_package
     set_progress_attributes_to_work_package
 
+    render progress_modal_component
+  end
+
+  def preview
+    if params[:work_package_id]
+      find_work_package
+    else
+      make_fake_initial_work_package
+    end
+
+    set_progress_attributes_to_work_package
     render progress_modal_component
   end
 

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -1,11 +1,13 @@
 <%=
-  render(
-    WorkPackages::DatePicker::DialogContentComponent.new(
-      work_package:,
-      schedule_manually:,
-      focused_field:,
-      triggering_field: params[:field].underscore.to_sym,
-      date_mode: params[:date_mode]
+  content_tag("turbo-frame", id: "wp-datepicker-dialog--content") do
+    render(
+      WorkPackages::DatePicker::DialogContentComponent.new(
+        work_package:,
+        schedule_manually:,
+        focused_field:,
+        triggering_field: params[:field].underscore.to_sym,
+        date_mode: params[:date_mode]
+      )
     )
-  )
+  end
 %>

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -7,8 +7,7 @@
         focused_field:,
         triggering_field: params[:triggering_field] || params[:field]&.underscore&.to_sym,
         touched_field_map:,
-        date_mode:,
-        live_region_message:
+        date_mode:
       )
     )
   end

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -1,5 +1,5 @@
 <%=
-  content_tag("turbo-frame", id: "wp-datepicker-dialog--content", refresh: :morph) do
+  content_tag("turbo-frame", id: "wp-datepicker-dialog--content") do
     render(
       WorkPackages::DatePicker::DialogContentComponent.new(
         work_package:,

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -5,8 +5,10 @@
         work_package:,
         schedule_manually:,
         focused_field:,
-        triggering_field: params[:field]&.underscore&.to_sym,
-        date_mode: params[:date_mode]
+        triggering_field: params[:triggering_field] || params[:field]&.underscore&.to_sym,
+        touched_field_map:,
+        date_mode:,
+        live_region_message:
       )
     )
   end

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -1,11 +1,11 @@
 <%=
-  content_tag("turbo-frame", id: "wp-datepicker-dialog--content") do
+  content_tag("turbo-frame", id: "wp-datepicker-dialog--content", refresh: :morph) do
     render(
       WorkPackages::DatePicker::DialogContentComponent.new(
         work_package:,
         schedule_manually:,
         focused_field:,
-        triggering_field: params[:field].underscore.to_sym,
+        triggering_field: params[:field]&.underscore&.to_sym,
         date_mode: params[:date_mode]
       )
     )

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -7,7 +7,8 @@
         focused_field:,
         triggering_field: params[:triggering_field] || params[:field]&.underscore&.to_sym,
         touched_field_map:,
-        date_mode:
+        date_mode:,
+        preview:
       )
     )
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -691,23 +691,32 @@ Rails.application.routes.draw do
 
     resources :hierarchy_relations, only: %i[new create destroy], controller: "work_package_hierarchy_relations"
 
-    resource :progress, only: %i[edit update], controller: "work_packages/progress"
+    resource :progress, only: %i[edit update], controller: "work_packages/progress" do
+      get :preview, on: :member
+    end
     collection do
       resource :progress,
                only: %i[create new],
                controller: "work_packages/progress",
-               as: :work_package_progress
+               as: :work_package_progress do
+        get :preview, on: :collection
+      end
     end
 
     resource :date_picker,
              only: %i[show edit update],
              controller: "work_packages/date_picker",
-             as: "date_picker"
+             as: "date_picker" do
+      get :preview, on: :member
+    end
+
     collection do
       resource :date_picker,
                only: %i[create new],
                controller: "work_packages/date_picker",
-               as: "date_picker"
+               as: "date_picker" do
+        get :preview, on: :collection
+      end
     end
 
     resources :relations_tab, only: %i[index], controller: "work_package_relations_tab"

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -309,7 +309,10 @@ export default class PreviewController extends DialogPreviewController {
     this.updateFlatpickrCalendar();
   }
 
-  afterRendering() {
+  afterRendering(params:{ shouldFocusBanner?:boolean }) {
+    if (params.shouldFocusBanner) {
+      this.focusOnOpen();
+    }
     this.readCurrentValues();
     this.updateFlatpickrCalendar();
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -74,8 +74,8 @@ export abstract class DialogPreviewController extends Controller {
     // caption and validation message unaccessible for screen readers and other
     // assistive technologies. This is why morph cannot be used here.
     this.frameMorphRenderer = (event:CustomEvent<TurboBeforeFrameRenderEventDetail>) => {
-      const oldFrame = event.srcElement as HTMLTurboFrameElement;
-      const requestUrl = new URL(oldFrame.src || '');
+      const target = event.target as HTMLTurboFrameElement;
+      const requestUrl = new URL(target.src || '', window.location.origin);
       // Do not replace the angular datepicker unless the schedule_manually flag is changed.
       const replaceAngularTags = requestUrl.searchParams.has('schedule_manually');
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -146,8 +146,7 @@ export abstract class DialogPreviewController extends Controller {
       });
     }
 
-    const wpAction = this.isUpdatingWorkPackage(form.action) ? 'edit' : 'new';
-    const previewUrl = `${form.action}/${wpAction}?${new URLSearchParams(wpParams).toString()}`;
+    const previewUrl = `${form.action}/preview?${new URLSearchParams(wpParams).toString()}`;
     const turboFrame = this.formTarget.closest('turbo-frame') as HTMLTurboFrameElement;
 
     if (turboFrame) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -78,9 +78,14 @@ export abstract class DialogPreviewController extends Controller {
         Idiomorph.morph(currentElement, newElement, {
           ignoreActiveValue: this.ignoreActiveValueWhenMorphing(),
           callbacks: {
-            beforeNodeMorphed: (oldNode:Element) => {
-              // In case the element is an OpenProject custom dom element, morphing is prevented.
-              return !oldNode.tagName?.startsWith('OPCE-');
+            beforeNodeMorphed: (oldNode:Element, newNode:Element) => {
+              // In case the element is an OpenProject custom dom element, prevent morphing and
+              // replace the angular tag with the new version.
+              if (oldNode.tagName?.startsWith('OPCE-')) {
+                oldNode.replaceWith(newNode);
+                return false;
+              }
+              return true;
             },
           },
         });

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -74,6 +74,11 @@ export abstract class DialogPreviewController extends Controller {
     // caption and validation message unaccessible for screen readers and other
     // assistive technologies. This is why morph cannot be used here.
     this.frameMorphRenderer = (event:CustomEvent<TurboBeforeFrameRenderEventDetail>) => {
+      const oldFrame = event.srcElement as HTMLTurboFrameElement;
+      const requestUrl = new URL(oldFrame.src || '');
+      // Do not replace the angular datepicker unless the schedule_manually flag is changed.
+      const replaceAngularTags = requestUrl.searchParams.has('schedule_manually');
+
       event.detail.render = (currentElement:HTMLElement, newElement:HTMLElement) => {
         Idiomorph.morph(currentElement, newElement, {
           ignoreActiveValue: this.ignoreActiveValueWhenMorphing(),
@@ -82,7 +87,9 @@ export abstract class DialogPreviewController extends Controller {
               // In case the element is an OpenProject custom dom element, prevent morphing and
               // replace the angular tag with the new version.
               if (oldNode.tagName?.startsWith('OPCE-')) {
-                oldNode.replaceWith(newNode);
+                if (replaceAngularTags) {
+                  oldNode.replaceWith(newNode);
+                }
                 return false;
               }
               return true;

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -77,7 +77,7 @@ export abstract class DialogPreviewController extends Controller {
       const target = event.target as HTMLTurboFrameElement;
       const requestUrl = new URL(target.src || '', window.location.origin);
       // Do not replace the angular datepicker unless the schedule_manually flag is changed.
-      const replaceAngularTags = requestUrl.searchParams.has('schedule_manually');
+      const schedulingChanged = requestUrl.searchParams.has('schedule_manually');
 
       event.detail.render = (currentElement:HTMLElement, newElement:HTMLElement) => {
         Idiomorph.morph(currentElement, newElement, {
@@ -87,7 +87,7 @@ export abstract class DialogPreviewController extends Controller {
               // In case the element is an OpenProject custom dom element, prevent morphing and
               // replace the angular tag with the new version.
               if (oldNode.tagName?.startsWith('OPCE-')) {
-                if (replaceAngularTags) {
+                if (schedulingChanged) {
                   oldNode.replaceWith(newNode);
                 }
                 return false;
@@ -96,7 +96,7 @@ export abstract class DialogPreviewController extends Controller {
             },
           },
         });
-        this.afterRendering();
+        this.afterRendering({ shouldFocusBanner: schedulingChanged });
       };
     };
 
@@ -170,7 +170,7 @@ export abstract class DialogPreviewController extends Controller {
     }
   }
 
-  abstract afterRendering():void;
+  abstract afterRendering(params?:object):void;
 
   // Whether to ignore the active element value when morphing.
   abstract ignoreActiveValueWhenMorphing():boolean;

--- a/spec/controllers/work_packages/date_picker_controller_spec.rb
+++ b/spec/controllers/work_packages/date_picker_controller_spec.rb
@@ -204,6 +204,8 @@ RSpec.describe WorkPackages::DatePickerController do
         )
       end
 
+      render_views
+
       it "includes the live region turbo-stream with the correct message and attributes" do
         get("new", params: params_after_changing_start_date)
 

--- a/spec/controllers/work_packages/date_picker_controller_spec.rb
+++ b/spec/controllers/work_packages/date_picker_controller_spec.rb
@@ -53,6 +53,37 @@ RSpec.describe WorkPackages::DatePickerController do
     work_package.errors.group_by_attribute.slice(:start_date, :due_date, :duration)
   end
 
+  # the parameters used to re-render the date picker after changing values is
+  # enriched by the stimulus preview controller. Here nothing is changed yet,
+  # each test uses this as a basis to update the values.
+  # captured on 2025-04-17.
+  let(:params_after_changing_values) do
+    {
+      "field" => "work_package[due_date]",
+      "date_mode" => "single",
+      "triggering_field" => "",
+      "work_package" => {
+        "start_date" => "",
+        "due_date" => "2025-04-18",
+        "duration" => "",
+        "ignore_non_working_days" => "0",
+        "schedule_manually" => "true",
+        "initial" => {
+          "start_date" => "",
+          "due_date" => "2025-04-18",
+          "duration" => "",
+          "ignore_non_working_days" => "false",
+          "schedule_manually" => "true"
+        },
+        "start_date_touched" => "false",
+        "due_date_touched" => "false",
+        "duration_touched" => "false",
+        "ignore_non_working_days_touched" => "false",
+        "schedule_manually_touched" => "false"
+      }
+    }
+  end
+
   describe "GET /work_packages/date_picker/new" do
     # the parameters as they are sent when the date picker is opened again
     # from the new work package page after a due date has been entered.
@@ -73,39 +104,13 @@ RSpec.describe WorkPackages::DatePickerController do
         }
       }
     end
-    # the parameters used to re-render the date picker after changing values is
-    # enriched by the stimulus preview controller. Here nothing is changed yet,
-    # each test uses this as a basis to update the values.
-    # captured on 2025-04-17.
-    let(:params_after_changing_values) do
-      {
-        "field" => "work_package[due_date]",
-        "date_mode" => "single",
-        "triggering_field" => "",
-        "work_package" => {
-          "start_date" => "",
-          "due_date" => "2025-04-18",
-          "duration" => "",
-          "ignore_non_working_days" => "0",
-          "schedule_manually" => "true",
-          "initial" => {
-            "start_date" => "",
-            "due_date" => "2025-04-18",
-            "duration" => "",
-            "ignore_non_working_days" => "false",
-            "schedule_manually" => "true"
-          },
-          "start_date_touched" => "false",
-          "due_date_touched" => "false",
-          "duration_touched" => "false",
-          "ignore_non_working_days_touched" => "false",
-          "schedule_manually_touched" => "false"
-        }
-      }
-    end
+
+    let(:params) { params_from_first_display_of_date_picker }
+
+    subject { get("new", params:) }
 
     it "assigns work package initialized with initial values" do
-      get("new", params: params_from_first_display_of_date_picker)
+      subject
 
       assigned_work_package = assigns(:work_package)
       expect(assigned_work_package).to be_new_record
@@ -118,7 +123,41 @@ RSpec.describe WorkPackages::DatePickerController do
     end
 
     context "when values for untouched fields are received (like derived values)" do
-      let(:params_with_due_date_value_but_untouched) do
+      let(:params) do
+        params_after_changing_values.deep_merge(
+          "work_package" => {
+            "start_date" => "2025-01-01",
+            "start_date_touched" => "false",
+            "due_date" => "2025-04-21",
+            "due_date_touched" => "false"
+          }
+        )
+      end
+
+      render_views
+
+      it "keeps the initial value for untouched fields in the assigned work package" do
+        subject
+
+        assigned_work_package = assigns(:work_package)
+        # initial values are used for untouched fields
+        expect(assigned_work_package.start_date).to be_nil
+        expect(assigned_work_package.due_date).to eq(Date.parse("2025-04-18"))
+      end
+
+      it "does not include the live region turbo-stream" do
+        subject
+
+        expect(response.body).not_to include('<turbo-stream action="liveRegion"')
+      end
+    end
+  end
+
+  describe "GET /work_packages/date_picker/preview" do
+    subject { get("preview", params:) }
+
+    context "when values for untouched fields are received (like derived values)" do
+      let(:params) do
         params_after_changing_values.deep_merge(
           "work_package" => {
             "start_date" => "2025-01-01",
@@ -130,8 +169,7 @@ RSpec.describe WorkPackages::DatePickerController do
       end
 
       it "keeps the initial value for untouched fields in the assigned work package" do
-        get("new", params: params_with_due_date_value_but_untouched)
-
+        subject
         assigned_work_package = assigns(:work_package)
         # initial values are used for untouched fields
         expect(assigned_work_package.start_date).to be_nil
@@ -140,7 +178,7 @@ RSpec.describe WorkPackages::DatePickerController do
     end
 
     context "when the user edits the dates" do
-      let(:params_after_editing_due_date) do
+      let(:params) do
         params_after_changing_values.deep_merge(
           "work_package" => {
             "start_date" => "2025-04-14",
@@ -152,7 +190,7 @@ RSpec.describe WorkPackages::DatePickerController do
       end
 
       it "assigns work package updated with touched and derived values" do
-        get("new", params: params_after_editing_due_date)
+        subject
 
         assigned_work_package = assigns(:work_package)
         expect(assigned_work_package).to be_new_record
@@ -168,7 +206,7 @@ RSpec.describe WorkPackages::DatePickerController do
         end
 
         it "displays read-only errors" do
-          get("new", params: params_after_editing_due_date)
+          subject
 
           assigned_work_package = assigns(:work_package)
           expect(date_errors(assigned_work_package)).to match(
@@ -184,7 +222,7 @@ RSpec.describe WorkPackages::DatePickerController do
         end
 
         it "does not display any errors" do
-          get("new", params: params_after_editing_due_date)
+          subject
 
           assigned_work_package = assigns(:work_package)
           expect(date_errors(assigned_work_package)).to be_empty
@@ -193,7 +231,7 @@ RSpec.describe WorkPackages::DatePickerController do
     end
 
     context "when changing the start date" do
-      let(:params_after_changing_start_date) do
+      let(:params) do
         params_after_changing_values.deep_merge(
           "work_package" => {
             "start_date" => "2025-04-15",
@@ -207,7 +245,7 @@ RSpec.describe WorkPackages::DatePickerController do
       render_views
 
       it "includes the live region turbo-stream with the correct message and attributes" do
-        get("new", params: params_after_changing_start_date)
+        subject
 
         expect(response.body).to include('<turbo-stream action="liveRegion"')
         expect(response.body).to include('politeness="polite"')

--- a/spec/features/a11y/work_packages/datepicker_spec.rb
+++ b/spec/features/a11y/work_packages/datepicker_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Datepicker accessibility", :js do
+  let(:project) { create(:project, types: [type]) }
+  let(:type) { create(:type) }
+
+  let(:user) { create(:user, member_with_roles: { project => role }) }
+
+  let!(:parent) do
+    create(:work_package,
+           project:,
+           type:,
+           subject: "Parent",
+           schedule_manually: false)
+  end
+
+  let!(:child) do
+    create(:work_package,
+           project:,
+           parent:,
+           type:,
+           subject: "Child")
+  end
+
+  let!(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let!(:query) do
+    query = build(:query, user:, project:)
+    query.column_names = %w(subject start_date due_date)
+    query.filters.clear
+    query.show_hierarchies = false
+
+    query.save!
+    query
+  end
+  let(:start_date_field) { wp_table.edit_field(parent, :startDate) }
+  let(:due_date_field) { wp_table.edit_field(parent, :dueDate) }
+  let(:datepicker) { start_date_field.datepicker }
+
+  before do
+    login_as(user)
+
+    wp_table.visit_query query
+    wp_table.expect_work_package_listed parent, child
+  end
+
+  context "with a user allowed to edit dates" do
+    let(:role) { create(:project_role, permissions: %i[view_work_packages edit_work_packages]) }
+
+    it "is accessible" do
+      # Open start date
+      start_date_field.activate!
+      datepicker.expect_visible
+
+      # Expect automatic scheduling
+      datepicker.expect_automatic_scheduling_mode
+
+      # Toggle to manual scheduling mode
+      datepicker.toggle_scheduling_mode_via_keyboard
+
+      # Datepicker banner is focused after switching scheduling to manual mode
+      datepicker.expect_manual_scheduling_mode
+      expect(page).to have_focus_on(".wp-datepicker--banner")
+
+      # Toggle to automatic scheduling mode
+      datepicker.toggle_scheduling_mode_via_keyboard
+
+      # Datepicker banner is focused after switching scheduling to automatic mode
+      datepicker.expect_automatic_scheduling_mode
+      expect(page).to have_focus_on(".wp-datepicker--banner")
+    end
+  end
+end

--- a/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
+++ b/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe "Manual scheduling", :js do
       # Toggle to manual scheduling mode
       datepicker.toggle_scheduling_mode
 
-      # Expect editable in single mode with due date field visible
-      datepicker.expect_add_start_date_button_visible
-      datepicker.expect_due_date ""
+      # Expect editable in single mode with start date field visible
+      datepicker.expect_add_finish_date_button_visible
+      datepicker.expect_start_date ""
       datepicker.expect_cancel_button_enabled
       datepicker.expect_save_button_enabled
 
@@ -99,8 +99,8 @@ RSpec.describe "Manual scheduling", :js do
       datepicker.toggle_scheduling_mode
 
       # Enable start date then set dates
-      datepicker.expect_add_start_date_button_visible
-      datepicker.enable_start_date
+      datepicker.expect_add_finish_date_button_visible
+      datepicker.enable_due_date
       datepicker.set_start_date "2020-07-20"
       datepicker.set_due_date "2020-07-25"
       datepicker.save!

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -104,6 +104,10 @@ module Components
       expect(container).to have_link("Start date")
     end
 
+    def expect_add_finish_date_button_visible
+      expect(container).to have_link("Finish date")
+    end
+
     def enable_due_date
       retry_block do
         page.find_test_selector("wp-datepicker--show-due-date").click

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -178,6 +178,13 @@ module Components
       end
     end
 
+    def toggle_scheduling_mode_via_keyboard
+      page.within_test_selector "op-datepicker-modal--scheduling" do
+        el = page.find('[data-qa-selected="false"]')
+        el.native.send_keys(:enter)
+      end
+    end
+
     def click_manual_scheduling_mode
       container.click_link I18n.t("work_packages.datepicker_modal.mode.manual")
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62523

# What are you trying to accomplish?
The calendar Turbo Frame rendering is buggy and bloats the DOM when switching between automatic and manual mode. This occurs because the response updates an element inside the Turbo Frame instead of replacing the frame itself, leading to deeply nested frames. To reproduce, toggle between modes several times—each render adds a new Turbo Frame inside the previous one.

It additionally fixed some focus issues which are documented here: https://community.openproject.org/wp/65236

## Screenshots
<img width="920" alt="image" src="https://github.com/user-attachments/assets/4dc1d926-ed04-484c-b548-a14919083fe4" />


# What approach did you choose and why?
- Use a plain turbo frame response to update turbo frames instead of a turbo stream response, because that is incorrect.
- Move the live region methods out of the datepicker controller and place it in the `WorkPackages::DatePicker::DialogContentComponent`
- Replace datepicker component during the morphing process when the Manual / Automatic switch is being toggled. The replacement will result in a re-initialisation too.
- Do not touch the datepicker component when turbo request does not switch between Manual / Automatic.
- As a future improvement, to avoid flickering, we could initialise the new angular tags in the shadow dom and morph them when they are complete.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
