### PR TITLE
[#61935] added first element to pattern input suggestions

### DIFF
--- a/app/components/work_packages/types/pattern_input.html.erb
+++ b/app/components/work_packages/types/pattern_input.html.erb
@@ -34,6 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
       classes: "pattern-input",
       "data-controller": "pattern-input",
       "data-pattern-input-pattern-initial-value": @value,
+      "data-pattern-input-insert-as-text-template-value": I18n.t("types.edit.subject_configuration.pattern.insert_as_text"),
       "data-pattern-input-suggestions-initial-value": suggestions_for_stimulus
     )
   ) do
@@ -63,6 +64,22 @@ See COPYRIGHT and LICENSE files for more details.
             data: {
               prop: "__placeholder__",
               action: "click->pattern-input#suggestions_select"
+            }
+          )
+        )
+      %>
+    </template>
+
+    <template data-pattern-input-target="insertAsTextTemplate">
+      <%=
+        render(
+          Primer::Alpha::ActionList::Item.new(
+            list: suggestions_list_component,
+            label: "__placeholder__",
+            role: "menuitem",
+            label_classes: "fgColor-muted text-italic",
+            data: {
+              action: "click->pattern-input#close_suggestions"
             }
           )
         )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -677,6 +677,7 @@ en:
         pattern:
           label: "Subject pattern"
           caption: "Search for an attribute or add text. To create a space between elements add it as a text."
+          insert_as_text: "Add as text: \"%{word}\""
       export_configuration:
         tab: "Generate PDF"
         intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."


### PR DESCRIPTION
# Ticket
[OP#61935](https://community.openproject.org/wp/61935)

# What are you trying to accomplish?
- first element in suggestion list should always show "Add as text: current_search"

# What approach did you choose and why?
- added new template with different click behavior