### PR TITLE
Fix sort direction translation in query component

### DIFF
--- a/app/components/queries/sort_by_field_component.html.erb
+++ b/app/components/queries/sort_by_field_component.html.erb
@@ -7,8 +7,8 @@
   <% flex.with_column do %>
     <%= render(Primer::Alpha::SegmentedControl.new("aria-label": "Sort order", hide_labels: true, ml: 3)) do |sort_buttons| %>
       <%#- The segmented control actions need to be included here as well as they do the visual styling of the currently selected option, just setting our action would remove their action %>
-      <% sort_buttons.with_item(icon: "sort-asc", label: "sort ascending", selected: order_asc?, data: { direction: "asc", action: "click:segmented-control#select click->sort-by-config#fieldChanged" }) %>
-      <% sort_buttons.with_item(icon: "sort-desc", label: "sort descending", selected: order_desc?, data: { direction: "desc", action: "click:segmented-control#select click->sort-by-config#fieldChanged" }) %>
+      <% sort_buttons.with_item(icon: "sort-asc", label: t("label_sort_ascending"), selected: order_asc?, data: { direction: "asc", action: "click:segmented-control#select click->sort-by-config#fieldChanged"}) %>
+      <% sort_buttons.with_item(icon: "sort-desc", label: t("label_sort_descending"), selected: order_desc?, data: { direction: "desc", action: "click:segmented-control#select click->sort-by-config#fieldChanged"}) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Fix sort direction translation component

# What are you trying to accomplish?
Translate  button popup 

## Screenshots
![Screenshot_20250307_144435](https://github.com/user-attachments/assets/c7b793a5-b0a0-4ed0-9aae-734b556904a7)
