### PR TITLE
[61960] Can now select automatic scheduling for new work packages

### DIFF
--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -39,7 +39,6 @@
                       qa_selected: !schedule_manually
                     },
                     test_selector: "op-datepicker-modal--scheduling_automatic",
-                    disabled: work_package.new_record?,
                     label: I18n.t("work_packages.datepicker_modal.mode.automatic"),
                     selected: !schedule_manually
                   )

--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -43,6 +43,45 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
     end
   end
 
+  context "when the work package is new" do
+    let(:work_package) { build(:work_package) }
+
+    context "when manually scheduled" do
+      let(:schedule_manually) { true }
+
+      it "shows the date form" do
+        expect(dialog_content).to have_field(I18n.t("attributes.start_date"))
+        expect(dialog_content).to have_field(I18n.t("attributes.due_date"))
+      end
+
+      it "has an enabled save button" do
+        expect(dialog_content).to have_button(I18n.t("button_save"), disabled: false)
+      end
+
+      it "can switch to automatic scheduling mode" do
+        expect(dialog_content).to have_link(I18n.t("work_packages.datepicker_modal.mode.automatic"))
+      end
+    end
+
+    context "when automatically scheduled" do
+      let(:schedule_manually) { false }
+
+      it "does not show the date form" do
+        expect(dialog_content).to have_no_field(I18n.t("attributes.start_date"), disabled: :all)
+        expect(dialog_content).to have_no_field(I18n.t("attributes.due_date"), disabled: :all)
+      end
+
+      it "displays a blank slate explaining it can't be automatically scheduled because there are no predecessors" do
+        expect(dialog_content).to have_text(I18n.t("work_packages.datepicker_modal.blankslate.title"))
+        expect(dialog_content).to have_text(I18n.t("work_packages.datepicker_modal.blankslate.description"))
+      end
+
+      it "has a disabled save button" do
+        expect(dialog_content).to have_button(I18n.t("button_save"), disabled: true)
+      end
+    end
+  end
+
   context "when manually scheduled" do
     let(:schedule_manually) { true }
     let(:work_package) { build_stubbed(:work_package) }
@@ -54,6 +93,10 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
 
     it "has an enabled save button" do
       expect(dialog_content).to have_button(I18n.t("button_save"), disabled: false)
+    end
+
+    it "can switch to automatic scheduling mode" do
+      expect(dialog_content).to have_link(I18n.t("work_packages.datepicker_modal.mode.automatic"))
     end
   end
 

--- a/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
@@ -69,6 +69,11 @@ RSpec.describe "New work package datepicker",
     # Bug #62300 - Manual scheduling mode button can be clicked without producing a 500 error
     datepicker.click_manual_scheduling_mode
 
+    # Bug #61960 - Automatic scheduling mode button can be clicked
+    datepicker.click_automatic_scheduling_mode
+    datepicker.expect_save_button_disabled
+    datepicker.click_manual_scheduling_mode
+
     date_field.save!
     date_field.expect_inactive!
     date_field.expect_value "#{start} - #{due}"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/61960

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When creating a new work package and opening datepicker, make it possible to click "Automatic" scheduling mode.

It will disable the save button and display the message explaining that there are no predecessors, but at least it's consistent with the bahvior with persisted work packages.

## Screenshots

none

# What approach did you choose and why?

remove the condition for `disabled:` for the segmented control button

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
