### PR TITLE
[#62429] added remaining work to attributes

### DIFF
--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -47,6 +47,7 @@ module Types
           category: { fn: ->(wp) { wp.category&.name }, label: -> { WorkPackage.human_attribute_name(:category) } },
           creation_date: { fn: ->(wp) { wp.created_at }, label: -> { WorkPackage.human_attribute_name(:created_at) } },
           estimated_time: { fn: ->(wp) { wp.estimated_hours }, label: -> { WorkPackage.human_attribute_name(:estimated_hours) } },
+          remaining_time: { fn: ->(wp) { wp.remaining_hours }, label: -> { WorkPackage.human_attribute_name(:remaining_hours) } },
           finish_date: { fn: ->(wp) { wp.due_date }, label: -> { WorkPackage.human_attribute_name(:due_date) } },
           parent_id: { fn: ->(wp) { wp.parent&.id }, label: -> { WorkPackage.human_attribute_name(:id) } },
           parent_assignee: { fn: ->(wp) { wp.parent&.assigned_to&.name }, label: -> {
@@ -59,6 +60,8 @@ module Types
                                   label: -> { WorkPackage.human_attribute_name(:created_at) } },
           parent_estimated_time: { fn: ->(wp) { wp.parent&.estimated_hours },
                                    label: -> { WorkPackage.human_attribute_name(:estimated_hours) } },
+          parent_remaining_time: { fn: ->(wp) { wp.parent&.remaining_hours },
+                                   label: -> { WorkPackage.human_attribute_name(:remaining_hours) } },
           parent_finish_date: { fn: ->(wp) { wp.parent&.due_date },
                                 label: -> { WorkPackage.human_attribute_name(:due_date) } },
           parent_priority: { fn: ->(wp) { wp.parent&.priority }, label: -> { WorkPackage.human_attribute_name(:priority) } },
@@ -94,7 +97,7 @@ module Types
       private
 
       def default_tokens
-        TOKEN_PROPERTY_MAP.keys.each_with_object({ project: {}, work_package: {}, parent: {} }) do |key, obj|
+        TOKEN_PROPERTY_MAP.keys.each_with_object({ work_package: {}, project: {}, parent: {} }) do |key, obj|
           label = TOKEN_PROPERTY_MAP.dig(key, :label).call
 
           case key.to_s

--- a/spec/models/types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/types/patterns/token_property_mapper_spec.rb
@@ -41,12 +41,13 @@ RSpec.describe Types::Patterns::TokenPropertyMapper do
 
   shared_let(:work_package_parent) do
     create(:work_package, project:, category:, start_date: Date.yesterday, estimated_hours: 120,
-                          due_date: 3.months.from_now, assigned_to: parent_assignee)
+                          remaining_hours: 80, due_date: 3.months.from_now, assigned_to: parent_assignee)
   end
 
   shared_let(:work_package) do
     create(:work_package, responsible:, project:, category:, due_date: 1.month.from_now, assigned_to: assignee,
-                          parent: work_package_parent, start_date: Time.zone.today, estimated_hours: 30)
+                          parent: work_package_parent, start_date: Time.zone.today, estimated_hours: 30,
+                          remaining_hours: 25)
   end
 
   shared_let(:string_custom_field) do


### PR DESCRIPTION
# Ticket
[OP#62429](https://community.openproject.org/wp/62429)

# What are you trying to accomplish?
- reordered groups to "work package", "project", "parent"
- have "remaining work" available in pattern attributes

