### PR TITLE
[62300] Fix 500 error when clicking manual scheduling mode button

### DIFF
--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -21,7 +21,7 @@
                   control.with_item(
                     tag: :a,
                     icon: :pin,
-                    href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: true).permit!),
+                    href: dialog_content_with(schedule_manually: true),
                     data: {
                       turbo_stream: true,
                       qa_selected: schedule_manually
@@ -33,7 +33,7 @@
                   control.with_item(
                     tag: :a,
                     icon: "op-auto-date",
-                    href: work_package_datepicker_dialog_content_path(params.merge(schedule_manually: false).permit!),
+                    href: dialog_content_with(schedule_manually: false),
                     data: {
                       turbo_stream: true,
                       qa_selected: !schedule_manually

--- a/app/components/work_packages/date_picker/form_component.rb
+++ b/app/components/work_packages/date_picker/form_component.rb
@@ -67,6 +67,17 @@ module WorkPackages
         end
       end
 
+      def dialog_content_with(schedule_manually:)
+        dialog_params = params.without(:on, :controller, :action)
+                              .merge(schedule_manually:)
+                              .permit!
+        if work_package.new_record?
+          new_work_package_datepicker_dialog_content_path("new", dialog_params)
+        else
+          work_package_datepicker_dialog_content_path(work_package, dialog_params)
+        end
+      end
+
       def disabled?
         !schedule_manually
       end

--- a/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "New work package datepicker",
 
   let(:wp_page_create) { Pages::FullWorkPackageCreate.new(project:) }
   let(:date_field) { wp_page_create.edit_field(:combinedDate) }
+  let(:datepicker) { date_field.datepicker }
 
   before do
     login_as(user)
@@ -64,6 +65,9 @@ RSpec.describe "New work package datepicker",
     date_field.set_active_date due
 
     date_field.expect_duration 3
+
+    # Bug #62300 - Manual scheduling mode button can be clicked without producing a 500 error
+    datepicker.click_manual_scheduling_mode
 
     date_field.save!
     date_field.expect_inactive!

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -171,6 +171,14 @@ module Components
       end
     end
 
+    def click_manual_scheduling_mode
+      container.click_link I18n.t("work_packages.datepicker_modal.mode.manual")
+    end
+
+    def click_automatic_scheduling_mode
+      container.click_link I18n.t("work_packages.datepicker_modal.mode.automatic")
+    end
+
     def expect_working_days_only_disabled
       expect(container)
         .to have_field("work_package[ignore_non_working_days]", disabled: true)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62300

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Fix 500 error occurring when clicking on "Manual" scheduling mode in a datepicker within a new work package form.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

For new work packages, the generated URL was incorrect (`#show` instead of `#new` action) and it then lead to a `ActiveRecord::RecordNotFound` for id=`new`.

The fix is to use a different url when the record is new.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
