### PR TITLE
Ensure to only store tokens for OIDC logins

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) the OpenProject GmbH
@@ -56,9 +58,11 @@ module OpenProject::OpenIDConnect
         controller = context.fetch(:controller)
         session = controller.session
 
-        session["omniauth.oidc_access_token"] = context.dig(:auth_hash, :credentials, :token)
-        session["omniauth.oidc_refresh_token"] = context.dig(:auth_hash, :credentials, :refresh_token)
-        session["omniauth.oidc_expires_in"] = context.dig(:auth_hash, :credentials, :expires_in)
+        if OpenIDConnect::Provider.exists?(slug: context.dig(:auth_hash, :provider))
+          session["omniauth.oidc_access_token"] = context.dig(:auth_hash, :credentials, :token)
+          session["omniauth.oidc_refresh_token"] = context.dig(:auth_hash, :credentials, :refresh_token)
+          session["omniauth.oidc_expires_in"] = context.dig(:auth_hash, :credentials, :expires_in)
+        end
 
         nil
       end


### PR DESCRIPTION
The hook we are using is firing for all kinds of omniauth logins. By ensuring that we have a matching OpenIDConnect provider, we know that we are currently performing an OIDC login, which is the only case where we want to try storing OIDC tokens.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/62086