### PR TITLE
Use settings based application name when generating costs report

### DIFF
--- a/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
+++ b/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
@@ -41,7 +41,7 @@ class CostQuery::PDF::TimesheetGenerator
   end
 
   def cover_page_title
-    "OpenProject"
+    @cover_page_title ||= Setting.app_title
   end
 
   def cover_page_heading


### PR DESCRIPTION
# What are you trying to accomplish?
Remove hardcoded "OpenProject" title from cover page in costs report PDF export. 

# What approach did you choose and why?
Take instance administrator defined name from Settings.app_title. It's "OpenProject" by default. 