### PR TITLE
[#62217] allow custom fields that are not enabled in project

### DIFF
--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -33,6 +33,7 @@ module Types
     class TokenPropertyMapper
       DEFAULT_FUNCTION = ->(key, context) do
         return nil if context.nil?
+        return nil unless context.respond_to?(key.to_sym)
 
         context.public_send(key.to_sym)
       end.curry

--- a/spec/models/types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/types/patterns/token_property_mapper_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Types::Patterns::TokenPropertyMapper do
     end
   end
 
+  shared_let(:not_activated_custom_field) do
+    create(:boolean_wp_custom_field).tap do |custom_field|
+      work_package.type.custom_fields << custom_field
+    end
+  end
+
   described_class::TOKEN_PROPERTY_MAP.each_pair do |key, details|
     it "the token named #{key} resolves successfully" do
       expect { details[:fn].call(work_package) }.not_to raise_error
@@ -76,6 +82,12 @@ RSpec.describe Types::Patterns::TokenPropertyMapper do
   it "multi value fields are supported" do
     function = described_class.new.fetch :"custom_field_#{mult_list_custom_field.id}"
     expect(function.call(work_package)).to eq(%w[A B])
+  end
+
+  it "must return nil if custom field is not activated in project" do
+    function = described_class.new.fetch :"custom_field_#{not_activated_custom_field.id}"
+    expect { function.call(work_package) }.not_to raise_error
+    expect(function.call(work_package)).to be_nil
   end
 
   it "returns all possible tokens" do


### PR DESCRIPTION
# Ticket
[OP#62217](https://community.openproject.org/work_packages/62217)

# What are you trying to accomplish?
- allow custom fields in generated subjects that are not enabled in project

# What approach did you choose and why?
- rescue when sending custom field methods