### PR TITLE
move more rubocop plugins into plugins section

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,14 @@
 require:
   - rubocop-openproject
-  - rubocop-rspec_rails
-  - rubocop-capybara
   - ./config/initializers/inflections.rb
 
 plugins:
+  - rubocop-capybara
+  - rubocop-factory_bot
+  - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
-  - rubocop-performance
-  - rubocop-factory_bot
+  - rubocop-rspec_rails
 
 # A rubocop-local.yml file can be added to customized the styles
 inherit_from:


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Have rubocop running on `dev` again.