### PR TITLE
[62581] Excess padding in the Activity tab comment box

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -35,8 +35,7 @@
                   journals_wrapper_container.with_row(
                     id: add_comment_wrapper_key,
                     classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
-                    px: 2,
-                    py: 3,
+                    p: 3,
                     bg: :subtle,
                     data: add_comment_wrapper_data_attributes
                   ) do

--- a/app/components/work_packages/activities_tab/index_component.sass
+++ b/app/components/work_packages/activities_tab/index_component.sass
@@ -1,4 +1,4 @@
-@mixin activities-tab-component($breakpoint, $input-container-padding-right: 10px)
+@mixin activities-tab-component($breakpoint)
     overflow-y: hidden
     &--content-container
         row-gap: var(--Layout-row-gap)
@@ -39,7 +39,6 @@
             right: 0
             border-radius: 0px
             border-top: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
-            padding-right: $input-container-padding-right !important
             margin-bottom: 0 !important
 
         &_sort-desc
@@ -52,7 +51,7 @@
 
 .work-packages-activities-tab-index-component--within-notification-center
     .work-packages-activities-tab-index-component
-        @include activities-tab-component($breakpoint-lg, 15px)
+        @include activities-tab-component($breakpoint-lg)
 
 .work-packages-activities-tab-index-component--within-split-screen
     .work-packages-activities-tab-index-component

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   component_wrapper(class: "work-packages-activities-tab-journals-new-component") do
-    flex_layout(my: 2, data: { test_selector: "op-work-package-journal-form" }) do |new_form_container|
+    flex_layout(data: { test_selector: "op-work-package-journal-form" }) do |new_form_container|
       new_form_container.with_row(
         display: button_row_display_value,
         data: {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62581/activity

# What are you trying to accomplish?
Harmonize spacings around comment box

## Screenshots
**Before**
<img width="400" alt="Bildschirmfoto 2025-04-01 um 13 30 18" src="https://github.com/user-attachments/assets/370be6ef-3037-43b7-8bce-f72d515339a7" />

**After**
<img width="400" alt="Bildschirmfoto 2025-04-01 um 13 29 48" src="https://github.com/user-attachments/assets/c4c15f09-03ae-4c16-86dd-1779eb23b62b" />
