### PR TITLE
[#62556] Long text CF not displayed when empty

### DIFF
--- a/app/models/work_package/pdf_export/export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/export/wp/attributes.rb
@@ -46,14 +46,10 @@ module WorkPackage::PDFExport::Export::Wp::Attributes
   def write_long_text_field!(work_package, field_id)
     custom_value = work_package.custom_field_values
                                .find { |cv| cv.custom_field.id == field_id && cv.custom_field.formattable? }
-    if custom_value&.value
-      write_long_text_custom_field!(work_package, custom_value.value, custom_value.custom_field.name)
-    end
+    write_long_text_custom_field!(work_package, custom_value.value || "", custom_value.custom_field.name)
   end
 
   def write_long_text_custom_field!(work_package, markdown, label)
-    return if markdown.blank?
-
     write_optional_page_break
     write_long_text_custom_field_label(label)
     write_markdown_field_value(work_package, markdown)

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
              project_custom_field_long_text.id => "foo"
            },
            work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool],
-           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id]) # cf_disabled_in_project.id is disabled
+
+           # cf_disabled_in_project.id not included == disabled
+           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id])
   end
   let(:forbidden_project) do
     create(:project,
@@ -79,7 +81,9 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
            active: true,
            parent: parent_project,
            work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool],
-           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id]) # cf_disabled_in_project.id is disabled
+
+           # cf_disabled_in_project.id not included == disabled
+           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id])
   end
   let(:user) do
     create(:user,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/62556

# What are you trying to achieve?

Display the label of a long text custom field even when the value is empty

# What approach did you choose and why?

Remove the check for emptiness

# Merge checklist

- [x] Added/updated tests
