### PR TITLE
Destroy old base components on turbo:load

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -394,6 +394,14 @@ export class OpenProjectModule implements DoBootstrap {
 
     // Connect ui router to turbo drive
     document.addEventListener('turbo:load', () => {
+      // Remove all previous references to components
+      // This is mainly the bsae component
+      appRef.components.slice().forEach((component) => {
+        appRef.detachView(component.hostView);
+        component.destroy();
+      });
+
+      // Run bootstrap again to initialize the new application
       this.runBootstrap(appRef);
     });
 

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.component.ts
@@ -92,7 +92,6 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
     const requiresConfirmation = ConfigurationService.warnOnLeavingUnsaved();
 
     this.unregisterListener = $transitions.onBefore({}, (transition:Transition) => {
-      this.removeIdleComponents();
       if (!this.editing) {
         return undefined;
       }
@@ -123,16 +122,6 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
   ngOnDestroy() {
     this.unregisterListener();
     this.globalEditFormChangesTrackerService.removeFromActiveForms(this);
-  }
-
-  // Hacky fix: remove inactive rendered components which aren't in DOM any more
-  removeIdleComponents() {
-    this.appRef.components.forEach((component) => {
-      const element = ((component.hostView as unknown) as { rootNodes:unknown[] }).rootNodes[0] as HTMLElement;
-      if (!document.body.contains(element)) {
-        this.appRef.detachView(component.hostView);
-      }
-    });
   }
 
   public async activateField(form:EditForm, schema:IFieldSchema, fieldName:string, errors:string[]):Promise<EditFieldHandler> {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/61428/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Ensure we don't keep old components around when navigating with turbo drive

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Destroy all components in the current appRef on a turbo drive request, before we initialize the base component again

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
