### PR TITLE
Remove specific work package permissions for comments with restricted visibility

### DIFF
--- a/app/components/work_packages/activities_tab/journals/index_component.rb
+++ b/app/components/work_packages/activities_tab/journals/index_component.rb
@@ -71,7 +71,7 @@ module WorkPackages
           API::V3::Activities::ActivityEagerLoadingWrapper.wrap(
             work_package
               .journals
-              .restricted_visible(work_package)
+              .restricted_visible(@work_package.project)
               .includes(:user, :customizable_journals, :attachable_journals, :storable_journals, :notifications)
               .reorder(version: journal_sorting)
               .with_sequence_version

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -60,7 +60,7 @@ module WorkPackages
 
         def adding_restricted_comment_allowed?
           OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
-            User.current.allowed_in_work_package?(:add_comments_with_restricted_visibility, work_package)
+            User.current.allowed_in_project?(:add_comments_with_restricted_visibility, work_package.project)
         end
       end
     end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -113,9 +113,9 @@ class Journal < ApplicationRecord
   scope :for_wiki_page, -> { where(journable_type: "WikiPage") }
   scope :for_work_package, -> { where(journable_type: "WorkPackage") }
   scope :for_meeting, -> { where(journable_type: "Meeting") }
-  scope :restricted_visible, ->(work_package) {
+  scope :restricted_visible, ->(project) {
     if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
-        User.current.allowed_in_work_package?(:view_comments_with_restricted_visibility, work_package)
+        User.current.allowed_in_project?(:view_comments_with_restricted_visibility, project)
       all
     else
       where(restricted: false)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -382,17 +382,12 @@ class WorkPackage < ApplicationRecord
   # check if user is allowed to edit WorkPackage Journals.
   # see Acts::Journalized::Permissions#journal_editable_by
   def journal_editable_by?(journal, user)
-    can_edit_journal_note = ->(edit_others_notes_permission, edit_own_notes_permission) {
-      user.allowed_in_project?(edit_others_notes_permission, project) ||
-        (user.allowed_in_work_package?(edit_own_notes_permission, self) && journal.user_id == user.id)
-    }
-
     if journal.restricted?
-      can_edit_journal_note.call(:edit_others_comments_with_restricted_visibility,
-                                 :edit_own_comments_with_restricted_visibility)
+      user.allowed_in_project?(:edit_others_comments_with_restricted_visibility, project) ||
+        (user.allowed_in_project?(:edit_own_comments_with_restricted_visibility, project) && journal.user_id == user.id)
     else
-      can_edit_journal_note.call(:edit_work_package_notes,
-                                 :edit_own_work_package_notes)
+      user.allowed_in_project?(:edit_work_package_notes, project) ||
+        (user.allowed_in_work_package?(:edit_own_work_package_notes, self) && journal.user_id == user.id)
     end
   end
 

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -311,30 +311,30 @@ Rails.application.reloader.to_prepare do
 
       wpt.permission :view_comments_with_restricted_visibility,
                      {},
-                     permissible_on: %i[work_package project],
+                     permissible_on: %i[project],
                      require: :loggedin,
                      dependencies: :view_work_packages,
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       wpt.permission :add_comments_with_restricted_visibility,
                      {},
-                     permissible_on: %i[work_package project],
+                     permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: %i[view_work_packages view_comments_with_restricted_visibility],
+                     dependencies: %i[view_project view_comments_with_restricted_visibility],
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       wpt.permission :edit_own_comments_with_restricted_visibility,
                      {},
-                     permissible_on: %i[work_package project],
+                     permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: %i[view_work_packages view_comments_with_restricted_visibility],
+                     dependencies: %i[view_project view_comments_with_restricted_visibility],
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       wpt.permission :edit_others_comments_with_restricted_visibility,
                      {},
-                     permissible_on: %i[work_package project],
+                     permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: %i[view_work_packages view_comments_with_restricted_visibility],
+                     dependencies: %i[view_project view_comments_with_restricted_visibility],
                      visible: -> { OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? }
 
       # WP attachments can be added with :edit_work_packages, this permission allows it without Edit WP as well.

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -38,7 +38,7 @@ module API
 
             journals = @work_package
               .journals
-              .restricted_visible(work_package)
+              .restricted_visible(@work_package.project)
               .includes(:data,
                         :customizable_journals,
                         :attachable_journals,

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Journal do
              version: 2)
     end
 
-    subject { described_class.restricted_visible(work_package) }
+    subject { described_class.restricted_visible(work_package.project) }
 
     before do
       login_as user
@@ -103,7 +103,7 @@ RSpec.describe Journal do
     context "when the user can see restricted" do
       before do
         mock_permissions_for(user) do |mock|
-          mock.allow_in_work_package :view_comments_with_restricted_visibility, work_package:
+          mock.allow_in_project(:view_comments_with_restricted_visibility, project: work_package.project)
         end
       end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/60978

# What are you trying to accomplish?

Adjust comments with restricted visibility permissions to project level only, not on individual work packages.

# Merge checklist

- [x] Added/updated tests