### PR TITLE
[61971] Add icon to indicate automatic scheduling mode

### DIFF
--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -20,6 +20,7 @@
                 ) do |control|
                   control.with_item(
                     tag: :a,
+                    icon: :pin,
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: true).permit!),
                     data: {
                       turbo_stream: true,
@@ -31,6 +32,7 @@
                   )
                   control.with_item(
                     tag: :a,
+                    icon: :zap,
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: false).permit!),
                     data: {
                       turbo_stream: true,

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -158,7 +158,7 @@ module WorkPackagesHelper
   end
 
   def work_package_dates_icon(work_package)
-    work_package.schedule_manually ? :pin : :calendar
+    work_package.schedule_manually ? :pin : :zap
   end
 
   def work_package_formatted_dates(work_package)

--- a/frontend/src/app/shared/components/fields/display/field-types/combined-date-display.field.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/combined-date-display.field.ts
@@ -44,12 +44,14 @@ export class CombinedDateDisplayField extends DateDisplayField {
     }
 
     if (this.startDate && (this.startDate === this.dueDate)) {
-      this.renderSingleDate('dueDate', element);
+      this.renderSingleDate('startDate', element);
       return;
     }
 
     if (!this.startDate && !this.dueDate) {
       element.innerHTML = this.customPlaceholder(`${this.text.placeholder.startDate} - ${this.text.placeholder.dueDate}`);
+
+      element.prepend(this.schedulingIcon());
       return;
     }
 

--- a/frontend/src/app/shared/components/fields/display/field-types/date-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/date-display-field.module.ts
@@ -26,15 +26,16 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Highlighting,
-} from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
-import {
-  HighlightableDisplayField,
-} from 'core-app/shared/components/fields/display/field-types/highlightable-display-field.module';
+import { Highlighting } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
+import { HighlightableDisplayField } from 'core-app/shared/components/fields/display/field-types/highlightable-display-field.module';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import {
+  pinIconData,
+  toDOMString,
+  zapIconData,
+} from '@openproject/octicons-angular';
 
 export class DateDisplayField extends HighlightableDisplayField {
   @InjectField() timezoneService:TimezoneService;
@@ -46,14 +47,7 @@ export class DateDisplayField extends HighlightableDisplayField {
 
     // Show scheduling mode in front of the start date field
     if (this.showSchedulingMode()) {
-      const schedulingIcon = document.createElement('span');
-      schedulingIcon.classList.add('icon-context');
-
-      if (this.resource.scheduleManually) {
-        schedulingIcon.classList.add('icon-pin');
-      }
-
-      element.prepend(schedulingIcon);
+      element.prepend(this.schedulingIcon());
     }
 
     // Highlight overdue tasks
@@ -83,6 +77,24 @@ export class DateDisplayField extends HighlightableDisplayField {
       return this.timezoneService.formattedDate(this.value, this.context.options.dateFormat);
     }
     return '';
+  }
+
+  protected schedulingIcon():HTMLElement {
+    const schedulingIcon = document.createElement('span');
+
+    const pinIconString:string = toDOMString(
+      pinIconData,
+      'small',
+      { 'aria-hidden': 'true', class: 'display-field--scheduling-icon' },
+    );
+    const zapIconString:string = toDOMString(
+      zapIconData,
+      'small',
+      { 'aria-hidden': 'true', class: 'display-field--scheduling-icon' },
+    );
+
+    schedulingIcon.innerHTML = this.resource.scheduleManually ? pinIconString : zapIconString;
+    return schedulingIcon;
   }
 
   private showSchedulingMode():boolean {

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -120,6 +120,10 @@ display-field
       & > span:last-child
         margin-right: 0
 
+  &.combinedDate
+    .display-field--scheduling-icon
+      vertical-align: text-top
+      margin-right: 0.25rem
 
 .wp-table--cell-container
   .inline-edit--display-field.-placeholder,
@@ -130,7 +134,7 @@ display-field
     .-placeholder
       @include wp-table--placeholder-time-values
 
-.wp-table--cell-container .dueDate .icon-pin
+.wp-table--cell-container .dueDate .display-field--scheduling-icon
   display: none
 
 .wp-table--cell-container
@@ -141,14 +145,17 @@ display-field
 
 .wp-table--cell-container.startDate
   padding-left: $work-package--start-date-display-field-padding-left
+  position: relative
 
-  .icon-context
-    position: relative
-
-  .icon-pin:before
+  .display-field--scheduling-icon
     position: absolute
-    left: -24px
-    top: -8px
+    left: 4px
+    top: 4px
+
+  .-placeholder
+    // The special alignment of placeholders requires a special alignment of the icon
+    .display-field--scheduling-icon
+      top: 6px
 
 // Sums in wp table
 .wp-table--sum-container.split-time-field


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61971/activity

# What are you trying to accomplish?
Always show an icon for the scheduling mode. For now, this will be `zap` until a new icon is designed.

## Screenshots
<img width="269" alt="Bildschirmfoto 2025-03-05 um 14 35 43" src="https://github.com/user-attachments/assets/bd90ff3b-91f1-4a89-bba5-55cdac79baaf" />
