### PR TITLE
[62012] Avoid resetting calendar when enabling a date field

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -7,7 +7,7 @@
             Primer::ButtonComponent.new(
               tag: :a,
               href: single_date_field_button_link("start_date"),
-              data: { turbo_stream: true },
+              data: { turbo_frame: "wp-datepicker-dialog--content", morph: true },
               classes: "wp-datepicker-dialog-date-form--add-button",
               test_selector: "wp-datepicker--show-start-date"
             )
@@ -34,7 +34,7 @@
               Primer::ButtonComponent.new(
                 tag: :a,
                 href: single_date_field_button_link("due_date"),
-                data: { turbo_stream: true },
+                data: { turbo_frame: "wp-datepicker-dialog--content", morph: true },
                 classes: "wp-datepicker-dialog-date-form--add-button",
                 test_selector: "wp-datepicker--show-due-date"
               )

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -43,6 +43,8 @@ class WorkPackages::DatePickerController < ApplicationController
   attr_accessor :work_package
 
   def show
+    set_date_attributes_to_work_package
+
     respond_to do |format|
       format.html do
         render :show,
@@ -51,8 +53,6 @@ class WorkPackages::DatePickerController < ApplicationController
       end
 
       format.turbo_stream do
-        set_date_attributes_to_work_package
-
         replace_via_turbo_stream(
           component: datepicker_modal_component
         )

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -3,7 +3,7 @@
     WorkPackages::DatePicker::DialogContentComponent.new(
       work_package:,
       schedule_manually:,
-      focused_field: params[:field].underscore.to_sym,
+      focused_field: (params[:focused_field] || params[:field]).underscore.to_sym,
       date_mode: params[:date_mode]
     )
   )

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -215,14 +215,14 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
       {
         start_date: Date.parse("2021-02-09"),
         due_date: Date.parse("2021-02-12"),
-        duration: 3
+        duration: 4
       }
     end
 
     it "also unsets the due date" do
       datepicker.expect_start_date "2021-02-09"
       datepicker.expect_due_date "2021-02-12"
-      datepicker.expect_duration 3
+      datepicker.expect_duration 4
 
       datepicker.clear_duration
 
@@ -674,7 +674,7 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     it "also removes duration, but keeps finish date" do
       datepicker.expect_start_date "2021-02-20"
       datepicker.expect_due_date "2021-02-21"
-      datepicker.expect_duration 1
+      datepicker.expect_duration 2
       datepicker.expect_working_days_only false
 
       datepicker.set_start_date ""
@@ -694,7 +694,7 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
       {
         start_date: Date.parse("2021-02-20"),
         due_date: Date.parse("2021-02-21"),
-        duration: 1,
+        duration: 2,
         ignore_non_working_days: true
       }
     end
@@ -702,7 +702,7 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     it "also removes duration, but keeps start date" do
       datepicker.expect_start_date "2021-02-20"
       datepicker.expect_due_date "2021-02-21"
-      datepicker.expect_duration 1
+      datepicker.expect_duration 2
       datepicker.expect_working_days_only false
 
       datepicker.set_due_date ""

--- a/spec/features/work_packages/datepicker/datepicker_single_date_mode_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_single_date_mode_logic_spec.rb
@@ -124,19 +124,23 @@ RSpec.describe "Datepicker: Single-date mode logic test cases (WP #61146)", :js,
       datepicker.expect_duration ""
 
       datepicker.focus_duration
-      datepicker.set_duration "3"
+      datepicker.set_duration "30"
 
       datepicker.expect_start_date "", visible: false
       datepicker.expect_due_date ""
-      datepicker.expect_duration "3"
+      datepicker.expect_duration "30"
+      # calendar is showing the current month
+      datepicker.expect_month Date.current.strftime("%B")
 
       datepicker.expect_duration_highlighted
 
       datepicker.set_date "2025-02-14"
 
-      datepicker.expect_start_date "2025-02-12"
+      datepicker.expect_start_date "2025-01-06"
       datepicker.expect_due_date "2025-02-14"
-      datepicker.expect_duration "3"
+      datepicker.expect_duration "30"
+      # calendar is showing the month of the start date
+      datepicker.expect_month "January"
 
       datepicker.expect_start_highlighted
     end
@@ -166,6 +170,20 @@ RSpec.describe "Datepicker: Single-date mode logic test cases (WP #61146)", :js,
       datepicker.expect_duration ""
 
       datepicker.expect_due_highlighted
+    end
+
+    it "keeps the calendar at its position (Bug #62012)" do
+      # calendar is showing the current month
+      datepicker.expect_month Date.current.strftime("%B")
+
+      in_6_months = Date.current.advance(months: 6)
+      datepicker.select_month in_6_months.strftime("%B")
+      datepicker.expect_month in_6_months.strftime("%B")
+
+      # After enabling the start date, the month shown by the calendar should not have changed
+      datepicker.enable_start_date
+      datepicker.expect_start_date ""
+      datepicker.expect_month in_6_months.strftime("%B")
     end
   end
 
@@ -455,6 +473,24 @@ RSpec.describe "Datepicker: Single-date mode logic test cases (WP #61146)", :js,
       datepicker.expect_duration "3"
 
       datepicker.expect_start_highlighted
+    end
+
+    it "keeps the calendar at its position when the finish date is enabled (Bug #62012)" do
+      # calendar is showing the month of the start date
+      datepicker.expect_month "February"
+
+      datepicker.select_month "May"
+      datepicker.expect_month "May"
+
+      datepicker.enable_due_date
+      datepicker.expect_due_highlighted
+      # After enabling the due date, the month shown by the calendar should not have changed
+      datepicker.expect_month "May"
+
+      datepicker.set_due_date "2025-02-14"
+      datepicker.expect_due_date "2025-02-14"
+      # After setting the due date, the calendar is showing the month of the due date
+      datepicker.expect_month "February"
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62012

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When clicking on a date field in single date mode, it reinitializes the flatpickr instance. So if the user has navigated to a particular month, this is lost and reset to the default displayed month.

## Screenshots

For before, see the screen recording from the [bug report](https://community.openproject.org/wp/62012)

For after, here is how it loooks:

[calendar not reset.webm](https://github.com/user-attachments/assets/fbeb6b20-97d7-446d-921a-704a58900203)


# What approach did you choose and why?

This happens because it was using a turbo-stream to update the dialog. When doing so, the node where the flatpickr is attached is replaced.

We have some logic to avoid this replacement in the preview controller: it listens to turbo:before-frame-render events and avoids morphing for tags starting with "opce".

As the logic is already there, this commit uses a turbo-frame instead of a turbo-stream. This way the flatpickr instance is not replaced and the calendar view is kept.

The controller had to be updated to alter the work package attributes with the given params.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
