### PR TITLE
[#62160] The Version custom field options are not grouped on project pages

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -67,7 +67,7 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   groupByFn = (item:HalResource):string|null => {
     if (!this.isVersionResource) return null;
     const project = item.definingProject as HalResource | undefined;
-    return project?.name ?? this.I18n.t('js.project.not_available');
+    return project?.name || this.I18n.t('js.project.not_available');
   };
 
   compareByHref = compareByHref;

--- a/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
@@ -56,7 +56,7 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
   groupByFn = (item:HalResource):string|null => {
     if (!item.id) return null; // Do not group non version options
     const project = item.definingProject as HalResource | undefined;
-    return project?.name ?? this.I18n.t('js.project.not_available');
+    return project?.name || this.I18n.t('js.project.not_available');
   };
 
   constructor(

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.html
@@ -13,6 +13,7 @@
   [clearOnBackspace]="to.clearOnBackspace"
   [clearSearchOnAdd]="to.clearSearchOnAdd"
   [hideSelected]="to.hideSelected"
+  [groupBy]="groupByFn"
 >
   <ng-template ng-tag-tmp let-search="searchTerm">
     <b [textContent]="to.text.add_new_action"></b>: {{search}}

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.ts
@@ -1,11 +1,30 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
-import idFromLink from 'core-app/features/hal/helpers/id-from-link';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
   selector: 'op-select-input',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './select-input.component.html',
   styleUrls: ['./select-input.component.scss'],
 })
 export class SelectInputComponent extends FieldType {
+  constructor(
+    readonly I18n:I18nService,
+  ) {
+    super();
+  }
+
+  groupByFn = (item:HalResource):string|null => {
+    if (!this.isVersionResource(item)) return null;
+    const links = (item._links || {}) as HalResource;
+    const project = links.definingProject as HalResource | undefined;
+
+    return String(project?.title || this.I18n.t('js.project.not_available'));
+  };
+
+  private isVersionResource(item:HalResource):boolean {
+    return item._type === 'Version';
+  }
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -50,7 +50,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   groupByFn = (item:HalResource):string|null => {
     if (!this.isVersionResource) return null;
     const project = item.definingProject as HalResource | undefined;
-    return project?.name ?? this.I18n.t('js.project.not_available');
+    return project?.name || this.I18n.t('js.project.not_available');
   };
 
   public availableOptions:any[] = [];

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -388,6 +388,58 @@ RSpec.describe "Projects copy", :js,
       end
     end
 
+    context "with a multi-select version custom field" do
+      include_context "ng-select-autocomplete helpers"
+
+      shared_let(:public_project) do
+        create(:project, name: "Public Pr", identifier: "public-pr", public: true)
+      end
+
+      let!(:versions) do
+        [
+          create(:version, project:, name: "Ringbo 1.0", sharing: "system"),
+          create(:version, project: public_project, name: "Ringbo 2.0", sharing: "system")
+        ]
+      end
+
+      let!(:version_custom_field) do
+        create(:version_project_custom_field,
+               name: "Version CF",
+               multi_value: true,
+               project_custom_field_section:,
+               projects: [project])
+      end
+
+      let(:version_field) { FormFields::SelectFormField.new version_custom_field }
+
+      before do
+        Pages::Projects::Settings::General.new(project).visit!
+
+        page.find_test_selector("project-settings-more-menu").click
+        page.find_test_selector("project-settings--copy").click
+
+        fill_in "Name", with: "Copied project"
+        click_on "Advanced settings"
+      end
+
+      it "can create a project" do
+        # expect the versions are grouped by the project name
+        version_field.expect_option(versions.first.name, grouping: project.name)
+        version_field.expect_option(versions.last.name, grouping: public_project.name)
+
+        version_field.select_option(versions.first.name, versions.last.name)
+
+        click_button "Save"
+
+        wait_for_copy_to_finish
+
+        copied_project = Project.find_by(name: "Copied project")
+        typed_values =
+          copied_project.custom_value_for(version_custom_field).map(&:typed_value)
+        expect(typed_values).to eq versions
+      end
+    end
+
     context "when the user has a view_project_attributes only" do
       let(:permissions) do
         %i(copy_projects

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe "Projects", "creation",
     expect(project.identifier).to eq "foo-project-1"
   end
 
-  context "with a multi-select custom field" do
-    let!(:list_custom_field) do
+  context "with a multi-select list custom field" do
+    shared_let(:list_custom_field) do
       create(:list_project_custom_field, name: "List CF", multi_value: true, project_custom_field_section:)
     end
     let(:list_field) { FormFields::SelectFormField.new list_custom_field }
@@ -103,6 +103,55 @@ RSpec.describe "Projects", "creation",
     end
   end
 
+  context "with a multi-select version custom field" do
+    include_context "ng-select-autocomplete helpers"
+
+    shared_let(:public_project) do
+      create(:project, name: "Public Pr", identifier: "public-pr", public: true)
+    end
+
+    shared_let(:versions) do
+      [
+        create(:version, project:, name: "Ringbo 1.0", sharing: "system"),
+        create(:version, project: public_project, name: "Ringbo 2.0", sharing: "system")
+      ]
+    end
+
+    shared_let(:version_custom_field) do
+      create(:version_project_custom_field,
+             name: "Version CF",
+             multi_value: true,
+             project_custom_field_section:)
+    end
+
+    let(:version_field) { FormFields::SelectFormField.new version_custom_field }
+
+    it "can create a project" do
+      projects_page.navigate_to_new_project_page_from_toolbar_items
+
+      name_field.set_value "Foo bar"
+
+      find(".op-fieldset--toggle", text: "ADVANCED SETTINGS").click
+
+      # expect the versions are grouped by the project name
+      version_field.expect_option(versions.first.name, grouping: project.name)
+      version_field.expect_option(versions.last.name, grouping: public_project.name)
+
+      version_field.select_option(versions.first.name, versions.last.name)
+
+      click_button "Save"
+
+      expect(page).to have_current_path /\/projects\/foo-bar\/?/
+      expect(page).to have_content "Foo bar"
+
+      project = Project.last
+      expect(project.name).to eq "Foo bar"
+
+      typed_values = project.custom_value_for(version_custom_field).map(&:typed_value)
+      expect(typed_values).to eq versions
+    end
+  end
+
   it "hides the active field and the identifier" do
     visit new_project_path
 
@@ -113,13 +162,13 @@ RSpec.describe "Projects", "creation",
   end
 
   context "with optional and required custom fields" do
-    let!(:optional_custom_field) do
+    shared_let(:optional_custom_field) do
       create(:project_custom_field, name: "Optional Foo",
                                     field_format: "string",
                                     is_for_all: true,
                                     project_custom_field_section:)
     end
-    let!(:required_custom_field) do
+    shared_let(:required_custom_field) do
       create(:project_custom_field, name: "Required Foo",
                                     field_format: "string",
                                     is_for_all: true,
@@ -128,7 +177,7 @@ RSpec.describe "Projects", "creation",
     end
 
     context "with required custom fields" do
-      let!(:required_user_custom_field) do
+      shared_let(:required_user_custom_field) do
         create(:user_project_custom_field, name: "Required User",
                                            is_for_all: true,
                                            is_required: true,
@@ -165,7 +214,7 @@ RSpec.describe "Projects", "creation",
     end
 
     context "with correct custom field activation" do
-      let!(:unused_custom_field) do
+      shared_let(:unused_custom_field) do
         create(:project_custom_field, name: "Unused Foo",
                                       field_format: "string",
                                       project_custom_field_section:)
@@ -196,19 +245,11 @@ RSpec.describe "Projects", "creation",
       end
 
       context "with correct handling of default values" do
-        let!(:custom_field_with_default_value) do
+        shared_let(:custom_field_with_default_value) do
           create(:project_custom_field, name: "Foo with default value",
                                         field_format: "string",
                                         default_value: "Default value",
                                         project_custom_field_section:)
-        end
-
-        before do
-          visit new_project_path
-          fill_in "Name", with: "Foo bar"
-          fill_in "Required Foo", with: "Required value"
-
-          click_on "Advanced settings"
         end
 
         it "enables custom fields with default values if not set to blank explicitly" do
@@ -263,32 +304,24 @@ RSpec.describe "Projects", "creation",
       end
 
       context "with correct handling of optional boolean values" do
-        let!(:custom_boolean_field_default_true) do
+        shared_let(:custom_boolean_field_default_true) do
           create(:project_custom_field, name: "Boolean with default true",
                                         field_format: "bool",
                                         default_value: true,
                                         project_custom_field_section:)
         end
 
-        let!(:custom_boolean_field_default_false) do
+        shared_let(:custom_boolean_field_default_false) do
           create(:project_custom_field, name: "Boolean with default false",
                                         field_format: "bool",
                                         default_value: false,
                                         project_custom_field_section:)
         end
 
-        let!(:custom_boolean_field_with_no_default) do
+        shared_let(:custom_boolean_field_with_no_default) do
           create(:project_custom_field, name: "Boolean with no default",
                                         field_format: "bool",
                                         project_custom_field_section:)
-        end
-
-        before do
-          visit new_project_path
-          fill_in "Name", with: "Foo bar"
-          fill_in "Required Foo", with: "Required value"
-
-          click_on "Advanced settings"
         end
 
         it "only enables boolean custom fields with default values if untouched" do
@@ -346,58 +379,50 @@ RSpec.describe "Projects", "creation",
           expect(project.custom_value_for(custom_boolean_field_default_true).typed_value).to be_falsy
         end
       end
-    end
 
-    context "with correct handling of invisible values" do
-      let!(:invisible_field) do
-        create(:string_project_custom_field, name: "Text for Admins only",
-                                             admin_only: true,
-                                             project_custom_field_section:)
-      end
-
-      before do
-        visit new_project_path
-        fill_in "Name", with: "Foo bar"
-        fill_in "Required Foo", with: "Required value"
-
-        click_on "Advanced settings"
-      end
-
-      context "with an admin user" do
-        it "shows invisible fields in the form and allows their activation" do
-          expect(page).to have_content "Text for Admins only"
-
-          fill_in "Text for Admins only", with: "foo"
-
-          click_on "Save"
-
-          expect(page).to have_current_path /\/projects\/foo-bar\/?/
-
-          project = Project.last
-
-          expect(project.project_custom_field_ids).to contain_exactly(
-            required_custom_field.id, invisible_field.id
-          )
-
-          expect(project.custom_value_for(invisible_field).typed_value).to eq("foo")
+      context "with correct handling of invisible values" do
+        shared_let(:invisible_field) do
+          create(:string_project_custom_field, name: "Text for Admins only",
+                                               admin_only: true,
+                                               project_custom_field_section:)
         end
-      end
 
-      context "with a non-admin user" do
-        current_user { create(:user, global_permissions: %i[add_project]) }
+        context "with an admin user" do
+          it "shows invisible fields in the form and allows their activation" do
+            expect(page).to have_content "Text for Admins only"
 
-        it "does not show invisible fields in the form and thus not activates the invisible field" do
-          expect(page).to have_no_content "Text for Admins only"
+            fill_in "Text for Admins only", with: "foo"
 
-          click_on "Save"
+            click_on "Save"
 
-          expect(page).to have_current_path /\/projects\/foo-bar\/?/
+            expect(page).to have_current_path /\/projects\/foo-bar\/?/
 
-          project = Project.last
+            project = Project.last
 
-          expect(project.project_custom_field_ids).to contain_exactly(
-            required_custom_field.id
-          )
+            expect(project.project_custom_field_ids).to contain_exactly(
+              required_custom_field.id, invisible_field.id
+            )
+
+            expect(project.custom_value_for(invisible_field).typed_value).to eq("foo")
+          end
+        end
+
+        context "with a non-admin user" do
+          current_user { create(:user, global_permissions: %i[add_project]) }
+
+          it "does not show invisible fields in the form and thus not activates the invisible field" do
+            expect(page).to have_no_content "Text for Admins only"
+
+            click_on "Save"
+
+            expect(page).to have_current_path /\/projects\/foo-bar\/?/
+
+            project = Project.last
+
+            expect(project.project_custom_field_ids).to contain_exactly(
+              required_custom_field.id
+            )
+          end
         end
       end
     end

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -184,6 +184,50 @@ RSpec.describe "Projects", "editing settings", :js do
     end
   end
 
+  context "with a version custom field" do
+    include_context "ng-select-autocomplete helpers"
+
+    shared_let(:public_project) do
+      create(:project, name: "Public Pr", identifier: "public-pr", public: true)
+    end
+
+    let!(:versions) do
+      [
+        create(:version, project:, name: "Ringbo 1.0", sharing: "system"),
+        create(:version, project: public_project, name: "Ringbo 2.0", sharing: "system")
+      ]
+    end
+
+    let!(:version_custom_field) do
+      create(:version_project_custom_field,
+             name: "List CF",
+             multi_value: true,
+             projects: [project])
+    end
+
+    let(:form_field) { FormFields::SelectFormField.new version_custom_field }
+
+    it "can select multiple values" do
+      visit project_settings_general_path(project.id)
+
+      # expect the versions are grouped by the project name
+      form_field.expect_option(versions.first.name, grouping: project.name)
+      form_field.expect_option(versions.last.name, grouping: public_project.name)
+
+      form_field.select_option(versions.first.name, versions.last.name)
+
+      click_on "Save"
+
+      expect(page).to have_content "Successful update."
+
+      refresh
+
+      expect(page).to have_no_content "Successful update."
+
+      form_field.expect_selected versions.first.name, versions.last.name
+    end
+  end
+
   context "with a date custom field" do
     let!(:date_custom_field) { create(:date_project_custom_field, name: "Date", projects: [project]) }
     let(:form_field) { FormFields::InputFormField.new date_custom_field }

--- a/spec/support/form_fields/select_form_field.rb
+++ b/spec/support/form_fields/select_form_field.rb
@@ -15,6 +15,31 @@ module FormFields
         .to have_no_css(".ng-option", text: option, visible: :all)
     end
 
+    def expect_option(option, grouping: nil)
+      field_container.find(".ng-select-container").click
+      if grouping
+        # Make sure the option is displayed under correct grouping title.
+        option_group = find(".ng-optgroup", text: grouping)
+        option = find(".ng-option.ng-option-child", text: option, visible: :visible)
+
+        expected_group = begin
+          option.find(:xpath,
+                      "preceding-sibling::*[contains(@class, 'ng-optgroup')][1]",
+                      wait: false)
+        rescue Capybara::ElementNotFound
+          raise "Unable to find the '.ng-optgroup' grouping for option '#{option.text}'"
+        end
+
+        expect(option_group).to eq(expected_group), <<~MSG
+          Expected the option '#{option.text}' to be under the group '#{option_group.text}',
+          but it was under '#{expected_group.text}' instead.
+        MSG
+      else
+        expect(page)
+          .to have_css(".ng-option", text: option, visible: :visible)
+      end
+    end
+
     def expect_visible
       expect(field_container).to have_css("ng-select")
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62160

# What are you trying to accomplish?

Add version field project grouping on the Project General settings, Project Copy and Project Create pages.

# What approach did you choose and why?
Apply the same `groupByFn` function on the `select-input.component.ts`

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
