### PR TITLE
avoid long list of ids in filter

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -129,8 +129,7 @@ module Filter
         url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals,
         filters: [
           { name: "type", operator: "=", values: ["User"] },
-          { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] },
-          { name: "member", operator: "=", values: Project.visible.pluck(:id) }
+          { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] }
         ],
         searchKey: "any_name_attribute",
         focusDirectly: false

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
              project => project_role,
              public_project => project_role,
              development_project => project_role
-           })
+           },
+           global_permissions: %i[view_user_email])
   end
 
   let(:news) { create(:news, project:) }
@@ -489,7 +490,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
     end
 
     it "filters for the project that has the corresponding value" do
-      load_and_open_filters admin
+      load_and_open_filters manager
 
       projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_user.name])
 
@@ -497,7 +498,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
     end
 
     it "displays the visible project members as available options" do
-      load_and_open_filters admin
+      load_and_open_filters manager
 
       expected_options = [
         { name: some_user.name, email: some_user.mail },


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/62541

# What are you trying to accomplish?

Avoid having a long list of ids in the filter that lead to the query url becoming too long.

# What approach did you choose and why?
The endpoint filtered against, /api/v3/principals, already has the [visible scope attached](https://github.com/opf/openproject/blob/dev/app/models/queries/principals/principal_query.rb#L38) to it. Therefore, no non visible principals can be retrieved anyway. The visible scope will result in filtering for those principals, that are in any visible project the current user is also in. Unless the user is admin in which case all principals are available. 
