### PR TITLE
[62891][63152] Recalculate start date correctly when toggling "Working days only"

### DIFF
--- a/app/components/work_package_relations_tab/closest_relation.rb
+++ b/app/components/work_package_relations_tab/closest_relation.rb
@@ -57,7 +57,7 @@ module WorkPackageRelationsTab
     def soonest_start
       return @soonest_start if defined?(@soonest_start)
 
-      @soonest_start = relation.successor_soonest_start(gap: 0.days)
+      @soonest_start = relation.successor_soonest_start
     end
 
     def inspect

--- a/app/components/work_packages/date_picker/form_component.html.erb
+++ b/app/components/work_packages/date_picker/form_component.html.erb
@@ -105,7 +105,6 @@
                                           ignore_non_working_days: work_package.ignore_non_working_days,
                                           schedule_manually:,
                                           is_schedulable: !disabled?,
-                                          minimal_scheduling_date:,
                                           is_milestone: milestone?,
                                           date_mode:,
                                           start_date_field_id: "work_package_start_date",

--- a/app/components/work_packages/date_picker/form_component.rb
+++ b/app/components/work_packages/date_picker/form_component.rb
@@ -95,10 +95,6 @@ module WorkPackages
       def disabled_checkbox?
         !schedule_manually && work_package.children.any?
       end
-
-      def minimal_scheduling_date
-        schedule_manually ? nil : work_package.start_date
-      end
     end
   end
 end

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -173,11 +173,10 @@ class Relation < ApplicationRecord
     successor.start_date || successor.due_date
   end
 
-  def successor_soonest_start(gap: 1.day)
+  def successor_soonest_start
     if follows? && predecessor_date
-      days = WorkPackages::Shared::Days.for(from)
-      relation_start_date = predecessor_date + gap
-      days.soonest_working_day(relation_start_date, lag:)
+      days = WorkPackages::Shared::WorkingDays.new
+      days.add_lag(predecessor_date, lag)
     end
   end
 

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -33,32 +33,40 @@ module WorkPackage::SchedulingRules
     !schedule_manually?
   end
 
-  # TODO: move into work package contract (possibly a module included into the contract)
-  # Calculates the minimum date that
-  # will not violate the precedes relations (max(finish date, start date) + relation lag)
-  # of this work package or its ancestors
-  # e.g.
-  # AP(due_date: 2017/07/25)-precedes(lag: 0)-A
-  #                                           |
-  #                                         parent
-  #                                           |
-  # BP(due_date: 2017/07/22)-precedes(lag: 2)-B
-  #                                           |
-  #                                         parent
-  #                                           |
-  # CP(due_date: 2017/07/25)-precedes(lag: 2)-C
+  # Calculates the minimum date that will not violate the precedes relations
+  # (max(finish date, start date) + relation lag) of this work package or its
+  # ancestors
   #
-  # Then soonest_start for:
-  #   C is 2017/07/28
-  #   B is 2017/07/26
-  #   A is 2017/07/26
+  # Lag is the number of non working days between 2 work packages of a
+  # follows/precedes relation.
+  #
+  # For instance:
+  #          AP -------------- precedes ----- A
+  # (due_date: 2017/07/25)     (lag: 0)       |
+  #                                         parent
+  #                                           |
+  #          BP -------------- precedes ----- B
+  # (due_date: 2017/07/22)     (lag: 2)       |
+  #                                         parent
+  #                                           |
+  #          CP -------------- precedes ----- C
+  # (due_date: 2017/07/25)     (lag: 2)
+  #
+  # Then successor_soonest_start for each relation is:
+  #   A is 2017/07/26 (AP due date: 25, no lag => 26)
+  #   B is 2017/07/27 (BP due date: 22, 23 and 24 are non-working days, 25 and 26 is the 2 days lag => 27)
+  #   C is 2017/07/28 (CP due date: 25, 26 and 27 is the 2 days lag => 28)
+  #
+  # The soonest start for this work package is the maximum of these values: 2017/07/28.
   def soonest_start
-    # eager load `to` and `from` to avoid n+1 on successor_soonest_start
-    @soonest_start ||=
+    # eager load `to` to avoid n+1 in #successor_soonest_start
+    @scheduling_relations_soonest_start ||=
       Relation
         .used_for_scheduling_of(self)
-        .includes(:to, :from)
+        .includes(:to)
         .filter_map(&:successor_soonest_start)
         .max
+    WorkPackages::Shared::Days.for(self)
+                              .soonest_working_day(@scheduling_relations_soonest_start)
   end
 end

--- a/app/services/work_packages/schedule_dependency/dependency.rb
+++ b/app/services/work_packages/schedule_dependency/dependency.rb
@@ -56,6 +56,7 @@ class WorkPackages::ScheduleDependency::Dependency
       follows_relations
         .filter_map(&:successor_soonest_start)
         .max
+        .then { days.soonest_working_day(it) }
   end
 
   def start_date
@@ -90,5 +91,9 @@ class WorkPackages::ScheduleDependency::Dependency
 
   def alive_descendants_dates
     alive_descendants.filter_map(&:due_date) + alive_descendants.filter_map(&:start_date)
+  end
+
+  def days
+    WorkPackages::Shared::Days.for(work_package)
   end
 end

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -398,23 +398,18 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
       days.soonest_working_day(new_start_date_from_parent)
     else
-      min_start = new_start_date_from_parent || new_start_date_from_self
+      min_start = new_start_date_from_parent || work_package.soonest_start
       days.soonest_working_day(min_start)
     end
   end
 
+  # Returns the soonest start date from the parent if the parent has changed.
+  # If the parent has changed, #soonest_start would be inaccurate.
   def new_start_date_from_parent
     return unless work_package.parent_id_changed? &&
                   work_package.parent
 
     work_package.parent.soonest_start
-  end
-
-  def new_start_date_from_self
-    # this method is only called by #new_start_date when there are no children
-    return unless work_package.schedule_manually_changed? || work_package.ignore_non_working_days_changed?
-
-    work_package.soonest_start
   end
 
   def new_due_date(min_start)

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -416,12 +416,20 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     # this method is only called by #update_dates_from_self when there are no children
     if work_package.due_date_came_from_user?
       work_package.due_date
-    elsif work_package.duration
-      days.due_date(min_start, work_package.duration)
-    elsif work_package.due_date
+    elsif reuse_current_due_date?
       # if due date is before start date, then start is used as due date.
       [min_start, work_package.due_date].max
+    elsif work_package.duration
+      days.due_date(min_start, work_package.duration)
     end
+  end
+
+  def reuse_current_due_date?
+    return false if work_package.due_date.nil?
+    return true if work_package.ignore_non_working_days_came_from_user?
+
+    # use due date only if duration cannot be used
+    work_package.duration.nil?
   end
 
   def work_package

--- a/app/services/work_packages/shared/all_days.rb
+++ b/app/services/work_packages/shared/all_days.rb
@@ -43,6 +43,11 @@ module WorkPackages
         WorkingDays.new.lag(predecessor_date, successor_date)
       end
 
+      def add_lag(date, lag)
+        # lag is *always* excluding non-working days (at least for now)
+        WorkingDays.new.add_lag(date, lag)
+      end
+
       def start_date(due_date, duration)
         return nil unless due_date && duration
         raise ArgumentError, "duration must be strictly positive" if duration.is_a?(Integer) && duration <= 0
@@ -57,9 +62,8 @@ module WorkPackages
         start_date + duration - 1
       end
 
-      def soonest_working_day(date, lag: nil)
-        lag ||= 0
-        date + lag.days if date
+      def soonest_working_day(date)
+        date
       end
 
       def working?(_date)

--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -40,7 +40,7 @@ module WorkPackages
       def duration(start_date, due_date)
         return nil unless start_date && due_date
 
-        (start_date..due_date).count { working?(_1) }
+        (start_date..due_date).count { working?(it) }
       end
 
       # Returns the number of working days between a predecessor date and
@@ -49,6 +49,18 @@ module WorkPackages
         return nil unless predecessor_date && successor_date
 
         duration(predecessor_date + 1.day, successor_date - 1.day)
+      end
+
+      def add_lag(date, lag)
+        return nil unless date
+
+        date_after_lag = date + 1.day
+        lag ||= 0
+        while lag > 0
+          lag -= 1 if working?(date_after_lag)
+          date_after_lag += 1
+        end
+        date_after_lag
       end
 
       def start_date(due_date, duration)
@@ -75,15 +87,8 @@ module WorkPackages
         due_date
       end
 
-      def soonest_working_day(date, lag: nil)
+      def soonest_working_day(date)
         return unless date
-
-        lag ||= 0
-
-        while lag > 0
-          lag -= 1 if working?(date)
-          date += 1
-        end
 
         until working?(date)
           date += 1
@@ -127,7 +132,7 @@ module WorkPackages
       def assert_some_working_week_days_exist
         return if @working_week_days_exist
 
-        if working_week_days.all? { |working| working == false }
+        if working_week_days.all?(false)
           raise "cannot have all week days as non-working days"
         end
 

--- a/frontend/src/app/core/datetime/timezone.service.ts
+++ b/frontend/src/app/core/datetime/timezone.service.ts
@@ -132,6 +132,10 @@ export class TimezoneService {
     return moment.duration(input, unit).toISOString();
   }
 
+  public utcDateToLocalDate(date:Date):Date {
+    return new Date(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
+  }
+
   public utcDateToISODateString(date:Date):string {
     return moment.utc(date).format('YYYY-MM-DD');
   }

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -198,13 +198,6 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
     }
   }
 
-  private isDifferentDates(dates:Date[], mode:DateMode):boolean {
-    const [start, end] = dates;
-    return mode === 'single'
-      ? start?.getTime() !== this.startDateValue?.getTime()
-      : start?.getTime() !== this.startDateValue?.getTime() || end?.getTime() !== this.dueDateValue?.getTime();
-  }
-
   private toDate(date:string|null):Date|null {
     return date ? new Date(date) : null;
   }

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -71,7 +71,6 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
   @Input() public dueDate:string|null;
 
   @Input() public isSchedulable:boolean = true;
-  @Input() public minimalSchedulingDate:Date|null;
   @Input() public dateMode:DateMode;
 
   @Input() startDateFieldId:string;
@@ -85,6 +84,7 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
   private datePickerInstance:DatePicker;
   private startDateValue:Date|null;
   private dueDateValue:Date|null;
+  private minimalSchedulingDate:Date|null;
   private onFlatpickrSetValuesBound = this.onFlatpickrSetValues.bind(this);
 
   constructor(
@@ -101,6 +101,7 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
     populateInputsFromDataset(this);
     this.startDateValue = this.toDate(this.startDate);
     this.dueDateValue = this.toDate(this.dueDate);
+    this.computeMinimalSchedulingDate();
   }
 
   ngAfterViewInit():void {
@@ -130,6 +131,7 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
     // that date if it's not visible.
     const dateToJumpTo = this.findDateToJumpTo(details.dates);
     [this.startDateValue, this.dueDateValue] = details.dates;
+    this.computeMinimalSchedulingDate();
     this.setDatePickerDates(details.dates, dateToJumpTo);
 
     this.datePickerInstance.setOption('mode', details.mode);
@@ -143,6 +145,10 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
     if (details.dates.length === 2) {
       this.allowHoverFor(this.datePickerInstance.datepickerInstance.calendarContainer);
     }
+  }
+
+  private computeMinimalSchedulingDate() {
+    this.minimalSchedulingDate = this.startDateValue && this.timezoneService.utcDateToLocalDate(this.startDateValue);
   }
 
   private findDateToJumpTo(dates:Date[]):Date|null {
@@ -250,11 +256,10 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
   }
 
   private isDayDisabled(dayElement:DayElement):boolean {
-    const minimalDate = this.minimalSchedulingDate || null;
     return !this.isSchedulable
       || (!this.scheduleManually
-        && !!minimalDate
-        && dayElement.dateObj.setHours(0, 0, 0, 0) < new Date(minimalDate).setHours(0, 0, 0, 0));
+        && !!this.minimalSchedulingDate
+        && dayElement.dateObj < this.minimalSchedulingDate);
   }
 
   /**

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -461,11 +461,6 @@ export default class PreviewController extends DialogPreviewController {
       return;
     }
 
-    if (!this.scheduleManuallyValue) {
-      // Fix the start date to avoid that it gets changed accidentally
-      this.markTouched('start_date');
-    }
-
     if (this.isBeingEdited('start_date')) {
       this.untouchFieldsWhenStartDateIsEdited();
     } else if (this.isBeingEdited('due_date')) {

--- a/spec/components/work_package_relations_tab/closest_relation_spec.rb
+++ b/spec/components/work_package_relations_tab/closest_relation_spec.rb
@@ -215,21 +215,21 @@ RSpec.describe WorkPackageRelationsTab::ClosestRelation do
       let(:due_date) { Date.new(2020, 7, 14) }
 
       context "without a lag" do
-        it "returns the due date" do
-          expect(closest_relation(due_date:).soonest_start).to eq(Date.new(2020, 7, 14))
+        it "returns the day after the due date" do
+          expect(closest_relation(due_date:).soonest_start).to eq(Date.new(2020, 7, 15))
         end
       end
 
       context "with a positive lag" do
-        it "returns the combined due date and lag" do
-          expect(closest_relation(lag: 11, due_date:).soonest_start).to eq(Date.new(2020, 7, 25))
+        it "returns the day after the due date plus the lag" do
+          expect(closest_relation(lag: 3, due_date:).soonest_start).to eq(Date.new(2020, 7, 18))
         end
       end
 
       context "with a negative lag" do
         it "returns the combined due date and lag" do
           pending "negative lags are not yet implemented"
-          expect(closest_relation(lag: -2, due_date:).soonest_start).to eq(Date.new(2020, 7, 12))
+          expect(closest_relation(lag: -2, due_date:).soonest_start).to eq(Date.new(2020, 7, 13))
         end
       end
     end
@@ -238,21 +238,21 @@ RSpec.describe WorkPackageRelationsTab::ClosestRelation do
       let(:start_date) { Date.new(2020, 7, 14) }
 
       context "with a zero lag" do
-        it "returns the start date" do
-          expect(closest_relation(start_date:).soonest_start).to eq(Date.new(2020, 7, 14))
+        it "returns the day after the start date" do
+          expect(closest_relation(start_date:).soonest_start).to eq(Date.new(2020, 7, 15))
         end
       end
 
       context "with a positive lag" do
-        it "returns the combined start date and lag" do
-          expect(closest_relation(lag: 11, start_date:).soonest_start).to eq(Date.new(2020, 7, 25))
+        it "returns the day after the start date plus the lag" do
+          expect(closest_relation(lag: 3, start_date:).soonest_start).to eq(Date.new(2020, 7, 18))
         end
       end
 
       context "with a negative lag" do
         it "returns the combined start date and lag" do
           pending "negative lags are not yet implemented (Feature OP#38606)"
-          expect(closest_relation(lag: -2, start_date:).soonest_start).to eq(Date.new(2020, 7, 12))
+          expect(closest_relation(lag: -2, start_date:).soonest_start).to eq(Date.new(2020, 7, 13))
         end
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe WorkPackageRelationsTab::ClosestRelation do
 
     it "outputs object for debugging" do
       expect(subject.inspect)
-        .to start_with("#<WorkPackageRelationsTab::ClosestRelation soonest_start: 2022-07-07")
+        .to start_with("#<WorkPackageRelationsTab::ClosestRelation soonest_start: 2022-07-08")
         .and include(subject.relation.inspect)
     end
   end

--- a/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
         datepicker.expect_working_days_only false
 
         datepicker.expect_start_date "2024-02-03", disabled: true
-        datepicker.expect_due_date "2024-02-06"
+        datepicker.expect_due_date "2024-02-08" # did not change
         datepicker.expect_disabled Date.parse("2024-02-01")
         datepicker.expect_disabled Date.parse("2024-02-02") # predecessor's due date
         datepicker.expect_not_disabled Date.parse("2024-02-03") # Saturday is non-working day but ignored

--- a/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_logic_spec.rb
@@ -54,20 +54,6 @@ RSpec.describe "Datepicker modal logic test cases (WP #43539)", :js, with_settin
   let(:current_user) { user }
   let(:work_package) { bug_wp }
 
-  shared_context "with default browser timezone" do
-    let(:_comment) do
-      "This context does not try to override the browser timezone. " \
-        "It will be the same as the system (positive offset for European devs, UTC for CI)."
-    end
-  end
-
-  shared_context "with a negative browser timezone (New York)", driver: :chrome_new_york_time_zone do
-    let(:_comment) do
-      "This context overrides browser timezone to be America/New_York. " \
-        "Timezone offset is -4/-5 hours (EDT/EST)."
-    end
-  end
-
   def apply_and_expect_saved(attributes)
     date_field.save!
 

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -160,12 +160,6 @@ RSpec.describe Relation do
   end
 
   describe "#successor_soonest_start" do
-    let(:monday) { Date.current.next_occurring(:monday) }
-    let(:tuesday) { monday + 1.day }
-    let(:wednesday) { monday + 2.days }
-    let(:thursday) { monday + 3.days }
-    let(:friday) { monday + 4.days }
-
     context "with a follows relation" do
       let_work_packages(<<~TABLE)
         subject  | MTWTFSS | predecessors
@@ -175,7 +169,7 @@ RSpec.describe Relation do
 
       it "returns predecessor due_date + 1" do
         relation = _table.relation(successor: "follower")
-        expect(relation.successor_soonest_start).to eq(tuesday)
+        expect(relation.successor_soonest_start).to eq(_table.tuesday)
       end
     end
 
@@ -188,7 +182,7 @@ RSpec.describe Relation do
 
       it "returns predecessor start_date + 1" do
         relation = _table.relation(successor: "follower")
-        expect(relation.successor_soonest_start).to eq(tuesday)
+        expect(relation.successor_soonest_start).to eq(_table.tuesday)
       end
     end
 
@@ -216,13 +210,13 @@ RSpec.describe Relation do
 
       it "returns predecessor due_date + lag + 1" do
         relation_a = _table.relation(successor: "follower_a")
-        expect(relation_a.successor_soonest_start).to eq(tuesday)
+        expect(relation_a.successor_soonest_start).to eq(_table.tuesday)
 
         relation_b = _table.relation(successor: "follower_b")
-        expect(relation_b.successor_soonest_start).to eq(wednesday)
+        expect(relation_b.successor_soonest_start).to eq(_table.wednesday)
 
         relation_c = _table.relation(successor: "follower_c")
-        expect(relation_c.successor_soonest_start).to eq(friday)
+        expect(relation_c.successor_soonest_start).to eq(_table.friday)
       end
     end
 
@@ -234,22 +228,27 @@ RSpec.describe Relation do
         follower_lag1 |  ░ ░ ░░ ░  | follows main with lag 1
         follower_lag2 |  ░ ░ ░░ ░  | follows main with lag 2
         follower_lag3 |  ░ ░ ░░ ░  | follows main with lag 3
+        follower_lag4 |  ░ ░ ░░ ░  | follows main with lag 4
       TABLE
 
-      it "returns a date such as the number of working days between both work package is equal to the lag" do
+      it "returns the soonest date for which the number of working days between " \
+         "both work packages is equal to the lag" do
         set_work_week("monday", "wednesday", "friday")
 
         relation_lag0 = _table.relation(successor: "follower_lag0")
-        expect(relation_lag0.successor_soonest_start).to eq(wednesday)
+        expect(relation_lag0.successor_soonest_start).to eq(_table.tuesday)
 
         relation_lag1 = _table.relation(successor: "follower_lag1")
-        expect(relation_lag1.successor_soonest_start).to eq(friday)
+        expect(relation_lag1.successor_soonest_start).to eq(_table.thursday) # working day in between is Wednesday
 
         relation_lag2 = _table.relation(successor: "follower_lag2")
-        expect(relation_lag2.successor_soonest_start).to eq(monday + 7.days)
+        expect(relation_lag2.successor_soonest_start).to eq(_table.saturday) # working days in between are Wednesday and Friday
 
         relation_lag3 = _table.relation(successor: "follower_lag3")
-        expect(relation_lag3.successor_soonest_start).to eq(wednesday + 7.days)
+        expect(relation_lag3.successor_soonest_start).to eq(_table.next_tuesday) # Wednesday, Friday, next Monday
+
+        relation_lag4 = _table.relation(successor: "follower_lag4")
+        expect(relation_lag4.successor_soonest_start).to eq(_table.next_thursday) # Wednesday, Friday, next Monday, next Wednesday
       end
     end
 
@@ -261,22 +260,28 @@ RSpec.describe Relation do
         follower_lag1 |  ░ ░ ░░ ░  | all days          | follows main with lag 1
         follower_lag2 |  ░ ░ ░░ ░  | all days          | follows main with lag 2
         follower_lag3 |  ░ ░ ░░ ░  | all days          | follows main with lag 3
+        follower_lag4 |  ░ ░ ░░ ░  | all days          | follows main with lag 4
       TABLE
 
-      it "returns predecessor due_date + lag + 1 (like without non-working days)" do
+      it "returns the soonest date for which the number of working days between " \
+         "both work packages is equal to the lag (saying it another way: it is the same " \
+         "regardless of followers ignoring non-working days or not)" do
         set_work_week("monday", "wednesday", "friday")
 
         relation_lag0 = _table.relation(successor: "follower_lag0")
-        expect(relation_lag0.successor_soonest_start).to eq(tuesday)
+        expect(relation_lag0.successor_soonest_start).to eq(_table.tuesday)
 
         relation_lag1 = _table.relation(successor: "follower_lag1")
-        expect(relation_lag1.successor_soonest_start).to eq(wednesday)
+        expect(relation_lag1.successor_soonest_start).to eq(_table.thursday) # working day in between is Wednesday
 
         relation_lag2 = _table.relation(successor: "follower_lag2")
-        expect(relation_lag2.successor_soonest_start).to eq(thursday)
+        expect(relation_lag2.successor_soonest_start).to eq(_table.saturday) # working days in between are Wednesday and Friday
 
         relation_lag3 = _table.relation(successor: "follower_lag3")
-        expect(relation_lag3.successor_soonest_start).to eq(friday)
+        expect(relation_lag3.successor_soonest_start).to eq(_table.next_tuesday) # Wednesday, Friday, next Monday
+
+        relation_lag4 = _table.relation(successor: "follower_lag4")
+        expect(relation_lag4.successor_soonest_start).to eq(_table.next_thursday) # Wednesday, Friday, next Monday, next Wednesday
       end
     end
   end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -2002,7 +2002,7 @@ RSpec.describe WorkPackages::SetAttributesService,
         let(:expected_attributes) do
           {
             start_date: next_monday,
-            due_date: next_monday + 7.days
+            due_date: WorkPackages::Shared::WorkingDays.new.soonest_working_day(Time.zone.today + 5.days)
           }
         end
       end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1478,6 +1478,80 @@ RSpec.describe WorkPackages::SetAttributesService,
           end
         end
       end
+
+      context "without changing anything, when scheduling mode is automatic " \
+              "and start date initial date is different from the calculated soonest start" do
+        let(:work_package) do
+          build_stubbed(:work_package, start_date: monday,
+                                       due_date: friday,
+                                       ignore_non_working_days: true)
+        end
+        let(:call_attributes) { {} }
+
+        before do
+          allow(work_package).to receive(:soonest_start).and_return(wednesday)
+        end
+
+        context "when scheduling mode is automatic" do
+          before do
+            work_package.schedule_manually = false
+          end
+
+          it_behaves_like "service call" do
+            it "moves the start date to the calculated soonest start, keeps duration and adjusts due date" do
+              expect { subject }
+                .to change { work_package.slice(:start_date, :due_date, :duration) }
+                .from(start_date: monday, due_date: friday, duration: 5)
+                .to(start_date: wednesday, due_date: sunday, duration: 5)
+            end
+          end
+        end
+
+        context "when scheduling mode is manual" do
+          before do
+            work_package.schedule_manually = true
+          end
+
+          it_behaves_like "service call" do
+            it "does not change any dates" do
+              expect { subject }
+                .not_to change { work_package.slice(:start_date, :due_date, :duration) }
+            end
+          end
+        end
+
+        context "when scheduling mode is initially manual and is changed to automatic" do
+          let(:call_attributes) { { schedule_manually: false } }
+
+          before do
+            work_package.schedule_manually = true
+          end
+
+          it_behaves_like "service call" do
+            it "moves the start date to the calculated soonest start, keeps duration and adjusts due date" do
+              expect { subject }
+                .to change { work_package.slice(:start_date, :due_date, :duration) }
+                .from(start_date: monday, due_date: friday, duration: 5)
+                .to(start_date: wednesday, due_date: sunday, duration: 5)
+            end
+          end
+        end
+
+        context "when scheduling mode is initially automatic and is changed to manual" do
+          let(:call_attributes) { { schedule_manually: true } }
+
+          before do
+            work_package.schedule_manually = false
+          end
+
+          it_behaves_like "service call" do
+            it "does not change any dates" do
+              expect { subject }
+                .not_to change { work_package.slice(:start_date, :due_date, :duration) }
+            end
+          end
+        end
+      end
     end
   end
 

--- a/spec/services/work_packages/shared/all_days_spec.rb
+++ b/spec/services/work_packages/shared/all_days_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe WorkPackages::Shared::AllDays do
 
   include_examples "lag computation excluding non-working days"
 
+  include_examples "add lag to a date"
+
   describe "#start_date" do
     it "returns the start date for a due date and a duration" do
       expect(subject.start_date(sunday_2022_07_31, 1)).to eq(sunday_2022_07_31)
@@ -144,33 +146,15 @@ RSpec.describe WorkPackages::Shared::AllDays do
       expect(subject.soonest_working_day(nil)).to be_nil
     end
 
-    context "with lag" do
-      it "returns the soonest working day from the given day, after a configurable lag of working days" do
-        expect(subject.soonest_working_day(sunday_2022_07_31, lag: nil)).to eq(sunday_2022_07_31)
-        expect(subject.soonest_working_day(sunday_2022_07_31, lag: 0)).to eq(sunday_2022_07_31)
-        expect(subject.soonest_working_day(sunday_2022_07_31, lag: 1)).to eq(Date.new(2022, 8, 1))
-      end
-    end
-
     context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
       it "returns the given day" do
         expect(subject.soonest_working_day(sunday_2022_07_31)).to eq(sunday_2022_07_31)
-      end
-
-      context "with lag" do
-        include_examples "soonest working day with lag", date: Date.new(2022, 1, 1), lag: 30, expected: Date.new(2022, 1, 31)
       end
     end
 
     context "with some non working days (Christmas 2022-12-25 and new year's day 2023-01-01)", :christmas_2022_new_year_2023 do
       it "returns the given day" do
         expect(subject.soonest_working_day(Date.new(2022, 12, 25))).to eq(Date.new(2022, 12, 25))
-      end
-
-      context "with lag" do
-        include_examples "soonest working day with lag", date: Date.new(2022, 12, 24),
-                                                         lag: 7,
-                                                         expected: Date.new(2022, 12, 31)
       end
     end
   end

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -71,6 +71,15 @@ RSpec.shared_examples "it returns duration" do |expected_duration, start_date, d
   end
 end
 
+RSpec.shared_examples "it adds lag" do |date:, lag:, expected_result:|
+  it "from date #{date.to_fs(:wday_date)} " \
+     "with lag #{lag} " \
+     "=> #{expected_result.to_fs(:wday_date)}" \
+  do
+    expect(subject.add_lag(date, lag)).to eq(expected_result)
+  end
+end
+
 RSpec.shared_examples "it returns lag" do |expected_lag, predecessor_date, successor_date|
   from_date_format = "%a %-d"
   from_date_format += " %b" if [predecessor_date.month, predecessor_date.year] != [successor_date.month, successor_date.year]
@@ -99,12 +108,6 @@ end
 RSpec.shared_examples "soonest working day" do |date:, expected:|
   it "soonest_working_day(#{date.to_fs(:wday_date)}) => #{expected.to_fs(:wday_date)}" do
     expect(subject.soonest_working_day(date)).to eq(expected)
-  end
-end
-
-RSpec.shared_examples "soonest working day with lag" do |date:, lag:, expected:|
-  it "soonest_working_day(#{date.to_fs(:wday_date)}, lag: #{lag.inspect}) => #{expected.to_fs(:wday_date)}" do
-    expect(subject.soonest_working_day(date, lag:)).to eq(expected)
   end
 end
 
@@ -167,6 +170,68 @@ RSpec.shared_examples "lag computation excluding non-working days" do
     context "without successor date" do
       it "returns nil" do
         expect(subject.lag(sunday_2022_07_31, nil)).to be_nil
+      end
+    end
+  end
+end
+
+RSpec.shared_examples "add lag to a date" do
+  describe "#add_lag" do
+    saturday_2022_07_30 = Date.new(2022, 7, 30)
+    sunday_2022_07_31 = Date.new(2022, 7, 31)
+    monday_2022_08_01 = Date.new(2022, 8, 1)
+
+    it "returns the soonest date after the given date where the number of working days in between equals the given lag" do
+      expect(subject.add_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
+      expect(subject.add_lag(sunday_2022_07_31, 1)).to eq(Date.new(2022, 8, 2))
+      expect(subject.add_lag(sunday_2022_07_31, 5)).to eq(Date.new(2022, 8, 6))
+      expect(subject.add_lag(sunday_2022_07_31, 6)).to eq(Date.new(2022, 8, 7))
+    end
+
+    it "returns the day after the given date when lag is negative (like lag = 0)" do
+      expect(subject.add_lag(sunday_2022_07_31, -100)).to eq(monday_2022_08_01)
+      expect(subject.add_lag(sunday_2022_07_31, -1)).to eq(monday_2022_08_01)
+      expect(subject.add_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
+    end
+
+    it "works with big lag value like 100_000" do
+      # Ensure implementation is not recursive and won't fail with SystemStackError: stack level too deep
+      expect { subject.add_lag(sunday_2022_07_31, 100_000) }
+        .not_to raise_error
+    end
+
+    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+      include_examples "it adds lag", date: saturday_2022_07_30, lag: 0, expected_result: sunday_2022_07_31
+      include_examples "it adds lag", date: saturday_2022_07_30, lag: 1, expected_result: Date.new(2022, 8, 2)
+
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: 0, expected_result: monday_2022_08_01
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: 1, expected_result: Date.new(2022, 8, 2)
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: 4, expected_result: Date.new(2022, 8, 5) # Friday
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: 5, expected_result: Date.new(2022, 8, 6) # Saturday
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: 6, expected_result: Date.new(2022, 8, 9) # Tuesday
+
+      include_examples "it adds lag", date: monday_2022_08_01, lag: 3, expected_result: Date.new(2022, 8, 5) # Friday
+      include_examples "it adds lag", date: monday_2022_08_01, lag: 4, expected_result: Date.new(2022, 8, 6) # Saturday
+      include_examples "it adds lag", date: monday_2022_08_01, lag: 5, expected_result: Date.new(2022, 8, 9) # Tuesday
+    end
+
+    context "with some non working days (Christmas 2022-12-25 and new year's day 2023-01-01)", :christmas_2022_new_year_2023 do
+      include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 0, expected_result: Date.new(2022, 12, 25)
+      include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 1, expected_result: Date.new(2022, 12, 27)
+      include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 6, expected_result: Date.new(2023, 1, 1)
+      include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 7, expected_result: Date.new(2023, 1, 3)
+    end
+
+    context "with nil date" do
+      it "returns nil" do
+        expect(subject.add_lag(nil, 5)).to be_nil
+      end
+    end
+
+    context "with nil lag" do
+      it "returns the day after the given date when lag is nil (like lag = 0)" do
+        expect(subject.add_lag(sunday_2022_07_31, nil)).to eq(monday_2022_08_01)
+        expect(subject.add_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
       end
     end
   end

--- a/spec/services/work_packages/shared/working_days_spec.rb
+++ b/spec/services/work_packages/shared/working_days_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
 
   include_examples "lag computation excluding non-working days"
 
+  include_examples "add lag to a date"
+
   describe "#start_date" do
     it "returns the start date for a due date and a duration" do
       expect(subject.start_date(monday_2022_08_01, 1)).to eq(monday_2022_08_01)
@@ -190,49 +192,17 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
       expect(subject.soonest_working_day(nil)).to be_nil
     end
 
-    context "with lag" do
-      it "returns the soonest working day from the given day, after a configurable lag of working days" do
-        expect(subject.soonest_working_day(sunday_2022_07_31, lag: nil)).to eq(sunday_2022_07_31)
-        expect(subject.soonest_working_day(sunday_2022_07_31, lag: 0)).to eq(sunday_2022_07_31)
-        expect(subject.soonest_working_day(sunday_2022_07_31, lag: 1)).to eq(monday_2022_08_01)
-      end
-
-      it "works with big lag value like 100_000" do
-        # First implementation was recursive and failed with SystemStackError: stack level too deep
-        expect { subject.soonest_working_day(sunday_2022_07_31, lag: 100_000) }
-          .not_to raise_error
-      end
-    end
-
     context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
       include_examples "soonest working day", date: friday_2022_07_29, expected: friday_2022_07_29
       include_examples "soonest working day", date: saturday_2022_07_30, expected: monday_2022_08_01
       include_examples "soonest working day", date: sunday_2022_07_31, expected: monday_2022_08_01
       include_examples "soonest working day", date: monday_2022_08_01, expected: monday_2022_08_01
-
-      context "with lag" do
-        include_examples "soonest working day with lag", date: friday_2022_07_29, lag: 0, expected: friday_2022_07_29
-        include_examples "soonest working day with lag", date: saturday_2022_07_30, lag: 0, expected: monday_2022_08_01
-        include_examples "soonest working day with lag", date: sunday_2022_07_31, lag: 0, expected: monday_2022_08_01
-        include_examples "soonest working day with lag", date: monday_2022_08_01, lag: 0, expected: monday_2022_08_01
-
-        include_examples "soonest working day with lag", date: friday_2022_07_29, lag: 1, expected: monday_2022_08_01
-        include_examples "soonest working day with lag", date: saturday_2022_07_30, lag: 1, expected: Date.new(2022, 8, 2)
-        include_examples "soonest working day with lag", date: sunday_2022_07_31, lag: 1, expected: Date.new(2022, 8, 2)
-        include_examples "soonest working day with lag", date: monday_2022_08_01, lag: 1, expected: Date.new(2022, 8, 2)
-
-        include_examples "soonest working day with lag", date: friday_2022_07_29, lag: 8, expected: Date.new(2022, 8, 10)
-      end
     end
 
     context "with some non working days (Christmas 2022-12-25 and new year's day 2023-01-01)", :christmas_2022_new_year_2023 do
       include_examples "soonest working day", date: Date.new(2022, 12, 25), expected: Date.new(2022, 12, 26)
       include_examples "soonest working day", date: Date.new(2022, 12, 31), expected: Date.new(2022, 12, 31)
       include_examples "soonest working day", date: Date.new(2023, 1, 1), expected: Date.new(2023, 1, 2)
-
-      context "with lag" do
-        include_examples "soonest working day with lag", date: Date.new(2022, 12, 24), lag: 7, expected: Date.new(2023, 1, 2)
-      end
     end
 
     context "with no working days", :no_working_days do

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1317,13 +1317,13 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
         let(:attributes) { { ignore_non_working_days: true } }
 
         it "moves the start date earlier to start on a non-working day " \
-           "and moves the due date too to keep same duration" do
+           "and keeps the current due date and updates the duration accordingly" do
           expect(subject).to be_success
 
           expect_work_packages_after_reload([work_package, predecessor], <<~TABLE)
             | subject      | MTWTFSSmtwtfss | scheduling mode | days counting
             | predecessor  |   XX           | manual          | working days only
-            | work_package |      XXX       | automatic       | all days
+            | work_package |      XXXXX     | automatic       | all days
           TABLE
         end
       end
@@ -1367,14 +1367,13 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
 
       let(:attributes) { { ignore_non_working_days: false } }
 
-      it "moves the start date earlier to start on a non-working day " \
-         "and moves the due date too to keep same duration" do
+      it "moves the dates to the next working day and adjusts the duration accordingly" do
         expect(subject).to be_success
 
         expect_work_packages_after_reload([work_package, predecessor], <<~TABLE)
-          | subject      | MTWTFSSmtwtfss    | duration | scheduling mode | days counting
-          | predecessor  |   XX              |        2 | manual          | working days only
-          | work_package |        XXXXX..XXX |        8 | automatic       | working days only
+          | subject      | MTWTFSSmtwtfss  | duration | scheduling mode | days counting
+          | predecessor  |   XX            |        2 | manual          | working days only
+          | work_package |        XXXXX..X |        6 | automatic       | working days only
         TABLE
       end
     end

--- a/spec/support/table_helpers/table.rb
+++ b/spec/support/table_helpers/table.rb
@@ -72,6 +72,13 @@ module TableHelpers
     def friday = monday + 4.days
     def saturday = monday + 5.days
     def sunday = monday + 6.days
+    def next_monday = monday + 7.days
+    def next_tuesday = monday + 8.days
+    def next_wednesday = monday + 9.days
+    def next_thursday = monday + 10.days
+    def next_friday = monday + 11.days
+    def next_saturday = monday + 12.days
+    def next_sunday = monday + 13.days
 
     private
 

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -47,3 +47,17 @@ RSpec::Matchers.define :equal_time_without_usec do |expected|
     expected_without_usec == actual_without_usec
   end
 end
+
+RSpec.shared_context "with default browser timezone" do
+  let(:_comment) do
+    "This context does not try to override the browser timezone. " \
+      "It will be the same as the system (positive offset for European devs, UTC for CI, etc.)."
+  end
+end
+
+RSpec.shared_context "with a negative browser timezone (New York)", driver: :chrome_new_york_time_zone do
+  let(:_comment) do
+    "This context overrides browser timezone to be America/New_York. " \
+      "Timezone offset is -4/-5 hours (EDT/EST)."
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62891
https://community.openproject.org/wp/63152

# What are you trying to accomplish?

There were weird recalculations of finish date when saving date picker, a bit hard to reproduce. It was due to the start date recalculation when toggling "Working days only" which was not reflected correctly in the date picker. On top of that, the calculation of the start date could be incorrect if lag was involved.

There was also a bug in date picker enabled dates when the timezone offset is negative.

For an automatically scheduled successor, when "Working days only" is turned off and the day before the start date is a non-working day, the start will shift to an earlier date. Multiple things need to work correctly:

- The start date must be recalculated and displayed in the date picker.
- The mini calendar of the date picker need to have enabled dates updated, as the start date has changed.
- If the due date was not set manually, duration must be kept and due date will be recalculated.
- If the due date was set manually, it must not be changed and duration will be recalculated.
- If the due date was unset manually, it must remain unset and duration must be unset too.

Also the lag calculation was partly incorrect: it was adding non-working days when "Working days only" was on, and days when "Working days only" was off. This has been fixed: lag is always about working days regardless of the successor "Working days only" setting.

For this reason, when the work package is automatically scheduled, the start date is always recalculated in the `SetAttributesService` to ensure we never open the date picker with an error message saying "Start date can only be set to 2025-04-16 or later so as not to violate the work package's relationships.".

## Screenshots

Before:

due date saved is not the chosen one, and can select date before start date as finish date (using New York time zone)

[bug when setting due date and toggling nwd.webm](https://github.com/user-attachments/assets/e0e50d54-bd1a-44e3-abe4-2af90739ea1c)

After:

due date saved is the chosen one, and dates before start date cannot be selected (using New York time zone)

[ok when setting due date and toggling nwd.webm](https://github.com/user-attachments/assets/fba63833-f96a-42e2-b230-83193925501d)

# What approach did you choose and why?

- Change the way the soonest_start is calculated: first calculate the date with the lag, which is always working days only, then move to next working day or not depending on "ignore_non_working_days" value of the work package.
- Change the algorithm in `WorkPackages::SetAttributesService` to prioritize keeping `due_date` if it has been set by the user
- Always calculate and set start date for automatically scheduled work packages, to fix any wrong start date
  - This has the side effect to recompute the start date when "Working days only" is toggled. Before it was recalculated only if scheduling mode was changed.
- In date picker, correctly convert start date to have the same time shift as the date from flatpickr for easier comparisons. And remove the minimalStartDate parameter as it's not needed: it's always the start date.

# Merge checklist

- [x] Added/updated tests
  - a lot
  - the test checking the enabled dates in the date picker is now run also in the New York time zone
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
