### PR TITLE
[#59247] String "All" within search cannot be translated

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,8 +330,9 @@ en:
   global_search:
     placeholder: "Search in %{app_title}"
     overwritten_tabs:
-      wiki_pages: "Wiki"
+      all: "All"
       messages: "Forum"
+      wiki_pages: "Wiki"
 
   groups:
     index:


### PR DESCRIPTION
# Ticket
[#59247](https://community.openproject.org/projects/openproject/work_packages/59247/activity)

# What are you trying to accomplish?
Fix tab naming

# What approach did you choose and why?
Add translation to en.yml.