### PR TITLE
[#60720] Download button for backup does not work

### DIFF
--- a/frontend/src/app/core/setup/globals/components/admin/backup.component.html
+++ b/frontend/src/app/core/setup/globals/components/admin/backup.component.html
@@ -1,4 +1,4 @@
-<form class="form -bordered -compressed" method="get" [action]="getDownloadUrl()" [hidden]="!isDownloadReady()">
+<form class="form -bordered -compressed" method="get" [action]="getDownloadUrl()" [hidden]="!isDownloadReady()" data-turbo="false">
   <section class="form--section">
     <h3 class="form--section-title">
       {{ text.lastBackup }}


### PR DESCRIPTION
https://community.openproject.org/work_packages/60720

Fixes the download button for backups by disabling turbo on the form since this is not meant to navigate but only trigger a download.