### PR TITLE
[#61895] Reduce flickering when switching between meeting states

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -21,6 +21,7 @@ $meeting-agenda-item--presenter-width--mobile: 150px
 
   &--content
     overflow-wrap: anywhere
+    min-height: 32px
 
   &--presenter
     max-width: $meeting-agenda-item--presenter-width

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.sass
@@ -5,7 +5,7 @@
 
   // To prevent flickering when changing meeting states due to the actions button icon
   .title
-    height: 32px
+    min-height: 32px
 
 .op-meeting-outcome-notes
   display: grid


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/61895

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Currently, the actions icon has a fixed height of 32px, which is greater than the title/other row content for both agenda items and outcomes
- The result of this is that the whole page flickers when switching between meeting states as this icon is state dependent
- This PR fixes that by defining the rows containing the actions icon to have a min-height of 32px as well, even if the actions aren't visible in a particular state, reducing vertical movement when switching
