### PR TITLE
Do not call create service when access token is missing

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -40,16 +40,20 @@ module OpenProject::OpenIDConnect
 
         user = context.fetch(:user)
 
-        # We clear previous tokens while adding this one to avoid keeping
-        # stale tokens around (and to avoid piling up duplicate IDP tokens)
-        # -> Fresh login causes fresh set of tokens
-        OpenIDConnect::UserTokens::CreateService.new(user).call(
-          access_token: session["omniauth.oidc_access_token"],
-          refresh_token: session["omniauth.oidc_refresh_token"],
-          expires_in: session["omniauth.oidc_expires_in"],
-          known_audiences: [OpenIDConnect::UserToken::IDP_AUDIENCE],
-          clear_previous: true
-        )
+        access_token = session["omniauth.oidc_access_token"]
+
+        if access_token
+          OpenIDConnect::UserTokens::CreateService.new(user).call(
+            access_token:,
+            refresh_token: session["omniauth.oidc_refresh_token"],
+            expires_in: session["omniauth.oidc_expires_in"],
+            known_audiences: [OpenIDConnect::UserToken::IDP_AUDIENCE],
+            # We clear previous tokens while adding this one to avoid keeping
+            # stale tokens around (and to avoid piling up duplicate IDP tokens)
+            # -> Fresh login causes fresh set of tokens
+            clear_previous: true
+          )
+        end
       end
 
       ##


### PR DESCRIPTION
Other parameters stored in the session are kind of optional, but without the access token we can't create a user token.

The most popular case for a missing access token should be that the login happened through a non-OIDC provider.

# Ticket
https://community.openproject.org/wp/62086

# Notes

This is a fix for a failed test. The previous PR for this work package did only prevent storing information in the session, but did not stop actual calls to the create service.