### PR TITLE
[61051] Improve date picker rendering in mobile screens

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -80,7 +80,7 @@ module WorkPackages
           show_clear_button: !disabled?(name) && !duration_field?(name),
           classes: "op-datepicker-modal--date-field #{'op-datepicker-modal--date-field_current' if @focused_field == name}",
           validation_message: validation_message(name),
-          type: duration_field?(name) ? :number : :text
+          type: field_type(name)
         )
 
         if duration_field?(name)
@@ -175,6 +175,12 @@ module WorkPackages
         else
           @work_package.public_send(name)
         end
+      end
+
+      def field_type(name)
+        return :number if duration_field?(name)
+
+        helpers.browser.device.mobile? ? :date : :text
       end
 
       def validation_message(name)

--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -22,8 +22,10 @@ $body-height: 460px
 
 @media screen and (max-width: $breakpoint-sm)
   .wp-datepicker-dialog
-    &--UnderlineNav
+    &--UnderlineNav,
+    &--date-picker-instance
       display: none !important
+
     &--body
       padding-top: var(--stack-padding-normal)
       min-height: unset

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -98,7 +98,7 @@
           )
         end
 
-        body.with_row("aria-hidden": true) do
+        body.with_row("aria-hidden": true, classes: "wp-datepicker-dialog--date-picker-instance") do
           helpers.angular_component_tag "opce-wp-date-picker-instance",
                                         inputs: {
                                           start_date: work_package.start_date,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/61051/activity

# What are you trying to accomplish?
Remove datepicker on mobile and use native date fields instead

## Screenshots
<img width="544" alt="Bildschirmfoto 2025-03-25 um 09 01 52" src="https://github.com/user-attachments/assets/0c4655d5-4558-4d4d-87ae-adcfd412e336" />

# What approach did you choose and why?
* The change for the field type had to be done in ruby. Thus, it relies on the browser helper to detect a mobile device and will not react on screen size changes.
