### PR TITLE
Bug/59081 misleading caption shown on project list table header

### DIFF
--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -157,9 +157,7 @@ module SortHelper
       @criteria.first && @criteria.first.last
     end
 
-    def empty?
-      @criteria.empty?
-    end
+    delegate :empty?, to: :@criteria
 
     private
 
@@ -167,7 +165,7 @@ module SortHelper
       @criteria ||= []
       @criteria = @criteria.map do |s|
         s = s.to_a
-        [s.first, !(s.last == false || s.last == "desc")]
+        [s.first, [false, "desc"].exclude?(s.last)]
       end
 
       if @available_criteria

--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -317,8 +317,8 @@ module SortHelper
   #       </div>
   #     </th>
   #
-  def sort_header_tag(column, allowed_params: nil, **options)
-    with_sort_header_options(column, allowed_params:, **options) do |col, cap, default_order, **opts|
+  def sort_header_tag(column, allowed_params: nil, **)
+    with_sort_header_options(column, with_title: true, allowed_params:, **) do |col, cap, default_order, **opts|
       sort_link(col, cap, default_order, **opts)
     end
   end
@@ -328,15 +328,15 @@ module SortHelper
   #
   # This is a more specific version of #sort_header_tag.
   # For "filter by" to work properly, you must pass a Hash for `filter_column_mapping`.
-  def sort_header_with_action_menu(column, all_columns, filter_column_mapping = {}, allowed_params: nil, **options)
-    with_sort_header_options(column.attribute, allowed_params:, **options) do |_col, cap, default_order, **opts|
-      action_menu(column, all_columns, cap, default_order, filter_column_mapping, **opts)
+  def sort_header_with_action_menu(column, all_columns, filter_column_mapping = {}, allowed_params: nil, **)
+    with_sort_header_options(column.attribute, with_title: false, allowed_params:, **) do |_col, cap, default_order, **opts|
+      action_menu(column, all_columns, cap, default_order, filter_column_mapping, **opts.except(:title))
     end
   end
 
   # Extracts the given `options` and provides them to a block.
   # See #sort_header_tag and #sort_header_with_action_menu for usage examples.
-  def with_sort_header_options(column, allowed_params: nil, **options)
+  def with_sort_header_options(column, allowed_params: nil, with_title: false, **options)
     caption = get_caption(column, options)
 
     default_order = options.delete(:default_order) || "asc"
@@ -344,7 +344,7 @@ module SortHelper
     param = options.delete(:param) || :sort
     data = options.delete(:data) || {}
 
-    options[:title] = sort_header_title(column, caption, options)
+    options[:title] = sort_header_title(column, caption, options) if with_title
     options[:icon_only_header] = column == :favored
 
     within_sort_header_tag_hierarchy(options, sort_class(column)) do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/59081

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Not have an html title attribute that makes no sense on the project list table headers as more options than just sorting exist there.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

Before:

<img width="403" alt="image" src="https://github.com/user-attachments/assets/e73c3be7-4eb2-4e92-be0c-ad3f1121b50e" />

After:
No tooltip on hover
