### PR TITLE
[62117] It shows an icon on wp card, when there is no dates for it

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -152,7 +152,7 @@
       data-test-selector="op-wp-single-card--content-assignee"
     ></op-principal>
     <display-field
-      *ngIf="!showAsInlineCard"
+      *ngIf="!showAsInlineCard && (workPackage.startDate || workPackage.dueDate)"
       [resource]="workPackage"
       [displayFieldOptions]="{ writable: false, dateFormat: 'MMM DD, YYYY', placeholder: '' }"
       [displayClass]="combinedDateDisplayField"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62117

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show display field for the dates on the WP card view, when there is start or end date.

## Screenshots
Before:
![Screenshot 2025-03-12 at 04 47 34](https://github.com/user-attachments/assets/56386b2a-3198-4a0e-bd47-788fee5c4284)

After:
![Screenshot 2025-03-12 at 04 47 13](https://github.com/user-attachments/assets/a52a3d49-e252-44da-89aa-7b315d1908b3)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
