### PR TITLE
Add banner type for EnterpriseToken

### DIFF
--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -53,6 +53,14 @@ class EnterpriseToken < ApplicationRecord
       end
     end
 
+    def banner_type_for(feature:)
+      if !active?
+        :no_token
+      elsif !allows_to?(feature)
+        :upsell
+      end
+    end
+
     def set_current_token
       token = EnterpriseToken.order(Arel.sql("created_at DESC")).first
 

--- a/spec/models/enterprise_token_spec.rb
+++ b/spec/models/enterprise_token_spec.rb
@@ -118,6 +118,43 @@ RSpec.describe EnterpriseToken do
     end
   end
 
+  describe ".banner_type_for" do
+    before do
+      allow(described_class).to receive(:allows_to?).with(:active_feature).and_return(true)
+      allow(described_class).to receive(:allows_to?).with(:inactive_feature).and_return(false)
+    end
+
+    context "without an EnterpriseToken" do
+      before do
+        allow(described_class).to receive(:active?).and_return(false)
+      end
+
+      it "returns :no_token" do
+        expect(described_class.banner_type_for(feature: :active_feature)).to eq(:no_token)
+      end
+    end
+
+    context "with a feature that is included in the EnterpriseToken" do
+      before do
+        allow(described_class).to receive(:active?).and_return(true)
+      end
+
+      it "returns nil" do
+        expect(described_class.banner_type_for(feature: :active_feature)).to be_nil
+      end
+    end
+
+    context "with a feature that is not included in the EnterpriseToken" do
+      before do
+        allow(described_class).to receive(:active?).and_return(true)
+      end
+
+      it "returns :upsell" do
+        expect(described_class.banner_type_for(feature: :inactive_feature)).to eq(:upsell)
+      end
+    end
+  end
+
   describe "existing token" do
     before do
       allow_any_instance_of(EnterpriseToken).to receive(:token_object).and_return(object)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/gmbh/work_packages/61299

# What are you trying to accomplish?
As we will be having multiple versions of the banner (no token, upsell if current plan does not include it) per feature, we need this method to determine what type of banner we want to show

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
