### PR TITLE
Bump dry-monads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,7 +504,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-monads (1.8.2)
+    dry-monads (1.8.3)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
@@ -1593,7 +1593,7 @@ CHECKSUMS
   dry-inflector (1.2.0) sha256=22f5d0b50fd57074ae57e2ca17e3b300e57564c218269dcf82ff3e42d3f38f2e
   dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3
   dry-logic (1.6.0) sha256=da6fedbc0f90fc41f9b0cc7e6f05f5d529d1efaef6c8dcc8e0733f685745cea2
-  dry-monads (1.8.2) sha256=662e0b4515bc41048e0e2c033db86327839649a53bff383489096e47a71f22b0
+  dry-monads (1.8.3) sha256=5fbc06ae4ff76ae081922a902be998673703304d10b46b08931696f2c8decc06
   dry-schema (1.14.1) sha256=2fcd7539a7099cacae6a22f6a3a2c1846fe5afeb1c841cde432c89c6cb9b9ff1
   dry-types (1.8.2) sha256=c84e9ada69419c727c3b12e191e0ed7d2c6d58d040d55e79ea16e0ebf8b3ec0f
   dry-validation (1.11.1) sha256=70900bb5a2d911c8aab566d3e360c6bff389b8bf92ea8e04885ce51c41ff8085


### PR DESCRIPTION
This fixes an issue where calls to `Warning.warn` could fail, if they included parameters such as the keyword `uplevel`.

In some cases this made the application fail to boot, when only a warning should've been printed.

# Ticket
https://community.openproject.org/wp/62764

# Notes

Reproduction on the console led to a slightly different error message than reported in the work package, but I am still optimistic that this fixes the reported issue.

Before update:

```
[1] pry(main)> require "dry/monads/do/all"
=> true
[2] pry(main)> Warning.warn("-Foo-", uplevel: 1)
ArgumentError: unknown keyword: :uplevel
from /usr/local/bundle/gems/dry-monads-1.8.2/lib/dry/monads/do/all.rb:159:in 'warn'
```

After update:

```
[1] pry(main)> require "dry/monads/do/all"
=> true
[2] pry(main)> Warning.warn("-Foo-", uplevel: 1)
(pry):2:in '__pry__': Foo (StructuredWarnings::BuiltInWarning)
=> nil
```