### PR TITLE
Fix polling of restricted comments

### DIFF
--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -329,6 +329,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   def generate_time_based_update_streams(last_update_timestamp)
     journals = @work_package
                  .journals
+                 .restricted_visible
                  .with_sequence_version
 
     if @filter == :only_comments

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -419,57 +419,117 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
   end
 
   context "when multiple users are commenting on a workpackage" do
-    current_user { admin }
-    let(:work_package) { create(:work_package, project:, author: admin) }
+    context "when the user has permissions to see restricted comments" do
+      current_user { admin }
+      let(:work_package) { create(:work_package, project:, author: admin) }
 
-    before do
-      # set WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS to 1000
-      # to speed up the polling interval for test duration
-      ENV["WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS"] = "1000"
+      before do
+        # set WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS to 1000
+        # to speed up the polling interval for test duration
+        ENV["WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS"] = "1000"
 
-      # for some reason the journal is set to the "Anonymous"
-      # although the work_package is created by the admin
-      # so we need to update the journal to the admin manually to simulate the real world case
-      work_package.journals.first.update!(user: admin)
+        # for some reason the journal is set to the "Anonymous"
+        # although the work_package is created by the admin
+        # so we need to update the journal to the admin manually to simulate the real world case
+        work_package.journals.first.update!(user: admin)
 
-      wp_page.visit!
-      wp_page.wait_for_activity_tab
+        wp_page.visit!
+        wp_page.wait_for_activity_tab
+      end
+
+      after do
+        ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
+      end
+
+      it "shows the comment of another user without browser reload" do
+        # simulate member creating a comment
+        first_journal = create(:work_package_journal,
+                               user: member,
+                               notes: "First comment by member",
+                               journable: work_package,
+                               version: 2)
+
+        # the comment is shown without browser reload
+        activity_tab.expect_journal_notes(text: "First comment by member")
+
+        # simulate comments made within the polling interval
+        create(:work_package_journal, user: member, notes: "Second comment by member", journable: work_package, version: 3)
+        create(:work_package_journal, user: member, notes: "Third comment by member", journable: work_package, version: 4)
+
+        activity_tab.add_comment(text: "First comment by admin")
+
+        activity_tab.expect_comments_order(
+          [
+            "First comment by member",
+            "Second comment by member",
+            "Third comment by member",
+            "First comment by admin"
+          ]
+        )
+
+        first_journal.update!(notes: "First comment by member updated")
+
+        # properly updates the comment when the comment is updated
+        activity_tab.expect_journal_notes(text: "First comment by member updated")
+      end
     end
 
-    after do
-      ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
-    end
+    context "when the user does not have permissions to see restricted comments" do
+      current_user { member }
+      let(:work_package) { create(:work_package, project:, author: admin) }
 
-    it "shows the comment of another user without browser reload" do
-      # simulate member creating a comment
-      first_journal = create(:work_package_journal,
-                             user: member,
-                             notes: "First comment by member",
-                             journable: work_package,
-                             version: 2)
+      before do
+        # set WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS to 1000
+        # to speed up the polling interval for test duration
+        ENV["WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS"] = "1000"
 
-      # the comment is shown without browser reload
-      activity_tab.expect_journal_notes(text: "First comment by member")
+        # for some reason the journal is set to the "Anonymous"
+        # although the work_package is created by the admin
+        # so we need to update the journal to the admin manually to simulate the real world case
+        work_package.journals.first.update!(user: admin)
 
-      # simulate comments made within the polling interval
-      create(:work_package_journal, user: member, notes: "Second comment by member", journable: work_package, version: 3)
-      create(:work_package_journal, user: member, notes: "Third comment by member", journable: work_package, version: 4)
+        wp_page.visit!
+        wp_page.wait_for_activity_tab
+      end
 
-      activity_tab.add_comment(text: "First comment by admin")
+      after do
+        ENV.delete("WORK_PACKAGES_ACTIVITIES_TAB_POLLING_INTERVAL_IN_MS")
+      end
 
-      activity_tab.expect_comments_order(
-        [
-          "First comment by member",
-          "Second comment by member",
-          "Third comment by member",
-          "First comment by admin"
-        ]
-      )
+      it "does not show the comment of another user if they don't have permissions to see it" do
+        # simulate member creating a comment
+        create(:work_package_journal,
+               user: admin,
+               notes: "First comment by admin",
+               journable: work_package,
+               version: 2)
 
-      first_journal.update!(notes: "First comment by member updated")
+        # the comment is shown without browser reload
+        activity_tab.expect_journal_notes(text: "First comment by admin")
 
-      # properly updates the comment when the comment is updated
-      activity_tab.expect_journal_notes(text: "First comment by member updated")
+        # simulate comments made within the polling interval
+        create(:work_package_journal,
+               user: admin,
+               notes: "Second comment by admin",
+               restricted: true,
+               journable: work_package,
+               version: 3)
+        create(:work_package_journal,
+               user: admin,
+               notes: "Third comment by admin",
+               restricted: true,
+               journable: work_package,
+               version: 4)
+
+        activity_tab.add_comment(text: "First comment by member")
+
+        activity_tab.expect_comments_order(
+          [
+            "First comment by admin",
+            "First comment by member"
+          ]
+        )
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62978

# What are you trying to accomplish?
Fix an issue that we were leaking restricted comments to users without permissions when polling for new comments/activities

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
