### PR TITLE
Extend comments with restricted visibility feature flag

### DIFF
--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -59,7 +59,8 @@ module WorkPackages
         end
 
         def adding_restricted_comment_allowed?
-          User.current.allowed_in_work_package?(:write_comments_with_restricted_visibility, work_package)
+          OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
+            User.current.allowed_in_work_package?(:write_comments_with_restricted_visibility, work_package)
         end
       end
     end

--- a/app/models/activities/fetcher.rb
+++ b/app/models/activities/fetcher.rb
@@ -117,7 +117,11 @@ module Activities
 
     def filter_by_visibility(events)
       events.reject! do |event|
-        event.journal.restricted? && !@user.allowed_in_project?(:view_comments_with_restricted_visibility, event.project)
+        if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active?
+          event.journal.restricted? && !@user.allowed_in_project?(:view_comments_with_restricted_visibility, event.project)
+        else
+          event.journal.restricted?
+        end
       end
     end
 

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -114,7 +114,8 @@ class Journal < ApplicationRecord
   scope :for_work_package, -> { where(journable_type: "WorkPackage") }
   scope :for_meeting, -> { where(journable_type: "Meeting") }
   scope :restricted_visible, ->(work_package) {
-    if User.current.allowed_in_work_package?(:view_comments_with_restricted_visibility, work_package)
+    if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
+        User.current.allowed_in_work_package?(:view_comments_with_restricted_visibility, work_package)
       all
     else
       where(restricted: false)

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -235,7 +235,8 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
     end
 
-    context "when a user cannot see comments with restricted visibility" do
+    context "when a user cannot see comments with restricted visibility",
+            with_flag: { comments_with_restricted_visibility: true } do
       current_user { member }
 
       before do
@@ -255,7 +256,8 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
     end
 
-    context "when a user can see comments with restricted visibility" do
+    context "when a user can see comments with restricted visibility",
+            with_flag: { comments_with_restricted_visibility: true } do
       current_user { admin }
 
       before do

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -30,7 +30,10 @@
 
 require "spec_helper"
 
-RSpec.describe "Work package comments with restricted visibility", :js, :with_cuprite do
+RSpec.describe "Work package comments with restricted visibility",
+               :js,
+               :with_cuprite,
+               with_flag: { comments_with_restricted_visibility: true } do
   let(:project) { create(:project) }
   let(:admin) { create(:admin) }
   let(:viewer) { create_user_with_restricted_comments_view_permissions }

--- a/spec/models/activities/fetcher_integration_spec.rb
+++ b/spec/models/activities/fetcher_integration_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Activities::Fetcher, "integration" do
       .not_to include("budgets")
   end
 
-  describe "#events" do
+  describe "#events", with_flag: { comments_with_restricted_visibility: true } do
     let(:event_user) { user }
     let(:work_package) { create(:work_package, project:, author: event_user) }
     let(:forum) { create(:forum, project:) }

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Journal do
     end
   end
 
-  describe ".restricted_visible scope" do
+  describe ".restricted_visible scope", with_flag: { comments_with_restricted_visibility: true } do
     let(:work_package) { create(:work_package) }
     let(:admin) { create(:admin) }
     let(:user) { create(:user) }

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI do # rubocop:disa
       allow(User).to receive(:current).and_return(current_user)
     end
 
-    describe "GET /api/v3/work_packages/:id/activities" do
+    describe "GET /api/v3/work_packages/:id/activities", with_flag: { comments_with_restricted_visibility: true } do
       context "when activities do not include restricted journals" do
         before do
           get api_v3_paths.work_package_activities work_package.id


### PR DESCRIPTION
https://community.openproject.org/wp/62009

When feature flag is off- restricted comments are hidden away completely; they cannot be added nor viewed. @brunopagno I think this would be the correct route- rather than allowing view rights.

Follows #18131, #18144 