### PR TITLE
[62580] Fix read-only error displayed when editing progress values

### DIFF
--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -172,8 +172,16 @@ class WorkPackages::ProgressController < ApplicationController
     WorkPackages::SetAttributesService
       .new(user: current_user,
            model: @work_package,
-           contract_class: WorkPackages::CreateContract)
+           contract_class:)
       .call(work_package_progress_params)
+  end
+
+  def contract_class
+    if @work_package.new_record?
+      WorkPackages::CreateContract
+    else
+      WorkPackages::UpdateContract
+    end
   end
 
   def formatted_duration(hours)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62580

# What are you trying to accomplish?

When editing progress values with a user having "Edit work packages" permission but missing "Add work packages" permission, an error message was displayed. This error message should not be displayed as the user is allowed to edit the work package.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/f01cebd4-963e-4493-91d6-8785b0f092de)

# What approach did you choose and why?

The contract class being used was always `WorkPackages::CreateContract`. It needs to be `WorkPackages::UpdateContract` when the user edits fields so that the correct permissions are checked.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
