### PR TITLE
[#60122] Required custom fields prevent a WorkPackage from being added as a child

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -222,6 +222,8 @@ module WorkPackages
     end
     alias_method :assignable_responsibles, :assignable_assignees
 
+    def valid?(context = :saving_custom_fields) = super
+
     private
 
     attr_reader :can

--- a/app/contracts/work_packages/update_parent_contract.rb
+++ b/app/contracts/work_packages/update_parent_contract.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  class UpdateParentContract < UpdateContract
+    # Replacing the :saving_custom_fields so that no no required custom fields
+    # are validated, when updating the parent relation for a work package.
+    def valid?(context = :update) = super
+  end
+end

--- a/app/controllers/work_package_children_relations_controller.rb
+++ b/app/controllers/work_package_children_relations_controller.rb
@@ -79,8 +79,11 @@ class WorkPackageChildrenRelationsController < ApplicationController
 
   def set_relation(child:, parent:)
     if allowed_to_set_parent?(child)
-      WorkPackages::UpdateService.new(user: current_user, model: child)
-                                 .call(parent:)
+      WorkPackages::UpdateService.new(
+        user: current_user,
+        model: child,
+        contract_class: WorkPackages::UpdateParentContract
+      ).call(parent:)
     else
       child.errors.add(:id, :cannot_add_child_because_of_lack_of_permission)
       ServiceResult.failure(result: child)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -119,7 +119,7 @@ class Project < ApplicationRecord
   def validation_context
     case Array(super)
     in [*, :saving_custom_fields, *] => context
-      context << default_validation_context
+      context | [default_validation_context]
     else
       super
     end

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -147,7 +147,7 @@ class WorkPackage < ApplicationRecord
   # thus the associated agenda items will be available at the time the callback method is performed.
   around_destroy :save_agenda_item_journals, prepend: true, if: -> { meeting_agenda_items.any? }
 
-  acts_as_customizable
+  acts_as_customizable validate_on: :saving_custom_fields
 
   acts_as_searchable columns: ["subject",
                                "#{table_name}.description",

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1515,6 +1515,28 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
           end
         end
       end
+
+      context "when the work package is invalid due to a required custom field" do
+        let!(:custom_field) do
+          create(:integer_wp_custom_field, is_required: true, is_for_all: true, default_value: nil) do |cf|
+            project.types.first.custom_fields << cf
+            project.work_package_custom_fields << cf
+          end
+        end
+
+        it "the creation call still succeeds" do
+          activity_tab.add_comment(text: "First comment by admin")
+
+          comment = work_package.journals.reload.last
+
+          activity_tab.within_journal_entry(comment) do
+            page.find_test_selector("op-wp-journal-#{comment.id}-action-menu").click
+
+            expect(page).to have_test_selector("op-wp-journal-#{comment.id}-edit")
+            expect(page).to have_test_selector("op-wp-journal-#{comment.id}-quote")
+          end
+        end
+      end
     end
 
     context "when editing a comment" do

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe WorkPackage, "acts_as_customizable" do
 
       # set that custom field with a value, should be fine
       work_package.custom_field_values = { cf1.id => "test" }
-      work_package.save!
+      work_package.save!(context: :saving_custom_fields)
       work_package.reload
 
       # now give the work_package another required custom field, but don't assign a value
@@ -173,7 +173,7 @@ RSpec.describe WorkPackage, "acts_as_customizable" do
       work_package.custom_field_values # #custom_field_values needs to be touched
 
       # that should not be valid
-      expect(work_package).not_to be_valid
+      expect(work_package).not_to be_valid(:saving_custom_fields)
 
       # assert that there is only one error
       expect(work_package.errors.size).to eq 1

--- a/spec/services/relations/delete_service_spec.rb
+++ b/spec/services/relations/delete_service_spec.rb
@@ -96,13 +96,13 @@ RSpec.describe Relations::DeleteService do
         it "still updates correctly" do
           # ensure the work package is invalid as intended
           expect(work_package.schedule_manually).to be false
-          expect(work_package).not_to be_valid
+          expect(work_package).not_to be_valid(:saving_custom_fields)
 
           expect(delete_service_result).to be_success
 
           # work package has been changed to manual scheduling though still invalid
           expect(work_package.schedule_manually).to be true
-          expect(work_package).not_to be_valid
+          expect(work_package).not_to be_valid(:saving_custom_fields)
         end
       end
     end
@@ -139,13 +139,13 @@ RSpec.describe Relations::DeleteService do
         it "still updates correctly" do
           # ensure the work package is invalid as intended
           expect(work_package.start_date).to eq(_table.friday)
-          expect(work_package).not_to be_valid
+          expect(work_package).not_to be_valid(:saving_custom_fields)
 
           expect(delete_service_result).to be_success
 
           # work package has been rescheduled though still invalid
           expect(work_package.start_date).to eq(_table.wednesday)
-          expect(work_package).not_to be_valid
+          expect(work_package).not_to be_valid(:saving_custom_fields)
         end
       end
     end

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1539,13 +1539,13 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
     end
 
     it "removes the parent successfully and reschedules the parent" do
-      expect(parent.valid?).to be(false)
+      expect(parent).not_to be_valid(:saving_custom_fields)
       expect(subject).to be_success
 
       expect(work_package.reload.parent).to be_nil
 
       parent.reload
-      expect(parent.valid?).to be(false)
+      expect(parent).not_to be_valid(:saving_custom_fields)
       expect(parent.start_date)
         .to eql(sibling.start_date)
       expect(parent.due_date)

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1561,6 +1561,8 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       # the `self_and_ancestors` association is loaded in an `after_save` hook. In order to happen,
       # we must validate or save a record again after it was already saved in the current request.
       # Once the issue is fixed, it is safe to remove the association reset.
+      # https://github.com/rails/rails/issues/54807
+
       work_package.association(:self_and_ancestors).reset
 
       expect(subject).to be_success

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1539,7 +1539,30 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
     end
 
     it "removes the parent successfully and reschedules the parent" do
-      expect(parent).not_to be_valid(:saving_custom_fields)
+      expect(parent.valid?(:saving_custom_fields)).to be(false)
+      # Unload the `ancestor_hierarchies` association so that we don't validate the associatied
+      # records. `closure_tree`'s behaviour is to reload the associations after save, even if they
+      # weren't loaded, see: https://github.com/ClosureTree/closure_tree/blob/
+      # 509f6dfa58da18bb4bff6ded0469263216579a90/lib/closure_tree/hierarchy_maintenance.rb#L44-L45
+      #
+      # However, having the associations loaded will cause an unexpected association validation
+      # in rails, when using custom validation contexts.
+      # The `associated_records_to_validate_or_save` method from AR will return different objects
+      # when a custom context is provided, vs when a default context is present, leading to a
+      # different set of associated objects being validated. As a result, calling `wp.valid?` will
+      # pass, while calling `wp.valid?(:custom_context)` will fail with an error on the
+      # `closure_tree`'s `self_and_ancestors` association.
+      # https://github.com/rails/rails/blob/9f39c019243138d73bb265ec32da9aee26b2c18f/
+      # activerecord/lib/active_record/autosave_association.rb#L298-L306
+      #
+      # The inconsistency is on rails' side, but in this testcase it can be avoided by
+      # unloading the `self_and_ancestors` relation on the work package.
+      # The likelihood of this issue to happen in the application is rather small because,
+      # the `self_and_ancestors` association is loaded in an `after_save` hook. In order to happen,
+      # we must validate or save a record again after it was already saved in the current request.
+      # Once the issue is fixed, it is safe to remove the association reset.
+      work_package.association(:self_and_ancestors).reset
+
       expect(subject).to be_success
 
       expect(work_package.reload.parent).to be_nil


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60122

# What are you trying to accomplish?
Allow saving work package relations when there is a custom field related validation error on the work package.

# What approach did you choose and why?
Apply context based validations while saving work packages, so custom fields won't get validated when we save work package related content, like relations. The custom field validation should only kick in when work package attributes are saved.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
