### PR TITLE
[#62319] PDF Export: Templates selection not translated

### DIFF
--- a/app/models/type/pdf_export_templates.rb
+++ b/app/models/type/pdf_export_templates.rb
@@ -84,10 +84,4 @@ class Type::PdfExportTemplates
     ordered_template_ids.insert(position, template_id)
     @type.export_templates_order = ordered_template_ids
   end
-
-  private
-
-  def built_in_templates
-    ::WorkPackage::PDFExport::Templates::TEMPLATES
-  end
 end

--- a/app/models/type/pdf_export_templates.rb
+++ b/app/models/type/pdf_export_templates.rb
@@ -29,6 +29,8 @@
 #++
 
 class Type::PdfExportTemplates
+  include WorkPackage::PDFExport::Templates
+
   Template = Data.define(:id, :label, :caption, :enabled)
 
   def initialize(type)

--- a/app/models/work_package/pdf_export/templates.rb
+++ b/app/models/work_package/pdf_export/templates.rb
@@ -29,16 +29,18 @@
 #++
 
 module WorkPackage::PDFExport::Templates
-  TEMPLATES = [
-    {
-      id: "attributes",
-      label: I18n.t("pdf_generator.template_attributes.label"),
-      caption: I18n.t("pdf_generator.template_attributes.caption")
-    },
-    {
-      id: "contract",
-      label: I18n.t("pdf_generator.template_contract.label"),
-      caption: I18n.t("pdf_generator.template_contract.caption")
-    }
-  ].freeze
+  def built_in_templates
+    [
+      {
+        id: "attributes",
+        label: I18n.t("pdf_generator.template_attributes.label"),
+        caption: I18n.t("pdf_generator.template_attributes.caption")
+      },
+      {
+        id: "contract",
+        label: I18n.t("pdf_generator.template_contract.label"),
+        caption: I18n.t("pdf_generator.template_contract.caption")
+      }
+    ]
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/62319

# What are you trying to achieve?
Fix a bug with translations cached in a module constant

# What approach did you choose and why?
Don't use a constant for strings with translations
