### PR TITLE
Add a guard for TimeEntry.hours being nil

### DIFF
--- a/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
+++ b/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
@@ -151,7 +151,7 @@ class CostQuery::PDF::TimesheetGenerator
       { content: format_date(spent_on), rowspan: entry.comments.present? ? 2 : 1 },
       entry.work_package&.subject || "",
       with_times_column? ? format_spent_on_time(entry) : nil,
-      format_hours(entry.hours),
+      format_hours(entry.hours || 0),
       entry.activity&.name || ""
     ].compact
   end
@@ -428,7 +428,7 @@ class CostQuery::PDF::TimesheetGenerator
   end
 
   def format_hours(hours)
-    return "" if hours < 0
+    return "" if hours.nil? || hours < 0
 
     DurationConverter.output(hours)
   end


### PR DESCRIPTION
# Ticket
https://appsignal.com/openproject-gmbh/sites/674718f1d2a5e4a7cb8b2298/exceptions/incidents/931/samples/674718f1d2a5e4a7cb8b2298-1374656534855470022417424624601

# What are you trying to achieve?
TimeEntry.hours should not but is maybe nil, so the export crashes

# What approach did you choose and why?
Add guards

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
