### PR TITLE
Fix production run after go Rails 7.2

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -164,11 +164,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Silence the following warning
-  # "Rails couldn't infer whether you are using multiple databases from your database.yml"
-  # This is deprecated in 7.1. and the warning got removed.
-  config.active_record.suppress_multiple_database_warning = true
-
   if OpenProject::Configuration.enable_internal_assets_server?
     config.public_file_server.enabled = true
     config.public_file_server.headers = {

--- a/config/initializers/06-pending_migrations_check.rb
+++ b/config/initializers/06-pending_migrations_check.rb
@@ -31,5 +31,5 @@ no_rake_task = !(Rake.respond_to?(:application) && Rake.application.top_level_ta
 no_override = ENV["OPENPROJECT_DISABLE__MIGRATIONS__CHECK"] != "true"
 
 if Rails.env.production? && !is_console && no_rake_task && no_override
-  ActiveRecord::Migration.check_pending! # will raise an exception and abort boot
+  ActiveRecord::Migration.check_all_pending! # will raise an exception and abort boot
 end

--- a/docker/prod/wait_for_db.rb
+++ b/docker/prod/wait_for_db.rb
@@ -8,7 +8,7 @@ Timeout::timeout(timeout) do
     sleep 4
 
     begin
-      ActiveRecord::Migration.check_pending!
+      ActiveRecord::Migration.check_all_pending!
 
       puts "[#{DateTime.now}] db ready"
       exit 0


### PR DESCRIPTION
# What are you trying to accomplish?

Make OpenProject can run in production mode.

# What approach did you choose and why?

Following Rails 7.2 [method rename](https://github.com/rails/rails/commit/02f66fe3e25cef2b0dec8bca26e777fe788af35c) and remove not available config.

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
