### PR TITLE
[61737] Edit relation modal doesn't show the WP subject

### DIFF
--- a/app/components/work_package_relations_tab/work_package_relation_form_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.rb
@@ -57,9 +57,7 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
   def displayable_field_value
     return nil if related_work_package.nil?
 
-    if relation_to_matches_wp?
-      "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}"
-    end
+    "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}"
   end
 
   def direction


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61737

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show details of a WP which is a relation in relations tab, no matter it is a from or to relation.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
