### PR TITLE
Bump vite to 5.4.17

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -350,7 +350,7 @@
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
         "undici": "6.11.1",
-        "vite": "5.4.16",
+        "vite": "5.4.17",
         "watchpack": "2.4.0",
         "webpack": "5.94.0",
         "webpack-dev-middleware": "6.1.2",
@@ -21131,9 +21131,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.16.tgz",
-      "integrity": "sha512-Y5gnfp4NemVfgOTDQAunSD4346fal44L9mszGGY/e+qxsRT5y1sMlS/8tiQ8AFAp+MFgYNSINdfEchJiPm41vQ==",
+      "version": "5.4.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.17.tgz",
+      "integrity": "sha512-5+VqZryDj4wgCs55o9Lp+p8GE78TLVg0lasCH5xFZ4jacZjtqZa6JUw9/p0WeAojaOfncSM6v77InkFPGnvPvg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -22539,7 +22539,7 @@
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
         "undici": "6.11.1",
-        "vite": "5.4.16",
+        "vite": "5.4.17",
         "watchpack": "2.4.0",
         "webpack": "5.94.0",
         "webpack-dev-middleware": "6.1.2",
@@ -37478,9 +37478,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vite": {
-      "version": "5.4.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.16.tgz",
-      "integrity": "sha512-Y5gnfp4NemVfgOTDQAunSD4346fal44L9mszGGY/e+qxsRT5y1sMlS/8tiQ8AFAp+MFgYNSINdfEchJiPm41vQ==",
+      "version": "5.4.17",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.17.tgz",
+      "integrity": "sha512-5+VqZryDj4wgCs55o9Lp+p8GE78TLVg0lasCH5xFZ4jacZjtqZa6JUw9/p0WeAojaOfncSM6v77InkFPGnvPvg==",
       "requires": {
         "esbuild": "^0.21.3",
         "fsevents": "~2.3.3",


### PR DESCRIPTION
### Dependency upgrade containing a moderate security fix

**5.4.17 (2025-04-03)**

- fix: backport #19782, fs check with svg and relative paths (#19784) ([84b2b46](https://github.com/vitejs/vite/commit/84b2b46ed129be8215108e789a90adbb33a9c42c)), closes https://github.com/vitejs/vite/issues/19782 https://github.com/vitejs/vite/issues/19784
