### PR TITLE
open-point/61949 primer colors for work package comments with restricted visibility

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -15,14 +15,13 @@
                 "anchor-activity-id": journal.sequence_version,
                 "anchor-comment-id": journal.id
               },
-              border_color: container_border_color
+              classes: container_classes
             )
           ) do |border_box_component|
             border_box_component.with_header(
               px: 2, py: 1,
               data: { test_selector: "op-journal-notes-header" },
-              classes: comment_header_classes,
-              border_color: container_border_color
+              classes: comment_header_classes
             ) do
               flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
                 header_container.with_column(
@@ -122,8 +121,7 @@
             end
             border_box_component.with_body(
               classes: comment_body_classes,
-              data: { test_selector: "op-journal-notes-body" },
-              border_color: container_border_color
+              data: { test_selector: "op-journal-notes-body" }
             ) do
               if noop?
                 render(Primer::Beta::Text.new(font_style: :italic, color: :subtle, mt: 1)) do

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -60,6 +60,14 @@ module WorkPackages
           }
         end
 
+        def container_classes
+          [].tap do |classes|
+            if journal.restricted?
+              classes << "work-packages-activities-tab-journals-item-component--container__restricted-comment"
+            end
+          end
+        end
+
         def comment_header_classes
           [].tap do |classes|
             if journal.restricted?
@@ -74,10 +82,6 @@ module WorkPackages
               classes << "work-packages-activities-tab-journals-item-component--journal-notes-body__restricted-comment"
             end
           end
-        end
-
-        def container_border_color
-          journal.restricted? ? :attention_emphasis : :default
         end
 
         def show_comment_container?

--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -12,10 +12,10 @@
     &--header-start-container
         flex-grow: 1
     &--container__restricted-comment
-        border-color: var(--display-auburn-borderColor-muted)
+        border-color: var(--display-brown-borderColor-emphasis)
     &--header__restricted-comment
-        border-color: var(--display-brown-borderColor-muted)
+        border-color: var(--display-brown-borderColor-emphasis)
         background-color: var(--display-brown-bgColor-muted)
     &--journal-notes-body__restricted-comment
-        border-color: var(--display-brown-borderColor-muted)
+        border-color: var(--display-brown-borderColor-emphasis)
 

--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -11,8 +11,14 @@
         color: var(--bgColor-accent-emphasis)
     &--header-start-container
         flex-grow: 1
+    &--container__restricted-comment
+        border-color: var(--display-auburn-borderColor-muted)
     &--header__restricted-comment
-        background-color: var(--data-auburn-color-muted)
+        color: var(--fgColor-default)
+        border-color: var(--display-auburn-borderColor-muted)
+        background-color: var(--display-auburn-borderColor-muted)
     &--journal-notes-body__restricted-comment
-        background-color: var(--bgColor-severe-muted)
+        color: var(--fgColor-default)
+        border-color: var(--display-auburn-borderColor-muted)
+        background-color: var(--display-auburn-bgColor-muted)
 

--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -14,11 +14,8 @@
     &--container__restricted-comment
         border-color: var(--display-auburn-borderColor-muted)
     &--header__restricted-comment
-        color: var(--fgColor-default)
-        border-color: var(--display-auburn-borderColor-muted)
-        background-color: var(--display-auburn-borderColor-muted)
+        border-color: var(--display-brown-borderColor-muted)
+        background-color: var(--display-brown-bgColor-muted)
     &--journal-notes-body__restricted-comment
-        color: var(--fgColor-default)
-        border-color: var(--display-auburn-borderColor-muted)
-        background-color: var(--display-auburn-bgColor-muted)
+        border-color: var(--display-brown-borderColor-muted)
 

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -28,5 +28,6 @@
         .ck-editor__preview
             max-height: 30vh
     &--journal-notes-body__restricted-comment
-        background-color: var(--bgColor-severe-muted) !important
-        border-top: var(--borderWidth-thick) solid var(--data-auburn-color-muted)
+        color: var(--fgColor-default)
+        background-color: var(--display-auburn-bgColor-muted) !important
+        border-top: var(--borderWidth-thick) solid var(--display-auburn-borderColor-muted)

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -29,4 +29,4 @@
             max-height: 30vh
     &--journal-notes-body__restricted-comment
         background-color: var(--display-brown-bgColor-muted) !important
-        border-top: var(--borderWidth-thick) solid var(--display-brown-borderColor-muted)
+        border-top: var(--borderWidth-thick) solid var(--display-brown-borderColor-emphasis)

--- a/app/components/work_packages/activities_tab/journals/new_component.sass
+++ b/app/components/work_packages/activities_tab/journals/new_component.sass
@@ -28,6 +28,5 @@
         .ck-editor__preview
             max-height: 30vh
     &--journal-notes-body__restricted-comment
-        color: var(--fgColor-default)
-        background-color: var(--display-auburn-bgColor-muted) !important
-        border-top: var(--borderWidth-thick) solid var(--display-auburn-borderColor-muted)
+        background-color: var(--display-brown-bgColor-muted) !important
+        border-top: var(--borderWidth-thick) solid var(--display-brown-borderColor-muted)


### PR DESCRIPTION
https://community.openproject.org/wp/61949

| Light | Light (High Contrast) | Dark |
|--------|--------|--------|
| <img width="1158" alt="Screenshot 2025-03-18 at 8 54 06 PM" src="https://github.com/user-attachments/assets/f0aeafb6-fbe3-4898-a37b-1dfb0fe28f30" /> | <img width="1158" alt="Screenshot 2025-03-18 at 8 52 56 PM" src="https://github.com/user-attachments/assets/62903a00-2acf-4f5c-9ce7-1e451b603203" /> | <img width="1159" alt="Screenshot 2025-03-18 at 8 51 51 PM" src="https://github.com/user-attachments/assets/0947516f-8f2a-44fe-a708-1df94fdccdf7" /> |

