### PR TITLE
[62834] Display error when clicking date field of a deleted work package

### DIFF
--- a/frontend/src/app/features/hal/schemas/schema-proxy.ts
+++ b/frontend/src/app/features/hal/schemas/schema-proxy.ts
@@ -39,8 +39,10 @@ export interface ISchemaProxy extends SchemaResource {
 }
 
 export class SchemaProxy implements ProxyHandler<SchemaResource> {
-  constructor(protected schema:SchemaResource,
-    protected resource:HalResource) {
+  constructor(
+    protected schema:SchemaResource,
+    protected resource:HalResource,
+  ) {
   }
 
   static create(schema:SchemaResource, resource:HalResource) {

--- a/frontend/src/app/features/work-packages/components/wp-edit/work-package-changeset.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit/work-package-changeset.ts
@@ -1,8 +1,8 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
-import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import { WorkPackageSchemaProxy } from 'core-app/features/hal/schemas/work-package-schema-proxy';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
+import { ISchemaProxy } from 'core-app/features/hal/schemas/schema-proxy';
 
 export class WorkPackageChangeset extends ResourceChangeset<WorkPackageResource> {
   public setValue(key:string, val:any) {
@@ -58,7 +58,7 @@ export class WorkPackageChangeset extends ResourceChangeset<WorkPackageResource>
    * If loaded, return the form schema, which provides better information on writable status
    * and contains available values.
    */
-  public get schema():SchemaResource {
+  public get schema():ISchemaProxy {
     if (this.form$.hasValue()) {
       return WorkPackageSchemaProxy.create(super.schema, this.projectedResource);
     }

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -30,9 +30,7 @@ import {
   input,
   InputState,
 } from '@openproject/reactivestates';
-import { take } from 'rxjs/operators';
 
-import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import {
@@ -43,7 +41,7 @@ import {
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
-import { SchemaProxy } from 'core-app/features/hal/schemas/schema-proxy';
+import { ISchemaProxy, SchemaProxy } from 'core-app/features/hal/schemas/schema-proxy';
 import { IHalOptionalTitledLink } from 'core-app/core/state/hal-resource';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { firstValueFrom } from 'rxjs';
@@ -350,7 +348,7 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
    * If loaded, return the form schema, which provides better information on writable status
    * and contains available values.
    */
-  public get schema():SchemaResource {
+  public get schema():ISchemaProxy {
     if (this.form$.hasValue()) {
       return SchemaProxy.create(this.form$.value!.schema, this.projectedResource);
     }

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
@@ -90,7 +90,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
   /**
    * Optional callback when the form is being saved
    */
-  protected onSaved(commit:ResourceChangesetCommit):void {
+  protected onSaved(_commit:ResourceChangesetCommit):void {
     // Does nothing by default
   }
 
@@ -134,7 +134,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    * Activate the field unless it is marked active already
    * (e.g., already being activated).
    */
-  public activateWhenNeeded(fieldName:string):Promise<unknown> {
+  public activateWhenNeeded(fieldName:string):Promise<void|EditFieldHandler> {
     const activeField = this.activeFields[fieldName];
     if (activeField) {
       return Promise.resolve();
@@ -196,7 +196,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
           this.onSaved(result);
           this.change.inFlight = false;
         })
-        .catch((error:ErrorResource|unknown) => {
+        .catch((error:ErrorResource) => {
           this.halNotification.handleRawError(error, this.resource);
 
           if (error instanceof HalError && error.resource) {
@@ -247,26 +247,20 @@ export abstract class EditForm<T extends HalResource = HalResource> {
       return;
     }
 
-    this.setErrorsForFields(erroneousAttributes);
+    void this.setErrorsForFields(erroneousAttributes);
   }
 
-  private setErrorsForFields(erroneousFields:string[]) {
-    // Accumulate errors for the given response
-    const promises:Promise<any>[] = erroneousFields.map((fieldName:string) => this.requireVisible(fieldName).then(() => {
+  private async setErrorsForFields(erroneousFields:string[]) {
+    const promises = erroneousFields.map(async (fieldName) => {
+      await this.requireVisible(fieldName);
       if (this.activeFields[fieldName]) {
         this.activeFields[fieldName].setErrors(this.errorsPerAttribute[fieldName] || []);
       }
+      return this.activateWhenNeeded(fieldName);
+    });
 
-      return this.activateWhenNeeded(fieldName) as any;
-    }));
-
-    Promise.all(promises)
-      .then(() => {
-        setTimeout(() => this.focusOnFirstError());
-      })
-      .catch(() => {
-        console.error('Failed to activate all erroneous fields.');
-      });
+    await Promise.all(promises);
+    void setTimeout(() => this.focusOnFirstError());
   }
 
   /**
@@ -275,7 +269,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    * @param fieldName
    */
   protected loadFieldSchema(fieldName:string, noWarnings = false):Promise<IFieldSchema> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.loadFormAndCheck(fieldName, noWarnings);
       const fieldSchema:IFieldSchema = this.change.schema.ofProperty(fieldName);
 
@@ -304,7 +298,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
           this.closeEditFields([fieldName]);
         }
       })
-      .catch((error:any) => {
+      .catch((error:ErrorResource) => {
         console.error('Failed to build edit field: %o', error);
         this.halNotification.handleRawError(error, this.resource);
         this.closeEditFields([fieldName]);
@@ -312,10 +306,12 @@ export abstract class EditForm<T extends HalResource = HalResource> {
   }
 
   private renderField(fieldName:string, schema:IFieldSchema):Promise<void|EditFieldHandler> {
-    const promise:Promise<EditFieldHandler> = this.activateField(this,
+    const promise:Promise<EditFieldHandler> = this.activateField(
+      this,
       schema,
       fieldName,
-      this.errorsPerAttribute[fieldName] || []);
+      this.errorsPerAttribute[fieldName] || [],
+    );
 
     return promise
       .then((fieldHandler:EditFieldHandler) => {


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62834

# What are you trying to accomplish?

When a work package is deleted but still visible in a page (because not refreshed yet), clicking on the date field to open the date picker fails badly with a 500.

Displaying a message instead and cancelling the edition like if the field was readonly or something similar

## Screenshots

# What approach did you choose and why?

First try to fix some eslint issues on the incriminating files.
Then there is a mechanism to cancel edition if there are some errors when loading the update form, but this mechanism is triggered too early in the process: it's ok when the update form is not loaded yet because the network request adds some delay and the edit fields have some time to be displayed, but when the update form is already loaded, it fails immediately and tries to close the edit fields but they are not open yet.

I try to add a synchronization so that the edit fields are closed only when they are displayed. Best would be to prevent displaying if there is an error.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
