### PR TITLE
attempt to fix flickering activity spec

### DIFF
--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1078,9 +1078,8 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         # the scroll position is at around 700, some other part of the frontend code seems to trigger a scroll
         # happens for the files tab as well for example
         #
-        it "does not scroll to the bottom when the newest journal entry is on the bottom" do
-          pending "bug/59916-on-narrow-screens-(including-mobile)-the-view-always-scrolls-to-the-activity"
-
+        it "does not scroll to the bottom when the newest journal entry is on the bottom",
+           skip: "bug/59916-on-narrow-screens-(including-mobile)-the-view-always-scrolls-to-the-activity" do
           sleep 1 # wait for a potential auto scrolling to finish
           # expect activity tab not to be visibe, as the page is not scrolled to the bottom
           scroll_position = page.evaluate_script("document.querySelector(\"#content-body\").scrollTop")

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       wp_page.wait_for_activity_tab
     end
 
-    it "shows and merges activities and comments correctly", :aggregate_failures do
+    it "shows and merges activities and comments correctly" do
       first_journal = work_package.journals.first
 
       # initial journal entry is shown without changeset or comment
@@ -330,7 +330,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       wp_page.wait_for_activity_tab
     end
 
-    it "shows and merges activities and comments correctly", :aggregate_failures do
+    it "shows and merges activities and comments correctly" do
       first_journal = work_package.journals.first
 
       # initial journal entry is shown without changeset or comment
@@ -398,7 +398,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
     end
 
-    it "shows the comment of another user without browser reload", :aggregate_failures do
+    it "shows the comment of another user without browser reload" do
       # simulate member creating a comment
       first_journal = create(:work_package_journal,
                              user: member,
@@ -494,7 +494,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "filters the activities based on type", :aggregate_failures do
+      it "filters the activities based on type" do
         # add a non-comment journal entry by changing the work package attributes
         wp_page.update_attributes(subject: "A new subject") # rubocop:disable Rails/ActiveRecordAliases
         wp_page.expect_and_dismiss_toaster(message: "Successful update.")
@@ -560,7 +560,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         end
       end
 
-      it "resets an only_changes filter if a comment is added by the user", :aggregate_failures do
+      it "resets an only_changes filter if a comment is added by the user" do
         activity_tab.filter_journals(:only_changes)
 
         # expect only the changes
@@ -585,7 +585,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       wp_page.wait_for_activity_tab
     end
 
-    it "focuses the editor", :aggregate_failures do
+    it "focuses the editor" do
       activity_tab.set_journal_sorting(:desc)
 
       activity_tab.open_new_comment_editor
@@ -617,7 +617,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       wp_page.wait_for_activity_tab
     end
 
-    it "sorts the activities based on the sorting preference", :aggregate_failures do
+    it "sorts the activities based on the sorting preference" do
       # expect the default sorting to be asc
       activity_tab.expect_comments_order(
         [
@@ -695,13 +695,13 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "shows the notification bubble", :aggregate_failures do
+      it "shows the notification bubble" do
         activity_tab.within_journal_entry(journal_mentioning_admin) do
           activity_tab.expect_notification_bubble
         end
       end
 
-      it "removes the notification bubble after the comment is read", :aggregate_failures do
+      it "removes the notification bubble after the comment is read" do
         notificaton_for_admin.update!(read_ian: true)
 
         wp_page.visit!
@@ -721,7 +721,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "does not show the notification bubble", :aggregate_failures do
+      it "does not show the notification bubble" do
         activity_tab.within_journal_entry(journal_mentioning_admin) do
           activity_tab.expect_no_notification_bubble
         end
@@ -746,7 +746,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "can edit own comments", :aggregate_failures do
+      it "can edit own comments" do
         # edit own comment
         activity_tab.edit_comment(first_comment_by_admin, text: "First comment by admin edited")
 
@@ -782,7 +782,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "can quote other user's comments", :aggregate_failures do
+      it "can quote other user's comments" do
         # quote other user's comment
         activity_tab.quote_comment(first_comment_by_member)
 
@@ -799,7 +799,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "can quote other user's comments", :aggregate_failures do
+      it "can quote other user's comments" do
         # open the editor and type something
         activity_tab.type_comment("Partial message:")
 
@@ -823,7 +823,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       wp_page.wait_for_activity_tab
     end
 
-    it "rescues the editor content when navigating to another workpackage tab", :aggregate_failures do
+    it "rescues the editor content when navigating to another workpackage tab" do
       # add a comment, but do not save it
       activity_tab.add_comment(text: "First comment by admin", save: false)
 
@@ -843,7 +843,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       activity_tab.expect_journal_notes(text: "First comment by admin")
     end
 
-    it "scopes the rescued content to the work package", :aggregate_failures do
+    it "scopes the rescued content to the work package" do
       # add a comment to the first work package, but do not save it
       activity_tab.add_comment(text: "First comment by admin", save: false)
 
@@ -865,7 +865,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
     end
 
-    it "scopes the rescued content to the user", :aggregate_failures do
+    it "scopes the rescued content to the user" do
       # add a comment to the first work package, but do not save it
       activity_tab.add_comment(text: "First comment by admin", save: false)
 
@@ -925,7 +925,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             wp_page.wait_for_activity_tab
           end
 
-          it "scrolls to the comment specified in the URL", :aggregate_failures do
+          it "scrolls to the comment specified in the URL" do
             wait_for_auto_scrolling_to_finish
             activity_tab.expect_journal_container_at_position(50) # would be at the bottom if no anchor would be provided
 
@@ -939,7 +939,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             wp_page.wait_for_activity_tab
           end
 
-          it "scrolls to the comment specified in the URL", :aggregate_failures do
+          it "scrolls to the comment specified in the URL" do
             wait_for_auto_scrolling_to_finish
             activity_tab.expect_journal_container_at_position(50) # would be at the bottom if no anchor would be provided
 
@@ -959,7 +959,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             wp_page.wait_for_activity_tab
           end
 
-          it "scrolls to the comment specified in the URL", :aggregate_failures do
+          it "scrolls to the comment specified in the URL" do
             wait_for_auto_scrolling_to_finish
             activity_tab.expect_journal_container_at_position(50) # would be at the bottom if no anchor would be provided
 
@@ -981,7 +981,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             wp_page.wait_for_activity_tab
           end
 
-          it "scrolls to the comment specified in the URL", :aggregate_failures do
+          it "scrolls to the comment specified in the URL" do
             wait_for_auto_scrolling_to_finish
             activity_tab.expect_journal_container_at_bottom # would be at the top if no anchor would be provided
 
@@ -995,7 +995,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             wp_page.wait_for_activity_tab
           end
 
-          it "scrolls to the comment specified in the URL", :aggregate_failures do
+          it "scrolls to the comment specified in the URL" do
             wait_for_auto_scrolling_to_finish
             activity_tab.expect_journal_container_at_bottom # would be at the top if no anchor would be provided
 
@@ -1020,7 +1020,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
 
       context "when on desktop" do
-        it "scrolls to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+        it "scrolls to the bottom when the newest journal entry is on the bottom" do
           sleep 1 # wait for auto scrolling to finish
           activity_tab.expect_journal_container_at_bottom
 
@@ -1055,7 +1055,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
           wp_page.wait_for_activity_tab
         end
 
-        it "does not scroll to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+        it "does not scroll to the bottom when the newest journal entry is on the bottom" do
           sleep 1 # wait for a potential auto scrolling to finish
           # expect activity tab not to be visibe, as the page is not scrolled to the bottom
           scroll_position = page.evaluate_script("document.querySelector(\"#content-body\").scrollTop")
@@ -1078,7 +1078,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         # the scroll position is at around 700, some other part of the frontend code seems to trigger a scroll
         # happens for the files tab as well for example
         #
-        it "does not scroll to the bottom when the newest journal entry is on the bottom", :aggregate_failures do
+        it "does not scroll to the bottom when the newest journal entry is on the bottom" do
           pending "bug/59916-on-narrow-screens-(including-mobile)-the-view-always-scrolls-to-the-activity"
 
           sleep 1 # wait for a potential auto scrolling to finish
@@ -1097,7 +1097,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         wp_page.wait_for_activity_tab
       end
 
-      it "does not scroll to the bottom as the newest journal entry is on the top", :aggregate_failures do
+      it "does not scroll to the bottom as the newest journal entry is on the top" do
         sleep 1 # wait for auto scrolling to finish
         activity_tab.expect_journal_container_at_top
       end
@@ -1113,7 +1113,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
     let(:editor) { Components::WysiwygEditor.new }
 
     context "if work package attachments are deactivated in project" do
-      it "shows the inline image and have it uploaded to the work package", :aggregate_failures do
+      it "shows the inline image and have it uploaded to the work package" do
         login_as admin
 
         wp_page.visit!
@@ -1149,7 +1149,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       wp_page.wait_for_activity_tab
     end
 
-    it "shows rectracted journal entries", :aggregate_failures do
+    it "shows rectracted journal entries" do
       activity_tab.within_journal_entry(second_comment_by_admin) do
         expect(page).to have_text(I18n.t(:"journals.changes_retracted"))
       end
@@ -1176,7 +1176,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
     end
 
-    it "shows the updated work package attribute without reload", :aggregate_failures do
+    it "shows the updated work package attribute without reload" do
       using_session(:admin) do
         login_as(admin)
 
@@ -1203,7 +1203,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       end
     end
 
-    it "shows the updated work package attribute without reload after switching back to the activity tab", :aggregate_failures do
+    it "shows the updated work package attribute without reload after switching back to the activity tab" do
       using_session(:admin) do
         login_as(admin)
 
@@ -1264,8 +1264,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
       ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
     end
 
-    it "raises a conflict warning when the work package is updated by another user while the current user is editing",
-       :aggregate_failures do
+    it "raises a conflict warning when the work package is updated by another user while the current user is editing" do
       using_session(:admin) do
         login_as(admin)
 
@@ -1304,8 +1303,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
     end
 
     it "does NOT raise a conflict warning when the work package has been only commented by another user while the current
-        user is editing",
-       :aggregate_failures do
+        user is editing" do
       using_session(:admin) do
         login_as(admin)
 
@@ -1338,8 +1336,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
     end
 
     context "when the current user does not have the activity tab open the whole time" do
-      it "raises a conflict warning when the work package is updated by another user while the current user is editing",
-         :aggregate_failures do
+      it "raises a conflict warning when the work package is updated by another user while the current user is editing" do
         using_session(:admin) do
           login_as(admin)
 
@@ -1389,8 +1386,8 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         end
       end
 
-      it "does NOT raise a conflict warning when the work package is updated by the same user while the current user is editing",
-         :aggregate_failures do
+      it "does NOT raise a conflict warning when the work package is updated by the same user
+          while the current user is editing" do
         using_session(:admin) do
           login_as(admin)
 

--- a/spec/features/activities/work_package/emoji_reactions_spec.rb
+++ b/spec/features/activities/work_package/emoji_reactions_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "Emoji reactions on work package activity", :js, :with_cuprite do
       ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
     end
 
-    it "shows the updated reactions without reload", :aggregate_failures do
+    it "shows the updated reactions without reload" do
       activity_tab.expect_journal_notes(text: first_comment_by_member.notes)
 
       # Simulate another user adding a reaction

--- a/spec/features/activities/work_package_activity_spec.rb
+++ b/spec/features/activities/work_package_activity_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Work package activity", :js do
       ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
     end
 
-    it "displays changed attributes in the activity tab", :aggregate_failures do
+    it "displays changed attributes in the activity tab" do
       activity_tab.expect_journal_changed_attribute(text: "% Complete set to 95%")
       activity_tab.expect_journal_changed_attribute(text: "Work set to 100h")
       activity_tab.expect_journal_changed_attribute(text: "Remaining work set to 5h")


### PR DESCRIPTION
The specs fail with

```
Failure/Error: wait_for { page }.to have_test_selector("op-wp-activity-tab")
expected page to have test selector op-wp-activity-tab
```

The reason for this seems to be the usage of wait_for in combination with aggregate_failures. If the selector is not found, wait_for will correctly wait until it eventually is found. But the aggregate_failures will already note the error on the element not being found. So even if the test later on continues successfully, the error from the waiting is logged and returned as the test result.
