### PR TITLE
Translate TimeEntry model name

### DIFF
--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -65,8 +65,10 @@ en:
         spent_on: Date
         start_time: Start time
         end_time: Finish time
-
     models:
+      time_entry:
+        one: "Time entry"
+        other: "Time entries"
       cost_type:
         one: "Cost type"
         other: "Cost types"
@@ -198,9 +200,6 @@ en:
   text_warning_hidden_elements: "Some entries may have been excluded from the aggregation."
 
   week: "week"
-
-  js:
-    text_are_you_sure: "Are you sure?"
 
   api_v3:
     errors:

--- a/modules/costs/config/locales/js-en.yml
+++ b/modules/costs/config/locales/js-en.yml
@@ -28,6 +28,7 @@
 
 en:
   js:
+    text_are_you_sure: "Are you sure?"
     work_packages:
       property_groups:
         costs: "Costs"


### PR DESCRIPTION
# What are you trying to accomplish?
Translate TimeEntry model name when(and not only) mass deleting work packages

## Screenshots
![Screenshot_20250320_133309](https://github.com/user-attachments/assets/9974cc6a-e48b-4cc7-923f-0d8e75c1c82d)

# What approach did you choose and why?
Codebase's fine and use I18n already. Just add translation for model.