### PR TITLE
hide internal comments for users without permission on atom export

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -226,6 +226,7 @@ class WorkPackagesController < ApplicationController
 
       work_package
         .journals
+        .restricted_visible
         .changing
         .includes(:user)
         .order(order).to_a

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -309,8 +309,44 @@ RSpec.describe WorkPackagesController do
     requires_permission_in_project do
       it "render the journal/index template" do
         call_action
-
         expect(response).to render_template("journals/index")
+      end
+    end
+
+    context "when there are internal comments", with_flag: { comments_with_restricted_visibility: true } do
+      render_views
+
+      let(:admin) { create(:admin) }
+      let(:project) do
+        create(:project, identifier: "test_project", public: false, enabled_comments_with_restricted_visibility: true)
+      end
+
+      before do
+        work_package = create(:work_package, id: 5173, project:)
+        create(:work_package_journal,
+               journable: work_package,
+               user: admin,
+               notes: "internal comment",
+               restricted: true,
+               version: 2)
+      end
+
+      context "and the user does not have permission to see such comments" do
+        it "does not include internal comments" do
+          get("show", params: { format: "atom", id: 5173 })
+          expect(response.body).not_to include("internal comment")
+        end
+      end
+
+      context "and the user has permission to see such comments" do
+        before do
+          login_as admin
+        end
+
+        it "includes internal comments" do
+          get("show", params: { format: "atom", id: 5173 })
+          expect(response.body).to include("internal comment")
+        end
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/63371

# What are you trying to accomplish?
Don't _atom export_ internal comments when the user requesting does not have access to it.

# What approach did you choose and why?
Just included the scope on the atom export

# Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
