### PR TITLE
Revert "delegate to CreateService instead of extracting methods to Helpers module"

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -41,12 +41,14 @@
 # rubocop:disable Rails/SquishedSQLHeredocs
 module Journals
   class CreateService
+    include Helpers
+
     attr_reader :journable, :user, :associations
 
     def initialize(journable, user)
       @user = user
       @journable = journable
-      @associations = Association.for(self)
+      @associations = Association.for(journable)
     end
 
     def call(notes: "", restricted: false, cause: CauseOfChange::NoCause.new)
@@ -62,8 +64,6 @@ module Journals
     end
 
     private
-
-    def journable_id = journable.id
 
     # Aggregatable journals must meet the following criteria:
     #
@@ -252,18 +252,6 @@ module Journals
                               :data_id)
     end
 
-    def cleanup_predecessor_for(predecessor, table_name, column, referenced_id)
-      return "SELECT 1" unless predecessor
-
-      sanitize(<<~SQL.squish, column => predecessor.send(referenced_id))
-        DELETE
-        FROM
-         #{table_name}
-        WHERE
-         #{column} = :#{column}
-      SQL
-    end
-
     def update_or_insert_journal_sql(predecessor, notes, restricted, cause)
       if predecessor
         update_journal_sql(predecessor, notes, cause)
@@ -359,10 +347,6 @@ module Journals
           #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
         RETURNING *
       SQL
-    end
-
-    def journable_class_name
-      journable.class.base_class.name
     end
 
     # Updates the updated_at timestamp of the journable.
@@ -508,14 +492,6 @@ module Journals
       end
     end
 
-    def only_if_created_sql
-      "EXISTS (SELECT * from inserted_journal)"
-    end
-
-    def id_from_inserted_journal_sql
-      "(SELECT id FROM inserted_journal)"
-    end
-
     def data_changes_condition_sql
       data_table = data_table_name
       journable_table = journable_table_name
@@ -584,10 +560,6 @@ module Journals
       journable.class.journal_class.table_name
     end
 
-    def normalize_newlines_sql(column)
-      "REGEXP_REPLACE(COALESCE(#{column},''), '\\r\\n', '\n', 'g')"
-    end
-
     def cause_sql(cause)
       # Using the same encoder mechanism that ActiveRecord uses for json/jsonb columns
       ActiveSupport::JSON.encode(cause || {})
@@ -641,9 +613,6 @@ module Journals
         Rails.logger.debug { "[#{self.class.name}] Inserting new journal for #{journable_type} ##{journable.id}" }
       end
     end
-
-    delegate :sanitize,
-             to: ::OpenProject::SqlSanitization
   end
 end
 # rubocop:enable Rails/SquishedSQLHeredocs


### PR DESCRIPTION
This reverts commit d67c9771a9488de4dd5f93e7c070372243aec447.

It shouldn't be possible to delegate to a private method, but it was hidden by a bug in ruby 3.4 (https://bugs.ruby-lang.org/issues/21196)

It is a better option than making all methods public instead (opf/openproject#18400)
