### PR TITLE
Translate units in time related filters

### DIFF
--- a/app/views/filters/date/_days.html.erb
+++ b/app/views/filters/date/_days.html.erb
@@ -8,7 +8,7 @@
                                class: "advanced-filters--text-field -slim",
                                "data-filter--filters-form-target": "days",
                                "data-filter-name": filter.name %>
-          <label for="<%= "#{filter.name}_value" %>" class="form-label -transparent">days</label>
+          <label for="<%= "#{filter.name}_value" %>" class="form-label -transparent"><%= t("datetime.units.day.other") %></label>
          </span>
     </div>
   </div>


### PR DESCRIPTION
# What are you trying to accomplish?
Use locale to render units in project filters of time type.

## Screenshots
![Screenshot_20250317_184852](https://github.com/user-attachments/assets/14033963-e606-4350-97c7-4c0a0a5f1e5b)

# What approach did you choose and why?
Use default rails locale definition of day unit.
