### PR TITLE
Update remote identity indices

### DIFF
--- a/db/migrate/20250402083709_change_remote_identities_foreign_key_indices.rb
+++ b/db/migrate/20250402083709_change_remote_identities_foreign_key_indices.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ChangeRemoteIdentitiesForeignKeyIndices < ActiveRecord::Migration[8.0]
+  def change
+    # Not needed, covered by composite unique index
+    remove_index :remote_identities, :user_id
+
+    # Not needed, we never query for this
+    remove_index :remote_identities, :origin_user_id
+  end
+end


### PR DESCRIPTION
### Fixing unique index

Since changing the table layout, uniqueness should be ensured across a wider range of columns.

In general it's necessary to include *_type and *_id columns of any polymorphic association.

Since the introduction of the integration association, it's also required to include this in the index. It's very expected to see remote identities of the same user in multiple integrations, but it's also (in some edge cases) possible to even have the same user twice per integration with different authentication providers.

### Optimizing foreign key indices

There were a few useless indices and some were too scattered to be optimal for queries. E.g. only indexing by integration_id is inefficient when there are multiple integrations and since integration is a polymorphic association, there is no useful query where anyone would just filter data by the integration_id, it's always a composite of integration type and id. Just filtering by integration type would at least semantically make sense (hence type is the first in the composite).

# Ticket
Discovered while working on https://community.openproject.org/wp/62328