### PR TITLE
Fix week splitting in spec helper

### DIFF
--- a/modules/meeting/spec/support/pages/meetings/index.rb
+++ b/modules/meeting/spec/support/pages/meetings/index.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -193,7 +194,7 @@ module Pages::Meetings
 
     def meeting_group_key(meeting)
       start_date = meeting.start_time.to_date
-      next_week = Time.current.next_occurring(OpenProject::Internationalization::Date.beginning_of_week)
+      next_week = Time.current.next_occurring(OpenProject::Internationalization::Date.beginning_of_week).beginning_of_day
 
       if start_date == Time.zone.today
         :today


### PR DESCRIPTION
Surprisingly next_occuring will forward the time to the next date where something occurs, but it will not change the time. So depending on when exactly a meeting is happening, the spec might have put it on the wrong "end" of the week-cutover.

This causes relatively stable CI failures today.