### PR TITLE
allow empty search values for autocompleter in certain modes

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
@@ -87,29 +87,29 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
   // If you need to fetch our default date sources like work_packages or users,
   // you should use the default method (loadAvailable), otherwise you should implement a function for
   // your desired resource
-  public loadData(matching:string|null, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string) {
+  public loadData(matching:string|null, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string, allowEmpty:boolean = false) {
     // Exit early if the query string is empty as there is no typeahead
-    if (matching === null || matching.length === 0) {
+    if (!allowEmpty && (matching === null || matching.length === 0)) {
       return of([]);
     }
 
     switch (resource) {
       // in this case we can add more functions for fetching usual resources
       default: {
-        return this.loadAvailable(matching, resource, filters, searchKey);
+        return this.loadAvailable(matching || '', resource, filters, searchKey);
       }
     }
   }
 
   // A method for returning data based on a custom URL (i.e. in time logging we have a special endpoint for retrieving
   // work packages)
-  public loadFromUrl(url:string, matching:string|null, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string) {
+  public loadFromUrl(url:string, matching:string|null, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string, allowEmpty:boolean = false) {
     // Exit early if the query string is empty as there is no typeahead
-    if (matching === null || matching.length === 0) {
+    if (!allowEmpty && (matching === null || matching.length === 0)) {
       return of([]);
     }
 
-    const finalFilters:ApiV3FilterBuilder = this.createFilters(filters ?? [], matching, searchKey);
+    const finalFilters:ApiV3FilterBuilder = this.createFilters(filters ?? [], matching || '', searchKey);
     const params = this.createParams(resource);
 
     const stringifiedBuiltOutUrl = addFiltersToPath(url, finalFilters, params).toString();

--- a/frontend/src/app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter.component.ts
@@ -141,6 +141,7 @@ export class TimeEntriesWorkPackageAutocompleterComponent extends OpAutocomplete
         this.resource,
         this.modeSpecificFilters,
         this.searchKey,
+        (this.mode === 'recent'), // allow empty typeahead for recent page, as this will list most recent WPs
       )
       .pipe(map((workPackages) => this.sortValues(workPackages)));
   }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/62163

# What are you trying to accomplish?
We added a quick exit to the autocompleter, that will exit early when we don't have any input. This broke the `Recent` tab on the time entries autocompleter. I added a new option to allow empty inputs

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
