### PR TITLE
[#62040] correct input of <,> characters

### DIFF
--- a/app/components/work_packages/types/pattern_input.html.erb
+++ b/app/components/work_packages/types/pattern_input.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
     <%= @input.builder.hidden_field(name, value: @value, data: { "pattern-input-target": "formInput" }) %>
 
     <template data-pattern-input-target="tokenTemplate">
-      <%= render(Primer::Beta::Label.new(tag: :span, scheme: :accent, "data-role": :token)) %>
+      <%= render(Primer::Beta::Label.new(tag: :span, scheme: :accent, data: { role: :token, prop: "__placeholder" })) %>
     </template>
 
     <template data-pattern-input-target="suggestionsHeadingTemplate">


### PR DESCRIPTION
# Ticket
[OP#62040](https://community.openproject.org/wp/62040)

# What are you trying to accomplish?
- allow usage of `<>` for pattern input
- rendered token show localized text

# What approach did you choose and why?
- escape <> on rendering html from blueprint
- render token with localized text
  - property is stored in `data-prop` instead of the text
