### PR TITLE
[62525] Non-working days can be choosen via date field

### DIFF
--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -270,17 +270,7 @@ class WorkPackages::DatePickerController < ApplicationController
                               contract_class: WorkPackages::CreateContract)
                          .call(wp_params)
 
-      fields_set_to_nwd = fields_set_to_non_working_day(wp_params)
-      fields_set_to_nwd.each do |field|
-        @work_package
-          .errors
-          .add(field,
-               I18n.t("activerecord.errors.models.work_package.attributes.#{field}.cannot_be_non_working"))
-
-        # The SetAttributesService will correct the field and set it to the next working day.
-        # We have to keep the params in sync
-        params[:work_package][field] = @work_package[field].to_s
-      end
+      handle_non_working_days_case wp_params
 
       service_result
     end
@@ -343,6 +333,20 @@ class WorkPackages::DatePickerController < ApplicationController
     wp_params["start_date"] = work_package.start_date.to_s
 
     wp_params
+  end
+
+  def handle_non_working_days_case(wp_params)
+    fields_set_to_nwd = fields_set_to_non_working_day(wp_params)
+    fields_set_to_nwd.each do |field|
+      @work_package
+        .errors
+        .add(field,
+             I18n.t("activerecord.errors.models.work_package.attributes.#{field}.cannot_be_non_working"))
+
+      # The SetAttributesService will correct the field and set it to the next working day.
+      # We have to keep the params in sync
+      params[:work_package][field] = @work_package[field].to_s
+    end
   end
 
   def fields_set_to_non_working_day(wp_params)

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -350,13 +350,9 @@ class WorkPackages::DatePickerController < ApplicationController
   end
 
   def fields_set_to_non_working_day(wp_params)
-    result = []
-
-    %i[start_date due_date].each do |field|
-      result << field if wp_params[field].present? && set_to_a_non_working_day?(field)
+    %i[start_date due_date].filter do |field|
+      wp_params[field].present? && set_to_a_non_working_day?(field)
     end
-
-    result
   end
 
   def set_to_a_non_working_day?(field)

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -276,6 +276,10 @@ class WorkPackages::DatePickerController < ApplicationController
           .errors
           .add(field,
                I18n.t("activerecord.errors.models.work_package.attributes.#{field}.cannot_be_non_working"))
+
+        # The SetAttributesService will correct the field and set it to the next working day.
+        # We have to keep the params in sync
+        params[:work_package][field] = @work_package[field].to_s
       end
 
       service_result

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1466,7 +1466,7 @@ en:
             due_date:
               not_start_date: "is not on start date, although this is required for milestones."
               cannot_be_null: "can not be set to null as start date and duration are known."
-              cannot_be_non_working: "Finish date can not be set to a non working day."
+              cannot_be_non_working: "can not be set to a non working day."
             duration:
               larger_than_dates: "is larger than the interval between the start and the finish date."
               smaller_than_dates: "is smaller than the interval between the start and the finish date."
@@ -1481,7 +1481,7 @@ en:
             start_date:
               violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
               cannot_be_null: "can not be set to null as finish date and duration are known."
-              cannot_be_non_working: "Start date can not be set to a non working day."
+              cannot_be_non_working: "can not be set to a non working day."
             status_id:
               status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
               status_invalid_in_type: "is invalid because the current status does not exist in this type."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1466,6 +1466,7 @@ en:
             due_date:
               not_start_date: "is not on start date, although this is required for milestones."
               cannot_be_null: "can not be set to null as start date and duration are known."
+              cannot_be_non_working: "Finish date can not be set to a non working day."
             duration:
               larger_than_dates: "is larger than the interval between the start and the finish date."
               smaller_than_dates: "is smaller than the interval between the start and the finish date."
@@ -1480,6 +1481,7 @@ en:
             start_date:
               violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
               cannot_be_null: "can not be set to null as finish date and duration are known."
+              cannot_be_non_working: "Start date can not be set to a non working day."
             status_id:
               status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
               status_invalid_in_type: "is invalid because the current status does not exist in this type."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1159,7 +1159,7 @@ en:
         duration: "Duration"
         end_insertion: "End of the insertion"
         end_deletion: "End of the deletion"
-        ignore_non_working_days: "Ignore non working days"
+        ignore_non_working_days: "Ignore non-working days"
         include_non_working_days:
           title: "Working days"
           false: "working days only"
@@ -1466,7 +1466,7 @@ en:
             due_date:
               not_start_date: "is not on start date, although this is required for milestones."
               cannot_be_null: "can not be set to null as start date and duration are known."
-              cannot_be_non_working: "can not be set to a non working day."
+              cannot_be_non_working: "can not be set to a non-working day."
             duration:
               larger_than_dates: "is larger than the interval between the start and the finish date."
               smaller_than_dates: "is smaller than the interval between the start and the finish date."
@@ -1481,7 +1481,7 @@ en:
             start_date:
               violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
               cannot_be_null: "can not be set to null as finish date and duration are known."
-              cannot_be_non_working: "can not be set to a non working day."
+              cannot_be_non_working: "can not be set to a non-working day."
             status_id:
               status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
               status_invalid_in_type: "is invalid because the current status does not exist in this type."

--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
       # Set the start date to a non working day
       datepicker.set_start_date non_working_day_this_week.date
       datepicker.expect_start_date_error(
-        I18n.t("activerecord.errors.models.work_package.attributes.start_date.cannot_be_non_working")
+        I18n.t("activerecord.errors.models.work_package.attributes.start_date.cannot_be_non_working").capitalize
       )
 
       # Set the start date to a working day again
@@ -122,7 +122,7 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
       # Set the due date to a non working day
       datepicker.set_due_date non_working_day_this_week.date
       datepicker.expect_due_date_error(
-        I18n.t("activerecord.errors.models.work_package.attributes.due_date.cannot_be_non_working")
+        I18n.t("activerecord.errors.models.work_package.attributes.due_date.cannot_be_non_working").capitalize
       )
 
       # Set the due date to a working day again

--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -89,4 +89,45 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
 
     it_behaves_like "shows individual non working days"
   end
+
+  context "when manually entering a date which is a non working day (regression #62525)" do
+    let(:work_package) { bug_wp }
+    let(:date_field) { work_packages_page.edit_field(:combinedDate) }
+    let(:datepicker) { date_field.datepicker }
+    let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
+
+    it "shows an error message" do
+      login_as user
+
+      work_packages_page.visit!
+      work_packages_page.ensure_page_loaded
+
+      date_field.activate!
+      date_field.expect_active!
+      # Wait for the datepicker to be initialized
+      datepicker.expect_visible
+
+      datepicker.enable_start_date
+
+      # Set the start date to a non working day
+      datepicker.set_start_date non_working_day_this_week.date
+      datepicker.expect_start_date_error(
+        I18n.t("activerecord.errors.models.work_package.attributes.start_date.cannot_be_non_working")
+      )
+
+      # Set the start date to a working day again
+      datepicker.set_start_date Time.zone.today
+      datepicker.expect_start_date_error nil
+
+      # Set the due date to a non working day
+      datepicker.set_due_date non_working_day_this_week.date
+      datepicker.expect_due_date_error(
+        I18n.t("activerecord.errors.models.work_package.attributes.due_date.cannot_be_non_working")
+      )
+
+      # Set the due date to a working day again
+      datepicker.set_due_date Time.zone.today
+      datepicker.expect_due_date_error nil
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62525/activity

# What are you trying to accomplish?
Show an error message when the user manually enters a non-working day

## Screenshots
<img width="400" alt="Bildschirmfoto 2025-04-14 um 10 41 22" src="https://github.com/user-attachments/assets/4dbcabbe-d3f9-4d13-8e69-66cc424304ef" />

# What approach did you choose and why?

The `SetAttributesService` silently shifts dates to the next possible date if a non-working day is entered. This makes absolutely sense for the Gantt view but in the datepicker we want some kind of feedback and prevent that shift. 



