### PR TITLE
[#62500] Shared versions are not available on Version filter on global wp page

### DIFF
--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -36,7 +36,7 @@ module API
                                                             # the distinct(false) is added in order to allow ORDER BY LOWER(name)
                                                             # which would otherwise be invalid in postgresql
                                                             # SELECT DISTINCT, ORDER BY expressions must appear in select list
-                                                            Version.visible(current_user).distinct(false)
+                                                            Version.visible(current_user).or(Version.systemwide).distinct(false)
                                                           })
                                                      .mount
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62500

# What are you trying to accomplish?
Show shared versions on the global work package page from projects that are not accessible for the user.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
