### PR TITLE
Ensure SSO users do not fallback to ensure_connection

### DIFF
--- a/modules/storages/app/controllers/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/project_storages_controller.rb
@@ -98,18 +98,34 @@ class Storages::ProjectStoragesController < ApplicationController
         format.html do
           case result.code
           when :unauthorized
-            redirect_to(
-              oauth_clients_ensure_connection_url(
-                oauth_client_id: @storage.oauth_client.client_id,
-                storage_id: @storage.id,
-                destination_url: request.url
-              )
-            )
+            redirect_to(storage_fallback_url, allow_other_host: true)
           when :forbidden
             redirect_to_project_overview_with_modal
           end
         end
       end
+    end
+  end
+
+  def storage_fallback_url
+    selector = Storages::Peripherals::StorageInteraction::AuthenticationMethodSelector.new(user: current_user, storage: @storage)
+    if selector.sso?
+      # Maybe the user just can't read folder because they are not provisioned in (Nextcloud) storage. We redirect them
+      # to the storage and leave error handling up to storage. Ideally they will login to the storage and thus prevent
+      # the same error in the future.
+      # This would not work for OneDrive, but for OneDrive we don't have SSO (yet).
+      res = Storages::Peripherals::Registry.resolve("#{@storage}.queries.open_file_link").call(
+        storage: @storage,
+        auth_strategy:,
+        file_id: @object.project_folder_id
+      )
+      res.result_or { |errors| raise "Could not redirect SSO user to storage: #{errors}" }
+    else
+      oauth_clients_ensure_connection_url(
+        oauth_client_id: @storage.oauth_client.client_id,
+        storage_id: @storage.id,
+        destination_url: request.url
+      )
     end
   end
 


### PR DESCRIPTION
ensure_connection is intended for OAuth2 authentication at storage, but does not work, if we don't have an OAuth client, like for SSO authentication.

In the SSO case we can simply try to redirect the user to the correct URL, because they will most likely be able to login there and if in doubt, the storage can still refuse their request to visit the desired path.
Logging in to the storage, can in some cases lead to the user account being created on the storage, which should fix the main case of failed authentication in the first place. So hopefully this fallback helps ensuring users are eventually provisioned on the storage.

# Ticket
https://community.openproject.org/wp/62166

# Notes

I was surprised by the complexity involved in opening a storage. The happy path seems to go through:

* `ProjectStoragesController`
* `ProjectStorageOpenAPI`
* `ProjectStorage#open`

All of those have their own differentiation between happy path and sad path and in two of them we are performing authentication.

This PR just hooks into the existing decision tree, but we should probably clean that up/trim it down.