### PR TITLE
[61965] Switch parent to automatic mode when adding first child

### DIFF
--- a/app/models/relations/scopes/used_for_scheduling_of.rb
+++ b/app/models/relations/scopes/used_for_scheduling_of.rb
@@ -33,12 +33,15 @@ module Relations::Scopes
     extend ActiveSupport::Concern
 
     class_methods do
-      # Returns all successor/predecessor relationships in which the work
-      # package or its automatically scheduled ancestors are a successor of. The
-      # automatically scheduled ancestors are the ancestors that are linked to
-      # the work package only through automatically scheduled parents. As soon
-      # as a parent is manually scheduled, its predecessors and ancestors are
-      # not involved in scheduling anymore.
+      # Returns all relations where:
+      # - either the work package is a successor (all direct predecessors)
+      # - or an automatically scheduled ancestor of the work package is a
+      #   successor (all indirect predecessors)
+      #
+      # The automatically scheduled ancestors are the ancestors that are linked
+      # to the work package only through automatically scheduled parents. As
+      # soon as a parent is manually scheduled, its predecessors and ancestors
+      # are not involved in scheduling anymore.
       def used_for_scheduling_of(work_package)
         automatically_scheduled_ancestors =
           WorkPackageHierarchy.where(descendant_id: work_package.id)

--- a/app/services/base_services/base_callable.rb
+++ b/app/services/base_services/base_callable.rb
@@ -33,11 +33,11 @@ module BaseServices
 
     include ::WithReversibleState
 
-    def call(params = {})
-      self.params = params.to_h.deep_symbolize_keys
+    def call(*args)
+      self.params = extract_options!(args).deep_symbolize_keys
 
       run_callbacks(:call) do
-        perform(**self.params)
+        perform(*args, **params)
       end
     end
 
@@ -47,6 +47,18 @@ module BaseServices
 
     def perform(*)
       raise NotImplementedError
+    end
+
+    private
+
+    def extract_options!(args)
+      if args.last.is_a?(Hash)
+        args.pop
+      elsif args.last.respond_to?(:permitted?) && args.last.respond_to?(:to_h)
+        args.pop.to_h
+      else
+        {}
+      end
     end
   end
 end

--- a/app/services/concerns/with_reversible_state.rb
+++ b/app/services/concerns/with_reversible_state.rb
@@ -50,9 +50,8 @@ module WithReversibleState
     ##
     # Assign state to the service result
     def assign_state
-      yield.tap do |call|
-        state.called!(self)
-        call.state = state
+      yield.tap do |service_result|
+        service_result.state = state
       end
     end
   end

--- a/app/services/shared/service_state.rb
+++ b/app/services/shared/service_state.rb
@@ -40,16 +40,5 @@ module Shared
     def self.build(state = {})
       self === state ? state : new(state)
     end
-
-    ##
-    # Remember that the state was passed to the given service
-    def called!(service)
-      service_chain << service
-    end
-
-    # Remembered service calls this context was used against
-    def service_chain
-      @service_chain ||= []
-    end
   end
 end

--- a/app/services/work_packages/bulk/copy_service.rb
+++ b/app/services/work_packages/bulk/copy_service.rb
@@ -111,6 +111,7 @@ module WorkPackages
           WorkPackages::CopyService
             .new(user:,
                  work_package:)
+            .with_state(bulk_copy_in_progress: true)
             .call(**overridden_attributes.symbolize_keys)
         end
       end

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class WorkPackages::CopyService
+class WorkPackages::CopyService < BaseServices::BaseCallable
   include ::Shared::ServiceContext
   include Contracted
   include ::Copy::Concerns::CopyAttachments
@@ -36,12 +36,13 @@ class WorkPackages::CopyService
                 :contract_class
 
   def initialize(user:, work_package:, contract_class: WorkPackages::CopyContract)
+    super()
     self.user = user
     self.work_package = work_package
     self.contract_class = contract_class
   end
 
-  def call(send_notifications: nil, copy_attachments: true, copy_share_members: true, **attributes)
+  def perform(send_notifications: nil, copy_attachments: true, copy_share_members: true, **attributes)
     in_context(work_package, send_notifications:) do
       copy(attributes, copy_attachments, copy_share_members, send_notifications)
     end
@@ -69,6 +70,7 @@ class WorkPackages::CopyService
     WorkPackages::CreateService
       .new(user:,
            contract_class:)
+      .with_state(state)
       .call(**copied_attributes(work_package, attribute_overrides).merge(send_notifications:).symbolize_keys)
   end
 

--- a/app/services/work_packages/shared/update_ancestors.rb
+++ b/app/services/work_packages/shared/update_ancestors.rb
@@ -65,6 +65,7 @@ module WorkPackages
         WorkPackages::UpdateAncestorsService
           .new(user:,
                work_package: wp)
+          .with_state(state)
           .call(changes)
       end
     end

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -101,6 +101,7 @@ class WorkPackages::UpdateAncestorsService
       #
       %i[estimated_hours remaining_hours status status_id] => :derive_total_estimated_and_remaining_hours,
       %i[estimated_hours remaining_hours done_ratio status status_id] => :derive_done_ratio,
+      %i[] => :switch_to_automatic_mode,
       %i[ignore_non_working_days] => :derive_ignore_non_working_days
     }.each do |derivative_attributes, method|
       if attributes.intersect?(derivative_attributes + %i[parent parent_id])
@@ -157,6 +158,30 @@ class WorkPackages::UpdateAncestorsService
       .children_of(work_package)
       .filter(&:included_in_totals_calculation?)
       .map { |child| child.derived_done_ratio || child.done_ratio || 0 }
+  end
+
+  # Switches the direct parent of the initiator to automatic scheduling mode if
+  # it is manually scheduled and has no direct or indirect predecessors and no
+  # other children.
+  #
+  # This method is called only when parent or parent_id attribute of the
+  # initiator work package has been changed
+  def switch_to_automatic_mode(work_package, loader)
+    # it only applies to the initiator's direct parent
+    return if initiator_work_package.parent_id.nil?
+    return if initiator_work_package.parent_id != work_package.id
+
+    # it only applies if the parent is manually scheduled
+    return if work_package.schedule_automatically?
+
+    # it only applies if the parent has no other children
+    return if loader.children_of(work_package).count != 1
+
+    # it only applies if the parent has no direct or indirect predecessors
+    return if Relation.used_for_scheduling_of(work_package).any?
+
+    # it can switch to automatic scheduling mode
+    work_package.schedule_manually = false
   end
 
   # Sets the ignore_non_working_days to true if any descendant has its value set to true.

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -68,13 +68,11 @@ RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
       ##
       # Add child #1
       relations.add_existing_child(child)
-      expect_and_dismiss_flash(message: "Successful update.")
       relations.expect_child(child)
 
       ##
       # Add child #2
       relations.add_existing_child(child2)
-      expect_and_dismiss_flash(message: "Successful update.")
       relations.expect_child(child2)
 
       # Count child relations in split view
@@ -161,7 +159,6 @@ RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
           ##
           # Add child
           relations.add_existing_child(child)
-          expect_and_dismiss_flash(message: "Successful update.")
           relations.expect_child(child)
 
           # Expect counter to add up child to the existing relations

--- a/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
+++ b/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
   # assume sat+sun are non working days
   shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }
 
+  before_all do
+    set_factory_default(:project_with_types, project)
+    set_factory_default(:user, user)
+  end
+
   let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
 
@@ -54,6 +59,8 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
   let(:current_user) { user }
   let(:work_package) { bug_wp }
 
+  let(:current_attributes) { {} }
+
   def apply_and_expect_saved(attributes)
     date_field.save!
 
@@ -62,14 +69,15 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
     work_package.reload
 
     attributes.each do |attr, value|
-      expect(work_package.send(attr)).to eq value
+      expect(work_package.send(attr))
+        .to eq(value), "After saving, expected #{attr} to be #{value.inspect} but got #{work_package.send(attr).inspect}"
     end
   end
 
   before do
     Setting.available_languages << current_user.language
     I18n.locale = current_user.language
-    work_package.update_columns(current_attributes)
+    work_package.update_columns(current_attributes) if current_attributes.any?
     login_as(current_user)
 
     work_packages_page.visit!
@@ -132,52 +140,236 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
 
   describe "Scenario 27a: Manual to automatic with multiple predecessors (no lag)" do
     context "when switching a work package with predecessors to automatic scheduling mode" do
-      it "changes the work package dates to start right after its closest predecessor", skip: "to be implemented later"
+      let_work_packages(<<~TABLE)
+        hierarchy         | start date | due date   | scheduling mode | predecessors
+        predecessor A     |            | 2024-12-30 | manual          |
+        predecessor B     |            | 2025-01-02 | manual          |
+        work package      | 2025-01-08 | 2025-01-10 | manual          | predecessor A, predecessor B
+      TABLE
+
+      it "changes the work package dates to start right after its closest predecessor" do
+        open_date_picker
+        datepicker.expect_manual_scheduling_mode
+
+        datepicker.toggle_scheduling_mode
+        datepicker.expect_automatic_scheduling_mode
+
+        datepicker.expect_start_date "2025-01-03", disabled: true
+        datepicker.expect_due_date "2025-01-07", disabled: true
+        datepicker.expect_duration "3", disabled: false
+
+        apply_and_expect_saved(
+          start_date: Date.parse("2025-01-03"),
+          due_date: Date.parse("2025-01-07"),
+          duration: 3,
+          schedule_manually: false
+        )
+      end
     end
   end
 
   describe "Scenario 27b: Manual to automatic with multiple predecessors (with lag)" do
     context "when switching a work package with predecessors with lag to automatic scheduling mode" do
-      it "changes the work package dates to start right after its closest predecessor", skip: "to be implemented later"
+      let_work_packages(<<~TABLE)
+        hierarchy         | start date | due date   | scheduling mode | predecessors
+        predecessor A     |            | 2024-12-30 | manual          |
+        predecessor B     |            | 2025-01-02 | manual          |
+        work package      | 2025-01-08 | 2025-01-10 | manual          | predecessor A with lag 14, predecessor B
+      TABLE
+
+      it "changes the work package dates to start right after its closest predecessor" do
+        open_date_picker
+        datepicker.expect_manual_scheduling_mode
+
+        datepicker.toggle_scheduling_mode
+        datepicker.expect_automatic_scheduling_mode
+
+        datepicker.expect_start_date "2025-01-20", disabled: true
+        datepicker.expect_due_date "2025-01-22", disabled: true
+        datepicker.expect_duration "3", disabled: false
+
+        apply_and_expect_saved(
+          start_date: Date.parse("2025-01-20"),
+          due_date: Date.parse("2025-01-22"),
+          duration: 3,
+          schedule_manually: false
+        )
+      end
     end
   end
 
   describe "Scenario 28: Add children (parent in manual originally; children all manual, all in working days only)" do
     context "when adding first children to a work package" do
-      it "switches its scheduling mode to automatic", skip: "to be implemented later"
+      let_work_packages(<<~TABLE)
+        subject      | start date | due date   | scheduling mode | days counting
+        work package | 2025-01-08 | 2025-01-10 | manual          | working days only
+        child 1      | 2025-01-16 | 2025-01-20 | manual          | working days only
+        child 2      | 2025-01-21 | 2025-01-24 | manual          | working days only
+      TABLE
+
+      it "switches its scheduling mode to automatic" do
+        # add children
+        work_packages_page.visit_tab!("relations")
+        work_packages_page.relations_tab.add_existing_child(child1)
+        work_packages_page.relations_tab.add_existing_child(child2)
+
+        # expect automatic with dates from children and working days only checked
+        open_date_picker
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-01-16", disabled: true
+        datepicker.expect_due_date "2025-01-24", disabled: true
+        datepicker.expect_duration "7", disabled: true
+        datepicker.expect_working_days_only_disabled
+        datepicker.expect_working_days_only true
+        datepicker.expect_banner_text I18n.t("work_packages.datepicker_modal.banner.title.automatic_with_children")
+      end
     end
   end
 
   describe "Scenario 29: Add children (parent in manual originally; children all manual, mixed working days)" do
     context "when adding first children to a work package, one having working days only unchecked" do
-      it "switches its scheduling mode to automatic with working days only unchecked", skip: "to be implemented later"
+      let_work_packages(<<~TABLE)
+        subject      | start date | due date   | scheduling mode | days counting
+        work package | 2025-01-15 | 2025-01-17 | manual          | working days only
+        child 1      | 2025-01-16 | 2025-01-20 | manual          | working days only
+        child 2      | 2025-01-21 | 2025-01-26 | manual          | all days
+      TABLE
+
+      it "switches its scheduling mode to automatic with working days only unchecked" do
+        # add children
+        work_packages_page.visit_tab!("relations")
+        work_packages_page.relations_tab.add_existing_child(child1)
+        work_packages_page.relations_tab.add_existing_child(child2)
+
+        # expect automatic with dates from children and working days only unchecked
+        open_date_picker
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-01-16", disabled: true
+        datepicker.expect_due_date "2025-01-26", disabled: true
+        datepicker.expect_duration "11", disabled: true
+        datepicker.expect_working_days_only_disabled
+        datepicker.expect_working_days_only false
+        datepicker.expect_banner_text I18n.t("work_packages.datepicker_modal.banner.title.automatic_with_children")
+      end
     end
   end
 
   describe "Scenario 30: Add children to a successor (start date derived children instead of predecessor)" do
     context "when adding manually scheduled children to an automatically scheduled work package being a successor" do
-      it "updates its duration and dates based on the children dates, not based on its predecessors dates",
-         skip: "to be implemented later"
+      let_work_packages(<<~TABLE)
+        subject      | start date | due date   | scheduling mode | days counting     | predecessors
+        predecessor  | 2025-01-10 | 2025-01-14 | manual          | working days only |
+        work package | 2025-01-15 | 2025-01-17 | automatic       | working days only | predecessor
+        child 1      | 2025-01-16 | 2025-01-20 | manual          | working days only |
+        child 2      | 2025-01-21 | 2025-01-26 | manual          | all days          |
+      TABLE
+
+      it "updates its duration and dates based on the children dates, not based on its predecessors dates" do
+        # add children
+        work_packages_page.visit_tab!("relations")
+        work_packages_page.relations_tab.add_existing_child(child1)
+        work_packages_page.relations_tab.add_existing_child(child2)
+
+        # expect automatic with dates from children and working days only checked
+        open_date_picker
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-01-16", disabled: true
+        datepicker.expect_due_date "2025-01-26", disabled: true
+        datepicker.expect_duration "11", disabled: true
+        datepicker.expect_working_days_only_disabled
+        datepicker.expect_working_days_only false
+        datepicker.expect_banner_text I18n.t("work_packages.datepicker_modal.banner.title.automatic_with_children")
+      end
     end
   end
 
-  describe "Scenario 30a: Automatically-scheduled successor with children loses all its children (Child 1 removed first)" do
-    context "when removing all children from an automatically scheduled work package being a successor" do
-      it "ends up with duration and 'working days only' attributes based on last removed child (child 1) " \
-         "and start date based on the predecessor", skip: "to be implemented later"
-    end
-  end
+  describe "Scenario 30a/30b: Automatically-scheduled successor with children loses all its children" do
+    shared_let_work_packages(<<~TABLE)
+      hierarchy    | start date | due date   | scheduling mode | days counting     | predecessors
+      predecessor  | 2025-01-10 | 2025-01-14 | manual          | working days only |
+      work package | 2025-01-16 | 2025-01-28 | automatic       | all days          | predecessor
+        child 1    | 2025-01-16 | 2025-01-20 | manual          | all days          |
+        child 2    | 2025-01-21 | 2025-01-28 | manual          | working days only |
+    TABLE
 
-  describe "Scenario 30b: Automatically-scheduled successor with children loses all its children (Child 2 removed first)" do
-    context "when removing all children from an automatically scheduled work package being a successor" do
-      it "ends up with duration 'working days only' attributes based on last removed child (child 2) " \
-         "and start date based on the predecessor", skip: "to be implemented later"
+    context "when removing all children (child 1 then child 2) from an automatically scheduled work package being a successor" do
+      it "ends up with duration and 'working days only' attributes based on last removed child (child 2) " \
+         "and start date based on the predecessor" do
+        work_packages_page.visit_tab!("relations")
+        # remove child 1, and then child 2
+        work_packages_page.relations_tab.remove_child(child1)
+        work_packages_page.relations_tab.remove_child(child2)
+
+        open_date_picker
+
+        # parent gets properties from last removed child: child 2
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-01-15", disabled: true
+        datepicker.expect_due_date "2025-01-22", disabled: true
+        datepicker.expect_duration "6"
+        datepicker.expect_working_days_only_enabled
+        datepicker.expect_working_days_only true
+        datepicker.expect_banner_text I18n.t("work_packages.datepicker_modal.banner.title.automatic_with_predecessor")
+      end
+    end
+
+    context "when removing all children (child 2 then child 1) from an automatically scheduled work package being a successor" do
+      it "ends up with duration 'working days only' attributes based on last removed child (child 1) " \
+         "and start date based on the predecessor" do
+        work_packages_page.visit_tab!("relations")
+        # remove child 2, and then child 1
+        work_packages_page.relations_tab.remove_child(child2)
+        work_packages_page.relations_tab.remove_child(child1)
+
+        open_date_picker
+
+        # parent gets properties from last removed child: child 1
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-01-15", disabled: true
+        datepicker.expect_due_date "2025-01-19", disabled: true
+        datepicker.expect_duration "5"
+        datepicker.expect_working_days_only_enabled
+        datepicker.expect_working_days_only false
+        datepicker.expect_banner_text I18n.t("work_packages.datepicker_modal.banner.title.automatic_with_predecessor")
+      end
     end
   end
 
   describe "Scenario 32: Switch parent with predecessor and children to manual" do
     context "when switching a work package with predecessors and children to manual scheduling mode" do
-      it "keeps its dates", skip: "to be implemented later"
+      shared_let_work_packages(<<~TABLE)
+        hierarchy    | start date | due date   | scheduling mode | days counting     | predecessors
+        predecessor  | 2025-01-24 | 2025-01-26 | manual          | working days only |
+        work package | 2025-01-27 | 2025-02-06 | automatic       | all days          | predecessor
+          child 1    | 2025-01-27 | 2025-01-29 | automatic       | all days          |
+          child 2    | 2025-01-30 | 2025-02-06 | automatic       | working days only | child 1
+      TABLE
+
+      it "keeps its dates and properties, and also switches the first child to manual scheduling mode" do
+        open_date_picker
+        datepicker.expect_automatic_scheduling_mode
+
+        datepicker.toggle_scheduling_mode
+        datepicker.expect_manual_scheduling_mode
+
+        datepicker.expect_start_date "2025-01-27"
+        datepicker.expect_due_date "2025-02-06"
+        datepicker.expect_duration "11"
+        datepicker.expect_working_days_only_enabled
+        datepicker.expect_working_days_only false
+
+        apply_and_expect_saved(
+          start_date: Date.parse("2025-01-27"),
+          due_date: Date.parse("2025-02-06"),
+          duration: 11,
+          schedule_manually: true
+        )
+        expect(child1.reload.schedule_manually).to be(true)
+        expect(child2.reload.schedule_manually).to be(false)
+      end
     end
   end
 end

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -88,9 +88,11 @@ module Components
     end
 
     def enable_start_date
-      page.find_test_selector("wp-datepicker--show-start-date").click
-      wait_for_network_idle
-      expect_start_highlighted
+      retry_block do
+        page.find_test_selector("wp-datepicker--show-start-date").click
+        wait_for_network_idle
+        expect_start_highlighted
+      end
     end
 
     def enable_start_date_if_visible
@@ -100,9 +102,11 @@ module Components
     end
 
     def enable_due_date
-      page.find_test_selector("wp-datepicker--show-due-date").click
-      wait_for_network_idle
-      expect_due_highlighted
+      retry_block do
+        page.find_test_selector("wp-datepicker--show-due-date").click
+        wait_for_network_idle
+        expect_due_highlighted
+      end
     end
 
     def enable_due_date_if_visible

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -12,6 +12,10 @@ module Components
       set_field(duration_field, "", wait_for_changes_to_be_applied: false)
     end
 
+    def expect_banner_text(text, **)
+      expect(container).to have_css(".wp-datepicker--banner", text:, **)
+    end
+
     ##
     # Expect the selected month
     def expect_month(month)
@@ -21,12 +25,12 @@ module Components
 
     ##
     # Expect duration
-    def expect_duration(value)
+    def expect_duration(value, **)
       if value.blank?
         value = ""
       end
 
-      expect(container).to have_field("work_package[duration]", with: value, wait: 10)
+      expect(container).to have_field("work_package[duration]", with: value, **)
     end
 
     def milestone_date_field

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -27,12 +27,14 @@
 #++
 
 require "support/components/autocompleter/ng_select_autocomplete_helpers"
+require "support/flash/expectations"
 
 module Components
   module WorkPackages
     class Relations
       include Capybara::DSL
       include Capybara::RSpecMatchers
+      include Flash::Expectations
       include RSpec::Matchers
       include RSpec::Wait
       include ::Components::Autocompleter::NgSelectAutocompleteHelpers
@@ -337,6 +339,7 @@ module Components
 
           click_link_or_button "Save"
         end
+        expect_and_dismiss_flash(message: "Successful update.")
       end
 
       def relations_group

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -53,6 +53,10 @@ module Pages
       visit path(tab)
     end
 
+    def relations_tab
+      Components::WorkPackages::Relations.new(work_package)
+    end
+
     def switch_to_tab(tab:)
       find(".op-tab-row--link", text: tab.upcase).click
     end


### PR DESCRIPTION


# Ticket

bug https://community.openproject.org/wp/61965
test scenarios https://community.openproject.org/wp/61054

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

If a manually scheduled work package has no direct or indirect predecessors and no children, it switches to automatic scheduling mode when a child is added.

This fixes the scenario 29 from #61054 and bug #61965. Other scenarios have been implemented too. 4 of them still need to be implemented.

## Screenshots



# What approach did you choose and why?

Handle switching in the `UpdateAncestorsService`, as that's where this kind of concerns are grouped.
I could also have added it to the `SetScheduleService`, but I felt like it would have been more complex. That would have saved some additional queries though, so maybe we'll revisit it in the future.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
