### PR TITLE
[#61967] Provide all the versions the user has access to on the Project and Global Work package list pages

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -137,12 +137,12 @@ class CustomField < ApplicationRecord
     is_required?
   end
 
-  def possible_values_options(obj = nil, options = {})
+  def possible_values_options(obj = nil, options: {})
     case field_format
     when "user"
       possible_user_values_options(obj)
     when "version"
-      possible_version_values_options(obj, options)
+      possible_version_values_options(obj, options:)
     when "list"
       possible_list_values_options
     else
@@ -318,13 +318,13 @@ class CustomField < ApplicationRecord
 
   private
 
-  def possible_versions(obj, options = {})
+  def possible_versions(obj, options: {})
     project = deduce_project(obj)
-    deduce_versions(project, options)
+    deduce_versions(project, options:)
   end
 
-  def possible_version_values_options(obj, options)
-    possible_versions(obj, options).references(:project)
+  def possible_version_values_options(obj, options: {})
+    possible_versions(obj, options:).references(:project)
                           .sort
                           .map { |u| [u.name, u.id.to_s, u.project.name] }
   end
@@ -369,7 +369,7 @@ class CustomField < ApplicationRecord
     end
   end
 
-  def deduce_versions(project, options = {})
+  def deduce_versions(project, options: {})
     if project&.persisted?
       project.shared_versions
     elsif options[:scope] == :visible

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -137,12 +137,12 @@ class CustomField < ApplicationRecord
     is_required?
   end
 
-  def possible_values_options(obj = nil)
+  def possible_values_options(obj = nil, options = {})
     case field_format
     when "user"
       possible_user_values_options(obj)
     when "version"
-      possible_version_values_options(obj)
+      possible_version_values_options(obj, options)
     when "list"
       possible_list_values_options
     else
@@ -318,13 +318,13 @@ class CustomField < ApplicationRecord
 
   private
 
-  def possible_versions(obj)
+  def possible_versions(obj, options = {})
     project = deduce_project(obj)
-    deduce_versions(project)
+    deduce_versions(project, options)
   end
 
-  def possible_version_values_options(obj)
-    possible_versions(obj).references(:project)
+  def possible_version_values_options(obj, options)
+    possible_versions(obj, options).references(:project)
                           .sort
                           .map { |u| [u.name, u.id.to_s, u.project.name] }
   end
@@ -369,9 +369,11 @@ class CustomField < ApplicationRecord
     end
   end
 
-  def deduce_versions(project)
+  def deduce_versions(project, options = {})
     if project&.persisted?
       project.shared_versions
+    elsif options[:scope] == :visible
+      Version.visible.or(Version.systemwide)
     else
       Version.systemwide
     end

--- a/app/models/queries/filters/shared/custom_fields/list_optional.rb
+++ b/app/models/queries/filters/shared/custom_fields/list_optional.rb
@@ -31,8 +31,10 @@ require_relative "base"
 module Queries::Filters::Shared
   module CustomFields
     class ListOptional < Base
+      delegate :field_format, to: :custom_field, allow_nil: true
+
       def value_objects
-        case custom_field.field_format
+        case field_format
         when "version"
           ::Version.where(id: values)
         when "list"
@@ -43,7 +45,8 @@ module Queries::Filters::Shared
       end
 
       def allowed_values
-        custom_field.possible_values_options(project, { scope: :visible })
+        options = field_format == "version" ? { scope: :visible } : {}
+        custom_field.possible_values_options(project, options:)
       end
 
       def ar_object_filter?

--- a/app/models/queries/filters/shared/custom_fields/list_optional.rb
+++ b/app/models/queries/filters/shared/custom_fields/list_optional.rb
@@ -42,6 +42,10 @@ module Queries::Filters::Shared
         end
       end
 
+      def allowed_values
+        custom_field.possible_values_options(project, { scope: :visible })
+      end
+
       def ar_object_filter?
         true
       end

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -62,7 +62,7 @@ class Queries::WorkPackages::Filter::VersionFilter <
     if project
       project.shared_versions
     else
-      Version.visible.systemwide
+      Version.visible.or(Version.systemwide)
     end
   end
 end

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -40,8 +40,6 @@ module API
             query_params = "sortBy=#{to_query [%i(semver_name asc)]}&pageSize=-1"
 
             if filter.project.nil?
-              filter_params = [{ sharing: { operator: "=", values: ["system"] } }]
-
               "#{api_v3_paths.versions}?#{query_params}"
             else
               "#{api_v3_paths.versions_by_project(filter.project.id)}?#{query_params}"

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -42,7 +42,7 @@ module API
             if filter.project.nil?
               filter_params = [{ sharing: { operator: "=", values: ["system"] } }]
 
-              "#{api_v3_paths.versions}?filters=#{to_query filter_params}&#{query_params}"
+              "#{api_v3_paths.versions}?#{query_params}"
             else
               "#{api_v3_paths.versions_by_project(filter.project.id)}?#{query_params}"
             end

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe "filter work packages", :js do
   end
 
   context "by version in project" do
+    shared_let(:other_project) { create(:project) }
+    shared_let(:inaccessible_version) { create(:version, project: other_project) }
+    shared_let(:shared_version) { create(:version, project: other_project, sharing: "system") }
+
     let(:version) { create(:version, project:) }
     let(:work_package_with_version) do
       create(:work_package, project:, subject: "With version", version:)
@@ -94,6 +98,19 @@ RSpec.describe "filter work packages", :js do
         page.find_by_id("values-version"),
         version,
         grouping: project.name,
+        results_selector: "body"
+      )
+
+      expect_ng_option(
+        page.find_by_id("values-version"),
+        shared_version,
+        grouping: other_project.name,
+        results_selector: "body"
+      )
+
+      expect_no_ng_option(
+        page.find_by_id("values-version"),
+        inaccessible_version,
         results_selector: "body"
       )
 

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -83,11 +83,8 @@ RSpec.describe API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
 
         context "global" do
           let(:project) { nil }
-          let(:filter_params) do
-            [{ sharing: { operator: "=", values: ["system"] } }]
-          end
           let(:href) do
-            "#{api_v3_paths.versions}?filters=#{CGI.escape(JSON.dump(filter_params))}&#{order}"
+            "#{api_v3_paths.versions}?#{order}"
           end
 
           context "for operator 'Queries::Operators::Equals'" do

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -327,13 +327,27 @@ RSpec.describe CustomField do
       end
 
       context "with nothing provided" do
-        it "returns the systemwide versions" do
-          allow(Version)
-            .to receive(:systemwide)
-            .and_return(shared_versions_scope)
+        context "and no scope provided" do
+          it "returns the systemwide versions" do
+            allow(Version)
+              .to receive(:systemwide)
+              .and_return(shared_versions_scope)
 
-          expect(field.possible_values_options)
-            .to eql(versions.sort.map { |u| [u.name, u.id.to_s, project.name] })
+            expect(field.possible_values_options)
+              .to eql(versions.sort.map { |u| [u.name, u.id.to_s, project.name] })
+          end
+        end
+
+        context "and scope: :visible is provided" do
+          it "returns the visible and systemwide versions" do
+            allow(Version).to receive(:visible).and_return(shared_versions_scope)
+            allow(shared_versions_scope).to receive(:or)
+                                        .with(Version.systemwide)
+                                        .and_return(shared_versions_scope)
+
+            expect(field.possible_values_options(options: { scope: :visible }))
+              .to eql(versions.sort.map { |u| [u.name, u.id.to_s, project.name] })
+          end
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
         bogus_return_value = ["user1", "user2"]
         allow(user_wp_custom_field)
           .to receive(:possible_values_options)
-          .with(project, { scope: :visible })
+          .with(project, options: {})
           .and_return(bogus_return_value)
 
         instance.context = project
@@ -294,7 +294,7 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
         bogus_return_value = ["version1", "version2"]
         allow(version_wp_custom_field)
           .to receive(:possible_values_options)
-          .with(project, { scope: :visible })
+          .with(project, options: { scope: :visible })
           .and_return(bogus_return_value)
 
         instance.context = project

--- a/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
         bogus_return_value = ["user1", "user2"]
         allow(user_wp_custom_field)
           .to receive(:possible_values_options)
-          .with(project)
+          .with(project, { scope: :visible })
           .and_return(bogus_return_value)
 
         instance.context = project
@@ -294,7 +294,7 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
         bogus_return_value = ["version1", "version2"]
         allow(version_wp_custom_field)
           .to receive(:possible_values_options)
-          .with(project)
+          .with(project, { scope: :visible })
           .and_return(bogus_return_value)
 
         instance.context = project


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61967

# What are you trying to accomplish?

Provide all the versions the user has access to:
- [x] On the Project list Version Custom field filter
- [x] On the Global WorkPackage list Version Custom field filter
- [x] On the Global WorkPackage list Version filter

# What approach did you choose and why?

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
