### PR TITLE
[#61916] Autofocus on text fields

### DIFF
--- a/frontend/src/stimulus/controllers/ckeditor-focus.controller.ts
+++ b/frontend/src/stimulus/controllers/ckeditor-focus.controller.ts
@@ -29,13 +29,31 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
+import { ICKEditorInstance } from 'core-app/shared/components/editor/components/ckeditor/ckeditor.types';
 
 export default class extends Controller {
+  static values = { autofocus: Boolean };
+  declare autofocusValue:boolean;
+
+  static targets = ['editor'];
+  declare readonly editorTarget:HTMLElement;
+
   connect():void {
-    this.focusInput();
+    if (this.autofocusValue) {
+      this.focusInput();
+    }
   }
 
   focusInput():void {
     this.element.scrollIntoView({ block: 'center' });
+
+    const ckeditorField = this.editorTarget.querySelector('op-ckeditor') as HTMLElement;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    void jQuery(ckeditorField)
+      .data('editor')
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      .then((editor:ICKEditorInstance) => {
+        editor.editing.view.focus();
+      });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/meeting-agenda-item-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meeting-agenda-item-form.controller.ts
@@ -34,14 +34,14 @@ import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
   static values = {
     cancelUrl: String,
+    autofocus: Boolean,
   };
 
   declare cancelUrlValue:string;
+  declare autofocusValue:boolean;
 
-  static targets = ['titleInput', 'notesInput', 'notesAddButton'];
-  declare readonly titleInputTarget:HTMLInputElement;
+  static targets = ['notesInput'];
   declare readonly notesInputTarget:HTMLInputElement;
-  declare readonly notesAddButtonTarget:HTMLInputElement;
 
   connect():void {
     this.focusInput();
@@ -52,7 +52,7 @@ export default class extends Controller {
     const titleInput = this.element.querySelector('input[name="meeting_agenda_item[title]"]');
 
     this.element.scrollIntoView({ block: 'center' });
-    if (titleInput) {
+    if (titleInput && this.autofocusValue) {
       (titleInput as HTMLInputElement).focus();
       this.setCursorAtEnd(titleInput as HTMLInputElement);
     }

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -18,6 +18,7 @@ import PreviewController from './controllers/dynamic/work-packages/date-picker/p
 import KeepScrollPositionController from './controllers/keep-scroll-position.controller';
 import PatternInputController from './controllers/pattern-input.controller';
 import HoverCardTriggerController from './controllers/hover-card-trigger.controller';
+import CkeditorFocusController from './controllers/ckeditor-focus.controller';
 
 declare global {
   interface Window {
@@ -51,3 +52,4 @@ instance.register('projects-zen-mode', OpProjectsZenModeController);
 instance.register('work-packages--date-picker--preview', PreviewController);
 instance.register('keep-scroll-position', KeepScrollPositionController);
 instance.register('pattern-input', PatternInputController);
+instance.register('ckeditor-focus', CkeditorFocusController);

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.html.erb
@@ -11,7 +11,7 @@
           when :simple
             render(MeetingAgendaItem::Title.new(f))
           when :work_package
-            render(MeetingAgendaItem::WorkPackage.new(f))
+            render(MeetingAgendaItem::WorkPackage.new(f, autofocus: @autofocus))
           end
         end
 

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.rb
@@ -36,7 +36,6 @@ module MeetingAgendaItems
     def initialize(meeting:, meeting_section:, meeting_agenda_item:, method:, submit_path:, cancel_path:, type: :simple,
                    display_notes_input: nil)
       super
-
       @meeting = meeting
       @meeting_section = meeting_section
       @meeting_agenda_item = meeting_agenda_item
@@ -45,6 +44,7 @@ module MeetingAgendaItems
       @cancel_path = cancel_path
       @type = type
       @display_notes_input = display_notes_input
+      @autofocus = display_notes_input.blank?
     end
 
     def wrapper_uniq_by
@@ -59,9 +59,12 @@ module MeetingAgendaItems
 
     def wrapper_data_attributes
       {
-        controller: "meeting-agenda-item-form",
+        controller: "meeting-agenda-item-form ckeditor-focus",
         "application-target": "dynamic",
-        "meeting-agenda-item-form-cancel-url-value": @cancel_path
+        "meeting-agenda-item-form-cancel-url-value": @cancel_path,
+        "meeting-agenda-item-form-autofocus-value": @autofocus,
+        "ckeditor-focus-target": "editor",
+        "ckeditor-focus-autofocus-value": !@autofocus
       }
     end
 

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  component_wrapper(data: wrapper_data_attributes) do
+  component_wrapper do
     primer_form_with(
       model: @meeting_outcome,
       method: @method,
@@ -8,10 +8,7 @@
       grid_layout("op-meeting-outcome-form", tag: :div) do |grid|
         grid.with_area(
           :notes,
-          data: {
-            "test-selector": "meeting-outcome-input",
-            "meeting-outcome-form-target": "notesInput"
-          }
+          data: wrapper_data_attributes
         ) do
           render(MeetingAgendaItem::Outcome::Notes.new(f))
         end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.rb
@@ -50,10 +50,12 @@ module MeetingAgendaItems::Outcomes
     private
 
     def wrapper_data_attributes
-      # {
-      #   controller: "meeting-outcome-form",
-      #   "application-target": "dynamic"
-      # }
+      {
+        controller: "ckeditor-focus",
+        "test-selector": "meeting-outcome-input",
+        "ckeditor-focus-target": "editor",
+        "ckeditor-focus-autofocus-value": "true"
+      }
     end
   end
 end

--- a/modules/meeting/app/forms/meeting_agenda_item/work_package.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/work_package.rb
@@ -38,14 +38,15 @@ class MeetingAgendaItem::WorkPackage < ApplicationForm
         data: {
           "test-selector": "op-agenda-items-wp-autocomplete"
         },
-        focusDirectly: true,
+        focusDirectly: @autofocus,
         disabled: @disabled
       }
     )
   end
 
-  def initialize(disabled: false)
+  def initialize(autofocus:, disabled: false)
     super()
     @disabled = disabled
+    @autofocus = autofocus
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/61916

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?

- Introduce a generic ckeditor focus stimulus controller and use it for outcomes and agenda items
- Always autofocus on the outcomes form
- Conditionally autofocus on either the notes field or title for agenda items and work package agenda items

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
