### PR TITLE
Display SAML metadata at the end, not at the start

### DIFF
--- a/modules/auth_saml/app/views/saml/providers/show.html.erb
+++ b/modules/auth_saml/app/views/saml/providers/show.html.erb
@@ -33,7 +33,7 @@
       render Saml::Providers::ViewComponent.new(@provider, view_mode: :show)
     end
 
-    content.with_sidebar(row_placement: :start, col_placement: :end) do
+    content.with_sidebar(row_placement: :end, col_placement: :end) do
       render Saml::Providers::SidePanelComponent.new(@provider)
     end
   end

--- a/modules/openid_connect/app/views/openid_connect/providers/show.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/show.html.erb
@@ -33,7 +33,7 @@
       render OpenIDConnect::Providers::ViewComponent.new(@provider, view_mode: :show)
     end
 
-    content.with_sidebar(row_placement: :start, col_placement: :end) do
+    content.with_sidebar(row_placement: :end, col_placement: :end) do
       render OpenIDConnect::Providers::SidePanelComponent.new(@provider)
     end
   end


### PR DESCRIPTION
This is more consistent with the placement on the end in the horizontal layout.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/58241

# Notes

While fixing the reported issue was straight-forward, I still asked for feedback from @psatyal, whether the fix being asked for is really offering the best possible UX. At least the current sort order seems to have been explicitly chosen at some point.

# Screenshots

Before:

![image](https://github.com/user-attachments/assets/d6e4bd81-a125-4a5d-9d72-16ead63bff8d)

After:

![image](https://github.com/user-attachments/assets/79320900-8734-4400-b30d-be3b6c07bd81)
