### PR TITLE
Feature/57388 save export configuration for next export of a view

### DIFF
--- a/app/components/work_packages/exports/base_export_settings_component.rb
+++ b/app/components/work_packages/exports/base_export_settings_component.rb
@@ -35,16 +35,16 @@ module WorkPackages
       include OpTurbo::Streamable
       include WorkPackagesHelper
 
-      attr_reader :query
+      def query
+        model
+      end
 
-      def initialize(query)
-        super
-
-        @query = query
+      def format
+        raise NotImplementedError, "Must be overridden in subclass"
       end
 
       def export_settings
-        @export_settings ||= query.export_settings.where(format: "csv").first_or_initialize
+        @export_settings ||= query.export_settings.where(format:).first_or_initialize
       end
     end
   end

--- a/app/components/work_packages/exports/base_export_settings_component.rb
+++ b/app/components/work_packages/exports/base_export_settings_component.rb
@@ -44,7 +44,7 @@ module WorkPackages
       end
 
       def export_settings
-        @export_settings ||= query.export_settings.where(format:).first_or_initialize
+        @export_settings ||= query.export_settings_for(format)
       end
     end
   end

--- a/app/components/work_packages/exports/base_export_settings_component.rb
+++ b/app/components/work_packages/exports/base_export_settings_component.rb
@@ -42,6 +42,10 @@ module WorkPackages
 
         @query = query
       end
+
+      def export_settings
+        @export_settings ||= query.export_settings.where(format: "csv").first_or_initialize
+      end
     end
   end
 end

--- a/app/components/work_packages/exports/column_selection_component.rb
+++ b/app/components/work_packages/exports/column_selection_component.rb
@@ -61,10 +61,11 @@ module WorkPackages
 
       def selected_columns
         if export_settings.settings.key?(:columns)
-          # FIXME: the order of the columns is not preserved
           saved_cols = export_settings.settings[:columns]
-          available_columns
-            .select { |column| saved_cols.include?(column[:id]) }
+          # Restore the saved columns, retaining the saved order
+          saved_cols.filter_map do |col|
+            available_columns.find { |c| c[:id] == col }
+          end
         else
           query
             .columns

--- a/app/components/work_packages/exports/column_selection_component.rb
+++ b/app/components/work_packages/exports/column_selection_component.rb
@@ -60,16 +60,20 @@ module WorkPackages
       end
 
       def selected_columns
-        if export_settings.settings.key?(:columns)
-          saved_cols = export_settings.settings[:columns]
-          # Restore the saved columns, retaining the saved order
-          saved_cols.filter_map do |col|
-            available_columns.find { |c| c[:id] == col }
-          end
-        else
-          query
-            .columns
-            .map { |column| { id: column.name.to_s, name: column.caption } }
+        return columns_from_saved_export_settings if export_settings.settings.key?(:columns)
+
+        query
+          .columns
+          .map { |column| { id: column.name.to_s, name: column.caption } }
+      end
+
+      private
+
+      def columns_from_saved_export_settings
+        saved_cols = export_settings.settings[:columns]
+        # Restore the saved columns, retaining the saved order
+        saved_cols.filter_map do |col|
+          available_columns.find { |c| c[:id] == col }
         end
       end
     end

--- a/app/components/work_packages/exports/column_selection_component.rb
+++ b/app/components/work_packages/exports/column_selection_component.rb
@@ -41,8 +41,7 @@ module WorkPackages
         super()
 
         @export_settings = export_settings
-        # TODO: respond_to can be removed once all ExportSettingComponents have been migrated
-        @query = export_settings.respond_to?(:query) ? export_settings.query : export_settings
+        @query = @export_settings.query
         @id = id
         @caption = caption
         @label = label
@@ -61,17 +60,16 @@ module WorkPackages
       end
 
       def selected_columns
-        # TODO: respond_to can be removed once all ExportSettingComponents have been migrated
-        if export_settings.respond_to?(:settings) && export_settings.settings.key?(:columns)
+        if export_settings.settings.key?(:columns)
+          # FIXME: the order of the columns is not preserved
           saved_cols = export_settings.settings[:columns]
-          query
-            .columns
-            .select { |column| saved_cols.include?(column.name.to_s) }
+          available_columns
+            .select { |column| saved_cols.include?(column[:id]) }
         else
           query
             .columns
+            .map { |column| { id: column.name.to_s, name: column.caption } }
         end
-          .map { |column| { id: column.name.to_s, name: column.caption } }
       end
     end
   end

--- a/app/components/work_packages/exports/csv/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/csv/export_settings_component.html.erb
@@ -17,7 +17,10 @@
             checked: export_settings.true?(:show_descriptions),
             label: I18n.t("export.dialog.xls.include_descriptions.label"),
             caption: I18n.t("export.dialog.xls.include_descriptions.caption"),
-            visually_hide_label: false
+            visually_hide_label: false,
+            data: {
+              test_selector: "show-descriptions-csv"
+            }
           )
         ) %>
   <% end %>

--- a/app/components/work_packages/exports/csv/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/csv/export_settings_component.html.erb
@@ -14,7 +14,7 @@
             name: "show_descriptions",
             value: "true",
             unchecked_value: "false",
-            checked: export_settings.settings.fetch(:show_descriptions, false),
+            checked: export_settings.true?(:show_descriptions),
             label: I18n.t("export.dialog.xls.include_descriptions.label"),
             caption: I18n.t("export.dialog.xls.include_descriptions.caption"),
             visually_hide_label: false

--- a/app/components/work_packages/exports/csv/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/csv/export_settings_component.html.erb
@@ -1,7 +1,7 @@
 <%= flex_layout do |container| %>
   <%= container.with_row do |_columns| %>
     <%= render WorkPackages::Exports::ColumnSelectionComponent.new(
-          query,
+          export_settings,
           "columns-select-export-csv",
           I18n.t("export.dialog.columns.input_caption_table")
         ) %>
@@ -14,6 +14,7 @@
             name: "show_descriptions",
             value: "true",
             unchecked_value: "false",
+            checked: export_settings.settings.fetch(:show_descriptions, false),
             label: I18n.t("export.dialog.xls.include_descriptions.label"),
             caption: I18n.t("export.dialog.xls.include_descriptions.caption"),
             visually_hide_label: false

--- a/app/components/work_packages/exports/csv/export_settings_component.rb
+++ b/app/components/work_packages/exports/csv/export_settings_component.rb
@@ -32,6 +32,9 @@ module WorkPackages
   module Exports
     module CSV
       class ExportSettingsComponent < BaseExportSettingsComponent
+        def format
+          "csv"
+        end
       end
     end
   end

--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -61,7 +61,10 @@
                 value: "true",
                 unchecked_value: "false",
                 checked: saved_export_settings?,
-                label: I18n.t("export.dialog.save_export_settings.label")
+                label: I18n.t("export.dialog.save_export_settings.label"),
+                data: {
+                  test_selector: "#{EXPORT_FORM_ID}-save-export-settings"
+                }
               )
             ) %>
       <% end %>

--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -51,7 +51,17 @@
       <% end %>
     <% end %>
   <% end %>
-  <% dialog.with_footer do %>
+  <% dialog.with_footer(show_divider: true) do %>
+    <%= render(
+          Primer::Alpha::CheckBox.new(
+            id: "#{EXPORT_FORM_ID}-save_export_settings",
+            name: "save_export_settings",
+            value: "true",
+            unchecked_value: "false",
+            checked: has_saved_export_settings?,
+            label: I18n.t("export.dialog.save_export_settings.label")
+          )
+        ) %>
     <%= render(Primer::ButtonComponent.new(data: { "close-dialog-id": MODAL_ID })) { I18n.t(:button_cancel) } %>
     <%= render(
           Primer::ButtonComponent.new(

--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -52,16 +52,18 @@
     <% end %>
   <% end %>
   <% dialog.with_footer(show_divider: true) do %>
-    <%= render(
-          Primer::Alpha::CheckBox.new(
-            id: "#{EXPORT_FORM_ID}-save_export_settings",
-            name: "save_export_settings",
-            value: "true",
-            unchecked_value: "false",
-            checked: has_saved_export_settings?,
-            label: I18n.t("export.dialog.save_export_settings.label")
-          )
-        ) %>
+    <%= render(Primer::BaseComponent.new(tag: :span, mr: :auto)) do %>
+      <%= render(
+            Primer::Alpha::CheckBox.new(
+              id: "#{EXPORT_FORM_ID}-save_export_settings",
+              name: "save_export_settings",
+              value: "true",
+              unchecked_value: "false",
+              checked: has_saved_export_settings?,
+              label: I18n.t("export.dialog.save_export_settings.label")
+            )
+          ) %>
+    <% end %>
     <%= render(Primer::ButtonComponent.new(data: { "close-dialog-id": MODAL_ID })) { I18n.t(:button_cancel) } %>
     <%= render(
           Primer::ButtonComponent.new(

--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -52,17 +52,19 @@
     <% end %>
   <% end %>
   <% dialog.with_footer(show_divider: true) do %>
-    <%= render(Primer::BaseComponent.new(tag: :span, mr: :auto)) do %>
-      <%= render(
-            Primer::Alpha::CheckBox.new(
-              id: "#{EXPORT_FORM_ID}-save_export_settings",
-              name: "save_export_settings",
-              value: "true",
-              unchecked_value: "false",
-              checked: has_saved_export_settings?,
-              label: I18n.t("export.dialog.save_export_settings.label")
-            )
-          ) %>
+    <% if offer_to_save_export_settings? %>
+      <%= render(Primer::BaseComponent.new(tag: :span, mr: :auto)) do %>
+        <%= render(
+              Primer::Alpha::CheckBox.new(
+                id: "#{EXPORT_FORM_ID}-save_export_settings",
+                name: "save_export_settings",
+                value: "true",
+                unchecked_value: "false",
+                checked: saved_export_settings?,
+                label: I18n.t("export.dialog.save_export_settings.label")
+              )
+            ) %>
+      <% end %>
     <% end %>
     <%= render(Primer::ButtonComponent.new(data: { "close-dialog-id": MODAL_ID })) { I18n.t(:button_cancel) } %>
     <%= render(

--- a/app/components/work_packages/exports/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/modal_dialog_component.rb
@@ -48,11 +48,11 @@ module WorkPackages
 
       def export_format_url(format)
         if @project.nil?
-          index_work_packages_path(format:)
-        elsif @query.id.present?
-          project_work_packages_path(project, query_id: @query.id, format:)
+          # Global work package list. The query_id might be nil for unsaved queries.
+          index_work_packages_path(format:, query_id: @query.id)
         else
-          project_work_packages_path(project, format:)
+          # Project work package list. The query_id might be nil for unsaved queries.
+          project_work_packages_path(project, query_id: @query.id, format:)
         end
       end
 

--- a/app/components/work_packages/exports/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/modal_dialog_component.rb
@@ -56,7 +56,12 @@ module WorkPackages
         end
       end
 
-      def has_saved_export_settings?
+      # Users can save their export settings, but only for saved queries.
+      def offer_to_save_export_settings?
+        @query.persisted?
+      end
+
+      def saved_export_settings?
         @query.export_settings.any?
       end
 

--- a/app/components/work_packages/exports/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/modal_dialog_component.rb
@@ -62,7 +62,7 @@ module WorkPackages
       end
 
       def saved_export_settings?
-        @query.export_settings.any?
+        @query.export_settings.any?(&:persisted?)
       end
 
       def export_formats_settings

--- a/app/components/work_packages/exports/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/modal_dialog_component.rb
@@ -56,6 +56,10 @@ module WorkPackages
         end
       end
 
+      def has_saved_export_settings?
+        @query.export_settings.any?
+      end
+
       def export_formats_settings
         [
           { id: "pdf", icon: :"op-pdf",

--- a/app/components/work_packages/exports/pdf/gantt/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/gantt/export_settings_component.html.erb
@@ -8,9 +8,9 @@
                    size: :medium,
                    input_width: :small
                  )) do |component|
-            selected = entry[:options].find { |e| e[:default] }[:value]
-            entry[:options].each do |entry|
-              component.option(label: entry[:label], value: entry[:value], selected: selected == entry[:value])
+            selected = find_selected_option(entry)
+            entry[:options].each do |e|
+              component.option(label: e[:label], value: e[:value], selected: selected[:value] == e[:value])
             end
           end %>
     <% end %>

--- a/app/components/work_packages/exports/pdf/gantt/export_settings_component.rb
+++ b/app/components/work_packages/exports/pdf/gantt/export_settings_component.rb
@@ -33,6 +33,10 @@ module WorkPackages
     module PDF
       module Gantt
         class ExportSettingsComponent < BaseExportSettingsComponent
+          def format
+            "pdf_gantt"
+          end
+
           def gantt_selects
             [
               {
@@ -53,6 +57,26 @@ module WorkPackages
                 options: pdf_paper_sizes
               }
             ]
+          end
+
+          # Reads the saved value from the export settings and returns the selected option.
+          # When there is no saved value, returns the default option.
+          # @param [Hash] entry one entry from `gantt_selects`
+          def find_selected_option(entry)
+            select_name = entry[:name].to_sym
+            if export_settings.settings.key?(select_name)
+              saved_value = export_settings.settings[select_name]
+
+              entry[:options].find { |option| option[:value] == saved_value } || find_default_option(entry)
+            else
+              find_default_option(entry)
+            end
+          end
+
+          # Returns the default option for a gantt_select entry.
+          # @param [Hash] entry one entry from `gantt_selects`
+          def find_default_option(entry)
+            entry[:options].find { |option| option[:default] }
           end
 
           def gantt_zoom_levels

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
@@ -31,7 +31,7 @@
     <%= render(
           Primer::Alpha::CheckBox.new(
             name: "show_images",
-            checked: export_settings.settings.fetch(:show_images, true).to_bool,
+            checked: export_settings.settings.fetch(:show_images, true).to_s.to_bool,
             value: "true",
             unchecked_value: "false",
             label: I18n.t("export.dialog.pdf.include_images.label"),

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
@@ -31,7 +31,7 @@
     <%= render(
           Primer::Alpha::CheckBox.new(
             name: "show_images",
-            checked: export_settings.settings.fetch(:show_images, true),
+            checked: export_settings.settings.fetch(:show_images, true).to_bool,
             value: "true",
             unchecked_value: "false",
             label: I18n.t("export.dialog.pdf.include_images.label"),

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
@@ -1,7 +1,7 @@
 <%= flex_layout do |container| %>
   <% container.with_row do |_columns| %>
     <%= render WorkPackages::Exports::ColumnSelectionComponent.new(
-          query,
+          export_settings,
           "columns-select-export-pdf-report",
           I18n.t("export.dialog.columns.input_caption_report"),
           I18n.t("export.dialog.columns.input_label_report"),
@@ -31,7 +31,7 @@
     <%= render(
           Primer::Alpha::CheckBox.new(
             name: "show_images",
-            checked: true,
+            checked: export_settings.settings.fetch(:show_images, true),
             value: "true",
             unchecked_value: "false",
             label: I18n.t("export.dialog.pdf.include_images.label"),

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.html.erb
@@ -31,7 +31,7 @@
     <%= render(
           Primer::Alpha::CheckBox.new(
             name: "show_images",
-            checked: export_settings.settings.fetch(:show_images, true).to_s.to_bool,
+            checked: export_settings.true?(:show_images, default: true),
             value: "true",
             unchecked_value: "false",
             label: I18n.t("export.dialog.pdf.include_images.label"),

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.rb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.rb
@@ -45,9 +45,7 @@ module WorkPackages
           end
 
           def selected_long_text_fields
-            default_long_text_fields = [DESCRIPTION_CF] + WorkPackageCustomField
-                                                            .where(field_format: "text")
-                                                            .map { |cf| { id: cf.id, name: cf.name } }
+            default_long_text_fields = available_long_text_fields
 
             saved_long_text_fields = if export_settings.settings.key?(:long_text_fields)
                                        saved = export_settings.settings.fetch(:long_text_fields, "").split

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.rb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.rb
@@ -45,17 +45,18 @@ module WorkPackages
           end
 
           def selected_long_text_fields
-            default_long_text_fields = [DESCRIPTION_CF] + WorkPackageCustomField.where(field_format: "text")
+            default_long_text_fields = [DESCRIPTION_CF] + WorkPackageCustomField
+                                                            .where(field_format: "text")
+                                                            .map { |cf| { id: cf.id, name: cf.name } }
 
             saved_long_text_fields = if export_settings.settings.key?(:long_text_fields)
                                        saved = export_settings.settings.fetch(:long_text_fields, "").split
                                        default_long_text_fields.select do |cf|
-                                         saved.include?(cf.respond_to?(:id) ? cf.id.to_s : cf[:id].to_s)
+                                         saved.include?(cf[:id].to_s)
                                        end
                                      end
 
-            (saved_long_text_fields || default_long_text_fields)
-              .map { |cf| { id: cf.id, name: cf.name } }
+            saved_long_text_fields || default_long_text_fields
           end
 
           def protected_long_text_fields

--- a/app/components/work_packages/exports/pdf/report/export_settings_component.rb
+++ b/app/components/work_packages/exports/pdf/report/export_settings_component.rb
@@ -35,13 +35,27 @@ module WorkPackages
         class ExportSettingsComponent < BaseExportSettingsComponent
           DESCRIPTION_CF = { id: "description", name: WorkPackage.human_attribute_name("description") }.freeze
 
+          def format
+            "pdf_report"
+          end
+
           def available_long_text_fields
             [DESCRIPTION_CF] + WorkPackageCustomField.where(field_format: "text")
                                                      .map { |cf| { id: cf.id, name: cf.name } }
           end
 
           def selected_long_text_fields
-            available_long_text_fields
+            default_long_text_fields = [DESCRIPTION_CF] + WorkPackageCustomField.where(field_format: "text")
+
+            saved_long_text_fields = if export_settings.settings.key?(:long_text_fields)
+                                       saved = export_settings.settings.fetch(:long_text_fields, "").split
+                                       default_long_text_fields.select do |cf|
+                                         saved.include?(cf.respond_to?(:id) ? cf.id.to_s : cf[:id].to_s)
+                                       end
+                                     end
+
+            (saved_long_text_fields || default_long_text_fields)
+              .map { |cf| { id: cf.id, name: cf.name } }
           end
 
           def protected_long_text_fields

--- a/app/components/work_packages/exports/pdf/table/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/table/export_settings_component.html.erb
@@ -1,5 +1,5 @@
 <%= render WorkPackages::Exports::ColumnSelectionComponent.new(
-      query,
+      export_settings,
       "columns-select-export-pdf-table",
       I18n.t("export.dialog.columns.input_caption_table")
     ) %>

--- a/app/components/work_packages/exports/pdf/table/export_settings_component.rb
+++ b/app/components/work_packages/exports/pdf/table/export_settings_component.rb
@@ -33,6 +33,9 @@ module WorkPackages
     module PDF
       module Table
         class ExportSettingsComponent < BaseExportSettingsComponent
+          def format
+            "pdf_table"
+          end
         end
       end
     end

--- a/app/components/work_packages/exports/xls/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/xls/export_settings_component.html.erb
@@ -14,7 +14,7 @@
             name: "show_relations",
             value: "true",
             unchecked_value: "false",
-            checked: export_settings.settings.fetch(:show_relations, false),
+            checked: export_settings.true?(:show_relations),
             label: I18n.t("export.dialog.xls.include_relations.label"),
             caption: I18n.t("export.dialog.xls.include_relations.caption"),
             visually_hide_label: false
@@ -29,7 +29,7 @@
             name: "show_descriptions",
             value: "true",
             unchecked_value: "false",
-            checked: export_settings.settings.fetch(:show_descriptions, false),
+            checked: export_settings.true?(:show_descriptions),
             label: I18n.t("export.dialog.xls.include_descriptions.label"),
             caption: I18n.t("export.dialog.xls.include_descriptions.caption"),
             visually_hide_label: false

--- a/app/components/work_packages/exports/xls/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/xls/export_settings_component.html.erb
@@ -1,7 +1,7 @@
 <%= flex_layout do |container| %>
   <%= container.with_row do |_columns| %>
     <%= render WorkPackages::Exports::ColumnSelectionComponent.new(
-          query,
+          export_settings,
           "columns-select-export-xls",
           I18n.t("export.dialog.columns.input_caption_table")
         ) %>
@@ -14,6 +14,7 @@
             name: "show_relations",
             value: "true",
             unchecked_value: "false",
+            checked: export_settings.settings.fetch(:show_relations, false),
             label: I18n.t("export.dialog.xls.include_relations.label"),
             caption: I18n.t("export.dialog.xls.include_relations.caption"),
             visually_hide_label: false
@@ -28,6 +29,7 @@
             name: "show_descriptions",
             value: "true",
             unchecked_value: "false",
+            checked: export_settings.settings.fetch(:show_descriptions, false),
             label: I18n.t("export.dialog.xls.include_descriptions.label"),
             caption: I18n.t("export.dialog.xls.include_descriptions.caption"),
             visually_hide_label: false

--- a/app/components/work_packages/exports/xls/export_settings_component.rb
+++ b/app/components/work_packages/exports/xls/export_settings_component.rb
@@ -32,6 +32,9 @@ module WorkPackages
   module Exports
     module XLS
       class ExportSettingsComponent < BaseExportSettingsComponent
+        def format
+          "xls"
+        end
       end
     end
   end

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -135,7 +135,7 @@ class WorkPackagesController < ApplicationController
   end
 
   def export_list(mime_type)
-    save_export_settings if params[:save_export_settings].to_bool
+    save_export_settings if params[:save_export_settings]&.to_bool
 
     job_id = WorkPackages::Exports::ScheduleService
                .new(user: current_user)

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -172,6 +172,9 @@ class WorkPackagesController < ApplicationController
   private
 
   def save_export_settings
+    # Saving export settings is only allowed for saved queries
+    return false if @query.new_record?
+
     relevant_keys = %i[format columns show_relations show_descriptions long_text_fields
                        show_images gantt_mode gantt_width paper_size]
 
@@ -183,7 +186,7 @@ class WorkPackagesController < ApplicationController
 
     export_settings = @query.export_settings_for(user_settings[:format])
     export_settings.settings = user_settings
-    export_settings.save!
+    export_settings.save
   end
 
   def authorize_on_work_package

--- a/app/models/export_setting.rb
+++ b/app/models/export_setting.rb
@@ -51,8 +51,8 @@ class ExportSetting < ApplicationRecord
 
   # Some boolean settings are saved as string. Use this method to conveniently check if they are
   # set to true. Assumes that all boolean settings default to false.
-  def true?(key)
-    settings.fetch(key, false).to_s.to_bool
+  def true?(key, default: false)
+    settings.fetch(key, default).to_s.to_bool
   end
 
   private

--- a/app/models/export_setting.rb
+++ b/app/models/export_setting.rb
@@ -50,9 +50,9 @@ class ExportSetting < ApplicationRecord
   end
 
   # Some boolean settings are saved as string. Use this method to conveniently check if they are
-  # set to true. Assumes that all boolean settings default to false.
+  # set to true.
   def true?(key, default: false)
-    settings.fetch(key, default).to_s.to_bool
+    %w[true 1].include?(settings.fetch(key, default).to_s)
   end
 
   private

--- a/app/models/export_setting.rb
+++ b/app/models/export_setting.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ExportSetting < ApplicationRecord
+  belongs_to :query
+
+  POSSIBLE_FORMATS = %w[csv xls pdf_table pdf_report pdf_gantt].freeze
+
+  validates :query_id, presence: true
+  validates :format, presence: true, inclusion: { in: POSSIBLE_FORMATS }
+  validates :settings, presence: true
+
+  validate :unique_format_per_query
+
+  private
+
+  def unique_format_per_query
+    if ExportSetting.exists?(query_id: query_id, format: format) && (new_record? || format_changed?)
+      errors.add(:format, "there already is an export setting for this query with this format")
+    end
+  end
+end

--- a/app/models/export_setting.rb
+++ b/app/models/export_setting.rb
@@ -49,6 +49,12 @@ class ExportSetting < ApplicationRecord
     super(value.stringify_keys)
   end
 
+  # Some boolean settings are saved as string. Use this method to conveniently check if they are
+  # set to true. Assumes that all boolean settings default to false.
+  def true?(key)
+    settings.fetch(key, false).to_bool
+  end
+
   private
 
   def unique_format_per_query

--- a/app/models/export_setting.rb
+++ b/app/models/export_setting.rb
@@ -39,6 +39,16 @@ class ExportSetting < ApplicationRecord
 
   validate :unique_format_per_query
 
+  def settings
+    # Read idiomatic symbol keys for JSONB column
+    super.symbolize_keys
+  end
+
+  def settings=(value)
+    # Provide database with string keys
+    super(value.stringify_keys)
+  end
+
   private
 
   def unique_format_per_query

--- a/app/models/export_setting.rb
+++ b/app/models/export_setting.rb
@@ -52,7 +52,7 @@ class ExportSetting < ApplicationRecord
   # Some boolean settings are saved as string. Use this method to conveniently check if they are
   # set to true. Assumes that all boolean settings default to false.
   def true?(key)
-    settings.fetch(key, false).to_bool
+    settings.fetch(key, false).to_s.to_bool
   end
 
   private

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -421,6 +421,10 @@ class Query < ApplicationRecord
     subproject_filter
   end
 
+  def export_settings_for(format)
+    export_settings.where(format: format).first_or_initialize
+  end
+
   private
 
   ##

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -43,6 +43,7 @@ class Query < ApplicationRecord
   has_many :ical_tokens,
            through: :ical_token_query_assignments,
            class_name: "Token::ICal"
+  has_many :export_settings, dependent: :destroy
   # no `dependent: :destroy` as the ical_tokens are destroyed in the following before_destroy callback
   # dependent: :destroy is not possible as this would only delete the ical_token_query_assignments
   before_destroy :destroy_ical_tokens

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -422,7 +422,7 @@ class Query < ApplicationRecord
   end
 
   def export_settings_for(format)
-    export_settings.where(format: format).first_or_initialize
+    export_settings.where(format:).first_or_initialize
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2142,6 +2142,8 @@ en:
     dialog:
       title: "Export"
       submit: "Export"
+      save_export_settings:
+        label: "Save settings"
       format:
         label: "File format"
         options:

--- a/db/migrate/20250326151553_export_settings.rb
+++ b/db/migrate/20250326151553_export_settings.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ExportSettings < ActiveRecord::Migration[8.0]
+  def change
+    create_table :export_settings do |t|
+      t.references :query, null: false, foreign_key: true
+      t.string :format, null: false
+      t.jsonb :settings, default: {}, null: false
+
+      t.timestamps
+    end
+
+    add_index :export_settings, %i[query_id format], unique: true
+  end
+end

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/export/form.controller.ts
@@ -53,17 +53,26 @@ export default class FormController extends Controller<HTMLFormElement> {
   submitForm(evt:CustomEvent) {
     evt.preventDefault(); // Don't submit
     const formData = new FormData(this.element);
+
     const columns = formData.get('columns');
     if (!columns && this.mustHaveColumns(formData)) {
       return false; // Error is already displayed on the element
     }
+
+    const saveExportSettingsCheckbox = document.getElementById('op-work-packages-export-dialog-form-save_export_settings') as HTMLInputElement;
+    if (saveExportSettingsCheckbox) {
+      formData.set('save_export_settings', saveExportSettingsCheckbox.checked ? 'true' : 'false');
+    }
+
     this.requestExport(this.generateExportURL(formData))
       .then((job_id) => this.showJobModal(job_id))
       .catch((error:HttpErrorResponse) => this.handleError(error));
+
     const dialog = document.getElementById(this.jobStatusDialogIdValue) as HTMLDialogElement;
     if (dialog) {
       dialog.close();
     }
+
     return true;
   }
 

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -414,12 +414,25 @@ RSpec.describe "work package export", :js, :selenium do
       end
 
       context "with long text fields selection" do
-        let(:expected_params) { default_params_report.merge({ long_text_fields: "description 43" }) }
+        let(:expected_params) { default_params_report.merge({ long_text_fields: "description #{cf_text_b.id}" }) }
 
         it "exports a pdf report with all remaining custom fields" do
-          find("span.op-draggable-autocomplete--item-text", text: "Long text custom field")
-            .sibling(".op-draggable-autocomplete--remove-item").click
-          export!
+          # Remove one custom field
+          page.within(".op-angular-component[data-id='\"ltf-select-export-pdf-report\"']") do
+            find(".op-draggable-autocomplete--item-text", text: "Long text custom field")
+              .sibling(".op-draggable-autocomplete--remove-item").click
+          end
+
+          # Save export settings, export and reopen dialog
+          check I18n.t("export.dialog.save_export_settings.label")
+          export_and_reopen_dialog!
+          choose export_sub_type
+
+          selected_long_fields = page.within(".op-angular-component[data-id='\"ltf-select-export-pdf-report\"']") do
+            all(".op-draggable-autocomplete--item-text").map(&:text)
+          end
+          # The removed field has been saved
+          expect(selected_long_fields).to contain_exactly("Description", cf_text_b.name)
         end
       end
 

--- a/spec/models/export_settings/export_setting_spec.rb
+++ b/spec/models/export_settings/export_setting_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.shared_examples "a successful creation" do |format|
+  it "creates successfully with format #{format}" do
+    expect(described_class.create(query:, settings:, format:)).to be_persisted
+  end
+end
+
+RSpec.describe ExportSetting do
+  let(:query) { create(:query, name: "some query") }
+  let(:format) { "csv" }
+  let(:settings) { { "columns" => %w[id subject], "show_descriptions" => "true" } }
+
+  it "returns its settings with symbol keys" do
+    export_settings = described_class.create(query:, settings:, format:)
+
+    expect(export_settings.settings).to eq({ columns: %w[id subject], show_descriptions: "true" })
+
+    export_settings.settings = { "foo" => "bar" }
+    expect(export_settings.settings).to eq({ foo: "bar" })
+  end
+
+  describe "creating" do
+    formats = %w[csv xls pdf_report pdf_table pdf_gantt]
+
+    formats.each do |format|
+      include_examples "a successful creation", format
+    end
+
+    it "fails with an invalid format" do
+      expect(described_class.create(query:, settings:, format: "invalid_format")).not_to be_persisted
+    end
+
+    it "fails without format" do
+      expect(described_class.create(query:, settings:)).not_to be_persisted
+    end
+
+    it "fails without settings" do
+      expect(described_class.create(query:, format:)).not_to be_persisted
+    end
+
+    it "fails without query" do
+      expect(described_class.create(settings:, format:)).not_to be_persisted
+    end
+
+    it "fails when there already is this query/format combination" do
+      expect(described_class.create(query:, settings:, format: "csv")).to be_persisted
+
+      duplicate = described_class.create(query:, settings:, format: "csv")
+      expect(duplicate).not_to be_persisted
+      expect(duplicate.errors[:format]).to include("there already is an export setting for this query with this format")
+
+      new_query = create(:query, name: "another query")
+      expect(described_class.create(query: new_query, settings:, format: "csv")).to be_persisted
+    end
+  end
+
+  describe "#true?" do
+    let(:settings) do
+      {
+        string_true: "true",
+        real_true: true,
+        string_one_true: "1",
+        one_true: 1,
+        string_false: "false",
+        real_false: false,
+        string_zero_false: "0",
+        zero_false: 0,
+        truthy_string: "any string is truthy",
+        truthy_array: []
+      }
+    end
+    let(:instance) { described_class.new(query:, settings:, format:) }
+
+    it "returns true for a value that looks like it should be true" do
+      true_keys = %i[
+        string_true
+        real_true
+        string_one_true
+        one_true
+      ]
+
+      true_keys.each do |key|
+        expect(instance.true?(key)).to be true
+      end
+    end
+
+    it "returns false for a value that looks like it should be false" do
+      false_keys = %i[
+        string_false
+        real_false
+        string_zero_false
+        zero_false
+      ]
+
+      false_keys.each do |key|
+        expect(instance.true?(key)).to be false
+      end
+    end
+
+    it "returns false for values that are truthy in Ruby" do
+      truthy_keys = %i[truthy_string truthy_array]
+
+      truthy_keys.each do |key|
+        expect(instance.true?(key)).to be false
+      end
+    end
+
+    it "returns false for keys that do not exist" do
+      expect(instance.true?(:non_existent_key)).to be false
+    end
+
+    it "returns a default value for non existent keys" do
+      expect(instance.true?(:non_existent_key, default: true)).to be true
+    end
+  end
+end

--- a/spec/models/query/query_export_settings_spec.rb
+++ b/spec/models/query/query_export_settings_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "query export settings" do # rubocop:disable RSpec/DescribeClass
+  let(:query) { create(:query) }
+
+  describe "export_settings_for" do
+    it "creates a new export setting for the given format" do
+      setting = query.export_settings_for("csv")
+
+      expect(setting).to be_a_new_record
+    end
+
+    context "with an existing export setting" do
+      let!(:export_setting) { ExportSetting.create(query_id: query.id, settings: { some_key: :some_value }, format: "xls") }
+
+      it "is returned" do
+        setting = query.export_settings_for("xls")
+
+        expect(setting).to be_persisted
+        expect(setting.settings).to eq({ some_key: "some_value" })
+      end
+
+      it "is not returned for a different format" do
+        setting = query.export_settings_for("pdf_report")
+
+        expect(setting).to be_a_new_record
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57388

# What are you trying to accomplish?
Offer a checkbox that users can use to save the settings for a work package export.

Important caveats:

* this feature is only offered for saved queries, unsaved queries cannot have their export settings saved
* each export type (csv, xls, pdf report, pdf gantt, pdf table) has their settings saved individually
* only the changes in the currently displayed tab are saved

## Screenshots
https://github.com/user-attachments/assets/ba7fe721-cc03-4cb4-be96-a77a15f028ff

# What approach did you choose and why?
Created a new table for saving export settings, tied to a query. Each format has its own row. This allows us to check for uniqueness so that each query can only have one setting per format. The actual settings are saved via JSONB, so that we can add more settings here without having to perform migrations.

Please note that this is my first Open Project migration. If there is a process I might have missed it. So take care while reviewing.

# Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
