### PR TITLE
Show proper error message even if fetching origin user id fails

### DIFF
--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -93,7 +93,7 @@ module OAuthClients
     def code_to_token(code)
       # Return a Rack::OAuth2::AccessToken::Bearer or an error string
       service_result = request_new_token(authorization_code: code)
-      return service_result unless service_result.success?
+      return service_result if service_result.failure?
 
       # Check for existing OAuthClientToken and update,
       # or create a new one from Rack::OAuth::AccessToken::Bearer
@@ -116,7 +116,7 @@ module OAuthClients
           oauth_client_token.save!
 
           RemoteIdentities::CreateService
-            .call(user: @user, integration: @oauth_client.integration, token: oauth_client_token)
+            .call(user: @user, integration: @oauth_client.integration, token: oauth_client_token, force_update: true)
             .on_failure do |e|
               id_create_error = e
               raise ActiveRecord::Rollback

--- a/app/services/remote_identities/create_service.rb
+++ b/app/services/remote_identities/create_service.rb
@@ -45,8 +45,8 @@ module RemoteIdentities
     end
 
     def call
-      @model.origin_user_id = @integration.extract_origin_user_id(@token)
-      if @model.changed?
+      if @model.new_record?
+        @model.origin_user_id = @integration.extract_origin_user_id(@token)
         if @model.save
           OpenProject::Notifications.send(
             OpenProject::Events::REMOTE_IDENTITY_CREATED,

--- a/app/services/remote_identities/create_service.rb
+++ b/app/services/remote_identities/create_service.rb
@@ -46,7 +46,10 @@ module RemoteIdentities
 
     def call
       if @model.new_record?
-        @model.origin_user_id = @integration.extract_origin_user_id(@token)
+        user_id = @integration.extract_origin_user_id(@token)
+        return user_id if user_id.failure?
+
+        @model.origin_user_id = user_id.result
         if @model.save
           OpenProject::Notifications.send(
             OpenProject::Events::REMOTE_IDENTITY_CREATED,

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -214,8 +214,12 @@ class ServiceResult
   def message
     if @message
       @message
-    elsif failure? && errors.is_a?(ActiveModel::Errors)
-      errors.full_messages.join(" ")
+    elsif failure?
+      if errors.is_a?(ActiveModel::Errors)
+        errors.full_messages.join(" ")
+      elsif errors.respond_to?(:message)
+        errors.message
+      end
     end
   end
 

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/fetch_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/fetch_service_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe OpenIDConnect::UserTokens::FetchService, :webmock do
                                             refresh_token: "refresh-token-exchanged",
                                             audiences: [aud]))
     end
+    allow(OpenProject::Notifications).to receive(:send)
   end
 
   describe "#access_token_for" do
@@ -67,10 +68,13 @@ RSpec.describe OpenIDConnect::UserTokens::FetchService, :webmock do
     end
 
     it "emits appropriate event" do
-      allow(OpenProject::Notifications)
-        .to receive(:send).with(described_class::TOKEN_OBTAINED_EVENT, token: instance_of(OpenIDConnect::UserToken),
-                                                                       audience: queried_audience).once
-      expect(result.value!).to eq(access_token)
+      result.value!
+
+      expect(OpenProject::Notifications).to have_received(:send).with(
+        described_class::TOKEN_OBTAINED_EVENT,
+        token: instance_of(OpenIDConnect::UserToken),
+        audience: queried_audience
+      ).once
     end
 
     it "does not create RemoteIdentity if storage with appropriate audience is absent" do
@@ -78,23 +82,15 @@ RSpec.describe OpenIDConnect::UserTokens::FetchService, :webmock do
       expect { result }.not_to change(RemoteIdentity, :count)
     end
 
-    context "when storage with appropriate audience is present", :storage_server_helpers, :webmock do
-      it "raises an error if auth source is not present" do
-        storage = create(:nextcloud_storage, storage_audience: existing_audience)
-        stub_nextcloud_user_query(storage.host)
+    context "when OpenProject notification raises an error" do
+      let(:error) { StandardError.new("I am an error") }
 
-        expect { result }.to raise_error("RemoteIdentity creation failed: Auth Source can't be blank.")
+      before do
+        allow(OpenProject::Notifications).to receive(:send).and_raise(error)
       end
 
-      it "creates remote identity if auth source is present" do
-        slug = create(:oidc_provider).slug
-        user.identity_url = "#{slug}:qweqweqweqwe"
-        user.save
-
-        storage = create(:nextcloud_storage, storage_audience: existing_audience)
-        stub_nextcloud_user_query(storage.host)
-
-        expect { result }.to change(RemoteIdentity, :count).from(0).to(1)
+      it "raises the same error" do
+        expect { result }.to raise_error(error)
       end
     end
 

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -233,10 +233,7 @@ module Storages
       ::Storages::Peripherals::Registry
         .resolve("#{self}.queries.user")
         .call(auth_strategy:, storage: self)
-        .match(
-          on_success: ->(user) { user[:id] },
-          on_failure: ->(error) { raise "UserQuery responed with #{error}" }
-        )
+        .map { |user| user[:id] } # rubocop:disable Rails/Pluck
     end
   end
 end

--- a/modules/storages/app/models/storages/storage_error.rb
+++ b/modules/storages/app/models/storages/storage_error.rb
@@ -49,6 +49,10 @@ module Storages
       errors
     end
 
+    def message
+      to_s
+    end
+
     def to_s
       output = code.to_s
       output << " | #{log_message}" unless log_message.nil?

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -145,7 +145,9 @@ module OpenProject::Storages
           if storage
             RemoteIdentities::CreateService
               .call(user: token.user, integration: storage, token:)
-              .on_failure { |failure| raise "RemoteIdentity creation failed: #{failure.message}" }
+              .on_failure do |failure|
+                Rails.logger.error("RemoteIdentity creation for user #{token.user.id} failed: #{failure.message}")
+              end
           end
         end
       end

--- a/modules/storages/spec/lib/notification_subscription_spec.rb
+++ b/modules/storages/spec/lib/notification_subscription_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Subscriptions to OpenProject::Notification" do # rubocop:disable RSpec/DescribeClass
+  describe "OpenIDConnect::UserTokens::FetchService::TOKEN_OBTAINED_EVENT" do
+    subject(:notification_sent) do
+      OpenProject::Notifications.send(
+        OpenIDConnect::UserTokens::FetchService::TOKEN_OBTAINED_EVENT,
+        token:,
+        audience:
+      )
+    end
+
+    let(:token) { create(:oidc_user_token) }
+    let(:audience) { "the-storage-audience" }
+    let(:id_create_result) { ServiceResult.success }
+
+    let!(:storage) { create(:nextcloud_storage, storage_audience: "the-storage-audience") }
+
+    before do
+      allow(RemoteIdentities::CreateService).to receive(:call).and_return(id_create_result)
+    end
+
+    it "creates a remote identity" do
+      notification_sent
+
+      expect(RemoteIdentities::CreateService).to have_received(:call).with(user: token.user, integration: storage, token:)
+    end
+
+    context "when obtained token is for an audience that's not a storage" do
+      let(:audience) { "not-the-storage-audience" }
+
+      it "does not create a remote identity for the storage" do
+        notification_sent
+
+        expect(RemoteIdentities::CreateService).not_to have_received(:call)
+      end
+    end
+
+    context "when creation of remote identity raises an error" do
+      let(:error) { StandardError.new("ouch, that hurt") }
+
+      before do
+        allow(RemoteIdentities::CreateService).to receive(:call).and_raise(error)
+      end
+
+      it "raises the same error" do
+        expect { notification_sent }.to raise_error(error)
+      end
+    end
+
+    context "when creation of remote identity fails" do
+      let(:id_create_result) { ServiceResult.failure(errors: StandardError.new(message)) }
+      let(:message) { "ouch, that was bad" }
+
+      before do
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "raises no error" do
+        expect { notification_sent }.not_to raise_error
+      end
+
+      it "logs an error" do
+        notification_sent
+
+        expect(Rails.logger).to have_received(:error).with(/#{message}/)
+      end
+    end
+  end
+end

--- a/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
+++ b/spec/services/oauth_clients/connection_manager_one_drive_spec.rb
@@ -74,8 +74,14 @@ RSpec.describe OAuthClients::ConnectionManager, :oauth_connection_helpers, :webm
           .to_return(status: 404)
       end
 
-      it "raises an error" do
-        expect { subject.code_to_token(code) }.to raise_error(RuntimeError, /Storages::StorageErrorData.*@status=404/)
+      it "returns a failure", :aggregate_failures do
+        result = subject.code_to_token(code)
+        expect(result).to be_failure
+        expect(result.errors).to be_a(Storages::StorageError)
+      end
+
+      it "does not create a token" do
+        expect { subject.code_to_token(code) }.not_to change(OAuthClientToken, :count)
       end
     end
   end

--- a/spec/services/remote_identities/create_service_spec.rb
+++ b/spec/services/remote_identities/create_service_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 require "services/base_services/behaves_like_create_service"
 
-RSpec.describe RemoteIdentities::CreateService, :storage_server_helpers, :webmock, type: :model do
+RSpec.describe RemoteIdentities::CreateService, :storage_server_helpers, type: :model do
   let(:user) { create(:user) }
   let(:integration) { create(:nextcloud_storage_configured) }
   let(:oauth_config) { integration.oauth_configuration }
@@ -17,16 +17,24 @@ RSpec.describe RemoteIdentities::CreateService, :storage_server_helpers, :webmoc
 
   subject(:service) { described_class.new(user:, token: oauth_client_token, integration:) }
 
-  before { stub_nextcloud_user_query(integration.host) }
+  before do
+    allow(OpenProject::Notifications).to receive(:send)
+    allow(integration).to receive(:extract_origin_user_id).and_return(ServiceResult.success(result: "the-extracted-user-id"))
+  end
 
   describe ".call" do
     it "requires certain parameters" do
       method = described_class.method :call
 
-      expect(method.parameters).to contain_exactly(%i[keyreq user], %i[keyreq token], %i[keyreq integration])
+      expect(method.parameters).to contain_exactly(
+        %i[keyreq user],
+        %i[keyreq token],
+        %i[keyreq integration],
+        %i[key force_update]
+      )
     end
 
-    it "succeeds", :webmock do
+    it "succeeds" do
       expect(described_class.call(user:, token: oauth_client_token, integration:)).to be_success
     end
   end
@@ -50,23 +58,66 @@ RSpec.describe RemoteIdentities::CreateService, :storage_server_helpers, :webmoc
     it "sets origin_user_id" do
       expect { service.call.result }.to change {
         RemoteIdentity.pluck(:origin_user_id)
-      }.from([]).to(["admin"])
+      }.from([]).to(["the-extracted-user-id"])
     end
 
-    it "emits only one event for a number of subsequent calls if model has not changed" do
-      allow(OpenProject::Notifications)
-        .to receive(:send).with(OpenProject::Events::REMOTE_IDENTITY_CREATED, integration:).once
-      3.times { service.call.result }
+    context "when calling multiple times, without the model changing in-between" do
+      before do
+        2.times { service.call }
+      end
+
+      it "emits only one event" do
+        expect(OpenProject::Notifications).to have_received(:send).with(
+          OpenProject::Events::REMOTE_IDENTITY_CREATED,
+          integration:
+        ).once
+      end
+
+      it "only queries for the origin_user_id once" do
+        expect(integration).to have_received(:extract_origin_user_id).once
+      end
     end
 
-    it "emits two events for 2 subsequent calls if model has changed between them" do
-      allow(OpenProject::Notifications)
-        .to receive(:send).with(OpenProject::Events::REMOTE_IDENTITY_CREATED, integration:).twice
+    context "when calling multiple times, with changes to the model in between" do
+      before do
+        model = service.call.result
+        model.update!(origin_user_id: "the-changed-user-id")
+        service.call
+      end
 
-      model = service.call.result
-      model.origin_user_id = "123123"
-      model.save
-      service.call.result
+      it "emits only one event" do
+        expect(OpenProject::Notifications).to have_received(:send).with(
+          OpenProject::Events::REMOTE_IDENTITY_CREATED,
+          integration:
+        ).once
+      end
+
+      it "only queries for the origin_user_id once" do
+        expect(integration).to have_received(:extract_origin_user_id).once
+      end
+
+      it "does not undo changes to the model" do
+        expect(RemoteIdentity.last.origin_user_id).to eq("the-changed-user-id")
+      end
+
+      context "when the force_update flag is enabled" do
+        subject(:service) { described_class.new(user:, token: oauth_client_token, integration:, force_update: true) }
+
+        it "emits multiple events" do
+          expect(OpenProject::Notifications).to have_received(:send).with(
+            OpenProject::Events::REMOTE_IDENTITY_CREATED,
+            integration:
+          ).twice
+        end
+
+        it "queries for the origin_user_id again" do
+          expect(integration).to have_received(:extract_origin_user_id).twice
+        end
+
+        it "updates the model" do
+          expect(RemoteIdentity.last.origin_user_id).to eq("the-extracted-user-id")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I noticed an additional case where we do not show the intended error message for 61612. Reproduction is comparatively easy:

1. Have a working setup using token **exchange**
2. Misconfigure the storage to use the IDP token instead of exchanging for a token with the right audience (storage will respond with 401 on every request)

This way, when opening the files tab, we'd previously not have shown the files, but would have displayed a red error message about an HTTP 500. The error occured while fetching the remote identity, but it would even have happened if we already knew the remote identity for the user.

This PR fixes two issues:
1. We only fetch the remote identity information, if there is no remote identity yet (causing fewer requests to storage in general, but also making reproduction harder: you need to have **no** remote identity)
2. Fetch errors of the remote identity are now only logged, but do not raise an error across the `OpenProject::Notification` boundary. This allows the UI to show an appropriate error message.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/61986