### PR TITLE
[62261] Fix error displayed when switching parent to automatic

### DIFF
--- a/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
+++ b/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
@@ -389,4 +389,34 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
       end
     end
   end
+
+  describe "Bug #62261: Invalid error displayed when switching parent to automatic" do
+    context "when changing dates to the ones that would be computed by automatic mode and then switching to automatic" do
+      let_work_packages(<<~TABLE)
+        hierarchy    | start date | due date   | scheduling mode
+        work package | 2025-01-27 | 2025-02-06 | manual
+          child      |            |            | manual
+      TABLE
+
+      it "does not display a 'read-only' error" do
+        open_date_picker
+        datepicker.set_start_date("")
+        datepicker.set_due_date("")
+
+        datepicker.toggle_scheduling_mode
+
+        datepicker.expect_start_date "", disabled: true
+        datepicker.expect_due_date "", disabled: true
+        read_only_error = I18n.t("activerecord.errors.messages.error_readonly")
+        expect(datepicker.container).to have_no_text(/#{Regexp.escape(read_only_error)}/i)
+
+        apply_and_expect_saved(
+          start_date: nil,
+          due_date: nil,
+          duration: nil,
+          schedule_manually: false
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/open_project/changed_by_system_spec.rb
+++ b/spec/lib/open_project/changed_by_system_spec.rb
@@ -90,6 +90,64 @@ RSpec.describe OpenProject::ChangedBySystem do
       end
     end
 
+    context "when an attribute is changed by the user first and then by the system to a different value" do
+      before do
+        model.title = "abc"
+
+        model.change_by_system do
+          model.title = "xyz"
+        end
+      end
+
+      it "returns no attribute" do
+        expect(model.changed_by_user)
+          .to be_empty
+      end
+    end
+
+    context "when an attribute is changed by the user first and then by the system to the same value" do
+      before do
+        model.title = "abc"
+
+        model.change_by_system do
+          model.title = "abc"
+        end
+      end
+
+      it "returns no attribute" do
+        expect(model.changed_by_user)
+          .to be_empty
+      end
+    end
+
+    context "when an attribute is changed by the user and the system modifies another attribute" do
+      before do
+        model.title = "abc"
+
+        model.change_by_system do
+          model.description = "desc"
+        end
+      end
+
+      it "returns the attribute modified by the user" do
+        expect(model.changed_by_user)
+          .to contain_exactly("title")
+      end
+    end
+
+    context "when an attribute is changed by the system only" do
+      before do
+        model.change_by_system do
+          model.title = "abc"
+        end
+      end
+
+      it "returns no attribute" do
+        expect(model.changed_by_user)
+          .to be_empty
+      end
+    end
+
     context "when the model has the acts_as_customizable plugin included" do
       subject(:model) do
         create(:work_package, project:).tap do |wp|


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62261

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When switching a parent to automatic scheduling mode, the date picker displayed an error that the dates are read-only when the selected dates in manual mode are the ones that would be computed by automatic mode.

This error should not be displayed.

## Screenshots

Please see screen recordings in ticket.

# What approach did you choose and why?

This was due to system changes being the same as user changes, and as they were done after, it was not detected.

Fix is to track the attributes directly (maybe using private activemodel api) and check if the instance changed, in which case it can be considered a system change.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
