### PR TITLE
Use job_id from URL to display errors from given job

### DIFF
--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "rubygems"
 require "bundler"
@@ -14,8 +15,8 @@ require "time"
 require "yaml"
 require "httpx"
 
-GITHUB_API_OPENPROJECT_PREFIX = "https://api.github.com/repos/opf/openproject".freeze
-GITHUB_HTML_OPENPROJECT_PREFIX = "https://github.com/opf/openproject".freeze
+GITHUB_API_OPENPROJECT_PREFIX = "https://api.github.com/repos/opf/openproject"
+GITHUB_HTML_OPENPROJECT_PREFIX = "https://github.com/opf/openproject"
 RAILS_ROOT = Pathname.new(__dir__).dirname
 EXCLUDED_JOB_NAMES = %w[eslint rubocop].freeze
 
@@ -33,17 +34,18 @@ class Options
     failed_jobs_logs: [],
     no_cache: false,
     run_id: nil,
+    job_id: nil,
     verbose: false
   }.freeze
 
   BANNER = <<~BANNER.freeze
     Usage: #{$0} [options] [url]
 
-    Fetches rspec failures from last completed GitHub actions on current
-    branch, and outputs them on standard output, one by line.
+    Fetches rspec failures from last completed GitHub actions on current branch,
+    and outputs them on standard output, one by line.
 
-    If given an url, it will fetch the failures from the given url instead of
-    the tip of the current branch.
+    If given an url, it will fetch the failures from the given url using the workflow
+    id and the job id if present instead of the tip of the current branch.
 
     Information is printed on standard error to preserve standard output.
 
@@ -129,10 +131,11 @@ class Options
 
     def parse_url(url)
       case url
-      when %r{^https://github.com/opf/openproject/actions/runs/(\d+)(?:/job/\d+(?:\?.*)?)?$}
+      when %r{^https://github.com/opf/openproject/actions/runs/(\d+)(?:/job/(\d+)(?:\?.*)?)?$}
         run_id = $1.to_i
-        say_verbose("Extracted run id #{run_id} from #{url}")
-        { run_id: }
+        job_id = $2&.to_i
+        say_verbose("Extracted run id #{run_id}#{" and job id #{job_id}" if job_id} from #{url}")
+        { run_id:, job_id: }
       else
         warn "Unrecognized url #{url}"
         exit 1
@@ -192,7 +195,7 @@ def error_details(error)
   parts << "Failed to perform API request GET #{response.uri}: #{error}"
   parts << "  #{response_body['message']}"
   parts << "  See #{response_body['documentation_url']}"
-  parts += error.backtrace.map { "    #{_1}" }
+  parts += error.backtrace.map { "    #{it}" }
   parts.join("\n")
 end
 
@@ -375,7 +378,7 @@ class JobErrorsFinder
         explanations << line
       end
     end
-    explanations.map! { _1[29..] } # Remove leading timestamp (like "2024-02-05T08:37:54.5175930Z")
+    explanations.map! { it[29..] } # Remove leading timestamp (like "2024-02-05T08:37:54.5175930Z")
     explanations.reject! do |line|
       line == "Failures:" ||
         line == "Failed examples:" ||
@@ -398,7 +401,7 @@ class JobErrorsFinder
 
   def find_screenshots(log)
     log.scan(SCREENSHOT_PATTERN)
-      .map { JSON.parse _1 }
+      .map { JSON.parse it }
       .each do |screenshot_info|
         id = screenshot_info["test_id"]
         location = screenshot_info["test_location"]
@@ -413,10 +416,10 @@ class JobErrorsFinder
     tests_groups = log
       .scan(TESTS_GROUP_PATTERN)
       .flatten
-      .map { build_tests_group_from_command(_1) }
+      .map { build_tests_group_from_command(it) }
 
     errors.each do |error|
-      error.tests_group = tests_groups.find { _1.include_error?(error) }
+      error.tests_group = tests_groups.find { it.include_error?(error) }
     end
   end
 
@@ -459,11 +462,12 @@ class Formatter
     warn "  Branch: #{report.head_branch.bold}"
     warn "  Commit SHA: #{report.head_sha.bold}"
     warn "  Commit message: #{report.commit_message.bold}"
-    warn "  Run started at: #{report.run_started_at.localtime.to_s.bold}"
+    warn "  Last attempted run started at: #{report.run_started_at.localtime.to_s.bold}"
     display_pull_request_info(workflow_run)
   end
 
   def display_workflow_status(workflow_run)
+    warn "  Run attempt: #{workflow_run['run_attempt']}"
     warn "  #{status_line(workflow_run)}"
   end
 
@@ -473,8 +477,8 @@ class Formatter
 
   def display_report(report)
     display_failures_explanation(report.failures_explanation)
-    display_checkout_test_commit_information(report) if Options.display_rerun_info
     display_errors(report.errors)
+    display_checkout_test_commit_information(report) if Options.display_rerun_info
   end
 
   def display_failures_explanation(failures_explanation)
@@ -498,7 +502,7 @@ class Formatter
   private
 
   def display_errors_compact(errors)
-    puts errors.map { escaped_location(_1) }.join(" ")
+    puts errors.map { escaped_location(it) }.join(" ")
   end
 
   def display_errors_detailed(errors)
@@ -508,13 +512,13 @@ class Formatter
         .group_by(&:tests_group)
         .each do |tests_group, tests_group_errors|
           display_tests_group_info(tests_group)
-          tests_group_errors.each { display_error(_1) }
+          tests_group_errors.each { display_error(it) }
           display_tests_group_rerun_commands(tests_group)
         end
     else
       errors
         .sort_by(&:location)
-        .each { display_error(_1) }
+        .each { display_error(it) }
     end
   end
 
@@ -565,6 +569,7 @@ class Formatter
     if report.merge_branch_sha
       warn <<~INSTRUCTIONS.white.dark
         GitHub Action run merged #{report.merge_branch_sha} into #{report.head_sha} before running.
+
         To be with the exact same source files as CI, use these commands (warning: stash your modifications first):
           git checkout -B repro_ci_failures #{report.head_sha}
           git merge --no-edit --no-verify #{report.merge_branch_sha}
@@ -575,7 +580,9 @@ class Formatter
           git checkout #{report.head_sha}
       INSTRUCTIONS
     end
-    warn # empty line
+    warn <<~INSTRUCTIONS.white.dark
+      Then run a test group with the rspec command above.
+    INSTRUCTIONS
   end
 
   def display_tests_group_info(tests_group)
@@ -645,18 +652,38 @@ class Formatter
   end
 end
 
+def get_jobs_from_job_id(job_id)
+  warn "  Looking for the job with id #{job_id.to_s.bold}"
+
+  # no need to fetch anything as we only use the job id to get the logs
+  # mock the same structure as the jobs response
+  [{ "id" => job_id }]
+end
+
+def get_failing_jobs_from_workflow_last_attempt(workflow_run, formatter)
+  get_jobs(workflow_run)
+    .then { |jobs_response| jobs_response["jobs"] }
+    .sort_by { it["name"] }
+    .each { |job| formatter.display_job_status(job) }
+    .select { it["conclusion"] == "failure" }
+    .reject { EXCLUDED_JOB_NAMES.include?(it["name"]) }
+end
+
+def get_relevant_jobs(job_id, workflow_run, formatter)
+  if job_id
+    get_jobs_from_job_id(job_id)
+  else
+    formatter.display_workflow_status(workflow_run)
+    get_failing_jobs_from_workflow_last_attempt(workflow_run, formatter)
+  end
+end
+
 def get_failed_jobs_logs_from_github(report, formatter)
   workflow_run = get_workflow_run(Options.run_id)
 
   formatter.display_workflow_run_info(report, workflow_run)
 
-  formatter.display_workflow_status(workflow_run)
-  job_logs = get_jobs(workflow_run)
-    .then { |jobs_response| jobs_response["jobs"] }
-    .sort_by { _1["name"] }
-    .each { |job| formatter.display_job_status(job) }
-    .select { _1["conclusion"] == "failure" }
-    .reject { EXCLUDED_JOB_NAMES.include?(_1["name"]) }
+  job_logs = get_relevant_jobs(Options.job_id, workflow_run, formatter)
     .map { |job| get_log(job) }
 
   [job_logs, job_logs.any? ? "error" : workflow_run["status"]]

--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -272,14 +272,56 @@ def get_workflow_run(run_id)
   end
 end
 
-class Report
-  attr_accessor :errors,
-                :failures_explanation,
-                :head_branch,
-                :head_sha,
-                :commit_message,
-                :run_started_at,
-                :merge_branch_sha
+class WorkflowRunDecorator
+  attr_reader :workflow_run
+
+  def initialize(workflow_run)
+    @workflow_run = workflow_run
+  end
+
+  def head_branch = workflow_run["head_branch"]
+  def head_sha = workflow_run["head_sha"]
+  def run_started_at = Time.parse(workflow_run["run_started_at"]).utc
+
+  def commit_message
+    workflow_run["head_commit"]
+      .then { |commit| commit["message"] }
+      .then { |message| message.split("\n", 2).first }
+  end
+end
+
+Report = Data.define(
+  :errors,
+  :failures_explanation,
+  :head_branch,
+  :head_sha,
+  :commit_message,
+  :run_started_at,
+  :run_status,
+  :failed_job_logs,
+  :merge_branch_sha
+) do
+  def initialize(errors: [],
+                 failures_explanation: nil,
+                 head_branch: nil,
+                 head_sha: nil,
+                 commit_message: nil,
+                 run_started_at: nil,
+                 run_status: nil,
+                 failed_job_logs: nil,
+                 merge_branch_sha: nil)
+    super
+  end
+
+  def with_workflow_run_info(workflow_run)
+    workflow_run = WorkflowRunDecorator.new(workflow_run)
+    with(
+      head_branch: workflow_run.head_branch,
+      head_sha: workflow_run.head_sha,
+      commit_message: workflow_run.commit_message,
+      run_started_at: workflow_run.run_started_at
+    )
+  end
 end
 
 class Error
@@ -322,10 +364,11 @@ class JobErrorsFinder
     logs.each do |log|
       finder.scan_log(log)
     end
-    report.errors = finder.errors
-    report.failures_explanation = finder.failures_explanation
-    report.merge_branch_sha = finder.merge_branch_sha
-    report
+    report.with(
+      errors: finder.errors,
+      failures_explanation: finder.failures_explanation,
+      merge_branch_sha: finder.merge_branch_sha
+    )
   end
 
   def scan_log(log)
@@ -454,16 +497,11 @@ class Formatter
     @compact
   end
 
-  def display_workflow_run_info(report, workflow_run)
-    report.head_branch = workflow_run["head_branch"]
-    report.head_sha = workflow_run["head_sha"]
-    report.commit_message = commit_message(workflow_run)
-    report.run_started_at = Time.parse(workflow_run["run_started_at"]).utc
+  def display_workflow_run_info(report)
     warn "  Branch: #{report.head_branch.bold}"
     warn "  Commit SHA: #{report.head_sha.bold}"
     warn "  Commit message: #{report.commit_message.bold}"
     warn "  Last attempted run started at: #{report.run_started_at.localtime.to_s.bold}"
-    display_pull_request_info(workflow_run)
   end
 
   def display_workflow_status(workflow_run)
@@ -475,7 +513,7 @@ class Formatter
     warn "    #{status_line(job)}"
   end
 
-  def display_report(report)
+  def display_errors_from_report(report)
     display_failures_explanation(report.failures_explanation)
     display_errors(report.errors)
     display_checkout_test_commit_information(report) if Options.display_rerun_info
@@ -496,6 +534,19 @@ class Formatter
       display_errors_compact(errors)
     else
       display_errors_detailed(errors)
+    end
+  end
+
+  def display_pull_request_info(workflow_run)
+    return unless workflow_run["event"] == "pull_request"
+
+    if pr = workflow_run["pull_requests"].first
+      pr_number = "##{pr['number']}"
+      pr_html_url = "#{GITHUB_HTML_OPENPROJECT_PREFIX}/pull/#{pr['number']}"
+      pr_display_title = "#{workflow_run['display_title']} #{pr_number.white.dark} #{pr_html_url.white.dark}"
+      warn "  Pull Request: #{pr_display_title} "
+    else
+      warn "  Pull Request: not found; perhaps it is already merged or closed?"
     end
   end
 
@@ -599,25 +650,6 @@ class Formatter
     warn ""
   end
 
-  def display_pull_request_info(workflow_run)
-    return unless workflow_run["event"] == "pull_request"
-
-    if pr = workflow_run["pull_requests"].first
-      pr_number = "##{pr['number']}"
-      pr_html_url = "#{GITHUB_HTML_OPENPROJECT_PREFIX}/pull/#{pr['number']}"
-      pr_display_title = "#{workflow_run['display_title']} #{pr_number.white.dark} #{pr_html_url.white.dark}"
-      warn "  Pull Request: #{pr_display_title} "
-    else
-      warn "  Pull Request: not found; perhaps it is already merged or closed?"
-    end
-  end
-
-  def commit_message(workflow_run)
-    workflow_run["head_commit"]
-      .then { |commit| commit["message"] }
-      .then { |message| message.split("\n", 2).first }
-  end
-
   def status_icon(job)
     case job["status"]
     when "queued", "in_progress"
@@ -680,13 +712,18 @@ end
 
 def get_failed_jobs_logs_from_github(report, formatter)
   workflow_run = get_workflow_run(Options.run_id)
+  report = report.with_workflow_run_info(workflow_run)
 
-  formatter.display_workflow_run_info(report, workflow_run)
+  formatter.display_workflow_run_info(report)
+  formatter.display_pull_request_info(workflow_run)
 
-  job_logs = get_relevant_jobs(Options.job_id, workflow_run, formatter)
+  failed_job_logs = get_relevant_jobs(Options.job_id, workflow_run, formatter)
     .map { |job| get_log(job) }
 
-  [job_logs, job_logs.any? ? "error" : workflow_run["status"]]
+  report.with(
+    failed_job_logs:,
+    run_status: failed_job_logs.any? ? "error" : workflow_run["status"]
+  )
 end
 
 def get_failed_jobs_logs_from_args
@@ -695,7 +732,11 @@ end
 
 def get_failed_jobs_logs(report, formatter)
   if Options.failed_jobs_logs.any?
-    [get_failed_jobs_logs_from_args, failed_jobs_logs.none? ? "completed" : "error"]
+    failed_job_logs = get_failed_jobs_logs_from_args
+    report.with(
+      failed_job_logs:,
+      run_status: failed_job_logs.none? ? "completed" : "error"
+    )
   else
     get_failed_jobs_logs_from_github(report, formatter)
   end
@@ -707,15 +748,15 @@ end
 report = Report.new
 formatter = Formatter.new(compact: Options.compact)
 
-failed_jobs_logs, status = get_failed_jobs_logs(report, formatter)
+report = get_failed_jobs_logs(report, formatter)
 
-JobErrorsFinder.scan_logs(report, failed_jobs_logs)
+report = JobErrorsFinder.scan_logs(report, report.failed_job_logs)
 
-case status
+case report.run_status
 when "completed"
   warn "All jobs successful 🎉"
 when "in_progress"
   # NOOP
 when "error"
-  formatter.display_report(report)
+  formatter.display_errors_from_report(report)
 end


### PR DESCRIPTION

# Ticket

None

# What are you trying to accomplish?

Improving `script/github_pr_errors`

When giving a url of the first attempt, the script was displaying the results of the last attempt. That's probably not the intended behavior.

Now it parses the job_id from the url, and if present it will display the errors from that job.

Also changed the output to display the instructions to checkout the correct commit at the end of the script, to make it easier to see.

## Screenshots

Before:
```
❯ script/github_pr_errors https://github.com/opf/openproject/actions/runs/14351429369/job/40230943474\?pr\=18587
Looking for the workflow run with id 14351429369
  Branch: dependabot/npm_and_yarn/frontend/dev/ng-select/ng-select-14.2.8
  Commit SHA: a064be5781073abc510f06f525264b2159b443d5
  Commit message: Bump @ng-select/ng-select from 14.2.6 to 14.2.8 in /frontend
  Run started at: 2025-04-09 10:06:47 +0200
  Pull Request: Bump @ng-select/ng-select from 14.2.6 to 14.2.8 in /frontend #18587 https://github.com/opf/openproject/pull/18587
  ✓ Test suite: success
    ✓ Units + Features: success
All jobs successful 🎉
```
It's fetching the second attempt, which is not intended

After:
```
❯ script/github_pr_errors https://github.com/opf/openproject/actions/runs/14351429369/job/40230943474\?pr\=18587
Looking for the workflow run with id 14351429369
  Branch: dependabot/npm_and_yarn/frontend/dev/ng-select/ng-select-14.2.8
  Commit SHA: a064be5781073abc510f06f525264b2159b443d5
  Commit message: Bump @ng-select/ng-select from 14.2.6 to 14.2.8 in /frontend
  Last attempted run started at: 2025-04-09 10:06:47 +0200
  Pull Request: Bump @ng-select/ng-select from 14.2.6 to 14.2.8 in /frontend #18587 https://github.com/opf/openproject/pull/18587
  Looking for the job with id 40230943474
Failures explanation:

  1) Boards enterprise spec when EE inactive shows a banner on the action board
     Failure/Error: example.run
       Expected page not to have Enterprise edition banner, but it does:
     # ./modules/boards/spec/features/board_enterprise_spec.rb:70:in 'block (3 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:204:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rspec_retry.rb:24:in 'block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:126:in 'block (2 levels) in <top (required)>'

Finished in 9 minutes 40 seconds (files took 26.08 seconds to load)
2623 examples, 1 failure, 15 pending, 1 error occurred outside of examples

'./modules/boards/spec/features/board_enterprise_spec.rb:63'
    ↳ html: /app/tmp/capybara/screenshot_2025-04-09-07-39-44.799.html
    ↳ screenshot: /app/tmp/capybara/screenshot_2025-04-09-07-39-44.799.png
```

Without the job info, it now displays the run attempt number:
```
❯ script/github_pr_errors https://github.com/opf/openproject/actions/runs/14351429369
Looking for the workflow run with id 14351429369
  Branch: dependabot/npm_and_yarn/frontend/dev/ng-select/ng-select-14.2.8
  Commit SHA: a064be5781073abc510f06f525264b2159b443d5
  Commit message: Bump @ng-select/ng-select from 14.2.6 to 14.2.8 in /frontend
  Last attempted run started at: 2025-04-09 10:06:47 +0200
  Pull Request: Bump @ng-select/ng-select from 14.2.6 to 14.2.8 in /frontend #18587 https://github.com/opf/openproject/pull/18587
  Run attempt: 2
  ✓ Test suite: success
    ✓ Units + Features: success
All jobs successful 🎉
```


# What approach did you choose and why?

The code of this small tool is becoming messy :/

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
