### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -31,7 +31,8 @@
 require "spec_helper"
 
 RSpec.describe "index users", :js do
-  shared_let(:current_user) { create(:admin, firstname: "admin", lastname: "admin", created_at: 1.hour.ago) }
+  shared_let(:admin) { create(:admin, firstname: "admin", lastname: "admin", created_at: 1.hour.ago) }
+  let(:current_user) { admin }
   let(:index_page) { Pages::Admin::Users::Index.new }
 
   before do
@@ -154,7 +155,7 @@ RSpec.describe "index users", :js do
 
       it "can too visit the page" do
         index_page.visit!
-        index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+        index_page.expect_listed(admin, current_user, active_user, registered_user, invited_user)
       end
     end
   end

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -37,12 +37,12 @@ module Pages
         end
 
         def expect_listed(*users)
-          rows = page.all "td.username a"
+          rows = page.all "td.username a", count: users.count
           expect(rows.map(&:text)).to include(*users.map(&:login))
         end
 
         def expect_order(*users)
-          rows = page.all "td.username a"
+          rows = page.all "td.username a", count: users.count
           expect(rows.map(&:text)).to eq(users.map(&:login))
         end
 


### PR DESCRIPTION
occured on spec `./spec/features/users/index_spec.rb:72`
on job https://github.com/opf/openproject/actions/runs/14200641973/job/39786500702

     Failure/Error: expect(rows.map(&:text)).to include(*users.map(&:login))
       expected [] to include "bob1"
     # ./spec/support/pages/admin/users/index.rb:41:in 'Pages::Admin::Users::Index#expect_listed'
     # ./spec/features/users/index_spec.rb:115:in 'block (3 levels) in <top (required)>'

I suppose the UI was not updated with the filtered content despite the previous command `filter_by_status` having a `wait_for_network_idle` in it.

By adding a `count` parameter to the `page.all` call, it will wait until the count matches the expected count, which should fix the flakiness seen.