### PR TITLE
[62595] Fix date buttons not opening input in Safari in date picker

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -29,7 +29,7 @@
     unless @is_milestone
       body.with_column(classes: "wp-datepicker-dialog-date-form--due-date") do
         flex_layout do |due_date|
-          due_date.with_row(classes: container_classes(:due_date), data: { skip_morphing: true }) do
+          due_date.with_row(classes: container_classes(:due_date)) do
             render(
               Primer::ButtonComponent.new(
                 tag: :a,

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -124,21 +124,21 @@ export default class PreviewController extends DialogPreviewController {
     }
   }
 
-  private get dueDateField():HTMLInputElement {
-    return document.getElementsByName('work_package[due_date]')[0] as HTMLInputElement;
+  private get dueDateField():HTMLInputElement|undefined {
+    return document.getElementsByName('work_package[due_date]')[0] as HTMLInputElement|undefined;
   }
 
-  private get startDateField():HTMLInputElement {
+  private get startDateField():HTMLInputElement|undefined {
     return document.getElementsByName('work_package[start_date]')[0] as HTMLInputElement;
   }
 
-  private get durationField():HTMLInputElement {
+  private get durationField():HTMLInputElement|undefined {
     return document.getElementsByName('work_package[duration]')[0] as HTMLInputElement;
   }
 
   handleFlatpickrDatesChanged(event:CustomEvent<{ dates:Date[] }>) {
     const dates = event.detail.dates;
-    let fieldUpdatedWithUserValue:HTMLInputElement|null = null;
+    let fieldUpdatedWithUserValue:HTMLInputElement|null|undefined = null;
 
     if (this.isMilestone) {
       this.currentStartDate = dates[0];
@@ -162,7 +162,7 @@ export default class PreviewController extends DialogPreviewController {
     }
   }
 
-  dateFieldToChange():HTMLInputElement {
+  dateFieldToChange():HTMLInputElement|undefined {
     if (this.isMilestone) {
       return this.startDateField;
     }
@@ -172,7 +172,7 @@ export default class PreviewController extends DialogPreviewController {
       this.highlightedField = currentlyHighledField as HTMLInputElement;
     }
 
-    let dateFieldToChange:HTMLInputElement;
+    let dateFieldToChange:HTMLInputElement|undefined;
     if (this.highlightedField === this.dueDateField
         || (this.highlightedField === this.durationField && !this.scheduleManuallyValue)
         || (this.highlightedField === this.durationField
@@ -185,7 +185,11 @@ export default class PreviewController extends DialogPreviewController {
     return dateFieldToChange;
   }
 
-  swapDateFieldsIfNeeded(selectedDate:Date, dateFieldToChange:HTMLInputElement) {
+  swapDateFieldsIfNeeded(selectedDate:Date, dateFieldToChange:HTMLInputElement|undefined) {
+    if (dateFieldToChange === undefined) {
+      return;
+    }
+
     // It needs to be swapped if the other field is set, the field to change is
     // unset, and setting it would make start and end be in the wrong order.
     if (
@@ -376,7 +380,11 @@ export default class PreviewController extends DialogPreviewController {
     }
   }
 
-  highlightField(newHighlightedField:HTMLInputElement) {
+  highlightField(newHighlightedField:HTMLInputElement|undefined) {
+    if (newHighlightedField === undefined) {
+      return;
+    }
+
     this.highlightedField = newHighlightedField;
     Array.from(document.getElementsByClassName('op-datepicker-modal--date-field_current')).forEach(
       (el) => {
@@ -555,10 +563,12 @@ export default class PreviewController extends DialogPreviewController {
    * See: https://stackoverflow.com/a/64886383/8900797
    */
   private prepareInputFieldsForSafari() {
-    [this.startDateField, this.dueDateField].forEach((field:HTMLInputElement) => {
-      const value = field.value;
-      field.defaultValue = '';
-      field.value = value;
-    });
+    [this.startDateField, this.dueDateField]
+      .filter((field):field is NonNullable<typeof field> => field != null)
+      .forEach((field) => {
+        const value = field.value;
+        field.defaultValue = '';
+        field.value = value;
+      });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -75,8 +75,12 @@ export abstract class DialogPreviewController extends Controller {
     // assistive technologies. This is why morph cannot be used here.
     this.frameMorphRenderer = (event:CustomEvent<TurboBeforeFrameRenderEventDetail>) => {
       event.detail.render = (currentElement:HTMLElement, newElement:HTMLElement) => {
+        let ignoreActiveValue = false;
+        if (document.activeElement?.tagName === 'INPUT') {
+          ignoreActiveValue = true;
+        }
         Idiomorph.morph(currentElement, newElement, {
-          ignoreActiveValue: true,
+          ignoreActiveValue,
           callbacks: {
             beforeNodeMorphed: (oldNode:Element) => {
               // In case the element is an OpenProject custom dom element, morphing is prevented.


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62595

# What are you trying to accomplish?

When no dates are set on a work package and the date field is clicked, the date picker opens in single date mode: one date field (generally finish date) is a focused field and the other date field is a button. Once clicked, it turns into an input field too.

But on Safari, clicking that button has no effect.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Idiomorph is used to morph the date picker dialog content, except the active element. When clicking the date button in Safari, it does not become the active element because it's actually a link, and for some reason links cannot be active in Safari. What becomes active instead is the closest focusable parent element. It is the whole `panel-wp-datepicker-dialog--content-tab--dates` as it has `tabindex: 0`. As idiomorph does not change the active element, that's why the date fields stayed the same.

To fix this, we make pass `ignoreActiveValue = true` to idiomorph only if the active element is an input. This way the whole date picker form is always updated when no input is focused.

It also fixes similar issues that existed on "Today" links and "Working days only" checkbox too.

# Merge checklist

- [ ] Added/updated tests
  - The ideal would be to run the whole date picker feature test suite using Safari.
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
