### PR TITLE
[#62047] location picker change detection is broken

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
@@ -47,6 +47,7 @@ import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-conte
 import {
   LocationPickerModalComponent,
 } from 'core-app/shared/components/storages/location-picker-modal/location-picker-modal.component';
+import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outlet-target.enum';
 import { storageConnected } from 'core-app/shared/components/storages/storages-constants.const';
 
 export default class ProjectStorageFormController extends Controller {
@@ -102,7 +103,8 @@ export default class ProjectStorageFormController extends Controller {
 
     this.pluginContext.subscribe((context) => {
       context.runInZone(() => {
-        context.services.opModalService.show(LocationPickerModalComponent, 'global', locals)
+        context.services.opModalService
+          .show(LocationPickerModalComponent, 'global', locals, false, false, this.OutletTarget)
           .pipe(
             switchMap((modal) => modal.closingEvent),
             filter((modal) => modal.submitted),
@@ -147,6 +149,10 @@ export default class ProjectStorageFormController extends Controller {
 
   protected get pluginContext():Observable<OpenProjectPluginContext> {
     return from(window.OpenProject.getPluginContext());
+  }
+
+  protected get OutletTarget():PortalOutletTarget {
+    return PortalOutletTarget.Default;
   }
 
   protected get storage():IStorage {

--- a/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
@@ -41,10 +41,9 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
-import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
 import { IStorage } from 'core-app/core/state/storages/storage.model';
-import { OpModalService } from 'core-app/shared/components/modal/modal.service';
-import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outlet-target.enum';
+import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
+import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import {
   LocationPickerModalComponent,
 } from 'core-app/shared/components/storages/location-picker-modal/location-picker-modal.component';
@@ -101,19 +100,22 @@ export default class ProjectStorageFormController extends Controller {
       storage: this.storage,
     };
 
-    this.modalService
-      .pipe(
-        switchMap((service) => service.show(LocationPickerModalComponent, 'global', locals, false, false, this.OutletTarget)),
-        switchMap((modal) => modal.closingEvent),
-        filter((modal) => modal.submitted),
-      )
-      .subscribe((modal) => {
-        if (this.hasProjectFolderIdValidationTarget) {
-          this.projectFolderIdValidationTarget.style.display = 'none';
-        }
-        this.selectedFolderTextTarget.innerText = modal.location.name;
-        this.projectFolderIdInputTarget.value = modal.location.id as string;
+    this.pluginContext.subscribe((context) => {
+      context.runInZone(() => {
+        context.services.opModalService.show(LocationPickerModalComponent, 'global', locals)
+          .pipe(
+            switchMap((modal) => modal.closingEvent),
+            filter((modal) => modal.submitted),
+          )
+          .subscribe((modal) => {
+            if (this.hasProjectFolderIdValidationTarget) {
+              this.projectFolderIdValidationTarget.style.display = 'none';
+            }
+            this.selectedFolderTextTarget.innerText = modal.location.name;
+            this.projectFolderIdInputTarget.value = modal.location.id as string;
+          });
       });
+    });
   }
 
   updateForm(evt:InputEvent):void {
@@ -143,13 +145,8 @@ export default class ProjectStorageFormController extends Controller {
     this.setProjectFolderModeQueryParam(mode);
   }
 
-  protected get OutletTarget():PortalOutletTarget {
-    return PortalOutletTarget.Default;
-  }
-
-  protected get modalService():Observable<OpModalService> {
-    return from(window.OpenProject.getPluginContext())
-      .pipe(map((pluginContext) => pluginContext.services.opModalService));
+  protected get pluginContext():Observable<OpenProjectPluginContext> {
+    return from(window.OpenProject.getPluginContext());
   }
 
   protected get storage():IStorage {

--- a/frontend/src/stimulus/controllers/password-confirmation-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/password-confirmation-dialog.controller.ts
@@ -68,24 +68,27 @@ export default class PasswordConfirmationDialogController extends ApplicationCon
     }
 
     this.activeDialog = true;
-    opModalService
-      .show(PasswordConfirmationModalComponent, 'global')
-      .subscribe((modal) => modal.closingEvent.subscribe(() => {
-        this.activeDialog = false;
 
-        if (!modal.confirmed) {
-          return;
-        }
+    pluginContext.runInZone(() => {
+      opModalService
+        .show(PasswordConfirmationModalComponent, 'global')
+        .subscribe((modal) => modal.closingEvent.subscribe(() => {
+          this.activeDialog = false;
 
-        const input = document.createElement('input');
-        input.type = 'hidden';
-        input.id = 'hidden_password_confirmation';
-        input.name = '_password_confirmation';
-        input.value = modal.password_confirmation as string;
+          if (!modal.confirmed) {
+            return;
+          }
 
-        form.append(input);
-        form.requestSubmit(event?.submitter);
-      }));
+          const input = document.createElement('input');
+          input.type = 'hidden';
+          input.id = 'hidden_password_confirmation';
+          input.name = '_password_confirmation';
+          input.value = modal.password_confirmation as string;
+
+          form.append(input);
+          form.requestSubmit(event?.submitter);
+        }));
+    });
 
     return false;
   }


### PR DESCRIPTION
# Ticket
[OP#62047](https://community.openproject.org/wp/62047)

# What are you trying to accomplish?
- Angular dialogs rendered directly with the modal service from stimulus controllers should correctly react to change detections.

# What approach did you choose and why?
- let angular service inside stimulus controller run in zone

