### PR TITLE
[#62316] PDF Export Report: no attributes are exported if the default columns of a query is used

### DIFF
--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -74,9 +74,13 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
   end
 
   def get_columns
-    return [] if query.column_names.empty? && wants_report?
+    return [] if wants_report? && without_columns?
 
     super
+  end
+
+  def without_columns?
+    ActiveModel::Type::Boolean.new.cast(options[:no_columns])
   end
 
   def export!

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
@@ -104,8 +104,10 @@ export default class FormController extends Controller<HTMLFormElement> {
         columns.forEach((v) => {
           query.append('columns[]', v);
         });
-        if (columns.length === 0) {
-          query.append('columns[]', ''); // add empty entry to indicate no columns
+        if (columns.length === 0 || value === '') {
+          // add special parameter to indicate no columns
+          // for an empty columns array the default columns would be used
+          query.append('no_columns', '1');
         }
         // Skip hidden fields (looped through query options or rails form fields)
       } else if (!['query', 'utf8', 'authenticity_token', 'format'].includes(key)) {
@@ -113,6 +115,7 @@ export default class FormController extends Controller<HTMLFormElement> {
         query.append(key, value);
       }
     });
+    console.log(query.toString());
     return query.toString();
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
@@ -115,7 +115,6 @@ export default class FormController extends Controller<HTMLFormElement> {
         query.append(key, value);
       }
     });
-    console.log(query.toString());
     return query.toString();
   }
 }

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe "work package export", :js, :selenium do
       context "with no columns" do
         let(:query_columns) { [] }
         let(:expected_params) do
-          default_expected_params.merge({ columns: [""], pdf_export_type: "report" })
+          default_expected_params.merge({ columns: [""], pdf_export_type: "report", no_columns: "1" })
         end
 
         it "does export a pdf" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62316

# What are you trying to achieve?
OP clears out the columns in a query if the default columns are used. So we can't differentiate for an empty query columns array, if this should be empty for an export (PDF report only) or the default columns are used.

# What approach did you choose and why?
Make it explicit and use a dedicated parameter for the export job.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
