### PR TITLE
[61979] Switch successor to automatic mode even without rescheduling

### DIFF
--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -192,8 +192,6 @@ class WorkPackages::ScheduleDependency
 
     # rehydrate the predecessors and followers of follows relations
     rehydrate_follows_relations
-
-    fix_switching_to_automatic_mode_work_packages
   end
 
   # Returns all the descendants of moved and moving work packages that are not
@@ -233,15 +231,6 @@ class WorkPackages::ScheduleDependency
     known_follows_relations.each do |relation|
       relation.from = work_package_by_id(relation.from_id)
       relation.to = work_package_by_id(relation.to_id)
-    end
-  end
-
-  def fix_switching_to_automatic_mode_work_packages
-    ids = switching_to_automatic_mode.map(&:id)
-    known_work_packages.each do |work_package|
-      if ids.include?(work_package.id)
-        work_package.schedule_manually = false
-      end
     end
   end
 end

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -84,6 +84,7 @@ class WorkPackages::SetScheduleService
     WorkPackages::ScheduleDependency.new(moved_work_packages, switching_to_automatic_mode:)
                                     .in_schedule_order do |scheduled, dependency|
       changes_before = scheduled.changes
+      apply_switching_to_automatic_scheduling(scheduled)
       reschedule(scheduled, dependency)
       changes_after = scheduled.changes
 
@@ -91,6 +92,15 @@ class WorkPackages::SetScheduleService
     end
 
     altered
+  end
+
+  # Switches the scheduling mode of a work package to automatic if it is in the
+  # switching_to_automatic_mode array.
+  def apply_switching_to_automatic_scheduling(work_package)
+    switching_to_automatic_mode_ids = switching_to_automatic_mode.pluck(:id)
+    if switching_to_automatic_mode_ids.include?(work_package.id)
+      work_package.schedule_manually = false
+    end
   end
 
   # Schedules work packages based on either

--- a/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
+++ b/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
@@ -134,7 +134,24 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
 
   describe "Scenario 26: Add a predecessor" do
     context "when adding a predecessor to a work package" do
-      it "changes the work package dates to start right after its predecessor", skip: "to be implemented later"
+      let_work_packages(<<~TABLE)
+        hierarchy          | start date | due date   | scheduling mode
+        future predecessor |            | 2025-01-02 | manual
+        work package       | 2025-01-08 | 2025-01-10 | manual
+      TABLE
+
+      it "changes the work package dates to start right after its predecessor" do
+        # add predecessor
+        work_packages_page.visit_tab!("relations")
+        work_packages_page.relations_tab.add_predecessor(future_predecessor)
+
+        # expect automatic with dates updated
+        open_date_picker
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-01-03", disabled: true
+        datepicker.expect_due_date "2025-01-07", disabled: true
+        datepicker.expect_duration "3"
+      end
     end
   end
 

--- a/spec/services/relations/scheduling_mode_switching_spec.rb
+++ b/spec/services/relations/scheduling_mode_switching_spec.rb
@@ -93,6 +93,33 @@ RSpec.describe "Scheduling mode switching", # rubocop:disable RSpec/DescribeClas
       end
     end
 
+    context "with 2 manually scheduled work packages already having the correct dates" do
+      let_work_packages(<<~TABLE)
+        | subject       | MTWTFSS | scheduling mode |
+        | pred          | XX      | manual          |
+        | succ          |   XX    | manual          |
+      TABLE
+
+      before do
+        attributes = {
+          "relation_type" => "follows",
+          "from_id" => succ.id,
+          "to_id" => pred.id
+        }
+        Relations::CreateService.new(user:).call(attributes)
+      end
+
+      it "switches successor scheduling mode to automatic without rescheduling it" do
+        expect_work_packages_after_reload([pred, succ], <<~TABLE)
+          | subject       | MTWTFSS | scheduling mode |
+          | pred          | XX      | manual          |
+          | succ          |   XX    | automatic       |
+        TABLE
+        expect(pred.journals.count).to eq(1)
+        expect(succ.journals.count).to eq(2)
+      end
+    end
+
     context "with a precedes relation with 2 manually scheduled work packages" do
       let_work_packages(<<~TABLE)
         | subject       | MTWTFSS | scheduling mode |

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -168,6 +168,10 @@ module Components
         expect(page).not_to have_test_selector("op-relation-row-#{actual_relatable.id}-delete-button")
       end
 
+      def add_predecessor(work_package)
+        add_relation(type: :follows, relatable: work_package)
+      end
+
       def add_relation(type:, relatable:, description: nil)
         i18n_namespace = "#{WorkPackageRelationsTab::IndexComponent::I18N_NAMESPACE}.relations"
         # Open create form


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61979

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Switch successor to automatic scheduling mode when adding a predecessor/successor link to a work package.
Sometimes it works, sometimes it does not. Actually it was working only when adding the predecessor would change the successor's dates. Without that condition, it would not switch (which is the bug).

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Switching to automatic mode was done in `ScheduleDependency` before. As the scheduling mode was changed outside of the `SetScheduleService`, it was not seen as a change and no dependent result was saved and eventually the scheduling mode change was not persisted.

By moving the scheduling mode change to the `SetScheduleService`, the dependent results are now correctly saved and the scheduling mode change is persisted.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
