### PR TITLE
[#57799] Udate meeting outcome visuals

### DIFF
--- a/app/components/op_primer/status_button_component.html.erb
+++ b/app/components/op_primer/status_button_component.html.erb
@@ -12,6 +12,7 @@
       @items.each do |option|
         menu.with_item(**option.item_arguments) do |item|
           item.with_leading_visual_icon(icon: option.icon) if option.icon
+          item.with_description.with_content(option.description) if option.description
 
           flex_layout(align_items: :center) do |flex|
             if option.icon.nil? && option.color

--- a/app/components/op_primer/status_button_option.rb
+++ b/app/components/op_primer/status_button_option.rb
@@ -30,12 +30,13 @@
 
 module OpPrimer
   class StatusButtonOption # rubocop:disable OpenProject/AddPreviewForViewComponent
-    attr_reader :name, :color, :icon, :item_arguments
+    attr_reader :name, :color, :icon, :item_arguments, :description
 
-    def initialize(name:, color: nil, icon: nil, **item_arguments)
+    def initialize(name:, color: nil, icon: nil, description: nil, **item_arguments)
       @name = name
       @color = color
       @icon = icon
+      @description = description
       @item_arguments = item_arguments
     end
 

--- a/lookbook/previews/op_primer/status_button_component_preview.rb
+++ b/lookbook/previews/op_primer/status_button_component_preview.rb
@@ -46,5 +46,29 @@ module OpPrimer
 
       render(component)
     end
+
+    # See the [component documentation](/lookbook/pages/components/status_button) for more details.
+    # @display min_height 200px
+    def with_description(size: :medium)
+      status = OpPrimer::StatusButtonOption.new(name: "Open",
+                                                icon: :unlock,
+                                                description: "The status is open",
+                                                color: Color.new(hexcode: "#FF0000"))
+
+      items = [
+        status,
+        OpPrimer::StatusButtonOption.new(name: "Closed",
+                                         icon: :lock,
+                                         description: "The status is closed",
+                                         color: Color.new(hexcode: "#00FF00"))
+      ]
+
+      component = OpPrimer::StatusButtonComponent.new(current_status: status,
+                                                      items: items,
+                                                      readonly: false,
+                                                      button_arguments: { size:, title: "foo" })
+
+      render(component)
+    end
   end
 end

--- a/modules/meeting/app/components/_index.sass
+++ b/modules/meeting/app/components/_index.sass
@@ -6,3 +6,4 @@
 @import "./recurring_meetings/table_header_component.sass"
 @import "./meeting_agenda_items/outcomes/show_notes_component.sass"
 @import "./meeting_agenda_items/outcomes/form_component.sass"
+@import "./meetings/header_infoline_component.sass"

--- a/modules/meeting/app/components/meetings/header_infoline_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_infoline_component.html.erb
@@ -1,15 +1,35 @@
-<%= render(Primer::BaseComponent.new(tag: :div)) do %>
+<%= render(Primer::BaseComponent.new(tag: :div, classes: "meeting-infoline")) do %>
   <% if @series && !@meeting.template? %>
-    <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
-    <%= t("recurring_meeting.occurrence.infoline", title: @series.title) %>
+    <%= render(Primer::BaseComponent.new(tag: :div, classes: "hidden-for-mobile", mr: 1)) do %>
+      <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
+    <% end %>
+    <%=
+      render(Primer::Beta::Text.new) do
+        t("recurring_meeting.occurrence.infoline", title: @series.title)
+      end
+    %>
   <% elsif !@meeting.template? %>
-    <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
-    <%= t(:label_meeting_created_by) %>
+    <%= render(Primer::BaseComponent.new(tag: :span, classes: "hidden-for-mobile", mr: 1)) do %>
+      <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
+    <% end %>
+    <%=
+      render(Primer::Beta::Text.new(mr: 1)) do
+        t(:label_meeting_created_by)
+      end
+    %>
     <%= helpers.primer_link_to_user(@meeting.author) %>.
   <% else %>
-    <%= t(:label_meeting_created_by) %>
+    <%=
+      render(Primer::Beta::Text.new(mr: 1)) do
+        t(:label_meeting_created_by)
+      end
+    %>
     <%= helpers.primer_link_to_user(@meeting.author) %>.
   <% end %>
-  <%= t("label_meeting_last_updated") %>
+  <%=
+    render(Primer::Beta::Text.new(ml: 1, mr: 1)) do
+      t("label_meeting_last_updated")
+    end
+  %>
   <%= render(OpPrimer::RelativeTimeComponent.new(datetime: last_updated_at, prefix: I18n.t(:label_on))) %>.
 <% end %>

--- a/modules/meeting/app/components/meetings/header_infoline_component.rb
+++ b/modules/meeting/app/components/meetings/header_infoline_component.rb
@@ -29,6 +29,8 @@
 
 module Meetings
   class HeaderInfolineComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
     def initialize(meeting)
       super
       @meeting = meeting

--- a/modules/meeting/app/components/meetings/header_infoline_component.sass
+++ b/modules/meeting/app/components/meetings/header_infoline_component.sass
@@ -1,0 +1,8 @@
+@import 'helpers'
+
+.meeting-infoline
+  display: flex
+  align-items: center
+
+  @media screen and (max-width: $breakpoint-md)
+    display: inline

--- a/modules/meeting/app/components/meetings/side_panel/state_component.sass
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.sass
@@ -1,6 +1,6 @@
 @import 'helpers'
 
-@media screen and (max-width: $breakpoint-md)
+@media screen and (max-width: $breakpoint-sm)
   .op-meeting-sidebar-state
     flex-direction: row !important
     justify-content: space-between

--- a/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
@@ -72,6 +72,7 @@ module Meetings
                                        color: Color.new(hexcode: "#1F883D"),
                                        icon: :"issue-opened",
                                        tag: :a,
+                                       description: t("text_meeting_open_dropdown_description"),
                                        href: change_state_project_meeting_path(@project, @meeting, state: "open"),
                                        content_arguments: {
                                          data: { "turbo-stream": true, "turbo-method": "put" }
@@ -83,6 +84,7 @@ module Meetings
                                        color: Color.new(hexcode: "#9A6700"),
                                        icon: :play,
                                        tag: :a,
+                                       description: t("text_meeting_in_progress_dropdown_description"),
                                        href: change_state_project_meeting_path(@project, @meeting, state: "in_progress"),
                                        content_arguments: {
                                          data: { "turbo-stream": true, "turbo-method": "put" }
@@ -91,9 +93,10 @@ module Meetings
 
     def closed_status
       OpPrimer::StatusButtonOption.new(name: t("label_meeting_state_closed"),
-                                       color: Color.new(hexcode: "#8250DF"),
-                                       icon: :"codescan-checkmark",
+                                       color: Color.new(hexcode: "#6E7781 "),
+                                       icon: :"issue-closed",
                                        tag: :a,
+                                       description: t("text_meeting_closed_dropdown_description"),
                                        href: change_state_project_meeting_path(@project, @meeting, state: "closed"),
                                        content_arguments: {
                                          data: { "turbo-stream": true, "turbo-method": "put" }

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -456,6 +456,9 @@ en:
   text_meeting_open_description: "This meeting is open. You can add/remove agenda items and edit them as you please. Once the agenda is ready, mark it as in progress to document outcomes."
   text_meeting_closed_description: "This meeting is closed. You cannot add/remove agenda items anymore."
   text_meeting_in_progress_description: "This meeting is in progress. You can document outcomes for each agenda item, re-arrange them, and even add new ones. Once the meeting is complete, you can mark it as closed to lock it."
+  text_meeting_open_dropdown_description: "Any existing outcomes will remain but users will not be able to add new outcomes."
+  text_meeting_in_progress_dropdown_description: "Once the agenda is ready, mark it as in progress to document outcomes."
+  text_meeting_closed_dropdown_description: "Once the meeting is complete, you can mark it as closed to lock it."
 
   label_meeting_manage_participants: "Manage participants"
   label_meeting_no_participants: "No participants"

--- a/modules/meeting/spec/support/pages/structured_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/structured_meeting/show.rb
@@ -319,10 +319,8 @@ module Pages::StructuredMeeting
 
     def close_meeting
       retry_block do
-        page.within(".PageHeader-description") do
-          click_on("Open")
-          page.find(".Overlay")
-        end
+        click_on("Open")
+        page.find(".Overlay")
       end
 
       page.within(".Overlay") do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/57799

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# To do

- [x] Add the description texts
- [x] Change the icon of closed to issue-closed instead of the current one that looks like a search
- [x] Make sure closed is not purple but grey like before
- [x] Make sure the button to change statuses in the header is not visible on mobile

# Note
The figma mockup for the dropdown has different labels for the options and the actual button. This is not possible with the component currently, so I have left it as is and asked Parimal for clarification

<img width="474" alt="image" src="https://github.com/user-attachments/assets/86548539-0162-4ba3-a154-eea9404b3725" />

vs.
<img width="566" alt="image" src="https://github.com/user-attachments/assets/93ce5fac-e1e3-49bc-a316-d6e0cdcd5575" />


