### PR TITLE
add secret_key_base for assets:precompile on packager

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -52,3 +52,4 @@ buildpack: https://github.com/opf/heroku-buildpack-multi.git#master
 env:
   - NODE_ENV=production
   - NPM_CONFIG_PRODUCTION=false
+  - SECRET_KEY_BASE=1


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Fix assets:precompile on packager

e.g. https://packager.io/gh/opf/openproject/builds/13719/logs/ubuntu-22.04
