### PR TITLE
[#62657] PDF Export of a single work package in query view does not open dialog

### DIFF
--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
@@ -120,6 +120,11 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
       case 'log_time':
         this.logTimeForSelectedWorkPackage();
         break;
+
+      case 'generate_pdf':
+        void this.turboRequests.requestStream(String(link));
+        break;
+
       case 'relations':
         void this.$state.go(
           `${splitViewRoute(this.$state)}.tabs`,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -139,7 +139,7 @@ module API
 
           {
             href: generate_pdf_dialog_work_package_path(id: represented.id),
-            type: "text/html",
+            type: "text/vnd.turbo-stream.html",
             title: "Generate PDF"
           }
         end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/62657

# What are you trying to achieve?

There are two context menus from where the generate PDF dialog can be invoked. One of them did not work properly.

# What approach did you choose and why?
Send a turbo request in both menus.
