### PR TITLE
[61961] Left side of mini-calendar is preferred over the right side

### DIFF
--- a/frontend/src/app/shared/components/datepicker/wp-modal-date-picker/wp-modal-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-modal-date-picker/wp-modal-date-picker.component.ts
@@ -129,7 +129,10 @@ export class OpWpModalDatePickerComponent extends UntilDestroyedMixin implements
     // flatpickr jumps the calendar date to the due date, which is annoying.
     if (this.isDifferentDates(details.dates, details.mode)) {
       [this.startDateValue, this.dueDateValue] = details.dates;
+      const currentMonth = this.datePickerInstance.datepickerInstance.currentMonth;
+
       this.datePickerInstance.setDates(details.dates);
+      this.datePickerInstance.datepickerInstance.changeMonth(currentMonth, false);
     }
     this.datePickerInstance.setOption('mode', details.mode);
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61961/activity

# What are you trying to accomplish?
Preserve the currentMonth to avoid weird jumps in the calendar


