### PR TITLE
Expand the number of families RunsOn can use

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -28,7 +28,8 @@ jobs:
       labels:
         - runs-on
         - runner=32cpu-linux-x64
-        - family=m7
+        - family=m7+c7+r7+i7
+        - ram=128
         - run-id=${{ github.run_id }}
     timeout-minutes: 40
     env:


### PR DESCRIPTION
All with at least 128GB RAM and 32 vCPUs. This increases the chances of finding spot instances, and reduces the risk of spot interruptions.