### PR TITLE
Make storage audience and authentication method available in API

### DIFF
--- a/docs/api/apiv3/components/schemas/storage_read_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_read_model.yml
@@ -17,6 +17,14 @@ properties:
   name:
     type: string
     description: Storage name
+  storageAudience:
+    type: string
+    description: |-
+      The audience that the storage expects in tokens for requests to it,
+      usually the storage's client ID at the identity provider.
+
+      This is only required for authentication through single-sign-on and so far
+      only supported for provider type Nextcloud.
   tenantId:
     type: string
     description: |-
@@ -76,6 +84,16 @@ properties:
 
               - urn:openproject-org:api:v3:storages:Nextcloud
               - urn:openproject-org:api:v3:storages:OneDrive
+
+              **Resource**: N/A
+      authenticationMethod:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The urn of the authentication method. Currently only Nextcloud storages support this setting.
+
+              - urn:openproject-org:api:v3:storages:authenticationMethod:TwoWayOAuth2 (default)
+              - urn:openproject-org:api:v3:storages:authenticationMethod:OAuth2SSO
 
               **Resource**: N/A
       origin:

--- a/docs/api/apiv3/components/schemas/storage_read_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_read_model.yml
@@ -72,7 +72,10 @@ properties:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              The urn of the storage type. Currently only nextcloud storages are supported.
+              The urn of the storage type. Currently Nextcloud and OneDrive storages are supported.
+
+              - urn:openproject-org:api:v3:storages:Nextcloud
+              - urn:openproject-org:api:v3:storages:OneDrive
 
               **Resource**: N/A
       origin:

--- a/docs/api/apiv3/components/schemas/storage_write_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_write_model.yml
@@ -5,6 +5,14 @@ properties:
   name:
     type: string
     description: Storage name, if not provided, falls back to a default.
+  storageAudience:
+    type: string
+    description: |-
+      The audience that the storage expects in tokens for requests to it,
+      usually the storage's client ID at the identity provider.
+
+      This is only required for authentication through single-sign-on and so far
+      only supported for provider type Nextcloud.
   applicationPassword:
     type:
       - string
@@ -35,6 +43,16 @@ properties:
 
               - urn:openproject-org:api:v3:storages:Nextcloud
               - urn:openproject-org:api:v3:storages:OneDrive
+
+              **Resource**: N/A
+      authenticationMethod:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The urn of the authentication method. Currently only Nextcloud storages support this setting.
+
+              - urn:openproject-org:api:v3:storages:authenticationMethod:TwoWayOAuth2 (default)
+              - urn:openproject-org:api:v3:storages:authenticationMethod:OAuth2SSO
 
               **Resource**: N/A
 

--- a/docs/api/apiv3/components/schemas/storage_write_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_write_model.yml
@@ -31,9 +31,10 @@ properties:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              The urn of the storage type. Currently only nextcloud storages are supported.
+              The urn of the storage type. Currently Nextcloud and OneDrive storages are supported.
 
               - urn:openproject-org:api:v3:storages:Nextcloud
+              - urn:openproject-org:api:v3:storages:OneDrive
 
               **Resource**: N/A
 

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -37,7 +37,10 @@ module Storages
 
     # oauth2_sso_with_two_way_oauth2_fallback has been temporarily removed because the openproject_integration
     # on the nextcloud side does not support this yet (we can't configure audience AND oauth_client at the same time)
-    AUTHENTICATION_METHODS = %w[two_way_oauth2 oauth2_sso].freeze
+    AUTHENTICATION_METHODS = [
+      AUTHENTICATION_METHOD_TWO_WAY_OAUTH2 = "two_way_oauth2",
+      AUTHENTICATION_METHOD_OAUTH2_SSO = "oauth2_sso"
+    ].freeze
 
     store_attribute :provider_fields, :automatically_managed, :boolean
     store_attribute :provider_fields, :username, :string

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -125,7 +125,7 @@ module API::V3::Storages
                           getter: ->(*) {
                             type = STORAGE_TYPE_URN_MAP[represented.provider_type] || represented.provider_type
 
-                            { href: type, title: "Nextcloud" }
+                            { href: type, title: type.split(":").last }
                           },
                           setter: ->(fragment:, **) {
                             href = fragment["href"]

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -46,10 +46,23 @@ module API::V3::Storages
     URN_STORAGE_TYPE_ONE_DRIVE => Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
   }.freeze
 
-  STORAGE_TYPE_URN_MAP = {
-    Storages::Storage::PROVIDER_TYPE_NEXTCLOUD => URN_STORAGE_TYPE_NEXTCLOUD,
-    Storages::Storage::PROVIDER_TYPE_ONE_DRIVE => URN_STORAGE_TYPE_ONE_DRIVE
+  STORAGE_TYPE_URN_MAP = STORAGE_TYPE_MAP.invert.freeze
+
+  URN_AUTHENTICATION_METHOD_OAUTH2_SSO = "#{::API::V3::URN_PREFIX}storages:authenticationMethod:OAuth2SSO".freeze
+  URN_AUTHENTICATION_METHOD_TWO_WAY_OAUTH2 = "#{::API::V3::URN_PREFIX}storages:authenticationMethod:TwoWayOAuth2".freeze
+  URN_AUTHENTICATION_METHOD_OAUTH2_SSO_WITH_FALLBACK =
+    "#{::API::V3::URN_PREFIX}storages:authenticationMethod:OAuth2SSOFallbackToTwoWayOAuth2".freeze
+
+  AUTHENTICATION_METHOD_MAP = {
+    URN_AUTHENTICATION_METHOD_OAUTH2_SSO => Storages::NextcloudStorage::AUTHENTICATION_METHOD_OAUTH2_SSO,
+    URN_AUTHENTICATION_METHOD_TWO_WAY_OAUTH2 => Storages::NextcloudStorage::AUTHENTICATION_METHOD_TWO_WAY_OAUTH2
+    # oauth2_sso_with_two_way_oauth2_fallback has been temporarily removed because the openproject_integration
+    # on the nextcloud side does not support this yet (we can't configure audience AND oauth_client at the same time)
+    # URN_AUTHENTICATION_METHOD_OAUTH2_SSO_WITH_FALLBACK =>
+    #   Storages::NextcloudStorage::AUTHENTICATION_METHOD_OAUTH2_SSO_WITH_TWO_WAY_OAUTH2_FALLBACK
   }.freeze
+
+  AUTHENTICATION_METHOD_URN_MAP = AUTHENTICATION_METHOD_MAP.invert.freeze
 
   class StorageRepresenter < ::API::Decorators::Single
     # LinkedResource module defines helper methods to describe attributes
@@ -78,6 +91,12 @@ module API::V3::Storages
     property :id
 
     property :name
+
+    property :storageAudience,
+             skip_render: ->(represented:, **) { !represented.provider_type_nextcloud? },
+             skip_parse: ->(represented:, **) { !represented.provider_type_nextcloud? },
+             getter: ->(represented:, **) { represented.provider_type_nextcloud? && represented.storage_audience },
+             setter: ->(fragment:, represented:, **) { represented.storage_audience = fragment }
 
     property :applicationPassword,
              skip_render: ->(*) { true },
@@ -140,6 +159,22 @@ module API::V3::Storages
                             break if fragment["href"].blank?
 
                             represented.host = fragment["href"].gsub(/\/+$/, "")
+                          }
+
+    link_without_resource :authenticationMethod,
+                          getter: ->(*) {
+                            break nil unless represented.provider_type_nextcloud?
+
+                            method = AUTHENTICATION_METHOD_URN_MAP[represented.authentication_method]
+                            { href: method }
+                          },
+                          setter: ->(fragment:, **) {
+                            break unless represented.provider_type_nextcloud?
+
+                            href = fragment["href"]
+                            break if href.blank? || !AUTHENTICATION_METHOD_MAP.key?(href)
+
+                            represented.authentication_method = AUTHENTICATION_METHOD_MAP.fetch(href)
                           }
 
     links :prepareUpload do

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_parsing_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_parsing_spec.rb
@@ -94,6 +94,23 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "parsing" do
       end
     end
 
+    context "with SSO authentication" do
+      before do
+        parsed_hash["_links"]["authenticationMethod"] = {
+          "href" => "urn:openproject-org:api:v3:storages:authenticationMethod:OAuth2SSO"
+        }
+        parsed_hash["storageAudience"] = "the-new-storage-audience"
+      end
+
+      it "parses the authentication method" do
+        expect(parsed.authentication_method).to eq("oauth2_sso")
+      end
+
+      it "parses the storage audience" do
+        expect(parsed.storage_audience).to eq("the-new-storage-audience")
+      end
+    end
+
     describe "automatically managed project folders" do
       context "with applicationPassword" do
         let(:parsed_hash) do

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -266,6 +266,18 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
           end
         end
       end
+
+      describe "storageAudience" do
+        it_behaves_like "no property", :storageAudience
+
+        context "when the storage is configured for SSO authentication" do
+          let(:storage) { create(:nextcloud_storage, :oidc_sso_enabled) }
+
+          it_behaves_like "property", :storageAudience do
+            let(:value) { "nextcloud" }
+          end
+        end
+      end
     end
 
     it_behaves_like "common file storage links"
@@ -275,6 +287,22 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
         it_behaves_like "has an untitled link" do
           let(:link) { "origin" }
           let(:href) { storage.host }
+        end
+      end
+
+      describe "authenticationMethod" do
+        it_behaves_like "has an untitled link" do
+          let(:link) { "authenticationMethod" }
+          let(:href) { "urn:openproject-org:api:v3:storages:authenticationMethod:TwoWayOAuth2" }
+        end
+
+        context "when storage authenticates through SSO" do
+          let(:storage) { create(:nextcloud_storage, :oidc_sso_enabled) }
+
+          it_behaves_like "has an untitled link" do
+            let(:link) { "authenticationMethod" }
+            let(:href) { "urn:openproject-org:api:v3:storages:authenticationMethod:OAuth2SSO" }
+          end
         end
       end
 

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
       end
     end
 
+    describe "type" do
+      it_behaves_like "has a titled link" do
+        let(:link) { "type" }
+        let(:href) { "urn:openproject-org:api:v3:storages:#{storage.provider_type_nextcloud? ? 'Nextcloud' : 'OneDrive'}" }
+        let(:title) { storage.provider_type_nextcloud? ? "Nextcloud" : "OneDrive" }
+      end
+    end
+
     describe "authorizationState" do
       it_behaves_like "has a titled link" do
         let(:link) { "authorizationState" }


### PR DESCRIPTION
This brings the API on par with the UI, where this is already configurable.

# Ticket
https://community.openproject.org/wp/62191

# Merge checklist

- [x] Added/updated tests
- [x] Updated openapi specs
