### PR TITLE
[#62142] Project name in version autocompleter not legible in dark mode

### DIFF
--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-/***** Auto-complete ****
+/***** Auto-complete ****/
 
 div.autocomplete
   position: absolute
@@ -104,6 +104,7 @@ div.autocomplete
 
 // Override some basic styles to ensure that ngSelect matches the current theme
 .ng-select-container,
+.ng-optgroup:not(.ng-option-marked, .ng-option-disabled),
 .ng-option:not(.ng-option-marked, .ng-option-disabled),
 .ng-dropdown-panel,
 .ng-dropdown-panel-items,
@@ -147,7 +148,7 @@ div.autocomplete
 .ng-option-label
   vertical-align: top
 
-.ng-option
+.ng-option, .ng-optgroup
   line-height: 22px
   font-size: var(--body-font-size)
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62142

# What are you trying to accomplish?
Make version autoselect group option visible in dark mode.

## Screenshots
<details><summary>Before</summary>
<p>

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/1b57a55d-3c8c-458f-9820-cfd916b2230f" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/2af5a46a-099f-4539-83c5-d324fe25230b" />


</p>
</details> 

# What approach did you choose and why?
Apply the styling of `.ng-option` to the  `.ng-optgroup` too.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
