### PR TITLE
Ensure to only store tokens for OIDC logins

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) the OpenProject GmbH
@@ -56,9 +58,11 @@ module OpenProject::OpenIDConnect
         controller = context.fetch(:controller)
         session = controller.session
 
-        session["omniauth.oidc_access_token"] = context.dig(:auth_hash, :credentials, :token)
-        session["omniauth.oidc_refresh_token"] = context.dig(:auth_hash, :credentials, :refresh_token)
-        session["omniauth.oidc_expires_in"] = context.dig(:auth_hash, :credentials, :expires_in)
+        if OpenIDConnect::Provider.exists?(slug: context.dig(:auth_hash, :provider))
+          session["omniauth.oidc_access_token"] = context.dig(:auth_hash, :credentials, :token)
+          session["omniauth.oidc_refresh_token"] = context.dig(:auth_hash, :credentials, :refresh_token)
+          session["omniauth.oidc_expires_in"] = context.dig(:auth_hash, :credentials, :expires_in)
+        end
 
         nil
       end

--- a/modules/openid_connect/spec/lib/open_project/openid_connect/hooks/hook_spec.rb
+++ b/modules/openid_connect/spec/lib/open_project/openid_connect/hooks/hook_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# +
+
+require "spec_helper"
+
+RSpec.describe OpenProject::OpenIDConnect::Hooks::Hook do
+  describe "#omniauth_user_authorized" do
+    subject(:call_hook) { described_class.instance.omniauth_user_authorized(context) }
+
+    let(:context) { { controller:, auth_hash: } }
+    let(:controller) { instance_double(ActionController::Base, session:) }
+    let(:session) { {} }
+
+    let(:existing_provider) { create(:oidc_provider, slug: "oidc-foo") }
+
+    let(:auth_hash) { { provider: "oidc-foo", credentials: { token:, refresh_token:, expires_in: } } }
+    let(:token) { "an-access-token" }
+    let(:refresh_token) { "a-refresh-token" }
+    let(:expires_in) { 3600 }
+
+    before do
+      existing_provider.save!
+    end
+
+    it "populates the session with token information", :aggregate_failures do
+      call_hook
+
+      expect(session["omniauth.oidc_access_token"]).to eq(token)
+      expect(session["omniauth.oidc_refresh_token"]).to eq(refresh_token)
+      expect(session["omniauth.oidc_expires_in"]).to eq(expires_in)
+    end
+
+    context "when the provider indicated in the auth hash can't be found" do
+      let(:existing_provider) { create(:oidc_provider, slug: "oidc-bar") }
+
+      it "does not change the session at all" do
+        call_hook
+
+        expect(session).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
The hook we are using is firing for all kinds of omniauth logins. By ensuring that we have a matching OpenIDConnect provider, we know that we are currently performing an OIDC login, which is the only case where we want to try storing OIDC tokens.

# Ticket
https://community.openproject.org/projects/cross-application-user-integration-stream/work_packages/62086