### PR TITLE
[#63386] Use rescue_from ActiveRecord::RecordNotFound

### DIFF
--- a/app/controllers/admin/attachments/quarantined_attachments_controller.rb
+++ b/app/controllers/admin/attachments/quarantined_attachments_controller.rb
@@ -73,8 +73,6 @@ module Admin
 
       def find_attachment
         @attachment = @attachments.find(params[:id])
-      rescue ActiveRecord::RecordNotFound
-        render_404
       end
     end
   end

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -146,8 +146,6 @@ module Admin
         def find_model_object
           @object = CustomField.hierarchy_root_and_children.find(params[:custom_field_id])
           @custom_field = @object
-        rescue ActiveRecord::RecordNotFound
-          render_404
         end
 
         def find_active_item
@@ -156,8 +154,6 @@ module Admin
                          else
                            @object.hierarchy_root
                          end
-        rescue ActiveRecord::RecordNotFound
-          render_404
         end
       end
     end

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -212,8 +212,6 @@ module Admin::Settings
 
     def find_custom_field
       @custom_field = ProjectCustomField.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def drop_success_streams(call)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,6 +133,10 @@ class ApplicationController < ActionController::Base
                payload: ::OpenProject::Logging::ThreadPoolContextBuilder.build!
   end
 
+  rescue_from ActiveRecord::RecordNotFound do
+    render_404
+  end
+
   before_action :authorization_check_required,
                 :user_setup,
                 :set_localization,
@@ -240,16 +244,12 @@ class ApplicationController < ActionController::Base
   # Note: find() is Project.friendly.find()
   def find_project
     @project = Project.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   # Find project of id params[:project_id]
   # Note: find() is Project.friendly.find()
   def find_project_by_project_id
     @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   # Finds and sets @project based on @object.project
@@ -257,8 +257,6 @@ class ApplicationController < ActionController::Base
     render_404 if @object.blank?
 
     @project = @object.project
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_model_object(object_id = :id)
@@ -267,8 +265,6 @@ class ApplicationController < ActionController::Base
       @object = model.find(params[object_id])
       instance_variable_set(:"@#{controller_name.singularize}", @object) if @object
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_model_object_and_project(object_id = :id)
@@ -280,8 +276,6 @@ class ApplicationController < ActionController::Base
     else
       @project = Project.find(params[:project_id])
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   # TODO: this method is right now only suited for controllers of objects that somehow have an association to Project
@@ -295,8 +289,6 @@ class ApplicationController < ActionController::Base
     associated.each do |a|
       instance_variable_set("@" + a.class.to_s.downcase, a)
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   # this method finds all records that are specified in the associations param
@@ -337,8 +329,6 @@ class ApplicationController < ActionController::Base
 
     @projects = @work_packages.filter_map(&:project).uniq
     @project = @projects.first if @projects.size == 1
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def back_url

--- a/app/controllers/attribute_help_texts_controller.rb
+++ b/app/controllers/attribute_help_texts_controller.rb
@@ -109,8 +109,6 @@ class AttributeHelpTextsController < ApplicationController
 
   def find_entry
     @attribute_help_text = AttributeHelpText.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_type_scope

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -101,7 +101,5 @@ class CategoriesController < ApplicationController
 
   def find_project
     @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 end

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -76,8 +76,6 @@ module Accounts::Authorization
     @project = Project.find(params[:project_id]) if params[:project_id].present?
 
     do_authorize({ controller: controller_path, action: action_name }, global: params[:project_id].blank?)
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   # Deny access if user is not allowed to do the specified action.
@@ -214,8 +212,6 @@ module Accounts::Authorization
       before_action(**args) do
         @project = Project.find(params[:project_id]) if params[:project_id].present?
         do_authorize(permission, global: params[:project_id].blank?)
-      rescue ActiveRecord::RecordNotFound
-        render_404
       end
     end
   end

--- a/app/controllers/concerns/custom_fields/shared_actions.rb
+++ b/app/controllers/concerns/custom_fields/shared_actions.rb
@@ -125,8 +125,6 @@ module CustomFields
 
       def find_custom_option
         @custom_option = CustomOption.find params[:option_id]
-      rescue ActiveRecord::RecordNotFound
-        render_404
       end
 
       def delete_custom_values!(custom_option)

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -75,8 +75,6 @@ class CustomFieldsController < ApplicationController
 
   def find_custom_field
     @custom_field = CustomField.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def check_custom_field

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -125,8 +125,6 @@ class ForumsController < ApplicationController
 
   def find_forum
     @forum = @project.forums.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def new_forum

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -59,8 +59,6 @@ class JournalsController < ApplicationController
                          journals: @journals }
       end
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def diff
@@ -87,8 +85,6 @@ class JournalsController < ApplicationController
     @journal = Journal.find(params[:id])
     @journable = @journal.journable
     @project = @journable.project
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def ensure_permitted

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -118,13 +118,9 @@ class NewsController < ApplicationController
 
   def find_news_object
     @news = @object = News.find(params[:id].to_i)
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_project
     @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 end

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -115,8 +115,6 @@ module OAuth
 
     def find_app
       @application = ::Doorkeeper::Application.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
   end
 end

--- a/app/controllers/placeholder_users/memberships_controller.rb
+++ b/app/controllers/placeholder_users/memberships_controller.rb
@@ -35,8 +35,6 @@ class PlaceholderUsers::MembershipsController < ApplicationController
 
   def find_individual_principal
     @individual_principal = PlaceholderUser.find(params[:placeholder_user_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def redirected_to_tab(_membership)

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -146,8 +146,6 @@ class PlaceholderUsersController < ApplicationController
 
   def find_placeholder_user
     @placeholder_user = PlaceholderUser.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   protected

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -320,8 +320,6 @@ class RepositoriesController < ApplicationController
     end
   rescue OpenProject::SCM::Exceptions::SCMEmpty
     render "empty"
-  rescue ActiveRecord::RecordNotFound
-    render_404
   rescue InvalidRevisionParam
     show_error_not_found
   end

--- a/app/controllers/users/memberships_controller.rb
+++ b/app/controllers/users/memberships_controller.rb
@@ -35,8 +35,6 @@ class Users::MembershipsController < ApplicationController
 
   def find_individual_principal
     @individual_principal = User.find(params[:user_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def redirected_to_tab(membership)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -244,8 +244,6 @@ class UsersController < ApplicationController
     else
       @user = User.find(params[:id])
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def authorize_for_user

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -136,8 +136,6 @@ class VersionsController < ApplicationController
 
   def find_project
     @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def retrieve_selected_type_ids(selectable_types, default_types = nil)

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -367,8 +367,6 @@ class WikiController < ApplicationController
     @project = Project.find(params[:project_id])
     @wiki = @project.wiki
     render_404 unless @wiki
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   # Finds or created the wiki page associated

--- a/app/controllers/work_package_relations_tab_controller.rb
+++ b/app/controllers/work_package_relations_tab_controller.rb
@@ -51,7 +51,5 @@ class WorkPackageRelationsTabController < ApplicationController
   def set_work_package
     @work_package = WorkPackage.find(params[:work_package_id])
     @project = @work_package.project # required for authorization via before_action
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 end

--- a/app/helpers/work_packages_controller_helper.rb
+++ b/app/helpers/work_packages_controller_helper.rb
@@ -61,8 +61,6 @@ module WorkPackagesControllerHelper
       request.format = "html"
       render_400(message: @query.errors.full_messages.join(". "))
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def atom_list

--- a/lib/individual_principals/membership_controller_methods.rb
+++ b/lib/individual_principals/membership_controller_methods.rb
@@ -35,8 +35,6 @@ module IndividualPrincipals
 
     def find_membership
       @membership = Member.visible(current_user).find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def respond_with_service_call(call, message:)

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -180,8 +180,6 @@ module Saml
 
     def find_provider
       @provider = Saml::Provider.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def check_provider_writable

--- a/modules/avatars/app/controllers/avatars/users_controller.rb
+++ b/modules/avatars/app/controllers/avatars/users_controller.rb
@@ -17,8 +17,6 @@ module ::Avatars
 
     def find_user
       @user = User.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
   end
 end

--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -199,8 +199,6 @@ class BudgetsController < ApplicationController
     # This function comes directly from issues_controller.rb (Redmine 0.8.4)
     @budget = Budget.includes(:project, :author).find_by(id: params[:id])
     @project = @budget.project if @budget
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_budgets
@@ -216,14 +214,10 @@ class BudgetsController < ApplicationController
       # TODO: let users bulk edit/move/destroy budgets from different projects
       render_error "Can not bulk edit/move/destroy cost objects from different projects" and return false
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_optional_project
     @project = Project.find(params[:project_id]) if params[:project_id].present?
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def render_item_as_json(element_id, costs, unit, project, permission)

--- a/modules/calendar/app/controllers/calendar/calendars_controller.rb
+++ b/modules/calendar/app/controllers/calendar/calendars_controller.rb
@@ -106,8 +106,6 @@ module ::Calendar
       @view = Query
                 .visible(current_user)
                 .find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
   end
 end

--- a/modules/calendar/app/controllers/calendar/ical_controller.rb
+++ b/modules/calendar/app/controllers/calendar/ical_controller.rb
@@ -33,15 +33,10 @@ module ::Calendar
     no_authorization_required! :show
 
     def show
-      begin
-        call = ::Calendar::ICalResponseService.new.call(
-          ical_token_string: params[:ical_token],
-          query_id: params[:id]
-        )
-      rescue ActiveRecord::RecordNotFound
-        render_404
-        return
-      end
+      call = ::Calendar::ICalResponseService.new.call(
+        ical_token_string: params[:ical_token],
+        query_id: params[:id]
+      )
 
       if call.present? && call.success?
         send_data call.result, filename: "openproject_calendar_#{DateTime.now.to_i}.ics"

--- a/modules/costs/app/controllers/admin/cost_types_controller.rb
+++ b/modules/costs/app/controllers/admin/cost_types_controller.rb
@@ -151,8 +151,6 @@ module Admin
 
     def find_cost_type
       @cost_type = CostType.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def show_local_breadcrumb

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -110,8 +110,6 @@ class CostlogController < ApplicationController
       render_404
       false
     end
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_associated_objects

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -172,19 +172,13 @@ class HourlyRatesController < ApplicationController
 
   def find_project
     @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_optional_project
     @project = params[:project_id].blank? ? nil : Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_user
     @user = params[:id] ? User.find(params[:id]) : User.current
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 end

--- a/modules/ldap_groups/app/controllers/ldap_groups/synchronized_filters_controller.rb
+++ b/modules/ldap_groups/app/controllers/ldap_groups/synchronized_filters_controller.rb
@@ -73,8 +73,6 @@ module LdapGroups
 
     def find_filter
       @filter = SynchronizedFilter.find(params[:ldap_filter_id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def check_ee

--- a/modules/ldap_groups/app/controllers/ldap_groups/synchronized_groups_controller.rb
+++ b/modules/ldap_groups/app/controllers/ldap_groups/synchronized_groups_controller.rb
@@ -52,8 +52,6 @@ module LdapGroups
 
     def find_group
       @group = SynchronizedGroup.find(params[:ldap_group_id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def check_ee

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -439,8 +439,6 @@ class MeetingsController < ApplicationController
     @meeting = Meeting
       .includes([:project, :author, { participants: :user }, :sections, { agenda_items: :outcomes }])
       .find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def convert_params # rubocop:disable Metrics/AbcSize
@@ -516,8 +514,6 @@ class MeetingsController < ApplicationController
     return unless copied_from_meeting_id
 
     @copy_from = Meeting.visible.find(copied_from_meeting_id)
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def copy_attributes

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -310,14 +310,10 @@ class RecurringMeetingsController < ApplicationController
 
   def find_optional_project
     @project = Project.find(params[:project_id]) if params[:project_id].present?
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def find_meeting
     @recurring_meeting = RecurringMeeting.visible.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def convert_params
@@ -341,8 +337,6 @@ class RecurringMeetingsController < ApplicationController
     return unless copied_from_meeting_id
 
     @copy_from = Meeting.visible.find(copied_from_meeting_id)
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def structured_meeting_params

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -101,8 +101,6 @@ class WorkPackageMeetingsTabController < ApplicationController
   def set_work_package
     @work_package = WorkPackage.find(params[:work_package_id])
     @project = @work_package.project # required for authorization via before_action
-  rescue ActiveRecord::RecordNotFound
-    render_404
   end
 
   def add_work_package_to_meeting_params

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -128,8 +128,6 @@ module OpenIDConnect
 
     def find_provider
       @provider = OpenIDConnect::Provider.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def default_breadcrumb; end

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -82,8 +82,6 @@ module ::TeamPlanner
       @view = Query
         .visible(current_user)
         .find(params[:id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def visible_plans(project = nil)

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -99,6 +99,8 @@ module ::TwoFactorAuthentication
     # Get the used device for verification
     def otp_service_for_verification(user)
       otp_service(user, use_device: remembered_device(user))
+    rescue ActiveRecord::RecordNotFound
+      render_404
       false
     end
 
@@ -118,6 +120,8 @@ module ::TwoFactorAuthentication
         end
 
       otp_service(@authenticated_user, use_channel: channel, use_device: device)
+    rescue ActiveRecord::RecordNotFound
+      render_404
       false
     end
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -99,8 +99,6 @@ module ::TwoFactorAuthentication
     # Get the used device for verification
     def otp_service_for_verification(user)
       otp_service(user, use_device: remembered_device(user))
-    rescue ActiveRecord::RecordNotFound
-      render_404
       false
     end
 
@@ -120,8 +118,6 @@ module ::TwoFactorAuthentication
         end
 
       otp_service(@authenticated_user, use_channel: channel, use_device: device)
-    rescue ActiveRecord::RecordNotFound
-      render_404
       false
     end
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
@@ -229,8 +229,6 @@ module ::TwoFactorAuthentication
 
     def find_device
       @device = target_user.otp_devices.find(params[:device_id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def find_user

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
@@ -105,8 +105,6 @@ module ::TwoFactorAuthentication
 
       def find_user
         @user = User.find(params[:id])
-      rescue ActiveRecord::RecordNotFound
-        render_404
       end
 
       def target_user

--- a/modules/webhooks/app/controllers/webhooks/outgoing/admin_controller.rb
+++ b/modules/webhooks/app/controllers/webhooks/outgoing/admin_controller.rb
@@ -58,8 +58,6 @@ module Webhooks
 
       def find_webhook
         @webhook = webhook_class.find(params[:webhook_id])
-      rescue ActiveRecord::RecordNotFound
-        render_404
       end
 
       def webhook_class

--- a/spec/controllers/shares_controller_spec.rb
+++ b/spec/controllers/shares_controller_spec.rb
@@ -57,8 +57,9 @@ RSpec.describe SharesController do
           mock_permissions_for(user, &:forbid_everything)
         end
 
-        it "raises a RecordNotFound error" do
-          expect { make_request }.to raise_error(ActiveRecord::RecordNotFound)
+        it "returns a 404 status" do
+          make_request
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -87,8 +88,9 @@ RSpec.describe SharesController do
           mock_permissions_for(user, &:forbid_everything)
         end
 
-        it "raises a RecordNotFound error" do
-          expect { make_request }.to raise_error(ActiveRecord::RecordNotFound)
+        it "returns a 404 status" do
+          make_request
+          expect(response).to have_http_status(:not_found)
         end
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/63386

# What are you trying to accomplish?
Remove duplicate `rescue ActiveRecord::RecordNotFound` declarations from the controllers.

# What approach did you choose and why?
Use a `rescue_from ActiveRecord::RecordNotFound` in the `ApplicationController` instead
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
