### PR TITLE
Allow access to new file links by creator

### DIFF
--- a/modules/storages/app/contracts/storages/file_links/delete_contract.rb
+++ b/modules/storages/app/contracts/storages/file_links/delete_contract.rb
@@ -35,6 +35,12 @@ module Storages
     class DeleteContract < ::DeleteContract
       # Check permissions to delete this FileLink
       delete_permission :manage_file_links
+
+      def authorized?
+        return super if model.container.present?
+
+        user == model.creator
+      end
     end
   end
 end

--- a/modules/storages/lib/api/v3/file_links/file_link_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_representer.rb
@@ -138,7 +138,11 @@ module API::V3::FileLinks
     private
 
     def user_allowed_to_manage?(model)
-      model.container.present? && current_user.allowed_in_project?(:manage_file_links, model.project)
+      if model.container.present?
+        current_user.allowed_in_project?(:manage_file_links, model.project)
+      else
+        current_user == model.creator
+      end
     end
 
     def make_origin_data(model)

--- a/modules/storages/spec/contracts/storages/file_links/delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/file_links/delete_contract_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe Storages::FileLinks::DeleteContract do
   let(:current_user) { create(:user) }
   let(:role) { create(:project_role, permissions: [:manage_file_links]) }
   let(:project) { create(:project, members: { current_user => role }) }
-  let(:work_package) { create(:work_package, project:) }
-  let(:file_link) { create(:file_link, container: work_package) }
+  let(:container) { create(:work_package, project:) }
+  let(:creator) { create(:user) }
+  let(:file_link) { create(:file_link, container:, creator:) }
   let(:contract) { described_class.new(file_link, current_user) }
 
   before do
@@ -48,15 +49,33 @@ RSpec.describe Storages::FileLinks::DeleteContract do
   # This tests works with manage_files_in_project permissions for current_user.
   it_behaves_like "contract is valid"
 
+  # Generic checks that the contract is valid for valid admin, but invalid otherwise
+  it_behaves_like "contract is valid for active admins and invalid for regular users"
+
+  include_examples "contract reuses the model errors"
+
   # Now we remove the permissions from the user by creating a role without special perms.
   context "without manage_files_in_project permission for project" do
     let(:role) { create(:project_role) }
 
     it_behaves_like "contract is invalid"
+
+    context "and when the current user initially created the file link" do
+      let(:creator) { current_user }
+
+      it_behaves_like "contract is invalid"
+    end
   end
 
-  # Generic checks that the contract is valid for valid admin, but invalid otherwise
-  it_behaves_like "contract is valid for active admins and invalid for regular users"
+  context "when there is no associated container" do
+    let(:container) { nil }
 
-  include_examples "contract reuses the model errors"
+    it_behaves_like "contract is invalid"
+
+    context "and when the current user initially created the file link" do
+      let(:creator) { current_user }
+
+      it_behaves_like "contract is valid"
+    end
+  end
 end

--- a/modules/storages/spec/lib/api/v3/file_links/file_link_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/file_links/file_link_representer_rendering_spec.rb
@@ -81,10 +81,24 @@ RSpec.describe API::V3::FileLinks::FileLinkRepresenter, "rendering" do
     describe "delete" do
       let(:permission) { :manage_file_links }
 
-      it_behaves_like "has an untitled action link" do
-        let(:link) { "delete" }
-        let(:href) { "/api/v3/file_links/#{file_link.id}" }
-        let(:method) { :delete }
+      let(:link) { "delete" }
+      let(:href) { "/api/v3/file_links/#{file_link.id}" }
+      let(:method) { :delete }
+
+      it_behaves_like "has an untitled action link"
+
+      context "when there is no associated container" do
+        before do
+          file_link.container = nil
+        end
+
+        it_behaves_like "has no link"
+
+        context "and the current user is creator of the file link" do
+          let(:user) { file_link.creator }
+
+          it { is_expected.to have_json_path("_links/#{link}") }
+        end
       end
     end
 

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_api_spec.rb
@@ -518,7 +518,17 @@ RSpec.describe "API v3 file links resource" do
     context "if file link does not have a container." do
       let(:file_link) { create(:file_link) }
 
-      it_behaves_like "not found"
+      context "and the current user is the creator of the link" do
+        let(:current_user) { file_link.creator }
+
+        it "is successful" do
+          expect(subject.status).to be 200
+        end
+      end
+
+      context "and the current user is not the creator of the link" do
+        it_behaves_like "not found"
+      end
     end
   end
 


### PR DESCRIPTION
For example on the work package create UI, it
is already possible to link files, even though the WP does not yet exist. In this case it's a usability issue if the UI elements do not yet work as they should.

As long as there is no associated container, it should be no issue to assume that the creator has all the necessary permissions to view a file link and delete it again. Downloading the associated file is still limited by permissions on the storage, so this should not be abusable to retain long-term access to a file.

# Ticket
https://community.openproject.org/projects/openproject/work_packages/61554

# Merge checklist

- [x] Added/updated tests
- [x] Tested Firefox
- [x] Fixed unlinking of files during create
