### PR TITLE
[65195] CkEditor is cut off on "add child" dialog

### DIFF
--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -128,3 +128,6 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
 .ck-icon_inherit-color
   path
     fill: var(--body-font-color) !important
+
+.ck-toolbar__items
+  font-size: var(--body-font-size)

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -130,4 +130,4 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
     fill: var(--body-font-color) !important
 
 .ck-toolbar__items
-  font-size: var(--body-font-size)
+  font-size: var(--body-font-size) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62195

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
CKEditor scales UI elements based on this font size. At 13px, the toolbar items might not fit properly, triggering the auto-collapse behavior. So by setting the font-size of toolbar to body-font-size, the icons and spacing slightly increase, preventing premature collapsing.
