### PR TITLE
implementation/60983 define quoting criteria for work package comments with restricted visibility

### DIFF
--- a/app/components/concerns/work_packages/activities_tab/stimulus_controllers.rb
+++ b/app/components/concerns/work_packages/activities_tab/stimulus_controllers.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module WorkPackages
+  module ActivitiesTab
+    module StimulusControllers
+      def index_stimulus_controller(suffix = nil) = "work-packages--activities-tab--index#{suffix}"
+      def restricted_comment_stimulus_controller(suffix = nil) = "work-packages--activities-tab--restricted-comment#{suffix}"
+      def quote_comments_stimulus_controller(suffix = nil) = "work-packages--activities-tab--quote-comment#{suffix}"
+
+      def items_index_selector = "##{WorkPackages::ActivitiesTab::IndexComponent.wrapper_key}"
+
+      def add_comment_selector
+        "##{WorkPackages::ActivitiesTab::IndexComponent.add_comment_wrapper_key}"
+      end
+    end
+  end
+end

--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -33,6 +33,7 @@
                 end
                 if adding_comment_allowed?
                   journals_wrapper_container.with_row(
+                    id: add_comment_wrapper_key,
                     classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
                     px: 2,
                     py: 3,

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -45,6 +45,9 @@ module WorkPackages
         @deferred = deferred
       end
 
+      def self.add_comment_wrapper_key = "work-packages-activities-tab-add-comment-component"
+      delegate :add_comment_wrapper_key, to: :class
+
       private
 
       attr_reader :work_package, :filter, :last_server_timestamp, :deferred

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -35,6 +35,7 @@ module WorkPackages
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
       include WorkPackages::ActivitiesTab::SharedHelpers
+      include WorkPackages::ActivitiesTab::StimulusControllers
 
       def initialize(work_package:, last_server_timestamp:, filter: :all, deferred: false)
         super
@@ -95,9 +96,6 @@ module WorkPackages
       def adding_comment_allowed?
         User.current.allowed_in_work_package?(:add_work_package_notes, @work_package)
       end
-
-      def index_stimulus_controller(suffix = nil) = "work-packages--activities-tab--index#{suffix}"
-      def restricted_comment_stimulus_controller(suffix = nil) = "work-packages--activities-tab--restricted-comment#{suffix}"
 
       def unsaved_changes_confirmation_message
         I18n.t("activities.work_packages.activity_tab.unsaved_changes_confirmation_message")

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -136,18 +136,29 @@ module WorkPackages
           menu.with_item(label: t("js.label_quote_comment"),
                          tag: :button,
                          content_arguments: {
-                           data: {
-                             action: "click->work-packages--activities-tab--index#quote",
-                             "content-param": journal.notes,
-                             "user-id-param": journal.user_id,
-                             "user-name-param": journal.user.name,
-                             "text-wrote-param": t(:text_wrote),
-                             test_selector: "op-wp-journal-#{journal.id}-quote"
-                           }
+                           data: quote_action_data_attributes
                          }) do |item|
             item.with_leading_visual_icon(icon: :quote)
           end
         end
+
+        def quote_action_data_attributes # rubocop:disable Metrics/AbcSize
+          {
+            controller: quote_comments_stimulus_controller,
+            "application-target": "dynamic",
+            action: "click->#{quote_comments_stimulus_controller}#quote:prevent",
+            quote_comments_stimulus_controller("-content-param") => journal.notes,
+            quote_comments_stimulus_controller("-user-id-param") => journal.user_id,
+            quote_comments_stimulus_controller("-user-name-param") => journal.user.name,
+            quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
+            quote_comments_stimulus_controller("-#{index_stimulus_controller}-outlet") => "##{index_stimulus_controller_wrapper_key}", # rubocop:disable Layout/LineLength
+            test_selector: "op-wp-journal-#{journal.id}-quote"
+          }
+        end
+
+        def quote_comments_stimulus_controller(suffix = nil) = "work-packages--activities-tab--quote-comment#{suffix}"
+        def index_stimulus_controller(suffix = nil) = "work-packages--activities-tab--index#{suffix}"
+        def index_stimulus_controller_wrapper_key = WorkPackages::ActivitiesTab::IndexComponent.wrapper_key
       end
     end
   end

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -150,15 +150,23 @@ module WorkPackages
             quote_comments_stimulus_controller("-content-param") => journal.notes,
             quote_comments_stimulus_controller("-user-id-param") => journal.user_id,
             quote_comments_stimulus_controller("-user-name-param") => journal.user.name,
+            quote_comments_stimulus_controller("-is-restricted-param") => journal.restricted?,
             quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
-            quote_comments_stimulus_controller("-#{index_stimulus_controller}-outlet") => "##{index_stimulus_controller_wrapper_key}", # rubocop:disable Layout/LineLength
+            quote_comments_stimulus_controller("-#{index_stimulus_controller}-outlet") => items_index_selector,
+            quote_comments_stimulus_controller("-#{restricted_comment_stimulus_controller}-outlet") => add_comment_selector,
             test_selector: "op-wp-journal-#{journal.id}-quote"
           }
         end
 
         def quote_comments_stimulus_controller(suffix = nil) = "work-packages--activities-tab--quote-comment#{suffix}"
         def index_stimulus_controller(suffix = nil) = "work-packages--activities-tab--index#{suffix}"
-        def index_stimulus_controller_wrapper_key = WorkPackages::ActivitiesTab::IndexComponent.wrapper_key
+        def restricted_comment_stimulus_controller(suffix = nil) = "work-packages--activities-tab--restricted-comment#{suffix}"
+
+        def items_index_selector = "##{WorkPackages::ActivitiesTab::IndexComponent.wrapper_key}"
+
+        def add_comment_selector
+          "##{WorkPackages::ActivitiesTab::IndexComponent.add_comment_wrapper_key}"
+        end
       end
     end
   end

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -31,9 +31,10 @@ module WorkPackages
     module Journals
       class ItemComponent < ApplicationComponent
         include ApplicationHelper
-        include WorkPackages::ActivitiesTab::SharedHelpers
         include OpPrimer::ComponentHelpers
         include OpTurbo::Streamable
+        include WorkPackages::ActivitiesTab::SharedHelpers
+        include WorkPackages::ActivitiesTab::StimulusControllers
 
         def initialize(journal:, filter:, grouped_emoji_reactions:, state: :show)
           super
@@ -156,16 +157,6 @@ module WorkPackages
             quote_comments_stimulus_controller("-#{restricted_comment_stimulus_controller}-outlet") => add_comment_selector,
             test_selector: "op-wp-journal-#{journal.id}-quote"
           }
-        end
-
-        def quote_comments_stimulus_controller(suffix = nil) = "work-packages--activities-tab--quote-comment#{suffix}"
-        def index_stimulus_controller(suffix = nil) = "work-packages--activities-tab--index#{suffix}"
-        def restricted_comment_stimulus_controller(suffix = nil) = "work-packages--activities-tab--restricted-comment#{suffix}"
-
-        def items_index_selector = "##{WorkPackages::ActivitiesTab::IndexComponent.wrapper_key}"
-
-        def add_comment_selector
-          "##{WorkPackages::ActivitiesTab::IndexComponent.add_comment_wrapper_key}"
         end
       end
     end

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -495,7 +495,7 @@ export default class IndexController extends Controller {
     return this.element.querySelector('opce-ckeditor-augmented-textarea');
   }
 
-  private getCkEditorInstance():ICKEditorInstance | null {
+  getCkEditorInstance():ICKEditorInstance | null {
     const AngularCkEditorElement = this.getCkEditorElement();
     return AngularCkEditorElement ? jQuery(AngularCkEditorElement).data('editor') as ICKEditorInstance : null;
   }
@@ -647,44 +647,6 @@ export default class IndexController extends Controller {
     const ckEditorInstance = this.getCkEditorInstance();
     if (ckEditorInstance) {
       setTimeout(() => ckEditorInstance.editing.view.focus(), timeout);
-    }
-  }
-
-  quote(event:Event) {
-    event.preventDefault();
-    const target = event.currentTarget as HTMLElement;
-    const userId = target.dataset.userIdParam as string;
-    const userName = target.dataset.userNameParam as string;
-    const textWrote = target.dataset.textWroteParam as string;
-    const content = target.dataset.contentParam as string;
-
-    const quotedText = this.quotedText(content, userId, userName, textWrote);
-    const formVisible = !this.formRowTarget.classList.contains('d-none');
-    if (formVisible) {
-      this.insertQuoteOnExistingEditor(quotedText);
-    } else {
-      this.openEditorWithInitialData(quotedText);
-    }
-  }
-
-  private quotedText(rawComment:string, userId:string, userName:string, textWrote:string) {
-    const quoted = rawComment.split('\n')
-      .map((line:string) => `\n> ${line}`)
-      .join('');
-
-    // if we ever change CKEditor or how @mentions work this will break
-    return `<mention class="mention" data-id="${userId}" data-type="user" data-text="@${userName}">@${userName}</mention> ${textWrote}:\n\n${quoted}`;
-  }
-
-  insertQuoteOnExistingEditor(quotedText:string) {
-    const ckEditorInstance = this.getCkEditorInstance();
-    if (ckEditorInstance) {
-      const editorData = ckEditorInstance.getData({ trim: false });
-      if (editorData.endsWith('<br>') || editorData.endsWith('\n')) {
-        ckEditorInstance.setData(`${editorData}${quotedText}`);
-      } else {
-        ckEditorInstance.setData(`${editorData}\n\n${quotedText}`);
-      }
     }
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
@@ -1,0 +1,88 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import type IndexController from './index.controller';
+
+type QuoteParams = {
+  userId:string;
+  userName:string;
+  textWrote:string;
+  content:string;
+};
+
+export default class QuoteCommentController extends Controller {
+  static outlets = ['work-packages--activities-tab--index'];
+
+  declare readonly workPackagesActivitiesTabIndexOutlet:IndexController;
+
+  quote({ params: { userId, userName, textWrote, content } }:{ params:QuoteParams }) {
+    const quotedText = this.quotedText(content, userId, userName, textWrote);
+
+    if (this.isFormVisible) {
+      this.insertQuoteOnExistingEditor(quotedText);
+    } else {
+      this.openEditorWithInitialData(quotedText);
+    }
+  }
+
+  private quotedText(rawComment:string, userId:string, userName:string, textWrote:string) {
+    const quoted = rawComment.split('\n')
+      .map((line:string) => `\n> ${line}`)
+      .join('');
+
+    // if we ever change CKEditor or how @mentions work this will break
+    return `<mention class="mention" data-id="${userId}" data-type="user" data-text="@${userName}">@${userName}</mention> ${textWrote}:\n\n${quoted}`;
+  }
+
+  private insertQuoteOnExistingEditor(quotedText:string) {
+    if (this.ckEditorInstance) {
+      const editorData = this.ckEditorInstance.getData({ trim: false });
+
+      if (editorData.endsWith('<br>') || editorData.endsWith('\n')) {
+        this.ckEditorInstance.setData(`${editorData}${quotedText}`);
+      } else {
+        this.ckEditorInstance.setData(`${editorData}\n\n${quotedText}`);
+      }
+    }
+  }
+
+  private openEditorWithInitialData(quotedText:string) {
+    this.workPackagesActivitiesTabIndexOutlet.openEditorWithInitialData(quotedText);
+  }
+
+  private get ckEditorInstance() {
+    return this.workPackagesActivitiesTabIndexOutlet.getCkEditorInstance();
+  }
+
+  private get isFormVisible():boolean {
+    return !this.workPackagesActivitiesTabIndexOutlet.formRowTarget.classList.contains('d-none');
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
@@ -29,21 +29,25 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
+
 import type IndexController from './index.controller';
+import type RestrictedCommentController from './restricted-comment.controller';
 
 type QuoteParams = {
   userId:string;
   userName:string;
   textWrote:string;
   content:string;
+  isRestricted:boolean;
 };
 
 export default class QuoteCommentController extends Controller {
-  static outlets = ['work-packages--activities-tab--index'];
+  static outlets = ['work-packages--activities-tab--index', 'work-packages--activities-tab--restricted-comment'];
 
   declare readonly workPackagesActivitiesTabIndexOutlet:IndexController;
+  declare readonly workPackagesActivitiesTabRestrictedCommentOutlet:RestrictedCommentController;
 
-  quote({ params: { userId, userName, textWrote, content } }:{ params:QuoteParams }) {
+  quote({ params: { userId, userName, textWrote, content, isRestricted } }:{ params:QuoteParams }) {
     const quotedText = this.quotedText(content, userId, userName, textWrote);
 
     if (this.isFormVisible) {
@@ -51,6 +55,8 @@ export default class QuoteCommentController extends Controller {
     } else {
       this.openEditorWithInitialData(quotedText);
     }
+
+    this.setCommentRestriction(isRestricted);
   }
 
   private quotedText(rawComment:string, userId:string, userName:string, textWrote:string) {
@@ -71,6 +77,13 @@ export default class QuoteCommentController extends Controller {
       } else {
         this.ckEditorInstance.setData(`${editorData}\n\n${quotedText}`);
       }
+    }
+  }
+
+  private setCommentRestriction(isRestricted:boolean) {
+    if (isRestricted && !this.workPackagesActivitiesTabRestrictedCommentOutlet.restrictedCheckboxTarget.checked) {
+      this.workPackagesActivitiesTabRestrictedCommentOutlet.restrictedCheckboxTarget.checked = isRestricted;
+      this.workPackagesActivitiesTabRestrictedCommentOutlet.toggleBackgroundColor();
     }
   }
 

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -148,11 +148,15 @@ RSpec.describe "Work package comments with restricted visibility",
     it "allows editing and quoting restricted comments" do
       activity_tab.expect_journal_notes(text: "A (restricted) comment by admin")
 
-      activity_tab.within_journal_entry(first_comment) do
-        page.find_test_selector("op-wp-journal-#{first_comment.id}-action-menu").click
+      activity_tab.edit_comment(first_comment, text: "A (restricted) comment by admin - EDITED")
 
-        expect(page).to have_test_selector("op-wp-journal-#{first_comment.id}-edit")
-        expect(page).to have_test_selector("op-wp-journal-#{first_comment.id}-quote")
+      activity_tab.within_journal_entry(first_comment) do
+        activity_tab.expect_journal_notes(text: "A (restricted) comment by admin - EDITED")
+      end
+
+      activity_tab.quote_comment(first_comment)
+      page.within_test_selector("op-work-package-journal-form-element") do
+        expect(page).to have_checked_field("Restrict visibility")
       end
     end
   end

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -138,8 +138,15 @@ RSpec.describe "Work package comments with restricted visibility",
   context "with a user that is allowed to view, create and edit all comments" do
     current_user { project_admin }
 
+    let(:unrestricted_comment) do
+      create(:work_package_journal,
+             user: project_admin, notes: "An unrestricted comment by member",
+             journable: work_package, version: (work_package.journals.reload.last.version + 1), restricted: false)
+    end
+
     before do
       first_comment
+      unrestricted_comment
 
       wp_page.visit!
       wp_page.wait_for_activity_tab
@@ -155,6 +162,11 @@ RSpec.describe "Work package comments with restricted visibility",
       end
 
       activity_tab.quote_comment(first_comment)
+      page.within_test_selector("op-work-package-journal-form-element") do
+        expect(page).to have_checked_field("Restrict visibility")
+      end
+
+      activity_tab.quote_comment(unrestricted_comment)
       page.within_test_selector("op-work-package-journal-form-element") do
         expect(page).to have_checked_field("Restrict visibility")
       end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/60983

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Quoting a restricted comment implicitly enables restriction if it did not exist before. When quoting both restricted and unrestricted comments within the same comment- the restricted state should triumph

This is to limit the risk of accidental/inadvertent leaking of the comment.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/2a5d59ff-65b7-40e3-a6cb-355a2d41f948


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Extracted quoting functionality from index.controller- leveraged [stimulus outlets](https://stimulus.hotwired.dev/reference/outlets) for inter-controller interfacing. This might be a good option to incrementally break down this controller @brunopagno 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
