### PR TITLE
[61790] Not enough spacing on Files Categories page (and other pages)

### DIFF
--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -182,8 +182,10 @@ export function initializeUiRouterListeners(injector:Injector) {
     openprojectBaseApp = document.querySelector(appBaseSelector);
     uiRouter.urlService.sync();
 
-    // Re-apply the body classes
-    bodyClass(_.get(uiRouter.globals.current, 'data.bodyClasses'), 'add');
+    // Re-apply the body classes if the turbo load event is on the same page (e.g. when creating a child from the relations tab)
+    if (stateService.href(uiRouter.globals.current) === window.location.pathname + window.location.search) {
+      bodyClass(_.get(uiRouter.globals.current, 'data.bodyClasses'), 'add');
+    }
   });
 
   // Uncomment to trace route changes

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -262,4 +262,17 @@ RSpec.describe "Work package navigation", :js, :selenium do
       expect(page).to have_css "li", text: "The requested resource could not be found"
     end
   end
+
+  # Introduced by regression #60629
+  it "can navigate correctly to non-angular pages (regression #61790)" do
+    global_work_packages = Pages::WorkPackagesTable.new
+    global_work_packages.visit!
+
+    # Navigate to the administration
+    page.find(".op-top-menu-user-avatar").click
+    page.find_test_selector("op-menu--item-action", text: "Administration").click
+
+    # Expect classes to be gone
+    expect(page).to have_no_css("body.router--work-packages-base")
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/61790/activity

# What are you trying to accomplish?
Be more strict when re-applying the body classes after a turbo:load event

