### PR TITLE
[#62032] Fix flickering time_entry_activity_spec

### DIFF
--- a/spec/features/activities/time_entry_activity_spec.rb
+++ b/spec/features/activities/time_entry_activity_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "TimeEntry activity",
 
     wait_for_reload
 
-    expect(find_field("work_package_id_arg_1_val").value).to eq(work_package.id.to_s)
+    expect(page).to have_field("Work package Value", with: work_package.id)
 
     old_comments = time_entry.comments
     old_spent_on = time_entry.spent_on
@@ -114,6 +114,6 @@ RSpec.describe "TimeEntry activity",
 
     wait_for_reload
 
-    expect(find_field("work_package_id_arg_1_val").value).to eq(work_package2.id.to_s)
+    expect(page).to have_field("Work package Value", with: work_package2.id)
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62032

# What are you trying to accomplish?

Fix the flickering spec.

# Screenshot

```
1) TimeEntry activity tracks the time_entry's activities
     Failure/Error: expect(find_field("work_package_id_arg_1_val").value).to eq(work_package2.id.to_s)

       expected: #<Encoding:US-ASCII> "4"
            got: #<Encoding:UTF-8> ""

       (compared using ==)
     # ./spec/features/activities/time_entry_activity_spec.rb:117:in 'block (2 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:204:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rspec_retry.rb:24:in 'block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:123:in 'block (2 levels) in <top (required)>'
```

# What approach did you choose and why?

Use synchronising matchers to wait for a field to update.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
