### PR TITLE
[62125] Avoid jumping to a different month when setting flatpickr dates

### DIFF
--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -895,8 +895,7 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
       }
     end
 
-    it "sets start to the selected value, moves focus to finish date",
-       skip: "broken for now, will be fixed within #62125" do
+    it "sets start to the selected value, moves focus to finish date" do
       datepicker.expect_start_date "", visible: false
       datepicker.expect_due_date ""
       datepicker.expect_duration ""

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -86,8 +86,7 @@ RSpec.describe "date inplace editor", :js, :selenium, with_settings: { date_form
     start_date.expect_state_text "2016-01-02 - 2016-01-25"
   end
 
-  it 'can set "today" as a date via the provided link',
-     skip: "broken for now, will be fixed within #62125" do
+  it 'can set "today" as a date via the provided link' do
     start_date.activate!
     start_date.expect_active!
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62125

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When setting flatpickr dates with `.setDates`, it jumps the calendar to the last date so that it's visible on the left side. This is annoying when clicking on a date on the right side because the calendar view then changes while it could stay the same.

This PR tries to avoid such jumping

With the previous fix of bug 61961 done in PR #18234 (commit 752c83b), there were issues and it was not jumping at all in some cases where it should have.

## Screenshots

Before fix of bug 61961, it would blindly jump to finish date to display it on the left side

[weird jumping to finish date.webm](https://github.com/user-attachments/assets/fa741322-d385-43b7-8e6e-e0000444f735)

[broken jump datepicker.webm](https://github.com/user-attachments/assets/653a9662-f582-472d-9fa0-c6401780c098)

After fix of bug 61961, it was not jumping anymore when setting dates through the input fields or "Today" buttons

[calendar not jumping to selected dates.webm](https://github.com/user-attachments/assets/04bf5fbf-4d47-4f24-bbd9-84717ba2e133)

Now, I should be correct and jump only to the selected date if it's not already visible.

[jumping correctly.webm](https://github.com/user-attachments/assets/4e446296-3fd9-4337-87ae-4df29f5b660c)

# What approach did you choose and why?

This commit fixes the issue in two steps:
- first it jumps to the date that has been changed, so that when setting the start date, the calendar shows the start date instead of showing the finish date
- then if the month previously displayed was on the right side, it jumps back to the previously displayed month so that the calendar view stays the same.

Also it does not jump to different dates if no dates have changed (for instance when focusing some other fields).

# Merge checklist

- [x] Added/updated tests
  - Reenabled 2 tests that were broken due to this bug 
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
