### PR TITLE
[61983] New icons look weird in card view - icon misalignment in firefox

### DIFF
--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -124,10 +124,9 @@ display-field
         margin-right: 0
 
   &.combinedDate, &.date
-    span:first-of-type
-      display: inline-flex
-      align-items: center
     .display-field--scheduling-icon
+      position: relative
+      top: 1px
       margin-right: 0.25rem
 
 .wp-table--cell-container
@@ -143,12 +142,11 @@ display-field
   display: none
 
 .op-wp-single-card--content-dates
-  span:first-of-type
-    display: inline-flex
-    align-items: center
-    gap: 0.25rem
   .display-field--scheduling-icon
     fill: var(--fgColor-muted)
+    position: relative
+    top: 1px
+    margin-right: 0.25rem
 
 .wp-table--cell-container
   &.duration,

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -126,6 +126,8 @@ display-field
   &.combinedDate, &.date
     span
       vertical-align: middle
+      @supports (-moz-appearance: none)
+        vertical-align: unset
     .display-field--scheduling-icon
       margin-right: 0.25rem
 

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -143,11 +143,12 @@ display-field
   display: none
 
 .op-wp-single-card--content-dates
-  span
-    vertical-align: middle
+  span:first-of-type
+    display: inline-flex
+    align-items: center
+    gap: 0.25rem
   .display-field--scheduling-icon
     fill: var(--fgColor-muted)
-    margin-right: 0.25rem
 
 .wp-table--cell-container
   &.duration,

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -124,10 +124,9 @@ display-field
         margin-right: 0
 
   &.combinedDate, &.date
-    span
-      vertical-align: middle
-      @supports (-moz-appearance: none)
-        vertical-align: unset
+    span:first-of-type
+      display: inline-flex
+      align-items: center
     .display-field--scheduling-icon
       margin-right: 0.25rem
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61983

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Removing vertical-align: middle css for parent of icon in firefox. Firefox handles vertical-align differently from Chrome, especially when applied to inline elements like <span>.

## Screenshots
Before:
![Screenshot 2025-03-13 at 15 21 41](https://github.com/user-attachments/assets/6e9408e9-6a37-4655-a9e9-668cbb7d79d8)

After:
![Screenshot 2025-03-13 at 14 05 21](https://github.com/user-attachments/assets/4d31f35c-c9e7-4dcc-9673-99effac47486)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
