### PR TITLE
[61780] Regression: Rich text headlines show link icon on hover before the headline, while rendering after would be correct

### DIFF
--- a/frontend/src/global_styles/content/user-content/_typography.sass
+++ b/frontend/src/global_styles/content/user-content/_typography.sass
@@ -17,9 +17,11 @@
   break-inside: avoid
   overflow-wrap: anywhere
   word-break: normal
+  display: flex
 
   &:hover .op-uc-link_permalink
     display: inline-flex
+    order: 2
 
 .op-uc-h1
   margin-bottom: 0.5rem


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61780

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Shoe icon after after headline

## Screenshots
Before:
![Screenshot 2025-03-17 at 12 19 28](https://github.com/user-attachments/assets/43e7cdc6-0acf-4132-bbcf-f734763de075)

After:
![Screenshot 2025-03-17 at 12 19 02](https://github.com/user-attachments/assets/51621e0b-444b-4dcd-8911-e78b14641b97)
