### PR TITLE
Cleanup requires in specs

### DIFF
--- a/modules/auth_saml/spec/lib/open_project/auth_saml_spec.rb
+++ b/modules/auth_saml/spec/lib/open_project/auth_saml_spec.rb
@@ -1,4 +1,4 @@
-require "#{File.dirname(__FILE__)}/../../spec_helper"
+require_relative "../../spec_helper"
 require "open_project/auth_saml"
 
 RSpec.describe OpenProject::AuthSaml do

--- a/modules/auth_saml/spec/lib/open_project/auth_saml_spec.rb
+++ b/modules/auth_saml/spec/lib/open_project/auth_saml_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require "open_project/auth_saml"
 

--- a/modules/avatars/spec/controllers/avatars/avatar_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/avatar_controller_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
-require File.expand_path(File.dirname(__FILE__) + "/../../shared_examples")
+require_relative "../../spec_helper"
+require_relative "../../shared_examples"
 
 RSpec.describe Avatars::AvatarController do
   include_context "there are users with and without avatars"

--- a/modules/avatars/spec/controllers/avatars/avatar_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/avatar_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../../shared_examples"
 

--- a/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
-require File.expand_path(File.dirname(__FILE__) + "/../../shared_examples")
+require_relative "../../spec_helper"
+require_relative "../../shared_examples"
 
 RSpec.describe Avatars::MyAvatarController do
   include_context "there are users with and without avatars"

--- a/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../../shared_examples"
 

--- a/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
-require File.expand_path(File.dirname(__FILE__) + "/../../shared_examples")
+require_relative "../../spec_helper"
+require_relative "../../shared_examples"
 
 RSpec.describe Avatars::UsersController do
   include_context "there are users with and without avatars"

--- a/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../../shared_examples"
 

--- a/modules/avatars/spec/models/user_spec.rb
+++ b/modules/avatars/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path("#{File.dirname(__FILE__)}/../spec_helper")
-require File.expand_path("#{File.dirname(__FILE__)}/../shared_examples")
+require_relative "../spec_helper"
+require_relative "../shared_examples"
 
 RSpec.describe User do
   let(:user) { build(:user) }

--- a/modules/avatars/spec/models/user_spec.rb
+++ b/modules/avatars/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 require_relative "../shared_examples"
 

--- a/modules/avatars/spec/services/avatars/update_service_spec.rb
+++ b/modules/avatars/spec/services/avatars/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 
 RSpec.describe Avatars::UpdateService do

--- a/modules/avatars/spec/services/avatars/update_service_spec.rb
+++ b/modules/avatars/spec/services/avatars/update_service_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe Avatars::UpdateService do
   let(:user_without_avatar) { build_stubbed(:user) }

--- a/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 require Rails.root + "spec/lib/api/v3/work_packages/eager_loading/eager_loading_mock_wrapper"

--- a/modules/budgets/spec/features/budgets/add_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/add_budget_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper"
 
 RSpec.describe "adding a new budget", :js do
   let(:project) { create(:project_with_types, members: project_members) }

--- a/modules/budgets/spec/features/budgets/copy_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/copy_budget_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper"
 
 RSpec.describe "Copying a budget", :js do
   let(:project) { create(:project, enabled_module_names: %i[budgets costs]) }

--- a/modules/budgets/spec/features/budgets/delete_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/delete_budget_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper.rb")
+require_relative "../../spec_helper"
 
 RSpec.describe "Deleting a budget", :js do
   let(:project) { create(:project, enabled_module_names: %i[budgets costs]) }

--- a/modules/budgets/spec/features/budgets/update_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/update_budget_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper.rb")
+require_relative "../../spec_helper"
 
 RSpec.describe "updating a budget", :js, :selenium do
   let(:project) do

--- a/modules/budgets/spec/features/costs_edit_fields_spec.rb
+++ b/modules/budgets/spec/features/costs_edit_fields_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe "Work Package budget fields",
                :js,

--- a/modules/budgets/spec/helpers/budgets_helper_spec.rb
+++ b/modules/budgets/spec/helpers/budgets_helper_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe BudgetsHelper do
   let(:project) { build(:project) }

--- a/modules/budgets/spec/models/budget_spec.rb
+++ b/modules/budgets/spec/models/budget_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe Budget do
   let(:budget) { build(:budget, project:) }

--- a/modules/budgets/spec/models/labor_budget_item_spec.rb
+++ b/modules/budgets/spec/models/labor_budget_item_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe LaborBudgetItem do
   let(:item) { build(:labor_budget_item, budget:, user:) }

--- a/modules/costs/spec/controllers/admin/cost_types_controller_spec.rb
+++ b/modules/costs/spec/controllers/admin/cost_types_controller_spec.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper.rb")
+require_relative "../../spec_helper"
 
 RSpec.describe Admin::CostTypesController do
   let(:admin)     { create(:admin) }

--- a/modules/costs/spec/controllers/costlog_controller_spec.rb
+++ b/modules/costs/spec/controllers/costlog_controller_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe CostlogController do
   include Cost::PluginSpecHelper

--- a/modules/costs/spec/controllers/hourly_rates_controller_spec.rb
+++ b/modules/costs/spec/controllers/hourly_rates_controller_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe HourlyRatesController do
   shared_let(:admin) { create(:admin) }

--- a/modules/costs/spec/controllers/time_entries_controller_spec.rb
+++ b/modules/costs/spec/controllers/time_entries_controller_spec.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe TimeEntriesController do
   include Redmine::I18n

--- a/modules/costs/spec/features/destroy_work_package_with_cost_entries_spec.rb
+++ b/modules/costs/spec/features/destroy_work_package_with_cost_entries_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe "Deleting time entries", :js do
   let(:project) { work_package.project }

--- a/modules/costs/spec/features/members_hourly_rates_spec.rb
+++ b/modules/costs/spec/features/members_hourly_rates_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe "hourly rates on a member", :js do
   let(:project) { build(:project) }

--- a/modules/costs/spec/features/time_entry_dialog_spec.rb
+++ b/modules/costs/spec/features/time_entry_dialog_spec.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe "time entry dialog", :js, with_flag: :track_start_and_end_times_for_time_entries do
   include Redmine::I18n

--- a/modules/costs/spec/features/view_own_rates_spec.rb
+++ b/modules/costs/spec/features/view_own_rates_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe "Only see your own rates", :js do
   let(:project) { work_package.project }

--- a/modules/costs/spec/helpers/costs/number_helper_spec.rb
+++ b/modules/costs/spec/helpers/costs/number_helper_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../../spec_helper"
+require_relative "../../spec_helper"
 
 RSpec.describe Costs::NumberHelper do
   describe "#parse_number_string" do

--- a/modules/costs/spec/models/cost_entry_spec.rb
+++ b/modules/costs/spec/models/cost_entry_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require_relative "../spec_helper"
 
 RSpec.describe CostEntry do
   include Cost::PluginSpecHelper

--- a/modules/costs/spec/models/cost_type_spec.rb
+++ b/modules/costs/spec/models/cost_type_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 
 RSpec.describe CostType do
   let(:klass) { CostType }

--- a/modules/costs/spec/models/default_hourly_rate_spec.rb
+++ b/modules/costs/spec/models/default_hourly_rate_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe DefaultHourlyRate do
   let(:project) { create(:project) }

--- a/modules/costs/spec/models/hourly_rate_spec.rb
+++ b/modules/costs/spec/models/hourly_rate_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe HourlyRate do
   let(:project) { create(:project) }

--- a/modules/costs/spec/models/permitted_params_spec.rb
+++ b/modules/costs/spec/models/permitted_params_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../spec_helper", __dir__)
+require_relative "../spec_helper"
 
 RSpec.describe PermittedParams do
   let(:user) { build(:user) }

--- a/modules/costs/spec/models/rate_spec.rb
+++ b/modules/costs/spec/models/rate_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe Rate do
   let(:rate) { build(:rate) }

--- a/modules/costs/spec/models/user_spec.rb
+++ b/modules/costs/spec/models/user_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe User do
   include Cost::PluginSpecHelper

--- a/modules/costs/spec/models/work_package_spec.rb
+++ b/modules/costs/spec/models/work_package_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require_relative "../spec_helper"
 
 RSpec.describe WorkPackage do
   let(:user) { create(:admin) }

--- a/modules/costs/spec/spec_helper.rb
+++ b/modules/costs/spec/spec_helper.rb
@@ -29,6 +29,6 @@
 # -- load spec_helper from OpenProject core
 require "spec_helper"
 
-require File.join(File.dirname(__FILE__), "plugin_spec_helper")
+require_relative "plugin_spec_helper"
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].sort.each { |f| require f }

--- a/modules/documents/spec/lib/redmine/access_control_spec.rb
+++ b/modules/documents/spec/lib/redmine/access_control_spec.rb
@@ -25,7 +25,7 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require File.dirname(__FILE__) + "/../../spec_helper"
+require_relative "../../spec_helper"
 
 RSpec.describe OpenProject::AccessControl do
   describe "manage documents permission" do

--- a/modules/documents/spec/mailers/documents_mailer_spec.rb
+++ b/modules/documents/spec/mailers/documents_mailer_spec.rb
@@ -25,7 +25,7 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe DocumentsMailer do
   let(:user) do

--- a/modules/documents/spec/models/document_category_spec.rb
+++ b/modules/documents/spec/models/document_category_spec.rb
@@ -25,7 +25,7 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe DocumentCategory do
   let(:project) { create(:project) }

--- a/modules/documents/spec/models/document_spec.rb
+++ b/modules/documents/spec/models/document_spec.rb
@@ -25,7 +25,7 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe Document do
   let(:documentation_category) { create(:document_category, name: "User documentation") }

--- a/modules/github_integration/spec/lib/open_project/github_integration/hook_handler_integration_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/hook_handler_integration_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../spec_helper", __dir__)
+require_relative "../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::HookHandler do
   subject(:process_webhook) do

--- a/modules/github_integration/spec/lib/open_project/github_integration/hook_handler_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/hook_handler_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../spec_helper", __dir__)
+require_relative "../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::HookHandler do
   describe "#process" do

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/check_run_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/check_run_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::NotificationHandler::CheckRun do
   subject(:process) { described_class.new.process(payload) }

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/helper_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/helper_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::NotificationHandler::Helper do
   subject(:handler) { Class.new.include(described_class).new }

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/issue_comment_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/issue_comment_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::NotificationHandler::IssueComment do
   subject(:process) { handler_instance.process(payload) }

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/pull_request_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::NotificationHandler::PullRequest do
   subject(:process) { handler_instance.process(payload) }

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../spec_helper", __dir__)
+require_relative "../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::NotificationHandler do
   let(:payload) { {} }

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_check_run_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_check_run_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::Services::UpsertCheckRun do
   subject(:upsert) { described_class.new.call(params, pull_request: github_pull_request) }

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_github_user_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_github_user_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::Services::UpsertGithubUser do
   subject(:upsert) { described_class.new.call(params) }

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_partial_pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_partial_pull_request_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::Services::UpsertPartialPullRequest do
   subject(:upsert) do

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../../../../spec_helper", __dir__)
+require_relative "../../../../spec_helper"
 
 RSpec.describe OpenProject::GithubIntegration::Services::UpsertPullRequest do
   subject(:upsert) { described_class.new.call(params, work_packages:) }

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 require "ladle"
 
 RSpec.describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 require "ladle"
 

--- a/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 require "ladle"
 
 RSpec.describe LdapGroups::SynchronizeFilterService, with_ee: %i[ldap_groups] do

--- a/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 require "ladle"
 

--- a/modules/meeting/spec/models/meeting_agenda_spec.rb
+++ b/modules/meeting/spec/models/meeting_agenda_spec.rb
@@ -27,7 +27,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe "MeetingAgenda" do
   before do

--- a/modules/meeting/spec/models/meeting_minutes_spec.rb
+++ b/modules/meeting/spec/models/meeting_minutes_spec.rb
@@ -27,7 +27,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe "MeetingMinutes" do
   before do

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -27,7 +27,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe Meeting do
   shared_let (:user1) { create(:user) }

--- a/modules/meeting/spec/models/permitted_params_spec.rb
+++ b/modules/meeting/spec/models/permitted_params_spec.rb
@@ -27,7 +27,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../spec_helper"
 
 RSpec.describe PermittedParams do
   let(:user) { build_stubbed(:user) }

--- a/modules/reporting/spec/controllers/cost_reports_controller_spec.rb
+++ b/modules/reporting/spec/controllers/cost_reports_controller_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../spec_helper")
+require_relative "../spec_helper"
 
 RSpec.describe CostReportsController do
   include OpenProject::Reporting::PluginSpecHelper

--- a/modules/reporting/spec/features/update_cost_report_spec.rb
+++ b/modules/reporting/spec/features/update_cost_report_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../spec_helper.rb")
+require_relative "../spec_helper"
 require_relative "support/pages/cost_report_page"
 
 RSpec.describe "updating a cost report's cost type", :js, :selenium do

--- a/modules/reporting/spec/models/cost_query/cache_spec.rb
+++ b/modules/reporting/spec/models/cost_query/cache_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.join(File.dirname(__FILE__), "..", "..", "support", "configuration_helper")
+require_relative "../../support/configuration_helper"
 
 RSpec.describe CostQuery::Cache do
   include OpenProject::Reporting::SpecHelper::ConfigurationHelper

--- a/modules/reporting/spec/models/cost_query/chaining_spec.rb
+++ b/modules/reporting/spec/models/cost_query/chaining_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe CostQuery, :reporting_query_helper do
   let(:project) { create(:project) }

--- a/modules/reporting/spec/models/cost_query/filter_spec.rb
+++ b/modules/reporting/spec/models/cost_query/filter_spec.rb
@@ -26,8 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
-require File.join(File.dirname(__FILE__), "..", "..", "support", "custom_field_filter")
+require_relative "../../spec_helper"
+require_relative "../../support/custom_field_filter"
 
 RSpec.describe CostQuery, :reporting_query_helper do
   minimal_query

--- a/modules/reporting/spec/models/cost_query/group_by_spec.rb
+++ b/modules/reporting/spec/models/cost_query/group_by_spec.rb
@@ -26,8 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
-require File.join(File.dirname(__FILE__), "..", "..", "support", "custom_field_filter")
+require_relative "../../spec_helper"
+require_relative "../../support/custom_field_filter"
 
 RSpec.describe CostQuery, :reporting_query_helper do
   let!(:type) { create(:type) }

--- a/modules/reporting/spec/models/cost_query/integration_spec.rb
+++ b/modules/reporting/spec/models/cost_query/integration_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe CostQuery, :reporting_query_helper do
   minimal_query

--- a/modules/reporting/spec/models/cost_query/operator_spec.rb
+++ b/modules/reporting/spec/models/cost_query/operator_spec.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe CostQuery::Operator, :reporting_query_helper do
   minimal_query

--- a/modules/reporting/spec/models/cost_query/result_spec.rb
+++ b/modules/reporting/spec/models/cost_query/result_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe CostQuery, :reporting_query_helper do
   before do

--- a/modules/reporting/spec/models/cost_query/validation_spec.rb
+++ b/modules/reporting/spec/models/cost_query/validation_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe "CostQuery::Validation" do
   class CostQuery::SomeBase

--- a/modules/reporting/spec/models/cost_query/walker_spec.rb
+++ b/modules/reporting/spec/models/cost_query/walker_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe CostQuery, :reporting_query_helper do
   minimal_query

--- a/modules/reporting/spec/requests/custom_field_cache_spec.rb
+++ b/modules/reporting/spec/requests/custom_field_cache_spec.rb
@@ -27,8 +27,8 @@
 #++
 
 require "spec_helper"
-require File.join(File.dirname(__FILE__), "..", "support", "custom_field_filter")
-require File.join(File.dirname(__FILE__), "..", "support", "configuration_helper")
+require_relative "../support/custom_field_filter"
+require_relative "../support/configuration_helper"
 
 RSpec.describe "Custom field filter and group by caching" do
   include OpenProject::Reporting::SpecHelper::CustomFieldFilterHelper

--- a/modules/two_factor_authentication/spec/services/token_delivery/message_bird_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_delivery/message_bird_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+require_relative "../../spec_helper"
 require "messagebird"
 
 RSpec.describe OpenProject::TwoFactorAuthentication::TokenStrategy::MessageBird do

--- a/modules/two_factor_authentication/spec/services/token_delivery/message_bird_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_delivery/message_bird_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require "messagebird"
 

--- a/modules/two_factor_authentication/spec/services/token_delivery/sns_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_delivery/sns_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 
 RSpec.describe OpenProject::TwoFactorAuthentication::TokenStrategy::Sns do

--- a/modules/two_factor_authentication/spec/services/token_delivery/sns_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_delivery/sns_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe OpenProject::TwoFactorAuthentication::TokenStrategy::Sns do
   describe "sending messages" do

--- a/modules/two_factor_authentication/spec/services/token_delivery/totp_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_delivery/totp_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + "/../../spec_helper")
+require_relative "../../spec_helper"
 
 RSpec.describe OpenProject::TwoFactorAuthentication::TokenStrategy::Totp do
   describe "sending messages" do

--- a/modules/two_factor_authentication/spec/services/token_delivery/totp_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_delivery/totp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 
 RSpec.describe OpenProject::TwoFactorAuthentication::TokenStrategy::Totp do

--- a/modules/webhooks/spec/controllers/webhooks_controller_spec.rb
+++ b/modules/webhooks/spec/controllers/webhooks_controller_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../spec_helper", __dir__)
+require_relative "../spec_helper"
 
 RSpec.describe Webhooks::Incoming::HooksController do
   let(:hook) { double(OpenProject::Webhooks::Hook) }

--- a/modules/webhooks/spec/lib/hook_spec.rb
+++ b/modules/webhooks/spec/lib/hook_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../spec_helper", __dir__)
+require_relative "../spec_helper"
 
 RSpec.describe OpenProject::Webhooks::Hook do
   describe "#relative_url" do

--- a/modules/webhooks/spec/lib/webhooks_spec.rb
+++ b/modules/webhooks/spec/lib/webhooks_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("../spec_helper", __dir__)
+require_relative "../spec_helper"
 
 RSpec.describe OpenProject::Webhooks do
   describe ".register_hook" do

--- a/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 require_relative "eager_loading_mock_wrapper"

--- a/spec/lib/api/v3/work_packages/eager_loading/custom_actions_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/custom_actions_integration_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 require_relative "eager_loading_mock_wrapper"

--- a/spec/lib/api/v3/work_packages/eager_loading/principals_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/principals_integration_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 require_relative "eager_loading_mock_wrapper"

--- a/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++require 'rspec'
+#++
 
 require "spec_helper"
 require_relative "eager_loading_mock_wrapper"

--- a/spec/lib/journal_formatter/day_count_spec.rb
+++ b/spec/lib/journal_formatter/day_count_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper.rb")
+require "spec_helper"
 
 RSpec.describe JournalFormatter::DayCount do
   let(:klass) { described_class }

--- a/spec/lib/journal_formatter/ignore_non_working_days_spec.rb
+++ b/spec/lib/journal_formatter/ignore_non_working_days_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper.rb")
+require "spec_helper"
 
 RSpec.describe OpenProject::JournalFormatter::IgnoreNonWorkingDays do
   let(:klass) { described_class }

--- a/spec/lib/journal_formatter/visibility_spec.rb
+++ b/spec/lib/journal_formatter/visibility_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper.rb")
+require "spec_helper"
 
 RSpec.describe OpenProject::JournalFormatter::Visibility do
   let(:instance) { described_class.new(build(:project_journal)) }

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -25,10 +25,8 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require "spec_helper"
-require File.expand_path("../support/shared/become_member", __dir__)
 
-require "support/shared/acts_as_watchable"
+require "spec_helper"
 
 RSpec.describe News do
   include BecomeMember

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -27,7 +27,6 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/shared/become_member", __dir__)
 
 RSpec.describe Project do
   include BecomeMember

--- a/spec/permissions/copy_projects_spec.rb
+++ b/spec/permissions/copy_projects_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe ProjectsController, "copy_projects permission", type: :controller do
   include PermissionSpecs

--- a/spec/permissions/delete_work_packages_spec.rb
+++ b/spec/permissions/delete_work_packages_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require_relative "../support/permission_specs"
+require "support/permission_specs"
 
 RSpec.describe WorkPackages::BulkController, "delete_work_packages permission", type: :controller do
   include PermissionSpecs

--- a/spec/permissions/edit_own_work_package_notes.rb
+++ b/spec/permissions/edit_own_work_package_notes.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe WorkPackages::ActivitiesTabController, "edit_own_work_package_notes permission", type: :controller do # rubocop:disable RSpec/EmptyExampleGroup
   include PermissionSpecs

--- a/spec/permissions/edit_project_attributes_spec.rb
+++ b/spec/permissions/edit_project_attributes_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe Overviews::OverviewsController, "edit_project_attributes permission", # rubocop:disable RSpec/EmptyExampleGroup,RSpec/SpecFilePathFormat
                type: :controller do

--- a/spec/permissions/edit_project_life_cycles_spec.rb
+++ b/spec/permissions/edit_project_life_cycles_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe Overviews::OverviewsController, "edit_project_life_cycles permission", # rubocop:disable RSpec/EmptyExampleGroup,RSpec/SpecFilePathFormat
                type: :controller do

--- a/spec/permissions/edit_work_package_notes.rb
+++ b/spec/permissions/edit_work_package_notes.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe WorkPackages::ActivitiesTabController, "edit_work_package_notes permission", type: :controller do # rubocop:disable RSpec/EmptyExampleGroup
   include PermissionSpecs

--- a/spec/permissions/export_work_packages_spec.rb
+++ b/spec/permissions/export_work_packages_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe WorkPackagesController, "export_work_packages permission", type: :controller do
   include PermissionSpecs

--- a/spec/permissions/manage_forums_spec.rb
+++ b/spec/permissions/manage_forums_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe ForumsController, "manage_forums permission", type: :controller do
   include PermissionSpecs

--- a/spec/permissions/manage_repositories_spec.rb
+++ b/spec/permissions/manage_repositories_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe RepositoriesController, "manage_repository permission", type: :controller do
   include PermissionSpecs

--- a/spec/permissions/select_project_custom_fields_spec.rb
+++ b/spec/permissions/select_project_custom_fields_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe Projects::Settings::ProjectCustomFieldsController, "select_project_custom_fields mappings permission", # rubocop:disable RSpec/EmptyExampleGroup,RSpec/SpecFilePathFormat
                type: :controller do

--- a/spec/permissions/view_project_attributes_spec.rb
+++ b/spec/permissions/view_project_attributes_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe Overviews::OverviewsController, "view_project_attributes permission", # rubocop:disable RSpec/EmptyExampleGroup,RSpec/SpecFilePathFormat
                type: :controller do

--- a/spec/permissions/view_project_life_cycles_spec.rb
+++ b/spec/permissions/view_project_life_cycles_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe Overviews::OverviewsController, "view_project_life_cycles permission", # rubocop:disable RSpec/EmptyExampleGroup,RSpec/SpecFilePathFormat
                type: :controller do

--- a/spec/permissions/view_work_packages_spec.rb
+++ b/spec/permissions/view_work_packages_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require File.expand_path("../support/permission_specs", __dir__)
+require "support/permission_specs"
 
 RSpec.describe WorkPackagesController, "view_work_packages permission", type: :controller do # rubocop:disable RSpec/EmptyExampleGroup,RSpec/MultipleDescribes
   include PermissionSpecs

--- a/spec/permissions/work_packages_bulk_spec.rb
+++ b/spec/permissions/work_packages_bulk_spec.rb
@@ -27,7 +27,7 @@
 #++
 
 require "spec_helper"
-require_relative "../support/permission_specs"
+require "support/permission_specs"
 
 RSpec.describe WorkPackages::BulkController, "edit_work_packages permission", type: :controller do
   include PermissionSpecs

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 
 ENV["RAILS_ENV"] ||= "test"
-require File.expand_path("../config/environment", __dir__)
+require_relative "../config/environment"
 require "factory_bot"
 require "factory_bot_rails"
 require "rspec/rails"

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path("shared/become_member", __dir__)
+require_relative "shared/become_member"
 
 module PermissionSpecs
   def self.included(base)

--- a/spec/validator/secure_context_uri_validator_spec.rb
+++ b/spec/validator/secure_context_uri_validator_spec.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
-
 require "spec_helper"
 
 RSpec.describe SecureContextUriValidator do


### PR DESCRIPTION
Use `require` where possible, otherwise `require_relative`, remove different forms of explicit path construction.