### PR TITLE
[60667] Automatic scheduling mode: make it possible to enter Finish date by direct input or by clicking on the mini calendar

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -157,12 +157,8 @@ module WorkPackages
       end
 
       def disabled?(name)
-        if name == :duration
-          if !@schedule_manually && @work_package.children.any?
-            return true
-          end
-
-          return false
+        if name == :start_date && !@schedule_manually
+          return true
         end
 
         @disabled
@@ -196,7 +192,7 @@ module WorkPackages
                          "focus->work-packages--date-picker--preview#onHighlightField",
                  test_selector: "op-datepicker-modal--#{name.to_s.dasherize}-field" }
 
-        if @focused_field == name
+        if @focused_field == name && !disabled?(name)
           data[:qa_highlighted] = "true"
           data[:focus] = "true"
         end

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -5,6 +5,7 @@
               controller: "work-packages--date-picker--preview",
               "work-packages--date-picker--preview-date-mode-value": date_mode,
               "work-packages--date-picker--preview-triggering-field-value": triggering_field,
+              "work-packages--date-picker--preview-schedule-manually-value": schedule_manually,
               test_selector: "op-datepicker-modal" },
       class: "wp-datepicker-dialog--content"
     ) do

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -105,6 +105,7 @@
                                           ignore_non_working_days: work_package.ignore_non_working_days,
                                           schedule_manually:,
                                           is_schedulable: !disabled?,
+                                          minimal_scheduling_date:,
                                           is_milestone: milestone?,
                                           date_mode:,
                                           start_date_field_id: "work_package_start_date",

--- a/app/components/work_packages/date_picker/form_component.rb
+++ b/app/components/work_packages/date_picker/form_component.rb
@@ -79,7 +79,7 @@ module WorkPackages
       end
 
       def disabled?
-        !schedule_manually
+        !schedule_manually && (milestone? || work_package.children.any?)
       end
 
       def milestone?
@@ -94,6 +94,10 @@ module WorkPackages
 
       def disabled_checkbox?
         !schedule_manually && work_package.children.any?
+      end
+
+      def minimal_scheduling_date
+        schedule_manually ? nil : work_package.start_date
       end
     end
   end

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -48,7 +48,7 @@ class WorkPackages::DatePickerController < ApplicationController
     respond_to do |format|
       format.html do
         render :show,
-               locals: { work_package:, schedule_manually:, params: params.merge(date_mode: date_mode).permit! },
+               locals: { work_package:, schedule_manually:, focused_field:, params: params.merge(date_mode: date_mode).permit! },
                layout: false
       end
 
@@ -120,10 +120,13 @@ class WorkPackages::DatePickerController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   def update
+    wp_params = work_package_datepicker_params
+    wp_params = manage_params_for_automatic_mode(wp_params)
+
     service_call = WorkPackages::UpdateService
                      .new(user: current_user,
                           model: @work_package)
-                     .call(work_package_datepicker_params)
+                     .call(wp_params)
 
     if service_call.success?
       respond_to do |format|
@@ -162,12 +165,21 @@ class WorkPackages::DatePickerController < ApplicationController
 
     trigger = params[:field]
 
+    # For automatic scheduling, we focus the due date initially and do not switch to start date after touching it
+    if !ActiveModel::Type::Boolean.new.cast(schedule_manually) && trigger != "duration"
+      return :due_date
+    end
+
     # Decide which field to focus next
     case trigger
+    when "startDate"
+      :start_date
     when "work_package[start_date]"
       handle_focus_order_for_fields(:start_date, :due_date)
-    when "work_package[duration]"
+    when "work_package[duration]", "duration"
       :duration
+    when "dueDate"
+      :due_date
     when "work_package[due_date]"
       handle_focus_order_for_fields(:due_date, :start_date)
     else
@@ -249,9 +261,7 @@ class WorkPackages::DatePickerController < ApplicationController
 
   def set_date_attributes_to_work_package
     wp_params = work_package_datepicker_params
-    if wp_params["schedule_manually"] == "false"
-      wp_params = wp_params.without("start_date", "due_date")
-    end
+    wp_params = manage_params_for_automatic_mode(wp_params)
 
     if wp_params.present?
       WorkPackages::SetAttributesService
@@ -307,5 +317,17 @@ class WorkPackages::DatePickerController < ApplicationController
     else
       alternative_field
     end
+  end
+
+  def manage_params_for_automatic_mode(wp_params)
+    return wp_params if wp_params["schedule_manually"] != "false"
+
+    # For WP with children the dates are always fixed
+    return wp_params.without("start_date", "due_date") if work_package.children.any?
+
+    # the start should be preserved and will thus be send as a parameter
+    wp_params["start_date"] = work_package.start_date.to_s
+
+    wp_params
   end
 end

--- a/app/views/work_packages/date_picker/show.html.erb
+++ b/app/views/work_packages/date_picker/show.html.erb
@@ -3,7 +3,7 @@
     WorkPackages::DatePicker::DialogContentComponent.new(
       work_package:,
       schedule_manually:,
-      focused_field: (params[:focused_field] || params[:field]).underscore.to_sym,
+      focused_field:,
       triggering_field: params[:field].underscore.to_sym,
       date_mode: params[:date_mode]
     )

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -258,7 +258,10 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
 
   private isDayDisabled(dayElement:DayElement):boolean {
     const minimalDate = this.minimalSchedulingDate || null;
-    return !this.isSchedulable || (!this.scheduleManually && !!minimalDate && dayElement.dateObj <= minimalDate);
+    return !this.isSchedulable
+      || (!this.scheduleManually
+        && !!minimalDate
+        && dayElement.dateObj.setHours(0, 0, 0, 0) < new Date(minimalDate).setHours(0, 0, 0, 0));
   }
 
   /**

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -172,6 +172,7 @@ export default class PreviewController extends DialogPreviewController {
 
     let dateFieldToChange:HTMLInputElement;
     if (this.highlightedField === this.dueDateField
+        || (this.highlightedField === this.durationField && !this.scheduleManuallyValue)
         || (this.highlightedField === this.durationField
         && (this.currentStartDate !== null || !this.isTouched('start_date'))
         && this.currentDueDate === null)) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -39,10 +39,12 @@ export default class PreviewController extends DialogPreviewController {
   static values = {
     dateMode: String,
     triggeringField: String,
+    scheduleManually: Boolean,
   };
 
   declare dateModeValue:string;
   declare triggeringFieldValue:string;
+  declare scheduleManuallyValue:boolean;
 
   private timezoneService:TimezoneService;
   private highlightedField:HTMLInputElement|null = null;
@@ -217,12 +219,11 @@ export default class PreviewController extends DialogPreviewController {
       this.setDurationFieldValue(this.currentDuration);
       this.doMarkFieldAsTouched('due_date');
     }
+
     this.currentStartDate = selectedDate;
     this.setStartDateFieldValue(this.currentStartDate);
     this.doMarkFieldAsTouched('start_date');
-    if (this.currentDueDate) {
-      this.highlightField(this.dueDateField);
-    }
+
     this.keepFieldValue();
   }
 
@@ -235,12 +236,11 @@ export default class PreviewController extends DialogPreviewController {
       this.setDurationFieldValue(this.currentDuration);
       this.doMarkFieldAsTouched('start_date');
     }
+
     this.currentDueDate = selectedDate;
     this.setDueDateFieldValue(this.currentDueDate);
     this.doMarkFieldAsTouched('due_date');
-    if (this.currentStartDate) {
-      this.highlightField(this.startDateField);
-    }
+
     this.keepFieldValue();
   }
 
@@ -448,12 +448,19 @@ export default class PreviewController extends DialogPreviewController {
       return;
     }
 
+    if (!this.scheduleManuallyValue) {
+      // Fix the start date to avoid that it gets changed accidentally
+      this.markTouched('start_date');
+    }
+
     if (this.isBeingEdited('start_date')) {
       this.untouchFieldsWhenStartDateIsEdited();
     } else if (this.isBeingEdited('due_date')) {
       this.untouchFieldsWhenDueDateIsEdited();
     } else if (this.isBeingEdited('duration')) {
       this.untouchFieldsWhenDurationIsEdited();
+    } else if (this.isBeingEdited('ignore_non_working_days')) {
+      this.untouchFieldsWhenIgnoreNonWorkingDaysIsEdited();
     }
   }
 
@@ -479,29 +486,47 @@ export default class PreviewController extends DialogPreviewController {
   }
 
   private untouchFieldsWhenDueDateIsEdited():void {
-    if (this.isTouchedAndEmpty('start_date') && this.isValueSet('duration')) {
-      // force start date derivation
-      this.markUntouched('start_date');
-      this.markTouched('duration');
-    } else if (this.isValueSet('start_date')) {
+    if (this.scheduleManuallyValue) {
+      if (this.isTouchedAndEmpty('start_date') && this.isValueSet('duration')) {
+        // force start date derivation
+        this.markUntouched('start_date');
+        this.markTouched('duration');
+      } else if (this.isValueSet('start_date')) {
+        this.markUntouched('duration');
+      }
+    } else {
       this.markUntouched('duration');
     }
   }
 
   private untouchFieldsWhenDurationIsEdited():void {
-    if (this.isTouched('start_date')) {
-      if (this.isValueSet('start_date')) {
-        this.markUntouched('due_date');
-      } else if (this.isValueSet('due_date')) {
-        this.markUntouched('start_date');
-        this.markTouched('due_date');
+    if (this.scheduleManuallyValue) {
+      if (this.isTouched('start_date')) {
+        if (this.isValueSet('start_date')) {
+          this.markUntouched('due_date');
+        } else if (this.isValueSet('due_date')) {
+          this.markUntouched('start_date');
+          this.markTouched('due_date');
+        }
+      } else if (this.isTouched('due_date')) {
+        if (this.isValueSet('due_date')) {
+          this.markUntouched('start_date');
+        } else if (this.isValueSet('start_date')) {
+          this.markUntouched('due_date');
+          this.markTouched('start_date');
+        }
       }
-    } else if (this.isTouched('due_date')) {
-      if (this.isValueSet('due_date')) {
-        this.markUntouched('start_date');
-      } else if (this.isValueSet('start_date')) {
+    } else {
+      this.markUntouched('due_date');
+    }
+  }
+
+  private untouchFieldsWhenIgnoreNonWorkingDaysIsEdited():void {
+    if (!this.scheduleManuallyValue) {
+      if (this.isTouched('duration')) {
         this.markUntouched('due_date');
-        this.markTouched('start_date');
+      } else if (this.isTouched('due_date')) {
+        this.markUntouched('duration');
       }
     }
   }

--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
 
       it "shows the date form with disabled fields" do
         expect(dialog_content).to have_field(I18n.t("attributes.start_date"), disabled: true)
-        expect(dialog_content).to have_field(I18n.t("attributes.due_date"), disabled: true)
+        expect(dialog_content).to have_field(I18n.t("attributes.due_date"), disabled: false)
       end
 
       it "shows the banner 'The start date is set by a predecessor'" do
@@ -169,7 +169,7 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
 
       it "shows the date form with disabled fields" do
         expect(dialog_content).to have_field(I18n.t("attributes.start_date"), disabled: true)
-        expect(dialog_content).to have_field(I18n.t("attributes.due_date"), disabled: true)
+        expect(dialog_content).to have_field(I18n.t("attributes.due_date"), disabled: false)
       end
 
       it "shows the banner 'The start date is set by a predecessor'" do

--- a/spec/features/work_packages/datepicker/datepicker_editable_finish_date_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_editable_finish_date_logic_spec.rb
@@ -1,0 +1,409 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "support/edit_fields/edit_field"
+
+RSpec.describe "Datepicker: Finish date field in auto-scheduled mode logic test cases (WP #62599)", :js,
+               with_settings: { date_format: "%Y-%m-%d" } do
+  shared_let(:user) { create(:admin) }
+
+  shared_let(:type_bug) { create(:type_bug) }
+  shared_let(:project) { create(:project, types: [type_bug]) }
+
+  shared_let(:work_package) do
+    create(:work_package,
+           project:,
+           type: type_bug,
+           start_date: "2025-04-08",
+           due_date: "2025-04-17",
+           duration: 8,
+           schedule_manually: false)
+  end
+  shared_let(:predecessor) { create(:work_package, project:, type: type_bug, start_date: "2025-04-07", due_date: "2025-04-07") }
+
+  let!(:relationship) do
+    create(:relation,
+           from: predecessor,
+           to: work_package,
+           relation_type: Relation::TYPE_PRECEDES)
+  end
+  let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let!(:query) do
+    query              = build(:query, user:, project:)
+    query.column_names = ["subject", "start_date", "due_date", "duration"]
+    query.filters.clear
+
+    query.save!
+    query
+  end
+  let(:date_attribute) { :combinedDate }
+  let(:date_field) { work_packages_page.edit_field(date_attribute) }
+  let(:datepicker) { date_field.datepicker }
+  let(:current_user) { user }
+
+  # assume sat+sun are non working days
+  shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }
+
+  before do
+    login_as(current_user)
+
+    work_packages_page.visit!
+    work_packages_page.ensure_page_loaded
+    date_field.activate!
+    date_field.expect_active!
+    # Wait for the datepicker to be initialized
+    datepicker.expect_visible
+    datepicker.expect_automatic_scheduling_mode
+    datepicker.expect_start_date "2025-04-08", disabled: true
+    datepicker.expect_due_date "2025-04-17", disabled: false
+    datepicker.expect_duration "8"
+
+    datepicker.expect_due_highlighted
+  end
+
+  describe "when changing finish date (manual input) (scenario 1)" do
+    it "sets the finish date and calculates the duration" do
+      datepicker.set_due_date "2025-04-23"
+
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-23", disabled: false
+      datepicker.expect_duration "12"
+
+      datepicker.expect_due_highlighted
+    end
+  end
+
+  describe "when changing finish date (click on calendar) (scenario 2)" do
+    it "sets the finish date and calculates the duration" do
+      datepicker.set_date "2025-04-23"
+
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-23", disabled: false
+      datepicker.expect_duration "12"
+
+      datepicker.expect_due_highlighted
+    end
+  end
+
+  describe "when changing duration (scenario 3)" do
+    it "sets the duration and calculates the finish date" do
+      datepicker.set_duration "12"
+
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-23", disabled: false
+      datepicker.expect_duration "12"
+
+      datepicker.expect_due_highlighted
+    end
+  end
+
+  describe "when changing finish date and non-working days (scenario 4)" do
+    it "keeps the finish date and calculates the duration" do
+      datepicker.set_date "2025-04-23"
+
+      datepicker.expect_working_days_only(true)
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-23", disabled: false
+      datepicker.expect_duration "12"
+
+      datepicker.toggle_working_days_only
+
+      datepicker.expect_working_days_only(false)
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-23", disabled: false
+      datepicker.expect_duration "16"
+    end
+  end
+
+  describe "when changing duration date and non-working days (scenario 5)" do
+    it "keeps the duration and calculates the finish date" do
+      datepicker.set_duration "14"
+
+      datepicker.expect_working_days_only(true)
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-25", disabled: false
+      datepicker.expect_duration "14"
+
+      datepicker.toggle_working_days_only
+
+      datepicker.expect_working_days_only(false)
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-21", disabled: false
+      datepicker.expect_duration "14"
+    end
+  end
+
+  describe "when launching date-picker with duration but change finish date (scenario 6)" do
+    let(:duration) { wp_table.edit_field(work_package, :duration) }
+
+    before do
+      wp_table.visit_query query
+    end
+
+    it "sets the finish date" do
+      duration.activate!
+      duration.expect_active!
+
+      datepicker.expect_visible
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-17", disabled: false
+      datepicker.expect_duration "8"
+      datepicker.expect_duration_highlighted
+
+      datepicker.set_date "2025-04-24"
+
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "2025-04-24", disabled: false
+      datepicker.expect_duration "13"
+    end
+  end
+
+  describe "when removing the finish date (scenario 7)" do
+    it "clears duration and finish date" do
+      datepicker.set_due_date ""
+
+      datepicker.expect_start_date "2025-04-08", disabled: true
+      datepicker.expect_due_date "", disabled: false
+      datepicker.expect_duration ""
+    end
+  end
+
+  describe "when switching to manual" do
+    before do
+      datepicker.click_manual_scheduling_mode
+
+      datepicker.expect_manual_scheduling_mode
+      datepicker.expect_start_date "2025-04-08", disabled: false
+      datepicker.expect_due_date "2025-04-17", disabled: false
+      datepicker.expect_duration "8"
+
+      datepicker.focus_due_date
+    end
+
+    describe "and changing the finish date (scenario 8)" do
+      it "keeps the finish date and calculates the duration" do
+        datepicker.set_due_date "2025-04-23"
+
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-23", disabled: false
+        datepicker.expect_duration "12"
+      end
+    end
+
+    describe "and changing the start date to the past and switching back to automatic (scenario 9)" do
+      it "resets the start date" do
+        datepicker.focus_start_date
+        datepicker.set_date "2025-04-02"
+
+        datepicker.expect_start_date "2025-04-02", disabled: false
+        datepicker.expect_due_date "2025-04-17", disabled: false
+        datepicker.expect_duration "12"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-17", disabled: false
+        datepicker.expect_duration "8"
+      end
+    end
+
+    describe "and changing the start date to the future and switching back to automatic (scenario 10)" do
+      it "resets the start date" do
+        datepicker.focus_start_date
+        datepicker.set_date "2025-04-14"
+
+        datepicker.expect_start_date "2025-04-14", disabled: false
+        datepicker.expect_due_date "2025-04-17", disabled: false
+        datepicker.expect_duration "4"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-17", disabled: false
+        datepicker.expect_duration "8"
+      end
+    end
+
+    describe "and changing new start and finish date (both before constraint) and switching back to automatic (scenario 11)" do
+      it "resets the start date and throws an error for the finish date" do
+        datepicker.focus_start_date
+        datepicker.set_date "2025-04-01"
+
+        datepicker.expect_start_date "2025-04-01", disabled: false
+        datepicker.expect_due_date "2025-04-17", disabled: false
+        datepicker.expect_duration "13"
+
+        datepicker.focus_due_date
+        datepicker.set_date "2025-04-07"
+
+        datepicker.expect_start_date "2025-04-01", disabled: false
+        datepicker.expect_due_date "2025-04-07", disabled: false
+        datepicker.expect_duration "5"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-07", disabled: false
+        datepicker.expect_duration "0"
+
+        datepicker.expect_due_date_error(
+          I18n.t("activerecord.errors.models.work_package.attributes.start_date.violates_relationships",
+                 soonest_start: "2025-04-08").capitalize
+        )
+        datepicker.expect_duration_error "Must be greater than 0."
+      end
+    end
+
+    describe "and changing new start (before constraint) and finish date (after constraint),
+              switching back to automatic (scenario 12)" do
+      it "resets the start date and preserves the finish date" do
+        datepicker.focus_start_date
+        datepicker.set_date "2025-04-01"
+
+        datepicker.expect_start_date "2025-04-01", disabled: false
+        datepicker.expect_due_date "2025-04-17", disabled: false
+        datepicker.expect_duration "13"
+
+        datepicker.focus_due_date
+        datepicker.set_date "2025-04-24"
+
+        datepicker.expect_start_date "2025-04-01", disabled: false
+        datepicker.expect_due_date "2025-04-24", disabled: false
+        datepicker.expect_duration "18"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-24", disabled: false
+        datepicker.expect_duration "13"
+      end
+    end
+
+    describe "and changing duration (start date unmodified) switching back to automatic (scenario 13a)" do
+      it "preserves the duration" do
+        datepicker.set_duration "14"
+
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "14"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "14"
+      end
+    end
+
+    describe "and changing duration and start date, switching back to automatic (scenario 13b)" do
+      it "preserves the duration and resets the start date" do
+        datepicker.set_duration "14"
+
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "14"
+
+        datepicker.focus_start_date
+        datepicker.set_date "2025-04-04"
+
+        datepicker.expect_start_date "2025-04-04", disabled: false
+        datepicker.expect_due_date "2025-04-23", disabled: false
+        datepicker.expect_duration "14"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "14"
+      end
+    end
+
+    describe "and change duration and non-working days, switching back to automatic (scenario 14a)" do
+      it "preserves the duration date" do
+        datepicker.set_duration "14"
+
+        datepicker.expect_working_days_only(true)
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "14"
+
+        datepicker.toggle_working_days_only
+
+        datepicker.expect_working_days_only(false)
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-21", disabled: false
+        datepicker.expect_duration "14"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_working_days_only(false)
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-21", disabled: false
+        datepicker.expect_duration "14"
+      end
+    end
+
+    describe "and change finish and non-working days, switching back to automatic (scenario 14b)" do
+      it "preserves the finish date" do
+        pending "Enable when #62641 has been fixed"
+        datepicker.set_date "2025-04-25"
+
+        datepicker.expect_working_days_only(true)
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "14"
+
+        datepicker.toggle_working_days_only
+
+        datepicker.expect_working_days_only(false)
+        datepicker.expect_start_date "2025-04-08", disabled: false
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "18"
+
+        datepicker.click_automatic_scheduling_mode
+
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_working_days_only(false)
+        datepicker.expect_start_date "2025-04-08", disabled: true
+        datepicker.expect_due_date "2025-04-25", disabled: false
+        datepicker.expect_duration "18"
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
@@ -39,46 +39,26 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
     create(:work_package,
            type:,
            project:,
-           start_date: Date.parse("2024-02-02"),
-           due_date: Date.parse("2024-02-06"))
+           start_date: Date.parse("2024-02-01"),
+           due_date: Date.parse("2024-02-01"))
   end
+  # assume sat+sun are non-working days
+  shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }
 
   let(:work_packages_page) { Pages::FullWorkPackage.new(follower) }
   let(:datepicker) { date_field.datepicker }
 
-  shared_examples "keeps the minimum date from the predecessor when toggling NWD" do
-    it "keeps the minimum dates disabled" do
-      login_as(user)
+  before do
+    login_as(user)
+    relation
 
-      work_packages_page.visit!
-      work_packages_page.ensure_page_loaded
+    work_packages_page.visit!
+    work_packages_page.ensure_page_loaded
 
-      date_field.activate!
-      date_field.expect_active!
-      # Wait for the datepicker to be initialized
-      datepicker.expect_visible
-
-      datepicker.expect_working_days_only true
-      datepicker.expect_automatic_scheduling_mode
-
-      datepicker.show_date "2024-02-06"
-      datepicker.expect_not_disabled Date.parse("2024-02-06")
-      datepicker.expect_not_disabled Date.parse("2024-02-05")
-      datepicker.expect_not_disabled Date.parse("2024-02-04")
-      datepicker.expect_not_disabled Date.parse("2024-02-03")
-      datepicker.expect_not_disabled Date.parse("2024-02-02")
-      datepicker.expect_disabled Date.parse("2024-02-01")
-
-      datepicker.toggle_working_days_only
-      datepicker.expect_working_days_only false
-
-      datepicker.expect_not_disabled Date.parse("2024-02-06")
-      datepicker.expect_not_disabled Date.parse("2024-02-05")
-      datepicker.expect_not_disabled Date.parse("2024-02-04")
-      datepicker.expect_not_disabled Date.parse("2024-02-03")
-      datepicker.expect_not_disabled Date.parse("2024-02-02")
-      datepicker.expect_disabled Date.parse("2024-02-01")
-    end
+    date_field.activate!
+    date_field.expect_active!
+    # Wait for the datepicker to be initialized
+    datepicker.expect_visible
   end
 
   context "if the follower is a task" do
@@ -93,7 +73,30 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
     let!(:relation) { create(:follows_relation, from: follower, to: predecessor) }
     let(:date_field) { work_packages_page.edit_field(:combinedDate) }
 
-    it_behaves_like "keeps the minimum date from the predecessor when toggling NWD"
+    it "keeps the minimum dates disabled" do
+      datepicker.expect_working_days_only true
+      datepicker.expect_automatic_scheduling_mode
+
+      datepicker.show_date "2024-02-01"
+      datepicker.expect_disabled Date.parse("2024-02-01") # predecessor's due date
+      datepicker.expect_not_disabled Date.parse("2024-02-02")
+      datepicker.expect_disabled Date.parse("2024-02-03") # Saturday is non-working day
+      datepicker.expect_disabled Date.parse("2024-02-04") # Sunday is non-working day
+      datepicker.expect_not_disabled Date.parse("2024-02-05")
+      datepicker.expect_not_disabled Date.parse("2024-02-06")
+      datepicker.expect_not_disabled Date.parse("2024-02-07")
+
+      datepicker.toggle_working_days_only
+      datepicker.expect_working_days_only false
+
+      datepicker.expect_disabled Date.parse("2024-02-01") # predecessor's due date
+      datepicker.expect_not_disabled Date.parse("2024-02-02")
+      datepicker.expect_not_disabled Date.parse("2024-02-03") # Saturday is non-working day but ignored
+      datepicker.expect_not_disabled Date.parse("2024-02-04") # Sunday is non-working day but ignored
+      datepicker.expect_not_disabled Date.parse("2024-02-05")
+      datepicker.expect_not_disabled Date.parse("2024-02-06")
+      datepicker.expect_not_disabled Date.parse("2024-02-07")
+    end
   end
 
   context "if the follower is a milestone" do
@@ -103,11 +106,26 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
              project:,
              schedule_manually: false,
              start_date: Date.parse("2024-02-02"),
-             due_date: Date.parse("2024-02-06"))
+             due_date: Date.parse("2024-02-02"))
     end
     let!(:relation) { create(:follows_relation, from: follower, to: predecessor) }
     let(:date_field) { work_packages_page.edit_field(:date) }
 
-    it_behaves_like "keeps the minimum date from the predecessor when toggling NWD"
+    it "disables the whole date picker" do
+      datepicker.expect_working_days_only true
+      datepicker.expect_automatic_scheduling_mode
+
+      datepicker.show_date "2024-02-02"
+      1.upto(29) do |day|
+        datepicker.expect_disabled Date.parse("2024-02-%02d" % day)
+      end
+
+      datepicker.toggle_working_days_only
+      datepicker.expect_working_days_only false
+
+      1.upto(29) do |day|
+        datepicker.expect_disabled Date.parse("2024-02-%02d" % day)
+      end
+    end
   end
 end

--- a/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
@@ -37,9 +37,10 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
   shared_let(:project) { create(:project, types: [milestone_type]) }
   shared_let(:predecessor) do
     create(:work_package,
-           type:, project:,
-           start_date: Date.parse("2024-02-01"),
-           due_date: Date.parse("2024-02-05"))
+           type:,
+           project:,
+           start_date: Date.parse("2024-02-02"),
+           due_date: Date.parse("2024-02-06"))
   end
 
   let(:work_packages_page) { Pages::FullWorkPackage.new(follower) }
@@ -60,26 +61,35 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
       datepicker.expect_working_days_only true
       datepicker.expect_automatic_scheduling_mode
 
-      datepicker.show_date "2024-02-05"
-      datepicker.expect_disabled Date.parse("2024-02-05")
-      datepicker.expect_disabled Date.parse("2024-02-04")
-      datepicker.expect_disabled Date.parse("2024-02-03")
-      datepicker.expect_disabled Date.parse("2024-02-02")
+      datepicker.show_date "2024-02-06"
+      datepicker.expect_not_disabled Date.parse("2024-02-06")
+      datepicker.expect_not_disabled Date.parse("2024-02-05")
+      datepicker.expect_not_disabled Date.parse("2024-02-04")
+      datepicker.expect_not_disabled Date.parse("2024-02-03")
+      datepicker.expect_not_disabled Date.parse("2024-02-02")
       datepicker.expect_disabled Date.parse("2024-02-01")
 
       datepicker.toggle_working_days_only
       datepicker.expect_working_days_only false
 
-      datepicker.expect_disabled Date.parse("2024-02-05")
-      datepicker.expect_disabled Date.parse("2024-02-04")
-      datepicker.expect_disabled Date.parse("2024-02-03")
-      datepicker.expect_disabled Date.parse("2024-02-02")
+      datepicker.expect_not_disabled Date.parse("2024-02-06")
+      datepicker.expect_not_disabled Date.parse("2024-02-05")
+      datepicker.expect_not_disabled Date.parse("2024-02-04")
+      datepicker.expect_not_disabled Date.parse("2024-02-03")
+      datepicker.expect_not_disabled Date.parse("2024-02-02")
       datepicker.expect_disabled Date.parse("2024-02-01")
     end
   end
 
   context "if the follower is a task" do
-    let!(:follower) { create(:work_package, type:, project:, schedule_manually: false) }
+    let!(:follower) do
+      create(:work_package,
+             type:,
+             project:,
+             schedule_manually: false,
+             start_date: Date.parse("2024-02-02"),
+             due_date: Date.parse("2024-02-06"))
+    end
     let!(:relation) { create(:follows_relation, from: follower, to: predecessor) }
     let(:date_field) { work_packages_page.edit_field(:combinedDate) }
 
@@ -87,7 +97,14 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
   end
 
   context "if the follower is a milestone" do
-    let!(:follower) { create(:work_package, type: milestone_type, project:, schedule_manually: false) }
+    let!(:follower) do
+      create(:work_package,
+             type: milestone_type,
+             project:,
+             schedule_manually: false,
+             start_date: Date.parse("2024-02-02"),
+             due_date: Date.parse("2024-02-06"))
+    end
     let!(:relation) { create(:follows_relation, from: follower, to: predecessor) }
     let(:date_field) { work_packages_page.edit_field(:date) }
 

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -1104,7 +1104,8 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
         datepicker.expect_working_days_only true
 
         # The non-working days are disabled
-        datepicker.expect_not_disabled Date.parse("2022-06-25")
+        datepicker.expect_disabled Date.parse("2022-06-25")
+        datepicker.expect_disabled Date.parse("2022-06-26")
         # The rest is not disabled
         datepicker.expect_not_disabled Date.parse("2022-06-27")
 
@@ -1113,6 +1114,10 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
         datepicker.expect_duration 6
 
         datepicker.uncheck_working_days_only
+
+        # The non-working days are no longer disabled
+        datepicker.expect_not_disabled Date.parse("2022-06-25")
+        datepicker.expect_not_disabled Date.parse("2022-06-26")
 
         # Since the due date was touched before, the value is kept and duration adjusted
         datepicker.expect_due_date "2022-06-27", disabled: false

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -1024,7 +1024,7 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
     end
   end
 
-  context "when setting 'Duration' and 'Working days only' of an automatically scheduled work package" do
+  context "when setting values of an automatically scheduled work package" do
     let(:work_package) do
       bug_wp.tap do |wp|
         # add a predecessor so that automatic scheduling mode can be selected and date picker is visible.
@@ -1047,27 +1047,112 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
       }
     end
 
-    it "updates the finish date, instead of disappearing (Regression #61894)" do
-      datepicker.expect_automatic_scheduling_mode
-      datepicker.expect_due_date "2022-06-21", disabled: true
-      datepicker.expect_duration 2
-      datepicker.expect_working_days_only true
+    context "when changing 'Duration' and 'Working days only'" do
+      it "updates the finish date, instead of disappearing (Regression #61894)" do
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_due_date "2022-06-21", disabled: false
+        datepicker.expect_duration 2
+        datepicker.expect_working_days_only true
 
-      datepicker.set_duration 6
+        datepicker.set_duration 6
 
-      # start date is 20 and Saturday and Sunday are non-working days, so finish date is 27
-      datepicker.expect_due_date "2022-06-27", disabled: true
+        # start date is 20 and Saturday and Sunday are non-working days, so finish date is 27
+        datepicker.expect_due_date "2022-06-27", disabled: false
 
-      datepicker.uncheck_working_days_only
+        datepicker.uncheck_working_days_only
 
-      # start date is 20, non-working days are ignored so finish date is 25
-      datepicker.expect_due_date "2022-06-25", disabled: true
+        # start date is 20, non-working days are ignored so finish date is 25
+        datepicker.expect_due_date "2022-06-25", disabled: false
 
-      apply_and_expect_saved start_date: Date.parse("2022-06-20"),
-                             due_date: Date.parse("2022-06-25"),
-                             duration: 6,
-                             ignore_non_working_days: true,
-                             schedule_manually: false
+        apply_and_expect_saved start_date: Date.parse("2022-06-20"),
+                               due_date: Date.parse("2022-06-25"),
+                               duration: 6,
+                               ignore_non_working_days: true,
+                               schedule_manually: false
+      end
+    end
+
+    context "when changing 'Due date'" do
+      it "can change it via the input field" do
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_due_date "2022-06-21", disabled: false
+        datepicker.expect_duration 2
+        datepicker.expect_working_days_only true
+
+        datepicker.set_due_date "2022-06-27"
+
+        datepicker.expect_duration 6
+
+        datepicker.uncheck_working_days_only
+
+        # Since the due date was touched before, the value is kept and duration adjusted
+        datepicker.expect_due_date "2022-06-27", disabled: false
+        datepicker.expect_duration 8
+
+        apply_and_expect_saved start_date: Date.parse("2022-06-20"),
+                               due_date: Date.parse("2022-06-27"),
+                               duration: 8,
+                               ignore_non_working_days: true,
+                               schedule_manually: false
+      end
+
+      it "can change it via the datepicker field" do
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_due_date "2022-06-21", disabled: false
+        datepicker.expect_due_highlighted
+        datepicker.expect_duration 2
+        datepicker.expect_working_days_only true
+
+        # The non-working days are disabled
+        datepicker.expect_not_disabled Date.parse("2022-06-25")
+        # The rest is not disabled
+        datepicker.expect_not_disabled Date.parse("2022-06-27")
+
+        datepicker.set_date Date.parse("2022-06-27")
+
+        datepicker.expect_duration 6
+
+        datepicker.uncheck_working_days_only
+
+        # Since the due date was touched before, the value is kept and duration adjusted
+        datepicker.expect_due_date "2022-06-27", disabled: false
+        datepicker.expect_duration 8
+
+        apply_and_expect_saved start_date: Date.parse("2022-06-20"),
+                               due_date: Date.parse("2022-06-27"),
+                               duration: 8,
+                               ignore_non_working_days: true,
+                               schedule_manually: false
+      end
+
+      it "can change duration as well while preserving the start date" do
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_due_date "2022-06-21", disabled: false
+        datepicker.expect_duration 2
+        datepicker.expect_working_days_only true
+
+        # Changing the due date will change the duration
+        datepicker.set_due_date "2022-06-27"
+        datepicker.expect_start_date "2022-06-20", disabled: true
+        datepicker.expect_duration 6
+
+        # Changing the duration afterwards, will change the due date again
+        datepicker.set_duration 7
+        datepicker.expect_due_date "2022-06-28", disabled: false
+        datepicker.expect_start_date "2022-06-20", disabled: true
+
+        # Changing the due date again, will again change the duration
+        datepicker.set_due_date "2022-06-27"
+        datepicker.expect_start_date "2022-06-20", disabled: true
+        datepicker.expect_duration 6
+
+        # Even unchecking the non working days will preserve the start date
+        # Since the due date was touched before, the value is kept and duration adjusted
+        datepicker.uncheck_working_days_only
+        datepicker.expect_due_date "2022-06-27", disabled: false
+        datepicker.expect_start_date "2022-06-20", disabled: true
+        datepicker.expect_duration 8
+      end
     end
   end
 

--- a/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
+++ b/spec/features/work_packages/scheduling/automatic_scheduling_logic_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
         open_date_picker
         datepicker.expect_automatic_scheduling_mode
         datepicker.expect_start_date "2025-01-03", disabled: true
-        datepicker.expect_due_date "2025-01-07", disabled: true
+        datepicker.expect_due_date "2025-01-07", disabled: false
         datepicker.expect_duration "3"
       end
     end
@@ -174,7 +174,7 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
         datepicker.expect_automatic_scheduling_mode
 
         datepicker.expect_start_date "2025-01-03", disabled: true
-        datepicker.expect_due_date "2025-01-07", disabled: true
+        datepicker.expect_due_date "2025-01-07", disabled: false
         datepicker.expect_duration "3", disabled: false
 
         apply_and_expect_saved(
@@ -204,7 +204,7 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
         datepicker.expect_automatic_scheduling_mode
 
         datepicker.expect_start_date "2025-01-20", disabled: true
-        datepicker.expect_due_date "2025-01-22", disabled: true
+        datepicker.expect_due_date "2025-01-22", disabled: false
         datepicker.expect_duration "3", disabled: false
 
         apply_and_expect_saved(
@@ -327,7 +327,7 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
         # parent gets properties from last removed child: child 2
         datepicker.expect_automatic_scheduling_mode
         datepicker.expect_start_date "2025-01-15", disabled: true
-        datepicker.expect_due_date "2025-01-22", disabled: true
+        datepicker.expect_due_date "2025-01-22", disabled: false
         datepicker.expect_duration "6"
         datepicker.expect_working_days_only_enabled
         datepicker.expect_working_days_only true
@@ -348,7 +348,7 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
         # parent gets properties from last removed child: child 1
         datepicker.expect_automatic_scheduling_mode
         datepicker.expect_start_date "2025-01-15", disabled: true
-        datepicker.expect_due_date "2025-01-19", disabled: true
+        datepicker.expect_due_date "2025-01-19", disabled: false
         datepicker.expect_duration "5"
         datepicker.expect_working_days_only_enabled
         datepicker.expect_working_days_only false
@@ -435,28 +435,28 @@ RSpec.describe "Automatic scheduling logic test cases (WP #61054)", :js, with_se
 
         # change dates in manual mode
         datepicker.set_start_date("2025-01-06")
-        datepicker.set_due_date("2025-01-08")
+        datepicker.set_due_date("2025-01-20")
 
         datepicker.expect_start_date "2025-01-06"
-        datepicker.expect_due_date "2025-01-08"
-        datepicker.expect_duration "3"
+        datepicker.expect_due_date "2025-01-20"
+        datepicker.expect_duration "11"
 
         # switch back to automatic
         datepicker.toggle_scheduling_mode
         datepicker.expect_automatic_scheduling_mode
 
-        # dates should be derived from predecessors, and the duration is the
-        # initial one despite the manual change
+        # start date should be derived from predecessors,
+        # while the changed finish date is kept and a new duration calculated
         datepicker.expect_start_date "2025-01-17", disabled: true
-        datepicker.expect_due_date "2025-01-17", disabled: true
-        datepicker.expect_duration "1"
+        datepicker.expect_due_date "2025-01-20", disabled: false
+        datepicker.expect_duration "2"
 
         expect(datepicker.container).to have_no_text(/Can only be set to ....-..-.. or later/i)
 
         apply_and_expect_saved(
           start_date: Date.parse("2025-01-17"),
-          due_date: Date.parse("2025-01-17"),
-          duration: 1,
+          due_date: Date.parse("2025-01-20"),
+          duration: 2,
           schedule_manually: false
         )
       end

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -186,14 +186,15 @@ module Components
     # Expect the given date to be visible and disabled
     def expect_disabled(date)
       label = date.strftime("%B %-d, %Y")
-      expect(page).to have_css(".flatpickr-day.flatpickr-disabled[aria-label='#{label}']")
+      expect(page).to have_css(".flatpickr-day.flatpickr-disabled[aria-label='#{label}']," \
+                               ".flatpickr-day.flatpickr-non-working-day[aria-label='#{label}']")
     end
 
     ##
     # Expect the given date to be visible and enabled
     def expect_not_disabled(date)
       label = date.strftime("%B %-d, %Y")
-      expect(page).to have_css(".flatpickr-day:not(.flatpickr-disabled)[aria-label='#{label}']")
+      expect(page).to have_css(".flatpickr-day:not(.flatpickr-disabled):not(.flatpickr-non-working-day)[aria-label='#{label}']")
     end
 
     protected


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/60667/activity

# What are you trying to accomplish?
* Allow editing the finish date in automatic scheduling mode

## Screenshots
<img width="631" alt="Bildschirmfoto 2025-03-24 um 14 48 14" src="https://github.com/user-attachments/assets/50b8ac87-5158-4334-8464-bcbcb3ea9966" />

# Merge checklist

- [ ] Added/updated tests

