### PR TITLE
Make unacceptable actually return a 422 status code

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -10,9 +10,10 @@ class ErrorsController < ApplicationController
     render_404
   end
 
+  # this may be called on CSRF validation failure
   def unacceptable
     render file: "#{Rails.public_path.join('422.html')}",
-           status: :not_acceptable,
+           status: :unprocessable_entity,
            layout: false
   end
 


### PR DESCRIPTION
Comes up after #18491, where I believe I wrongly assumed 406 was what was implied by the `:unacceptable` status symbol.