### PR TITLE
[62641] toggling non working days keeps dates and updates duration

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -92,12 +92,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   # If +ignore_non_working_days+ has been changed, try deriving +due_date+ and
   # +start_date+ before +duration+.
   def derivable_date_attribute_by_others_presence
-    fields =
-      if work_package.ignore_non_working_days_changed?
-        %i[due_date start_date duration]
-      else
-        %i[duration due_date start_date]
-      end
+    fields = %i[duration due_date start_date]
     fields.find { |field| derivable_by_others_presence?(field) }
   end
 

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -70,8 +70,8 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
       update_dates
     end
     shift_dates_to_soonest_working_days
-    update_duration
-    update_derivable
+    update_duration_to_one_day_for_milestones
+    update_derivable_date_attribute
     update_progress_attributes
     update_project_dependent_attributes
     reassign_invalid_status_if_type_changed
@@ -79,8 +79,8 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     set_cause_for_readonly_attributes
   end
 
-  def derivable_attribute
-    derivable_attribute_by_others_presence || derivable_attribute_by_others_absence
+  def derivable_date_attribute
+    derivable_date_attribute_by_others_presence || derivable_date_attribute_by_others_absence
   end
 
   # Returns a field derivable by the presence of the two others, or +nil+ if
@@ -91,7 +91,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   #
   # If +ignore_non_working_days+ has been changed, try deriving +due_date+ and
   # +start_date+ before +duration+.
-  def derivable_attribute_by_others_presence
+  def derivable_date_attribute_by_others_presence
     fields =
       if work_package.ignore_non_working_days_changed?
         %i[due_date start_date duration]
@@ -116,7 +116,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   #
   # Matching is done in the order :duration, :due_date, :start_date. The first
   # one to match is returned.
-  def derivable_attribute_by_others_absence
+  def derivable_date_attribute_by_others_absence
     %i[duration due_date start_date].find { |field| derivable_by_others_absence?(field) }
   end
 
@@ -145,8 +145,8 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   end
 
   # rubocop:disable Metrics/AbcSize
-  def update_derivable
-    case derivable_attribute
+  def update_derivable_date_attribute
+    case derivable_date_attribute
     when :duration
       work_package.duration =
         if work_package.milestone?
@@ -320,7 +320,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     work_package.due_date = days.soonest_working_day(work_package.due_date)
   end
 
-  def update_duration
+  def update_duration_to_one_day_for_milestones
     work_package.duration = 1 if work_package.milestone?
   end
 
@@ -365,7 +365,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     available_types = work_package.project.types.order(:position)
 
     work_package.type = available_types.first
-    update_duration
+    update_duration_to_one_day_for_milestones
     unify_milestone_dates
 
     reassign_status assignable_statuses
@@ -470,14 +470,14 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     start = work_package.parent&.start_date
     due = work_package.due_date || work_package.parent&.due_date
 
-    (start && !due) || ((due && start) && (start < due))
+    (start && !due) || (due && start && (start < due))
   end
 
   def parent_due_later_than_start?
     due = work_package.parent&.due_date
     start = work_package.start_date || work_package.parent&.start_date
 
-    (due && !start) || ((due && start) && (due > start))
+    (due && !start) || (due && start && (due > start))
   end
 
   def set_cause_for_readonly_attributes

--- a/spec/features/work_packages/datepicker/datepicker_editable_finish_date_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_editable_finish_date_logic_spec.rb
@@ -381,7 +381,6 @@ RSpec.describe "Datepicker: Finish date field in auto-scheduled mode logic test 
 
     describe "and change finish and non-working days, switching back to automatic (scenario 14b)" do
       it "preserves the finish date" do
-        pending "Enable when #62641 has been fixed"
         datepicker.set_date "2025-04-25"
 
         datepicker.expect_working_days_only(true)

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -522,46 +522,47 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
   describe "when all values set, changing include NWD to true (Scenario 15)" do
     let(:current_attributes) do
       {
-        start_date: Date.parse("2021-02-11"),
-        due_date: Date.parse("2021-02-16"),
-        duration: 4
+        start_date: Date.parse("2025-01-09"),
+        due_date: Date.parse("2025-01-14"),
+        duration: 4,
+        ignore_non_working_days: false
       }
     end
 
-    it "conserves the duration and updates the finish date" do
-      datepicker.expect_start_date "2021-02-11"
-      datepicker.expect_due_date "2021-02-16"
+    it "conserves the finish date and updates the duration" do
+      datepicker.expect_start_date "2025-01-09"
+      datepicker.expect_due_date "2025-01-14"
       datepicker.expect_duration 4
 
       datepicker.toggle_working_days_only
 
-      datepicker.expect_start_date "2021-02-11"
-      datepicker.expect_due_date "2021-02-14"
-      datepicker.expect_duration 4
+      datepicker.expect_start_date "2025-01-09"
+      datepicker.expect_due_date "2025-01-14"
+      datepicker.expect_duration 6
     end
   end
 
   describe "when all values set and include NWD true, changing include NWD to false (Scenario 16)" do
     let(:current_attributes) do
       {
-        start_date: Date.parse("2021-02-11"),
-        due_date: Date.parse("2021-02-14"),
-        duration: 4,
+        start_date: Date.parse("2025-01-09"),
+        due_date: Date.parse("2025-01-14"),
+        duration: 6,
         ignore_non_working_days: true
       }
     end
 
-    it "conserves the duration and updates the finish date" do
-      datepicker.expect_start_date "2021-02-11"
-      datepicker.expect_due_date "2021-02-14"
-      datepicker.expect_duration 4
+    it "conserves the finish date and updates the duration" do
+      datepicker.expect_start_date "2025-01-09"
+      datepicker.expect_due_date "2025-01-14"
+      datepicker.expect_duration 6
       datepicker.expect_working_days_only false
 
       datepicker.toggle_working_days_only
 
       datepicker.expect_working_days_only true
-      datepicker.expect_start_date "2021-02-11"
-      datepicker.expect_due_date "2021-02-16"
+      datepicker.expect_start_date "2025-01-09"
+      datepicker.expect_due_date "2025-01-14"
       datepicker.expect_duration 4
     end
   end
@@ -569,54 +570,54 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
   describe "when all values set and include NWD true, changing include NWD to false (Scenario 17)" do
     let(:current_attributes) do
       {
-        start_date: Date.parse("2021-02-13"),
-        due_date: Date.parse("2021-02-14"),
+        start_date: Date.parse("2025-01-11"),
+        due_date: Date.parse("2025-01-12"),
         duration: 2,
         ignore_non_working_days: true
       }
     end
 
-    it "shifts the start date to soonest working day, and updates finish date to conserve duration" do
-      datepicker.expect_start_date "2021-02-13"
-      datepicker.expect_due_date "2021-02-14"
+    it "shifts the start and finish dates to soonest working day, and updates duration accordingly" do
+      datepicker.expect_start_date "2025-01-11"
+      datepicker.expect_due_date "2025-01-12"
       datepicker.expect_duration 2
       datepicker.expect_working_days_only false
 
       datepicker.toggle_working_days_only
 
       datepicker.expect_working_days_only true
-      datepicker.expect_start_date "2021-02-15"
-      datepicker.expect_due_date "2021-02-16"
-      datepicker.expect_duration 2
+      datepicker.expect_start_date "2025-01-13"
+      datepicker.expect_due_date "2025-01-13"
+      datepicker.expect_duration 1
     end
   end
 
   describe "when all values set and include NWD true, changing include NWD to false (Scenario 18)" do
     let(:current_attributes) do
       {
-        start_date: Date.parse("2021-02-13"),
-        due_date: Date.parse("2021-02-23"),
+        start_date: Date.parse("2025-01-11"),
+        due_date: Date.parse("2025-01-21"),
         duration: 11,
         ignore_non_working_days: true
       }
     end
 
-    it "shifts the start date to soonest working day, and updates finish date to conserve duration" do
-      datepicker.expect_start_date "2021-02-13"
-      datepicker.expect_due_date "2021-02-23"
+    it "shifts the start date to soonest working day, conserves the finish date, and updates duration accordingly" do
+      datepicker.expect_start_date "2025-01-11"
+      datepicker.expect_due_date "2025-01-21"
       datepicker.expect_duration 11
       datepicker.expect_working_days_only false
 
       datepicker.toggle_working_days_only
 
       datepicker.expect_working_days_only true
-      datepicker.expect_start_date "2021-02-15"
-      datepicker.expect_due_date "2021-03-01"
-      datepicker.expect_duration 11
+      datepicker.expect_start_date "2025-01-13"
+      datepicker.expect_due_date "2025-01-21"
+      datepicker.expect_duration 7
 
-      apply_and_expect_saved duration: 11,
-                             start_date: Date.parse("2021-02-15"),
-                             due_date: Date.parse("2021-03-01"),
+      apply_and_expect_saved duration: 7,
+                             start_date: Date.parse("2025-01-13"),
+                             due_date: Date.parse("2025-01-21"),
                              ignore_non_working_days: false
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62641


# What are you trying to accomplish?

Previously we tried to keep duration over the dates when updating "Working days only", also known as `ignore_non_working_days`. The behavior was a bit surprising and was inconsistent with the fact that setting a new start date would keep the the finish date and update the duration.

Now it's consistent for any attribute changed in the date picker modal: the dates are kept and the duration is updated, (unless the duration is set by the user).

## Screenshots

Before:

[before.webm](https://github.com/user-attachments/assets/04f4e361-39a2-4bb3-8a6a-934f50aa9a05)


After:

[after.webm](https://github.com/user-attachments/assets/1c1fa894-cc8b-43de-9170-4042d1a8e56c)


# What approach did you choose and why?

There was a condition to explicitly check if "ignore_non_working_days" was changed and change the derived attributes priority. I simply removed the special case.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
