### PR TITLE
Removed mention of closed bug

### DIFF
--- a/docs/user-guide/work-packages/exporting/README.md
+++ b/docs/user-guide/work-packages/exporting/README.md
@@ -128,7 +128,6 @@ If you activate the **Include relations** option, additional columns to list eac
 
 The OpenProject XLS export currently does not respect all options in the work package view being exported from:
 
-- The order of work packages in a manually sorted query is not respected. This is a known limitation ([Ticket](https://community.openproject.org/projects/openproject/work_packages/34971/activity)).
 - The hierarchy of work packages as displayed in the work package view. The exported XLS is always in "flat" mode.
 - The description is exported in 'raw' format, so it may contain HTML tags.
 
@@ -151,7 +150,6 @@ If you select the **Include descriptions** option, the work package description 
 
 The OpenProject CSV export currently does not respect all options in the work package view being exported from:
 
-- The order of work packages in a manually sorted query is not respected. This is a known limitation ([Ticket](https://community.openproject.org/projects/openproject/work_packages/34971/activity)).
 - The hierarchy of work packages as displayed in the work package view. The exported CSV is always in "flat" mode.
 - The description is exported in 'raw' format, so it may contain HTML tags.
 


### PR DESCRIPTION
<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

_Doc writers_ 

# What are you trying to accomplish?

Removed a noted limitation for XLS and CSV exports of manually sorted views. The mentioned bug 34971 has been closed in the meantime. Limitation is no longer present.

## Screenshots
![grafik](https://github.com/user-attachments/assets/9f7dc481-61c2-45a8-a6b1-1c00eec308c3)

![grafik](https://github.com/user-attachments/assets/dc2d15be-7c52-4bbe-b42f-5845458ec830)


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
