### PR TITLE
implementation/60980 - Define restricted extension on work package journals for query safety

### DIFF
--- a/app/components/work_packages/activities_tab/journals/index_component.rb
+++ b/app/components/work_packages/activities_tab/journals/index_component.rb
@@ -71,7 +71,7 @@ module WorkPackages
           API::V3::Activities::ActivityEagerLoadingWrapper.wrap(
             work_package
               .journals
-              .restricted_visible(@work_package.project)
+              .restricted_visible
               .includes(:user, :customizable_journals, :attachable_journals, :storable_journals, :notifications)
               .reorder(version: journal_sorting)
               .with_sequence_version

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -113,14 +113,6 @@ class Journal < ApplicationRecord
   scope :for_wiki_page, -> { where(journable_type: "WikiPage") }
   scope :for_work_package, -> { where(journable_type: "WorkPackage") }
   scope :for_meeting, -> { where(journable_type: "Meeting") }
-  scope :restricted_visible, ->(project) {
-    if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
-        User.current.allowed_in_project?(:view_comments_with_restricted_visibility, project)
-      all
-    else
-      where(restricted: false)
-    end
-  }
 
   # In conjunction with the included Comparable module, allows comparison of journal records
   # based on their corresponding version numbers, creation timestamps and IDs.

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -30,7 +30,16 @@ module WorkPackage::Journalized
   extend ActiveSupport::Concern
 
   included do
-    acts_as_journalized
+    acts_as_journalized do
+      def restricted_visible
+        if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
+            User.current.allowed_in_project?(:view_comments_with_restricted_visibility, proxy_association.owner.project)
+          all
+        else
+          where(restricted: false)
+        end
+      end
+    end
 
     # This one is here only to ease reading
     module JournalizedProcs

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -30,7 +30,7 @@ module WorkPackage::Journalized
   extend ActiveSupport::Concern
 
   included do
-    acts_as_journalized do
+    acts_as_journalized journals_association_extension: proc {
       def restricted_visible
         if OpenProject::FeatureDecisions.comments_with_restricted_visibility_active? &&
             User.current.allowed_in_project?(:view_comments_with_restricted_visibility, proxy_association.owner.project)
@@ -39,7 +39,7 @@ module WorkPackage::Journalized
           where(restricted: false)
         end
       end
-    end
+    }
 
     # This one is here only to ease reading
     module JournalizedProcs

--- a/lib/api/v3/activities/activities_by_work_package_api.rb
+++ b/lib/api/v3/activities/activities_by_work_package_api.rb
@@ -38,7 +38,7 @@ module API
 
             journals = @work_package
               .journals
-              .restricted_visible(@work_package.project)
+              .restricted_visible
               .includes(:data,
                         :customizable_journals,
                         :attachable_journals,

--- a/lib_static/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -67,16 +67,18 @@ module Acts
       end
 
       # This call will start journaling the model.
-      def acts_as_journalized(options = {}, &)
+      def acts_as_journalized(options = {})
         return if journaled?
 
         include_aaj_modules
+
+        journals_association_extension = options.delete(:journals_association_extension) || proc {}
 
         prepare_journaled_options(options)
 
         has_many(:journals, -> {
           order("#{Journal.table_name}.version ASC")
-        }, **has_many_journals_options, &)
+        }, **has_many_journals_options, &journals_association_extension)
       end
 
       private

--- a/lib_static/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -67,16 +67,16 @@ module Acts
       end
 
       # This call will start journaling the model.
-      def acts_as_journalized(options = {})
+      def acts_as_journalized(options = {}, &)
         return if journaled?
 
         include_aaj_modules
 
         prepare_journaled_options(options)
 
-        has_many :journals, -> {
+        has_many(:journals, -> {
           order("#{Journal.table_name}.version ASC")
-        }, **has_many_journals_options
+        }, **has_many_journals_options, &)
       end
 
       private

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -65,50 +67,6 @@ RSpec.describe Journal do
 
         expect(described_class.count)
           .to eq 0
-      end
-    end
-  end
-
-  describe ".restricted_visible scope", with_flag: { comments_with_restricted_visibility: true } do
-    let(:work_package) { create(:work_package) }
-    let(:admin) { create(:admin) }
-    let(:user) { create(:user) }
-    let!(:restricted_note) do
-      create(:work_package_journal,
-             user: admin,
-             notes: "First comment by admin",
-             journable: work_package,
-             restricted: true,
-             version: 2)
-    end
-
-    subject { described_class.restricted_visible(work_package.project) }
-
-    before do
-      login_as user
-    end
-
-    context "when the user cannot see restricted" do
-      before do
-        mock_permissions_for(user) do |mock|
-          mock.allow_in_work_package :view_work_packages, work_package:
-        end
-      end
-
-      it "does not return the restricted journal" do
-        expect(subject.map(&:id)).not_to include(restricted_note.id)
-      end
-    end
-
-    context "when the user can see restricted" do
-      before do
-        mock_permissions_for(user) do |mock|
-          mock.allow_in_project(:view_comments_with_restricted_visibility, project: work_package.project)
-        end
-      end
-
-      it "returns the restricted journal" do
-        expect(subject.map(&:id)).to include(restricted_note.id)
       end
     end
   end


### PR DESCRIPTION
AR association extensions ensure the `restricted_visible` scope is only visible on the work package journals association.

https://github.com/opf/openproject/pull/18091#discussion_r1993034943