### PR TITLE
[#61959] Segmented control jumps when changing the date field

### DIFF
--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -23,7 +23,8 @@
                     icon: :pin,
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: true).permit!),
                     data: {
-                      turbo_stream: true,
+                      turbo_frame: "wp-datepicker-dialog--content",
+                      morph: true,
                       qa_selected: schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_manual",
@@ -35,7 +36,8 @@
                     icon: "op-auto-date",
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: false).permit!),
                     data: {
-                      turbo_stream: true,
+                      turbo_frame: "wp-datepicker-dialog--content",
+                      morph: true,
                       qa_selected: !schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_automatic",

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -23,8 +23,7 @@
                     icon: :pin,
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: true).permit!),
                     data: {
-                      turbo_frame: "wp-datepicker-dialog--content",
-                      morph: true,
+                      turbo_stream: true,
                       qa_selected: schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_manual",
@@ -36,8 +35,7 @@
                     icon: "op-auto-date",
                     href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: false).permit!),
                     data: {
-                      turbo_frame: "wp-datepicker-dialog--content",
-                      morph: true,
+                      turbo_stream: true,
                       qa_selected: !schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_automatic",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/61959

# What are you trying to accomplish?
Prevent the segmented control jumping.

## Screenshots
<details><summary>Before (Please note the jumping on the "Automatic" segment control.)</summary>
<p>

![before](https://github.com/user-attachments/assets/568700c2-9ac6-42c2-8326-1324c2bb6617)


</p>
</details> 

<details><summary>After</summary>
<p>

![after](https://github.com/user-attachments/assets/229d6ddc-5b0a-463f-85ba-a3d7e047f793)


</p>
</details> 

# What approach did you choose and why?
~Enabling morphing on the datepicker seems to solve the flickering issue. Additionally, it solves another bug: When opening the datpicker and switching to manual, not the correct field is activated. It always activates the end date.~

There is an invisible text in bold over the segmented control buttons. This is to prevent jumping when the button gets clicked, because the active button is in bold and the width would shift without it.

Problem is: this invisble text is set from a `data-content` property which is set on the `onConnected` callback. This callback is not called when the content is morphed. When it's morphed, the `data-content` is removed, the invisible text is removed and the button text "jumps".

The fix is to hook into the morphing and call that callback manually for the segmented control so that the invisible text is there and there is no jumps.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
