### PR TITLE
[62743] The add relations drop down list doesn't indicate that there are other options hidden behind a scroll

### DIFF
--- a/app/components/work_package_relations_tab/index_component.sass
+++ b/app/components/work_package_relations_tab/index_component.sass
@@ -2,5 +2,5 @@
 // It can't be nested inside the BEM model as it's placed as a #top-layer element.
 #new-relation-action-menu-list,
 #new-child-action-menu-list
-  max-height: 450px
+  max-height: 470px
   max-width: 280px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62743/activity

# What are you trying to accomplish?
Increase the height of the dropdown so that some elements are cut and thus indicate that there are more items

## Screenshots
<img width="200" alt="Bildschirmfoto 2025-04-03 um 13 59 16" src="https://github.com/user-attachments/assets/7e2c7848-6f31-4349-825d-bb81ba8ab027" />
<img width="200" alt="Bildschirmfoto 2025-04-03 um 13 56 14" src="https://github.com/user-attachments/assets/8adfa63f-55da-4c85-a460-5ff5e46abf9b" />
<img width="200" alt="Bildschirmfoto 2025-04-03 um 13 58 48" src="https://github.com/user-attachments/assets/7e1ccd9b-50a5-4ba0-a3fe-abff5b5b7c7f" />
<img width="200" alt="Bildschirmfoto 2025-04-03 um 13 58 17" src="https://github.com/user-attachments/assets/ea0eafae-f435-47ba-ad08-cffe0d6e025d" />
