### PR TITLE
[62341] Correctly convert dates when timezone is negative in datepicker

### DIFF
--- a/frontend/src/app/core/datetime/timezone.service.ts
+++ b/frontend/src/app/core/datetime/timezone.service.ts
@@ -132,6 +132,14 @@ export class TimezoneService {
     return moment.duration(input, unit).toISOString();
   }
 
+  public utcDateToISODateString(date:Date):string {
+    return moment.utc(date).format('YYYY-MM-DD');
+  }
+
+  public utcDatesToISODateStrings(dates:Date[]):string[] {
+    return dates.map((date) => this.utcDateToISODateString(date));
+  }
+
   public formattedDuration(durationString:string, unit:'hour'|'days' = 'hour'):string {
     switch (unit) {
       case 'hour':

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -157,14 +157,21 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
     return null;
   }
 
+  private isDifferentFromDatePickerSelectedDates(isoDates:string[]):boolean {
+    const datePickerSelectedDates = this.datePickerInstance.datepickerInstance.selectedDates;
+    const isoDatePickerSelectedDates = datePickerSelectedDates.map((date) => this.timezoneService.formattedISODate(date));
+    return !_.isEqual(isoDates, isoDatePickerSelectedDates);
+  }
+
   // set dates on flatpickr, trying to avoid jumping to a different month when possible
   private setDatePickerDates(dates:Date[], jumpToDate:Date|null) {
     const monthBefore = this.datePickerInstance.datepickerInstance.currentMonth;
     const yearBefore = this.datePickerInstance.datepickerInstance.currentYear;
 
     // only set dates if they changed to avoid jumping
-    if (!_.isEqual(dates, this.datePickerInstance.datepickerInstance.selectedDates)) {
-      this.datePickerInstance.setDates(dates);
+    const isoDates = this.timezoneService.utcDatesToISODateStrings(dates);
+    if (this.isDifferentFromDatePickerSelectedDates(isoDates)) {
+      this.datePickerInstance.setDates(isoDates);
     }
 
     // jump to the date that has been changed if there is one
@@ -202,8 +209,9 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
     return date ? new Date(date) : null;
   }
 
-  private currentDates():Date[] {
-    return _.compact([this.startDateValue, this.dueDateValue]);
+  private currentDates():string[] {
+    const compactedDates = _.compact([this.startDateValue, this.dueDateValue]);
+    return this.timezoneService.utcDatesToISODateStrings(compactedDates);
   }
 
   private initializeDatepicker() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -261,13 +261,13 @@ export default class PreviewController extends DialogPreviewController {
   }
 
   private lastClickedDate(changedDates:Date[]):Date|null {
-    const flatPickrDates = changedDates.map((date) => this.timezoneService.formattedISODate(date));
+    const flatPickrDates = this.timezoneService.utcDatesToISODateStrings(changedDates);
     if (flatPickrDates.length === 1) {
       return this.toDate(flatPickrDates[0]);
     }
 
     const fieldDates = _.compact([this.currentStartDate, this.currentDueDate])
-                        .map((date) => this.timezoneService.formattedISODate(date));
+                        .map((date) => this.timezoneService.utcDateToISODateString(date));
     const diff = _.difference(flatPickrDates, fieldDates);
     return this.toDate(diff[0]);
   }
@@ -409,7 +409,7 @@ export default class PreviewController extends DialogPreviewController {
     if (targetFieldID) {
       const inputField = document.getElementById(targetFieldID);
       if (inputField) {
-        (inputField as HTMLInputElement).value = this.timezoneService.formattedISODate(Date.now());
+        (inputField as HTMLInputElement).value = this.timezoneService.utcDateToISODateString(new Date(Date.now()));
         inputField.dispatchEvent(new Event('input'));
       }
     }
@@ -417,7 +417,7 @@ export default class PreviewController extends DialogPreviewController {
 
   private datetoIso(date:Date|null):string {
     if (date) {
-      return this.timezoneService.formattedISODate(date);
+      return this.timezoneService.utcDateToISODateString(date);
     }
     return '';
   }

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
   let(:current_user) { user }
   let(:work_package) { bug_wp }
 
+  shared_context "with default browser timezone" do
+    let(:_comment) do
+      "This context does not try to override the browser timezone. " \
+        "It will be the same as the system (positive offset for European devs, UTC for CI)."
+    end
+  end
+
+  shared_context "with a negative browser timezone (New York)", driver: :chrome_new_york_time_zone do
+    let(:_comment) do
+      "This context overrides browser timezone to be America/New_York. " \
+        "Timezone offset is -4/-5 hours (EDT/EST)."
+    end
+  end
+
   def apply_and_expect_saved(attributes)
     date_field.save!
 
@@ -80,29 +94,32 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     datepicker.expect_visible
   end
 
-  context "when only start_date set, updating duration (scenario 1)" do
-    let(:current_attributes) do
-      {
-        start_date: Date.parse("2021-02-08"),
-        due_date: nil,
-        duration: nil
-      }
-    end
+  for_each_context "with default browser timezone",
+                   "with a negative browser timezone (New York)" do
+    context "when only start_date set, updating duration (scenario 1)" do
+      let(:current_attributes) do
+        {
+          start_date: Date.parse("2021-02-08"),
+          due_date: nil,
+          duration: nil
+        }
+      end
 
-    it "sets finish date" do
-      datepicker.expect_start_date "2021-02-08"
-      datepicker.expect_due_date "", visible: false
-      datepicker.expect_duration ""
+      it "sets finish date" do
+        datepicker.expect_start_date "2021-02-08"
+        datepicker.expect_due_date "", visible: false
+        datepicker.expect_duration ""
 
-      datepicker.set_duration 10
+        datepicker.set_duration 10
 
-      datepicker.expect_start_date "2021-02-08"
-      datepicker.expect_due_date "2021-02-19"
-      datepicker.expect_duration 10
+        datepicker.expect_start_date "2021-02-08"
+        datepicker.expect_due_date "2021-02-19"
+        datepicker.expect_duration 10
 
-      apply_and_expect_saved duration: 10,
-                             start_date: Date.parse("2021-02-08"),
-                             due_date: Date.parse("2021-02-19")
+        apply_and_expect_saved duration: 10,
+                               start_date: Date.parse("2021-02-08"),
+                               due_date: Date.parse("2021-02-19")
+      end
     end
   end
 
@@ -432,27 +449,30 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     end
   end
 
-  describe "when only start date set, changing the finish date to the past with today (Scenario 13a)" do
-    let(:current_attributes) do
-      {
-        start_date: 2.days.from_now,
-        due_date: nil,
-        duration: nil,
-        ignore_non_working_days: true
-      }
-    end
+  for_each_context "with default browser timezone",
+                   "with a negative browser timezone (New York)" do
+    describe "when only start date set, changing the finish date to the past with today (Scenario 13a)" do
+      let(:current_attributes) do
+        {
+          start_date: 2.days.from_now,
+          due_date: nil,
+          duration: nil,
+          ignore_non_working_days: true
+        }
+      end
 
-    it "unsets the other two values" do
-      datepicker.expect_start_date 2.days.from_now.to_date.iso8601
-      datepicker.expect_due_date "", visible: false
+      it "unsets the other two values" do
+        datepicker.expect_start_date 2.days.from_now.to_date.iso8601
+        datepicker.expect_due_date "", visible: false
 
-      datepicker.enable_due_date
+        datepicker.enable_due_date
 
-      datepicker.set_today :due
+        datepicker.set_today :due
 
-      datepicker.expect_start_date ""
-      datepicker.expect_due_date Time.zone.today.iso8601
-      datepicker.expect_duration ""
+        datepicker.expect_start_date ""
+        datepicker.expect_due_date Time.zone.today.iso8601
+        datepicker.expect_duration ""
+      end
     end
   end
 
@@ -847,42 +867,45 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     end
   end
 
-  describe "when all values set and duration highlighted, selecting date in datepicker" do
-    let(:current_attributes) do
-      {
-        start_date: Date.parse("2021-02-08"),
-        due_date: Date.parse("2021-02-11"),
-        duration: 4
-      }
-    end
+  for_each_context "with default browser timezone",
+                   "with a negative browser timezone (New York)" do
+    describe "when all values set and duration highlighted, selecting date in datepicker" do
+      let(:current_attributes) do
+        {
+          start_date: Date.parse("2021-02-08"),
+          due_date: Date.parse("2021-02-11"),
+          duration: 4
+        }
+      end
 
-    it "sets start to the selected value, keeps finish date and derives duration" do
-      datepicker.expect_start_date "2021-02-08"
-      datepicker.expect_due_date "2021-02-11"
-      datepicker.expect_duration 4
+      it "sets start to the selected value, keeps finish date and derives duration" do
+        datepicker.expect_start_date "2021-02-08"
+        datepicker.expect_due_date "2021-02-11"
+        datepicker.expect_duration 4
 
-      # Focus duration
-      datepicker.duration_field.click
-      datepicker.expect_duration_highlighted
+        # Focus duration
+        datepicker.duration_field.click
+        datepicker.expect_duration_highlighted
 
-      # Select date in datepicker
-      datepicker.select_day 5
+        # Select date in datepicker
+        datepicker.select_day 5
 
-      datepicker.expect_start_date "2021-02-05"
-      datepicker.expect_due_date "2021-02-11"
-      datepicker.expect_duration 5
+        datepicker.expect_start_date "2021-02-05"
+        datepicker.expect_due_date "2021-02-11"
+        datepicker.expect_duration 5
 
-      # Focus is on finish date
-      datepicker.expect_due_highlighted
-      datepicker.select_day 15
+        # Focus is on finish date
+        datepicker.expect_due_highlighted
+        datepicker.select_day 15
 
-      datepicker.expect_start_date "2021-02-05"
-      datepicker.expect_due_date "2021-02-15"
-      datepicker.expect_duration 7
+        datepicker.expect_start_date "2021-02-05"
+        datepicker.expect_due_date "2021-02-15"
+        datepicker.expect_duration 7
 
-      apply_and_expect_saved duration: 7,
-                             start_date: Date.parse("2021-02-05"),
-                             due_date: Date.parse("2021-02-15")
+        apply_and_expect_saved duration: 7,
+                               start_date: Date.parse("2021-02-05"),
+                               due_date: Date.parse("2021-02-15")
+      end
     end
   end
 
@@ -1048,40 +1071,43 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     end
   end
 
-  context "when setting start and due date through today links" do
-    let(:current_attributes) do
-      {
-        start_date: nil,
-        due_date: nil,
-        duration: nil,
-        ignore_non_working_days: true
-      }
-    end
+  for_each_context "with default browser timezone",
+                   "with a negative browser timezone (New York)" do
+    context "when setting start and due date through today links" do
+      let(:current_attributes) do
+        {
+          start_date: nil,
+          due_date: nil,
+          duration: nil,
+          ignore_non_working_days: true
+        }
+      end
 
-    it "allows to persist that value (Regression #44140)" do
-      datepicker.expect_start_date "", visible: false
-      datepicker.expect_due_date ""
-      datepicker.expect_duration ""
+      it "allows to persist that value (Regression #44140)" do
+        datepicker.expect_start_date "", visible: false
+        datepicker.expect_due_date ""
+        datepicker.expect_duration ""
 
-      today = Time.zone.today
-      today_str = today.iso8601
+        today = Time.zone.today
+        today_str = today.iso8601
 
-      datepicker.enable_start_date
+        datepicker.enable_start_date
 
-      # Setting start will set active to due
-      datepicker.set_today "start"
-      datepicker.expect_start_date today_str
-      datepicker.expect_due_highlighted
+        # Setting start will set active to due
+        datepicker.set_today "start"
+        datepicker.expect_start_date today_str
+        datepicker.expect_due_highlighted
 
-      datepicker.set_today "due"
-      datepicker.expect_due_date today_str
-      datepicker.expect_start_highlighted
+        datepicker.set_today "due"
+        datepicker.expect_due_date today_str
+        datepicker.expect_start_highlighted
 
-      datepicker.expect_duration 1
+        datepicker.expect_duration 1
 
-      apply_and_expect_saved start_date: today,
-                             due_date: today,
-                             duration: 1
+        apply_and_expect_saved start_date: today,
+                               due_date: today,
+                               duration: 1
+      end
     end
   end
 

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -665,15 +665,20 @@ RSpec.describe "date inplace editor", :js, :selenium, with_settings: { date_form
       start_date.activate!
       start_date.expect_active!
 
-      start_date.datepicker.expect_year "2016"
-      start_date.datepicker.expect_month "January"
-      start_date.datepicker.select_day "25"
+      datepicker.expect_start_date("2016-01-02")
+      datepicker.expect_duration("")
+      datepicker.expect_year "2016"
+      datepicker.expect_month "January"
 
-      sleep 2
+      datepicker.enable_due_date
+      datepicker.select_day "25"
 
-      start_date.datepicker.expect_year "2016"
-      start_date.datepicker.expect_month "January"
-      start_date.datepicker.expect_day "25"
+      datepicker.expect_start_date("2016-01-02")
+      datepicker.expect_due_date("2016-01-25")
+      datepicker.expect_duration("24")
+      datepicker.expect_year "2016"
+      datepicker.expect_month "January"
+      datepicker.expect_day "25"
 
       start_date.save!
       start_date.expect_inactive!

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -108,7 +108,10 @@ register_better_cuprite "en"
 RSpec.configure do |config|
   config.around(:each, :js, type: :feature) do |example|
     # Skip if driver is explicitly requested
-    next if example.metadata[:driver]
+    if example.metadata[:driver]
+      example.run
+      next
+    end
 
     original_driver = Capybara.javascript_driver
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62341



<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

The dates are off by 1 or 2 days when in a negative timezone, both in the calendar view and the date fields.

## Screenshots

Video in to linked ticket.

# What approach did you choose and why?

flatpickr is using local dates at midnight internally and in its callback functions. In datepicker component and stimulus controller we are using UTC dates at midnight.

And the timezone service is assuming local time when converting to iso dates.

Usingtimezones with positive offset is ok, but with negative offset, the conversions and comparisons do not work properly.

Fixed it by explicitly converting from utc date to iso string, and using iso date strings when setting flatpickr dates, avoiding any issues.

It could be a good idea to use iso date strings everywhere as much as possible instead of always jumping back and forth from dates to iso string.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
