### PR TITLE
Allow custom and application link schemes

### DIFF
--- a/app/models/setting/allowed_link_protocols.rb
+++ b/app/models/setting/allowed_link_protocols.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,25 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Admin::Settings
-  class GeneralSettingsController < ::Admin::SettingsController
-    menu_item :settings_general
+class Setting
+  module AllowedLinkProtocols
+    ALWAYS_ALLOWED = %w[http https mailto].freeze
 
-    def settings_params
-      super.tap do |settings|
-        settings["allowed_link_protocols"] = settings["allowed_link_protocols"].split(/\r?\n/)
-      end
-    end
-
-    def extra_permitted_filters
-      # attachment_whitelist is normally permitted as an array parameter.
-      # Explicitly permit it as a string here.
-      [:allowed_link_protocols]
-    end
-
-    def show
-      super
-      @guessed_host = request.host_with_port.dup
+    def self.all
+      (Setting.allowed_link_protocols + ALWAYS_ALLOWED).compact
     end
   end
 end

--- a/app/views/admin/settings/general_settings/show.html.erb
+++ b/app/views/admin/settings/general_settings/show.html.erb
@@ -60,6 +60,12 @@ See COPYRIGHT and LICENSE files for more details.
       </span>
     </div>
     <div class="form--field"><%= setting_check_box :cache_formatted_text %></div>
+    <div class="form--field">
+      <%= setting_text_area :allowed_link_protocols, rows: 5, container_class: "-wide" %>
+      <div class="form--field-instructions">
+        <%= t(:setting_allowed_link_protocols_text_html) %>
+      </div>
+    </div>
     <div class="form--field"><%= setting_check_box :feeds_enabled, size: 6 %></div>
     <div class="form--field"><%= setting_text_field :feeds_limit, size: 6, container_class: "-xslim" %></div>
     <div class="form--field"><%= setting_text_field :work_packages_projects_export_limit, size: 6, container_class: "-xslim" %></div>

--- a/app/views/admin/settings/general_settings/show.html.erb
+++ b/app/views/admin/settings/general_settings/show.html.erb
@@ -63,7 +63,13 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="form--field">
       <%= setting_text_area :allowed_link_protocols, rows: 5, container_class: "-wide" %>
       <div class="form--field-instructions">
-        <%= t(:setting_allowed_link_protocols_text_html) %>
+        <%= t(:setting_allowed_link_protocols_text_html,
+              tel_code: content_tag(:code, "tel"),
+              element_code: content_tag(:code, "element"),
+              http_code: content_tag(:code, "http"),
+              https_code: content_tag(:code, "https"),
+              mailto_code: content_tag(:code, "mailto"),
+              ) %>
       </div>
     </div>
     <div class="form--field"><%= setting_check_box :feeds_enabled, size: 6 %></div>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -44,6 +44,11 @@ module Settings
         format: :string,
         default: nil
       },
+      allowed_link_protocols: {
+        format: :array,
+        description: "Allowed protocols for links in the WYSIWYG editor and formatted texts",
+        default: []
+      },
       apiv3_cors_enabled: {
         description: "Enable CORS headers for APIv3 server responses",
         default: false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3694,6 +3694,11 @@ en:
 
   search_input_placeholder: "Search ..."
 
+  setting_allowed_link_protocols: "Allowed link protocols"
+  setting_allowed_link_protocols_text_html: >
+    Allow these protocols to be rendered as links in work package descriptions, long text fields and comments. For example, <code>tel</code> or <code>element</code>
+    <br/>
+    http(s) and mailto are always allowed.
   setting_after_first_login_redirect_url: "First login redirect"
   setting_after_first_login_redirect_url_text_html: >
     Set a path to redirect users after their first login. If empty, redirects to the home page for the onboarding tour.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3695,10 +3695,11 @@ en:
   search_input_placeholder: "Search ..."
 
   setting_allowed_link_protocols: "Allowed link protocols"
-  setting_allowed_link_protocols_text_html: >
-    Allow these protocols to be rendered as links in work package descriptions, long text fields and comments. For example, <code>tel</code> or <code>element</code>
+  setting_allowed_link_protocols_text_html: >-
+    Allow these protocols to be rendered as links in work package descriptions, long text fields and comments.
+    For example, <code>tel</code> or <code>element</code>.
     <br/>
-    http(s) and mailto are always allowed.
+    Protocols <code>http</code>, <code>https</code>, and <code>mailto</code> are always allowed.
   setting_after_first_login_redirect_url: "First login redirect"
   setting_after_first_login_redirect_url_text_html: >
     Set a path to redirect users after their first login. If empty, redirects to the home page for the onboarding tour.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3697,9 +3697,9 @@ en:
   setting_allowed_link_protocols: "Allowed link protocols"
   setting_allowed_link_protocols_text_html: >-
     Allow these protocols to be rendered as links in work package descriptions, long text fields and comments.
-    For example, <code>tel</code> or <code>element</code>.
+    For example, %{tel_code} or %{element_code}. Enter one protocol per line.
     <br/>
-    Protocols <code>http</code>, <code>https</code>, and <code>mailto</code> are always allowed.
+    Protocols %{http_code}, %{https_code}, and %{mailto_code} are always allowed.
   setting_after_first_login_redirect_url: "First login redirect"
   setting_after_first_login_redirect_url_text_html: >
     Set a path to redirect users after their first login. If empty, redirects to the home page for the onboarding tour.

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -87,6 +87,10 @@ export class ConfigurationService {
     return this.systemPreference('perPageOptions');
   }
 
+  public get allowedLinkProtocols():string[]|null {
+    return this.systemPreference('allowedLinkProtocols') || null;
+  }
+
   public dateFormatPresent():boolean {
     return !!this.systemPreference('dateFormat');
   }

--- a/frontend/src/app/features/hal/resources/configuration-resource.ts
+++ b/frontend/src/app/features/hal/resources/configuration-resource.ts
@@ -29,5 +29,6 @@
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 export class ConfigurationResource extends HalResource {
-  public perPageOptions:Array<number>;
+  public perPageOptions:number[];
+  public allowedLinkProtocols?:string[];
 }

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
@@ -106,7 +106,7 @@ export class CKEditorSetupService {
 
     const allowedLinkProtocols = this.configurationService.allowedLinkProtocols;
     if (allowedLinkProtocols) {
-      config.link = { allowedLinkProtocols };
+      config.link = { allowedProtocols: allowedLinkProtocols };
     }
 
     return config;

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -98,6 +98,9 @@ module API
                      .map { |flag| flag.camelize(:lower) }
                  }
 
+        property :allowed_link_protocols,
+                 getter: ->(*) { Setting::AllowedLinkProtocols.all }
+
         property :user_preferences,
                  embedded: true,
                  exec_context: :decorator,

--- a/lib/open_project/text_formatting/filters/sanitization_filter.rb
+++ b/lib/open_project/text_formatting/filters/sanitization_filter.rb
@@ -62,7 +62,12 @@ module OpenProject::TextFormatting
           transformers: base[:transformers] + transformers,
 
           # Allow relaxed CSS styles for the given attributes
-          css: ::Sanitize::Config::RELAXED[:css]
+          css: ::Sanitize::Config::RELAXED[:css],
+
+          # Allow our protocols, and relative links always
+          protocols: {
+            "a" => { "href" => Setting::AllowedLinkProtocols.all + %i[relative] }
+          }
         )
       end
 

--- a/spec/lib/open_project/text_formatting/allowed_link_protocols_spec.rb
+++ b/spec/lib/open_project/text_formatting/allowed_link_protocols_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "markdown/expected_markdown"
+
+RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols" do # rubocop:disable RSpec/SpecFilePathFormat
+  include_context "expected markdown modules"
+
+  context "with default link protocols" do
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link to [OpenProject](https://www.openproject.org)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link to <a href="https://www.openproject.org" rel="noopener noreferrer" target="_top" class="op-uc-link">OpenProject</a></p>
+        EXPECTED
+      end
+    end
+
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          Contact us via [email](mailto:info@openproject.org)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">Contact us via <a href="mailto:info@openproject.org" rel="noopener noreferrer" target="_top" class="op-uc-link">email</a></p>
+        EXPECTED
+      end
+    end
+
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link with [custom protocol](ftp://example.org)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link with <a rel="noopener noreferrer" target="_top" class="op-uc-link">custom protocol</a></p>
+        EXPECTED
+      end
+    end
+  end
+
+  context "with custom allowed protocols", with_settings: { allowed_link_protocols: %w[ftp sftp] } do
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link to [OpenProject](https://www.openproject.org)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link to <a href="https://www.openproject.org" rel="noopener noreferrer" target="_top" class="op-uc-link">OpenProject</a></p>
+        EXPECTED
+      end
+    end
+
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link with [FTP protocol](ftp://example.org)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link with <a href="ftp://example.org" rel="noopener noreferrer" target="_top" class="op-uc-link">FTP protocol</a></p>
+        EXPECTED
+      end
+    end
+
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link with [SFTP protocol](sftp://example.org)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link with <a href="sftp://example.org" rel="noopener noreferrer" target="_top" class="op-uc-link">SFTP protocol</a></p>
+        EXPECTED
+      end
+    end
+
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link with [data protocol](data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link with <a rel="noopener noreferrer" target="_top" class="op-uc-link">data protocol</a></p>
+        EXPECTED
+      end
+    end
+  end
+
+  context "with data protocol allowed", with_settings: { allowed_link_protocols: %w[data] } do
+    it_behaves_like "format_text produces" do
+      let(:raw) do
+        <<~RAW
+          A link with [data protocol](data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==)
+        RAW
+      end
+
+      let(:expected) do
+        <<~EXPECTED
+          <p class="op-uc-p">A link with <a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==" rel="noopener noreferrer" target="_top" class="op-uc-link">data protocol</a></p>
+        EXPECTED
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/45052


<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Allow users to customize the previously static allowlist from CKEditor on the link schemes that you can generate and output in Markdown.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Add new configuration flag that is used for setting up CKEditor (https://ckeditor.com/docs/ckeditor5/latest/features/link.html#adding-custom-protocols-in-links), and in the SanitizationFilter when generating Markdown