### PR TITLE
[61990] On Gantt view, unidentified bar appears behind the date on hover, add margin right to the icon

### DIFF
--- a/frontend/src/global_styles/content/work_packages/timelines/elements/_labels.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/elements/_labels.sass
@@ -1,13 +1,19 @@
 @mixin timeline-label
   display: flex
   align-items: center
-  height: 16px
   min-width: 20px
   width: max-content
   font-size: 14px
   white-space: nowrap
   vertical-align: middle
   pointer-events: none
+
+@mixin scheduling-icon
+  span
+    display: flex
+    align-items: center
+    .display-field--scheduling-icon
+      margin-right: 0.25rem
 
 .timeline-element
   // Label style
@@ -37,6 +43,7 @@
     transform: translateX(calc(-100% - 15px))
     // Ensure line-height is normal
     line-height: 1
+    @include scheduling-icon
 
   .containerRight
     @include timeline-label
@@ -49,6 +56,7 @@
   .labelRight.not-empty
     @include timeline-label
     margin-left: 20px
+    @include scheduling-icon
 
   .labelFarRight
     @include timeline-label
@@ -68,6 +76,7 @@
     // Then translate by its own width + some margin
     transform: translateX(calc(100% + 10px))
     font-size: 12px
+    @include scheduling-icon
 
   &.-editable
     cursor: ew-resize

--- a/frontend/src/global_styles/content/work_packages/timelines/elements/_labels.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/elements/_labels.sass
@@ -52,6 +52,7 @@
     margin: 0
     padding: 0
     left: 100%
+    line-height: 1rem
 
   .labelRight.not-empty
     @include timeline-label
@@ -74,7 +75,7 @@
     position: absolute
     right: 0px
     // Then translate by its own width + some margin
-    transform: translateX(calc(100% + 10px))
+    transform: translateX(calc(100% + 15px))
     font-size: 12px
     @include scheduling-icon
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61990

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add margin right to the scheduling icon, and align it with the text

## Screenshots
Before:
![Screenshot 2025-03-14 at 16 34 42](https://github.com/user-attachments/assets/e89373b6-7959-4096-825a-a7ef171246ec)

After:
![Screenshot 2025-03-14 at 16 11 52](https://github.com/user-attachments/assets/7e5449d5-2169-4d05-901a-7f7f6707d9d7)

