### PR TITLE
[62190] Fix errors when setting type of a parent to milestone

### DIFF
--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -32,7 +32,8 @@ require "spec_helper"
 
 RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
   shared_let(:type) { create(:type_standard) }
-  shared_let(:project_types) { [type] }
+  shared_let(:milestone_type) { create(:type_milestone) }
+  shared_let(:project_types) { [type, milestone_type] }
   shared_let(:project) do
     create(:project, types: project_types)
   end
@@ -1297,6 +1298,21 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
           | child        |  X      | manual
         TABLE
       end
+    end
+  end
+
+  context "when changing the type of a work package with children into a milestone" do
+    let_work_packages(<<~TABLE)
+      | hierarchy    | MTWTFSS | scheduling mode
+      | work_package | XXX     | automatic
+      |   child      | XXX     | manual
+    TABLE
+    let(:attributes) { { type: milestone_type } }
+
+    it "returns only one error: work package has children and cannot be changed into a milestone (Bug #62190)" do
+      expect(subject).to be_failure
+      expect(subject.errors.attribute_names).to contain_exactly(:type)
+      expect(subject.errors.details).to include(type: [{ error: :cannot_be_milestone_due_to_children }])
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62190

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

The code was trying to derive dates from children's dates, and then there were additional errors like "due date is different from start date" and "duration should be 1" which are inappropriate.

The only error worth displaying is "Type cannot be a milestone because this work package has children."

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/7708a042-4ac3-4658-90ef-3399ee8b6711)


After:
![image](https://github.com/user-attachments/assets/e420fc04-9590-4ca8-94f4-4a3870780923)


# What approach did you choose and why?

Do not derive dates from children if the type has been changed to milestone.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
