### PR TITLE
rewrite keyword args on enums

### DIFF
--- a/modules/github_integration/app/models/github_check_run.rb
+++ b/modules/github_integration/app/models/github_check_run.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,13 +31,13 @@
 class GithubCheckRun < ApplicationRecord
   belongs_to :github_pull_request, touch: true
 
-  enum status: {
+  enum :status, {
     completed: "completed",
     in_progress: "in_progress",
     queued: "queued"
   }
 
-  enum conclusion: {
+  enum :conclusion, {
     action_required: "action_required",
     cancelled: "cancelled",
     failure: "failure",

--- a/modules/gitlab_integration/app/models/gitlab_pipeline.rb
+++ b/modules/gitlab_integration/app/models/gitlab_pipeline.rb
@@ -33,7 +33,7 @@ class GitlabPipeline < ApplicationRecord
   belongs_to :gitlab_merge_request, touch: true
 
   # TODO: confirm with the gitlab documentation what are the different statuses.
-  enum status: {
+  enum :status, {
     created: "created",
     running: "running",
     success: "success",

--- a/modules/meeting/app/models/meeting_outcome.rb
+++ b/modules/meeting/app/models/meeting_outcome.rb
@@ -31,11 +31,11 @@ class MeetingOutcome < ApplicationRecord
   belongs_to :meeting_agenda_item
   belongs_to :work_package
 
-  enum kind: {
+  enum :kind, {
     information: 0,
     decision: 1,
     work_package: 2
-  }.freeze, _suffix: true, _default: "information"
+  }.freeze, suffix: true, default: "information"
 
   validates_presence_of :meeting_agenda_item
   validates_presence_of :notes, if: -> { information_kind? }

--- a/modules/storages/app/models/storages/last_project_folder.rb
+++ b/modules/storages/app/models/storages/last_project_folder.rb
@@ -31,5 +31,5 @@
 class Storages::LastProjectFolder < ApplicationRecord
   belongs_to :project_storage, class_name: "Storages::ProjectStorage"
 
-  enum mode: { inactive: "inactive", manual: "manual", automatic: "automatic" }.freeze
+  enum :mode, { inactive: "inactive", manual: "manual", automatic: "automatic" }.freeze
 end


### PR DESCRIPTION
# Ticket

Part of https://community.openproject.org/wp/61352

# What are you trying to accomplish?

Prepare OP for rails 8. As part of this, enums defined with keyword args need to be modified

```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:
```