### PR TITLE
[61915] Missing scrollbar in Predecessor, Children and Successor tabs

### DIFF
--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -15,7 +15,7 @@
         collection.with_component(Primer::Alpha::Dialog::Body.new(classes: "wp-datepicker-dialog--body", p: 0)) do
           render(
             Primer::Alpha::UnderlinePanels.new(
-              'aria-label': I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
+              "aria-label": I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
               label: I18n.t("work_packages.datepicker_modal.tabs.aria_label"),
               classes: "wp-datepicker-dialog--UnderlineNav",
               px: 3
@@ -43,7 +43,7 @@
                 relation_group = tab.relation_group
                 tab_content.with_text { I18n.t("work_packages.datepicker_modal.tabs.#{tab.key}") }
                 tab_content.with_counter(count: relation_group.count)
-                tab_content.with_panel(m: 3) do
+                tab_content.with_panel(m: 3, classes: "wp-datepicker-dialog--content-tab--relation-tab") do
                   if relation_group.any?
                     render(border_box_container(padding: :condensed)) do |box|
                       relation_group.visible_relations.each do |relation|

--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -1,9 +1,21 @@
+$body-height: 490px
+
 @media screen and (min-width: $breakpoint-sm)
   .wp-datepicker-dialog
+    &--content
+      max-height: calc(var(--app-height) - 2rem)
+      overflow: auto
+
     &--body
       // We set a fixed height for this dialog zo avoid that it jumps around when the tabs are switched or errors shown
-      min-height: 490px
+      min-height: $body-height
       width: 600px
+
+    &--content-tab
+      &--relation-tab
+        // Height of the body - (navBarHeight + Margins)
+        height: calc($body-height - 80px)
+        overflow: auto
 
 @media screen and (max-width: $breakpoint-sm)
   .wp-datepicker-dialog


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61915/activity

# What are you trying to accomplish?
Make relation tabs scrollable

## Screenshots
**Before**
<img width="600" alt="Bildschirmfoto 2025-03-11 um 08 36 25" src="https://github.com/user-attachments/assets/f8b7fa4c-a07e-4ab0-84e7-cc9d3e6b7d8a" />


**After**
<img width="600" alt="Bildschirmfoto 2025-03-11 um 08 35 21" src="https://github.com/user-attachments/assets/c4568941-be5c-4744-a4d1-916ae0f209bd" />

