### PR TITLE
Fix SSO storage creation via API

### DIFF
--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -94,7 +94,6 @@ module API::V3::Storages
 
     property :storageAudience,
              skip_render: ->(represented:, **) { !represented.provider_type_nextcloud? },
-             skip_parse: ->(represented:, **) { !represented.provider_type_nextcloud? },
              getter: ->(represented:, **) { represented.provider_type_nextcloud? && represented.storage_audience },
              setter: ->(fragment:, represented:, **) { represented.storage_audience = fragment }
 
@@ -169,8 +168,6 @@ module API::V3::Storages
                             { href: method }
                           },
                           setter: ->(fragment:, **) {
-                            break unless represented.provider_type_nextcloud?
-
                             href = fragment["href"]
                             break if href.blank? || !AUTHENTICATION_METHOD_MAP.key?(href)
 


### PR DESCRIPTION
There were several bad assumptions in the previous implementation. First, the represented is not a storage, but effectively a Hashie::Mash, so just a fancy hash. Thus methods such a provider_type_nextcloud? don't exist, but sadly no error is raised, because `?` methods will just return false if a key with the same name is missing.

Also on a more general level, it doesn't make sense skip parsing certain fields depending on the type, because we can't make sure that the type is being parsed first. Thus we might skip parsing fields and afterwards realize that we should have parsed them in the first place.

If we wanted to prevent assigning attributes that we don't want to assign, it would be the responsibility of SetAttributesService and contracts to ensure that.

# Ticket
https://community.openproject.org/wp/62191

# Merge checklist

- [x] Added/updated tests
