### PR TITLE
[#61885] Sort relations in relations tab by created_at

### DIFF
--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -57,6 +57,7 @@
           # Combine visible and invisible relations into a single list
           all_relations = relation_group.visible_relations.map { |r| [r, :visible] } +
             relation_group.ghost_relations.map { |r| [r, :ghost] }
+          all_relations.sort_by! { |r| r[0].id }
 
           flex.with_row(mb: 4) do
             render_relation_group(
@@ -84,6 +85,7 @@
           # Combine visible and invisible children into a single list
           all_children = visible_children.map { |r| [r, :visible] } +
             ghost_children.map { |r| [r, :ghost] }
+          all_children.sort_by! { |r| r[0].created_at }
 
           flex.with_row do
             render_relation_group(

--- a/spec/components/work_package_relations_tab/index_component_spec.rb
+++ b/spec/components/work_package_relations_tab/index_component_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageRelationsTab::IndexComponent, type: :component do
+  shared_let(:user) { create(:admin) }
+  shared_let(:work_package) { create(:work_package) }
+
+  current_user { user }
+
+  def render_component(**params)
+    render_inline(described_class.new(work_package:, **params))
+    page
+  end
+
+  context "with no relations" do
+    it "renders a message" do
+      expect(render_component).to have_heading "No relations"
+      expect(page).to have_text "This work package does not have any relations yet."
+    end
+  end
+
+  context "with child relations" do
+    shared_let_work_packages(<<~TABLE)
+      hierarchy      | MTWTFSS | scheduling mode |
+      work_package   |       X | automatic       |
+        child1       | XXX     | manual          |
+        child2       |         | automatic       |
+    TABLE
+
+    it "renders the relations group" do
+      expect(render_component).to have_test_selector("op-relation-group-children")
+    end
+
+    it "renders the relations" do
+      expect(render_component).to have_list "Children"
+
+      list = page.find(:list, "Children")
+      expect(list).to have_list_item count: 2, text: /child\d/
+    end
+  end
+
+  context "with follows relations" do
+    shared_let_work_packages(<<~TABLE)
+      hierarchy    | MTWTFSS    | scheduling mode | predecessors
+      predecessor1 | XXX        | manual          |
+      predecessor2 | XX         | manual          |
+      predecessor3 | XX         | manual          |
+      predecessor4 |            | manual          |
+      work_package |          X | automatic       | predecessor1 with lag 2, predecessor2 with lag 7, predecessor3 with lag 7, predecessor4 with lag 10
+    TABLE
+
+    it "renders the relations group" do
+      expect(render_component).to have_test_selector("op-relation-group-follows")
+    end
+
+    it "renders the relations" do
+      expect(render_component).to have_list "Predecessors (before)"
+
+      list = page.find(:list, "Predecessors (before)")
+      expect(list).to have_list_item count: 4, text: /predecessor\d/
+    end
+
+    it "renders the closest relation" do
+      render_component
+
+      list_item = page.find(:list_item, text: "predecessor2")
+      expect(list_item).to have_primer_label("Closest")
+    end
+  end
+end

--- a/spec/components/work_package_relations_tab/relation_component_spec.rb
+++ b/spec/components/work_package_relations_tab/relation_component_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
+  shared_let(:user) { create(:admin) }
+  shared_let(:work_package) { create(:work_package) }
+
+  current_user { user }
+
+  shared_let_work_packages(<<~TABLE)
+    hierarchy    | MTWTFSS    | scheduling mode | predecessors
+    predecessor  | XXX        | manual          |
+    work_package |          X | automatic       | predecessor with lag 2
+      child      |            | automatic       |
+  TABLE
+
+  def render_component(**params)
+    render_inline(described_class.new(work_package:, **params))
+  end
+
+  context "with child relations" do
+    context "when visible" do
+      it "renders a title link" do
+        expect(render_component(relation: nil, child: child, visibility: :visible))
+          .to have_link "child"
+      end
+
+      context "when editable" do
+        it "renders an action menu" do
+          component = render_component(relation: nil, child: child, visibility: :visible, editable: true)
+          expect(component).to have_menu # FIXME: aria-labelledby does not resolve here "Relation actions"
+          expect(component).to have_selector :menuitem, "Delete relation"
+        end
+      end
+    end
+
+    context "when ghost" do
+      it "does not render a title link" do
+        expect(render_component(relation: nil, child: child, visibility: :ghost))
+          .to have_no_link "child"
+      end
+
+      it "renders a title and message without details" do
+        expect(render_component(relation: nil, child: child, visibility: :ghost))
+          .to have_text "Related work package"
+        expect(render_component(relation: nil, child: child, visibility: :ghost))
+          .to have_text "This is not visible to you due to permissions."
+      end
+
+      it "does not render an action menu" do
+        expect(render_component(relation: nil, child: child, visibility: :ghost))
+          .to have_no_menu
+      end
+    end
+  end
+
+  context "with follows relations" do
+    context "when visible" do
+      it "renders a title link" do
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :visible))
+          .to have_link "predecessor"
+      end
+
+      it "renders the lag" do
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :visible))
+          .to have_text "Lag: 2 days"
+      end
+
+      context "when editable" do
+        it "renders a action menu" do
+          component = render_component(relation: _table.relation(predecessor: predecessor), visibility: :visible, editable: true)
+          expect(component).to have_menu # FIXME: aria-labelledby does not resolve here "Relation actions"
+          expect(component).to have_selector :menuitem, "Edit relation"
+          expect(component).to have_selector :menuitem, "Delete relation"
+        end
+      end
+    end
+
+    context "when ghost" do
+      it "does not render a title link" do
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :ghost))
+          .to have_no_link "child"
+      end
+
+      it "renders a title and message without details" do
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :ghost))
+          .to have_text "Related work package"
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :ghost))
+          .to have_text "This is not visible to you due to permissions."
+      end
+
+      it "does not render an action menu" do
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :ghost))
+          .to have_no_menu
+      end
+    end
+
+    context "when closest" do
+      it "always renders a closest label" do
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :visible, closest: true))
+          .to have_primer_label "Closest", scheme: :primary
+        expect(render_component(relation: _table.relation(predecessor: predecessor), visibility: :ghost, closest: true))
+          .to have_primer_label "Closest", scheme: :primary
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61885
https://community.openproject.org/wp/61950

# What are you trying to accomplish?

Update the sort order of relations in the relations tab and date picker by relation creation date, oldest first.
Mix visible and ghost relations together instead of having visible first and then ghost.

## Screenshots

![image](https://github.com/user-attachments/assets/003fe261-4f8d-4899-aea6-9f4785aad8b5)


# What approach did you choose and why?

This is the simplest possible implementation, with the fewest code changes. I did explore some refactoring to try to reduce the number of times we iterate over the relations, but didn't come up with a solution that I liked.

This PR also adds a bunch of component tests - these could certainly be DRY'ed up, but it's a start (see #18107 for an aborted attempt to use test these components with snapshot testing).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
