### PR TITLE
Add ScimClient model

### DIFF
--- a/app/contracts/scim_clients/create_contract.rb
+++ b/app/contracts/scim_clients/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
-
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
+module ScimClients
+  class CreateContract < BaseContract
   end
 end

--- a/app/contracts/scim_clients/delete_contract.rb
+++ b/app/contracts/scim_clients/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
-
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
+module ScimClients
+  class DeleteContract < ::DeleteContract
+    delete_permission :admin
   end
 end

--- a/app/contracts/scim_clients/update_contract.rb
+++ b/app/contracts/scim_clients/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
-
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
+module ScimClients
+  class UpdateContract < BaseContract
   end
 end

--- a/app/models/scim_client.rb
+++ b/app/models/scim_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
+class ScimClient < ApplicationRecord
+  belongs_to :auth_provider
 
-  has_many :scim_clients, dependent: :restrict_with_error
+  has_one :oauth_application, class_name: "::Doorkeeper::Application", as: :integration, dependent: :destroy
 
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
+  has_one :service_account_association, as: :service, dependent: :destroy
+  has_one :service_account, through: :service_account_association
 
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
-  end
+  enum :authentication_method, {
+    sso: 0,
+    oauth2_client: 1,
+    oauth2_token: 2
+  }, scopes: false, prefix: true
 end

--- a/app/services/scim_clients/create_service.rb
+++ b/app/services/scim_clients/create_service.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ScimClients::CreateService < BaseServices::Create
+  def after_perform(_)
+    super.tap do |service_result|
+      self.model = service_result.result
+
+      update_service_account
+      update_oauth_application(service_result)
+    end
+  end
+
+  private
+
+  def update_service_account
+    service_account.name = params[:name]
+    if model.authentication_method_sso?
+      service_account.user_auth_provider_links.build(
+        auth_provider_id: params[:auth_provider_id],
+        external_id: params[:jwt_sub]
+      )
+    end
+    service_account.save!
+  end
+
+  def update_oauth_application(service_result)
+    return if !model.authentication_method_oauth2_client? && !model.authentication_method_oauth2_token?
+
+    persist_service_result = create_oauth_application
+    model.oauth_application = persist_service_result.result if persist_service_result.success?
+    service_result.add_dependent!(persist_service_result)
+  end
+
+  def service_account
+    @service_account ||= model.build_service_account(admin: true)
+  end
+
+  def create_oauth_application
+    ::OAuth::Applications::CreateService
+      .new(user:)
+      .call(
+        name: "#{model.name} (#{ScimClient.model_name.human})",
+        redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+        scopes: "scim_v2",
+        confidential: true,
+        integration: model,
+        owner: user
+      )
+  end
+end

--- a/app/services/scim_clients/delete_service.rb
+++ b/app/services/scim_clients/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
+class ScimClients::DeleteService < BaseServices::Delete
+  def after_perform(call)
+    return call if call.failure?
 
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
+    client = call.result
+    client.service_account.update_column(:status, User.statuses[:locked])
+    call
   end
 end

--- a/app/services/scim_clients/set_attributes_service.rb
+++ b/app/services/scim_clients/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
+module ScimClients
+  class SetAttributesService < BaseServices::SetAttributes
+    private
 
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
+    def set_attributes(params)
+      super(params.except(:jwt_sub))
     end
   end
 end

--- a/app/services/scim_clients/update_service.rb
+++ b/app/services/scim_clients/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
-
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
+class ScimClients::UpdateService < BaseServices::Update
+  def after_perform(_)
+    super.tap do |result|
+      update_service_account(result.result)
     end
+  end
+
+  private
+
+  def update_service_account(scim_client)
+    scim_client.service_account&.update!(params.slice(:name))
+
+    if model.authentication_method_sso?
+      link = scim_client.service_account&.user_auth_provider_links&.find_or_initialize_by({})
+      update_user_auth_provider_link(link)
+    end
+  end
+
+  def update_user_auth_provider_link(link)
+    return if link.nil?
+
+    link.auth_provider_id = params[:auth_provider_id] if params.key?(:auth_provider_id)
+    link.external_id = params[:jwt_sub] if params.key?(:jwt_sub)
+    link.save!
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -99,6 +99,8 @@ Doorkeeper.configure do
   #
   default_scopes :api_v3
 
+  optional_scopes :scim_v2
+
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
   # falls back to the `:client_id` and `:client_secret` params from the `params` object.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -944,6 +944,8 @@ en:
       attribute_help_text:
         attribute_name: "Attribute"
         help_text: "Help text"
+      auth_provider:
+        scim_clients: "SCIM Clients"
       capability:
         context: "Context"
       changeset:
@@ -1617,6 +1619,9 @@ en:
       role:
         one: "Role"
         other: "Roles"
+      scim_client:
+        one: "SCIM Client"
+        other: "SCIM Clients"
       status: "Work package status"
       token/api:
         one: Access token

--- a/db/migrate/20250605133700_create_scim_clients.rb
+++ b/db/migrate/20250605133700_create_scim_clients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
+class CreateScimClients < ActiveRecord::Migration[8.0]
+  def change
+    create_table :scim_clients do |t|
+      t.string :name, null: false
+      t.belongs_to :auth_provider, null: false, foreign_key: { on_delete: :restrict }
+      t.integer :authentication_method, null: false
 
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
+      t.timestamps null: false
     end
   end
 end

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -106,7 +106,7 @@ module Saml
       if call.success?
         flash[:notice] = I18n.t(:notice_successful_delete)
       else
-        flash[:error] = I18n.t(:error_failed_to_delete_entry)
+        flash[:error] = call.errors.full_messages
       end
 
       redirect_to action: :index

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -114,7 +114,7 @@ module OpenIDConnect
       if @provider.destroy
         flash[:notice] = I18n.t(:notice_successful_delete)
       else
-        flash[:error] = I18n.t(:error_failed_to_delete_entry)
+        flash[:error] = @provider.errors.full_messages
       end
 
       redirect_to action: :index

--- a/modules/openid_connect/spec/factories/oidc_provider_factory.rb
+++ b/modules/openid_connect/spec/factories/oidc_provider_factory.rb
@@ -30,8 +30,8 @@
 
 FactoryBot.define do
   factory :oidc_provider, class: "OpenIDConnect::Provider" do
-    display_name { "Foobar" }
-    slug { "oidc-foobar" }
+    sequence(:display_name) { |n| "Foobar ##{n}" }
+    sequence(:slug) { |n| "oidc-foobar-#{n}" }
     limit_self_registration { true }
     creator factory: :user
 

--- a/spec/factories/scim_client_factory.rb
+++ b/spec/factories/scim_client_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
-
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users, through: :user_auth_provider_links
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def self.slug_fragment
-    raise NotImplementedError
-  end
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
-  end
-
-  def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
+FactoryBot.define do
+  factory :scim_client do
+    sequence(:name) { |n| "SCIM Client #{n}" }
+    auth_provider factory: :oidc_provider
+    authentication_method { :sso }
   end
 end

--- a/spec/models/scim_clients/form_model_spec.rb
+++ b/spec/models/scim_clients/form_model_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe ScimClients::FormModel do
+  describe ".from_client" do
+    subject { described_class.from_client(client) }
+
+    let(:client) do
+      create(
+        :scim_client, service_account: create(:service_account, authentication_provider: auth_provider, external_id: "abc-def"),
+                      authentication_method: :sso,
+                      auth_provider:
+      )
+    end
+    let(:auth_provider) { create(:oidc_provider) }
+
+    it "builds a proper FormModel", :aggregate_failures do
+      expect(subject.name).to eq(client.name)
+      expect(subject.auth_provider_id).to eq(auth_provider.id)
+      expect(subject.authentication_method).to eq("sso")
+      expect(subject.jwt_sub).to eq("abc-def")
+    end
+
+    context "when the auth provider link is missing" do
+      let(:client) do
+        create :scim_client, service_account: create(:service_account),
+                             authentication_method: :sso,
+                             auth_provider:
+      end
+
+      it "fills the auth_provider_id correctly" do
+        expect(subject.auth_provider_id).to eq(auth_provider.id)
+      end
+
+      it "leaves the jwt_sub blank" do
+        expect(subject.jwt_sub).to be_nil
+      end
+    end
+  end
+
+  describe ".from_params" do
+    subject { described_class.from_params(params) }
+
+    let(:params) { { name: "The Client", auth_provider_id: 42, authentication_method: :banana, jwt_sub: "a-sub" } }
+
+    it "builds a proper FormModel", :aggregate_failures do
+      expect(subject.name).to eq("The Client")
+      expect(subject.auth_provider_id).to eq(42)
+      expect(subject.authentication_method).to eq("banana")
+      expect(subject.jwt_sub).to eq("a-sub")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -374,12 +374,13 @@ RSpec.describe User do
   end
 
   describe "#authentication_provider" do
+    let!(:authentication_provider) { create(:oidc_provider) }
+
     context "when there is a link between user and auth provider" do
-      let!(:user) { create(:user, identity_url: "provider:123123213") }
+      let(:user) { create(:user, authentication_provider:) }
 
       it "returns the provider when there is a link" do
-        provider = AuthProvider.find_by!(slug: "provider")
-        expect(user.authentication_provider).to eql(provider)
+        expect(user.authentication_provider).to eql(authentication_provider)
       end
     end
 
@@ -391,17 +392,19 @@ RSpec.describe User do
   end
 
   describe "#human_authentication_provider" do
+    let!(:authentication_provider) { create(:oidc_provider) }
+
     context "when there is a link between user and auth provider" do
-      let(:user) { create(:user, identity_url: "provider:123123213") }
+      let(:user) { create(:user, authentication_provider:) }
 
       it "returns a human readable name" do
-        expect(user.human_authentication_provider).to eql("Foobar")
+        expect(user.human_authentication_provider).to eql(authentication_provider.display_name)
       end
     end
 
     context "when no provider exists" do
       it "returns nil" do
-        expect(user.authentication_provider).to be_nil
+        expect(user.human_authentication_provider).to be_nil
       end
     end
   end

--- a/spec/services/scim_clients/create_service_spec.rb
+++ b/spec/services/scim_clients/create_service_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "services/base_services/behaves_like_create_service"
+
+RSpec.describe ScimClients::CreateService, type: :model do
+  subject { instance.call(params) }
+
+  let(:user) { create(:admin) }
+  let(:instance) { described_class.new(user:) }
+  let(:params) do
+    {
+      name: "The client name",
+      auth_provider_id: auth_provider.id,
+      authentication_method: "sso",
+      jwt_sub: "123-456"
+    }
+  end
+  let(:auth_provider) { create(:oidc_provider, slug: "provider-slug") }
+
+  it_behaves_like "BaseServices create service" do
+    let(:user) { create(:admin) }
+    let(:call_attributes) { params }
+  end
+
+  it "creates a service account", :aggregate_failures do
+    client = subject.result
+    expect(client.service_account).to be_present
+    expect(client.service_account&.reload&.name).to eq("The client name")
+  end
+
+  it "creates a user auth provider link", :aggregate_failures do
+    expect { subject }.to change(UserAuthProviderLink, :count).by(1)
+
+    link = subject.result.service_account.user_auth_provider_links.first
+    expect(link.auth_provider).to eq(auth_provider)
+    expect(link.external_id).to eq("123-456")
+  end
+
+  it "creates no OAuth application" do
+    expect { subject }.not_to change(Doorkeeper::Application, :count)
+  end
+
+  context "when using oauth2_client as authentication_method" do
+    let(:params) do
+      {
+        name: "The client name",
+        auth_provider_id: auth_provider.id,
+        authentication_method: "oauth2_client"
+      }
+    end
+
+    it { is_expected.to be_success }
+
+    it "creates no auth provider link" do
+      expect { subject }.not_to change(UserAuthProviderLink, :count)
+    end
+
+    it "creates an OAuth application", :aggregate_failures do
+      expect { subject }.to change(Doorkeeper::Application, :count).by(1)
+      expect(subject.result.oauth_application).to be_present
+    end
+  end
+
+  context "when using oauth2_token as authentication_method" do
+    let(:params) do
+      {
+        name: "The client name",
+        auth_provider_id: auth_provider.id,
+        authentication_method: "oauth2_token"
+      }
+    end
+
+    it { is_expected.to be_success }
+
+    it "creates no auth provider link" do
+      expect { subject }.not_to change(UserAuthProviderLink, :count)
+    end
+
+    it "creates an OAuth application", :aggregate_failures do
+      expect { subject }.to change(Doorkeeper::Application, :count).by(1)
+      expect(subject.result.oauth_application).to be_present
+    end
+  end
+end

--- a/spec/services/scim_clients/update_service_spec.rb
+++ b/spec/services/scim_clients/update_service_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "services/base_services/behaves_like_update_service"
+
+RSpec.describe ScimClients::UpdateService, type: :model do
+  subject { instance.call(params) }
+
+  let(:user) { build_stubbed(:user) }
+  let(:instance) { described_class.new(user:, model: scim_client) }
+  let(:params) do
+    {
+      name: "The client name",
+      auth_provider_id: auth_provider.id,
+      authentication_method: "sso",
+      jwt_sub: "123-456"
+    }
+  end
+  let(:auth_provider) { create(:oidc_provider, slug: "provider-slug") }
+  let(:scim_client) do
+    create(:scim_client, service_account: create(:service_account))
+  end
+
+  it_behaves_like "BaseServices update service"
+
+  context "when updating an SSO-based SCIM client with a missing auth provider link" do
+    let(:scim_client) do
+      create(:scim_client, service_account: create(:service_account), authentication_method: :sso)
+    end
+
+    it "updates the service account's name" do
+      expect { subject }.to change { scim_client.reload.service_account.name }.to("The client name")
+    end
+
+    it "creates the service account's auth provider link", :aggregate_failures do
+      expect { subject }.to change(UserAuthProviderLink, :count).by(1)
+
+      link = scim_client.reload.service_account.user_auth_provider_links.first
+      expect(link&.auth_provider_id).to eq(auth_provider.id)
+      expect(link&.external_id).to eq("123-456")
+    end
+  end
+
+  context "when updating an SSO-based SCIM client with an existing auth provider link" do
+    let(:scim_client) do
+      create :scim_client, service_account: create(:service_account, authentication_provider: auth_provider),
+                           authentication_method: :sso
+    end
+
+    it "updates the service account's name" do
+      expect { subject }.to change { scim_client.reload.service_account.name }.to("The client name")
+    end
+
+    it "updates the service account's auth provider link", :aggregate_failures do
+      subject
+      link = scim_client.reload.service_account.user_auth_provider_links.first
+      expect(link.auth_provider_id).to eq(auth_provider.id)
+      expect(link.external_id).to eq("123-456")
+    end
+  end
+
+  context "when updating an OAuth2-client-based SCIM client" do
+    let(:scim_client) do
+      create :scim_client, service_account: create(:service_account),
+                           authentication_method: :oauth2_client,
+                           oauth_application: create(:oauth_application)
+    end
+    let(:params) { super().merge(authentication_method: :oauth2_client) }
+
+    it "updates the service account's name" do
+      expect { subject }.to change { scim_client.reload.service_account.name }.to("The client name")
+    end
+
+    it "does not create an auth provider link" do
+      expect { subject }.not_to change(UserAuthProviderLink, :count)
+    end
+  end
+
+  context "when updating an OAuth2-token-based SCIM client" do
+    let(:scim_client) do
+      create :scim_client, service_account: create(:service_account),
+                           authentication_method: :oauth2_token,
+                           oauth_application: create(:oauth_application)
+    end
+    let(:params) { super().merge(authentication_method: :oauth2_token) }
+
+    it "updates the service account's name" do
+      expect { subject }.to change { scim_client.reload.service_account.name }.to("The client name")
+    end
+
+    it "does not create an auth provider link" do
+      expect { subject }.not_to change(UserAuthProviderLink, :count)
+    end
+  end
+end


### PR DESCRIPTION
Including basic services to manipulate them. The
service account is managed as part of the ScimClient's lifecycle.

We make sure to revoke non-chosen authentication methods with every update, so that it's not possible to keep authenticating through an outdated (and most likely UI-invisible) method anymore.

# Ticket
https://community.openproject.org/work_packages/62516/activity

# What are you trying to accomplish?

To process SCIM requests we need to authenticate an entity during the corresponding API requests. This must be possible via three high-level methods:

* JWT from an identity provider
* access token issued by OpenProject `Doorkeeper::Application`
* static token issued "by OpenProject"

# Which approach did you choose and why?

The ScimClient is the central entity to configure settings around a configured SCIM client. It's related to a user (new subtype `ServiceAccount`) and optionally an oauth application. The service account is the authenticated entity. In this model we can cover all three authentication modes:

* JWT is natively supported by adding an `identity_url` to the service account
*  access token and static token can both be supported through a `Doorkeeper::Application` that uses the service account as a client credentials user
    * static token is a special case of this config, where we directly offer a token created for this oauth app to the user, without really performing an oauth token request

# Merge checklist

- [ ] Added/updated tests
