### PR TITLE
[62596] User can't delete a date with mobile date picker

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -77,7 +77,7 @@ module WorkPackages
           value: field_value(name),
           disabled: disabled?(name),
           label:,
-          show_clear_button: !disabled?(name) && !duration_field?(name),
+          show_clear_button: show_clear_button?(name),
           classes: "op-datepicker-modal--date-field #{'op-datepicker-modal--date-field_current' if @focused_field == name}",
           validation_message: validation_message(name),
           type: field_type(name)
@@ -243,6 +243,10 @@ module WorkPackages
 
       def normalized_underscore_name(name)
         name.to_s.underscore
+      end
+
+      def show_clear_button?(name)
+        !disabled?(name) && !duration_field?(name) && !helpers.browser.device.mobile?
       end
     end
   end

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -80,6 +80,8 @@ export default class PreviewController extends DialogPreviewController {
 
     document.addEventListener('date-picker:flatpickr-dates-changed', this.handleFlatpickrDatesChangedBound);
     this.focusOnOpen();
+
+    this.prepareInputFieldsForSafari();
   }
 
   disconnect() {
@@ -542,5 +544,21 @@ export default class PreviewController extends DialogPreviewController {
       tabs.setAttribute('tabindex', '-1');
       tabs.focus();
     }
+  }
+
+  /*
+   * This method qualifies as the most stupid thing I had to do in a long time.
+   * Safari is the only browser which does not clear the input when using the native datepicker "clear" method.
+   * It rather resets it to the original value of the input.
+   * That is why we manually set the defaultValue to an empty string,
+   * but since the defaultValue is used for the value, we have to manually set this again.
+   * See: https://stackoverflow.com/a/64886383/8900797
+   */
+  private prepareInputFieldsForSafari() {
+    [this.startDateField, this.dueDateField].forEach((field:HTMLInputElement) => {
+      const value = field.value;
+      field.defaultValue = '';
+      field.value = value;
+    });
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62596/activity

# What are you trying to accomplish?
* Manually set the defaultValue for the date inputs so that the native date field "reset" button works in Safari
* Hide the "x" button on the date fields on mobile

