### PR TITLE
[62249] Many WP fields are visually misaligned when populated with data

### DIFF
--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -37,6 +37,10 @@
 
 .wp-table--row
   cursor: pointer
+  // Some padding for the inner cells of the display fields
+  .inline-edit--display-field:not(.op-table-baseline--field)
+    padding: 2px
+
 
 .wp-table--row,
 #empty-row-notification
@@ -151,10 +155,6 @@ html:not(.-browser-mobile)
 
     &.bcfThumbnail
       outline: none
-
-// Some padding for the inner cells of the display fields
-.inline-edit--display-field:not(.op-table-baseline--field)
-  padding: 2px
 
 .inplace-editing--container
   @include unset-button-styles


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62249

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Align the fields in WP full page

## Screenshots
Before:
![Screenshot 2025-03-24 at 15 47 39](https://github.com/user-attachments/assets/5c373e9f-c1fc-44cd-8f9c-b81ae2b37ef8)

After:
![Screenshot 2025-03-24 at 15 17 37](https://github.com/user-attachments/assets/e94f5ba5-7ecb-46bb-9a1b-26de92f890be)

# What approach did you choose and why?
Set padding only for inline edit field in table view 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
