### PR TITLE
[62570] Replace opToast with Primer Banner component in progress admin form

### DIFF
--- a/app/views/admin/settings/progress_tracking/show.html.erb
+++ b/app/views/admin/settings/progress_tracking/show.html.erb
@@ -55,14 +55,13 @@ primer_form_with(
       }
     )
     form.html_content do
-      tag.div(
-        class: "op-toast -warning -with-bottom-spacing",
-        hidden: true,
-        data: { admin__progress_tracking_target: "warningToast" }
+      render(
+        Primer::Alpha::Banner.new(
+          scheme: :warning,
+          data: { admin__progress_tracking_target: "warningToast" }
+        )
       ) do
-        tag.div(class: "op-toast--content") do
-          tag.p(data: { admin__progress_tracking_target: "warningText" })
-        end
+        render(Primer::Beta::Text.new(data: { admin__progress_tracking_target: "warningText" }))
       end
     end
     form.radio_button_group(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/62570/activity

# What are you trying to accomplish?
Replace opToast with Primer::Banner

## Screenshots
<img width="1817" alt="Bildschirmfoto 2025-03-27 um 10 22 37" src="https://github.com/user-attachments/assets/1b13f3b2-4f31-416f-a9c9-30718d5d648c" />

# What approach did you choose and why?
* I simply replace the component and did not improve any other code around that

