### PR TITLE
Add a new attribute to limit entries to a single project

### DIFF
--- a/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
@@ -5,7 +5,8 @@
           TimeEntries::TimeEntryFormComponent.new(
             time_entry: time_entry,
             show_user: show_user,
-            show_work_package: show_work_package
+            show_work_package: show_work_package,
+            limit_to_project_id: limit_to_project_id
           )
         ) %>
   <% end %>

--- a/modules/costs/app/components/time_entries/entry_dialog_component.rb
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.rb
@@ -35,21 +35,17 @@ module TimeEntries
 
     MODAL_ID = "time-entry-dialog"
 
-    def initialize(time_entry:, show_user: true, show_work_package: true)
-      super()
-      @time_entry = time_entry
-      @show_user = show_user
-      @show_work_package = show_work_package
-    end
+    options time_entry: nil,
+            limit_to_project_id: nil,
+            show_user: true,
+            show_work_package: true
 
     private
-
-    attr_reader :time_entry, :open, :show_user, :show_work_package
 
     def can_delete_time_entry?
       return false if time_entry.new_record?
 
-      DeleteContract.deletion_allowed?(@time_entry, User.current)
+      DeleteContract.deletion_allowed?(time_entry, User.current)
     end
   end
 end

--- a/modules/costs/app/components/time_entries/time_entry_form_component.html.erb
+++ b/modules/costs/app/components/time_entries/time_entry_form_component.html.erb
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             body.with_row { render(TimeEntries::DaysAndHoursForm.new(form)) }
             body.with_row(display: show_work_package ? :block : :none) do
               render(
-                TimeEntries::WorkPackageForm.new(form, visible: show_work_package)
+                TimeEntries::WorkPackageForm.new(form, visible: show_work_package, limit_to_project_id: limit_to_project_id)
               )
             end
             body.with_row { render(TimeEntries::ActivityForm.new(form)) }

--- a/modules/costs/app/components/time_entries/time_entry_form_component.rb
+++ b/modules/costs/app/components/time_entries/time_entry_form_component.rb
@@ -33,16 +33,12 @@ module TimeEntries
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(time_entry:, show_user: true, show_work_package: true)
-      super()
-      @time_entry = time_entry
-      @show_user = show_user
-      @show_work_package = show_work_package
-    end
+    options time_entry: nil,
+            limit_to_project_id: nil,
+            show_user: true,
+            show_work_package: true
 
     private
-
-    attr_reader :time_entry, :show_user, :show_work_package
 
     delegate :project, :work_package, to: :time_entry
 

--- a/modules/costs/app/components/time_entries/work_package_form.rb
+++ b/modules/costs/app/components/time_entries/work_package_form.rb
@@ -30,13 +30,15 @@
 
 module TimeEntries
   class WorkPackageForm < ApplicationForm
-    def initialize(visible: true)
+    def initialize(visible: true, limit_to_project_id: nil)
       super()
       @visible = visible
+      @limit_to_project_id = limit_to_project_id
     end
 
     form do |f|
       f.hidden name: :show_work_package, value: @visible
+      f.hidden name: :limit_to_project_id, value: @limit_to_project_id
 
       if show_work_package_field?
         f.work_package_autocompleter name: :work_package_id,
@@ -95,8 +97,8 @@ module TimeEntries
     def work_package_completer_filters
       filters = []
 
-      if model.project_id
-        filters << { name: "project_id", operator: "=", values: [model.project_id] }
+      if @limit_to_project_id
+        filters << { name: "project_id", operator: "=", values: [@limit_to_project_id] }
       end
 
       filters

--- a/modules/costs/app/controllers/time_entries_controller.rb
+++ b/modules/costs/app/controllers/time_entries_controller.rb
@@ -47,6 +47,7 @@ class TimeEntriesController < ApplicationController
   def dialog
     @show_work_package = params[:work_package_id].blank?
     @show_user = show_user_input_in_dialog
+    @limit_to_project_id = @project&.id
 
     @time_entry.spent_on ||= params[:date].presence || Time.zone.today
   end
@@ -141,7 +142,8 @@ class TimeEntriesController < ApplicationController
   def form_config_options
     {
       show_user: params[:time_entry][:show_user] == "true",
-      show_work_package: params[:time_entry][:show_work_package] == "true"
+      show_work_package: params[:time_entry][:show_work_package] == "true",
+      limit_to_project_id: params[:time_entry][:limit_to_project_id].presence
     }
   end
 

--- a/modules/costs/app/views/time_entries/dialog.turbo_stream.erb
+++ b/modules/costs/app/views/time_entries/dialog.turbo_stream.erb
@@ -3,7 +3,8 @@
         TimeEntries::EntryDialogComponent.new(
           time_entry: @time_entry,
           show_user: @show_user,
-          show_work_package: @show_work_package
+          show_work_package: @show_work_package,
+          limit_to_project_id: @limit_to_project_id
         )
       )
     end %>

--- a/modules/costs/spec/features/time_entry_dialog_spec.rb
+++ b/modules/costs/spec/features/time_entry_dialog_spec.rb
@@ -216,6 +216,38 @@ RSpec.describe "time entry dialog", :js, with_flag: :track_start_and_end_times_f
     let(:permissions) { %i[log_own_time view_own_time_entries edit_own_time_entries view_work_packages] }
     let!(:time_entry) { create(:time_entry, work_package: work_package_a, project: work_package_a.project, user: user) }
 
+    context "with work packages from different projects" do
+      let(:other_project) { create(:project_with_types) }
+      let(:work_package_c) { create(:work_package, subject: "WP C", project: other_project) }
+
+      let(:user) { create(:user, member_with_permissions: { project => permissions, other_project => permissions }) }
+
+      it "allows switching to a work package of a different project (Regression #62066)" do
+        visit cost_reports_path(work_package_a.project_id,
+                                { fields: ["WorkPackageId"],
+                                  operators: { WorkPackageId: "=" },
+                                  values: { WorkPackageId: [work_package_a.id, work_package_b.id, work_package_c.id] },
+                                  set_filter: 1 })
+
+        # make sure that the work package is shown in the table
+        expect(page).to have_css("#result-table td[raw-data='#{work_package_a.id}']", text: work_package_a.subject)
+
+        find("opce-time-entry-trigger-actions .icon-edit").click
+
+        time_logging_modal.is_visible(true)
+        time_logging_modal.update_field("work_package_id", work_package_c.id)
+        wait_for_network_idle # form refresh is happening here
+        time_logging_modal.submit
+        wait_for_network_idle
+
+        expect(page).to have_css("#result-table td[raw-data='#{work_package_c.id}']", text: work_package_c.subject)
+
+        # also check that everything is updated in the database
+        time_entry.reload
+        expect(time_entry.work_package).to eq(work_package_c)
+      end
+    end
+
     it "updates the time entry instead of creating a new one (Regression #61657)" do
       visit cost_reports_path(work_package_a.project_id,
                               { fields: ["WorkPackageId"],


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62066

# What are you trying to accomplish?
Currently the presence of a project on the time entry determines if the WP list is filtered for that project. This leads to the issue described here. This PR changes this behavior so that the context the dialog is opened in determines if the WP autocompleter is limited to a certain project or not.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
