### PR TITLE
[61982] Milestones show the wrong label in the date form

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -18,7 +18,7 @@
         end
 
         start_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: I18n.t("attributes.start_date"))))
+          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label)))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
           render_today_link(name: :start_date)

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -100,7 +100,7 @@ module WorkPackages
         render(
           Primer::Beta::Link.new(
             href: "",
-            "aria-label": I18n.t("label_today_as_#{name}"),
+            "aria-label": @is_milestone ? I18n.t("label_today_as_date") : I18n.t("label_today_as_#{name}"),
             data: {
               action: "work-packages--date-picker--preview#setTodayForField",
               "work-packages--date-picker--preview-field-reference-param": "work_package_#{name}",

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -114,6 +114,14 @@ module WorkPackages
         name == :duration
       end
 
+      def start_date_label
+        if @is_milestone
+          I18n.t("attributes.date")
+        else
+          I18n.t("attributes.start_date")
+        end
+      end
+
       def update_focused_field(focused_field)
         if @date_mode.nil? || @date_mode != "range"
           return focused_field_for_single_date_mode(focused_field)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2985,6 +2985,7 @@ en:
   label_token_version: "Token Version"
   label_today_as_start_date: "Select today as start date."
   label_today_as_due_date: "Select today as finish date."
+  label_today_as_date: "Select today as date."
   label_top_menu: "Top Menu"
   label_topic_plural: "Topics"
   label_total: "Total"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61982

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Change the label of start date to date when the WP is milestone

## Screenshots
Before:
![Screenshot 2025-03-07 at 13 16 54](https://github.com/user-attachments/assets/4491a31b-51ef-42d2-9a29-267edb557224)

After:
![Screenshot 2025-03-07 at 13 16 28](https://github.com/user-attachments/assets/3b9e5786-6391-46c8-8bce-f7df335eda0c)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
