### PR TITLE
[62650] The duration field is not visible on focus in mobile screens

### DIFF
--- a/frontend/src/app/shared/components/modal/modal.component.ts
+++ b/frontend/src/app/shared/components/modal/modal.component.ts
@@ -94,7 +94,8 @@ export abstract class OpModalComponent extends UntilDestroyedMixin implements On
     this.updateAppHeight();
     this.cdRef.detectChanges();
 
-    window.addEventListener('resize', this.onResize);
+    // It is important to check for visualViewport changes as that includes also keyboard opening (especially on iOS)
+    window.visualViewport?.addEventListener('resize', this.onResize);
     window.addEventListener('orientationchange', this.onResize);
   }
 

--- a/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
@@ -10,6 +10,13 @@
   align-items: center
   display: none
 
+  .-browser-safari &
+    // Again, iOS and Safari are being special. When the keyboard opens, that pushes the whole viewport to the top.
+    // Thus, when using `top: 0` half of the modal is pushed out of the screen.
+    // Instead, we only set `bottom: 0` and set the height to the app height which is set programmatically on every screen resize
+    height: var(--app-height)
+    top: unset
+
   &_active
     display: flex
     flex-direction: column-reverse

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -373,6 +373,10 @@ export default class PreviewController extends DialogPreviewController {
     const fieldToHighlight = e.target as HTMLInputElement;
     if (fieldToHighlight) {
       this.highlightField(fieldToHighlight);
+      window.setTimeout(() => {
+        // For mobile, we have to make sure that the active field is scrolled into view after the keyboard is opened
+        fieldToHighlight.scrollIntoView(true);
+      }, 200);
       // Datepicker can need an update when the focused field changes. This
       // allows to switch between single and range mode in certain edge cases.
       this.readCurrentValues();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62650/activity

# What are you trying to accomplish?
Change the modalOverlay height calculation to make sure that the Datepicker is correctly shown when opened on iOS and the keyboard opens

## Screenshots
**Before**
<img width="200" alt="Bildschirmfoto 2025-04-03 um 09 41 48" src="https://github.com/user-attachments/assets/3ec5c96d-33cb-43e6-8f99-b33587914a33" />

**After**
<img width="200" alt="Bildschirmfoto 2025-04-03 um 09 39 29" src="https://github.com/user-attachments/assets/1043c41e-8af0-40f8-9723-4448f47ea811" />
