### PR TITLE
[62043] Predecessor/Successor tab are visually cramped

### DIFF
--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   flex_layout do |flex|
     if visible?
-      flex.with_row(flex_layout: true, justify_content: :space_between, align_items: :center) do |row|
+      flex.with_row(flex_layout: true, justify_content: :space_between, align_items: :center, classes: "relation-row--info-line") do |row|
         row.with_column do
           render(WorkPackages::InfoLineComponent.new(work_package: related_work_package))
         end
@@ -9,34 +9,40 @@
         if should_render_action_menu?
           row.with_column do
             render(Primer::Alpha::ActionMenu.new(test_selector: action_menu_test_selector)) do |menu|
-              menu.with_show_button(icon: "kebab-horizontal",
-                                    "aria-label": I18n.t(:label_relation_actions),
-                                    scheme: :invisible,
-                                    ml: 2)
+              menu.with_show_button(
+                icon: "kebab-horizontal",
+                "aria-label": I18n.t(:label_relation_actions),
+                scheme: :invisible,
+                ml: 2
+              )
 
               if should_render_edit_option?
-                menu.with_item(label: I18n.t(:label_relation_edit),
-                               href: edit_path,
-                               test_selector: edit_button_test_selector,
-                               content_arguments: {
-                                 data: { turbo_stream: true }
-                               }) do |item|
+                menu.with_item(
+                  label: I18n.t(:label_relation_edit),
+                  href: edit_path,
+                  test_selector: edit_button_test_selector,
+                  content_arguments: {
+                    data: { turbo_stream: true }
+                  }
+                ) do |item|
                   item.with_leading_visual_icon(icon: :pencil)
                 end
               end
 
-              menu.with_item(label: I18n.t(:label_relation_delete),
-                             scheme: :danger,
-                             href: destroy_path,
-                             form_arguments: {
-                               method: :delete,
-                               data: {
-                                 confirm: t("text_are_you_sure"),
-                                 turbo_stream: true,
-                                 update_work_package: true
-                               }
-                             },
-                             test_selector: delete_button_test_selector) do |item|
+              menu.with_item(
+                label: I18n.t(:label_relation_delete),
+                scheme: :danger,
+                href: destroy_path,
+                form_arguments: {
+                  method: :delete,
+                  data: {
+                    confirm: t("text_are_you_sure"),
+                    turbo_stream: true,
+                    update_work_package: true
+                  }
+                },
+                test_selector: delete_button_test_selector
+              ) do |item|
                 item.with_leading_visual_icon(icon: :trash)
               end
             end
@@ -45,12 +51,16 @@
       end
 
       flex.with_row(mb: 2, classes: "relation-row--subject") do
-        render(Primer::Beta::Link.new(href: work_package_path(related_work_package),
-                                      color: :default,
-                                      underline: false,
-                                      font_size: :normal,
-                                      font_weight: :bold,
-                                      target: "_blank")) { related_work_package.subject }
+        render(
+          Primer::Beta::Link.new(
+            href: work_package_path(related_work_package),
+            color: :default,
+            underline: false,
+            font_size: :normal,
+            font_weight: :bold,
+            target: "_blank"
+          )
+        ) { related_work_package.subject }
       end
 
       if should_display_description?

--- a/app/components/work_package_relations_tab/relation_component.sass
+++ b/app/components/work_package_relations_tab/relation_component.sass
@@ -1,2 +1,6 @@
-.relation-row--subject
-  @include text-shortener(false)
+.relation-row
+  &--subject
+    @include text-shortener(false)
+
+  &--info-line
+    flex-basis: 2rem


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/62043/activity

# What are you trying to accomplish?
Fix the line height for the info line to avoid that it shrinks when the action menu is not visible


## Screenshots
**Before**
<img width="500" alt="Bildschirmfoto 2025-03-11 um 12 01 43" src="https://github.com/user-attachments/assets/f23d6098-aee4-42e5-9187-b4340674e513" />

**After**
<img width="500" alt="Bildschirmfoto 2025-03-11 um 12 00 11" src="https://github.com/user-attachments/assets/fa5f3fc7-bf3e-4a6c-90d5-9de14efabc50" />
