### PR TITLE
[62848] Don't use native date fields for mobile safari

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -80,8 +80,6 @@ export default class PreviewController extends DialogPreviewController {
 
     document.addEventListener('date-picker:flatpickr-dates-changed', this.handleFlatpickrDatesChangedBound);
     this.focusOnOpen();
-
-    this.prepareInputFieldsForSafari();
   }
 
   disconnect() {
@@ -552,23 +550,5 @@ export default class PreviewController extends DialogPreviewController {
       tabs.setAttribute('tabindex', '-1');
       tabs.focus();
     }
-  }
-
-  /*
-   * This method qualifies as the most stupid thing I had to do in a long time.
-   * Safari is the only browser which does not clear the input when using the native datepicker "clear" method.
-   * It rather resets it to the original value of the input.
-   * That is why we manually set the defaultValue to an empty string,
-   * but since the defaultValue is used for the value, we have to manually set this again.
-   * See: https://stackoverflow.com/a/64886383/8900797
-   */
-  private prepareInputFieldsForSafari() {
-    [this.startDateField, this.dueDateField]
-      .filter((field):field is NonNullable<typeof field> => field != null)
-      .forEach((field) => {
-        const value = field.value;
-        field.defaultValue = '';
-        field.value = value;
-      });
   }
 }


### PR DESCRIPTION
# Ticket
1. https://community.openproject.org/work_packages/62848
2. Affects this as well: https://community.openproject.org/work_packages/62596

# What are you trying to accomplish?
Don't use native date fields for mobile safari


# What approach did you choose and why?
Safari and datepicker are biting us again. The native datepicker of Safari (the one that opens on mobile when clicking the date field) is behaving totally different than any of the other browsers. Let me try to explain the issues that we have:

* Given a date field with no value: When Safari opens its native datepicker, the first thing it does is to set the date to Today. And not only in the datepicker but directly in the field. 
* This behaviour has however consequences:
  * The "reset" button in the datepicker does not clear the input (as the other browsers do it) but it resets it to the original value it had when you opened it. So if the value was empty, it sets it back to empty. If the value was set before, you cannot clear it, but only set it back to that value. (This is bug 2)
  * Since the input changes, the whole datepicker updates without the user even knowing about it, since the form is hidden behind the datepicker. That leads to this: when you enter a start date after today, and then open the datepicker for finish date, it will reset the start date because the finish date is set automatically to today, but the finish date can't be before the start date. So we manually clear it. (This is bug 1)
  
tl;dr: Safari is behaving weird. 


