### PR TITLE
update omniauth-saml to 10.1.6, remove duplicate definition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ PATH
   remote: modules/auth_saml
   specs:
     openproject-auth_saml (1.0.0)
-      omniauth-saml (~> 1.10.5)
+      omniauth-saml (~> 1.10.6)
 
 PATH
   remote: modules/avatars
@@ -840,9 +840,9 @@ GEM
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     okcomputer (1.19.0)
-    omniauth-saml (1.10.5)
+    omniauth-saml (1.10.6)
       omniauth (~> 1.3, >= 1.3.2)
-      ruby-saml (~> 1.17)
+      ruby-saml (~> 1.18)
     op-clamav-client (3.4.2)
     open4 (1.3.4)
     openid_connect (2.2.1)
@@ -1109,7 +1109,7 @@ GEM
     ruby-prof (1.7.1)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
-    ruby-saml (1.17.0)
+    ruby-saml (1.18.0)
       nokogiri (>= 1.13.10)
       rexml
     ruby2_keywords (0.0.5)
@@ -1370,7 +1370,6 @@ DEPENDENCIES
   omniauth!
   omniauth-openid-connect!
   omniauth-openid_connect-providers!
-  omniauth-saml (~> 1.10.1)
   op-clamav-client (~> 3.4)
   openproject-auth_plugins!
   openproject-auth_saml!
@@ -1734,7 +1733,7 @@ CHECKSUMS
   omniauth (1.9.2)
   omniauth-openid-connect (0.4.1)
   omniauth-openid_connect-providers (0.2.0)
-  omniauth-saml (1.10.5) sha256=946f0c6eb9266642835ad54eca1d0725f5e5cf26e18d1fd7711dabeceddfea8c
+  omniauth-saml (1.10.6) sha256=13dde22f4fd1beff0ef2d6dae576f7b68594f159990e8e886d8a02b32397afbd
   op-clamav-client (3.4.2) sha256=f28d697d11758a2ba3dc530cfdf4871a00ecd517631e8bac30dee30cd6012964
   open4 (1.3.4) sha256=a1df037310624ecc1ea1d81264b11c83e96d0c3c1c6043108d37d396dcd0f4b1
   openid_connect (2.2.1) sha256=31264e85b5a36e33dff5e31560cc176175c26f30c260d7e95af93ff0065f3101
@@ -1858,7 +1857,7 @@ CHECKSUMS
   ruby-prof (1.7.1) sha256=026393448cf92fd24a91739bf71ccd2bfe88fe8a1401ee8afc4948a16d62ea24
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-rc4 (0.1.5) sha256=00cc40a39d20b53f5459e7ea006a92cf584e9bc275e2a6f7aa1515510e896c03
-  ruby-saml (1.17.0) sha256=0419839ba3312d255e35fe3cc7ae155e4a241fd468796caebcf61164aa01b8a9
+  ruby-saml (1.18.0) sha256=de342a55925fd5ce6114d0802651c324428c0fec26e7fe52bf3a7cfa54dbfa6d
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubytree (2.1.1) sha256=4925016356a81730e982f1f8c3b5f8da461f18906c77d238bad4c4ba896abd41
   rubyzip (2.3.2) sha256=3f57e3935dc2255c414484fbf8d673b4909d8a6a57007ed754dde39342d2373f

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -1,9 +1,3 @@
-##
-# Defines OpenProject (CE) modules and their dependencies
-# the dependencies from the gemspec from a git repo are ignored
-# see also https://github.com/bundler/bundler/issues/1041
-gem 'omniauth-saml', '~> 1.10.1'
-
 group :development, :test do
   gem 'ladle'
 end

--- a/modules/auth_saml/openproject-auth_saml.gemspec
+++ b/modules/auth_saml/openproject-auth_saml.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*"] + %w(README.md)
 
-  s.add_dependency "omniauth-saml", "~> 1.10.5"
+  s.add_dependency "omniauth-saml", "~> 1.10.6"
   s.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
WP [#62370](https://community.openproject.org/projects/openproject/work_packages/62370/activity)

- the PR updates omniauth-saml to 1.10.6 and also removes a duplicate dependency definition to omniauth-saml