### PR TITLE
Hide SSO+fallback authentication method

### DIFF
--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -35,7 +35,9 @@ module Storages
       username: "OpenProject"
     }.freeze
 
-    AUTHENTICATION_METHODS = %w[two_way_oauth2 oauth2_sso oauth2_sso_with_two_way_oauth2_fallback].freeze
+    # oauth2_sso_with_two_way_oauth2_fallback has been temporarily removed because the openproject_integration
+    # on the nextcloud side does not support this yet (we can't configure audience AND oauth_client at the same time)
+    AUTHENTICATION_METHODS = %w[two_way_oauth2 oauth2_sso].freeze
 
     store_attribute :provider_fields, :automatically_managed, :boolean
     store_attribute :provider_fields, :username, :string


### PR DESCRIPTION
While it's useful and works as intended, we can't
configure the same on the openproject_integration in Nextcloud so far. This means, right now this option would only make sense for one-way integrations.

The plan is to support this in a future version of the integration, which is when we can reactivate the option in OpenProject as well.

# Ticket
https://community.openproject.org/wp/62192