### PR TITLE
[61091] Show datepicker as dialog instead of drop-modal

### DIFF
--- a/app/components/work_packages/date_picker/banner_component.rb
+++ b/app/components/work_packages/date_picker/banner_component.rb
@@ -181,7 +181,8 @@ module WorkPackages
           scheme:,
           full: true,
           icon: :info,
-          test_selector:
+          test_selector:,
+          pr: 3
         }
       end
     end

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -15,7 +15,7 @@
         collection.with_component(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
           render(
             Primer::Alpha::UnderlinePanels.new(
-              'aria-label': I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
+              "aria-label": I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
               label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
               classes: "wp-datepicker-dialog--UnderlineNav",
               px: 3
@@ -43,7 +43,7 @@
                 relation_group = tab.relation_group
                 tab_content.with_text { I18n.t("work_packages.datepicker_modal.tabs.#{tab.key}") }
                 tab_content.with_counter(count: relation_group.count)
-                tab_content.with_panel(m: 3) do
+                tab_content.with_panel(m: 3, classes: "wp-datepicker-dialog--content-tab--relation-tab") do
                   if relation_group.any?
                     render(border_box_container(padding: :condensed)) do |box|
                       relation_group.visible_relations.each do |relation|

--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -1,9 +1,21 @@
+$body-height: 490px
+
 @media screen and (min-width: $breakpoint-sm)
   .wp-datepicker-dialog
+    &--content
+      max-height: calc(var(--app-height) - 2rem)
+      overflow: auto
+
     &--body
       // We set a fixed height for this dialog zo avoid that it jumps around when the tabs are switched or errors shown
-      min-height: 490px
+      min-height: $body-height
       width: 600px
+
+    &--content-tab
+      &--relation-tab
+        // Height of the body - (navBarHeight + Margins)
+        height: calc($body-height - 80px)
+        overflow: auto
 
 @media screen and (max-width: $breakpoint-sm)
   .wp-datepicker-dialog

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -96,7 +96,7 @@
         end
 
         body.with_row("aria-hidden": true) do
-          helpers.angular_component_tag "opce-wp-modal-date-picker",
+          helpers.angular_component_tag "opce-wp-date-picker-instance",
                                         inputs: {
                                           start_date: work_package.start_date,
                                           due_date: work_package.due_date,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -232,7 +232,7 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 import {
   TimeEntriesWorkPackageAutocompleterComponent,
 } from 'core-app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter.component';
-import { OpWpModalDatePickerComponent } from 'core-app/shared/components/datepicker/wp-modal-date-picker/wp-modal-date-picker.component';
+import { OpWpDatePickerInstanceComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component';
 
 export function initializeServices(injector:Injector) {
   return () => {
@@ -445,7 +445,7 @@ export class OpenProjectModule implements DoBootstrap {
     registerCustomElement('opce-wp-split-view', WorkPackageSplitViewEntryComponent, { injector });
     registerCustomElement('opce-timer-account-menu', TimerAccountMenuComponent, { injector });
     registerCustomElement('opce-remote-field-updater', RemoteFieldUpdaterComponent, { injector });
-    registerCustomElement('opce-wp-modal-date-picker', OpWpModalDatePickerComponent, { injector });
+    registerCustomElement('opce-wp-date-picker-instance', OpWpDatePickerInstanceComponent, { injector });
     registerCustomElement('opce-spot-drop-modal-portal', SpotDropModalPortalComponent, { injector });
     registerCustomElement('opce-spot-switch', SpotSwitchComponent, { injector });
     registerCustomElement('opce-modal-overlay', OpModalOverlayComponent, { injector });

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -403,6 +403,7 @@ import {
 import {
   WorkPackageSplitViewEntryComponent,
 } from 'core-app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component';
+import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal';
 
 @NgModule({
   imports: [
@@ -637,6 +638,8 @@ import {
     OpBaselineComponent,
     OpBaselineLoadingComponent,
     OpBaselineLegendsComponent,
+
+    OpWpDatePickerModalComponent,
   ],
   exports: [
     WorkPackagesTableComponent,
@@ -668,6 +671,7 @@ import {
     WorkPackageSingleViewComponent,
     WorkPackageSplitViewComponent,
     BackButtonComponent,
+    OpWpDatePickerModalComponent,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/frontend/src/app/shared/components/datepicker/datepicker.module.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.module.ts
@@ -13,7 +13,8 @@ import { OpSpotModule } from 'core-app/spot/spot.module';
 import { OpenprojectModalModule } from '../modal/modal.module';
 import { OpDatePickerSheetComponent } from 'core-app/shared/components/datepicker/sheet/date-picker-sheet.component';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
-import { OpWpModalDatePickerComponent } from 'core-app/shared/components/datepicker/wp-modal-date-picker/wp-modal-date-picker.component';
+import { OpWpDatePickerInstanceComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component';
+import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal';
 
 @NgModule({
   imports: [
@@ -34,14 +35,16 @@ import { OpWpModalDatePickerComponent } from 'core-app/shared/components/datepic
   declarations: [
     OpModalSingleDatePickerComponent,
     OpDatePickerSheetComponent,
-    OpWpModalDatePickerComponent,
+    OpWpDatePickerInstanceComponent,
+    OpWpDatePickerModalComponent,
   ],
 
   exports: [
     OpModalSingleDatePickerComponent,
     OpBasicDatePickerModule,
     OpDatePickerSheetComponent,
-    OpWpModalDatePickerComponent,
+    OpWpDatePickerInstanceComponent,
+    OpWpDatePickerModalComponent,
   ],
 })
 export class OpDatePickerModule { }

--- a/frontend/src/app/shared/components/datepicker/datepicker.module.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.module.ts
@@ -14,7 +14,6 @@ import { OpenprojectModalModule } from '../modal/modal.module';
 import { OpDatePickerSheetComponent } from 'core-app/shared/components/datepicker/sheet/date-picker-sheet.component';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
 import { OpWpDatePickerInstanceComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component';
-import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal';
 
 @NgModule({
   imports: [
@@ -36,7 +35,6 @@ import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepic
     OpModalSingleDatePickerComponent,
     OpDatePickerSheetComponent,
     OpWpDatePickerInstanceComponent,
-    OpWpDatePickerModalComponent,
   ],
 
   exports: [
@@ -44,7 +42,6 @@ import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepic
     OpBasicDatePickerModule,
     OpDatePickerSheetComponent,
     OpWpDatePickerInstanceComponent,
-    OpWpDatePickerModalComponent,
   ],
 })
 export class OpDatePickerModule { }

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -54,7 +54,7 @@ import * as _ from 'lodash';
 export type DateMode = 'single'|'range';
 
 @Component({
-  selector: 'op-wp-modal-date-picker',
+  selector: 'op-wp-date-picker-instance',
   template: `
     <input
       id="flatpickr-input"
@@ -63,7 +63,7 @@ export type DateMode = 'single'|'range';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OpWpModalDatePickerComponent extends UntilDestroyedMixin implements AfterViewInit {
+export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin implements AfterViewInit {
   @Input() public ignoreNonWorkingDays:boolean;
   @Input() public scheduleManually:boolean;
 

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.html
@@ -1,0 +1,25 @@
+<div
+  class="spot-modal spot-modal_auto-size loading-indicator--location"
+  data-indicator-name="modal"
+  tabindex="0"
+>
+  <turbo-frame *ngIf="turboFrameSrc"
+               [src]="turboFrameSrc"
+               opModalWithTurboContent
+               [change]="locals.change"
+               [resource]="locals.resource"
+               (successfulCreate)="handleSuccessfulCreate($event)"
+               (successfulUpdate)="handleSuccessfulUpdate()"
+               (cancel)="handleCancel()"
+               id="wp-datepicker-dialog--content">
+    <op-content-loader viewBox="0 0 100 100">
+      <svg:rect x="5" y="5" width="70" height="5" rx="1"/>
+
+      <svg:rect x="80" y="5" width="15" height="5" rx="1"/>
+
+      <svg:rect x="5" y="15" width="90" height="8" rx="1"/>
+
+      <svg:rect x="5" y="30" width="90" height="12" rx="1"/>
+    </op-content-loader>
+  </turbo-frame>
+</div>

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.ts
@@ -1,0 +1,131 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Inject,
+  OnInit,
+} from '@angular/core';
+
+import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
+import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
+import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+
+@Component({
+  templateUrl: './wp-date-picker.modal.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OpWpDatePickerModalComponent extends OpModalComponent implements OnInit {
+  turboFrameSrc:string;
+
+  constructor(
+    readonly elementRef:ElementRef,
+    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
+    readonly cdRef:ChangeDetectorRef,
+    readonly pathHelper:PathHelperService,
+  ) {
+    super(locals, cdRef, elementRef);
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+    this.updateFrameSrc();
+  }
+
+  public handleSuccessfulCreate(JSONResponse:{ duration:number, startDate:Date, dueDate:Date, includeNonWorkingDays:boolean, scheduleManually:boolean }):void {
+    document.dispatchEvent(
+      new CustomEvent('date-picker-modal:create', {
+        detail: JSONResponse,
+      }),
+    );
+
+    this.closeModal();
+  }
+
+  public handleSuccessfulUpdate():void {
+    document.dispatchEvent(new CustomEvent('date-picker-modal:update'));
+
+    this.closeModal();
+  }
+
+  public handleCancel():void {
+    document.dispatchEvent(new CustomEvent('date-picker-modal:cancel'));
+
+    this.closeModal();
+  }
+
+  public closeModal():void {
+    this.closeMe();
+  }
+
+  public updateFrameSrc():void {
+    const url = new URL(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      this.pathHelper.workPackageDatepickerDialogContentPath(this.locals.resource.id as string),
+      window.location.origin,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('field', this.locals.name);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('work_package[initial][start_date]', this.nullAsEmptyStringFormatter(this.locals.resource.startDate));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('work_package[initial][due_date]', this.nullAsEmptyStringFormatter(this.locals.resource.dueDate));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('work_package[initial][duration]', this.nullAsEmptyStringFormatter(this.locals.resource.duration));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+    url.searchParams.set('work_package[initial][ignore_non_working_days]', this.nullAsEmptyStringFormatter(this.locals.resource.includeNonWorkingDays));
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('work_package[start_date]', this.nullAsEmptyStringFormatter(this.locals.resource.startDate));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('work_package[due_date]', this.nullAsEmptyStringFormatter(this.locals.resource.dueDate));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+    url.searchParams.set('work_package[duration]', this.nullAsEmptyStringFormatter(this.locals.resource.duration));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+    url.searchParams.set('work_package[ignore_non_working_days]', this.nullAsEmptyStringFormatter(this.locals.resource.includeNonWorkingDays));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (this.locals.resource?.id === 'new' && this.locals.resource.startDate) {
+      url.searchParams.set('work_package[start_date_touched]', 'true');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    this.turboFrameSrc = url.toString();
+  }
+
+  private nullAsEmptyStringFormatter(value:null|undefined|string):string {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return value;
+  }
+}

--- a/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.html
@@ -1,36 +1,7 @@
-<spot-drop-modal
-  [opened]="opened"
-  (closed)="onModalClosed()"
-  alignment="bottom-center"
->
-  <input
-    slot="trigger"
-    type="text"
-    class="spot-input"
-    (click)="onInputClick($event)"
-    [value]="dates"
-    (focus)="showDatePickerModal()"
-  />
-
-  <ng-container slot="body">
-    <turbo-frame *ngIf="turboFrameSrc && opened"
-                 [src]="turboFrameSrc"
-                 opModalWithTurboContent
-                 [change]="change"
-                 [resource]="resource"
-                 (successfulCreate)="handleSuccessfulCreate($event)"
-                 (successfulUpdate)="handleSuccessfulUpdate()"
-                 (cancel)="cancel()"
-                 id="wp-datepicker-dialog--content">
-      <op-content-loader viewBox="0 0 100 100">
-        <svg:rect x="5" y="5" width="70" height="5" rx="1"/>
-
-        <svg:rect x="80" y="5" width="15" height="5" rx="1"/>
-
-        <svg:rect x="5" y="15" width="90" height="8" rx="1"/>
-
-        <svg:rect x="5" y="30" width="90" height="12" rx="1"/>
-      </op-content-loader>
-    </turbo-frame>
-  </ng-container>
-</spot-drop-modal>
+<input
+  type="text"
+  class="inline-edit--field op-input"
+  (click)="onInputClick($event)"
+  [value]="dates"
+  (focus)="showDatePickerModal()"
+/>

--- a/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.ts
@@ -57,13 +57,8 @@ export class CombinedDateEditFieldComponent extends DatePickerEditFieldComponent
     event.stopPropagation();
   }
 
-  public showDatePickerModal():void {
-    this.updateFrameSrc();
-    this.opened = true;
-  }
-
   public onModalClosed():void {
-    this.opened = false;
+    super.onModalClosed();
 
     if (!this.handler.inEditMode) {
       this.handler.deactivate(false);

--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -27,13 +27,13 @@
  */
 
 import {
+  ChangeDetectorRef,
   Directive,
-  OnDestroy,
-  OnInit,
-  Injector,
   ElementRef,
   Inject,
-  ChangeDetectorRef,
+  Injector,
+  OnDestroy,
+  OnInit,
 } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
@@ -50,6 +50,8 @@ import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/r
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
+import { OpModalService } from 'core-app/shared/components/modal/modal.service';
+import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal';
 
 @Directive()
 export abstract class DatePickerEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
@@ -58,6 +60,11 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
   @InjectField() deviceService:DeviceService;
 
   turboFrameSrc:string;
+  opened = false;
+
+  private createHandler:EventListener = this.handleSuccessfulCreate.bind(this);
+  private updateHandler:EventListener = this.handleSuccessfulUpdate.bind(this);
+  private cancelHandler:EventListener = this.cancel.bind(this);
 
   constructor(
     readonly I18n:I18nService,
@@ -68,6 +75,7 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
     readonly cdRef:ChangeDetectorRef,
     readonly injector:Injector,
     readonly pathHelper:PathHelperService,
+    readonly opModalService:OpModalService,
   ) {
     super(I18n, elementRef, change, schema, handler, cdRef, injector);
   }
@@ -84,25 +92,47 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
       .subscribe(() => {
         this.showDatePickerModal();
       });
+
+    document.addEventListener('date-picker-modal:create', this.createHandler);
+    document.addEventListener('date-picker-modal:update', this.updateHandler);
+    document.addEventListener('date-picker-modal:cancel', this.cancelHandler);
   }
 
   ngOnDestroy():void {
     super.ngOnDestroy();
+
+    document.removeEventListener('date-picker-modal:create', this.createHandler);
+    document.removeEventListener('date-picker-modal:update', this.updateHandler);
+    document.removeEventListener('date-picker-modal:cancel', this.cancelHandler);
   }
 
-  public showDatePickerModal():void { }
+  public showDatePickerModal():void {
+    this.opModalService.show(
+      OpWpDatePickerModalComponent,
+      this.injector,
+      { resource: this.resource, name: this.name },
+    );
+    this.opened = true;
+  }
 
-  public handleSuccessfulCreate(JSONResponse:{ duration:number, startDate:Date, dueDate:Date, includeNonWorkingDays:boolean, scheduleManually:boolean }):void {
+  public handleSuccessfulCreate(event:CustomEvent):void {
+    const { detail: {
+      duration,
+      startDate,
+      dueDate,
+      includeNonWorkingDays,
+      scheduleManually } } = event as { detail:{ duration:number, startDate:Date, dueDate:Date, includeNonWorkingDays:boolean, scheduleManually:boolean } };
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.duration = JSONResponse.duration ? this.timezoneService.toISODuration(JSONResponse.duration, 'days') : null;
+    this.resource.duration = duration ? this.timezoneService.toISODuration(duration, 'days') : null;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.dueDate = JSONResponse.dueDate;
+    this.resource.dueDate = dueDate;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.startDate = JSONResponse.startDate;
+    this.resource.startDate = startDate;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.includeNonWorkingDays = JSONResponse.includeNonWorkingDays;
+    this.resource.includeNonWorkingDays = includeNonWorkingDays;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.scheduleManually = JSONResponse.scheduleManually;
+    this.resource.scheduleManually = scheduleManually;
 
     this.onModalClosed();
   }
@@ -111,46 +141,13 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
     this.onModalClosed();
   }
 
-  public onModalClosed():void { }
+  public onModalClosed():void {
+    this.opened = false;
 
-  public updateFrameSrc():void {
-    const url = new URL(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      this.pathHelper.workPackageDatepickerDialogContentPath(this.resource.id as string),
-      window.location.origin,
-    );
-
-    url.searchParams.set('field', this.name);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-    url.searchParams.set('work_package[initial][start_date]', this.nullAsEmptyStringFormatter(this.resource.startDate));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-    url.searchParams.set('work_package[initial][due_date]', this.nullAsEmptyStringFormatter(this.resource.dueDate));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-    url.searchParams.set('work_package[initial][duration]', this.nullAsEmptyStringFormatter(this.resource.duration));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-    url.searchParams.set('work_package[initial][ignore_non_working_days]', this.nullAsEmptyStringFormatter(this.resource.includeNonWorkingDays));
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-    url.searchParams.set('work_package[start_date]', this.nullAsEmptyStringFormatter(this.resource.startDate));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-    url.searchParams.set('work_package[due_date]', this.nullAsEmptyStringFormatter(this.resource.dueDate));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-    url.searchParams.set('work_package[duration]', this.nullAsEmptyStringFormatter(this.resource.duration));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
-    url.searchParams.set('work_package[ignore_non_working_days]', this.nullAsEmptyStringFormatter(this.resource.includeNonWorkingDays));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (this.resource?.id === 'new' && this.resource.startDate) {
-      url.searchParams.set('work_package[start_date_touched]', 'true');
+    if (!this.handler.inEditMode) {
+      this.handler.deactivate(false);
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    this.turboFrameSrc = url.toString();
   }
 
-  private nullAsEmptyStringFormatter(value:null|undefined|string):string {
-    if (value === undefined || value === null) {
-      return '';
-    }
-    return value;
-  }
+  public cancel():void {}
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -84,15 +84,6 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
     super.ngOnInit();
     this.turboFrameSrc = `${this.pathHelper.workPackageDatepickerDialogContentPath(this.change.id)}?field=${this.name}`;
 
-    this.handler
-      .$onUserActivate
-      .pipe(
-        this.untilDestroyed(),
-      )
-      .subscribe(() => {
-        this.showDatePickerModal();
-      });
-
     document.addEventListener('date-picker-modal:create', this.createHandler);
     document.addEventListener('date-picker-modal:update', this.updateHandler);
     document.addEventListener('date-picker-modal:cancel', this.cancelHandler);
@@ -107,12 +98,23 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
   }
 
   public showDatePickerModal():void {
-    this.opModalService.show(
-      OpWpDatePickerModalComponent,
-      this.injector,
-      { resource: this.resource, name: this.name },
-    );
-    this.opened = true;
+    this.opModalService
+      .show(
+        OpWpDatePickerModalComponent,
+        this.injector,
+        { resource: this.resource, name: this.name, change: this.change },
+      )
+      .subscribe((modal) => {
+        modal
+          .closingEvent
+          .subscribe(() => {
+            if (this.opened) {
+              this.onModalClosed();
+            }
+        });
+
+       this.opened = true;
+      });
   }
 
   public handleSuccessfulCreate(event:CustomEvent):void {

--- a/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.component.html
@@ -1,36 +1,8 @@
-<spot-drop-modal
-  [opened]="opened"
-  (closed)="cancel()"
-  alignment="bottom-center"
->
-  <input
-    type="number"
-    slot="trigger"
-    class="inline-edit--field op-input"
-    [ngModel]="formattedValue"
-    (click)="onInputClick($event)"
-    (focus)="showDatePickerModal()"
-    [id]="handler.htmlId"
-  />
-  <ng-container slot="body">
-    <turbo-frame *ngIf="turboFrameSrc && opened"
-                 [src]="turboFrameSrc"
-                 opModalWithTurboContent
-                 [change]="change"
-                 [resource]="resource"
-                 (successfulCreate)="handleSuccessfulCreate($event)"
-                 (successfulUpdate)="handleSuccessfulUpdate()"
-                 (cancel)="cancel()"
-                 id="wp-datepicker-dialog--content">
-      <op-content-loader viewBox="0 0 100 100">
-        <svg:rect x="5" y="5" width="70" height="5" rx="1"/>
-
-        <svg:rect x="80" y="5" width="15" height="5" rx="1"/>
-
-        <svg:rect x="5" y="15" width="90" height="8" rx="1"/>
-
-        <svg:rect x="5" y="30" width="90" height="12" rx="1"/>
-      </op-content-loader>
-    </turbo-frame>
-  </ng-container>
-</spot-drop-modal>
+<input
+  type="number"
+  class="inline-edit--field op-input"
+  [ngModel]="formattedValue"
+  (click)="onInputClick($event)"
+  (focus)="showDatePickerModal()"
+  [id]="handler.htmlId"
+/>

--- a/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/days-duration-edit-field.component.ts
@@ -37,8 +37,6 @@ import * as moment from 'moment-timezone';
   templateUrl: './days-duration-edit-field.component.html',
 })
 export class DaysDurationEditFieldComponent extends DatePickerEditFieldComponent implements OnInit {
-  opened = false;
-
   public get formattedValue():number {
     return Number(moment.duration(this.value).asDays().toFixed(0));
   }
@@ -51,14 +49,9 @@ export class DaysDurationEditFieldComponent extends DatePickerEditFieldComponent
     event.stopPropagation();
   }
 
-  showDatePickerModal():void {
-    this.updateFrameSrc();
-    this.opened = true;
-  }
-
   onModalClosed() {
+    super.onModalClosed();
     void this.handler.handleUserSubmit();
-    this.opened = false;
   }
 
   cancel():void {

--- a/frontend/src/app/shared/components/fields/openproject-fields.module.ts
+++ b/frontend/src/app/shared/components/fields/openproject-fields.module.ts
@@ -26,7 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  CUSTOM_ELEMENTS_SCHEMA,
+  Injector,
+  NgModule,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OpenprojectModalModule } from 'core-app/shared/components/modal/modal.module';
 import { OpenprojectEditorModule } from 'core-app/shared/components/editor/openproject-editor.module';
@@ -39,74 +44,35 @@ import { DisplayFieldService } from 'core-app/shared/components/fields/display/d
 import { initializeCoreEditFields } from 'core-app/shared/components/fields/edit/edit-field.initializer';
 import { initializeCoreDisplayFields } from 'core-app/shared/components/fields/display/display-field.initializer';
 import { FloatEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/float-edit-field.component';
-import {
-  MultiSelectEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/multi-select-edit-field.component';
-import {
-  EditFormPortalComponent,
-} from 'core-app/shared/components/fields/edit/editing-portal/edit-form-portal.component';
-import {
-  SelectAutocompleterRegisterService,
-} from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-autocompleter-register.service';
+import { MultiSelectEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/multi-select-edit-field.component';
+import { EditFormPortalComponent } from 'core-app/shared/components/fields/edit/editing-portal/edit-form-portal.component';
+import { SelectAutocompleterRegisterService } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-autocompleter-register.service';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
-import {
-  WorkPackageEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/work-package-edit-field.component';
-import {
-  EditableAttributeFieldComponent,
-} from 'core-app/shared/components/fields/edit/field/editable-attribute-field.component';
-import {
-  ProjectStatusEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/project-status-edit-field.component';
-import {
-  PlainFormattableEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/plain-formattable-edit-field.component';
+import { WorkPackageEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/work-package-edit-field.component';
+import { EditableAttributeFieldComponent } from 'core-app/shared/components/fields/edit/field/editable-attribute-field.component';
+import { ProjectStatusEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/project-status-edit-field.component';
+import { PlainFormattableEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/plain-formattable-edit-field.component';
 import { AttributeValueMacroComponent } from 'core-app/shared/components/fields/macros/attribute-value-macro.component';
 import { AttributeLabelMacroComponent } from 'core-app/shared/components/fields/macros/attribute-label-macro.component';
-import {
-  WorkPackageQuickinfoMacroComponent,
-} from 'core-app/shared/components/fields/macros/work-package-quickinfo-macro.component';
+import { WorkPackageQuickinfoMacroComponent } from 'core-app/shared/components/fields/macros/work-package-quickinfo-macro.component';
 import { DisplayFieldComponent } from 'core-app/shared/components/fields/display/display-field.component';
-import {
-  OpenprojectAutocompleterModule,
-} from 'core-app/shared/components/autocompleter/openproject-autocompleter.module';
-import {
-  BooleanEditFieldModule,
-} from 'core-app/shared/components/fields/edit/field-types/boolean-edit-field/boolean-edit-field.module';
-import {
-  IntegerEditFieldModule,
-} from 'core-app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.module';
-import {
-  TextEditFieldModule,
-} from 'core-app/shared/components/fields/edit/field-types/text-edit-field/text-edit-field.module';
-import {
-  DateEditFieldModule,
-} from 'core-app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.module';
-import {
-  SelectEditFieldModule,
-} from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.module';
-import {
-  FormattableEditFieldModule,
-} from 'core-app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.module';
-import {
-  EditFieldControlsModule,
-} from 'core-app/shared/components/fields/edit/field-controls/edit-field-controls.module';
+import { OpenprojectAutocompleterModule } from 'core-app/shared/components/autocompleter/openproject-autocompleter.module';
+import { BooleanEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/boolean-edit-field/boolean-edit-field.module';
+import { IntegerEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.module';
+import { TextEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/text-edit-field/text-edit-field.module';
+import { DateEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.module';
+import { SelectEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.module';
+import { FormattableEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.module';
+import { EditFieldControlsModule } from 'core-app/shared/components/fields/edit/field-controls/edit-field-controls.module';
 import { ProjectEditFieldComponent } from './edit/field-types/project-edit-field.component';
-import {
-  HoursDurationEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/hours-duration-edit-field.component';
-import {
-  ProgressPopoverEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/progress-popover-edit-field.component';
+import { HoursDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/hours-duration-edit-field.component';
+import { ProgressPopoverEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/progress-popover-edit-field.component';
 import { OpExclusionInfoComponent } from 'core-app/shared/components/fields/display/info/op-exclusion-info.component';
 import { UserEditFieldComponent } from './edit/field-types/user-edit-field.component';
-import {
-  DaysDurationEditFieldComponent,
-} from 'core-app/shared/components/fields/edit/field-types/days-duration-edit-field.component';
+import { DaysDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/days-duration-edit-field.component';
 import { CombinedDateEditFieldComponent } from './edit/field-types/combined-date-edit-field.component';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { FormsModule } from '@angular/forms';
-import { ModalWithTurboContentDirective } from 'core-app/shared/components/fields/edit/modal-with-turbo-content/modal-with-turbo-content.directive';
 
 @NgModule({
   imports: [
@@ -170,8 +136,6 @@ import { ModalWithTurboContentDirective } from 'core-app/shared/components/field
     AttributeLabelMacroComponent,
 
     WorkPackageQuickinfoMacroComponent,
-
-    ModalWithTurboContentDirective,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/frontend/src/app/shared/components/modal/modal.module.ts
+++ b/frontend/src/app/shared/components/modal/modal.module.ts
@@ -8,6 +8,7 @@ import { OpModalBannerComponent } from 'core-app/shared/components/modal/modal-b
 import { OpModalOverlayComponent } from 'core-app/shared/components/modal/modal-overlay.component';
 import { CommonModule } from '@angular/common';
 import { OpCustomModalOverlayComponent } from 'core-app/shared/components/modal/custom-modal-overlay.component';
+import { ModalWithTurboContentDirective } from 'core-app/shared/components/fields/edit/modal-with-turbo-content/modal-with-turbo-content.directive';
 
 @NgModule({
   imports: [
@@ -21,6 +22,7 @@ import { OpCustomModalOverlayComponent } from 'core-app/shared/components/modal/
     OpModalOverlayComponent,
     OpCustomModalOverlayComponent,
     OpModalBannerComponent,
+    ModalWithTurboContentDirective,
   ],
   providers: [
     OpModalWrapperAugmentService,
@@ -29,6 +31,7 @@ import { OpCustomModalOverlayComponent } from 'core-app/shared/components/modal/
     OpModalBannerComponent,
     OpModalOverlayComponent,
     OpCustomModalOverlayComponent,
+    ModalWithTurboContentDirective,
   ],
 })
 export class OpenprojectModalModule { }

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -30,6 +30,11 @@
     width: 60rem
     min-height: 40vh
 
+  &_auto-size
+    @media #{$spot-mq-desktop}
+      width: auto
+      min-height: auto
+
   &--header
     @include spot-subheader-big
 

--- a/spec/features/work_packages/table/milestones_spec.rb
+++ b/spec/features/work_packages/table/milestones_spec.rb
@@ -38,8 +38,11 @@ RSpec.describe "Inline editing milestones", :js do
     start_date.activate!
     start_date.expect_active!
 
-    # Open second date, closes first
-    scroll_to_and_click(due_date.display_element)
+    # Open second date, close first
+    start_date.cancel_by_escape
+    start_date.expect_inactive!
+
+    due_date.activate!
     due_date.expect_active!
 
     # Close with escape

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -88,7 +88,7 @@ class DateEditField < EditField
     if active?
       modal_element.find(input_selector)
     else
-      page.find(".#{property_name} .spot-input")
+      page.find(".#{property_name} .op-input")
     end
   end
 
@@ -149,7 +149,7 @@ class DateEditField < EditField
   end
 
   def expect_value(value)
-    expect(page).to have_css(".#{property_name} .spot-input", value:)
+    expect(page).to have_css(".#{property_name} .op-input", value:)
   end
 
   def set_active_date(value)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61091/activity

# What are you trying to accomplish?
* The datepicker should not be rendereed outside the screen limit and create artifical white space


## Screenshots
<img width="2082" alt="Bildschirmfoto 2025-03-06 um 14 46 24" src="https://github.com/user-attachments/assets/94f1bfb0-e7c6-451a-b803-bbe4e618b7e2" />


# What approach did you choose and why?
* Instead of a spot-drop-modal, use an angular modal
* This was much simpler than using a Primer Dialog, an attempt is shown here: https://github.com/opf/openproject/pull/18126

