### PR TITLE
Translate WikiPage text attribute

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1131,6 +1131,7 @@ en:
       wiki_page:
         parent_title: "Parent page"
         redirect_existing_links: "Redirect existing links"
+        text: "Page content"
       work_package:
         begin_insertion: "Begin of the insertion"
         begin_deletion: "Begin of the deletion"

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Wiki Activity", :js do
 
     within("li.op-activity-list--item", match: :first) do
       expect(page)
-        .to have_css("li", text: "Text changed (Details)")
+        .to have_css("li", text: "Page content changed (Details)")
       expect(page)
         .to have_link("Details")
     end

--- a/spec/lib/journal_formatter/wiki_diff_spec.rb
+++ b/spec/lib/journal_formatter/wiki_diff_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe OpenProject::JournalFormatter::WikiDiff do
   end
   let(:wiki_instance) { klass.new(wiki_journal) }
   let(:wiki_key) { "text" }
+  let(:wiki_attribute_name) { WikiPage.human_attribute_name(wiki_key) }
   let(:path) do # path
     url_helper.wiki_diff_compare_project_wiki_path(id: wiki_page.slug,
                                                    project_id: project.identifier,
@@ -74,7 +75,7 @@ RSpec.describe OpenProject::JournalFormatter::WikiDiff do
     describe "a wiki diff for a wiki journal correctly" do
       let(:expected) do
         I18n.t(:text_journal_changed_with_diff,
-               label: "<strong>#{wiki_key.camelize}</strong>",
+               label: "<strong>#{wiki_attribute_name}</strong>",
                link:)
       end
 


### PR DESCRIPTION
# What are you trying to accomplish?
"Translate" activity record for Wiki pages changes visible at Users' activity page (/users/me) 

## Screenshots
![Screenshot_20250319_202117](https://github.com/user-attachments/assets/281fa5f0-3d7b-419c-af04-29432e8ef3e0)

# What approach did you choose and why?
Journaling system uses ActiveRecord I18N locale definitions. Adding it.