### PR TITLE
[#62386] Project attribute list entries not displayed when applied as filter in project list

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -43,17 +43,16 @@ module Filter
     # Returns filters, active and inactive.
     # In case a filter is active, the active one will be preferred over the inactive one.
     def each_filter
-      allowed_filters.each do |filter|
-        active_filter = query.find_active_filter(filter.name)
-        additional_attributes = additional_filter_attributes(filter)
+      allowed_filters.each do |allowed_filter|
+        active_filter = query.find_active_filter(allowed_filter.name)
+        filter = active_filter || allowed_filter
 
-        yield active_filter.presence || filter, active_filter.present?, additional_attributes
+        yield filter, active_filter.present?, additional_filter_attributes(filter)
       end
     end
 
     def allowed_filters
-      query
-        .available_advanced_filters
+      query.available_advanced_filters
     end
 
     def value_hidden_class(selected_operator)
@@ -99,8 +98,7 @@ module Filter
                 else
                   { items: filter.allowed_values.map { |name, id| { name:, id: } } }
                 end
-
-      autocomplete_options.merge(options)
+      autocomplete_options.merge(options).merge(model: filter.values)
     end
 
     def list_autocomplete_options(filter)

--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -100,7 +100,7 @@ module Filter
                   { items: filter.allowed_values.map { |name, id| { name:, id: } } }
                 end
 
-      autocomplete_options.merge(options).merge(model: filter.values)
+      autocomplete_options.merge(options)
     end
 
     def list_autocomplete_options(filter)

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -11,7 +11,6 @@
                               multiple: true,
                               multipleAsSeparateInputs: false,
                               inputValue: filter.values,
-                              model: filter.values,
                               appendTo: "body",
                               id: "#{filter.name}_value",
                               hiddenFieldAction: "change->filter--filters-form#autocompleteSendForm"

--- a/app/views/filters/_autocomplete.html.erb
+++ b/app/views/filters/_autocomplete.html.erb
@@ -11,6 +11,7 @@
                               multiple: true,
                               multipleAsSeparateInputs: false,
                               inputValue: filter.values,
+                              model: filter.values,
                               appendTo: "body",
                               id: "#{filter.name}_value",
                               hiddenFieldAction: "change->filter--filters-form#autocompleteSendForm"
@@ -19,6 +20,5 @@
                               # the action can't be registered on the input field at the time
                               # of the #connect lifecycle hook of the filter--filters-form
                               # Stimulus controller.
-                            }.merge(autocomplete_options.except(:component))
-  %>
+                            }.merge(autocomplete_options.except(:component)) %>
 <% end %>

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -370,7 +370,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     }
 
     if (Array.isArray(this.model)) {
-      return this.model.map((el) => el[this.inputBindValue as 'id'] as string);
+      return this.model.map((el) => (_.isObject(el) ? el[this.inputBindValue as 'id'] : el) as string);
     }
 
     return this.model[this.inputBindValue as 'id'] as string;

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -343,25 +343,25 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
         });
     }
 
-    this.ngZone.runOutsideAngular(() => {
-      setTimeout(() => {
-        this.results$ = merge(
-          this.items$,
-          this.autocompleteInputStream(),
-        );
+    setTimeout(() => {
+      this.results$ = merge(
+        this.items$,
+        this.autocompleteInputStream(),
+      );
 
-        if (this.fetchDataDirectly) {
-          this.typeahead?.next('');
-        }
+      if (this.fetchDataDirectly) {
+        this.typeahead?.next('');
+      }
 
-        if (this.openDirectly) {
-          this.ngSelectInstance.open();
-          this.ngSelectInstance.focus();
-        } else if (this.focusDirectly) {
-          this.ngSelectInstance.focus();
-        }
-      }, 25);
-    });
+      if (this.openDirectly) {
+        this.ngSelectInstance.open();
+        this.ngSelectInstance.focus();
+      } else if (this.focusDirectly) {
+        this.ngSelectInstance.focus();
+      }
+
+      this.cdRef.detectChanges();
+    }, 25);
   }
 
   public get mappedInputValue():string|string[] {

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -151,9 +151,6 @@ describe('autocompleter', () => {
       const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
 
       fixture.detectChanges();
-      tick();
-      expect(getOptionsFnSpy).not.toHaveBeenCalled();
-      tick(50);
       expect(getOptionsFnSpy).toHaveBeenCalledWith("");
       getOptionsFnSpy.calls.reset();
 

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -217,6 +217,7 @@ module Pages
 
     def save
       page.find(".editable-toolbar-title--save").click
+      wait_for_lists_reload
       expect_and_dismiss_toaster message: "Successful update."
     end
 

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -450,7 +452,6 @@ RSpec.describe "Persisted lists on projects index page",
 
     it "keep the query active when applying orders, page and column changes" do
       projects_page.visit!
-
       # The user can select the list but cannot see another user's list
       projects_page.set_sidebar_filter(my_projects_list.name)
       projects_page.expect_no_sidebar_filter(another_users_projects_list.name)
@@ -549,6 +550,15 @@ RSpec.describe "Persisted lists on projects index page",
                                            public_project) # Because it is now in the filter set
       projects_page.expect_projects_not_listed(another_project, # Because it is on the second page
                                                development_project) # Because it is on the second page
+    end
+
+    it "shows the saved filter values in the filter section" do
+      my_projects_list.where("project_status_code", "=", Project.status_codes["on_track"])
+      my_projects_list.save!
+
+      projects_page.visit!
+      projects_page.set_sidebar_filter(my_projects_list.name)
+      projects_page.expect_filter_set("project_status_code", value: "On track")
     end
 
     it "cannot access another user`s list" do

--- a/spec/features/types/form_configuration_query_spec.rb
+++ b/spec/features/types/form_configuration_query_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe "form query configuration", :js do
       expect(column_names).to eq %i[id]
 
       form.edit_query_group("Second query")
+
       modal.switch_to "Columns"
       columns.expect_checked "ID"
       columns.apply

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -312,9 +312,8 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
 
     within(".custom-actions") do
       # When hovering over the button, the description is displayed
-      button = find(".custom-action--button", text: "Unassign")
-      expect(button["title"])
-        .to eql "Removes the assignee"
+      expect(page)
+        .to have_button("Unassign", title: "Removes the assignee")
     end
 
     wp_page.click_custom_action("Unassign")

--- a/spec/features/work_packages/details/milestones_spec.rb
+++ b/spec/features/work_packages/details/milestones_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Milestones full screen v iew", :js do
   end
 
   let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
-  let(:button) { find(".add-work-package", wait: 5) }
 
   before do
     login_as(user)
@@ -28,9 +27,7 @@ RSpec.describe "Milestones full screen v iew", :js do
     end
 
     it "shows the button as enabled" do
-      expect(button).not_to be_disabled
-
-      button.click
+      click_button("Create", class: "add-work-package")
       expect(page).to have_css(".menu-item", text: type.name.upcase)
     end
   end
@@ -45,7 +42,7 @@ RSpec.describe "Milestones full screen v iew", :js do
     end
 
     it "shows the button as correctly disabled" do
-      expect(button["disabled"]).to be_truthy
+      expect(page).to have_button("Create", class: "add-work-package", disabled: true)
     end
   end
 end

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -166,7 +166,11 @@ module Components
       end
 
       def edit_query_group(name)
-        SeleniumHubWaiter.wait unless using_cuprite?
+        if using_cuprite?
+          wait_for_reload
+        else
+          SeleniumHubWaiter.wait
+        end
 
         group = find_group(name)
         group.find(".type-form-query-group--edit-button").click

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -170,7 +170,8 @@ module Components
 
         group = find_group(name)
         group.find(".type-form-query-group--edit-button").click
-        wait_for_reload if using_cuprite?
+        # Wait for the modal to appear.
+        expect(page).to have_css(".wp-table--configuration-modal")
       end
 
       def add_attribute_group(name, expect: true)

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -164,7 +164,7 @@ module Components
           end
         when "between"
           if send_keys
-            find_field("from_value").send_keysvalues.first
+            find_field("from_value").send_keys values.first
             find_field("to_value").send_keys values.second
           else
             fill_in "from_value", with: values.first
@@ -220,6 +220,10 @@ module Components
 
       def date_filter?(filter)
         filter[:"data-filter-type"] == "date"
+      end
+
+      def date_time_filter?(filter)
+        filter[:"data-filter-type"] == "datetime_past"
       end
 
       def boolean_filter?(_filter)

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -39,11 +39,16 @@ module Components
         expect(page).to have_css(".op-filters-form", visible: :hidden)
       end
 
-      def expect_filter_set(filter_name)
+      def expect_filter_set(filter_name, value: nil)
         if filter_name == "name_and_identifier"
           expect(page.find_by_id(filter_name).value).not_to be_empty
+        elsif value
+          within("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :hidden) do
+            expect(page).to have_css(".advanced-filters--filter-value", text: value, visible: :all)
+          end
         else
-          expect(page).to have_css("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :hidden)
+          expect(page)
+            .to have_css("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :hidden)
         end
       end
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -56,11 +56,21 @@ module Components
         end
       end
 
+      def expect_tab_is_loaded
+        # Search the current window in order to avoid within scope restrictions
+        within_window(page.current_window) do
+          within("wp-relations-tab") do
+            expect(page).to have_no_css("op-content-loader")
+          end
+        end
+      end
+
       def expect_add_relation_button
         expect(page).to have_test_selector("new-relation-action-menu")
       end
 
       def expect_no_add_relation_button
+        expect_tab_is_loaded # Make sure the tab is loaded before checking non existing elements
         expect(page).not_to have_test_selector("new-relation-action-menu")
       end
 
@@ -83,6 +93,7 @@ module Components
       end
 
       def expect_no_row(relatable)
+        expect_tab_is_loaded # Make sure the tab is loaded before checking non existing elements
         actual_relatable = find_relatable(relatable)
         expect(page).not_to have_test_selector("op-relation-row-visible-#{actual_relatable.id}"),
                             "expected no relation row for work package " \
@@ -307,6 +318,7 @@ module Components
       end
 
       def expect_no_parent
+        expect_tab_is_loaded # Make sure the tab is loaded before checking non existing elements
         expect(page).not_to have_test_selector "op-wp-breadcrumb-parent", wait: 10
       end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -238,7 +238,6 @@ module Pages
 
       def set_advanced_filter(name, human_name, human_operator = nil, values = [], send_keys: false)
         selected_filter = select_filter(name, human_name)
-        apply_operator(name, human_operator)
 
         within(selected_filter) do
           return unless values.any?
@@ -519,7 +518,7 @@ module Pages
       end
 
       def project_in_first_row(column_text_separator: "\n")
-        first_row = within("#projects-table") { find(".op-project-row-component", match: :first) }
+        first_row = within("#projects-table") { first(".op-project-row-component") }
         Project.find_by!(name: first_row.text.split(column_text_separator).first)
       end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -250,26 +250,7 @@ module Pages
           elsif date_filter?(selected_filter) || date_time_filter?(selected_filter)
             select(human_operator, from: "operator")
             wait_for_network_idle
-            set_date_filter(human_operator, values, send_keys:)
-          end
-        end
-      end
-
-      def set_date_filter(human_operator, values, send_keys: false)
-        case human_operator
-        when "on", "less than days ago", "more than days ago", "days ago"
-          if send_keys
-            find_field("value").send_keys values.first
-          else
-            fill_in "value", with: values.first
-          end
-        when "between"
-          if send_keys
-            find_field("from_value").send_keys values.first
-            find_field("to_value").send_keys values.second
-          else
-            fill_in "from_value", with: values.first
-            fill_in "to_value", with: values.second
+            set_created_at_filter(human_operator, values, send_keys:)
           end
         end
       end
@@ -538,10 +519,6 @@ module Pages
 
       def boolean_filter?(filter)
         %w[active member_of favored public templated].include?(filter.to_s)
-      end
-
-      def date_time_filter?(filter)
-        filter[:"data-filter-type"] == "datetime_past"
       end
 
       def submenu

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -240,6 +240,8 @@ module Pages
         selected_filter = select_filter(name, human_name)
 
         within(selected_filter) do
+          apply_operator(name, human_operator)
+
           return unless values.any?
 
           if boolean_filter?(name)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62386

# What are you trying to accomplish?
Load the autocompleter  values of project filters from saved queries. Additionally, fix 4 flaky specs by using synchronous matchers instead of asynchronous ones.

# What approach did you choose and why?
The solution consists of 2 parts:
 - Fix the change detection mechanism of the autocompleter to pick up the selected value.
 - Fix the additional attribute computation to use the active filters whenever is possible in order to retrieve the values from the saved project queries.

The flaky specs fixed:
```
'./spec/features/work_packages/custom_actions/custom_actions_spec.rb:316'
'./spec/features/work_packages/details/milestones_spec.rb:48'
'./modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb:112'
'./spec/features/notifications/notification_center/split_screen_spec.rb:55'
'./spec/features/types/form_configuration_query_spec.rb:174'
```

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
