### PR TITLE
[61985] Mobile/Firefox: Picker gets zoomed in when opened and is difficult to use

### DIFF
--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -65,7 +65,7 @@
   .-browser-safari,
   .-browser-chrome,
   .-browser-firefox
-    // Special rule for mobile safari and chrome to prevent zooming into the text field
+    // Special rule for mobile safari, chrome and firefox to prevent zooming into the text field
     // when focused.
     select,
     textarea,

--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -63,7 +63,8 @@
     width: auto !important
 
   .-browser-safari,
-  .-browser-chrome
+  .-browser-chrome,
+  .-browser-firefox
     // Special rule for mobile safari and chrome to prevent zooming into the text field
     // when focused.
     select,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61985

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
On small screen devices, when an input field has a font size smaller than 16px, some browsers automatically zooms in when the input is focused. This is an accessibility feature meant to make small text more readable.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
