### PR TITLE
[#62317] redefine WorkPackageCustomField#visible_by_user scope

### DIFF
--- a/app/models/attribute_help_text/work_package.rb
+++ b/app/models/attribute_help_text/work_package.rb
@@ -49,7 +49,7 @@ class AttributeHelpText::WorkPackage < AttributeHelpText
 
   def self.visible_condition(user)
     visible_cf_names = WorkPackageCustomField
-                       .visible_by_user(user)
+                       .manageable_by_user(user)
                        .pluck(:id)
                        .map { |id| "custom_field_#{id}" }
 

--- a/app/models/work_package_custom_field.rb
+++ b/app/models/work_package_custom_field.rb
@@ -38,15 +38,19 @@ class WorkPackageCustomField < CustomField
            source: :customized,
            source_type: "WorkPackage"
 
-  scope :visible_by_user, ->(user) {
+  scope :manageable_by_user, ->(user) {
     if user.allowed_in_any_project?(:select_custom_fields)
       all
     else
-      where(projects: { id: Project.visible(user) })
-        .where(types: { id: Type.enabled_in(Project.visible(user)) })
-        .or(where(is_for_all: true).references(:projects, :types))
-        .includes(:projects, :types)
+      visible_by_user(user)
     end
+  }
+
+  scope :visible_by_user, ->(user) {
+    where(projects: { id: Project.visible(user) })
+      .where(types: { id: Type.enabled_in(Project.visible(user)) })
+      .or(where(is_for_all: true).references(:projects, :types))
+      .includes(:projects, :types)
   }
 
   scope :usable_as_custom_action, -> {

--- a/spec/models/query/results_sums_integration_spec.rb
+++ b/spec/models/query/results_sums_integration_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Query::Results, "sums" do
     create(:type) do |t|
       t.custom_fields << int_cf
       t.custom_fields << float_cf
+      project.types << t
     end
   end
   let(:current_user) do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62317

# What are you trying to accomplish?
The old scope meant to determine if a user could "manage" custom fields. It was never about seeing them. Updated the scope names to reflect that.

# Merge checklist

- [x] Added/updated tests
- ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- ~Tested major browsers (Chrome, Firefox, Edge, ...)~
