### PR TITLE
[62109] work packages links in relation tab should open in same browser tab

### DIFF
--- a/app/components/work_package_relations_tab/relation_component.html.erb
+++ b/app/components/work_package_relations_tab/relation_component.html.erb
@@ -57,8 +57,7 @@
             color: :default,
             underline: false,
             font_size: :normal,
-            font_weight: :bold,
-            target: "_blank"
+            font_weight: :bold
           )
         ) { related_work_package.subject }
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/62109/activity

# What are you trying to accomplish?
Open relations in the same tab