### PR TITLE
[61597] Should not display "Delete relation" for child if lacking "Manage work package hierarchies" permission

### DIFF
--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -24,22 +24,19 @@
                   item.with_leading_visual_icon(icon: :pencil)
                 end
               end
-
-              if should_render_delete_option?
-                menu.with_item(label: I18n.t(:label_relation_delete),
-                               scheme: :danger,
-                               href: destroy_path,
-                               form_arguments: {
-                                 method: :delete,
-                                 data: {
-                                   confirm: t("text_are_you_sure"),
-                                   turbo_stream: true,
-                                   update_work_package: true
-                                 }
-                               },
-                               test_selector: delete_button_test_selector) do |item|
-                  item.with_leading_visual_icon(icon: :trash)
-                end
+              menu.with_item(label: I18n.t(:label_relation_delete),
+                             scheme: :danger,
+                             href: destroy_path,
+                             form_arguments: {
+                               method: :delete,
+                               data: {
+                                 confirm: t("text_are_you_sure"),
+                                 turbo_stream: true,
+                                 update_work_package: true
+                               }
+                             },
+                             test_selector: delete_button_test_selector) do |item|
+                item.with_leading_visual_icon(icon: :trash)
               end
             end
           end

--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -24,6 +24,7 @@
                   item.with_leading_visual_icon(icon: :pencil)
                 end
               end
+
               menu.with_item(label: I18n.t(:label_relation_delete),
                              scheme: :danger,
                              href: destroy_path,

--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -25,19 +25,21 @@
                 end
               end
 
-              menu.with_item(label: I18n.t(:label_relation_delete),
-                             scheme: :danger,
-                             href: destroy_path,
-                             form_arguments: {
-                               method: :delete,
-                               data: {
-                                 confirm: t("text_are_you_sure"),
-                                 turbo_stream: true,
-                                 update_work_package: true
-                               }
-                             },
-                             test_selector: delete_button_test_selector) do |item|
-                item.with_leading_visual_icon(icon: :trash)
+              if should_render_delete_option?
+                menu.with_item(label: I18n.t(:label_relation_delete),
+                               scheme: :danger,
+                               href: destroy_path,
+                               form_arguments: {
+                                 method: :delete,
+                                 data: {
+                                   confirm: t("text_are_you_sure"),
+                                   turbo_stream: true,
+                                   update_work_package: true
+                                 }
+                               },
+                               test_selector: delete_button_test_selector) do |item|
+                  item.with_leading_visual_icon(icon: :trash)
+                end
               end
             end
           end

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -63,6 +63,12 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
     helpers.current_user.allowed_in_project?(:manage_work_package_relations, @work_package.project)
   end
 
+  def should_render_delete_option?
+    return true unless parent_child_relationship?
+
+    helpers.current_user.allowed_in_project?(:manage_subtasks, @child.project)
+  end
+
   def visible?
     @visibility == :visible
   end

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -56,17 +56,12 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   end
 
   def allowed_to_manage_subtasks?
-    helpers.current_user.allowed_in_project?(:manage_subtasks, @work_package.project)
+    helpers.current_user.allowed_in_project?(:manage_subtasks, @work_package.project) &&
+      helpers.current_user.allowed_in_project?(:manage_subtasks, @child.project)
   end
 
   def allowed_to_manage_relations?
     helpers.current_user.allowed_in_project?(:manage_work_package_relations, @work_package.project)
-  end
-
-  def should_render_delete_option?
-    return true unless parent_child_relationship?
-
-    helpers.current_user.allowed_in_project?(:manage_subtasks, @child.project)
   end
 
   def visible?

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -487,6 +487,38 @@ RSpec.describe "Primerized work package relations tab",
       end
     end
 
+    context "when the user does not have manage_subtasks in child's project" do
+      let(:child_wp_project) { create(:project) }
+      let!(:child_wp) do
+        create(:work_package,
+               subject: "child_wp",
+               parent: work_package,
+               type: type1,
+               project: child_wp_project)
+      end
+
+      let(:restricted_role) { create(:project_role, permissions: %i[view_work_packages]) }
+
+      let(:user_without_manage_subtasks) do
+        create(:user,
+               member_with_roles: {
+                 project => create(:project_role, permissions: %i[view_work_packages manage_subtasks]),
+                 child_wp_project => restricted_role
+               })
+      end
+
+      let(:current_user) { user_without_manage_subtasks }
+
+      it "does not show the option to delete the child relation" do
+        scroll_to_element relations_panel
+
+        wait_for_network_idle
+
+        # The menu should NOT be available for child_wp since user lacks manage_subtasks permission
+        relations_tab.expect_no_relatable_action_menu(child_wp)
+      end
+    end
+
     context "with manage_subtasks permissions" do
       let(:no_permissions_role) { create(:project_role, permissions: %i(view_work_packages edit_work_packages manage_subtasks)) }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61597

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show Delete option in relation row if the user has permission of 'Manage work package hierarchies' in child's project.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
