### PR TITLE
Fix display in form component when WorkPackage relation is ‘from’

### DIFF
--- a/app/components/work_package_relations_tab/work_package_relation_form_component.rb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.rb
@@ -57,7 +57,7 @@ class WorkPackageRelationsTab::WorkPackageRelationFormComponent < ApplicationCom
   def displayable_field_value
     return nil if related_work_package.nil?
 
-    if relation_to_matches_wp?
+    if related_work_package
       "#{related_work_package.type.name.upcase} ##{related_work_package.id} - #{related_work_package.subject}"
     end
   end


### PR DESCRIPTION
Fix display in form component when WorkPackage relation is ‘from’ -- (now displays only 'to' related work packages)

app/components/work_package_relations_tab/work_package_relation_form_component.rb

<img width="671" alt="Снимок экрана 2025-03-14 в 10 14 31" src="https://github.com/user-attachments/assets/5eab8151-82a6-4ed1-a551-7322e20f0c32" />
