### PR TITLE
[55802] Add % complete sum to work package table sums

### DIFF
--- a/app/models/query/results/sums.rb
+++ b/app/models/query/results/sums.rb
@@ -48,7 +48,7 @@ module ::Query::Results::Sums
   private
 
   def sums_by_group_id
-    sums_select(true).inject({}) do |result, group_sum|
+    sums_select(grouped: true).inject({}) do |result, group_sum|
       result[group_sum["group_id"]] = {}
 
       query.summed_up_columns.each do |column|
@@ -59,7 +59,7 @@ module ::Query::Results::Sums
     end
   end
 
-  def sums_select(grouped = false)
+  def sums_select(grouped: false)
     select = if grouped
                ["work_packages.group_id"]
              else

--- a/app/models/work_package/exports/formatters/done_ratio.rb
+++ b/app/models/work_package/exports/formatters/done_ratio.rb
@@ -34,8 +34,14 @@ module WorkPackage::Exports
 
       def format(work_package, **)
         derived_done_ratio = work_package.derived_done_ratio
-        derived = derived_done_ratio&.positive? ? " · Σ #{derived_done_ratio}%" : ""
-        "#{work_package.done_ratio}%#{derived}"
+        derived = derived_done_ratio&.positive? ? " · Σ #{format_value(derived_done_ratio)}" : ""
+        "#{format_value(work_package.done_ratio)}#{derived}"
+      end
+
+      def format_value(value, _options = {})
+        return "" if value.nil?
+
+        "#{value}%"
       end
     end
   end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -122,17 +122,19 @@ module API
       end
 
       def format_column_keys(hash_by_column)
-        hash_by_column.map do |column, value|
-          match = /cf_(\d+)/.match(column.name.to_s)
+        hash_by_column.transform_keys do |column|
+          column_name(column)
+        end
+      end
 
-          column_name = if match
-                          "custom_field_#{match[1]}"
-                        else
-                          column.name.to_s
-                        end
+      def column_name(column)
+        match = /cf_(\d+)/.match(column.name.to_s)
 
-          [column_name, value]
-        end.to_h
+        if match
+          "custom_field_#{match[1]}"
+        else
+          column.name.to_s
+        end
       end
 
       def collection_representer(work_packages, params:, project:, groups:, sums:)

--- a/lib/api/v3/work_packages/schema/work_package_sums_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_sums_schema_representer.rb
@@ -64,6 +64,12 @@ module API
                  required: false,
                  writable: false
 
+          schema :percentage_done,
+                 type: "Integer",
+                 name_source: :done_ratio,
+                 required: false,
+                 writable: false
+
           schema :overall_costs,
                  type: "String",
                  required: false,

--- a/lib/api/v3/work_packages/work_package_sums_representer.rb
+++ b/lib/api/v3/work_packages/work_package_sums_representer.rb
@@ -29,6 +29,12 @@ module API
         property :story_points,
                  render_nil: true
 
+        property :percentage_done,
+                 render_nil: true,
+                 getter: ->(*) {
+                   done_ratio
+                 }
+
         property :remaining_time,
                  render_nil: true,
                  exec_context: :decorator,

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -509,11 +509,12 @@ RSpec.describe API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   end
 
   context "when passing sums" do
-    let(:total_sums) { OpenStruct.new(estimated_hours: 1) }
+    let(:total_sums) { API::ParserStruct.new(estimated_hours: 1) }
 
     it "renders the groups object as json" do
       expected = { "estimatedTime" => "PT1H",
                    "remainingTime" => nil,
+                   "percentageDone" => nil,
                    "storyPoints" => nil }
       expect(collection).to be_json_eql(expected.to_json).at_path("totalSums")
     end

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -37,15 +37,16 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSumsRepresenter do
     end
   end
   let(:sums) do
-    double("sums",
-           story_points: 5,
-           remaining_hours: 10,
-           estimated_hours: 5,
-           material_costs: 5,
-           labor_costs: 10,
-           overall_costs: 15,
-           custom_field_1: 5,
-           available_custom_fields: [custom_field])
+    API::ParserStruct.new(
+      story_points: 5,
+      remaining_hours: 10,
+      estimated_hours: 5,
+      material_costs: 5,
+      labor_costs: 10,
+      overall_costs: 15,
+      custom_field_1: 5,
+      available_custom_fields: [custom_field]
+    )
   end
   let(:current_user) { build_stubbed(:user) }
   let(:representer) do
@@ -54,48 +55,48 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSumsRepresenter do
 
   subject { representer.to_json }
 
-  context "estimated_time" do
+  describe "estimated_time" do
     it "is represented" do
       expected = "PT5H"
       expect(subject).to be_json_eql(expected.to_json).at_path("estimatedTime")
     end
   end
 
-  context "remainingTime" do
+  describe "remainingTime" do
     it "is represented" do
       expected = "PT10H"
       expect(subject).to be_json_eql(expected.to_json).at_path("remainingTime")
     end
   end
 
-  context "storyPoints" do
+  describe "storyPoints" do
     it "is represented" do
       expect(subject).to be_json_eql(sums.story_points.to_json).at_path("storyPoints")
     end
   end
 
-  context "materialCosts" do
+  describe "materialCosts" do
     it "is represented" do
       expected = "5.00 EUR"
       expect(subject).to be_json_eql(expected.to_json).at_path("materialCosts")
     end
   end
 
-  context "laborCosts" do
+  describe "laborCosts" do
     it "is represented" do
       expected = "10.00 EUR"
       expect(subject).to be_json_eql(expected.to_json).at_path("laborCosts")
     end
   end
 
-  context "overallCosts" do
+  describe "overallCosts" do
     it "is represented" do
       expected = "15.00 EUR"
       expect(subject).to be_json_eql(expected.to_json).at_path("overallCosts")
     end
   end
 
-  context "custom field x" do
+  describe "custom field x" do
     it "is represented" do
       expect(subject).to be_json_eql(sums.custom_field_1.to_json).at_path("customField1")
     end

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSumsRepresenter do
       story_points: 5,
       remaining_hours: 10,
       estimated_hours: 5,
+      done_ratio: 50,
       material_costs: 5,
       labor_costs: 10,
       overall_costs: 15,
@@ -66,6 +67,13 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSumsRepresenter do
     it "is represented" do
       expected = "PT10H"
       expect(subject).to be_json_eql(expected.to_json).at_path("remainingTime")
+    end
+  end
+
+  describe "percentageDone" do
+    it "is represented" do
+      expected = 50
+      expect(subject).to be_json_eql(expected.to_json).at_path("percentageDone")
     end
   end
 

--- a/spec/models/work_package/exports/formatters/done_ratio_spec.rb
+++ b/spec/models/work_package/exports/formatters/done_ratio_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackage::Exports::Formatters::DoneRatio do
+  subject { described_class.new(:done_ratio) }
+
+  describe "#format" do
+    it "returns empty string if neither done_ratio or derived_done_ratio is set" do
+      work_package = build(:work_package, done_ratio: nil, derived_done_ratio: nil)
+      expect(subject.format(work_package)).to eq("")
+    end
+
+    it "returns something like '40%' when only done_ratio is set" do
+      work_package = build(:work_package, done_ratio: 40)
+      expect(subject.format(work_package)).to eq("40%")
+    end
+
+    it "returns something like ' · Σ 70%' when only derived_done_ratio is set" do
+      work_package = build(:work_package, done_ratio: nil, derived_done_ratio: 70)
+      expect(subject.format(work_package)).to eq(" · Σ 70%")
+    end
+
+    it "returns something like '40% · Σ 70%' when both done_ratio and derived_done_ratio are set" do
+      work_package = build(:work_package, done_ratio: 40, derived_done_ratio: 70)
+      expect(subject.format(work_package)).to eq("40% · Σ 70%")
+    end
+  end
+
+  describe "#format_value" do
+    it "returns the value as a percentage" do
+      expect(subject.format_value(40)).to eq("40%")
+    end
+
+    it "returns empty string if value is nil" do
+      expect(subject.format_value(nil)).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/55802

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Add % Complete to total sums of work packages list and PDF exports.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

Before

work package table with sums activated

![image](https://github.com/user-attachments/assets/621796d5-28aa-4d6f-9c11-ac6f21330ba1)

pdf report with sums

![image](https://github.com/user-attachments/assets/40bbddc7-324c-4b77-b827-5b33b290a2c2)


After

work package table with sums activated

![image](https://github.com/user-attachments/assets/69f7e9b9-db4f-4a2f-bf53-fc77adf78745)

pdf report with sums

![image](https://github.com/user-attachments/assets/6068bfcf-036c-4416-afcf-a431e113dc9b)


# What approach did you choose and why?

Calculate it based on work sum and remaining work sum.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
