### PR TITLE
enable multi user custom fields on the project settings page

### DIFF
--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/user-input/user-input.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/user-input/user-input.component.html
@@ -4,6 +4,7 @@
   [attr.aria-required]="to.required"
   [attr.required]="to.required"
   [url]="to.allowedValuesHref"
+  [multiple]="to.multiple"
   [inviteUserToProject]="projectId"
 >
 </op-user-autocompleter>

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Projects", "editing settings", :js do
     end
   end
 
-  context "with a multi-select custom field" do
+  context "with a multi-select list custom field" do
     include_context "ng-select-autocomplete helpers"
 
     let!(:list_custom_field) { create(:list_project_custom_field, name: "List CF", multi_value: true, projects: [project]) }
@@ -150,6 +150,37 @@ RSpec.describe "Projects", "editing settings", :js do
       cvs = project.reload.custom_value_for(list_custom_field)
       expect(cvs.count).to eq 2
       expect(cvs.map(&:typed_value)).to contain_exactly "A", "B"
+    end
+  end
+
+  context "with a multi-select user custom field" do
+    include_context "ng-select-autocomplete helpers"
+
+    let!(:list_custom_field) { create(:user_project_custom_field, name: "List CF", multi_value: true, projects: [project]) }
+    let(:dummy_role) { create(:project_role) }
+    let!(:users) do
+      [
+        create(:user, firstname: "First", lastname: "User", member_with_roles: { project => [dummy_role] }),
+        create(:user, firstname: "Second", lastname: "User", member_with_roles: { project => [dummy_role] }),
+        create(:user, firstname: "Third", lastname: "User", member_with_roles: { project => [dummy_role] })
+      ]
+    end
+    let(:form_field) { FormFields::SelectFormField.new list_custom_field }
+
+    it "can select multiple values" do
+      visit project_settings_general_path(project.id)
+
+      form_field.select_option users.first.name, users.last.name
+
+      click_on "Save"
+
+      expect(page).to have_content "Successful update."
+
+      refresh
+
+      expect(page).to have_no_content "Successful update."
+
+      form_field.expect_selected users.first.name, users.last.name
     end
   end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/57504

# What are you trying to accomplish?

Allow multi value custom fields on the project settings page

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
