### PR TITLE
Fix more non synchronous capybara expectations #2

### DIFF
--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "Admin Edit File storage",
       aggregate_failures "Storage Audience" do
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page.find(:radio_button, "Define storage audience manually")).to be_checked
+          expect(page).to have_checked_field("Define storage audience manually")
           expect(page).to have_field("Storage Audience")
 
           click_on "Save and continue"
@@ -304,7 +304,7 @@ RSpec.describe "Admin Edit File storage",
           choose("Use first access token obtained by identity provider")
           expect(page).to have_no_field("Storage Audience")
           choose("Define storage audience manually")
-          expect(find_field("Storage Audience").value).to eq("schmaudience")
+          expect(page).to have_field("Storage Audience", with: "schmaudience")
 
           click_on "Save and continue"
         end
@@ -314,8 +314,8 @@ RSpec.describe "Admin Edit File storage",
 
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page.find(:radio_button, "Define storage audience manually")).to be_checked
-          expect(find_field("Storage Audience").value).to eq("schmaudience")
+          expect(page).to have_checked_field("Define storage audience manually")
+          expect(page).to have_field("Storage Audience", with: "schmaudience")
 
           choose("Use first access token obtained by identity provider")
           click_on "Save and continue"
@@ -329,11 +329,11 @@ RSpec.describe "Admin Edit File storage",
 
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page.find(:radio_button, "Use first access token obtained by identity provider")).to be_checked
+          expect(page).to have_checked_field("Use first access token obtained by identity provider")
           expect(page).to have_no_field("Storage Audience")
 
           choose("Define storage audience manually")
-          expect(find_field("Storage Audience").value).to be_empty
+          expect(page).to have_field("Storage Audience", with: "")
         end
       end
     end

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Admin lists project mappings for a storage",
         find(".ng-option-label", text: project.name).click
         check "Include sub-projects"
 
-        expect(page.find_by_id("storages_project_storage_project_folder_mode_automatic")).to be_checked
+        expect(page).to have_checked_field("storages_project_storage_project_folder_mode_automatic")
 
         click_on "Add"
       end
@@ -205,7 +205,8 @@ RSpec.describe "Admin lists project mappings for a storage",
             find(".ng-option-label", text: project.name).click
             check "Include sub-projects"
 
-            expect(page.find_by_id("storages_project_storage_project_folder_mode_automatic")).to be_checked
+            expect(page)
+              .to have_checked_field("storages_project_storage_project_folder_mode_automatic")
 
             choose "Existing folder with manually managed permissions"
             wait_for { page }.to have_text("No selected folder")
@@ -251,7 +252,8 @@ RSpec.describe "Admin lists project mappings for a storage",
               click_on "Add"
 
               expect(page).to have_text("Please select a folder.")
-              expect(page.find_by_id("storages_project_storage_project_folder_mode_manual")).to be_checked
+              expect(page)
+                .to have_checked_field("storages_project_storage_project_folder_mode_manual")
               expect(page).to have_text("No selected folder")
             end
           end

--- a/spec/features/projects/work_package_type_mgmt_spec.rb
+++ b/spec/features/projects/work_package_type_mgmt_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -41,18 +43,14 @@ RSpec.describe "Projects", "work package type mgmt", :js do
     click_on "Project settings"
     click_on "Work package types"
 
-    expect(find_field("Phase", visible: false)["checked"])
-      .to be_truthy
-
-    expect(find_field("Milestone", visible: false)["checked"])
-      .to be_truthy
+    expect(page).to have_checked_field("Phase", visible: :all)
+    expect(page).to have_checked_field("Milestone", visible: :all)
 
     # Disable a type
     find_field("Milestone", visible: false).click
 
     click_button "Save"
 
-    expect(find_field("Milestone", visible: false)["checked"])
-      .to be_falsey
+    expect(page).to have_unchecked_field("Milestone", visible: :all)
   end
 end

--- a/spec/features/repositories/repository_settings_spec.rb
+++ b/spec/features/repositories/repository_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -55,15 +57,14 @@ RSpec.describe "Repository Settings", :js do
   shared_examples "manages the repository" do |type|
     it "displays the repository" do
       expect(page).to have_css('select[name="scm_vendor"]')
-      expect(find("#attributes-group--content-#{type}", visible: true))
-        .not_to be_nil
+      expect(page).to have_css("#attributes-group--content-#{type}", visible: :visible)
     end
 
     it "deletes the repository" do
       expect(Repository.exists?(repository.id)).to be true
 
+      SeleniumHubWaiter.wait
       if type == "managed"
-        SeleniumHubWaiter.wait
         find("a.icon-delete", text: I18n.t(:button_delete)).click
 
         dangerzone = DangerZone.new(page)
@@ -82,7 +83,6 @@ RSpec.describe "Repository Settings", :js do
         SeleniumHubWaiter.wait
         dangerzone.danger_button.click
       else
-        SeleniumHubWaiter.wait
         find("a.icon-remove", text: I18n.t(:button_remove)).click
         expect(page).to have_css(".op-toast.-warning")
         SeleniumHubWaiter.wait

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -163,7 +165,7 @@ RSpec.describe "Work package create uses attributes from filters", :js, :seleniu
 
       # Assignee is synced
       assignee_field = split_view_create.edit_field :assignee
-      expect(assignee_field.input_element.find(".ng-value-label").text).to eql("An assignee")
+      expect(assignee_field.input_element.find(".ng-value-label")).to have_text("An assignee")
 
       within ".work-packages--edit-actions" do
         click_button "Save"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62032

# What are you trying to accomplish?
Follow up PR to change other occurrences that might be flaky due to non-synchronizing matchers.

# What approach did you choose and why?
Use synchronized capybara matchers, such as `find`.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
