### PR TITLE
Ensure that sorting of locales always works

### DIFF
--- a/app/seeders/basic_data/setting_seeder.rb
+++ b/app/seeders/basic_data/setting_seeder.rb
@@ -69,7 +69,7 @@ module BasicData
         settings["commit_fix_status_id"] = status_closed.try(:id)
 
         # Add the current locale to the list of available languages
-        settings["available_languages"] = (Setting.available_languages + [I18n.locale.to_s]).uniq.sort
+        settings["available_languages"] = (Setting.available_languages + [I18n.locale]).map(&:to_s).uniq.sort
 
         settings.compact
       end


### PR DESCRIPTION
This intends to fix rarely occuring errors on that line according to AppSignal:

    comparison of String with :en failed
    Backtrace: app/seeders/basic_data/setting_seeder.rb:72:in 'Array#sort'

I don't know how the symbol ended up in the array, there is possibly a root cause elsewhere to be found. However, considering that this line of code already acknowledged that locales are sometimes represented as a symbol, it is probably sensible to convert the whole array to its string representation anyways.

# Ticket
https://appsignal.com/openproject-gmbh/sites/678fa146338a5d816f8d696c/exceptions/incidents/260

# What are you trying to accomplish?
Prevent seeding errors that are repeatedly observed in the wild.

# What approach did you choose and why?
Ensure the error is prevented where it occurs, mostly because I have a hard time following the issue to its root.
If someone has an idea where the symbol leaks into the settings, that place might be the better location for a fix.
