### PR TITLE
JWT: Allow authentication through client credentials

### DIFF
--- a/app/models/service_account.rb
+++ b/app/models/service_account.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ServiceAccount < User
+  alias_attribute(:name, :lastname)
+  validates :name, presence: true
+  validates :name, length: { maximum: 256 }
+
+  has_one :service_account_association, dependent: :destroy
+
+  def to_s
+    name
+  end
+
+  def available_custom_fields = []
+
+  def logged? = false
+
+  def builtin? = true
+
+  def mail = ""
+
+  def time_zone
+    ActiveSupport::TimeZone[Setting.user_default_timezone.presence || "Etc/UTC"]
+  end
+
+  def rss_key = nil
+end

--- a/app/models/service_account_association.rb
+++ b/app/models/service_account_association.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ServiceAccountAssociation < ApplicationRecord
+  belongs_to :service_account
+  belongs_to :service, polymorphic: true
+end

--- a/db/migrate/20250324133701_create_service_account_associations.rb
+++ b/db/migrate/20250324133701_create_service_account_associations.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CreateServiceAccountAssociations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :service_account_associations do |t|
+      t.belongs_to :service_account, null: false, index: { unique: true }
+      t.belongs_to :service, null: false, index: false # necessary index covered by composite
+      t.string :service_type, null: false
+
+      t.timestamps null: false
+
+      t.index %i[service_type service_id], unique: true
+    end
+  end
+end

--- a/lib_static/open_project/authentication/strategies/warden/jwt_oidc.rb
+++ b/lib_static/open_project/authentication/strategies/warden/jwt_oidc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject
   module Authentication
     module Strategies
@@ -24,7 +26,11 @@ module OpenProject
               ->(payload_and_provider) do
                 payload, provider = payload_and_provider
                 user = User.find_by(identity_url: "#{provider.slug}:#{payload['sub']}")
-                success!(user) if user
+                if user
+                  success!(user)
+                else
+                  fail_with_header!(error: "invalid_token", error_description: "The user identified by the token is not known")
+                end
               end,
               ->(error) { fail_with_header!(error: "invalid_token", error_description: error) }
             )

--- a/spec/factories/service_account_factory.rb
+++ b/spec/factories/service_account_factory.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :service_account, parent: :user, class: "ServiceAccount" do
+    transient do
+      service { nil }
+    end
+
+    after(:create) do |instance, evaluator|
+      if evaluator.service.present?
+        instance.create_service_account_association!(service: evaluator.service)
+      end
+    end
+  end
+end

--- a/spec/workers/principals/delete_job_integration_spec.rb
+++ b/spec/workers/principals/delete_job_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -512,6 +514,25 @@ RSpec.describe Principals::DeleteJob, type: :model do
           job
 
           expect(watched.watchers.reload).to be_empty
+        end
+      end
+    end
+
+    context "with a service account" do
+      describe "service account association" do
+        let(:principal) { create(:service_account, service:) }
+        let(:service) { create(:oauth_application) }
+
+        before do
+          principal.save!
+        end
+
+        it "deletes the service account association" do
+          expect { job }.to change(ServiceAccountAssociation, :count).from(1).to(0)
+        end
+
+        it "does not delete the service associated to the service account" do
+          expect { job }.not_to change(Doorkeeper::Application, :count)
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62301

# What are you trying to accomplish?
Adding a basic framework of entities to allow authenticating requests with a JWT that represents not a single user, but another client in the realm of the identity provider.

# What approach did you choose and why?
Introducing a new class called `ServiceAccount` that is a special kind (i.e. subclass) of user. Being a `User` means that we can still rely on our regular authentication mechanism, which APIs already rely on. For many existing APIs it's essential to have a `current_user`, e.g. to perform permission checks.

`ServiceAccounts` are linked to a service, which is the entity that _owns_ the service account. The first service intended to be built is the `ScimClient`, which will be added in a later PR.

Since the number of service accounts will usually be very low compared to the number of users in a system, I extracted the association between the account and the service into a separate table, so that normal users don't receive "useless" columns related to service associations.

# Usage

A service implementation essentially needs to add relations to the `ServiceAccountAssociation` and `ServiceAccount` model, e.g.

```ruby
  has_one :service_account_association, as: :service
  has_one :service_account, through: :service_account_association
```

In general the service is responsible for the lifecycle of the service account. I.e. creating and deleting it.

To be usable for the `JwtOidc` strategy, the service account needs to have a prefilled `identity_url`, allowing the strategy to recognize which service account is associated to a given client credentials token. E.g. in the case of Keycloak, each client has an associated service account (on Keycloak's side) whose UUID will be passed into the token.

To be usable for the client credentials flow of an `oauth_application` built into OpenProject, the `client_credentials_user_id` of the given `Doorkeeper::Application` has to be set to the id of the service account.

# Merge checklist

- [x] Added/updated tests
- [x] Think about and implement proper default for deletion of dependent records
