### PR TITLE
[62261] Fix error displayed when switching parent to automatic

### DIFF
--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -249,6 +249,9 @@ class WorkPackages::DatePickerController < ApplicationController
 
   def set_date_attributes_to_work_package
     wp_params = work_package_datepicker_params
+    if wp_params["schedule_manually"] == "false"
+      wp_params = wp_params.without("start_date", "due_date")
+    end
 
     if wp_params.present?
       WorkPackages::SetAttributesService

--- a/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
+++ b/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
@@ -391,4 +391,75 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
       end
     end
   end
+
+  describe "Bug #62261: Invalid error displayed when switching parent to automatic" do
+    context "when changing dates to the ones that would be computed by automatic mode and then switching to automatic" do
+      let_work_packages(<<~TABLE)
+        hierarchy    | start date | due date   | scheduling mode
+        work package | 2025-01-27 | 2025-02-06 | manual
+          child      |            |            | manual
+      TABLE
+
+      it "does not display a 'read-only' error" do
+        open_date_picker
+        datepicker.set_start_date("")
+        datepicker.set_due_date("")
+
+        datepicker.toggle_scheduling_mode
+
+        datepicker.expect_start_date "", disabled: true
+        datepicker.expect_due_date "", disabled: true
+        read_only_error = I18n.t("activerecord.errors.messages.error_readonly")
+        expect(datepicker.container).to have_no_text(/#{Regexp.escape(read_only_error)}/i)
+
+        apply_and_expect_saved(
+          start_date: nil,
+          due_date: nil,
+          duration: nil,
+          schedule_manually: false
+        )
+      end
+    end
+
+    context "when manually changing dates of an automatically scheduled successor, and then switch back to automatic" do
+      let_work_packages(<<~TABLE)
+        subject      | start date | due date   | scheduling mode | predecessors
+        predecessor  | 2025-01-14 | 2025-01-16 | manual          |
+        work package | 2025-01-17 | 2025-01-17 | automatic       | predecessor
+      TABLE
+
+      it "does not display a 'must be set to a later date' error" do
+        open_date_picker
+        datepicker.toggle_scheduling_mode
+        datepicker.expect_manual_scheduling_mode
+
+        # change dates in manual mode
+        datepicker.set_start_date("2025-01-06")
+        datepicker.set_due_date("2025-01-08")
+
+        datepicker.expect_start_date "2025-01-06"
+        datepicker.expect_due_date "2025-01-08"
+        datepicker.expect_duration "3"
+
+        # switch back to automatic
+        datepicker.toggle_scheduling_mode
+        datepicker.expect_automatic_scheduling_mode
+
+        # dates should be derived from predecessors, and the duration is the
+        # initial one despite the manual change
+        datepicker.expect_start_date "2025-01-17", disabled: true
+        datepicker.expect_due_date "2025-01-17", disabled: true
+        datepicker.expect_duration "1"
+
+        expect(datepicker.container).to have_no_text(/Can only be set to ....-..-.. or later/i)
+
+        apply_and_expect_saved(
+          start_date: Date.parse("2025-01-17"),
+          due_date: Date.parse("2025-01-17"),
+          duration: 1,
+          schedule_manually: false
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62261

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When switching a parent to automatic scheduling mode, the date picker displayed an error because the dates set in manual mode are reused.

## Screenshots

See 3 videos from the linked ticket

# What approach did you choose and why?

Dismiss dates from `params` when the scheduling mode is automatic, so that the dates are always computed.

This is a much simpler fix than the one I tried in #18353. If this one is approved, I'll close #18353.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
