### PR TITLE
[60904] Accessibility for new datepicker

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -18,7 +18,7 @@
         end
 
         start_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label)))
+          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label), "aria-live": "polite"))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
           render_today_link(name: :start_date)
@@ -45,7 +45,7 @@
           end
 
           due_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))))
+            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))), "aria-live": "polite")
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
             render_today_link(name: :due_date)
@@ -54,7 +54,7 @@
       end
 
       body.with_column(classes: "wp-datepicker-dialog-date-form--duration") do
-        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration"))))
+        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration")), "aria-live": "polite"))
       end
     end
   end

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -18,7 +18,7 @@
         end
 
         start_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label), "aria-live": "polite"))
+          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label), aria: { live: :polite }))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
           render_today_link(name: :start_date)
@@ -45,7 +45,7 @@
           end
 
           due_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date")), "aria-live": "polite"))
+            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date")), aria: { live: :polite }))
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
             render_today_link(name: :due_date)
@@ -54,7 +54,7 @@
       end
 
       body.with_column(classes: "wp-datepicker-dialog-date-form--duration") do
-        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration")), "aria-live": "polite"))
+        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration")), aria: { live: :polite }))
       end
     end
   end

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -45,7 +45,7 @@
           end
 
           due_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))), "aria-live": "polite")
+            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date")), "aria-live": "polite"))
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
             render_today_link(name: :due_date)

--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -50,14 +50,9 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
       let(:schedule_manually) { true }
 
       it "shows the date form" do
-        expect(dialog_content).to have_field(I18n.t("attributes.start_date"))
-        expect(dialog_content).to have_field(I18n.t("attributes.due_date"))
-        expect(dialog_content).to have_css(
-          'input[data-test-selector="op-datepicker-modal--start-date-field"]' \
-          '[aria-live="polite"]'
-        )
-        expect(dialog_content).to have_css('input[data-test-selector="op-datepicker-modal--due-date-field"][aria-live="polite"]')
-        expect(dialog_content).to have_css('input[data-test-selector="op-datepicker-modal--duration-field"][aria-live="polite"]')
+        expect(dialog_content).to have_field(I18n.t("attributes.start_date"), aria: { live: :polite })
+        expect(dialog_content).to have_field(I18n.t("attributes.due_date"), aria: { live: :polite })
+        expect(dialog_content).to have_field(WorkPackage.human_attribute_name("duration"), aria: { live: :polite })
       end
 
       it "has an enabled save button" do

--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
       it "shows the date form" do
         expect(dialog_content).to have_field(I18n.t("attributes.start_date"))
         expect(dialog_content).to have_field(I18n.t("attributes.due_date"))
+        expect(dialog_content).to
+        have_css('input[data-test-selector="op-datepicker-modal--start-date-field"][aria-live="polite"]')
+        expect(dialog_content).to
+        have_css('input[data-test-selector="op-datepicker-modal--due-date-field"][aria-live="polite"]')
+        expect(dialog_content).to
+        have_css('input[data-test-selector="op-datepicker-modal--duration-field"][aria-live="polite"]')
       end
 
       it "has an enabled save button" do

--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
       it "shows the date form" do
         expect(dialog_content).to have_field(I18n.t("attributes.start_date"))
         expect(dialog_content).to have_field(I18n.t("attributes.due_date"))
-        expect(dialog_content).to
-        have_css('input[data-test-selector="op-datepicker-modal--start-date-field"][aria-live="polite"]')
-        expect(dialog_content).to
-        have_css('input[data-test-selector="op-datepicker-modal--due-date-field"][aria-live="polite"]')
-        expect(dialog_content).to
-        have_css('input[data-test-selector="op-datepicker-modal--duration-field"][aria-live="polite"]')
+        expect(dialog_content).to have_css(
+          'input[data-test-selector="op-datepicker-modal--start-date-field"]' \
+          '[aria-live="polite"]'
+        )
+        expect(dialog_content).to have_css('input[data-test-selector="op-datepicker-modal--due-date-field"][aria-live="polite"]')
+        expect(dialog_content).to have_css('input[data-test-selector="op-datepicker-modal--duration-field"][aria-live="polite"]')
       end
 
       it "has an enabled save button" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60904

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Improve accessibility for date picker:

Add aria liver for start-date, end-date and duration inputs 

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
