### PR TITLE
Fix timezone parsing for reminder form and tests

### DIFF
--- a/app/controllers/work_packages/reminders_controller.rb
+++ b/app/controllers/work_packages/reminders_controller.rb
@@ -184,7 +184,7 @@ class WorkPackages::RemindersController < ApplicationController
 
   def build_remind_at_from_params(remind_at_date, remind_at_time)
     if remind_at_date.present? && remind_at_time.present?
-      DateTime.parse("#{remind_at_date} #{User.current.time_zone.parse(remind_at_time)}")
+      User.current.time_zone.parse("#{remind_at_date} #{remind_at_time}")
     end
   end
 


### PR DESCRIPTION
Today + 2 weeks is past the DST cutoff for central europe timezone. So the tests uncovered that we parsed the time wrongly. This PR fixes the parsing for the timestamp and the tests.