### PR TITLE
Fix remaining unit test failures due to frozen string literals

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -185,7 +187,7 @@ class ApplicationController < ActionController::Base
   # Create CSRF issue
   def log_csrf_failure
     message = "CSRF validation error"
-    message << " (No session cookie present)" if openproject_cookie_missing?
+    message += " (No session cookie present)" if openproject_cookie_missing?
 
     op_handle_error message, reference: :csrf_validation_failed
   end

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -47,7 +49,7 @@ module RepositoriesHelper
 
   def render_properties(properties)
     unless properties.nil? || properties.empty?
-      content = ""
+      content = +""
       properties.keys.sort.each do |property|
         content << content_tag("li", raw("<b>#{h property}</b>: <span>#{h properties[property]}</span>"))
       end

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -46,7 +48,7 @@ module WorkPackage::Journalized
       def self.event_title
         Proc.new do |o|
           title = o.to_s
-          title << " (#{o.status.name})" if o.status.present?
+          title += " (#{o.status.name})" if o.status.present?
 
           title
         end
@@ -63,7 +65,7 @@ module WorkPackage::Journalized
           journal = o.last_journal
           t = "work_package"
 
-          t << if journal && journal.details.empty? && !journal.initial?
+          t += if journal && journal.details.empty? && !journal.initial?
                  "-note"
                else
                  status = Status.find_by(id: o.status_id)

--- a/lib/open_project/scm/adapters/checkout_instructions.rb
+++ b/lib/open_project/scm/adapters/checkout_instructions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -69,7 +71,7 @@ module OpenProject
         def with_trailing_slash(url)
           url = url.to_s
 
-          url << "/" unless url.end_with?("/")
+          url += "/" unless url.end_with?("/")
           url
         end
       end

--- a/lib/redmine/helpers/diff.rb
+++ b/lib/redmine/helpers/diff.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -52,7 +54,7 @@ module Redmine
           add_at = nil
           add_to = nil
           del_at = nil
-          deleted = ""
+          deleted = +""
           diff.each do |change|
             pos = change[1]
             if change[0] == "+"

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -229,7 +231,7 @@ module Redmine::MenuManager::MenuHelper
     link_text = "".html_safe
 
     if item.icon(project).present?
-      link_text << render(Primer::Beta::Octicon.new(
+      link_text += render(Primer::Beta::Octicon.new(
                             icon: item.icon,
                             mr: shown_in_main_menu ? 3 : 0,
                             size: shown_in_main_menu ? :small : :medium
@@ -238,12 +240,12 @@ module Redmine::MenuManager::MenuHelper
 
     badge_class = item.badge(project:).present? ? " #{menu_class}--item-title_has-badge" : ""
 
-    link_text << content_tag(:span,
+    link_text += content_tag(:span,
                              class: "#{menu_class}--item-title#{badge_class}",
                              lang: menu_item_locale(item)) do
       title_text = "".html_safe + content_tag(:span, caption, class: "ellipsis") + badge_for(item)
       if item.enterprise_feature.present? && !EnterpriseToken.allows_to?(item.enterprise_feature)
-        title_text << ("".html_safe + render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons",
+        title_text += ("".html_safe + render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons",
                                                                        classes: "upsale-colored",
                                                                        ml: 2)))
       end
@@ -251,7 +253,7 @@ module Redmine::MenuManager::MenuHelper
     end
 
     if item.icon_after.present?
-      link_text << ("".html_safe + render(Primer::Beta::Octicon.new(icon: item.icon_after, classes: "trailing-icon")))
+      link_text += ("".html_safe + render(Primer::Beta::Octicon.new(icon: item.icon_after, classes: "trailing-icon")))
     end
 
     html_options = item.html_options(selected:)
@@ -295,7 +297,7 @@ module Redmine::MenuManager::MenuHelper
   def render_unattached_children_menu(node, project)
     return nil unless node.child_menus
 
-    "".tap do |child_html|
+    (+"").tap do |child_html|
       unattached_children = node.child_menus.call(project)
       # Tree nodes support #each so we need to do object detection
       if unattached_children.is_a? Array

--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -221,7 +223,7 @@ class CostReportsController < ApplicationController
     filter = f_cls.new.tap do |f|
       f.values = JSON.parse(params[:values].tr("'", '"')) if params[:values].present? && params[:values]
     end
-    render_widget Widget::Filters::Option, filter, to: canvas = ""
+    render_widget Widget::Filters::Option, filter, to: canvas = +""
 
     render plain: canvas, layout: !request.xhr?
   end

--- a/modules/reporting/lib/widget/base.rb
+++ b/modules/reporting/lib/widget/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -55,7 +57,7 @@ module ::Widget
     ##
     # Write a string to the canvas.
     def write(str)
-      @output ||= "".html_safe
+      @output ||= (+"").html_safe
       @output << str
       str
     end

--- a/modules/reporting/lib/widget/filters/heavy.rb
+++ b/modules/reporting/lib/widget/filters/heavy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -47,7 +49,7 @@ class Widget::Filters::Heavy < Widget::Filters::Base
                           class: "advanced-filters--select filter-value",
                           "data-filter-name": filter_class.underscore_name }
       box = content_tag :select, select_options do
-        render_widget Widget::Filters::Option, filter, to: "", content: opts
+        render_widget Widget::Filters::Option, filter, content: opts
       end
       box
     end

--- a/spec/lib/api/v3/repositories/revision_representer_spec.rb
+++ b/spec/lib/api/v3/repositories/revision_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -58,7 +60,7 @@ RSpec.describe API::V3::Repositories::RevisionRepresenter do
       it_behaves_like "API V3 formattable", "message" do
         let(:format) { "plain" }
         let(:raw) { revision.comments }
-        let(:html) { "<p>" + revision.comments + "</p>" }
+        let(:html) { "<p>#{revision.comments}</p>" }
       end
 
       describe "identifier" do
@@ -94,12 +96,12 @@ RSpec.describe API::V3::Repositories::RevisionRepresenter do
       let(:html_reference) do
         id = work_package.id
 
-        str = "Totally references <a"
-        str << " class=\"issue work_package\""
-        str << " data-hover-card-trigger-target=\"trigger\""
-        str << " data-hover-card-url=\"/work_packages/#{id}/hover_card\""
-        str << " href=\"/work_packages/#{id}\">"
-        str << "##{id}</a>"
+        "Totally references <a " \
+          "class=\"issue work_package\" " \
+          "data-hover-card-trigger-target=\"trigger\" " \
+          "data-hover-card-url=\"/work_packages/#{id}/hover_card\" " \
+          "href=\"/work_packages/#{id}\">" \
+          "##{id}</a>"
       end
 
       before do
@@ -112,7 +114,7 @@ RSpec.describe API::V3::Repositories::RevisionRepresenter do
       it_behaves_like "API V3 formattable", "message" do
         let(:format) { "plain" }
         let(:raw) { revision.comments }
-        let(:html) { "<p>" + html_reference + "</p>" }
+        let(:html) { "<p>#{html_reference}</p>" }
       end
     end
 

--- a/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -375,7 +377,7 @@ RSpec.describe OpenProject::SCM::Adapters::Git do
           end
 
           describe "encoding" do
-            let (:char1_hex) { "\xc3\x9c".force_encoding("UTF-8") }
+            let (:char1_hex) { (+"\xc3\x9c").force_encoding("UTF-8") }
 
             context "with default encoding" do
               it_behaves_like "retrieve entries"

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -726,8 +728,8 @@ RSpec.describe MailHandler do
             expect do
               expect(subject.author).to be_active
               expect(subject.author.mail).to eq("foo@example.org")
-              expect(subject.author.firstname).to eq("\xc3\x84\xc3\xa4".force_encoding("UTF-8"))
-              expect(subject.author.lastname).to eq("\xc3\x96\xc3\xb6".force_encoding("UTF-8"))
+              expect(subject.author.firstname).to eq((+"\xc3\x84\xc3\xa4").force_encoding("UTF-8"))
+              expect(subject.author.lastname).to eq((+"\xc3\x96\xc3\xb6").force_encoding("UTF-8"))
             end.to change(User, :count).by(1)
           end
         end

--- a/spec/models/repository/git_spec.rb
+++ b/spec/models/repository/git_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -439,7 +441,7 @@ RSpec.describe Repository::Git do
 
         context "with latin-1 encoding" do
           let (:encoding) { "ISO-8859-1" }
-          let (:char1_hex) { "\xc3\x9c".force_encoding("UTF-8") }
+          let (:char1_hex) { (+"\xc3\x9c").force_encoding("UTF-8") }
 
           it "latests changesets latin 1 dir" do
             instance.fetch_changesets

--- a/spec/models/repository/subversion_spec.rb
+++ b/spec/models/repository/subversion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -267,8 +269,8 @@ RSpec.describe Repository::Subversion do
       context "with windows-1252 encoding",
               with_settings: { commit_logs_encoding: %w(windows-1252) } do
         it "logs encoding ignore setting" do
-          s1 = "\xC2\x80"
-          s2 = "\xc3\x82\xc2\x80"
+          s1 = +"\xC2\x80"
+          s2 = +"\xc3\x82\xc2\x80"
           if s1.respond_to?(:force_encoding)
             s1.force_encoding("ISO-8859-1")
             s2.force_encoding("UTF-8")


### PR DESCRIPTION
This should fix the last known unit test failures occuring due to the usage of
frozen string literal comments. Those were tested in a separate
commit. Broadly enabling frozen string literals will happen in multiple
separate commits after this one and only after feature tests have been fixed
as well.

# References

* https://github.com/opf/openproject/pull/18039