### PR TITLE
Update Ruby copyright headers using rake task

### DIFF
--- a/app/components/op_primer/copy_to_clipboard_component.rb
+++ b/app/components/op_primer/copy_to_clipboard_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/item_component/edit.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/edit.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/item_component/show.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/show.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2023 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/components/work_packages/update_conflict_component.rb
+++ b/app/components/work_packages/update_conflict_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/emoji_reactions/base_contract.rb
+++ b/app/contracts/emoji_reactions/base_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/emoji_reactions/create_contract.rb
+++ b/app/contracts/emoji_reactions/create_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/emoji_reactions/delete_contract.rb
+++ b/app/contracts/emoji_reactions/delete_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/oauth/applications/base_contract.rb
+++ b/app/contracts/oauth/applications/base_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/oauth/applications/delete_contract.rb
+++ b/app/contracts/oauth/applications/delete_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/oauth/applications/update_contract.rb
+++ b/app/contracts/oauth/applications/update_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/reminders/base_contract.rb
+++ b/app/contracts/reminders/base_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/reminders/create_contract.rb
+++ b/app/contracts/reminders/create_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/reminders/delete_contract.rb
+++ b/app/contracts/reminders/delete_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/contracts/reminders/update_contract.rb
+++ b/app/contracts/reminders/update_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/controllers/concerns/op_modal_flashable.rb
+++ b/app/controllers/concerns/op_modal_flashable.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/controllers/concerns/op_turbo/flash_stream_helper.rb
+++ b/app/controllers/concerns/op_turbo/flash_stream_helper.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/forms/work_packages/activities_tab/journals/notes_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/notes_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/forms/work_packages/activities_tab/journals/submit.rb
+++ b/app/forms/work_packages/activities_tab/journals/submit.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/helpers/secure_headers_helper.rb
+++ b/app/helpers/secure_headers_helper.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/models/concerns/remindable.rb
+++ b/app/models/concerns/remindable.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/models/queries/projects/selects/default.rb
+++ b/app/models/queries/projects/selects/default.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
 class Queries::Projects::Selects::Default < Queries::Selects::Base
   KEYS = %i[id identifier status_explanation hierarchy name public description].freeze

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/models/reminder_notification.rb
+++ b/app/models/reminder_notification.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/seeders/oauth_applications_seeder.rb
+++ b/app/seeders/oauth_applications_seeder.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/emoji_reactions/create_service.rb
+++ b/app/services/emoji_reactions/create_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/emoji_reactions/delete_service.rb
+++ b/app/services/emoji_reactions/delete_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/emoji_reactions/set_attributes_service.rb
+++ b/app/services/emoji_reactions/set_attributes_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/oauth/applications/create_service.rb
+++ b/app/services/oauth/applications/create_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/oauth/applications/delete_service.rb
+++ b/app/services/oauth/applications/delete_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/oauth/applications/update_service.rb
+++ b/app/services/oauth/applications/update_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/reminders/create_service.rb
+++ b/app/services/reminders/create_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/reminders/delete_service.rb
+++ b/app/services/reminders/delete_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/reminders/set_attributes_service.rb
+++ b/app/services/reminders/set_attributes_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/app/services/reminders/update_service.rb
+++ b/app/services/reminders/update_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/db/migrate/20240801105918_add_auth_providers.rb
+++ b/db/migrate/20240801105918_add_auth_providers.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/lib/open_project/html_diff.rb
+++ b/lib/open_project/html_diff.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/lib/open_project/patches/secure_headers_turbo_aware_nonce.rb
+++ b/lib/open_project/patches/secure_headers_turbo_aware_nonce.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/sections/form_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/form_component.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/sections/metadata_form_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/metadata_form_component.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/sections/request_attributes_form_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/request_attributes_form_component.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/sections/section_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/section_component.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/sections/show_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/show_component.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/side_panel/information_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel/information_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/side_panel/metadata_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel/metadata_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/side_panel_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel_component.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/components/saml/providers/view_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/view_component.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/constants/saml/defaults.rb
+++ b/modules/auth_saml/app/constants/saml/defaults.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/contracts/saml/providers/create_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/create_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/contracts/saml/providers/delete_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/delete_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/contracts/saml/providers/update_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/update_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/base_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/base_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/encryption_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/encryption_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/mapping_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/mapping_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/metadata_options_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/metadata_options_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/metadata_url_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/metadata_url_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/metadata_xml_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/metadata_xml_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/name_input_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/name_input_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/request_attributes_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/request_attributes_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/forms/saml/providers/submit_or_cancel_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/submit_or_cancel_form.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/configuration_mapper.rb
+++ b/modules/auth_saml/app/services/saml/configuration_mapper.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/providers/create_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/create_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/providers/delete_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/delete_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/providers/set_attributes_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/set_attributes_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/providers/update_metadata.rb
+++ b/modules/auth_saml/app/services/saml/providers/update_metadata.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/providers/update_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/update_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/sync_service.rb
+++ b/modules/auth_saml/app/services/saml/sync_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/auth_saml/app/services/saml/update_metadata_service.rb
+++ b/modules/auth_saml/app/services/saml/update_metadata_service.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/modules/meeting/spec/features/structured_meetings/meeting_outcomes/meeting_outcomes_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/meeting_outcomes/meeting_outcomes_crud_spec.rb
@@ -11,14 +11,18 @@
 # Copyright (C) 2006-2013 Jean-Philippe Lang
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
-# This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/features/activities/work_package/emoji_reactions_spec.rb
+++ b/spec/features/activities/work_package/emoji_reactions_spec.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/features/activities/work_package/revision_component_spec.rb
+++ b/spec/features/activities/work_package/revision_component_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/lib/open_project/html_diff_spec.rb
+++ b/spec/lib/open_project/html_diff_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/services/oauth/applications/create_service_spec.rb
+++ b/spec/services/oauth/applications/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/services/oauth/applications/delete_service_spec.rb
+++ b/spec/services/oauth/applications/delete_service_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/services/oauth/applications/set_attributes_service_spec.rb
+++ b/spec/services/oauth/applications/set_attributes_service_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/services/oauth/applications/update_service_spec.rb
+++ b/spec/services/oauth/applications/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/services/work_packages/set_attributes_service/shared_examples.rb
+++ b/spec/services/work_packages/set_attributes_service/shared_examples.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/days_counting.rb
+++ b/spec/support/table_helpers/column_type/days_counting.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/duration.rb
+++ b/spec/support/table_helpers/column_type/duration.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/generic.rb
+++ b/spec/support/table_helpers/column_type/generic.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/hierarchy.rb
+++ b/spec/support/table_helpers/column_type/hierarchy.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/percentage.rb
+++ b/spec/support/table_helpers/column_type/percentage.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/predecessor_relations.rb
+++ b/spec/support/table_helpers/column_type/predecessor_relations.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/related_to_relations.rb
+++ b/spec/support/table_helpers/column_type/related_to_relations.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/schedule.rb
+++ b/spec/support/table_helpers/column_type/schedule.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/scheduling_mode.rb
+++ b/spec/support/table_helpers/column_type/scheduling_mode.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/status.rb
+++ b/spec/support/table_helpers/column_type/status.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/subject.rb
+++ b/spec/support/table_helpers/column_type/subject.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support/table_helpers/column_type/with_identifier_metadata.rb
+++ b/spec/support/table_helpers/column_type/with_identifier_metadata.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/days_counting_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/days_counting_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/generic_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/generic_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/hierarchy_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/hierarchy_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/percentage_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/percentage_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/predecessor_relations_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/predecessor_relations_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/related_to_relations_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/related_to_relations_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/schedule_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/schedule_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/scheduling_mode_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/scheduling_mode_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/status_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/status_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.

--- a/spec/support_spec/table_helpers/column_type/subject_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/subject_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.


### PR DESCRIPTION
This effectively removes the year from a bunch of copyright headers. We stopped indicating a specific year at some point, but didn't propagate this change to every file yet.

This PR was effectively achieved through:

    rake copyright:update_rb