### PR TITLE
[62554] Children label are not the right colour in dark mode

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/relation-row-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/relation-row-builder.ts
@@ -97,7 +97,7 @@ relationGroupClass(from.id!),
     columnId:string,
   ):void {
     const relationLabel = document.createElement('span');
-    relationLabel.classList.add('relation-row--type-label');
+    relationLabel.classList.add('relation-row--type-label', 'badge');
     relationLabel.textContent = typeLabel;
 
     jRow.find(`.${relationCellClassName}`).empty();

--- a/frontend/src/global_styles/content/work_packages/_table_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_relations.sass
@@ -34,12 +34,8 @@ body
 
 // Style the relation label
 .relation-row--type-label
-  background: white
-  padding: 2px
-  border: 1px solid var(--gray)
   border-radius: 5px
   margin-right: 5px
-  font-size: 0.7rem
 
 .relation-row--type
   @include unset-button-styles


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62554/activity#comment-1018033

# What are you trying to accomplish?
Apply badge style to child label badge in WP table

## Screenshots

<img width="267" alt="Bildschirmfoto 2025-04-07 um 07 53 52" src="https://github.com/user-attachments/assets/0fffce16-5f88-4805-b7e2-6625816f4598" />