### PR TITLE
Feature/36743 filter work packages by an ancestor

### DIFF
--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,6 +30,7 @@
 
 module Queries::WorkPackages
   ::Queries::Register.register(Query) do
+    filter Filter::AncestorFilter
     filter Filter::AssignedToFilter
     filter Filter::AssigneeOrGroupFilter
     filter Filter::AttachmentContentFilter

--- a/app/models/queries/work_packages/filter/ancestor_filter.rb
+++ b/app/models/queries/work_packages/filter/ancestor_filter.rb
@@ -33,7 +33,11 @@ class Queries::WorkPackages::Filter::AncestorFilter <
   include ::Queries::WorkPackages::Filter::FilterForWpMixin
 
   def where
-    descendant_ids = WorkPackageHierarchy.where(ancestor_id: no_templated_values).pluck(:descendant_id)
+    descendant_ids = WorkPackageHierarchy
+                       .where(ancestor_id: no_templated_values)
+                       # exclude the selected ancestors:
+                       .where.not(descendant_id: no_templated_values)
+                       .pluck(:descendant_id)
 
     operator_strategy.sql_for_field(descendant_ids, self.class.model.table_name, :id)
   end

--- a/app/models/queries/work_packages/filter/ancestor_filter.rb
+++ b/app/models/queries/work_packages/filter/ancestor_filter.rb
@@ -32,7 +32,6 @@ class Queries::WorkPackages::Filter::AncestorFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
   include ::Queries::WorkPackages::Filter::FilterForWpMixin
 
-  # TODO all of the below is just copied. Change!
   def relation_type
     # While this is not a relation (in the sense of it being stored in a different database table) we still
     # want it to be used same as every other relation filter.
@@ -40,11 +39,19 @@ class Queries::WorkPackages::Filter::AncestorFilter <
   end
 
   def apply_to(_query_scope)
+    operator = operator_strategy.symbol
+
+    condition = if operator == "="
+                  "WHERE id IN (:ids)"
+                else
+                  "WHERE id NOT IN (:ids)"
+                end
+
     cte = <<~SQL.squish
       WITH RECURSIVE descendants AS (
         SELECT id
         FROM work_packages
-        WHERE id IN (:ids)
+        #{condition}
         UNION ALL
         SELECT wp.id
         FROM work_packages wp
@@ -61,6 +68,6 @@ class Queries::WorkPackages::Filter::AncestorFilter <
   end
 
   def where
-    "1 = 1"
+    "1=1"
   end
 end

--- a/app/models/queries/work_packages/filter/ancestor_filter.rb
+++ b/app/models/queries/work_packages/filter/ancestor_filter.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::WorkPackages::Filter::AncestorFilter <
+  Queries::WorkPackages::Filter::WorkPackageFilter
+  include ::Queries::WorkPackages::Filter::FilterForWpMixin
+
+  # TODO all of the below is just copied. Change!
+  def relation_type
+    # While this is not a relation (in the sense of it being stored in a different database table) we still
+    # want it to be used same as every other relation filter.
+    Relation::TYPE_PARENT
+  end
+
+  def where
+    # The filter had been called parent before and it is stored in the database like that.
+    # The other association filters all have _id in their self.key.
+    operator_strategy.sql_for_field(no_templated_values, self.class.model.table_name, :parent_id)
+  end
+end

--- a/app/models/queries/work_packages/filter/ancestor_filter.rb
+++ b/app/models/queries/work_packages/filter/ancestor_filter.rb
@@ -33,7 +33,7 @@ class Queries::WorkPackages::Filter::AncestorFilter <
   include ::Queries::WorkPackages::Filter::FilterForWpMixin
 
   def where
-    descendant_ids = WorkPackage.find(no_templated_values).map(&:descendants).flatten.pluck(:id)
+    descendant_ids = WorkPackage.where(id: no_templated_values).flat_map(&:descendants).pluck(:id)
     descendant_ids.concat(no_templated_values)
 
     operator_strategy.sql_for_field(descendant_ids, self.class.model.table_name, :id)

--- a/app/models/queries/work_packages/filter/ancestor_filter.rb
+++ b/app/models/queries/work_packages/filter/ancestor_filter.rb
@@ -33,8 +33,7 @@ class Queries::WorkPackages::Filter::AncestorFilter <
   include ::Queries::WorkPackages::Filter::FilterForWpMixin
 
   def where
-    descendant_ids = WorkPackage.where(id: no_templated_values).flat_map(&:descendants).pluck(:id)
-    descendant_ids.concat(no_templated_values)
+    descendant_ids = WorkPackageHierarchy.where(ancestor_id: no_templated_values).pluck(:descendant_id)
 
     operator_strategy.sql_for_field(descendant_ids, self.class.model.table_name, :id)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1136,7 +1136,7 @@ en:
         parent_title: "Parent page"
         redirect_existing_links: "Redirect existing links"
       work_package:
-        ancestor: "Ancestor"
+        ancestor: "Descendants of" # used for filtering of work packages that are descendants of a given work package
         begin_insertion: "Begin of the insertion"
         begin_deletion: "Begin of the deletion"
         children: "Subelements"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1136,6 +1136,7 @@ en:
         parent_title: "Parent page"
         redirect_existing_links: "Redirect existing links"
       work_package:
+        ancestor: "Ancestor"
         begin_insertion: "Begin of the insertion"
         begin_deletion: "Begin of the deletion"
         children: "Subelements"

--- a/lib/api/v3/queries/schemas/ancestor_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/ancestor_filter_dependency_representer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Queries
+      module Schemas
+        class AncestorFilterDependencyRepresenter < ByWorkPackageFilterDependencyRepresenter; end
+      end
+    end
+  end
+end

--- a/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
+  let(:project) { build_stubbed(:project) }
+  let(:query) do
+    build_stubbed(:query, project:)
+  end
+
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :ancestor }
+    let(:type) { :list }
+
+    before do
+      instance.context = query
+    end
+
+    describe "#available?" do
+      context "within a project" do
+        it "is true if any work package exists and is visible" do
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :for_projects, :exists?) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(project)
+            .with(no_args)
+            .and_return true
+
+          expect(instance).to be_available
+        end
+
+        it "is false if no work package exists/ is visible" do
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :for_projects, :exists?) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(project)
+            .with(no_args)
+            .and_return false
+
+          expect(instance).not_to be_available
+        end
+      end
+
+      context "when outside of a project" do
+        let(:project) { nil }
+
+        it "is true if any work package exists and is visible" do
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :exists?) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .and_return true
+
+          expect(instance).to be_available
+        end
+
+        it "is false if no work package exists/ is visible" do
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :exists?) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .and_return false
+
+          expect(instance).not_to be_available
+        end
+      end
+    end
+
+    describe "#ar_object_filter?" do
+      it "is true" do
+        expect(instance).to be_ar_object_filter
+      end
+    end
+
+    describe "#allowed_values" do
+      it "raises an error" do
+        expect { instance.allowed_values }.to raise_error NotImplementedError
+      end
+    end
+
+    describe "#value_object" do
+      let(:visible_wp) { build_stubbed(:work_package) }
+
+      it "returns the work package for the values" do
+        allow(WorkPackage)
+          .to receive_message_chain(:visible, :for_projects, :find) # rubocop:disable RSpec/MessageChain
+          .with(no_args)
+          .with(project)
+          .with(instance.values)
+          .and_return([visible_wp])
+
+        expect(instance.value_objects)
+          .to contain_exactly(visible_wp)
+      end
+
+      context "with the 'templated' value" do
+        before do
+          instance.values = ["templated"]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :for_projects, :find) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(project)
+            .with([])
+            .and_return([])
+        end
+
+        it "returns a TemplatedValue object" do
+          expect(instance.value_objects.length).to be 1
+          expect(instance.value_objects[0].id).to eql "{id}"
+        end
+      end
+    end
+
+    describe "#allowed_objects" do
+      it "raises an error" do
+        expect { instance.allowed_objects }.to raise_error NotImplementedError
+      end
+    end
+
+    describe "#valid_values!" do
+      let(:visible_wp) { build_stubbed(:work_package) }
+      let(:invisible_wp) { build_stubbed(:work_package) }
+
+      context "within a project" do
+        it "removes all non existing/non visible ids" do
+          instance.values = [visible_wp.id.to_s, invisible_wp.id.to_s, "999999"]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :for_projects, :where, :pluck) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(project)
+            .with(id: instance.values)
+            .with(:id)
+            .and_return([visible_wp.id])
+
+          instance.valid_values!
+
+          expect(instance.values)
+            .to contain_exactly(visible_wp.id.to_s)
+        end
+      end
+
+      context "when outside of a project" do
+        let(:project) { nil }
+
+        it "removes all non existing/non visible ids" do
+          instance.values = [visible_wp.id.to_s, invisible_wp.id.to_s, "999999"]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :where, :pluck) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(id: instance.values)
+            .with(:id)
+            .and_return([visible_wp.id])
+
+          instance.valid_values!
+
+          expect(instance.values)
+            .to contain_exactly(visible_wp.id.to_s)
+        end
+      end
+    end
+
+    describe "#validate" do
+      let(:visible_wp) { build_stubbed(:work_package) }
+      let(:invisible_wp) { build_stubbed(:work_package) }
+
+      context "with old templated value" do
+        it "is still valid" do
+          instance.values = %w[templated]
+          expect(instance).to be_valid
+        end
+      end
+
+      context "with new templated value" do
+        it "is still valid" do
+          instance.values = %w[{id}]
+          expect(instance).to be_valid
+        end
+      end
+
+      context "within a project" do
+        it "is valid if only visible wps are values" do
+          instance.values = [visible_wp.id.to_s]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :for_projects, :where, :pluck) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(project)
+            .with(id: instance.values)
+            .with(:id)
+            .and_return([visible_wp.id])
+
+          expect(instance).to be_valid
+        end
+
+        it "is invalid if invisible wps are values" do
+          instance.values = [invisible_wp.id.to_s, visible_wp.id.to_s]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :for_projects, :where, :pluck) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(project)
+            .with(id: instance.values)
+            .with(:id)
+            .and_return([visible_wp.id])
+
+          expect(instance).not_to be_valid
+        end
+      end
+
+      context "when outside of a project" do
+        let(:project) { nil }
+
+        it "is valid if only visible wps are values" do
+          instance.values = [visible_wp.id.to_s]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :where, :pluck) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(id: instance.values)
+            .with(:id)
+            .and_return([visible_wp.id])
+
+          expect(instance).to be_valid
+        end
+
+        it "is invalid if invisible wps are values" do
+          instance.values = [invisible_wp.id.to_s, visible_wp.id.to_s]
+
+          allow(WorkPackage)
+            .to receive_message_chain(:visible, :where, :pluck) # rubocop:disable RSpec/MessageChain
+            .with(no_args)
+            .with(id: instance.values)
+            .with(:id)
+            .and_return([visible_wp.id])
+
+          expect(instance).not_to be_valid
+        end
+      end
+    end
+
+    describe "#where and #includes" do
+      let(:parent) { create(:work_package) }
+      let(:child) { create(:work_package, parent:) }
+      let(:grandchild) { create(:work_package, parent: child) }
+      let(:another_wp) { create(:work_package) }
+
+      before do
+        grandchild
+        another_wp
+        instance.values = [parent.id.to_s]
+        instance.operator = "="
+      end
+
+      it "filters" do
+        scope = WorkPackage
+                .references(instance.includes)
+                .includes(instance.includes)
+                .where(instance.where)
+
+        # The ancestor filter will include all descendants of the parent work package, as well as the parent itself.
+        expect(scope).to contain_exactly(parent, child, grandchild)
+      end
+
+      context "with the `!` operator" do
+        before do
+          grandchild
+          another_wp
+          instance.values = [parent.id.to_s]
+          instance.operator = "!"
+        end
+
+        it "excludes the parent and its descendants" do
+          scope = WorkPackage
+                    .references(instance.includes)
+                    .includes(instance.includes)
+                    .where(instance.where)
+
+          expect(scope).to contain_exactly(another_wp)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
@@ -287,8 +287,8 @@ RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
                 .includes(instance.includes)
                 .where(instance.where)
 
-        # The ancestor filter will include all descendants of the parent work package, as well as the parent itself.
-        expect(scope).to contain_exactly(parent, child, grandchild)
+        # The ancestor filter will include all descendants of the parent work package, but not the parent itself.
+        expect(scope).to contain_exactly(child, grandchild)
       end
 
       context "with the `!` operator" do
@@ -299,13 +299,13 @@ RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
           instance.operator = "!"
         end
 
-        it "excludes the parent and its descendants" do
+        it "excludes the parents descendants, but not the parent itself" do
           scope = WorkPackage
                     .references(instance.includes)
                     .includes(instance.includes)
                     .where(instance.where)
 
-          expect(scope).to contain_exactly(another_wp, grandparent)
+          expect(scope).to contain_exactly(another_wp, grandparent, parent)
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
@@ -268,7 +268,8 @@ RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
     end
 
     describe "#where and #includes" do
-      let(:parent) { create(:work_package) }
+      let(:grandparent) { create(:work_package) }
+      let(:parent) { create(:work_package, parent: grandparent) }
       let(:child) { create(:work_package, parent:) }
       let(:grandchild) { create(:work_package, parent: child) }
       let(:another_wp) { create(:work_package) }
@@ -304,7 +305,7 @@ RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
                     .includes(instance.includes)
                     .where(instance.where)
 
-          expect(scope).to contain_exactly(another_wp)
+          expect(scope).to contain_exactly(another_wp, grandparent)
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/36743

# What are you trying to accomplish?
Provide an ancestor filter that allows users to filter for any descendant of a given work package.

## Screenshots

https://github.com/user-attachments/assets/a77d0b38-0b24-4dc8-9bae-c68fb531075e

# What approach did you choose and why?
Copied the existing parent filter as a base and adjusted the query. Thanks to the excellent work package hierarchy table, I could use an existing method to filter for all descendants.

I decided to make the IS (OR) filter _inclusive_, which means that the selected ancestor _**will** show up_ in the result.
At the same time, the IS NOT filter will _exclude_ the ancestor in the result list, meaning it will _**not** show up._

This solution felt the most intuitive to me.

The selected translation is still a bit open to debate. Initially, I named the filter (label) "Ancestor", but later renamed it to "Descendants of", as stated in the work package description, because it seemed easier to understand for a non-technical person. Both are not ideal and I am open for suggestions.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
