### PR TITLE
[63352] Insufficient spacing between automatic-scheduling icon and date in work package macro in CkEditor

### DIFF
--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -53,6 +53,7 @@ display-field
 
 .display-field--scheduling-icon
   fill: var(--body-font-color)
+  margin-right: 0.25rem
 
 // READ value of edit fields
 .inline-edit--display-field
@@ -127,7 +128,6 @@ display-field
     .display-field--scheduling-icon
       position: relative
       top: 1px
-      margin-right: 0.25rem
 
 .wp-table--cell-container
   .inline-edit--display-field.-placeholder,
@@ -146,7 +146,6 @@ display-field
     fill: var(--fgColor-muted)
     position: relative
     top: 1px
-    margin-right: 0.25rem
 
 .wp-table--cell-container
   &.duration,
@@ -162,6 +161,7 @@ display-field
     position: absolute
     left: 4px
     top: 6px
+    margin-right: 0
 
   .-placeholder
     // The special alignment of placeholders requires a special alignment of the icon


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/63352/activity

# What are you trying to accomplish?
Always have a margin next to the scheduling icon except for within the table

