### PR TITLE
[62554] Children number icon and children label are not the right colour in dark mode

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -12,7 +12,7 @@
   <op-icon icon-classes="{{ iconClass }} button--icon"></op-icon>
   <span class="button--text">
     {{ buttonText }}
-    <span class="badge -secondary" *ngIf="initialized" [textContent]="filterCount"></span>
+    <span class="badge" *ngIf="initialized" [textContent]="filterCount"></span>
   </span>
   <span class="spot-icon spot-icon_dropdown"></span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.html
@@ -10,7 +10,7 @@
     size="small"
   ></svg>
   <span class="button--text" *ngIf="(shareCount$ | async) as shareCount">
-    <span class="badge -secondary"
+    <span class="badge"
           [textContent]="shareCount"></span>
   </span>
 

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relation-cell-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relation-cell-builder.ts
@@ -73,7 +73,7 @@ export class RelationCellbuilder {
     badge.classList.add('wp-table--relation-count');
 
     badge.textContent = count.toString();
-    badge.classList.add('badge', '-border-only');
+    badge.classList.add('badge');
 
     return badge;
   }

--- a/frontend/src/app/shared/components/fields/display/field-types/resources-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/resources-display-field.module.ts
@@ -72,7 +72,7 @@ export class ResourcesDisplayField extends DisplayField {
     content.appendChild(abridged);
 
     if (values.length > 2) {
-      const badge = this.optionDiv(values.length.toString(), 'badge', '-secondary');
+      const badge = this.optionDiv(values.length.toString(), 'badge');
       content.appendChild(badge);
     }
 

--- a/frontend/src/app/shared/components/principal/principal-renderer.service.ts
+++ b/frontend/src/app/shared/components/principal/principal-renderer.service.ts
@@ -61,7 +61,7 @@ export class PrincipalRendererService {
 
     if (users.length > maxCount) {
       const badge = document.createElement('span');
-      badge.classList.add('op-principal-list--badge', 'badge', '-secondary');
+      badge.classList.add('op-principal-list--badge', 'badge');
       badge.textContent = users.length.toString();
       wrapper.appendChild(badge);
     }

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -14,7 +14,7 @@
     {{ text.toggle_title }}
     <span
       *ngIf="(numberOfProjectsInFilter$ | async) as count"
-      class="badge -secondary"
+      class="badge"
       [textContent]="count"
     >
     </span>

--- a/frontend/src/global_styles/content/_badges.sass
+++ b/frontend/src/global_styles/content/_badges.sass
@@ -27,8 +27,7 @@
 //++
 
 $badge-diameter: 1.25rem
-$badge-background: var(--buttonCounter-default-bgColor-rest)
-$badge-secondary-background: var(--buttonCounter-default-bgColor-rest)
+$badge-background: var(--bgColor-neutral-muted)
 $badge-color: var(--fgColor-default)
 
 @mixin badge-layout($diameter: $badge-diameter)
@@ -40,6 +39,7 @@ $badge-color: var(--fgColor-default)
   color: $color
 
 .badge
+  font-size: var(--text-body-size-small)
   display: inline-flex
   align-items: center
   justify-content: center
@@ -51,13 +51,3 @@ $badge-color: var(--fgColor-default)
   min-width: 1.25rem
   padding-left: 0.3rem
   padding-right: 0.3rem
-
-  &.-secondary
-    @include badge-style($badge-secondary-background, $badge-color)
-
-  &.-border-only
-    border-color: var(--button-default-borderColor-rest)
-    color: var(--body-font-color)
-    background: transparent
-    border-width: 1px
-    border-style: solid

--- a/frontend/src/global_styles/content/work_packages/_table_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_relations.sass
@@ -20,9 +20,8 @@ body
     @extend .icon-arrow-up1
 
 // Add some margin between badge and indicator
-.wp-table--relation-count.-border-only
+.wp-table--relation-count
   margin-right: 5px
-  background: white
 
 // Override default left-align of cells
 .wp-table--relation-cell-td

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -138,10 +138,7 @@ $nm-color-success-background: #d8fdd1
       margin-left: 0.2em
 
     .badge
-      font-size: 14px
       vertical-align: 1px
-
-      font-size: 14px
       line-height: 1
 
       i

--- a/lookbook/previews/open_project/deprecated/badges_preview/border_only.html.erb
+++ b/lookbook/previews/open_project/deprecated/badges_preview/border_only.html.erb
@@ -1,3 +1,0 @@
-<span class="badge -border-only">0</span>
-<span class="badge -border-only">1</span>
-<span class="badge -border-only">2</span>

--- a/lookbook/previews/open_project/deprecated/badges_preview/secondary.html.erb
+++ b/lookbook/previews/open_project/deprecated/badges_preview/secondary.html.erb
@@ -1,3 +1,0 @@
-<span class="badge -secondary">0</span>
-<span class="badge -secondary">1</span>
-<span class="badge -secondary">2</span>

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
@@ -32,7 +32,7 @@ module ::Webhooks
           if count <= 3
             selected_events.join(", ")
           else
-            content_tag("span", count, class: "badge -border-only")
+            content_tag("span", count, class: "badge")
           end
         end
 
@@ -52,7 +52,7 @@ module ::Webhooks
           elsif selected.size <= 3
             webhook.projects.pluck(:name).join(", ")
           else
-            content_tag("span", selected, class: "badge -border-only")
+            content_tag("span", selected, class: "badge")
           end
         end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62554/activity

# What are you trying to accomplish?
* Remove old classes `-border-only` and `-secondary` for badges and move it's look and feel closer to the Counter component of Primer
  * `-secondary` used the exact same colours as the default class, so it could be removed
  * `-border-only` was used in the WP table and the webhooks index table. Both are replaced by the default class. For the WP table this is what was requested in the ticket
  * the background color and the font-size was adapted to what the `Primer::Beta::Counter` is using

## Screenshots
<img width="700" alt="Bildschirmfoto 2025-04-01 um 15 20 01" src="https://github.com/user-attachments/assets/ae6f056f-1686-4bcd-a4ff-aa618f5bd10e" />

<img width="700" alt="Bildschirmfoto 2025-04-01 um 15 19 30" src="https://github.com/user-attachments/assets/f128b542-b54e-45b2-a6e4-7e350e99a518" />


