### PR TITLE
Remove Time Tracking Feature Flag and add enterprise check for enforcement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,7 +201,7 @@ gem "aws-sdk-core", "~> 3.107"
 # File upload via fog + screenshots on travis
 gem "aws-sdk-s3", "~> 1.91"
 
-gem "openproject-token", "~> 5.1.2"
+gem "openproject-token", "~> 5.2.0"
 
 gem "plaintext", "~> 0.3.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -863,7 +863,7 @@ GEM
       activesupport (>= 5.0.0)
       openproject-octicons (>= 19.23.0)
       view_component (>= 3.1, < 4.0)
-    openproject-token (5.1.2)
+    openproject-token (5.2.0)
       activemodel
     openssl (3.3.0)
     openssl-signature_algorithm (1.3.0)
@@ -1396,7 +1396,7 @@ DEPENDENCIES
   openproject-reporting!
   openproject-storages!
   openproject-team_planner!
-  openproject-token (~> 5.1.2)
+  openproject-token (~> 5.2.0)
   openproject-two_factor_authentication!
   openproject-webhooks!
   openproject-xls_export!
@@ -1762,7 +1762,7 @@ CHECKSUMS
   openproject-reporting (1.0.0)
   openproject-storages (1.0.0)
   openproject-team_planner (1.0.0)
-  openproject-token (5.1.2) sha256=5114494eda1b068acf75c26040516fcda94c9d5dc2c28cb33cf15ff22a24628a
+  openproject-token (5.2.0) sha256=dd30482ea94897f24b7dc19d1f1cdd5a149e76635e29bf2ca34d31cf82f9d394
   openproject-two_factor_authentication (1.0.0)
   openproject-webhooks (1.0.0)
   openproject-xls_export (1.0.0)

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -38,6 +38,9 @@
   &-input-wrap[invalid='true'] input:not(:focus)
     border-color: var(--control-borderColor-danger)
 
+  &-spacingWrapper > :empty
+    display: none
+
 .UnderlineNav
   @include no-visible-scroll-bar
   margin-bottom: 12px

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -168,14 +168,14 @@ class TimeEntry < ApplicationRecord
   end
 
   class << self
-    def can_track_start_and_end_time?(_project: nil)
+    def can_track_start_and_end_time?
       Setting.allow_tracking_start_and_end_times?
-      # TODO: Add project check when we have decided if we also want a project specific flag
     end
 
-    def must_track_start_and_end_time?(_project: nil)
-      Setting.enforce_tracking_start_and_end_times?
-      # TODO: Add project check when we have decided if we also want a project specific flag
+    def must_track_start_and_end_time?
+      EnterpriseToken.allows_to?(:time_entry_time_restrictions) &&
+        can_track_start_and_end_time? &&
+        Setting.enforce_tracking_start_and_end_times?
     end
   end
 

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -169,13 +169,12 @@ class TimeEntry < ApplicationRecord
 
   class << self
     def can_track_start_and_end_time?(_project: nil)
-      OpenProject::FeatureDecisions.track_start_and_end_times_for_time_entries_active? &&
-        Setting.allow_tracking_start_and_end_times?
+      Setting.allow_tracking_start_and_end_times?
       # TODO: Add project check when we have decided if we also want a project specific flag
     end
 
     def must_track_start_and_end_time?(_project: nil)
-      can_track_start_and_end_time? && Setting.enforce_tracking_start_and_end_times?
+      Setting.enforce_tracking_start_and_end_times?
       # TODO: Add project check when we have decided if we also want a project specific flag
     end
   end

--- a/modules/costs/app/views/admin/costs_settings/show.html.erb
+++ b/modules/costs/app/views/admin/costs_settings/show.html.erb
@@ -58,10 +58,8 @@ render(Primer::Alpha::TabPanels.new(label: I18n.t(:project_module_costs))) do |c
 
           form.check_box(name: :allow_tracking_start_and_end_times)
 
-          unless EnterpriseToken.allows_to?(:time_entry_time_restrictions)
-            form.html_content do
-              render(::EnterpriseEdition::BannerComponent.new(:time_entry_time_restrictions, dismissable: false))
-            end
+          form.html_content do
+            render(::EnterpriseEdition::BannerComponent.new(:time_entry_time_restrictions, dismissable: false))
           end
           form.check_box(name: :enforce_tracking_start_and_end_times, disabled: !EnterpriseToken.allows_to?(:time_entry_time_restrictions))
 

--- a/modules/costs/app/views/admin/costs_settings/show.html.erb
+++ b/modules/costs/app/views/admin/costs_settings/show.html.erb
@@ -57,7 +57,13 @@ render(Primer::Alpha::TabPanels.new(label: I18n.t(:project_module_costs))) do |c
           end
 
           form.check_box(name: :allow_tracking_start_and_end_times)
-          form.check_box(name: :enforce_tracking_start_and_end_times)
+
+          unless EnterpriseToken.allows_to?(:time_entry_time_restrictions)
+            form.html_content do
+              render(::EnterpriseEdition::BannerComponent.new(:time_entry_time_restrictions, dismissable: false))
+            end
+          end
+          form.check_box(name: :enforce_tracking_start_and_end_times, disabled: !EnterpriseToken.allows_to?(:time_entry_time_restrictions))
 
           form.submit
         end

--- a/modules/costs/app/views/admin/costs_settings/show.html.erb
+++ b/modules/costs/app/views/admin/costs_settings/show.html.erb
@@ -44,30 +44,28 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
 render(Primer::Alpha::TabPanels.new(label: I18n.t(:project_module_costs))) do |component|
-  if OpenProject::FeatureDecisions.track_start_and_end_times_for_time_entries_active?
-    component.with_tab(selected: true, id: "tab-time") do |tab|
-      tab.with_text { I18n.t(:label_time) }
-      tab.with_panel do
-        admin_settings_primer_form_with(scope: :settings, action: :update, method: :patch) do |time_form|
-          render_inline_settings_form(time_form) do |form|
-            form.html_content do
-              render(Primer::Beta::Subhead.new(hide_border: true)) do |subhead|
-                subhead.with_heading(size: :medium) { I18n.t(:label_mandatory_fields) }
-                subhead.with_description { I18n.t(:description_time_settings) }
-              end
+  component.with_tab(selected: true, id: "tab-time") do |tab|
+    tab.with_text { I18n.t(:label_time) }
+    tab.with_panel do
+      admin_settings_primer_form_with(scope: :settings, action: :update, method: :patch) do |time_form|
+        render_inline_settings_form(time_form) do |form|
+          form.html_content do
+            render(Primer::Beta::Subhead.new(hide_border: true)) do |subhead|
+              subhead.with_heading(size: :medium) { I18n.t(:label_mandatory_fields) }
+              subhead.with_description { I18n.t(:description_time_settings) }
             end
-
-            form.check_box(name: :allow_tracking_start_and_end_times)
-            form.check_box(name: :enforce_tracking_start_and_end_times)
-
-            form.submit
           end
+
+          form.check_box(name: :allow_tracking_start_and_end_times)
+          form.check_box(name: :enforce_tracking_start_and_end_times)
+
+          form.submit
         end
       end
     end
   end
 
-  component.with_tab(id: "tab-costs", selected: !OpenProject::FeatureDecisions.track_start_and_end_times_for_time_entries_active?) do |tab|
+  component.with_tab(id: "tab-costs") do |tab|
     tab.with_text { I18n.t(:label_costs) }
     tab.with_panel do
       admin_settings_primer_form_with(scope: :settings, action: :update, method: :patch) do |time_form|

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -119,7 +119,6 @@ en:
   description_costs_settings: "Define the desired format for the costs in all projects."
   description_time_settings: "Define which fields are mandatory to fill when logging time in all projects."
 
-
   group_by_others: "not in any group"
 
   label_between: "between"
@@ -208,3 +207,10 @@ en:
     errors:
       validation:
         start_time_different_date: "Date part of startTime (%{start_time}) must be the same as the spentOn (%{spent_on}) date."
+
+  ee:
+    features:
+      time_entry_time_restrictions: Require exact time tracking
+    upsale:
+      time_entry_time_restrictions:
+        description: "Improve your time tracking by requiring exact start and finish times when logging time."

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -153,11 +153,6 @@ module Costs
       ::Settings::Definition.add "enforce_tracking_start_and_end_times", default: false, format: :boolean
     end
 
-    initializer "costs.feature_decisions" do
-      OpenProject::FeatureDecisions.add :track_start_and_end_times_for_time_entries,
-                                        description: "Allows admins to enable tracking start and end times for time entries"
-    end
-
     activity_provider :time_entries, class_name: "Activities::TimeEntryActivityProvider", default: false
 
     patches %i[Project User PermittedParams]

--- a/modules/costs/spec/features/time_entry_dialog_spec.rb
+++ b/modules/costs/spec/features/time_entry_dialog_spec.rb
@@ -30,7 +30,7 @@
 
 require_relative "../spec_helper"
 
-RSpec.describe "time entry dialog", :js, with_flag: :track_start_and_end_times_for_time_entries do
+RSpec.describe "time entry dialog", :js do
   include Redmine::I18n
 
   shared_let(:project) { create(:project_with_types) }
@@ -80,7 +80,11 @@ RSpec.describe "time entry dialog", :js, with_flag: :track_start_and_end_times_f
     end
 
     context "when start and end time is enforced",
-            with_settings: { allow_tracking_start_and_end_times: true, enforce_tracking_start_and_end_times: true } do
+            with_ee: %i[time_entry_time_restrictions],
+            with_settings: {
+              allow_tracking_start_and_end_times: true,
+              enforce_tracking_start_and_end_times: true
+            } do
       it "shows fields to track start and end times" do
         time_logging_modal.shows_field("start_time", true)
         time_logging_modal.requires_field("start_time")

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -414,24 +414,12 @@ RSpec.describe TimeEntry do
   end
 
   describe ".can_track_start_and_end_time?" do
-    context "with the feature flag enabled", with_flag: { track_start_and_end_times_for_time_entries: true } do
-      context "with the setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
-        it { expect(described_class).to be_can_track_start_and_end_time }
-      end
-
-      context "with the setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
-        it { expect(described_class).not_to be_can_track_start_and_end_time }
-      end
+    context "with the setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
+      it { expect(described_class).to be_can_track_start_and_end_time }
     end
 
-    context "with the feature flag disabled", with_flag: { track_start_and_end_times_for_time_entries: false } do
-      context "with the setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
-        it { expect(described_class).not_to be_can_track_start_and_end_time }
-      end
-
-      context "with the setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
-        it { expect(described_class).not_to be_can_track_start_and_end_time }
-      end
+    context "with the setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
+      it { expect(described_class).not_to be_can_track_start_and_end_time }
     end
   end
 
@@ -545,47 +533,23 @@ RSpec.describe TimeEntry do
   end
 
   describe ".must_track_start_and_end_time?" do
-    context "with the feature flag enabled", with_flag: { track_start_and_end_times_for_time_entries: true } do
-      context "with the allow setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
-        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
-          it { expect(described_class).to be_must_track_start_and_end_time }
-        end
-
-        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
+    context "with the allow setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
+      context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
+        it { expect(described_class).to be_must_track_start_and_end_time }
       end
 
-      context "with the allow setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
-        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
-
-        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
+      context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
+        it { expect(described_class).not_to be_must_track_start_and_end_time }
       end
     end
 
-    context "with the feature flag disabled", with_flag: { track_start_and_end_times_for_time_entries: false } do
-      context "with the allow setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
-        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
-
-        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
+    context "with the allow setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
+      context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
+        it { expect(described_class).not_to be_must_track_start_and_end_time }
       end
 
-      context "with the allow setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
-        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
-
-        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
-          it { expect(described_class).not_to be_must_track_start_and_end_time }
-        end
+      context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
+        it { expect(described_class).not_to be_must_track_start_and_end_time }
       end
     end
   end

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -533,23 +533,47 @@ RSpec.describe TimeEntry do
   end
 
   describe ".must_track_start_and_end_time?" do
-    context "with the allow setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
-      context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
-        it { expect(described_class).to be_must_track_start_and_end_time }
+    context "when the EnterpriseToken does not allow enforcement", with_ee: [] do
+      context "with the allow setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
+        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
+
+        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
       end
 
-      context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
-        it { expect(described_class).not_to be_must_track_start_and_end_time }
+      context "with the allow setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
+        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
+
+        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
       end
     end
 
-    context "with the allow setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
-      context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
-        it { expect(described_class).not_to be_must_track_start_and_end_time }
+    context "when the EnterpriseToken allows enforcement", with_ee: [:time_entry_time_restrictions] do
+      context "with the allow setting enabled", with_settings: { allow_tracking_start_and_end_times: true } do
+        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
+          it { expect(described_class).to be_must_track_start_and_end_time }
+        end
+
+        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
       end
 
-      context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
-        it { expect(described_class).not_to be_must_track_start_and_end_time }
+      context "with the allow setting disabled", with_settings: { allow_tracking_start_and_end_times: false } do
+        context "with the enforce setting enabled", with_settings: { enforce_tracking_start_and_end_times: true } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
+
+        context "with the enforce setting disabled", with_settings: { enforce_tracking_start_and_end_times: false } do
+          it { expect(described_class).not_to be_must_track_start_and_end_time }
+        end
       end
     end
   end

--- a/modules/costs/spec/requests/api/time_entries/create_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/create_resource_spec.rb
@@ -33,7 +33,6 @@ require "rack/test"
 
 RSpec.describe "API v3 Time Entries resource",
                content_type: :json,
-               with_flag: :track_start_and_end_times_for_time_entries,
                with_settings: { allow_tracking_start_and_end_times: true } do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -330,9 +330,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "when start- & end-time tracking is enabled",
-            with_flag: { track_start_and_end_times_for_time_entries: true },
-            with_settings: { allow_tracking_start_and_end_times: true } do
+    context "when start- & end-time tracking is enabled", with_settings: { allow_tracking_start_and_end_times: true } do
       context "when start and end time were tracked" do
         let!(:time_entry) do
           create(:time_entry, :with_start_and_end_time, project:, work_package:, user: current_user)
@@ -370,9 +368,7 @@ RSpec.describe "API v3 time_entry resource" do
       end
     end
 
-    context "when start- & end-time tracking is disabled",
-            with_flag: { track_start_and_end_times_for_time_entries: false },
-            with_settings: { allow_tracking_start_and_end_times: false } do
+    context "when start- & end-time tracking is disabled", with_settings: { allow_tracking_start_and_end_times: false } do
       context "when start and end time were tracked" do
         let!(:time_entry) do
           create(:time_entry, :with_start_and_end_time, project:, work_package:, user: current_user)

--- a/modules/reporting/spec/features/export_cost_report_spec.rb
+++ b/modules/reporting/spec/features/export_cost_report_spec.rb
@@ -31,7 +31,7 @@
 require_relative "../spec_helper"
 require_relative "support/pages/cost_report_page"
 
-RSpec.describe "Cost reports XLS export", :js, with_flag: { track_start_and_end_times_for_time_entries: true } do
+RSpec.describe "Cost reports XLS export", :js do
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
   shared_let(:cost_type) { create(:cost_type, name: "Post-war", unit: "cap", unit_plural: "caps") }

--- a/modules/reporting/spec/features/time_entries_spec.rb
+++ b/modules/reporting/spec/features/time_entries_spec.rb
@@ -4,8 +4,7 @@ require "spec_helper"
 require_relative "support/pages/cost_report_page"
 require_relative "support/components/cost_reports_base_table"
 
-RSpec.describe "Cost report showing time entries with start & end times", :js,
-               with_flag: { track_start_and_end_times_for_time_entries: true } do
+RSpec.describe "Cost report showing time entries with start & end times", :js do
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
   shared_let(:work_package) { create(:work_package, project:) }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/62624

# What are you trying to accomplish?
- Remove the FF for exact times in time tracking
- Add the enterprise check when enforcing exact times

## Screenshots
![Bildschirmfoto 2025-04-10 um 10 51 31](https://github.com/user-attachments/assets/9db7d208-e8d5-459e-8e1f-29e8cc068225)


# What approach did you choose and why?

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
