### PR TITLE
[62362] Show "working days only" checkbox only if date form is shown too

### DIFF
--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -48,23 +48,25 @@
             end
           end
 
-          first_row.with_column(mb: 1) do
-            render(
-              Primer::Alpha::CheckBox.new(
-                name: "work_package[ignore_non_working_days]",
-                id: "work_package_ignore_non_working_days",
-                label: I18n.t("work_packages.datepicker_modal.ignore_non_working_days.title"),
-                checked: !work_package.ignore_non_working_days,
-                disabled: disabled_checkbox?,
-                test_selector: "op-datepicker-modal--ignore-non-working-days",
-                value: 0,
-                unchecked_value: 1,
-                data: { "work-packages--date-picker--preview-target": "fieldInput",
-                        action: "work-packages--date-picker--preview#markFieldAsTouched " \
-                                "work-packages--date-picker--preview#inputChanged " \
-                                "work-packages--date-picker--preview#setIgnoreNonWorkingDays" }
+          if show_date_form
+            first_row.with_column(mb: 1) do
+              render(
+                Primer::Alpha::CheckBox.new(
+                  name: "work_package[ignore_non_working_days]",
+                  id: "work_package_ignore_non_working_days",
+                  label: I18n.t("work_packages.datepicker_modal.ignore_non_working_days.title"),
+                  checked: !work_package.ignore_non_working_days,
+                  disabled: disabled_checkbox?,
+                  test_selector: "op-datepicker-modal--ignore-non-working-days",
+                  value: 0,
+                  unchecked_value: 1,
+                  data: { "work-packages--date-picker--preview-target": "fieldInput",
+                          action: "work-packages--date-picker--preview#markFieldAsTouched " \
+                                  "work-packages--date-picker--preview#inputChanged " \
+                                  "work-packages--date-picker--preview#setIgnoreNonWorkingDays" }
+                )
               )
-            )
+            end
           end
         end
       end

--- a/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
+++ b/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
@@ -105,10 +105,12 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
       it "cannot change scheduling mode to automatic" do
         open_date_picker
         datepicker.expect_manual_scheduling_mode
+        datepicker.expect_working_days_only_checkbox_visible
 
         datepicker.toggle_scheduling_mode
         datepicker.expect_automatic_scheduling_mode
 
+        datepicker.expect_no_working_days_only_checkbox_visible
         datepicker.expect_save_button_disabled
       end
     end

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -179,6 +179,16 @@ module Components
       container.click_link I18n.t("work_packages.datepicker_modal.mode.automatic")
     end
 
+    def expect_working_days_only_checkbox_visible
+      expect(container)
+        .to have_field(I18n.t("work_packages.datepicker_modal.ignore_non_working_days.title"), disabled: :all)
+    end
+
+    def expect_no_working_days_only_checkbox_visible
+      expect(container)
+        .to have_no_field(I18n.t("work_packages.datepicker_modal.ignore_non_working_days.title"))
+    end
+
     def expect_working_days_only_disabled
       expect(container)
         .to have_field("work_package[ignore_non_working_days]", disabled: true)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62362

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When clicking the checkbox, it takes all form data and sends it to the server for rerendering the form with the value updated.

Problem is: when the date form is not displayed and the "no predecessors" message is displayed instead, there is no form data, so it sends incomplete data to the server, and the server renders a minimalist form.

See video from ticket

# What approach did you choose and why?

The fix is to hide the checkbox too if the other form elements are hidden. No checkbox, no click, no problem.


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
