### PR TITLE
[62058] In single date mode, focus is on finish date even if user selects start date

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -221,7 +221,7 @@ module WorkPackages
 
         # Special case, if the use explicitly clicks on start date, we want to show that field
         if table_triggered_date_field?
-          return name == @triggering_field
+          return normalized_underscore_name(name) == normalized_underscore_name(@triggering_field)
         end
 
         # Start date is only shown in the assertion above
@@ -236,7 +236,11 @@ module WorkPackages
       end
 
       def table_triggered_date_field?
-        @triggering_field == :start_date || @triggering_field == :due_date
+        ["start_date", "due_date"].include?(normalized_underscore_name(@triggering_field))
+      end
+
+      def normalized_underscore_name(name)
+        name.to_s.underscore
       end
     end
   end

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -39,6 +39,7 @@ module WorkPackages
                      disabled:,
                      is_milestone:,
                      focused_field: :start_date,
+                     triggering_field: nil,
                      touched_field_map: nil,
                      date_mode: nil)
         super()
@@ -48,6 +49,7 @@ module WorkPackages
         @is_milestone = is_milestone
         @date_mode = date_mode
         @touched_field_map = touched_field_map
+        @triggering_field = triggering_field
         @focused_field = update_focused_field(focused_field)
         @disabled = disabled
       end
@@ -217,6 +219,11 @@ module WorkPackages
       def show_text_field_in_single_date_mode?(name)
         return true if field_value_present_or_touched?(name)
 
+        # Special case, if the use explicitly clicks on start date, we want to show that field
+        if table_triggered_date_field?
+          return name == @triggering_field
+        end
+
         # Start date is only shown in the assertion above
         return false if name != :due_date
 
@@ -226,6 +233,10 @@ module WorkPackages
         # and suddenly hides the start date. That is why we check for the touched value.
         true if field_value(:start_date).nil? &&
           (@touched_field_map["start_date_touched"] == false || @touched_field_map["start_date_touched"].nil?)
+      end
+
+      def table_triggered_date_field?
+        @triggering_field == :start_date || @triggering_field == :due_date
       end
     end
   end

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -31,6 +31,7 @@
                     work_package:,
                     schedule_manually:,
                     focused_field:,
+                    triggering_field:,
                     touched_field_map:,
                     date_mode:
                   )

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -4,6 +4,7 @@
       data: { "application-target": "dynamic",
               controller: "work-packages--date-picker--preview",
               "work-packages--date-picker--preview-date-mode-value": date_mode,
+              "work-packages--date-picker--preview-triggering-field-value": triggering_field,
               test_selector: "op-datepicker-modal" },
       class: "wp-datepicker-dialog--content"
     ) do

--- a/app/components/work_packages/date_picker/dialog_content_component.rb
+++ b/app/components/work_packages/date_picker/dialog_content_component.rb
@@ -39,14 +39,20 @@ module WorkPackages
       # Used for the three tabs for predecessors, successors and children in the date picker modal.
       Tab = Data.define(:key, :relation_group)
 
-      attr_reader :work_package, :schedule_manually, :focused_field, :touched_field_map, :date_mode
+      attr_reader :work_package, :schedule_manually, :focused_field, :triggering_field, :touched_field_map, :date_mode
 
-      def initialize(work_package:, schedule_manually: true, focused_field: :start_date, touched_field_map: {}, date_mode: nil)
+      def initialize(work_package:,
+                     schedule_manually: true,
+                     focused_field: :start_date,
+                     triggering_field: nil,
+                     touched_field_map: {},
+                     date_mode: nil)
         super
 
         @work_package = work_package
         @schedule_manually = ActiveModel::Type::Boolean.new.cast(schedule_manually)
         @focused_field = focused_field
+        @triggering_field = triggering_field
         @touched_field_map = touched_field_map
         @date_mode = date_mode
       end

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -77,6 +77,7 @@
               schedule_manually:,
               is_milestone: milestone?,
               focused_field:,
+              triggering_field:,
               touched_field_map:,
               date_mode:,
               disabled: disabled?

--- a/app/components/work_packages/date_picker/form_component.rb
+++ b/app/components/work_packages/date_picker/form_component.rb
@@ -34,13 +34,15 @@ module WorkPackages
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 
-      attr_accessor :form_id, :show_date_form, :work_package, :schedule_manually, :focused_field, :touched_field_map, :date_mode
+      attr_accessor :form_id, :show_date_form, :work_package, :schedule_manually, :focused_field, :triggering_field,
+                    :touched_field_map, :date_mode
 
       def initialize(form_id:,
                      show_date_form:,
                      work_package:,
                      schedule_manually: true,
                      focused_field: :start_date,
+                     triggering_field: nil,
                      touched_field_map: {},
                      date_mode: nil)
         super
@@ -50,6 +52,7 @@ module WorkPackages
         @work_package = work_package
         @schedule_manually = ActiveModel::Type::Boolean.new.cast(schedule_manually)
         @focused_field = focused_field
+        @triggering_field = triggering_field
         @touched_field_map = touched_field_map
         @date_mode = date_mode
       end

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -152,7 +152,7 @@ class WorkPackages::DatePickerController < ApplicationController
     WorkPackages::DatePicker::DialogContentComponent.new(work_package: @work_package,
                                                          schedule_manually:,
                                                          focused_field:,
-                                                         triggering_field: params[:field],
+                                                         triggering_field: params[:triggering_field],
                                                          touched_field_map:,
                                                          date_mode:)
   end
@@ -222,7 +222,7 @@ class WorkPackages::DatePickerController < ApplicationController
 
       params.require(:work_package)
             .slice(*allowed_touched_params)
-            .merge(schedule_manually:, date_mode:)
+            .merge(schedule_manually:, date_mode:, triggering_field: params[:triggering_field])
             .permit!
     end
   end

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -152,6 +152,7 @@ class WorkPackages::DatePickerController < ApplicationController
     WorkPackages::DatePicker::DialogContentComponent.new(work_package: @work_package,
                                                          schedule_manually:,
                                                          focused_field:,
+                                                         triggering_field: params[:field],
                                                          touched_field_map:,
                                                          date_mode:)
   end

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -4,6 +4,7 @@
       work_package:,
       schedule_manually:,
       focused_field: (params[:focused_field] || params[:field]).underscore.to_sym,
+      triggering_field: params[:field].underscore.to_sym,
       date_mode: params[:date_mode]
     )
   )

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -38,9 +38,11 @@ import {
 export default class PreviewController extends DialogPreviewController {
   static values = {
     dateMode: String,
+    triggeringField: String,
   };
 
   declare dateModeValue:string;
+  declare triggeringFieldValue:string;
 
   private timezoneService:TimezoneService;
   private highlightedField:HTMLInputElement|null = null;
@@ -88,7 +90,10 @@ export default class PreviewController extends DialogPreviewController {
   }
 
   async preview(field:HTMLInputElement|null) {
-    await super.preview(field, [{ key: 'date_mode', val: this.dateModeValue }]);
+    await super.preview(field, [
+      { key: 'date_mode', val: this.dateModeValue },
+      { key: 'triggering_field', val: this.triggeringFieldValue },
+    ]);
   }
 
   inputChanged(event:Event) {

--- a/spec/features/work_packages/datepicker/datepicker_single_date_mode_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_single_date_mode_logic_spec.rb
@@ -916,51 +916,236 @@ RSpec.describe "Datepicker: Single-date mode logic test cases (WP #61146)", :js,
   end
 
   context "when being on the WP table" do
-    let(:current_attributes) do
-      {
-        start_date: nil,
-        due_date: nil,
-        duration: nil
-      }
-    end
+    let(:start_field) { wp_table.edit_field(work_package, :startDate) }
+    let(:due_field) { wp_table.edit_field(work_package, :dueDate) }
+    let(:duration) { wp_table.edit_field(work_package, :duration) }
 
     before do
       wp_table.visit_query query
     end
 
-    it "can open the datepicker" do
-      start_field = wp_table.edit_field(work_package, :startDate)
-      start_field.activate!
-      start_field.expect_active!
+    context "with empty values" do
+      let(:current_attributes) do
+        {
+          start_date: nil,
+          due_date: nil,
+          duration: nil
+        }
+      end
 
-      datepicker.expect_visible
-      datepicker.expect_start_date "", visible: false
-      datepicker.expect_due_date ""
-      datepicker.expect_duration ""
-      datepicker.expect_due_highlighted
-      datepicker.cancel!
+      it "can open the datepicker" do
+        start_field.activate!
+        start_field.expect_active!
 
-      due_field = wp_table.edit_field(work_package, :dueDate)
-      due_field.activate!
-      due_field.expect_active!
+        datepicker.expect_visible
+        datepicker.expect_start_date ""
+        datepicker.expect_due_date "", visible: false
+        datepicker.expect_duration ""
+        datepicker.expect_start_highlighted
+        datepicker.cancel!
 
-      datepicker.expect_visible
-      datepicker.expect_start_date "", visible: false
-      datepicker.expect_due_date ""
-      datepicker.expect_duration ""
-      datepicker.expect_due_highlighted
-      datepicker.cancel!
+        due_field.activate!
+        due_field.expect_active!
 
-      duration = wp_table.edit_field(work_package, :duration)
-      duration.activate!
-      duration.expect_active!
+        datepicker.expect_visible
+        datepicker.expect_start_date "", visible: false
+        datepicker.expect_due_date ""
+        datepicker.expect_duration ""
+        datepicker.expect_due_highlighted
+        datepicker.cancel!
 
-      datepicker.expect_visible
-      datepicker.expect_start_date "", visible: false
-      datepicker.expect_due_date ""
-      datepicker.expect_duration ""
-      datepicker.expect_duration_highlighted
-      datepicker.cancel!
+        duration.activate!
+        duration.expect_active!
+
+        datepicker.expect_visible
+        datepicker.expect_start_date "", visible: false
+        datepicker.expect_due_date ""
+        datepicker.expect_duration ""
+        datepicker.expect_duration_highlighted
+        datepicker.cancel!
+      end
+    end
+
+    context "when clicking in a specific date field (regression #62058)" do
+      context "when no dates are set" do
+        let(:current_attributes) do
+          {
+            start_date: nil,
+            due_date: nil,
+            duration: nil
+          }
+        end
+
+        it "opens the clicked date in single-date mode" do
+          start_field.activate!
+          start_field.expect_active!
+
+          # Start date is clicked and expected to be active in single-date mode with the due date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date ""
+          datepicker.expect_due_date "", visible: false
+          datepicker.expect_duration ""
+          datepicker.expect_start_highlighted
+          datepicker.cancel!
+
+          due_field.activate!
+          due_field.expect_active!
+
+          # Due date is clicked and expected to be active in single-date mode with the start date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "", visible: false
+          datepicker.expect_due_date ""
+          datepicker.expect_duration ""
+          datepicker.expect_due_highlighted
+          datepicker.cancel!
+
+          duration.activate!
+          duration.expect_active!
+
+          # Duration is clicked and expected to be active in single-date mode with the start date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "", visible: false
+          datepicker.expect_due_date ""
+          datepicker.expect_duration ""
+          datepicker.expect_duration_highlighted
+          datepicker.cancel!
+        end
+      end
+
+      context "when only start date is set" do
+        let(:current_attributes) do
+          {
+            start_date: "2025-02-12",
+            due_date: nil,
+            duration: nil
+          }
+        end
+
+        it "opens the clicked date and goes to range mode if necessary" do
+          start_field.activate!
+          start_field.expect_active!
+
+          # Start date is clicked and expected to be active in single-date mode with the due date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "2025-02-12"
+          datepicker.expect_due_date "", visible: false
+          datepicker.expect_duration ""
+          datepicker.expect_start_highlighted
+          datepicker.cancel!
+
+          due_field.activate!
+          due_field.expect_active!
+
+          # Due date is clicked and expected to be active in range mode
+          datepicker.expect_visible
+          datepicker.expect_start_date "2025-02-12"
+          datepicker.expect_due_date ""
+          datepicker.expect_duration ""
+          datepicker.expect_due_highlighted
+          datepicker.cancel!
+
+          duration.activate!
+          duration.expect_active!
+
+          # Duration is clicked and expected to be active in single-date mode with the due date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "2025-02-12"
+          datepicker.expect_due_date "", visible: false
+          datepicker.expect_duration ""
+          datepicker.expect_duration_highlighted
+          datepicker.cancel!
+        end
+      end
+
+      context "when only finish date is set" do
+        let(:current_attributes) do
+          {
+            start_date: nil,
+            due_date: "2025-02-14",
+            duration: nil
+          }
+        end
+
+        it "opens the clicked date and goes to range mode if necessary" do
+          start_field.activate!
+          start_field.expect_active!
+
+          # Start date is clicked and expected to be active in range mode
+          datepicker.expect_visible
+          datepicker.expect_start_date ""
+          datepicker.expect_due_date "2025-02-14"
+          datepicker.expect_duration ""
+          datepicker.expect_start_highlighted
+          datepicker.cancel!
+
+          due_field.activate!
+          due_field.expect_active!
+
+          # Due date is clicked and expected to be active in single-date mode with the start date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "", visible: false
+          datepicker.expect_due_date "2025-02-14"
+          datepicker.expect_duration ""
+          datepicker.expect_due_highlighted
+          datepicker.cancel!
+
+          duration.activate!
+          duration.expect_active!
+
+          # Duration is clicked and expected to be active in single-date mode with the start date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "", visible: false
+          datepicker.expect_due_date "2025-02-14"
+          datepicker.expect_duration ""
+          datepicker.expect_duration_highlighted
+          datepicker.cancel!
+        end
+      end
+
+      context "when both dates are set" do
+        let(:current_attributes) do
+          {
+            start_date: "2025-02-12",
+            due_date: "2025-02-14",
+            duration: 3
+          }
+        end
+
+        it "opens the clicked date and stays in range mode" do
+          start_field.activate!
+          start_field.expect_active!
+
+          # Start date is clicked and expected to be active in range mode
+          datepicker.expect_visible
+          datepicker.expect_start_date "2025-02-12"
+          datepicker.expect_due_date "2025-02-14"
+          datepicker.expect_duration "3"
+          datepicker.expect_start_highlighted
+          datepicker.cancel!
+
+          due_field.activate!
+          due_field.expect_active!
+
+          # Due date is clicked and expected to be active in single-date mode with the start date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "2025-02-12"
+          datepicker.expect_due_date "2025-02-14"
+          datepicker.expect_duration "3"
+          datepicker.expect_due_highlighted
+          datepicker.cancel!
+
+          duration.activate!
+          duration.expect_active!
+
+          # Duration is clicked and expected to be active in single-date mode with the start date being hidden
+          datepicker.expect_visible
+          datepicker.expect_start_date "2025-02-12"
+          datepicker.expect_due_date "2025-02-14"
+          datepicker.expect_duration "3"
+          datepicker.expect_duration_highlighted
+          datepicker.cancel!
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/62058/activity

# What are you trying to accomplish?
Implement special logic for clicking in a table date field which should enforce that field to be opended even if there would normally be a single-date mode 

# Merge checklist

- [x] Added/updated tests
