### PR TITLE
[#62127] The background for outcomes appears too dark in dark mode

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.sass
@@ -1,7 +1,7 @@
 @import 'helpers'
 
 .outcome-container
-  background-color: var(--grid-background-color)
+  background-color: var(--bgColor-muted)
 
   // To prevent flickering when changing meeting states due to the actions button icon
   .title


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/62127
<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->
