### PR TITLE
Missing translation prevents dev. rendering of copy form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1146,6 +1146,7 @@ en:
           title: "Working days"
           false: "working days only"
           true: "include non-working days"
+        lock_version: Lock version
         notify: "Notify" # used in custom actions
         parent: "Parent"
         parent_issue: "Parent"

--- a/frontend/src/app/features/calendar/op-calendar.service.spec.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.spec.ts
@@ -1,0 +1,69 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* jshint expr: true */
+
+import { waitForAsync } from '@angular/core/testing';
+import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
+
+describe('OP calendar service', () => {
+  let service:OpCalendarService;
+
+  beforeEach(waitForAsync(() => {
+    // This is not a valid constructor call, but since we only want to test a helper method that does not
+    // depend on injected services, we can pass null values here.
+    // @ts-expect-error ignore invalid constructor call since we don't need a completely valid instance
+    service = new OpCalendarService(null, null, null);
+  }));
+
+  describe('stripYearFromDateFormat', () => {
+    it('from dotted syntax', () => {
+      expect(service.stripYearFromDateFormat('DD.MM.YYYY')).toEqual('DD.MM.');
+    });
+
+    it('from slash syntax', () => {
+      expect(service.stripYearFromDateFormat('MM/DD/YYYY')).toEqual('MM/DD');
+      expect(service.stripYearFromDateFormat('DD/MM/YYYY')).toEqual('DD/MM');
+    });
+
+    it('from dash syntax', () => {
+      expect(service.stripYearFromDateFormat('DD-MM-YYYY')).toEqual('DD-MM');
+      expect(service.stripYearFromDateFormat('YYYY-MM-DD')).toEqual('MM-DD');
+    });
+
+    it('from spaced syntax', () => {
+      expect(service.stripYearFromDateFormat('DD MMM YYYY')).toEqual('DD MMM');
+      expect(service.stripYearFromDateFormat('DD MMMM YYYY')).toEqual('DD MMMM');
+    });
+
+    it('from comma syntax', () => {
+      expect(service.stripYearFromDateFormat('MMM DD, YYYY')).toEqual('MMM DD');
+      expect(service.stripYearFromDateFormat('MMMM DD, YYY')).toEqual('MMMM DD');
+    });
+  });
+});

--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -8,6 +8,7 @@ import { WeekdayService } from 'core-app/core/days/weekday.service';
 import { DayResourceService } from 'core-app/core/state/days/day.service';
 import { IDay } from 'core-app/core/state/days/day.model';
 import * as moment from 'moment-timezone';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Injectable()
 export class OpCalendarService extends UntilDestroyedMixin {
@@ -18,6 +19,7 @@ export class OpCalendarService extends UntilDestroyedMixin {
   constructor(
     readonly weekdayService:WeekdayService,
     readonly dayService:DayResourceService,
+    readonly configurationService:ConfigurationService,
   ) {
     super();
   }
@@ -31,7 +33,7 @@ export class OpCalendarService extends UntilDestroyedMixin {
       this.resizeObs = new ResizeObserver(() => this.resize$.next());
     }
 
-    this.resizeObs.observe(v.nativeElement);
+    this.resizeObs.observe(v.nativeElement as Element);
   }
 
   applyNonWorkingDay({ date }:{ date?:Date }, nonWorkingDays:IDay[]):string[] {
@@ -41,5 +43,15 @@ export class OpCalendarService extends UntilDestroyedMixin {
       return ['fc-non-working-day'];
     }
     return [];
+  }
+
+  dayHeaderContent({ date }:{ date?:Date }):string {
+    const utcDate = moment(date).utc();
+
+    // If no date format is configured, use a very unambiguous one as default
+    const configuredDateFormat = this.configurationService.dateFormatPresent()
+      ? this.configurationService.dateFormat() : 'YYYY-MM-DD';
+
+    return utcDate.format(`ddd ${configuredDateFormat}`);
   }
 }

--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -9,6 +9,7 @@ import { DayResourceService } from 'core-app/core/state/days/day.service';
 import { IDay } from 'core-app/core/state/days/day.model';
 import * as moment from 'moment-timezone';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
+import { DayHeaderContentArg } from '@fullcalendar/core';
 
 @Injectable()
 export class OpCalendarService extends UntilDestroyedMixin {
@@ -45,13 +46,22 @@ export class OpCalendarService extends UntilDestroyedMixin {
     return [];
   }
 
-  dayHeaderContent({ date }:{ date?:Date }):string {
-    const utcDate = moment(date).utc();
+  dayHeaderContent(event:DayHeaderContentArg):string {
+    // When the user did not configure a custom date format, we can always return the default content for the
+    // fullcalendar day header.
+    if (!this.configurationService.dateFormatPresent()) {
+      return event.text;
+    }
 
-    // If no date format is configured, use a very unambiguous one as default
-    const configuredDateFormat = this.configurationService.dateFormatPresent()
-      ? this.configurationService.dateFormat() : 'YYYY-MM-DD';
+    // Additionally, we must use the default in dayGridMonth view, as it displays the day of the week:
+    if (event.view.type === 'dayGridMonth') {
+      return event.text;
+    }
 
+    // We are not in month grid view and there is a date format configured => return a formatted date according to
+    // the settings. Prefix the day of the week name for better readability.
+    const configuredDateFormat = this.configurationService.dateFormat();
+    const utcDate = moment(event.date).utc();
     return utcDate.format(`ddd ${configuredDateFormat}`);
   }
 }

--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -61,7 +61,13 @@ export class OpCalendarService extends UntilDestroyedMixin {
     // We are not in month grid view and there is a date format configured => return a formatted date according to
     // the settings. Prefix the day of the week name for better readability.
     const configuredDateFormat = this.configurationService.dateFormat();
+    const formatWithoutYear = this.stripYearFromDateFormat(configuredDateFormat);
     const utcDate = moment(event.date).utc();
-    return utcDate.format(`ddd ${configuredDateFormat}`);
+
+    return utcDate.format(`ddd ${formatWithoutYear}`);
+  }
+
+  stripYearFromDateFormat(format:string):string {
+    return format.replace(/(\/|-|,?\s?)Y{3,4}$/, '').replace(/^Y{4}-/, '');
   }
 }

--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -124,7 +124,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     if (this.isMilestone(workPackage)) {
       return workPackage.date;
     }
-    return workPackage[`${type}Date`] as string;
+    return workPackage[`${type}Date`];
   }
 
   isMilestone(workPackage:WorkPackageResource):boolean {
@@ -133,11 +133,13 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
 
   warnOnTooManyResults(collection:WorkPackageCollectionResource, isStatic = false):void {
     if (collection.count < collection.total) {
-      this.tooManyResultsText = this.I18n.t('js.calendar.too_many',
+      this.tooManyResultsText = this.I18n.t(
+        'js.calendar.too_many',
         {
           count: collection.total,
           max: OpWorkPackagesCalendarService.MAX_DISPLAYED,
-        });
+        },
+      );
     } else {
       this.tooManyResultsText = null;
     }
@@ -180,7 +182,6 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     // 3. We are already loaded and are refetching data (for changed dates, e.g.)
     let queryProps:string|undefined;
 
-
     if (this.initializingWithQuery) {
       // This is the case on initially loading the calendar with a query_id present in the url params but no
       // query props to overwrite the query settings.
@@ -201,7 +202,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
       // There might also be a query_id but the settings persisted in it are overwritten by the props.
       if (this.urlParams.query_props) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const oldQueryProps:{ [key:string]:unknown } = JSON.parse(this.urlParams.query_props);
+        const oldQueryProps:{ [key:string]:unknown } = JSON.parse(this.urlParams.query_props as string);
 
         // Update the date period of the calendar in the filter
         const newQueryProps = {
@@ -231,9 +232,9 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
 
     return Promise.all([this
       .wpListService
-      .fromQueryParams({ query_id: queryId, query_props: queryProps, }, projectIdentifier || undefined)
+      .fromQueryParams({ query_id: queryId, query_props: queryProps }, projectIdentifier || undefined)
       .toPromise(),
-    ])
+    ]);
   }
 
   public generateQueryProps(
@@ -360,6 +361,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
       dayGridClassNames: (data:DayCellContentArg) => this.calendarService.applyNonWorkingDay(data, this.nonWorkingDays),
       slotLaneClassNames: (data:SlotLaneContentArg) => this.calendarService.applyNonWorkingDay(data, this.nonWorkingDays),
       slotLabelClassNames: (data:SlotLabelContentArg) => this.calendarService.applyNonWorkingDay(data, this.nonWorkingDays),
+      dayHeaderContent: (data:DayHeaderContentArg) => this.calendarService.dayHeaderContent(data),
     };
   }
 

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -184,6 +184,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
     dayGridClassNames: (data:DayCellContentArg) => this.calendar.applyNonWorkingDay(data, this.nonWorkingDays),
     slotLaneClassNames: (data:SlotLaneContentArg) => this.calendar.applyNonWorkingDay(data, this.nonWorkingDays),
     slotLabelClassNames: (data:SlotLabelContentArg) => this.calendar.applyNonWorkingDay(data, this.nonWorkingDays),
+    dayHeaderContent: (data:DayHeaderContentArg) => this.calendar.dayHeaderContent(data),
   };
 
   private initializeCalendar(displayedDayss:DisplayedDays) {
@@ -308,7 +309,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
     return entries.map((entry) => {
       let start:Moment;
       let end:Moment;
-      const hours = this.timezone.toHours(entry.hours) * this.scaleRatio;
+      const hours = this.timezone.toHours(entry.hours as string) * this.scaleRatio;
       const spentOn = entry.spentOn;
 
       if (hoursDistribution[spentOn]) {
@@ -347,7 +348,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
     const dateSums:{ [key:string]:number } = {};
 
     entries.forEach((entry) => {
-      const hours = this.timezone.toHours(entry.hours);
+      const hours = this.timezone.toHours(entry.hours as string);
       const spentOn = entry.spentOn;
 
       if (dateSums[spentOn]) {
@@ -421,7 +422,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
 
   private dispatchEventClick(event:CalendarViewEvent):void {
     if (event.event.extendedProps.entry) {
-      this.editEvent(event.event.extendedProps.entry);
+      this.editEvent(event.event.extendedProps.entry as TimeEntryResource);
     } else if (event.el.classList.contains(ADD_ENTRY_CLASS_NAME) && !event.el.classList.contains(ADD_ENTRY_PROHIBITED_CLASS_NAME)) {
       this.addEvent(moment(event.event.startStr));
     }
@@ -535,7 +536,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
     const schema = (await this.schemaCache.ensureLoaded(entry as TimeEntryResource)) as TimeEntrySchema;
 
     jQuery(event.el).tooltip({
-      content: this.tooltipContentString(event.event.extendedProps.entry, schema),
+      content: this.tooltipContentString(event.event.extendedProps.entry as TimeEntryResource, schema),
       items: '.fc-event',
       close() {
         jQuery('.ui-helper-hidden-accessible').remove();
@@ -555,11 +556,11 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
   private prependDuration(event:CalendarViewEvent):void {
     const timeEntry = event.event.extendedProps.entry as TimeEntryResource;
 
-    if (this.timezone.toHours(timeEntry.hours) < 0.5) {
+    if (this.timezone.toHours(timeEntry.hours as string) < 0.5) {
       return;
     }
 
-    const formattedDuration = this.timezone.formattedDuration(timeEntry.hours);
+    const formattedDuration = this.timezone.formattedDuration(timeEntry.hours as string);
 
     jQuery(event.el)
       .find('.fc-event-title')
@@ -578,7 +579,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
   private appendFadeout(event:CalendarViewEvent):void {
     const timeEntry = event.event.extendedProps.entry as TimeEntryResource;
 
-    if (this.timezone.toHours(timeEntry.hours) < 0.5) {
+    if (this.timezone.toHours(timeEntry.hours as string) < 0.5) {
       return;
     }
 
@@ -636,7 +637,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
           </li>
           <li class="tooltip--map--item">
             <span class="tooltip--map--key">${schema.hours.name}:</span>
-            <span class="tooltip--map--value">${this.timezone.formattedDuration(entry.hours)}</span>
+            <span class="tooltip--map--value">${this.timezone.formattedDuration(entry.hours as string)}</span>
           </li>
           <li class="tooltip--map--item">
             <span class="tooltip--map--key">${schema.comment.name}:</span>

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -28,6 +28,9 @@
     .fc-non-working-day
       background: rgb(109 109 109 / 20%)
 
+    .fc-col-header-cell
+      word-break: break-word
+
     // The days in full calendar are anchor elements which we do not
     // want to like like actual links
     .fc-col-header-cell a,

--- a/frontend/src/tsconfig.app.json
+++ b/frontend/src/tsconfig.app.json
@@ -15,7 +15,6 @@
   ],
   "include": [
     "src/**/*.ts",
-    "**/*.ts",
     "stimulus/**/*.ts",
     "**/*.d.ts",
   ],

--- a/frontend/src/tsconfig.app.json
+++ b/frontend/src/tsconfig.app.json
@@ -15,6 +15,7 @@
   ],
   "include": [
     "src/**/*.ts",
+    "**/*.ts",
     "stimulus/**/*.ts",
     "**/*.d.ts",
   ],

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -122,4 +122,21 @@ RSpec.describe "Calendar Widget", :js, with_settings: { start_of_week: 1 } do
     work_package.reload
     expect(work_package.due_date).to eq Time.zone.today.beginning_of_week.next_occurring(:tuesday)
   end
+
+  context "when looking at the date headers" do
+    let(:next_tuesday) { Time.zone.today.beginning_of_week.next_occurring(:tuesday) }
+    let(:tue_css_selector) { ".fc-day-tue .fc-col-header-cell-cushion" }
+
+    it "shows the default date format" do
+      expected = /Tue #{next_tuesday.month}\/#{next_tuesday.day}/
+      expect(page).to have_css(tue_css_selector, text: expected)
+    end
+
+    context "with a date format configured", with_settings: { date_format: "%d.%m.%Y" } do
+      it "shows the configured date format" do
+        expected = /Tue #{next_tuesday.day.to_s.rjust(2, '0')}\.#{next_tuesday.month.to_s.rjust(2, '0')}\./
+        expect(page).to have_css(tue_css_selector, text: expected)
+      end
+    end
+  end
 end

--- a/modules/calendar/spec/features/calendars_spec.rb
+++ b/modules/calendar/spec/features/calendars_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe "Work package calendars", :js do
     expect(page)
       .to have_no_css ".fc-event-title", text: another_future_work_package.subject
 
+    # The columns are set correctly according to month view.
+    expect(page).to have_css ".fc-day-mon .fc-col-header-cell-cushion", text: "Mon"
+    expect(page).to have_css ".fc-day-tue .fc-col-header-cell-cushion", text: "Tue"
+
     filters.expect_filter_count 1
 
     filters.open


### PR DESCRIPTION
# Ticket
(I decided against creating a bug for this, because it purely seems to affect development)

# What are you trying to accomplish?
Fix rendering of WP copy form that fails due to missing translation.

# What approach did you choose and why?
Adding the missing translation (though we probably never show this attribute to the user).