### PR TITLE
[62002] Use correct icon for automatic scheduling mode and bump octicon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -410,6 +410,6 @@ gemfiles.each do |file|
   send(:eval_gemfile, file) if File.readable?(file)
 end
 
-gem "openproject-octicons", "~>19.20.0 "
-gem "openproject-octicons_helper", "~>19.20.0 "
+gem "openproject-octicons", "~>19.21.0 "
+gem "openproject-octicons_helper", "~>19.21.0 "
 gem "openproject-primer_view_components", "~>0.56.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -857,10 +857,10 @@ GEM
       validate_email
       validate_url
       webfinger (~> 2.0)
-    openproject-octicons (19.20.0)
-    openproject-octicons_helper (19.20.0)
+    openproject-octicons (19.21.0)
+    openproject-octicons_helper (19.21.0)
       actionview
-      openproject-octicons (= 19.20.0)
+      openproject-octicons (= 19.21.0)
       railties
     openproject-primer_view_components (0.56.0)
       actionview (>= 5.0.0)
@@ -1386,8 +1386,8 @@ DEPENDENCIES
   openproject-job_status!
   openproject-ldap_groups!
   openproject-meeting!
-  openproject-octicons (~> 19.20.0)
-  openproject-octicons_helper (~> 19.20.0)
+  openproject-octicons (~> 19.21.0)
+  openproject-octicons_helper (~> 19.21.0)
   openproject-openid_connect!
   openproject-primer_view_components (~> 0.56.0)
   openproject-recaptcha!
@@ -1752,8 +1752,8 @@ CHECKSUMS
   openproject-job_status (1.0.0)
   openproject-ldap_groups (1.0.0)
   openproject-meeting (1.0.0)
-  openproject-octicons (19.20.0) sha256=f8a4ad2aa708505aba81b8362ddf9e4f8e992433f30a63d96f2007795c5419ec
-  openproject-octicons_helper (19.20.0) sha256=517f2feb3f9526d640f57b77579325abdb7218a0f81a1fcda28837873498efb0
+  openproject-octicons (19.21.0) sha256=8eccc93943f37589ebdb531e1b9ad9cfd344e84c102bd3d422b45ab5c390e2ae
+  openproject-octicons_helper (19.21.0) sha256=7dea0e4a3fb45f71f087e2dab518aa2f9914fcde193baf7ab200450b14bdb474
   openproject-openid_connect (1.0.0)
   openproject-primer_view_components (0.56.0) sha256=a54603c33cb154bdbe6f24e8cbad9ce99a4f12be6f5526196bb5df73bb68eb1e
   openproject-recaptcha (1.0.0)

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -32,7 +32,7 @@
                   )
                   control.with_item(
                     tag: :a,
-                    icon: :zap,
+                    icon: 'op-auto-date',
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: false).permit!),
                     data: {
                       turbo_stream: true,

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -158,7 +158,7 @@ module WorkPackagesHelper
   end
 
   def work_package_dates_icon(work_package)
-    work_package.schedule_manually ? :pin : :zap
+    work_package.schedule_manually ? :pin : "op-auto-date"
   end
 
   def work_package_formatted_dates(work_package)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,7 +47,7 @@
         "@ng-select/ng-select": "^13.2.0",
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
-        "@openproject/octicons-angular": "^19.20.0",
+        "@openproject/octicons-angular": "^19.21.0",
         "@openproject/primer-view-components": "^0.56.0",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.5.0",
@@ -4874,9 +4874,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@openproject/octicons-angular": {
-      "version": "19.20.0",
-      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.20.0.tgz",
-      "integrity": "sha512-mX9QHKvCi+84Q5qCF3f1fH96+ZhwdNLCgn3MPkBvzTgvSRPuXfoboV/WVfl1jrPPiKBPUQuDBlq0UdmeklwLlw==",
+      "version": "19.21.0",
+      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.21.0.tgz",
+      "integrity": "sha512-MUPpTgI6AhFWf6mSVw0mZIM5SUIcN0+wypVTSoRyeiv8FfGoNQGnVRR5hKT7fJ24vrfITyZm2LtsfmGe2XsxNw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -25709,9 +25709,9 @@
       "integrity": "sha512-iFrvar5SOMtKFOSjYvs4z9UlLqDdJbMx0mgISLcPedv+g0ac5sgeETLGtipHCVIae6HJPclNEH5aCyD1RZaEHw=="
     },
     "@openproject/octicons-angular": {
-      "version": "19.20.0",
-      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.20.0.tgz",
-      "integrity": "sha512-mX9QHKvCi+84Q5qCF3f1fH96+ZhwdNLCgn3MPkBvzTgvSRPuXfoboV/WVfl1jrPPiKBPUQuDBlq0UdmeklwLlw==",
+      "version": "19.21.0",
+      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.21.0.tgz",
+      "integrity": "sha512-MUPpTgI6AhFWf6mSVw0mZIM5SUIcN0+wypVTSoRyeiv8FfGoNQGnVRR5hKT7fJ24vrfITyZm2LtsfmGe2XsxNw==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,7 @@
     "@ng-select/ng-select": "^13.2.0",
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
-    "@openproject/octicons-angular": "^19.20.0",
+    "@openproject/octicons-angular": "^19.21.0",
     "@openproject/primer-view-components": "^0.56.0",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.5.0",

--- a/frontend/src/app/shared/components/fields/display/field-types/date-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/date-display-field.module.ts
@@ -34,7 +34,7 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import {
   pinIconData,
   toDOMString,
-  zapIconData,
+  opAutoDateIconData,
 } from '@openproject/octicons-angular';
 
 export class DateDisplayField extends HighlightableDisplayField {
@@ -87,13 +87,13 @@ export class DateDisplayField extends HighlightableDisplayField {
       'small',
       { 'aria-hidden': 'true', class: 'display-field--scheduling-icon' },
     );
-    const zapIconString:string = toDOMString(
-      zapIconData,
+    const autoDateIconString:string = toDOMString(
+      opAutoDateIconData,
       'small',
       { 'aria-hidden': 'true', class: 'display-field--scheduling-icon' },
     );
 
-    schedulingIcon.innerHTML = this.resource.scheduleManually ? pinIconString : zapIconString;
+    schedulingIcon.innerHTML = this.resource.scheduleManually ? pinIconString : autoDateIconString;
     return schedulingIcon;
   }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62002
https://community.openproject.org/wp/61992

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

- [x] Update Core Repository with the latest changes in Octicon repository
- [x] Replace zap icon with op-auto-date icon

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
