### PR TITLE
remove automatic wp config from live docs

### DIFF
--- a/docs/system-admin-guide/manage-work-packages/work-package-types/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-types/README.md
@@ -104,7 +104,3 @@ The **Activated for new projects by default** setting in the Types will only act
 This can be also configured in the [project settings](../../../user-guide/projects/project-settings).
 
 ![activate projects for work package types](image-20200116150513323.png)
-
-## Work package subject configuration (Enterprise add-on)
-
-Under **Administration -> Work packages -> Types** on the tab **Subject configuration** you can choose whether work package subjects should be defined automatically.


### PR DESCRIPTION
automatic work package subject configuration was moved from 15.4 release and should not be displayed in the live documentation -> removing it here. 
it was already removed from release 15.4 branch as well. 