### PR TITLE
Correctly handle when expires_in is a string

### DIFF
--- a/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/hooks/hook.rb
@@ -65,10 +65,19 @@ module OpenProject::OpenIDConnect
         if OpenIDConnect::Provider.exists?(slug: context.dig(:auth_hash, :provider))
           session["omniauth.oidc_access_token"] = context.dig(:auth_hash, :credentials, :token)
           session["omniauth.oidc_refresh_token"] = context.dig(:auth_hash, :credentials, :refresh_token)
-          session["omniauth.oidc_expires_in"] = context.dig(:auth_hash, :credentials, :expires_in)
+          session["omniauth.oidc_expires_in"] = parse_expires_in(context.dig(:auth_hash, :credentials, :expires_in))
         end
 
         nil
+      end
+
+      private
+
+      def parse_expires_in(expires_in)
+        expires_in = expires_in.to_i
+        return nil if expires_in.zero?
+
+        expires_in
       end
     end
   end

--- a/modules/openid_connect/spec/lib/open_project/openid_connect/hooks/hook_spec.rb
+++ b/modules/openid_connect/spec/lib/open_project/openid_connect/hooks/hook_spec.rb
@@ -66,6 +66,26 @@ RSpec.describe OpenProject::OpenIDConnect::Hooks::Hook do
         expect(session).to be_empty
       end
     end
+
+    context "when expires_in is missing" do
+      let(:expires_in) { nil }
+
+      it "does not store an expires_in" do
+        call_hook
+
+        expect(session["omniauth.oidc_expires_in"]).to be_nil
+      end
+    end
+
+    context "when expires_in is passed as a string" do
+      let(:expires_in) { "7200" }
+
+      it "stores expires_in as integer" do
+        call_hook
+
+        expect(session["omniauth.oidc_expires_in"]).to eq(7200)
+      end
+    end
   end
 
   describe "#user_logged_in" do


### PR DESCRIPTION
Azure/Entra ID seems to return stringly typed expiry dates under certain conditions. We'll now also handle properly readable numeric strings.

Missing expiration times or non-numeric strings, such as "banana" will be treated as not knowing the expiration time.

# Ticket
https://community.openproject.org/wp/62299

# Merge checklist

- [x] Added/updated tests