### PR TITLE
[62557][62607] date picker successor and children tabs must show the same correct chronological order

### DIFF
--- a/app/components/work_package_relations_tab/closest_relation.rb
+++ b/app/components/work_package_relations_tab/closest_relation.rb
@@ -35,6 +35,15 @@ module WorkPackageRelationsTab
 
     delegate :predecessor, to: :relation
 
+    def self.of(work_package, relations)
+      relations
+        .filter { |relation| relation.try(:relation_type_for, work_package) == Relation::TYPE_FOLLOWS }
+        .map { WorkPackageRelationsTab::ClosestRelation.new(it) }
+        .select(&:soonest_start)
+        .max
+        &.relation
+    end
+
     def <=>(other)
       comparison = compare_nilable_dates(soonest_start, other.soonest_start)
       comparison = -compare_nilable_dates(predecessor.created_at, other.predecessor.created_at) if comparison.zero?

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -52,23 +52,15 @@
 
         # Relations
         directionally_aware_grouped_relations.each do |relation_group|
-          base_key = "#{I18N_NAMESPACE}.relations.label_#{relation_group.type}"
-
-          # Combine visible and invisible relations into a single list
-          all_relation_items = relation_group.all_relation_items
+          base_key = "#{key_namespace}.label_#{relation_group.type}"
 
           flex.with_row(mb: 4) do
             render_relation_group(
               title: t("#{base_key}_plural").upcase_first,
-              relation_type: relation_group.type,
-              relation_items: all_relation_items
+              relation_group:
             ) do |relation_item|
-              # Render each relation with its visibility
               render(
-                WorkPackageRelationsTab::RelationComponent.new(
-                  relation_item:,
-                  closest: relation_group.closest_relation?(relation_item.relation)
-                )
+                WorkPackageRelationsTab::RelationComponent.new(relation_item:)
               )
             end
           end
@@ -78,13 +70,10 @@
         if any_children?
           base_key = "#{key_namespace}.label_child"
 
-          all_relation_items = relations_mediator.relation_group("children").all_relation_items
-
           flex.with_row do
             render_relation_group(
               title: t("#{base_key}_plural").upcase_first,
-              relation_type: :children,
-              relation_items: all_relation_items
+              relation_group: relations_mediator.relation_group("children")
             ) do |relation_item|
               render(
                 WorkPackageRelationsTab::RelationComponent.new(relation_item:)

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -47,33 +47,12 @@
 
   <%=
     flex_layout(mb: 3) do |flex|
-      if any_relations?
-        key_namespace = "#{I18N_NAMESPACE}.relations"
-
-        # Relations
-        directionally_aware_grouped_relations.each do |relation_group|
-          base_key = "#{key_namespace}.label_#{relation_group.type}"
-
+      if relation_groups.any?
+        relation_groups.each do |relation_group|
           flex.with_row(mb: 4) do
             render_relation_group(
-              title: t("#{base_key}_plural").upcase_first,
+              title: t("#{I18N_NAMESPACE}.relations.label_#{relation_group.type}_plural").upcase_first,
               relation_group:
-            ) do |relation_item|
-              render(
-                WorkPackageRelationsTab::RelationComponent.new(relation_item:)
-              )
-            end
-          end
-        end
-
-        # Children
-        if any_children?
-          base_key = "#{key_namespace}.label_child"
-
-          flex.with_row do
-            render_relation_group(
-              title: t("#{base_key}_plural").upcase_first,
-              relation_group: relations_mediator.relation_group("children")
             ) do |relation_item|
               render(
                 WorkPackageRelationsTab::RelationComponent.new(relation_item:)

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -66,9 +66,7 @@
               # Render each relation with its visibility
               render(
                 WorkPackageRelationsTab::RelationComponent.new(
-                  work_package:,
                   relation_item:,
-                  relation: relation_item.relation,
                   closest: relation_group.closest_relation?(relation_item.relation)
                 )
               )
@@ -89,12 +87,7 @@
               relation_items: all_relation_items
             ) do |relation_item|
               render(
-                WorkPackageRelationsTab::RelationComponent.new(
-                  work_package:,
-                  relation_item:,
-                  relation: nil,
-                  child: relation_item.related
-                )
+                WorkPackageRelationsTab::RelationComponent.new(relation_item:)
               )
             end
           end

--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -55,23 +55,21 @@
           base_key = "#{I18N_NAMESPACE}.relations.label_#{relation_group.type}"
 
           # Combine visible and invisible relations into a single list
-          all_relations = relation_group.visible_relations.map { |r| [r, :visible] } +
-            relation_group.ghost_relations.map { |r| [r, :ghost] }
-          all_relations.sort_by! { |r| r[0].id }
+          all_relation_items = relation_group.all_relation_items
 
           flex.with_row(mb: 4) do
             render_relation_group(
               title: t("#{base_key}_plural").upcase_first,
               relation_type: relation_group.type,
-              items: all_relations
-            ) do |relation, visibility|
+              relation_items: all_relation_items
+            ) do |relation_item|
               # Render each relation with its visibility
               render(
                 WorkPackageRelationsTab::RelationComponent.new(
-                  work_package: work_package,
-                  relation: relation,
-                  visibility: visibility,
-                  closest: relation_group.closest_relation?(relation)
+                  work_package:,
+                  relation_item:,
+                  relation: relation_item.relation,
+                  closest: relation_group.closest_relation?(relation_item.relation)
                 )
               )
             end
@@ -82,23 +80,20 @@
         if any_children?
           base_key = "#{key_namespace}.label_child"
 
-          # Combine visible and invisible children into a single list
-          all_children = visible_children.map { |r| [r, :visible] } +
-            ghost_children.map { |r| [r, :ghost] }
-          all_children.sort_by! { |r| r[0].created_at }
+          all_relation_items = relations_mediator.relation_group("children").all_relation_items
 
           flex.with_row do
             render_relation_group(
               title: t("#{base_key}_plural").upcase_first,
               relation_type: :children,
-              items: all_children
-            ) do |child, visibility|
+              relation_items: all_relation_items
+            ) do |relation_item|
               render(
                 WorkPackageRelationsTab::RelationComponent.new(
                   work_package:,
+                  relation_item:,
                   relation: nil,
-                  child:,
-                  visibility: visibility
+                  child: relation_item.related
                 )
               )
             end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -21,9 +21,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   delegate :work_package,
            :visible_children,
            :ghost_children,
-           :directionally_aware_grouped_relations,
-           :any_relations?,
-           :any_children?,
+           :relation_groups,
            to: :relations_mediator
 
   # Initialize the component with required data
@@ -62,7 +60,7 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
              padding: :condensed,
              data: { test_selector: "op-relation-group-#{relation_group.type}" }
            )) do |border_box|
-      if relation_group.type.children? && should_render_add_child?
+      if relation_group.type.child? && should_render_add_child?
         render_children_header(border_box, title, relation_group.count)
       else
         render_header(border_box, title, relation_group.count)

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -57,34 +57,34 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     should_render_add_child? || should_render_add_relations?
   end
 
-  def render_relation_group(title:, relation_type:, relation_items:, &_block)
+  def render_relation_group(title:, relation_group:, &)
     render(border_box_container(
              padding: :condensed,
-             data: { test_selector: "op-relation-group-#{relation_type}" }
+             data: { test_selector: "op-relation-group-#{relation_group.type}" }
            )) do |border_box|
-      if relation_type == :children && should_render_add_child?
-        render_children_header(border_box, title, relation_items)
+      if relation_group.type.children? && should_render_add_child?
+        render_children_header(border_box, title, relation_group.count)
       else
-        render_header(border_box, title, relation_items)
+        render_header(border_box, title, relation_group.count)
       end
 
-      render_items(border_box, relation_items, &_block)
+      render_items(border_box, relation_group.all_relation_items, &)
     end
   end
 
-  def render_header(border_box, title, relation_items)
+  def render_header(border_box, title, count)
     border_box.with_header(py: 3) do
       concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
-      concat render(Primer::Beta::Counter.new(count: relation_items.count, round: true, scheme: :primary))
+      concat render(Primer::Beta::Counter.new(count:, round: true, scheme: :primary))
     end
   end
 
-  def render_children_header(border_box, title, relation_items) # rubocop:disable Metrics/AbcSize
+  def render_children_header(border_box, title, count) # rubocop:disable Metrics/AbcSize
     border_box.with_header(py: 3) do
       flex_layout(justify_content: :space_between, align_items: :center) do |header|
         header.with_column(mr: 2) do
           concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
-          concat render(Primer::Beta::Counter.new(count: relation_items.count, round: true, scheme: :primary))
+          concat render(Primer::Beta::Counter.new(count:, round: true, scheme: :primary))
         end
         header.with_column do
           render(Primer::Alpha::ActionMenu.new(menu_id: NEW_CHILD_ACTION_MENU)) do |menu|

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -57,34 +57,34 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     should_render_add_child? || should_render_add_relations?
   end
 
-  def render_relation_group(title:, relation_type:, items:, &_block)
+  def render_relation_group(title:, relation_type:, relation_items:, &_block)
     render(border_box_container(
              padding: :condensed,
              data: { test_selector: "op-relation-group-#{relation_type}" }
            )) do |border_box|
       if relation_type == :children && should_render_add_child?
-        render_children_header(border_box, title, items)
+        render_children_header(border_box, title, relation_items)
       else
-        render_header(border_box, title, items)
+        render_header(border_box, title, relation_items)
       end
 
-      render_items(border_box, items, &_block)
+      render_items(border_box, relation_items, &_block)
     end
   end
 
-  def render_header(border_box, title, items)
+  def render_header(border_box, title, relation_items)
     border_box.with_header(py: 3) do
       concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
-      concat render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
+      concat render(Primer::Beta::Counter.new(count: relation_items.count, round: true, scheme: :primary))
     end
   end
 
-  def render_children_header(border_box, title, items) # rubocop:disable Metrics/AbcSize
+  def render_children_header(border_box, title, relation_items) # rubocop:disable Metrics/AbcSize
     border_box.with_header(py: 3) do
       flex_layout(justify_content: :space_between, align_items: :center) do |header|
         header.with_column(mr: 2) do
           concat render(Primer::Beta::Text.new(mr: 2, font_size: :normal, font_weight: :bold)) { title }
-          concat render(Primer::Beta::Counter.new(count: items.size, round: true, scheme: :primary))
+          concat render(Primer::Beta::Counter.new(count: relation_items.count, round: true, scheme: :primary))
         end
         header.with_column do
           render(Primer::Alpha::ActionMenu.new(menu_id: NEW_CHILD_ACTION_MENU)) do |menu|
@@ -127,13 +127,15 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     end
   end
 
-  def render_items(border_box, items)
-    items.each do |relation, visibility|
+  def render_items(border_box, relation_items)
+    relation_items.each do |relation_item|
+      relation = relation_item.relation || relation_item.related
+      visibility = relation_item.visibility
       border_box.with_row(
         test_selector: row_test_selector(relation, visibility),
         data: data_attribute(relation)
       ) do
-        yield(relation, visibility)
+        yield(relation_item)
       end
     end
   end

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -34,7 +34,7 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
 
   attr_reader :relation_item, :editable
 
-  delegate :relation, :work_package, to: :relation_item
+  delegate :closest?, :relation, :visible?, :work_package, to: :relation_item
 
   # Checks if the relation or child work package is visible to the current user
   #
@@ -52,10 +52,10 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   end
 
   def child
-    if parent_child_relationship?
-      relation_item.related
-    end
+    relation_item.related if parent_child_relationship?
   end
+
+  def editable? = editable
 
   private
 
@@ -67,7 +67,7 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   end
 
   def should_render_action_menu?
-    return false unless editable
+    return false unless editable?
 
     if parent_child_relationship?
       allowed_to_manage_subtasks?
@@ -83,10 +83,6 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
 
   def allowed_to_manage_relations?
     helpers.current_user.allowed_in_project?(:manage_work_package_relations, work_package.project)
-  end
-
-  def visible?
-    relation_item.visible?
   end
 
   def should_display_description?
@@ -113,10 +109,6 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
     return false if parent_child_relationship?
 
     relation.relation_type_for(work_package) == Relation::TYPE_PRECEDES
-  end
-
-  def closest?
-    relation_item.closest?
   end
 
   def edit_path

--- a/app/components/work_package_relations_tab/relation_component.rb
+++ b/app/components/work_package_relations_tab/relation_component.rb
@@ -32,7 +32,7 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   include ApplicationHelper
   include OpPrimer::ComponentHelpers
 
-  attr_reader :relation_item, :editable, :closest
+  attr_reader :relation_item, :editable
 
   delegate :relation, :work_package, to: :relation_item
 
@@ -40,15 +40,11 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   #
   # @param relation_item [WorkPackageRelationsTab::RelationsMediator::RelationItem] The relation item to display
   # @param editable [Boolean] Whether the relation can be edited
-  # @param closest [Boolean] Whether the follows relation is the closest
-  def initialize(relation_item:,
-                 editable: true,
-                 closest: false)
+  def initialize(relation_item:, editable: true)
     super()
 
     @relation_item = relation_item
     @editable = editable
-    @closest = closest
   end
 
   def related_work_package
@@ -120,7 +116,7 @@ class WorkPackageRelationsTab::RelationComponent < ApplicationComponent
   end
 
   def closest?
-    closest
+    relation_item.closest?
   end
 
   def edit_path

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -32,18 +32,8 @@ class WorkPackageRelationsTab::RelationsMediator
   RelationGroup = Data.define(:type, :work_package, :visible_relations, :ghost_relations, :closest_relation) do
     def initialize(type:, work_package:, visible_relations:, ghost_relations:)
       type = ActiveSupport::StringInquirer.new(type.to_s)
-      closest_relation = self.class.closest_relation(type, visible_relations + ghost_relations)
+      closest_relation = WorkPackageRelationsTab::ClosestRelation.of(work_package, visible_relations + ghost_relations)
       super(type:, work_package:, visible_relations:, ghost_relations:, closest_relation:)
-    end
-
-    def self.closest_relation(type, relations)
-      return nil unless type.follows?
-
-      relations
-        .map { WorkPackageRelationsTab::ClosestRelation.new(it) }
-        .select(&:soonest_start)
-        .max
-        &.relation
     end
 
     def count
@@ -87,7 +77,7 @@ class WorkPackageRelationsTab::RelationsMediator
   # @param work_package [WorkPackage] The work package for which the relation
   #   is displayed
   # @param related [WorkPackage] The related work package: the other work
-  #   package of therelation, or the child for child relations.
+  #   package of the relation, or the child for child relations.
   # @param relation [Relation, nil] The relation, `nil` for child relations
   # @param visibility [Symbol] The visibility of the relation, `:visible` to
   #   show related work package information or `:ghost` to show a placeholder

--- a/app/components/work_package_relations_tab/relations_mediator.rb
+++ b/app/components/work_package_relations_tab/relations_mediator.rb
@@ -71,7 +71,7 @@ class WorkPackageRelationsTab::RelationsMediator
     end
   end
 
-  RelationItem = Data.define(:type, :relation, :related, :visibility) do
+  RelationItem = Data.define(:type, :work_package, :related, :relation, :visibility) do
     def initialize(type:, work_package:, relation:, visibility:)
       if relation.is_a?(Relation)
         related = relation.other_work_package(work_package)
@@ -79,7 +79,7 @@ class WorkPackageRelationsTab::RelationsMediator
         related = relation # relation is the child
         relation = nil
       end
-      super(type:, relation:, related:, visibility:)
+      super(type:, work_package:, related:, relation:, visibility:)
     end
 
     def visible? = visibility == :visible

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -52,10 +52,7 @@
                         box.with_row(scheme: :default) do
                           render(
                             WorkPackageRelationsTab::RelationComponent.new(
-                              work_package:,
                               relation_item:,
-                              relation: (relation_item.relation unless relation_group.type.children?),
-                              child: (relation_item.relation if relation_group.type.children?),
                               editable: false,
                               closest: relation_group.closest_relation?(relation_item.relation)
                             )

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -53,8 +53,7 @@
                           render(
                             WorkPackageRelationsTab::RelationComponent.new(
                               relation_item:,
-                              editable: false,
-                              closest: relation_group.closest_relation?(relation_item.relation)
+                              editable: false
                             )
                           )
                         end

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -48,40 +48,26 @@
                 tab_content.with_panel(m: 3, classes: "wp-datepicker-dialog--content-tab--relation-tab") do
                   if relation_group.any?
                     render(border_box_container(padding: :condensed)) do |box|
-                      relation_group.visible_relations.each do |relation|
+                      relation_group.all_relation_items.each do |relation_item|
                         box.with_row(scheme: :default) do
                           render(
                             WorkPackageRelationsTab::RelationComponent.new(
                               work_package:,
-                              relation: (relation unless relation_group.type.children?),
-                              visibility: :visible,
-                              child: (relation if relation_group.type.children?),
+                              relation_item:,
+                              relation: (relation_item.relation unless relation_group.type.children?),
+                              child: (relation_item.relation if relation_group.type.children?),
                               editable: false,
-                              closest: relation_group.closest_relation?(relation)
-                            )
-                          )
-                        end
-                      end
-                      relation_group.ghost_relations.each do |relation|
-                        box.with_row(scheme: :default) do
-                          render(
-                            WorkPackageRelationsTab::RelationComponent.new(
-                              work_package:,
-                              relation: (relation unless relation_group.type.children?),
-                              visibility: :ghost,
-                              child: (relation if relation_group.type.children?),
-                              editable: false,
-                              closest: relation_group.closest_relation?(relation)
+                              closest: relation_group.closest_relation?(relation_item.relation)
                             )
                           )
                         end
                       end
                     end
                   else
-                    render(Primer::Beta::Blankslate.new(border: true)) do |component|
-                      component.with_visual_icon(icon: :book, size: :medium)
-                      component.with_heading(tag: :h2) { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.title") }
-                      component.with_description { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.description") }
+                    render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
+                      blankslate.with_visual_icon(icon: :book, size: :medium)
+                      blankslate.with_heading(tag: :h2) { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.title") }
+                      blankslate.with_description { I18n.t("work_packages.datepicker_modal.tabs.blankslate.#{tab.key}.description") }
                     end
                   end
                 end

--- a/app/components/work_packages/date_picker/dialog_content_component.rb
+++ b/app/components/work_packages/date_picker/dialog_content_component.rb
@@ -82,9 +82,9 @@ module WorkPackages
       def additional_tabs
         mediator = WorkPackageRelationsTab::RelationsMediator.new(work_package:)
         [
-          Tab.new("predecessors", mediator.relation_group("follows")),
-          Tab.new("successors", mediator.relation_group("precedes")),
-          Tab.new("children", mediator.relation_group("children"))
+          Tab.new("predecessors", mediator.relation_group(Relation::TYPE_FOLLOWS)),
+          Tab.new("successors", mediator.relation_group(Relation::TYPE_PRECEDES)),
+          Tab.new("children", mediator.relation_group(Relation::TYPE_CHILD))
         ]
       end
 

--- a/app/controllers/work_packages/split_view_controller.rb
+++ b/app/controllers/work_packages/split_view_controller.rb
@@ -46,7 +46,8 @@ class WorkPackages::SplitViewController < ApplicationController
   end
 
   def get_relations_counter
-    render json: { count: WorkPackageRelationsTab::RelationsMediator.new(work_package: @work_package).all_relations_count }
+    mediator = WorkPackageRelationsTab::RelationsMediator.new(work_package: @work_package)
+    render json: { count: mediator.all_relations_count }
   end
 
   private

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -54,7 +54,8 @@ class Relation < ApplicationRecord
   # menu or the relations tab.
   TYPES = {
     TYPE_RELATES => {
-      name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: TYPE_RELATES
+      name: :label_relates_to, sym_name: :label_relates_to, order: 1,
+      sym: TYPE_RELATES
     },
     TYPE_FOLLOWS => {
       name: :label_follows, sym_name: :label_precedes, order: 7,
@@ -65,14 +66,16 @@ class Relation < ApplicationRecord
       sym: TYPE_FOLLOWS, reverse: TYPE_FOLLOWS
     },
     TYPE_DUPLICATES => {
-      name: :label_duplicates, sym_name: :label_duplicated_by, order: 6, sym: TYPE_DUPLICATED
+      name: :label_duplicates, sym_name: :label_duplicated_by, order: 6,
+      sym: TYPE_DUPLICATED
     },
     TYPE_DUPLICATED => {
       name: :label_duplicated_by, sym_name: :label_duplicates, order: 7,
       sym: TYPE_DUPLICATES, reverse: TYPE_DUPLICATES
     },
     TYPE_BLOCKS => {
-      name: :label_blocks, sym_name: :label_blocked_by, order: 4, sym: TYPE_BLOCKED
+      name: :label_blocks, sym_name: :label_blocked_by, order: 4,
+      sym: TYPE_BLOCKED
     },
     TYPE_BLOCKED => {
       name: :label_blocked_by, sym_name: :label_blocks, order: 5,

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -49,6 +49,9 @@ class Relation < ApplicationRecord
   TYPE_PARENT       = "parent"
   TYPE_CHILD        = "child"
 
+  # The order of the types is important. It's used to build up `ORDERED_TYPES`
+  # which is used to order relations of different kind like in the "Add relation"
+  # menu or the relations tab.
   TYPES = {
     TYPE_RELATES => {
       name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: TYPE_RELATES
@@ -92,6 +95,8 @@ class Relation < ApplicationRecord
       sym: TYPE_REQUIRES, reverse: TYPE_REQUIRES
     }
   }.freeze
+
+  ORDERED_TYPES = [*TYPES.keys, TYPE_CHILD].freeze
 
   include ::Scopes::Scoped
 

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -88,7 +89,7 @@ RSpec.describe "Structured meetings CRUD",
   end
 
   it "can create a structured meeting and add agenda items" do
-    expect_flash(type: :success, message: "Successful creation")
+    expect_and_dismiss_flash(type: :success, message: "Successful creation")
 
     # Does not send invitation mails by default
     perform_enqueued_jobs
@@ -177,6 +178,7 @@ RSpec.describe "Structured meetings CRUD",
     end
 
     show_page.select_action(item, I18n.t(:label_sort_lowest))
+    show_page.assert_agenda_order! "Important task", "Updated title"
 
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"

--- a/spec/components/work_package_relations_tab/index_component_spec.rb
+++ b/spec/components/work_package_relations_tab/index_component_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe WorkPackageRelationsTab::IndexComponent, type: :component do
     TABLE
 
     it "renders the relations group" do
-      expect(render_component).to have_test_selector("op-relation-group-children")
+      expect(render_component).to have_test_selector("op-relation-group-child")
     end
 
     it "renders the relations in child creation order" do

--- a/spec/components/work_package_relations_tab/relation_component_spec.rb
+++ b/spec/components/work_package_relations_tab/relation_component_spec.rb
@@ -48,21 +48,20 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
   end
 
   def render_component(**params)
-    render_inline(described_class.new(work_package:, **params))
+    render_inline(described_class.new(**params))
   end
 
   context "with child relations" do
     context "when visible" do
       it "renders a title link" do
-        expect(render_component(relation_item: relation_item(type: "children", relation: child, visibility: :visible),
-                                relation: nil, child: child))
+        expect(render_component(relation_item: relation_item(type: "children", relation: child, visibility: :visible)))
           .to have_link "child"
       end
 
       context "when editable" do
         it "renders an action menu" do
           component = render_component(relation_item: relation_item(type: "children", relation: child, visibility: :visible),
-                                       relation: nil, child: child, editable: true)
+                                       editable: true)
           expect(component).to have_menu # FIXME: aria-labelledby does not resolve here "Relation actions"
           expect(component).to have_selector :menuitem, "Delete relation"
         end
@@ -71,21 +70,18 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
 
     context "when ghost" do
       it "does not render a title link" do
-        expect(render_component(relation_item: relation_item(type: "children", relation: child, visibility: :ghost),
-                                relation: nil, child: child))
+        expect(render_component(relation_item: relation_item(type: "children", relation: child, visibility: :ghost)))
           .to have_no_link "child"
       end
 
       it "renders a title and message without details" do
-        rendered_component = render_component(relation_item: relation_item(type: "children", relation: child, visibility: :ghost),
-                                              relation: nil, child: child)
+        rendered_component = render_component(relation_item: relation_item(type: "children", relation: child, visibility: :ghost))
         expect(rendered_component).to have_text "Related work package"
         expect(rendered_component).to have_text "This is not visible to you due to permissions."
       end
 
       it "does not render an action menu" do
-        expect(render_component(relation_item: relation_item(type: "children", relation: child, visibility: :ghost),
-                                relation: nil, child: child))
+        expect(render_component(relation_item: relation_item(type: "children", relation: child, visibility: :ghost)))
           .to have_no_menu
       end
     end
@@ -96,21 +92,19 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
 
     context "when visible" do
       it "renders a title link" do
-        rendered_component = render_component(relation_item: relation_item(type: "follows", relation:, visibility: :visible),
-                                              relation:)
+        rendered_component = render_component(relation_item: relation_item(type: "follows", relation:, visibility: :visible))
         expect(rendered_component).to have_link "predecessor"
       end
 
       it "renders the lag" do
-        rendered_component = render_component(relation_item: relation_item(type: "follows", relation:, visibility: :visible),
-                                              relation:)
+        rendered_component = render_component(relation_item: relation_item(type: "follows", relation:, visibility: :visible))
         expect(rendered_component).to have_text "Lag: 2 days"
       end
 
       context "when editable" do
         it "renders a action menu" do
           rendered_component = render_component(relation_item: relation_item(type: "follows", relation:, visibility: :visible),
-                                                relation:, editable: true)
+                                                editable: true)
           expect(rendered_component).to have_menu # FIXME: aria-labelledby does not resolve here "Relation actions"
           expect(rendered_component).to have_selector :menuitem, "Edit relation"
           expect(rendered_component).to have_selector :menuitem, "Delete relation"
@@ -120,8 +114,7 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
 
     context "when ghost" do
       subject(:rendered_component) do
-        render_component(relation_item: relation_item(type: "follows", relation:, visibility: :ghost),
-                         relation:)
+        render_component(relation_item: relation_item(type: "follows", relation:, visibility: :ghost))
       end
 
       it "does not render a title link" do
@@ -141,11 +134,11 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
     context "when closest" do
       it "always renders a closest label" do
         relation_item = relation_item(type: "follows", relation:, visibility: :visible)
-        expect(render_component(relation_item:, relation:, closest: true))
+        expect(render_component(relation_item:, closest: true))
           .to have_primer_label "Closest", scheme: :primary
 
         relation_item = relation_item(type: "follows", relation:, visibility: :ghost)
-        expect(render_component(relation_item:, relation:, closest: true))
+        expect(render_component(relation_item:, closest: true))
           .to have_primer_label "Closest", scheme: :primary
       end
     end

--- a/spec/components/work_package_relations_tab/relation_component_spec.rb
+++ b/spec/components/work_package_relations_tab/relation_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
 
   context "with child relation item" do
     context "when visible" do
-      let(:relation_item) { build_relation_item(type: "children", relation: child, visibility: :visible) }
+      let(:relation_item) { build_relation_item(type: Relation::TYPE_CHILD, relation: child, visibility: :visible) }
 
       it "renders a title link" do
         expect(render_component(relation_item:))
@@ -77,7 +77,7 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
     end
 
     context "when ghost" do
-      let(:relation_item) { build_relation_item(type: "children", relation: child, visibility: :ghost) }
+      let(:relation_item) { build_relation_item(type: Relation::TYPE_CHILD, relation: child, visibility: :ghost) }
 
       it "does not render a title link" do
         expect(render_component(relation_item:))
@@ -99,7 +99,7 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
 
   context "with follows relations" do
     let(:relation) { _table.relation(predecessor: predecessor) }
-    let(:relation_item) { build_relation_item(type: "follows", relation:, visibility: :visible) }
+    let(:relation_item) { build_relation_item(type: Relation::TYPE_FOLLOWS, relation:, visibility: :visible) }
 
     context "when visible" do
       it "renders a title link" do
@@ -130,7 +130,7 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
     end
 
     context "when ghost" do
-      let(:relation_item) { build_relation_item(type: "follows", relation:, visibility: :ghost) }
+      let(:relation_item) { build_relation_item(type: Relation::TYPE_FOLLOWS, relation:, visibility: :ghost) }
 
       subject(:rendered_component) { render_component(relation_item:) }
 
@@ -150,11 +150,11 @@ RSpec.describe WorkPackageRelationsTab::RelationComponent, type: :component do
 
     context "when closest" do
       it "always renders a closest label" do
-        relation_item = build_relation_item(type: "follows", relation:, visibility: :visible, closest: true)
+        relation_item = build_relation_item(type: Relation::TYPE_FOLLOWS, relation:, visibility: :visible, closest: true)
         expect(render_component(relation_item:))
           .to have_primer_label "Closest", scheme: :primary
 
-        relation_item = build_relation_item(type: "follows", relation:, visibility: :ghost, closest: true)
+        relation_item = build_relation_item(type: Relation::TYPE_FOLLOWS, relation:, visibility: :ghost, closest: true)
         expect(render_component(relation_item:))
           .to have_primer_label "Closest", scheme: :primary
       end

--- a/spec/components/work_package_relations_tab/relations_mediator_spec.rb
+++ b/spec/components/work_package_relations_tab/relations_mediator_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe WorkPackageRelationsTab::RelationsMediator do
       it "returns all relations of the group as RelationItem instances, " \
          "ordered by oldest first (lowest id first), mixing visible and ghost relations" do
         relation_group = described_class::RelationGroup.new(
-          type: "relates",
+          type: Relation::TYPE_RELATES,
           work_package:,
           visible_relations: [
             build_stubbed(:relates_relation, id: 4, from: work_package),

--- a/spec/components/work_package_relations_tab/relations_mediator_spec.rb
+++ b/spec/components/work_package_relations_tab/relations_mediator_spec.rb
@@ -88,12 +88,12 @@ RSpec.describe WorkPackageRelationsTab::RelationsMediator do
 
     context "having a closest relation" do
       shared_let_work_packages(<<~TABLE)
-        hierarchy    | MTWTFSS    | scheduling mode | predecessors
-        predecessor1 | XXX        | manual          |
-        predecessor2 | XX         | manual          |
-        predecessor3 | XX         | manual          |
-        predecessor4 |            | manual          |
-        work_package |          X | automatic       | predecessor1 with lag 2, predecessor2 with lag 7, predecessor3 with lag 7, predecessor4 with lag 10
+        hierarchy    | MTWTFSS    | scheduling mode | successors
+        predecessor1 | XXX        | manual          | work_package with lag 2
+        predecessor2 | XX         | manual          | work_package with lag 7
+        predecessor3 | XX         | manual          | work_package with lag 7
+        predecessor4 |            | manual          | work_package with lag 10
+        work_package |          X | automatic       |
       TABLE
 
       describe "#closest_relation" do

--- a/spec/components/work_package_relations_tab/relations_mediator_spec.rb
+++ b/spec/components/work_package_relations_tab/relations_mediator_spec.rb
@@ -51,18 +51,22 @@ RSpec.describe WorkPackageRelationsTab::RelationsMediator do
     TABLE
 
     it "returns all relations of the work package" do
-      expect(mediator.relation_group("children").all_relation_items).to contain_exactly(
-        have_attributes(class: described_class::RelationItem, type: "children", related: child, visibility: :visible)
+      expect(mediator.relation_group(Relation::TYPE_CHILD).all_relation_items).to contain_exactly(
+        have_attributes(class: described_class::RelationItem, type: Relation::TYPE_CHILD, related: child, visibility: :visible)
       )
-      expect(mediator.relation_group("precedes").all_relation_items).to contain_exactly(
-        have_attributes(class: described_class::RelationItem, type: "precedes", related: successor, visibility: :visible)
+      expect(mediator.relation_group(Relation::TYPE_PRECEDES).all_relation_items).to contain_exactly(
+        have_attributes(class: described_class::RelationItem, type: Relation::TYPE_PRECEDES, related: successor,
+                        visibility: :visible)
       )
-      expect(mediator.relation_group("follows").all_relation_items).to contain_exactly(
-        have_attributes(class: described_class::RelationItem, type: "follows", related: predecessor, visibility: :visible)
+      expect(mediator.relation_group(Relation::TYPE_FOLLOWS).all_relation_items).to contain_exactly(
+        have_attributes(class: described_class::RelationItem, type: Relation::TYPE_FOLLOWS, related: predecessor,
+                        visibility: :visible)
       )
-      expect(mediator.relation_group("relates").all_relation_items).to contain_exactly(
-        have_attributes(class: described_class::RelationItem, type: "relates", related: related1, visibility: :visible),
-        have_attributes(class: described_class::RelationItem, type: "relates", related: related2, visibility: :visible)
+      expect(mediator.relation_group(Relation::TYPE_RELATES).all_relation_items).to contain_exactly(
+        have_attributes(class: described_class::RelationItem, type: Relation::TYPE_RELATES, related: related1,
+                        visibility: :visible),
+        have_attributes(class: described_class::RelationItem, type: Relation::TYPE_RELATES, related: related2,
+                        visibility: :visible)
       )
     end
   end

--- a/spec/factories/relation_factory.rb
+++ b/spec/factories/relation_factory.rb
@@ -28,24 +28,28 @@
 
 FactoryBot.define do
   factory :relation do
-    from factory: :work_package
-    to { build(:work_package, project: from.project) }
+    from { association :work_package }
+    to { association :work_package, project: from.project }
     relation_type { "relates" } # "relates", "duplicates", "duplicated", "blocks", "blocked", "precedes", "follows"
     lag { nil }
     description { nil }
-  end
 
-  factory :follows_relation, parent: :relation do
-    # Use these transient attributes if you always mix up `from` and `to`
-    # attributes in a follows relation
-    transient do
-      predecessor { nil }
-      successor { nil }
+    factory :relates_relation do
+      relation_type { "relates" }
     end
 
-    from { successor || super() }
-    to { predecessor || super() }
-    relation_type { "follows" }
-    lag { 0 }
+    factory :follows_relation do
+      # Use these transient attributes if you always mix up `from` and `to`
+      # attributes in a follows relation
+      transient do
+        predecessor { nil }
+        successor { nil }
+      end
+
+      from { successor || super() }
+      to { predecessor || super() }
+      relation_type { "follows" }
+      lag { 0 }
+    end
   end
 end

--- a/spec/factories/relation_factory.rb
+++ b/spec/factories/relation_factory.rb
@@ -51,5 +51,19 @@ FactoryBot.define do
       relation_type { "follows" }
       lag { 0 }
     end
+
+    factory :precedes_relation do
+      # Use these transient attributes if you always mix up `from` and `to`
+      # attributes in a precedes relation
+      transient do
+        predecessor { nil }
+        successor { nil }
+      end
+
+      from { predecessor || super() }
+      to { successor || super() }
+      relation_type { "precedes" }
+      lag { 0 }
+    end
   end
 end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -312,7 +312,7 @@ module Components
       end
 
       def children_table
-        page.find_test_selector("op-relation-group-children")
+        page.find_test_selector("op-relation-group-child")
       end
 
       def add_existing_child(work_package)

--- a/spec/support/table_helpers/column.rb
+++ b/spec/support/table_helpers/column.rb
@@ -40,6 +40,7 @@ require_relative "column_type/related_to_relations"
 require_relative "column_type/schedule"
 require_relative "column_type/scheduling_mode"
 require_relative "column_type/status"
+require_relative "column_type/successor_relations"
 require_relative "column_type/subject"
 
 module TableHelpers
@@ -61,6 +62,7 @@ module TableHelpers
       schedule_manually: ColumnType::SchedulingMode,
       status: ColumnType::Status,
       subject: ColumnType::Subject,
+      successor_relations: ColumnType::SuccessorRelations,
       __fallback__: ColumnType::Generic
     }.freeze
 
@@ -100,6 +102,8 @@ module TableHelpers
         :schedule_manually
       when /\s*predecessors\s*/
         :predecessor_relations
+      when /\s*successors\s*/
+        :successor_relations
       when /\s*relate[ds][ _]to\s*/
         :related_to_relations
       when /status/, /hierarchy/

--- a/spec/support/table_helpers/column_type/predecessor_relations.rb
+++ b/spec/support/table_helpers/column_type/predecessor_relations.rb
@@ -60,8 +60,9 @@ module TableHelpers
       end
 
       def parse_predecessors(predecessors)
-        relations = predecessors.map do |predecessor|
-          parse_predecessor(predecessor)
+        relations = predecessors.to_h do |predecessor|
+          relation = parse_predecessor(predecessor)
+          [relation[:with], relation]
         end
         { relations: }.compact_blank
       end

--- a/spec/support/table_helpers/column_type/successor_relations.rb
+++ b/spec/support/table_helpers/column_type/successor_relations.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module TableHelpers
+  module ColumnType
+    # Column to add successors to work packages like "wp1, wp2 with lag 2, wp3".
+    #
+    # Supported texts:
+    #   - :wp
+    #   - :wp with lag :int
+    #   - precedes :wp
+    #   - precedes :wp with lag :int
+    # They can be combined by separated them with commas: "precedes wp1, wp2 with lag 2, wp3".
+    #
+    # Example:
+    #
+    #   | subject      | successors                   |
+    #   | predecessor2 | main, predecessor with lag 2 |
+    #   | predecessor  | precedes main                |
+    #   | main         |                              |
+    class SuccessorRelations < Generic
+      def attributes_for_work_package(_attribute, _work_package)
+        {}
+      end
+
+      def extract_data(_attribute, raw_header, work_package_data, _work_packages_data)
+        successors = work_package_data.dig(:row, raw_header)
+        successors = successors.split(",").map(&:strip).compact_blank
+        parse_successors(successors)
+      end
+
+      def parse_successors(successors)
+        relations = successors.to_h do |successor|
+          relation = parse_successor(successor)
+          [relation[:with], relation]
+        end
+        { relations: }.compact_blank
+      end
+
+      def parse_successor(successor)
+        case successor
+        when /^(?:precedes)?\s*(.+?)(?: with lag (\d+))?\s*$/
+          {
+            raw: successor,
+            type: :precedes,
+            with: $1,
+            lag: $2.to_i
+          }
+        else
+          spell_checker = DidYouMean::SpellChecker.new(
+            dictionary: [
+              ":wp",
+              ":wp with lag :int",
+              "precedes :wp",
+              "precedes :wp with lag :int"
+            ]
+          )
+          suggestions = spell_checker.correct(successor).map(&:inspect).join(" ")
+          did_you_mean = " Did you mean #{suggestions} instead?" if suggestions.present?
+          raise "unable to parse successor #{successor.inspect}.#{did_you_mean}"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/table_helpers/table_data.rb
+++ b/spec/support/table_helpers/table_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -43,7 +45,7 @@ module TableHelpers
         attributes = columns.reduce({}) do |attrs, column|
           attrs.merge!(column.attributes_for_work_package(work_package))
         end
-        row = columns.to_h { [_1.title, nil] }
+        row = columns.to_h { [it.title, nil] }
         identifier = to_identifier(work_package.subject)
         {
           attributes:,
@@ -87,7 +89,7 @@ module TableHelpers
       ordered_identifiers = other_table.work_package_identifiers
       extra_identifiers = work_package_identifiers - ordered_identifiers
       @work_packages_data = work_packages_data
-        .index_by { _1[:identifier] }
+        .index_by { it[:identifier] }
         .values_at(*(ordered_identifiers + extra_identifiers))
         .compact
     end
@@ -178,7 +180,7 @@ module TableHelpers
       end
 
       def work_package_relations(identifier)
-        work_package_data(identifier)[:relations] || []
+        work_package_data(identifier)[:relations]&.values || []
       end
     end
   end

--- a/spec/support_spec/table_helpers/column_type/predecessor_relations_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/predecessor_relations_spec.rb
@@ -65,8 +65,12 @@ module TableHelpers::ColumnType
         TABLE
         expect(work_package_data)
           .to eq([
-                   [{ raw: "follows main with lag 3", type: :follows, with: "main", lag: 3 }],
-                   [{ raw: "main with lag 3", type: :follows, with: "main", lag: 3 }]
+                   {
+                     "main" => { raw: "follows main with lag 3", type: :follows, with: "main", lag: 3 }
+                   },
+                   {
+                     "main" => { raw: "main with lag 3", type: :follows, with: "main", lag: 3 }
+                   }
                  ])
       end
 
@@ -78,8 +82,12 @@ module TableHelpers::ColumnType
         TABLE
         expect(work_package_data)
           .to eq([
-                   [{ raw: "follows main", type: :follows, with: "main", lag: 0 }],
-                   [{ raw: "main", type: :follows, with: "main", lag: 0 }]
+                   {
+                     "main" => { raw: "follows main", type: :follows, with: "main", lag: 0 }
+                   },
+                   {
+                     "main" => { raw: "main", type: :follows, with: "main", lag: 0 }
+                   }
                  ])
       end
 
@@ -91,15 +99,15 @@ module TableHelpers::ColumnType
         TABLE
         expect(work_package_data)
           .to eq([
-                   [
-                     { raw: "follows wp1", type: :follows, with: "wp1", lag: 0 },
-                     { raw: "follows wp2", type: :follows, with: "wp2", lag: 0 }
-                   ],
-                   [
-                     { raw: "follows wp1", type: :follows, with: "wp1", lag: 0 },
-                     { raw: "wp2", type: :follows, with: "wp2", lag: 0 },
-                     { raw: "wp3", type: :follows, with: "wp3", lag: 0 }
-                   ]
+                   {
+                     "wp1" => { raw: "follows wp1", type: :follows, with: "wp1", lag: 0 },
+                     "wp2" => { raw: "follows wp2", type: :follows, with: "wp2", lag: 0 }
+                   },
+                   {
+                     "wp1" => { raw: "follows wp1", type: :follows, with: "wp1", lag: 0 },
+                     "wp2" => { raw: "wp2", type: :follows, with: "wp2", lag: 0 },
+                     "wp3" => { raw: "wp3", type: :follows, with: "wp3", lag: 0 }
+                   }
                  ])
       end
     end

--- a/spec/support_spec/table_helpers/column_type/related_to_relations_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/related_to_relations_spec.rb
@@ -64,7 +64,9 @@ module TableHelpers::ColumnType
         TABLE
         expect(work_package_data)
           .to eq([
-                   [{ raw: "main", type: :relates, with: "main" }]
+                   {
+                     "main" => { raw: "main", type: :relates, with: "main" }
+                   }
                  ])
       end
 
@@ -75,11 +77,11 @@ module TableHelpers::ColumnType
         TABLE
         expect(work_package_data)
           .to eq([
-                   [
-                     { raw: "wp1", type: :relates, with: "wp1" },
-                     { raw: "wp2", type: :relates, with: "wp2" },
-                     { raw: "wp3", type: :relates, with: "wp3" }
-                   ]
+                   {
+                     "wp1" => { raw: "wp1", type: :relates, with: "wp1" },
+                     "wp2" => { raw: "wp2", type: :relates, with: "wp2" },
+                     "wp3" => { raw: "wp3", type: :relates, with: "wp3" }
+                   }
                  ])
       end
     end

--- a/spec/support_spec/table_helpers/column_type/successor_relations_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/successor_relations_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+module TableHelpers::ColumnType
+  RSpec.describe SuccessorRelations do
+    subject(:column_type) { described_class.new }
+
+    def parsed_data(table)
+      TableHelpers::TableParser.new.parse(table)
+    end
+
+    describe "empty" do
+      it "stores nothing when empty" do
+        work_package_data = parsed_data(<<~TABLE).first
+          | successors |
+          |            |
+        TABLE
+        expect(work_package_data[:relations]).to be_nil
+        expect(work_package_data[:attributes]).to be_empty
+
+        work_package_data = parsed_data(<<~TABLE).first
+          | successors |
+          |            |
+        TABLE
+        expect(work_package_data[:relations]).to be_nil
+        expect(work_package_data[:attributes]).to be_empty
+      end
+    end
+
+    describe "[precedes] <successor> [with lag <nb_days>]" do
+      it "stores precedes relations in work_package_data" do
+        work_package_data = parsed_data(<<~TABLE).pluck(:relations)
+          | successors               |
+          | precedes main with lag 3 |
+          | main with lag 3          |
+        TABLE
+        expect(work_package_data)
+          .to eq([
+                   {
+                     "main" => { raw: "precedes main with lag 3", type: :precedes, with: "main", lag: 3 }
+                   },
+                   {
+                     "main" => { raw: "main with lag 3", type: :precedes, with: "main", lag: 3 }
+                   }
+                 ])
+      end
+
+      it "has a default lag of 0 days when not specified" do
+        work_package_data = parsed_data(<<~TABLE).pluck(:relations)
+          | successors    |
+          | precedes main |
+          | main          |
+        TABLE
+        expect(work_package_data)
+          .to eq([
+                   {
+                     "main" => { raw: "precedes main", type: :precedes, with: "main", lag: 0 }
+                   },
+                   {
+                     "main" => { raw: "main", type: :precedes, with: "main", lag: 0 }
+                   }
+                 ])
+      end
+
+      it "can store multiple relations" do
+        work_package_data = parsed_data(<<~TABLE).pluck(:relations)
+          | successors                 |
+          | precedes wp1, precedes wp2 |
+          | precedes wp1, wp2, wp3     |
+        TABLE
+        expect(work_package_data)
+          .to eq([
+                   {
+                     "wp1" => { raw: "precedes wp1", type: :precedes, with: "wp1", lag: 0 },
+                     "wp2" => { raw: "precedes wp2", type: :precedes, with: "wp2", lag: 0 }
+                   },
+                   {
+                     "wp1" => { raw: "precedes wp1", type: :precedes, with: "wp1", lag: 0 },
+                     "wp2" => { raw: "wp2", type: :precedes, with: "wp2", lag: 0 },
+                     "wp3" => { raw: "wp3", type: :precedes, with: "wp3", lag: 0 }
+                   }
+                 ])
+      end
+    end
+  end
+end

--- a/spec/support_spec/table_helpers/table_data_spec.rb
+++ b/spec/support_spec/table_helpers/table_data_spec.rb
@@ -176,6 +176,32 @@ module TableHelpers
         expect(follower.follows_relations.first.lag).to eq(2)
       end
 
+      it "creates 'precedes' relations between work packages out of the table data" do
+        table_representation = <<~TABLE
+          subject     | successors
+          predecessor | precedes main with lag 2
+          main        | precedes successor
+          successor   |
+        TABLE
+
+        table_data = described_class.for(table_representation)
+        table = table_data.create_work_packages
+        expect(table.work_packages.count).to eq(3)
+        predecessor = table.work_package(:predecessor)
+        main = table.work_package(:main)
+        successor = table.work_package(:successor)
+
+        expect(main.follows_relations.count).to eq(1)
+        expect(main.follows_relations.first.predecessor).to eq(predecessor)
+        expect(main.follows_relations.first.successor).to eq(main)
+        expect(main.follows_relations.first.lag).to eq(2)
+
+        expect(main.precedes_relations.count).to eq(1)
+        expect(main.precedes_relations.first.predecessor).to eq(main)
+        expect(main.precedes_relations.first.successor).to eq(successor)
+        expect(main.precedes_relations.first.lag).to eq(0)
+      end
+
       it "creates 'relates' relations between work packages out of the table data" do
         table_representation = <<~TABLE
           subject  | related to

--- a/spec/support_spec/table_helpers/table_data_spec.rb
+++ b/spec/support_spec/table_helpers/table_data_spec.rb
@@ -193,6 +193,25 @@ module TableHelpers
         expect(other.relations.relates.first.lag).to be_nil
       end
 
+      it "can creates 'follows' and 'relates' relations at the same time out of the table data" do
+        table_representation = <<~TABLE
+          subject     | related to | predecessors
+          pred        |            |
+          other       |            |
+          main        | other      | pred
+        TABLE
+
+        table_data = described_class.for(table_representation)
+        table = table_data.create_work_packages
+        expect(table.work_packages.count).to eq(3)
+        pred = table.work_package(:pred)
+        other = table.work_package(:other)
+        main = table.work_package(:main)
+        expect(main.relations.count).to eq(2)
+        expect(main.relations.relates.first.to).to eq(other)
+        expect(main.relations.follows.first.to).to eq(pred)
+      end
+
       it "raises an error if a given status name does not exist" do
         table_representation = <<~TABLE
           subject | status |


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62557
https://community.openproject.org/wp/62607

# What are you trying to accomplish?

The relations order was not the same between date picker tabs and relation tab for the same relation group.

Also the order of relation groups was not the same from one work package to another in the relations tab.

This needs to be consistent.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Move the ordering logic out of the view and put it in the `WorkPackageRelationsTab::RelationsMediator` object instead:
* `WorkPackageRelationsTab::RelationsMediator` returns all relation groups, child and relations, ordered as they should be
* `WorkPackageRelationsTab::RelationsMediator::RelationGroup` is ordering and returning `WorkPackageRelationsTab::RelationsMediator::RelationItem` objects as they should be
* `WorkPackageRelationsTab::RelationsMediator::RelationItem` have every information needed to do the rendering: visibility, relation, related work package, is the closest one, etc.

This is to alleviate most of the logic from the view, replacing conditionals with more specialized value objects.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
