### PR TITLE
[63014] The "Create meeting" drop down in the Meetings subheader doesn't not properly right-align with the button

### DIFF
--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -13,7 +13,7 @@
 
       if render_create_button?
         subheader.with_action_component do
-          render Primer::Alpha::ActionMenu.new(anchor_align: :end) do |menu|
+          render Primer::Alpha::ActionMenu.new(anchor_align: :end, size: :medium) do |menu|
             menu.with_show_button(
               scheme: :primary,
               test_selector: "add-meeting-button",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/63014/activity

# What are you trying to accomplish?
The dropdown is for whatever reason misaligned, and setting an explicit width for it, seems to do the trick. I still have to investigate the underlying reason for it, but for 15.5 this should be fine
