### PR TITLE
[#62257] display parent and project prefix in attribute tokens

### DIFF
--- a/app/components/work_packages/types/pattern_input.html.erb
+++ b/app/components/work_packages/types/pattern_input.html.erb
@@ -34,6 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
       classes: "pattern-input",
       "data-controller": "pattern-input",
       "data-pattern-input-pattern-initial-value": @value,
+      "data-pattern-input-heading-locales-value": heading_locales,
       "data-pattern-input-insert-as-text-template-value": I18n.t("types.edit.subject_configuration.pattern.insert_as_text"),
       "data-pattern-input-suggestions-initial-value": suggestions_for_stimulus
     )

--- a/app/components/work_packages/types/pattern_input.rb
+++ b/app/components/work_packages/types/pattern_input.rb
@@ -47,7 +47,7 @@ module WorkPackages
       end
 
       def heading_locales
-        @suggestions.keys.reduce({}) do |key, acc|
+        @suggestions.keys.reduce({}) do |acc, key|
           acc[key] = I18n.t("types.edit.subject_configuration.pattern.headings.#{key}")
           acc
         end.to_json

--- a/app/components/work_packages/types/pattern_input.rb
+++ b/app/components/work_packages/types/pattern_input.rb
@@ -43,9 +43,14 @@ module WorkPackages
       end
 
       def suggestions_for_stimulus
-        @suggestions_for_stimulus ||= @suggestions
-                                        .transform_keys { |key| key.to_s.humanize }
-                                        .to_json
+        @suggestions_for_stimulus ||= @suggestions.to_json
+      end
+
+      def heading_locales
+        @suggestions.keys.reduce({}) do |key, acc|
+          acc[key] = I18n.t("types.edit.subject_configuration.pattern.headings.#{key}")
+          acc
+        end.to_json
       end
 
       def suggestions_list_component

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -677,6 +677,10 @@ en:
         pattern:
           label: "Subject pattern"
           caption: "Add text or type / to search for an attribute. You can add spaces to separate them."
+          headings:
+            work_package: "Work package"
+            parent: "Parent"
+            project: "Project"
           insert_as_text: "No attributes found. Add as text: \"%{word}\""
       export_configuration:
         tab: "Generate PDF"


### PR DESCRIPTION
# Ticket
[OP#62257](https://community.openproject.org/wp/62257)

# What are you trying to accomplish?
- show project or parent attributes tokens

# What approach did you choose and why?
- use localized group keys
- add prefixes in token display texts

