### PR TITLE
put the sidebar on top on the project overview page on narrow screens

### DIFF
--- a/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
+++ b/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
@@ -13,7 +13,7 @@
   </div>
 
   <!-- copied css classes from primer to have a UX behaviour consistent with other pages having a sidebar -->
-  <div class="Layout Layout--flowRow-until-md Layout--sidebarPosition-end Layout--sidebarPosition-flowRow-start" *ngIf="isTurboFrameSidebarEnabled()">
+  <div class="Layout Layout--flowRow-until-md Layout--sidebarPosition-end Layout--sidebarPosition-flowRow-start Layout--sidebar-narrow" *ngIf="isTurboFrameSidebarEnabled()">
     <div class="Layout-main">
       <grid *ngIf="grid" [grid]="grid"></grid>
     </div>

--- a/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
+++ b/frontend/src/app/shared/components/grids/grid/page/grid-page.component.html
@@ -12,11 +12,12 @@
       </ul>
   </div>
 
-  <div class="op-grid-page--grid-container" *ngIf="isTurboFrameSidebarEnabled()">
-    <div class="op-grid-page--main-content">
+  <!-- copied css classes from primer to have a UX behaviour consistent with other pages having a sidebar -->
+  <div class="Layout Layout--flowRow-until-md Layout--sidebarPosition-end Layout--sidebarPosition-flowRow-start" *ngIf="isTurboFrameSidebarEnabled()">
+    <div class="Layout-main">
       <grid *ngIf="grid" [grid]="grid"></grid>
     </div>
-    <div class="op-grid-page--sidebar">
+    <div class="Layout-sidebar">
       <turbo-frame
         *ngIf="isLifeCyclesSidebarEnabled()"
         [src]="lifeCyclesSidebarSrc()"

--- a/frontend/src/app/shared/components/grids/grid/page/grid-page.component.sass
+++ b/frontend/src/app/shared/components/grids/grid/page/grid-page.component.sass
@@ -13,31 +13,7 @@
   &--toolbar-items
     padding-right: 20px
 
-  &--grid-container
-    display: grid
-    // grid-template-columns: auto 324px
-    // firefox issue when using auto or 1fr
-    // inner content width of the main-content is calculated dynamically
-    // chrome and firefox seem to come to different results
-    // temporary fix: use more specific width rules, e.g. 75% and 25%
-    // same issue with flex-box approach
-    grid-template-columns: 75% 25%
-    gap: 20px
-
-  &--sidebar
-    margin-top: 20px
-    margin-right: 40px
-
 @media only screen and (max-width: $breakpoint-sm)
   .op-grid-page--title-container
     margin-left: 0
     margin-bottom: 0
-
-@media only screen and (max-width: $breakpoint-lg)
-  .op-grid-page--grid-container
-    grid-template-columns: 100%
-    gap: 0
-
-  .op-grid-page--sidebar
-    display: none
-

--- a/spec/support/pages/projects/show.rb
+++ b/spec/support/pages/projects/show.rb
@@ -51,12 +51,12 @@ module Pages
 
       def expect_no_visible_sidebar
         expect_angular_frontend_initialized
-        expect(page).to have_no_css(".op-grid-page--sidebar")
+        expect(page).to have_no_css(".Layout-sidebar")
       end
 
       def expect_visible_sidebar
         expect_angular_frontend_initialized
-        expect(page).to have_css(".op-grid-page--sidebar")
+        expect(page).to have_css(".Layout-sidebar")
       end
 
       def within_project_attributes_sidebar(&)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58229

# What are you trying to accomplish?

Have the sidebar of the project overview page displayed on top when the screen is narrow.

# What approach did you choose and why?

Apply the CSS styles of primer. But because the functionality is Angular powered, the view component could not be used.
