### PR TITLE
Activity for deleted project life cycle steps

### DIFF
--- a/lib/open_project/journal_formatter/project_life_cycle_step_active.rb
+++ b/lib/open_project/journal_formatter/project_life_cycle_step_active.rb
@@ -32,7 +32,8 @@ class OpenProject::JournalFormatter::ProjectLifeCycleStepActive < JournalFormatt
   def render(key, values, options = { html: true })
     return if !values[0] == !values[1]
 
-    step = Project::LifeCycleStep.find(key[/\d+/])
+    step = Project::LifeCycleStep.find_by(id: key[/\d+/])
+    return unless step
 
     name = step.definition.name
     label = options[:html] ? content_tag(:strong, name) : name

--- a/lib/open_project/journal_formatter/project_life_cycle_step_dates.rb
+++ b/lib/open_project/journal_formatter/project_life_cycle_step_dates.rb
@@ -30,7 +30,8 @@
 
 class OpenProject::JournalFormatter::ProjectLifeCycleStepDates < JournalFormatter::Base
   def render(key, values, options = { html: true })
-    step = Project::LifeCycleStep.find(key[/\d+/])
+    step = Project::LifeCycleStep.find_by(id: key[/\d+/])
+    return unless step
 
     name = step.definition.name
     label = options[:html] ? content_tag(:strong, name) : name

--- a/spec/lib/open_project/journal_formatter/project_life_cycle_step_active_spec.rb
+++ b/spec/lib/open_project/journal_formatter/project_life_cycle_step_active_spec.rb
@@ -32,12 +32,13 @@ require "spec_helper"
 
 RSpec.describe OpenProject::JournalFormatter::ProjectLifeCycleStepActive do
   describe "#render" do
-    let(:key) { "project_life_cycle_step_#{step.id}_active" }
+    let(:key) { "project_life_cycle_step_#{id}_active" }
+    let(:id) { step.id.to_s }
 
     subject(:result) { described_class.new(nil).render(key, values, html:) }
 
     before do
-      allow(Project::LifeCycleStep).to receive(:find).with(step.id.to_s).and_return(step)
+      allow(Project::LifeCycleStep).to receive(:find_by).with(id:).and_return(step)
     end
 
     def date(day) = Date.new(2025, 1, day)
@@ -91,6 +92,16 @@ RSpec.describe OpenProject::JournalFormatter::ProjectLifeCycleStepActive do
 
         include_examples "test result"
       end
+
+      context "when gate was deleted" do
+        let(:step) { nil }
+        let(:id) { "42" }
+        let(:values) { [true, false] }
+        let(:plain_result) { nil }
+        let(:html_result) { nil }
+
+        include_examples "test result"
+      end
     end
 
     describe "for stage changes" do
@@ -123,6 +134,16 @@ RSpec.describe OpenProject::JournalFormatter::ProjectLifeCycleStepActive do
 
       context "when no change between falsey values" do
         let(:values) { [nil, false] }
+        let(:plain_result) { nil }
+        let(:html_result) { nil }
+
+        include_examples "test result"
+      end
+
+      context "when stage was deleted" do
+        let(:step) { nil }
+        let(:id) { "42" }
+        let(:values) { [true, false] }
         let(:plain_result) { nil }
         let(:html_result) { nil }
 

--- a/spec/lib/open_project/journal_formatter/project_life_cycle_step_dates_spec.rb
+++ b/spec/lib/open_project/journal_formatter/project_life_cycle_step_dates_spec.rb
@@ -32,12 +32,13 @@ require "spec_helper"
 
 RSpec.describe OpenProject::JournalFormatter::ProjectLifeCycleStepDates do
   describe "#render" do
-    let(:key) { "project_life_cycle_step_#{step.id}_date_range" }
+    let(:key) { "project_life_cycle_step_#{id}_date_range" }
+    let(:id) { step.id.to_s }
 
     subject(:result) { described_class.new(nil).render(key, values, html:) }
 
     before do
-      allow(Project::LifeCycleStep).to receive(:find).with(step.id.to_s).and_return(step)
+      allow(Project::LifeCycleStep).to receive(:find_by).with(id:).and_return(step)
     end
 
     def date(day) = Date.new(2025, 1, day)
@@ -91,6 +92,16 @@ RSpec.describe OpenProject::JournalFormatter::ProjectLifeCycleStepDates do
 
         include_examples "test result"
       end
+
+      context "when gate was deleted" do
+        let(:step) { nil }
+        let(:id) { "42" }
+        let(:values) { [date(28).., date(29)..] }
+        let(:plain_result) { nil }
+        let(:html_result) { nil }
+
+        include_examples "test result"
+      end
     end
 
     describe "for stage changes" do
@@ -123,6 +134,16 @@ RSpec.describe OpenProject::JournalFormatter::ProjectLifeCycleStepDates do
 
       context "when both date ranges absent" do
         let(:values) { [nil, nil] }
+        let(:plain_result) { nil }
+        let(:html_result) { nil }
+
+        include_examples "test result"
+      end
+
+      context "when stage was deleted" do
+        let(:step) { nil }
+        let(:id) { "42" }
+        let(:values) { [date(28)..date(29), date(28)..date(30)] }
         let(:plain_result) { nil }
         let(:html_result) { nil }
 


### PR DESCRIPTION
Noticed while implementing [OP#62330](https://community.openproject.org/wp/62330) that project life cycle step activity formatters will raise if life cycle steps were deleted