### PR TITLE
[62245] Fix date picker width to 600px

### DIFF
--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -7,12 +7,12 @@ $body-height: 460px
   .wp-datepicker-dialog
     &--content
       max-height: calc(var(--app-height) - 2rem)
+      width: 600px
       overflow: auto
 
     &--body
       // We set a fixed height for this dialog zo avoid that it jumps around when the tabs are switched or errors shown
       min-height: $body-height
-      width: 600px
 
     &--content-tab
       &--relation-tab


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62245

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Text in the header banner can make the date picker too wide. The width is now fixed to 600px to avoid it and let the banner text wrap.

## Screenshots


Before

![image](https://github.com/user-attachments/assets/224c3cb1-2174-4e15-89a9-9b5761c072d4)

After

![image](https://github.com/user-attachments/assets/c0344ff7-3f22-4776-bfda-d555e924e3bf)


# What approach did you choose and why?

Before the limit was already 600px, but it was only applied to the body. Now it's applied to the whole content (header, body and footer).

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
