### PR TITLE
Translate more button in meetings table

### DIFF
--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -89,7 +89,7 @@ module Meetings
     def action_menu
       render(Primer::Alpha::ActionMenu.new) do |menu|
         menu.with_show_button(icon: "kebab-horizontal",
-                              "aria-label": "More",
+                              "aria-label": t(:label_more),
                               scheme: :invisible,
                               data: {
                                 "test-selector": "more-button"

--- a/modules/meeting/app/components/recurring_meetings/row_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/row_component.rb
@@ -137,7 +137,7 @@ module RecurringMeetings
     def action_menu
       render(Primer::Alpha::ActionMenu.new) do |menu|
         menu.with_show_button(icon: "kebab-horizontal",
-                              "aria-label": "More",
+                              "aria-label": t(:label_more),
                               scheme: :invisible,
                               data: {
                                 "test-selector": "more-button"


### PR DESCRIPTION
# What are you trying to accomplish?
Use existing translation for button popup.

# What approach did you choose and why?
Simply remove hardcoded "More" string to translatable :label_more.