### PR TITLE
[#62047] fix creating folders from location picker

### DIFF
--- a/frontend/src/app/core/state/storage-files/storage-files.service.ts
+++ b/frontend/src/app/core/state/storage-files/storage-files.service.ts
@@ -87,6 +87,10 @@ export class StorageFilesResourceService {
     this.store.reset();
   }
 
+  removeCollection(link:IHalResourceLink):void {
+    delete this.store.getValue().files[link.href];
+  }
+
   private lookup(id:ID):Observable<IStorageFile> {
     return this
       .query

--- a/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.ts
+++ b/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.ts
@@ -40,7 +40,11 @@ import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.mod
 import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { SortFilesPipe } from 'core-app/shared/components/storages/pipes/sort-files.pipe';
-import { isDirectory, storageLocaleString } from 'core-app/shared/components/storages/functions/storages.functions';
+import {
+  isDirectory,
+  makeFilesCollectionLink,
+  storageLocaleString,
+} from 'core-app/shared/components/storages/functions/storages.functions';
 import { StorageFilesResourceService } from 'core-app/core/state/storage-files/storage-files.service';
 import {
   StorageFileListItem,
@@ -195,7 +199,12 @@ export class LocationPickerModalComponent extends FilePickerBaseModalComponent {
         parent_id: this.currentDirectory.id,
       },
     ).subscribe({
-      next: (newlyCreatedDirectory) => this.changeLevel(newlyCreatedDirectory),
+      next: (newlyCreatedDirectory) => {
+        // clear cache for the current directory
+        const cacheKey = makeFilesCollectionLink(this.storage._links.self, this.currentDirectory.location);
+        this.storageFilesResourceService.removeCollection(cacheKey);
+        this.changeLevel(newlyCreatedDirectory);
+      },
       error: (_) => this.showAlert.next('cannotCreateFolder'),
     });
   }

--- a/frontend/src/app/spot/styles/sass/components/breadcrumbs.sass
+++ b/frontend/src/app/spot/styles/sass/components/breadcrumbs.sass
@@ -16,6 +16,7 @@
 
       &:not(.spot-breadcrumbs--crumb-divider)
         color: var(--accent-color)
+        margin-right: $spot-spacing-0_25
 
     &_collapsed:before
       content: '...'

--- a/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/project-storage-form.controller.ts
@@ -98,6 +98,7 @@ export default class ProjectStorageFormController extends Controller {
   selectProjectFolder(_evt:Event):void {
     const locals = {
       projectFolderHref: this.projectFolderHref,
+      createFolderHref: `${this.storage._links.self.href}/folders`,
       storage: this.storage,
     };
 


### PR DESCRIPTION
# Ticket
[OP#62047](https://community.openproject.org/wp/62047)

# What are you trying to accomplish?
- create folder should work
- created folder is shown when navigating breadcrumbs

# What approach did you choose and why?
- enable create folder from location picker shown in project storage mode selection
- also fix location picker state, when a folder was created, so that new folder shows, if user navigates breadcrumbs after creation
