### PR TITLE
Improve rendering of floating actions on focus

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -97,6 +97,7 @@
       opacity: 0.5
 
     &-floating-wrapper:hover > &-floating-actions,
+    &-floating-wrapper:focus-within > &-floating-actions,
     &-floating-actions:focus-within,
     &-floating-actions:hover
       opacity: 1

--- a/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
+++ b/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
@@ -66,7 +66,9 @@
       flex-shrink: 0
 
     &-floating-wrapper:not(&-floating-wrapper__disabled):hover &-text,
-    &-floating-wrapper:not(&-floating-wrapper__disabled):hover &-avatar
+    &-floating-wrapper:not(&-floating-wrapper__disabled):hover &-avatar,
+    &-floating-wrapper:not(&-floating-wrapper__disabled):focus-within &-text,
+    &-floating-wrapper:not(&-floating-wrapper__disabled):focus-within &-avatar
       visibility: hidden
 
     &-floating-text


### PR DESCRIPTION
Floating actions will now be displayed when the wrapper is hovered OR has focus inside it. Attachment and file links views will hide their right-hand side content accordingly.

Previously the file links did not hide their content at all, leading to floating actions being drawn on top of that content.

On the other hand, attachments did hide their content, but without showing the floating actions. Those only became visible once moving the focus onto them.

# Ticket
https://community.openproject.org/projects/document-workflows-stream/work_packages/62113

## Screenshots
![focus-navigation](https://github.com/user-attachments/assets/7667277a-1404-4609-b8ac-9a260497717a)
