### PR TITLE
Define user @mention criterion for work package comments with restricted visibility

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -80,7 +80,8 @@ module WorkPackages
           action: index_stimulus_controller(":onSubmit-end@window->#{restricted_comment_stimulus_controller}#onSubmitEnd"),
           restricted_comment_stimulus_controller("-highlight-class") => "work-packages-activities-tab-journals-new-component--journal-notes-body__restricted-comment", # rubocop:disable Layout/LineLength
           restricted_comment_stimulus_controller("-hidden-class") => "d-none",
-          restricted_comment_stimulus_controller("-#{index_stimulus_controller}-outlet") => "##{wrapper_key}"
+          restricted_comment_stimulus_controller("-#{index_stimulus_controller}-outlet") => "##{wrapper_key}",
+          restricted_comment_stimulus_controller("-is-restricted-value") => false # Initial value
         }
       end
 

--- a/app/components/work_packages/activities_tab/journals/item_component/edit.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/edit.html.erb
@@ -1,5 +1,5 @@
 <%=
-  component_wrapper(class: "work-packages-activities-tab-journals-item-component-edit") do
+  component_wrapper(class: "work-packages-activities-tab-journals-item-component-edit", data: wrapper_data_attributes) do
     render(Primer::Box.new(my: 3)) do
       primer_form_with(
         id: "work-package-journal-form-element", # required for specs

--- a/app/components/work_packages/activities_tab/journals/item_component/edit.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/edit.rb
@@ -33,6 +33,7 @@ module WorkPackages
         include ApplicationHelper
         include OpPrimer::ComponentHelpers
         include OpTurbo::Streamable
+        include WorkPackages::ActivitiesTab::StimulusControllers
 
         def initialize(journal:, filter:)
           super
@@ -48,6 +49,12 @@ module WorkPackages
 
         def wrapper_uniq_by
           journal.id
+        end
+
+        def wrapper_data_attributes
+          {
+            restricted_comment_stimulus_controller("-is-restricted-value") => journal.restricted?
+          }
         end
       end
     end

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -139,6 +139,13 @@ class WorkPackages::ActivitiesTabController < ApplicationController
     respond_with_turbo_streams
   end
 
+  def sanitize_restricted_mentions
+    sanitizer = WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer.new(@work_package, journal_params[:notes])
+    sanitized_notes = sanitizer.call
+
+    render plain: sanitized_notes
+  end
+
   def toggle_reaction # rubocop:disable Metrics/AbcSize
     emoji_reaction_service =
       if @journal.emoji_reactions.exists?(user: User.current, reaction: params[:reaction])

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -141,6 +141,9 @@ class WorkPackages::ActivitiesTabController < ApplicationController
 
   def sanitize_restricted_mentions
     render plain: sanitized_journal_notes
+  rescue StandardError => e
+    handle_internal_server_error(e)
+    respond_with_turbo_streams
   end
 
   def toggle_reaction # rubocop:disable Metrics/AbcSize
@@ -226,7 +229,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def sanitized_journal_notes
-    WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer.new(@work_package, journal_params[:notes]).call
+    WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer.sanitize(@work_package, journal_params[:notes])
   end
 
   def journal_params

--- a/app/models/queries/principals.rb
+++ b/app/models/queries/principals.rb
@@ -32,6 +32,7 @@ module Queries::Principals
     filter Filters::TypeFilter
     filter Filters::MemberFilter
     filter Filters::MentionableOnWorkPackageFilter
+    filter Filters::RestrictedMentionableOnWorkPackageFilter
     filter Filters::StatusFilter
     filter Filters::NameFilter
     filter Filters::AnyNameAttributeFilter

--- a/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
@@ -28,8 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-class Queries::Principals::Filters::MentionableOnWorkPackageFilter <
-  Queries::Principals::Filters::PrincipalFilter
+class Queries::Principals::Filters::MentionableOnWorkPackageFilter < Queries::Principals::Filters::PrincipalFilter
   def allowed_values
     raise NotImplementedError, "There would be too many candidates"
   end
@@ -47,7 +46,7 @@ class Queries::Principals::Filters::MentionableOnWorkPackageFilter <
   end
 
   def human_name
-    "mentionable" # intenral use
+    "mentionable" # Internal use
   end
 
   def apply_to(query_scope)

--- a/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/mentionable_on_work_package_filter.rb
@@ -29,6 +29,8 @@
 # ++
 
 class Queries::Principals::Filters::MentionableOnWorkPackageFilter < Queries::Principals::Filters::PrincipalFilter
+  validate :values_are_a_single_work_package_id
+
   def allowed_values
     raise NotImplementedError, "There would be too many candidates"
   end
@@ -45,58 +47,34 @@ class Queries::Principals::Filters::MentionableOnWorkPackageFilter < Queries::Pr
     :mentionable_on_work_package
   end
 
+  def permission
+    :add_work_package_notes
+  end
+
   def human_name
-    "mentionable" # Internal use
+    "mentionable" # Only for Internal use, not visible in the UI
   end
 
   def apply_to(query_scope)
     case operator
     when "="
-      query_scope.where(id: principals_with_a_membership)
+      query_scope.where(id: User.allowed_members_on_work_package(permission, work_package))
     when "!"
-      query_scope.where(id: visible_scope.where.not(id: principals_with_a_membership.select(:id)))
+      query_scope.where.not(id: User.allowed_members_on_work_package(permission, work_package))
     end
   end
 
   private
 
+  def values_are_a_single_work_package_id
+    errors.add(:base, "You must select a single work package") if values.size > 1
+  end
+
   def type_strategy
     @type_strategy ||= Queries::Filters::Strategies::HugeList.new(self)
   end
 
-  def principals_with_a_membership
-    visible_scope.where(id: work_package_members.select(:user_id))
-                 .or(visible_scope.where(id: project_members.select(:user_id)))
-  end
-
-  def visible_scope
-    Principal.visible(User.current)
-             .includes(members: :roles)
-             .references(members: :roles)
-  end
-
-  def work_package_members
-    Member.joins(:member_roles)
-          .of_work_package(values)
-          .where(member_roles: { role_id: mentionable_work_package_role_ids })
-  end
-
-  def mentionable_work_package_role_ids
-    Role.where(builtin: [Role::BUILTIN_WORK_PACKAGE_EDITOR,
-                         Role::BUILTIN_WORK_PACKAGE_COMMENTER])
-        .select(:id)
-  end
-
-  def project_members
-    Member.of_project(projects)
-          .where(entity: nil)
-  end
-
-  def work_packages
-    WorkPackage.where(id: values)
-  end
-
-  def projects
-    Project.where(id: work_packages.select(:project_id))
+  def work_package
+    WorkPackage.find(values.first)
   end
 end

--- a/app/models/queries/principals/filters/restricted_mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/restricted_mentionable_on_work_package_filter.rb
@@ -35,6 +35,10 @@ class Queries::Principals::Filters::RestrictedMentionableOnWorkPackageFilter <
   end
 
   def human_name
-    "restricted mentionable" # Internal use
+    "restricted mentionable" # Only for Internal use, not visible in the UI
+  end
+
+  def permission
+    :view_comments_with_restricted_visibility
   end
 end

--- a/app/models/queries/principals/filters/restricted_mentionable_on_work_package_filter.rb
+++ b/app/models/queries/principals/filters/restricted_mentionable_on_work_package_filter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,19 +26,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
-module WorkPackages::ActivitiesTab::Journals
-  class RestrictedNoteForm < ApplicationForm
-    form do |notes_form|
-      notes_form.check_box(
-        name: :restricted,
-        label: I18n.t("activities.work_packages.activity_tab.restrict_visibility"),
-        checked: false,
-        data: {
-          "work-packages--activities-tab--restricted-comment-target": "restrictedCheckbox",
-          action: "input->work-packages--activities-tab--restricted-comment#toggleRestriction"
-        }
-      )
-    end
+# ++
+
+class Queries::Principals::Filters::RestrictedMentionableOnWorkPackageFilter <
+    Queries::Principals::Filters::MentionableOnWorkPackageFilter
+  def key
+    :restricted_mentionable_on_work_package
+  end
+
+  def human_name
+    "restricted mentionable" # Internal use
   end
 end

--- a/app/services/work_packages/activities_tab/restricted_mentions_sanitizer.rb
+++ b/app/services/work_packages/activities_tab/restricted_mentions_sanitizer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer
+  def initialize(work_package, notes)
+    @work_package = work_package
+    @parser = Nokogiri::HTML.fragment(notes)
+  end
+
+  def call
+    convert_unmentionable_principals_to_plain_text
+    CGI.unescapeHTML(parser.to_html)
+  end
+
+  private
+
+  attr_reader :work_package, :parser
+
+  def convert_unmentionable_principals_to_plain_text
+    mentionable_principals_ids = mentionable_principals.pluck(:id)
+
+    parser.css("mention").each do |mention|
+      unless mentionable_principals_ids.include?(mention["data-id"].to_i)
+        mention.replace(mention.content)
+      end
+    end
+  end
+
+  def mentionable_principals
+    @mentionable_principals ||= Queries::Principals::PrincipalQuery.new(user: User.current)
+      .where(:restricted_mentionable_on_work_package, "=", [work_package.id])
+      .where(:status, "!", [Principal.statuses[:locked]])
+      .where(:type, "=", %w[User Group])
+      .results
+  end
+end

--- a/app/services/work_packages/activities_tab/restricted_mentions_sanitizer.rb
+++ b/app/services/work_packages/activities_tab/restricted_mentions_sanitizer.rb
@@ -31,17 +31,19 @@
 class WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer
   def initialize(work_package, notes)
     @work_package = work_package
-    @parser = Nokogiri::HTML.fragment(notes)
+    @notes = notes
   end
 
   def call
+    return "" if notes.blank?
+
     convert_unmentionable_principals_to_plain_text
     CGI.unescapeHTML(parser.to_html)
   end
 
   private
 
-  attr_reader :work_package, :parser
+  attr_reader :work_package, :notes
 
   def convert_unmentionable_principals_to_plain_text
     mentionable_principals_ids = mentionable_principals.pluck(:id)
@@ -51,6 +53,10 @@ class WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer
         mention.replace(mention.content)
       end
     end
+  end
+
+  def parser
+    @parser ||= Nokogiri::HTML.fragment(notes)
   end
 
   def mentionable_principals

--- a/app/services/work_packages/activities_tab/restricted_mentions_sanitizer.rb
+++ b/app/services/work_packages/activities_tab/restricted_mentions_sanitizer.rb
@@ -29,6 +29,10 @@
 #++
 
 class WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer
+  def self.sanitize(work_package, notes)
+    new(work_package, notes).call
+  end
+
   def initialize(work_package, notes)
     @work_package = work_package
     @notes = notes

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -289,7 +289,7 @@ Rails.application.reloader.to_prepare do
                        # FIXME: Although the endpoint is removed, the code checking whether a user
                        # is eligible to add work packages through the API still seems to rely on this.
                        journals: [:new],
-                       "work_packages/activities_tab": %i[create toggle_reaction]
+                       "work_packages/activities_tab": %i[create toggle_reaction sanitize_restricted_mentions]
                      },
                      permissible_on: %i[work_package project],
                      dependencies: :view_work_packages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1409,6 +1409,10 @@ en:
             values:
               inclusion: "filter has invalid values."
               format: "%{message}"
+        queries/principals/filters/restricted_mentionable_on_work_package_filter:
+          attributes:
+            values:
+              single_value_requirement: "must be a single work package"
         relation:
           typed_dag:
             circular_dependency: "The relationship creates a circle of relationships."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -650,10 +650,12 @@ Rails.application.routes.draw do
         get :cancel_edit
         put :toggle_reaction
       end
+
       collection do
         get :update_streams
         get :update_filter # filter not persisted
         put :update_sorting # sorting is persisted
+        post :sanitize_restricted_mentions
       end
     end
 

--- a/frontend/src/app/core/path-helper/apiv3-paths.ts
+++ b/frontend/src/app/core/path-helper/apiv3-paths.ts
@@ -46,13 +46,12 @@ export class ApiV3Paths {
       // that are members of that project:
       filters.add('member', '=', [(workPackage.project as HalResource).id as string]);
     } else {
-      const isRestrictedAttribute = 'data-work-packages--activities-tab--restricted-comment-is-restricted-value';
-      const addCommentIsRestricted = document.getElementById('work-packages-activities-tab-add-comment-component')?.getAttribute(isRestrictedAttribute) === 'true';
-      const editorIsRestricted = document.querySelector('.work-packages-activities-tab-journals-item-component-edit')?.getAttribute(isRestrictedAttribute) === 'true';
-      const isRestricted = addCommentIsRestricted || editorIsRestricted;
+      const isRestrictedAttributeValue = 'data-work-packages--activities-tab--restricted-comment-is-restricted-value';
+      const addingCommentIsRestricted = document.getElementById('work-packages-activities-tab-add-comment-component')?.getAttribute(isRestrictedAttributeValue) === 'true';
+      const editingCommentIsRestricted = document.querySelector('.work-packages-activities-tab-journals-item-component-edit')?.getAttribute(isRestrictedAttributeValue) === 'true';
 
       // that are mentionable on the work package
-      if (isRestricted) {
+      if (addingCommentIsRestricted || editingCommentIsRestricted) {
         filters.add('restricted_mentionable_on_work_package', '=', [workPackage.id.toString()]);
       } else {
         filters.add('mentionable_on_work_package', '=', [workPackage.id.toString()]);

--- a/frontend/src/app/core/path-helper/apiv3-paths.ts
+++ b/frontend/src/app/core/path-helper/apiv3-paths.ts
@@ -46,11 +46,13 @@ export class ApiV3Paths {
       // that are members of that project:
       filters.add('member', '=', [(workPackage.project as HalResource).id as string]);
     } else {
-      const addCommentElement = document.getElementById('work-packages-activities-tab-add-comment-component');
-      const isRestricted = addCommentElement?.getAttribute('data-work-packages--activities-tab--restricted-comment-is-restricted-value') === 'true';
+      const isRestrictedAttribute = 'data-work-packages--activities-tab--restricted-comment-is-restricted-value';
+      const addCommentIsRestricted = document.getElementById('work-packages-activities-tab-add-comment-component')?.getAttribute(isRestrictedAttribute) === 'true';
+      const editorIsRestricted = document.querySelector('.work-packages-activities-tab-journals-item-component-edit')?.getAttribute(isRestrictedAttribute) === 'true';
+      const isRestricted = addCommentIsRestricted || editorIsRestricted;
 
       // that are mentionable on the work package
-      if (addCommentElement && isRestricted) {
+      if (isRestricted) {
         filters.add('restricted_mentionable_on_work_package', '=', [workPackage.id.toString()]);
       } else {
         filters.add('mentionable_on_work_package', '=', [workPackage.id.toString()]);

--- a/frontend/src/app/core/path-helper/apiv3-paths.ts
+++ b/frontend/src/app/core/path-helper/apiv3-paths.ts
@@ -46,8 +46,15 @@ export class ApiV3Paths {
       // that are members of that project:
       filters.add('member', '=', [(workPackage.project as HalResource).id as string]);
     } else {
+      const addCommentElement = document.getElementById('work-packages-activities-tab-add-comment-component');
+      const isRestricted = addCommentElement?.getAttribute('data-work-packages--activities-tab--restricted-comment-is-restricted-value') === 'true';
+
       // that are mentionable on the work package
-      filters.add('mentionable_on_work_package', '=', [workPackage.id.toString()]);
+      if (addCommentElement && isRestricted) {
+        filters.add('restricted_mentionable_on_work_package', '=', [workPackage.id.toString()]);
+      } else {
+        filters.add('mentionable_on_work_package', '=', [workPackage.id.toString()]);
+      }
     }
     // That are users:
     filters.add('type', '=', ['User', 'Group']);
@@ -57,8 +64,6 @@ export class ApiV3Paths {
       filters.add('name', '~', [term]);
     }
 
-    return `${this.apiV3Base
-    }/principals?${
-      filters.toParams({ sortBy: '[["name","asc"]]', offset: '1', pageSize: '10' })}`;
+    return `${this.apiV3Base}/principals?${filters.toParams({ sortBy: '[["name","asc"]]', offset: '1', pageSize: '10' })}`;
   }
 }

--- a/frontend/src/app/core/path-helper/apiv3-paths.ts
+++ b/frontend/src/app/core/path-helper/apiv3-paths.ts
@@ -46,16 +46,12 @@ export class ApiV3Paths {
       // that are members of that project:
       filters.add('member', '=', [(workPackage.project as HalResource).id as string]);
     } else {
-      const isRestrictedAttributeValue = 'data-work-packages--activities-tab--restricted-comment-is-restricted-value';
-      const addingCommentIsRestricted = document.getElementById('work-packages-activities-tab-add-comment-component')?.getAttribute(isRestrictedAttributeValue) === 'true';
-      const editingCommentIsRestricted = document.querySelector('.work-packages-activities-tab-journals-item-component-edit')?.getAttribute(isRestrictedAttributeValue) === 'true';
-
       // that are mentionable on the work package
-      if (addingCommentIsRestricted || editingCommentIsRestricted) {
-        filters.add('restricted_mentionable_on_work_package', '=', [workPackage.id.toString()]);
-      } else {
-        filters.add('mentionable_on_work_package', '=', [workPackage.id.toString()]);
-      }
+      filters.add(
+        (this.isRestrictedMentionable() ? 'restricted_mentionable_on_work_package' : 'mentionable_on_work_package'),
+        '=',
+        [workPackage.id.toString()],
+      );
     }
     // That are users:
     filters.add('type', '=', ['User', 'Group']);
@@ -66,5 +62,19 @@ export class ApiV3Paths {
     }
 
     return `${this.apiV3Base}/principals?${filters.toParams({ sortBy: '[["name","asc"]]', offset: '1', pageSize: '10' })}`;
+  }
+
+  /**
+   * Check if either adding or editing a comment is restricted, and thus
+   * the mentionable principals are to be restricted
+   *
+   * @returns {boolean}
+   */
+  private isRestrictedMentionable():boolean {
+    const isRestrictedAttributeValue = 'data-work-packages--activities-tab--restricted-comment-is-restricted-value';
+    const addingCommentIsRestricted = document.getElementById('work-packages-activities-tab-add-comment-component')?.getAttribute(isRestrictedAttributeValue) === 'true';
+    const editingCommentIsRestricted = document.querySelector('.work-packages-activities-tab-journals-item-component-edit')?.getAttribute(isRestrictedAttributeValue) === 'true';
+
+    return addingCommentIsRestricted || editingCommentIsRestricted;
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
@@ -83,7 +83,7 @@ export default class QuoteCommentController extends Controller {
   private setCommentRestriction(isRestricted:boolean) {
     if (isRestricted && !this.workPackagesActivitiesTabRestrictedCommentOutlet.restrictedCheckboxTarget.checked) {
       this.workPackagesActivitiesTabRestrictedCommentOutlet.restrictedCheckboxTarget.checked = isRestricted;
-      this.workPackagesActivitiesTabRestrictedCommentOutlet.toggleBackgroundColor();
+      this.workPackagesActivitiesTabRestrictedCommentOutlet.toggleRestriction();
     }
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -36,23 +36,30 @@ export default class RestrictedCommentController extends Controller {
   static outlets = ['work-packages--activities-tab--index'];
   static classes = ['highlight', 'hidden'];
 
+  static values = {
+    isRestricted: { type: Boolean, default: false },
+  };
+
   declare readonly restrictedCheckboxTarget:HTMLInputElement;
   declare readonly formContainerTarget:HTMLElement;
   declare readonly learnMoreLinkTarget:HTMLAnchorElement;
   declare readonly workPackagesActivitiesTabIndexOutlet:IndexController;
-
   declare readonly highlightClass:string;
   declare readonly hiddenClass:string;
 
+  declare isRestrictedValue:boolean;
+
   onSubmitEnd(_event:CustomEvent):void {
-    this.toggleBackgroundColor();
+    this.toggleRestriction();
   }
 
-  toggleBackgroundColor():void {
+  toggleRestriction():void {
     const isChecked = this.restrictedCheckboxTarget.checked;
 
     this.formContainerTarget.classList.toggle(this.highlightClass, isChecked);
     this.toggleLearnMoreLink(isChecked);
+
+    this.isRestrictedValue = isChecked;
   }
 
   private toggleLearnMoreLink(isChecked:boolean):void {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -79,20 +79,20 @@ export default class RestrictedCommentController extends Controller {
       const sanitizePath = `/work_packages/${this.workPackagesActivitiesTabIndexOutlet.workPackageIdValue}/activities/sanitize_restricted_mentions`;
       const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement).content;
 
-      const response = await fetch(sanitizePath, {
-        method: 'POST',
-        body: JSON.stringify({ journal: { notes: editorData } }),
-        headers: {
-          'X-CSRF-Token': csrfToken,
-          'Content-Type': 'application/json',
-        },
-      });
+      try {
+        const response = await fetch(sanitizePath, {
+          method: 'POST',
+          body: JSON.stringify({ journal: { notes: editorData } }),
+          headers: {
+            'X-CSRF-Token': csrfToken,
+            'Content-Type': 'application/json',
+          },
+        });
 
-      if (response.ok) {
         const sanitizedNotes = await response.text();
         this.ckEditorInstance.setData(sanitizedNotes);
-      } else {
-        console.error('Failed to sanitize restricted mentions');
+      } catch (error) {
+        console.error(`Failed to sanitize restricted mentions: ${error}`);
       }
     }
   }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/restricted-comment.controller.ts
@@ -29,6 +29,7 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
+import { renderStreamMessage } from '@hotwired/turbo';
 import type IndexController from './index.controller';
 
 export default class RestrictedCommentController extends Controller {
@@ -89,10 +90,16 @@ export default class RestrictedCommentController extends Controller {
           },
         });
 
-        const sanitizedNotes = await response.text();
-        this.ckEditorInstance.setData(sanitizedNotes);
+        const sanitizedNotesResponse = await response.text();
+
+        if (response.ok) {
+          this.ckEditorInstance.setData(sanitizedNotesResponse);
+        } else {
+          renderStreamMessage(sanitizedNotesResponse);
+          throw new Error(`Failed to sanitize restricted mentions. Response status: ${response.status}`);
+        }
       } catch (error) {
-        console.error(`Failed to sanitize restricted mentions: ${error}`);
+        console.error(error);
       }
     }
   }

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -33,6 +33,8 @@ require "spec_helper"
 RSpec.describe "Work package comments with restricted visibility",
                :js,
                with_flag: { comments_with_restricted_visibility: true } do
+  include RestrictedVisibilityCommentsHelpers
+
   shared_let(:project) { create(:project) }
   shared_let(:admin) { create(:admin) }
   shared_let(:viewer) { create_user_with_restricted_comments_view_permissions }
@@ -246,46 +248,5 @@ RSpec.describe "Work package comments with restricted visibility",
             .to contain_exactly("Project Admin", "Restricted Viewer", "Restricted ViewerCommenter")
       end
     end
-  end
-
-  def create_user_without_restricted_comments_view_permissions
-    viewer_role = create(:project_role, permissions: %i[view_work_packages])
-    create(:user,
-           firstname: "A",
-           lastname: "Viewer",
-           member_with_roles: { project => viewer_role })
-  end
-
-  def create_user_as_project_admin
-    member_role = create(:project_role,
-                         permissions: %i[view_work_packages add_work_package_notes
-                                         edit_own_work_package_notes
-                                         view_comments_with_restricted_visibility
-                                         add_comments_with_restricted_visibility
-                                         edit_own_comments_with_restricted_visibility
-                                         edit_others_comments_with_restricted_visibility])
-    create(:user, firstname: "Project", lastname: "Admin",
-                  member_with_roles: { project => member_role })
-  end
-
-  def create_user_with_restricted_comments_view_permissions
-    viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
-    create(:user,
-           firstname: "Restricted",
-           lastname: "Viewer",
-           member_with_roles: { project => viewer_role })
-  end
-
-  def create_user_with_restricted_comments_view_and_write_permissions
-    viewer_role_with_commenting_permission = create(:project_role,
-                                                    permissions: %i[view_work_packages add_work_package_notes
-                                                                    edit_own_work_package_notes
-                                                                    view_comments_with_restricted_visibility
-                                                                    add_comments_with_restricted_visibility
-                                                                    edit_own_comments_with_restricted_visibility])
-    create(:user,
-           firstname: "Restricted",
-           lastname: "ViewerCommenter",
-           member_with_roles: { project => viewer_role_with_commenting_permission })
   end
 end

--- a/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
+++ b/spec/features/activities/work_package/restricted_visibility_comments_spec.rb
@@ -248,5 +248,23 @@ RSpec.describe "Work package comments with restricted visibility",
             .to contain_exactly("Project Admin", "Restricted Viewer", "Restricted ViewerCommenter")
       end
     end
+
+    context "with a server error" do
+      before do
+        allow(WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer).to receive(:sanitize)
+          .and_raise(RuntimeError, "Something went wrong!!!")
+      end
+
+      it "shows an error message" do
+        activity_tab.type_comment("@Restricted")
+        page.first(".mention-list-item", text: "Restricted Viewer").click
+
+        activity_tab.check_restricted_visibility_comment_checkbox
+
+        page.within_test_selector("op-primer-flash-message") do
+          expect(page).to have_text("Something went wrong!!!")
+        end
+      end
+    end
   end
 end

--- a/spec/models/queries/principals/filters/restricted_mentionable_on_work_package_filter_spec.rb
+++ b/spec/models/queries/principals/filters/restricted_mentionable_on_work_package_filter_spec.rb
@@ -91,6 +91,28 @@ RSpec.describe Queries::Principals::Filters::RestrictedMentionableOnWorkPackageF
             .to contain_exactly(user_with_restricted_comments_view_permissions,
                                 user_with_restricted_comments_view_and_write_permissions)
         end
+
+        context "with users and groups" do
+          let(:group_member1) { create(:user) }
+          let(:group_member2) { create(:user) }
+          let(:group_role) { create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility]) }
+          let(:group) do
+            create(:group, members: [group_member1, group_member2]) do |group|
+              Members::CreateService
+               .new(user: User.system, contract_class: EmptyContract)
+               .call(project:, principal: group, roles: [group_role])
+            end
+          end
+
+          it "returns all mentionable principals including group and group members" do
+            expect(subject)
+              .to contain_exactly(user_with_restricted_comments_view_permissions,
+                                  user_with_restricted_comments_view_and_write_permissions,
+                                  group,
+                                  group_member1,
+                                  group_member2)
+          end
+        end
       end
 
       context "with a ! operator" do

--- a/spec/models/queries/principals/filters/restricted_mentionable_on_work_package_filter_spec.rb
+++ b/spec/models/queries/principals/filters/restricted_mentionable_on_work_package_filter_spec.rb
@@ -32,6 +32,8 @@ require "spec_helper"
 
 RSpec.describe Queries::Principals::Filters::RestrictedMentionableOnWorkPackageFilter do
   it_behaves_like "basic query filter" do
+    include RestrictedVisibilityCommentsHelpers
+
     let(:class_key) { :restricted_mentionable_on_work_package }
     let(:type) { :list_optional }
     let(:human_name) { "restricted mentionable" }
@@ -99,35 +101,6 @@ RSpec.describe Queries::Principals::Filters::RestrictedMentionableOnWorkPackageF
             .to contain_exactly(user_without_restricted_comments_view_permissions)
         end
       end
-    end
-
-    def create_user_without_restricted_comments_view_permissions
-      viewer_role = create(:project_role, permissions: %i[view_work_packages])
-      create(:user,
-             firstname: "A",
-             lastname: "Viewer",
-             member_with_roles: { project => viewer_role })
-    end
-
-    def create_user_with_restricted_comments_view_permissions
-      viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
-      create(:user,
-             firstname: "Restricted",
-             lastname: "Viewer",
-             member_with_roles: { project => viewer_role })
-    end
-
-    def create_user_with_restricted_comments_view_and_write_permissions
-      viewer_role_with_commenting_permission = create(:project_role,
-                                                      permissions: %i[view_work_packages add_work_package_notes
-                                                                      edit_own_work_package_notes
-                                                                      view_comments_with_restricted_visibility
-                                                                      add_comments_with_restricted_visibility
-                                                                      edit_own_comments_with_restricted_visibility])
-      create(:user,
-             firstname: "Restricted",
-             lastname: "ViewerCommenter",
-             member_with_roles: { project => viewer_role_with_commenting_permission })
     end
   end
 end

--- a/spec/models/queries/principals/filters/restricted_mentionable_on_work_package_filter_spec.rb
+++ b/spec/models/queries/principals/filters/restricted_mentionable_on_work_package_filter_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe Queries::Principals::Filters::RestrictedMentionableOnWorkPackageFilter do
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :restricted_mentionable_on_work_package }
+    let(:type) { :list_optional }
+    let(:human_name) { "restricted mentionable" }
+
+    shared_let(:project) { create(:project) }
+    shared_let(:work_package) { create(:work_package, project:) }
+    shared_let(:other_work_package) { create(:work_package, project:) }
+
+    shared_let(:user_without_restricted_comments_view_permissions) { create_user_without_restricted_comments_view_permissions }
+    shared_let(:user_with_restricted_comments_view_permissions) { create_user_with_restricted_comments_view_permissions }
+    shared_let(:user_with_restricted_comments_view_and_write_permissions) do
+      create_user_with_restricted_comments_view_and_write_permissions
+    end
+
+    let(:user) { user_with_restricted_comments_view_permissions }
+
+    before { allow(User).to receive(:current).and_return(user) }
+
+    describe "#validate" do
+      it "is valid with a single work package id" do
+        instance.values = [work_package.id.to_s]
+        expect(instance).to be_valid
+      end
+
+      it "is invalid with multiple work package ids" do
+        instance.values = [work_package.id.to_s, other_work_package.id.to_s]
+        expect(instance).not_to be_valid
+        expect(instance.errors.messages).to eq(values: ["must be a single work package"])
+      end
+
+      it "is invalid with no work package id" do
+        instance.values = []
+        expect(instance).not_to be_valid
+        expect(instance.errors.messages).to eq(values: ["can't be blank.", "filter has invalid values."])
+      end
+    end
+
+    describe "#scope" do
+      subject { instance.apply_to(Principal.visible(user)) }
+
+      let(:values) { [work_package.id.to_s] }
+
+      let(:instance) do
+        described_class.create!.tap do |filter|
+          filter.values = values
+          filter.operator = operator
+        end
+      end
+
+      context "with an = operator" do
+        let(:operator) { "=" }
+
+        it "returns all mentionable principals on the work package and its project" do
+          expect(subject)
+            .to contain_exactly(user_with_restricted_comments_view_permissions,
+                                user_with_restricted_comments_view_and_write_permissions)
+        end
+      end
+
+      context "with a ! operator" do
+        let(:operator) { "!" }
+
+        it "returns all non-mentionable users on the work package and its project" do
+          expect(subject)
+            .to contain_exactly(user_without_restricted_comments_view_permissions)
+        end
+      end
+    end
+
+    def create_user_without_restricted_comments_view_permissions
+      viewer_role = create(:project_role, permissions: %i[view_work_packages])
+      create(:user,
+             firstname: "A",
+             lastname: "Viewer",
+             member_with_roles: { project => viewer_role })
+    end
+
+    def create_user_with_restricted_comments_view_permissions
+      viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
+      create(:user,
+             firstname: "Restricted",
+             lastname: "Viewer",
+             member_with_roles: { project => viewer_role })
+    end
+
+    def create_user_with_restricted_comments_view_and_write_permissions
+      viewer_role_with_commenting_permission = create(:project_role,
+                                                      permissions: %i[view_work_packages add_work_package_notes
+                                                                      edit_own_work_package_notes
+                                                                      view_comments_with_restricted_visibility
+                                                                      add_comments_with_restricted_visibility
+                                                                      edit_own_comments_with_restricted_visibility])
+      create(:user,
+             firstname: "Restricted",
+             lastname: "ViewerCommenter",
+             member_with_roles: { project => viewer_role_with_commenting_permission })
+    end
+  end
+end

--- a/spec/services/work_packages/activities_tab/restricted_mentions_sanitizer_spec.rb
+++ b/spec/services/work_packages/activities_tab/restricted_mentions_sanitizer_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer do
     expect(subject).to eq(expected_output)
   end
 
+  context "when the notes are empty" do
+    let(:input) { "" }
+
+    it "returns an empty string" do
+      expect(subject).to eq("")
+    end
+  end
+
   def create_user_without_restricted_comments_view_permissions
     viewer_role = create(:project_role, permissions: %i[view_work_packages])
     create(:user,

--- a/spec/services/work_packages/activities_tab/restricted_mentions_sanitizer_spec.rb
+++ b/spec/services/work_packages/activities_tab/restricted_mentions_sanitizer_spec.rb
@@ -31,6 +31,8 @@
 require "spec_helper"
 
 RSpec.describe WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer do
+  include RestrictedVisibilityCommentsHelpers
+
   shared_let(:project) { create(:project) }
   shared_let(:admin_but_non_member) { create(:admin) }
   shared_let(:viewer) { create_user_without_restricted_comments_view_permissions }
@@ -94,46 +96,5 @@ RSpec.describe WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer do
     it "returns an empty string" do
       expect(subject).to eq("")
     end
-  end
-
-  def create_user_without_restricted_comments_view_permissions
-    viewer_role = create(:project_role, permissions: %i[view_work_packages])
-    create(:user,
-           firstname: "A",
-           lastname: "Viewer",
-           member_with_roles: { project => viewer_role })
-  end
-
-  def create_user_as_project_admin
-    member_role = create(:project_role,
-                         permissions: %i[view_work_packages add_work_package_notes
-                                         edit_own_work_package_notes
-                                         view_comments_with_restricted_visibility
-                                         add_comments_with_restricted_visibility
-                                         edit_own_comments_with_restricted_visibility
-                                         edit_others_comments_with_restricted_visibility])
-    create(:user, firstname: "Project", lastname: "Admin",
-                  member_with_roles: { project => member_role })
-  end
-
-  def create_user_with_restricted_comments_view_permissions
-    viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
-    create(:user,
-           firstname: "Restricted",
-           lastname: "Viewer",
-           member_with_roles: { project => viewer_role })
-  end
-
-  def create_user_with_restricted_comments_view_and_write_permissions
-    viewer_role_with_commenting_permission = create(:project_role,
-                                                    permissions: %i[view_work_packages add_work_package_notes
-                                                                    edit_own_work_package_notes
-                                                                    view_comments_with_restricted_visibility
-                                                                    add_comments_with_restricted_visibility
-                                                                    edit_own_comments_with_restricted_visibility])
-    create(:user,
-           firstname: "Restricted",
-           lastname: "ViewerCommenter",
-           member_with_roles: { project => viewer_role_with_commenting_permission })
   end
 end

--- a/spec/services/work_packages/activities_tab/restricted_mentions_sanitizer_spec.rb
+++ b/spec/services/work_packages/activities_tab/restricted_mentions_sanitizer_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::ActivitiesTab::RestrictedMentionsSanitizer do
+  shared_let(:project) { create(:project) }
+  shared_let(:admin_but_non_member) { create(:admin) }
+  shared_let(:viewer) { create_user_without_restricted_comments_view_permissions }
+  shared_let(:user_with_restricted_comments_view_and_write_permissions) do
+    create_user_with_restricted_comments_view_and_write_permissions
+  end
+  shared_let(:project_admin) { create_user_as_project_admin }
+  shared_let(:work_package) { create(:work_package, project:) }
+
+  let(:input) do
+    <<~HTML
+      <mention class="mention" data-id="#{admin_but_non_member.id}" data-type="user" data-text="@#{admin_but_non_member.firstname}">@#{admin_but_non_member.firstname}</mention> wrote:
+
+      > Well Done!
+
+      <mention class="mention" data-id="#{viewer.id}" data-type="user" data-text="@#{viewer.firstname}">@#{viewer.firstname}</mention> wrote:
+
+      > <mention class="mention" data-id="#{user_with_restricted_comments_view_and_write_permissions.id}" data-type="user" data-text="@#{user_with_restricted_comments_view_and_write_permissions.firstname}">@#{user_with_restricted_comments_view_and_write_permissions.firstname}</mention> wrote:
+      >
+      > > <mention class="mention" data-id="#{project_admin.id}" data-type="user" data-text="@#{project_admin.firstname}">@#{project_admin.firstname}</mention> wrote:
+      > >
+      > > > FooBar
+      > >
+      > > <mention class="mention" data-id="435" data-type="user" data-text="@Firstname">@Firstname</mention> wrote:
+      > >
+      > > > BooBar
+    HTML
+  end
+
+  let(:expected_output) do
+    <<~HTML
+      @#{admin_but_non_member.firstname} wrote:
+
+      > Well Done!
+
+      @#{viewer.firstname} wrote:
+
+      > <mention class="mention" data-id="#{user_with_restricted_comments_view_and_write_permissions.id}" data-type="user" data-text="@#{user_with_restricted_comments_view_and_write_permissions.firstname}">@#{user_with_restricted_comments_view_and_write_permissions.firstname}</mention> wrote:
+      >
+      > > <mention class="mention" data-id="#{project_admin.id}" data-type="user" data-text="@#{project_admin.firstname}">@#{project_admin.firstname}</mention> wrote:
+      > >
+      > > > FooBar
+      > >
+      > > @Firstname wrote:
+      > >
+      > > > BooBar
+    HTML
+  end
+
+  subject { described_class.new(work_package, input).call }
+
+  before { allow(User).to receive(:current).and_return(user_with_restricted_comments_view_and_write_permissions) }
+
+  it "sanitizes the notes" do
+    expect(subject).to eq(expected_output)
+  end
+
+  def create_user_without_restricted_comments_view_permissions
+    viewer_role = create(:project_role, permissions: %i[view_work_packages])
+    create(:user,
+           firstname: "A",
+           lastname: "Viewer",
+           member_with_roles: { project => viewer_role })
+  end
+
+  def create_user_as_project_admin
+    member_role = create(:project_role,
+                         permissions: %i[view_work_packages add_work_package_notes
+                                         edit_own_work_package_notes
+                                         view_comments_with_restricted_visibility
+                                         add_comments_with_restricted_visibility
+                                         edit_own_comments_with_restricted_visibility
+                                         edit_others_comments_with_restricted_visibility])
+    create(:user, firstname: "Project", lastname: "Admin",
+                  member_with_roles: { project => member_role })
+  end
+
+  def create_user_with_restricted_comments_view_permissions
+    viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
+    create(:user,
+           firstname: "Restricted",
+           lastname: "Viewer",
+           member_with_roles: { project => viewer_role })
+  end
+
+  def create_user_with_restricted_comments_view_and_write_permissions
+    viewer_role_with_commenting_permission = create(:project_role,
+                                                    permissions: %i[view_work_packages add_work_package_notes
+                                                                    edit_own_work_package_notes
+                                                                    view_comments_with_restricted_visibility
+                                                                    add_comments_with_restricted_visibility
+                                                                    edit_own_comments_with_restricted_visibility])
+    create(:user,
+           firstname: "Restricted",
+           lastname: "ViewerCommenter",
+           member_with_roles: { project => viewer_role_with_commenting_permission })
+  end
+end

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -183,9 +183,14 @@ module Components
         page.find_test_selector("op-open-work-package-journal-form-trigger").click
       end
 
+      def refocus_editor
+        ckeditor.refocus
+        expect_focus_on_editor
+      end
+
       def expect_focus_on_editor
         page.within_test_selector("op-work-package-journal-form-element") do
-          expect(page).to have_css(".ck-content:focus")
+          expect(page).to have_css(".ck-content:focus", wait: 10)
         end
       end
 
@@ -201,7 +206,11 @@ module Components
       end
 
       def type_comment(text)
-        open_new_comment_editor if page.find_test_selector("op-open-work-package-journal-form-trigger")
+        begin
+          open_new_comment_editor if page.find_test_selector("op-open-work-package-journal-form-trigger")
+        rescue Capybara::ElementNotFound
+          # If the editor is already open, we don't need to open it again
+        end
 
         # Wait for the editor form to be present and ready
         wait_for { page }.to have_test_selector("op-work-package-journal-form-element")
@@ -242,10 +251,7 @@ module Components
         page.within_test_selector("op-work-package-journal-form-element") do
           get_editor_form_field_element.set_value(text)
 
-          if restricted
-            expect(page).to have_test_selector("op-work-package-journal-restricted-comment-checkbox")
-            page.check("Restrict visibility")
-          end
+          check_restricted_visibility_comment_checkbox if restricted
 
           page.find_test_selector("op-submit-work-package-journal-form").click if save
         end
@@ -298,6 +304,11 @@ module Components
         end
 
         expect(page).to have_test_selector("op-work-package-journal-form-element")
+      end
+
+      def check_restricted_visibility_comment_checkbox
+        expect(page).to have_test_selector("op-work-package-journal-restricted-comment-checkbox")
+        page.check("Restrict visibility")
       end
 
       def dismiss_comment_editor_with_esc

--- a/spec/support/work_packages/activities_tab/restricted_visibility_comments_helpers.rb
+++ b/spec/support/work_packages/activities_tab/restricted_visibility_comments_helpers.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "spec_helper"
+
+module RestrictedVisibilityCommentsHelpers
+  def create_user_without_restricted_comments_view_permissions
+    viewer_role = create(:project_role, permissions: %i[view_work_packages])
+    create(:user,
+           firstname: "A",
+           lastname: "Viewer",
+           member_with_roles: { project => viewer_role })
+  end
+
+  def create_user_as_project_admin
+    member_role = create(:project_role,
+                         permissions: %i[view_work_packages add_work_package_notes
+                                         edit_own_work_package_notes
+                                         view_comments_with_restricted_visibility
+                                         add_comments_with_restricted_visibility
+                                         edit_own_comments_with_restricted_visibility
+                                         edit_others_comments_with_restricted_visibility])
+    create(:user, firstname: "Project", lastname: "Admin",
+                  member_with_roles: { project => member_role })
+  end
+
+  def create_user_with_restricted_comments_view_permissions
+    viewer_role = create(:project_role, permissions: %i[view_work_packages view_comments_with_restricted_visibility])
+    create(:user,
+           firstname: "Restricted",
+           lastname: "Viewer",
+           member_with_roles: { project => viewer_role })
+  end
+
+  def create_user_with_restricted_comments_view_and_write_permissions
+    viewer_role_with_commenting_permission = create(:project_role,
+                                                    permissions: %i[view_work_packages add_work_package_notes
+                                                                    edit_own_work_package_notes
+                                                                    view_comments_with_restricted_visibility
+                                                                    add_comments_with_restricted_visibility
+                                                                    edit_own_comments_with_restricted_visibility])
+    create(:user,
+           firstname: "Restricted",
+           lastname: "ViewerCommenter",
+           member_with_roles: { project => viewer_role_with_commenting_permission })
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/60988

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- [x] It should not be possible to @mention users who will not be able to view the comment with restricted visibilty (i.e, the drop-down needs to exclude users without the requisite permissions)
- [x] If a user who does not have the permissions to view restricted-visibility comments is mentioned in a regular comment and the 'Restrict visibility' checkbox is then checked, the @mention is turned into plain text. Unchecking the "Restrict visibility" checkbox will not re-convert previously stripped @mentions back to links.
- [x] Cover edit case

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/44b1c6bb-2e93-4f9a-85d3-f399cf87a502

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Introduce a sanitization endpoint on the server side that converts users mentions that do not have restricted visibility permissions- the functionality is further applied in create/update of comments.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
