### PR TITLE
[63296] Fix date error when creating parent-child relationship

### DIFF
--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -58,7 +60,13 @@ module WorkPackage::SchedulingRules
   #   C is 2017/07/28 (CP due date: 25, 26 and 27 is the 2 days lag => 28)
   #
   # The soonest start for this work package is the maximum of these values: 2017/07/28.
-  def soonest_start
+  #
+  # @param working_days_from [WorkPackage, nil] the work package for which to
+  #   find the next working day after the soonest start given by the scheduling
+  #   relations. If nil, the work package itself is used. Useful for a work
+  #   package calculating the soonest start given by its parent as it may have a
+  #   different `ignore_working_days` value than its parent.
+  def soonest_start(working_days_from: nil)
     @scheduling_relations_soonest_start ||=
       Relation
         .used_for_scheduling_of(self)
@@ -69,7 +77,7 @@ module WorkPackage::SchedulingRules
     # The final result should not be cached as it depends on
     # ignore_non_working_days value, which can change between consecutive calls
     # to #soonest_start
-    WorkPackages::Shared::Days.for(self)
-                              .soonest_working_day(@scheduling_relations_soonest_start)
+    days = WorkPackages::Shared::Days.for(working_days_from || self)
+    days.soonest_working_day(@scheduling_relations_soonest_start)
   end
 end

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -398,7 +398,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
       days.soonest_working_day(new_start_date_from_parent)
     else
-      min_start = new_start_date_from_parent || work_package.soonest_start
+      min_start = [new_start_date_from_parent, work_package.soonest_start].compact.max
       days.soonest_working_day(min_start)
     end
   end
@@ -409,7 +409,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     return unless work_package.parent_id_changed? &&
                   work_package.parent
 
-    work_package.parent.soonest_start
+    work_package.parent.soonest_start(working_days_from: work_package)
   end
 
   def new_due_date(min_start)

--- a/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
+++ b/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe "Manual scheduling", :js do
     query.save!
     query
   end
+  let(:start_date_field) { wp_table.edit_field(parent, :startDate) }
+  let(:due_date_field) { wp_table.edit_field(parent, :dueDate) }
+  let(:datepicker) { start_date_field.datepicker }
 
   before do
     login_as(user)
@@ -46,74 +49,64 @@ RSpec.describe "Manual scheduling", :js do
     let(:role) { create(:project_role, permissions: %i[view_work_packages edit_work_packages]) }
 
     it "allows to edit start and due date multiple times switching between scheduling modes" do
-      start_date = wp_table.edit_field(parent, :startDate)
-      due_date = wp_table.edit_field(parent, :dueDate)
-
       # Open start date
-      start_date.activate!
-      start_date.expect_active!
+      start_date_field.activate!
+      datepicker.expect_visible
 
-      # Expect not to be scheduled manually
-      start_date.expect_automatic_scheduling_mode
+      # Expect automatic scheduling
+      datepicker.expect_automatic_scheduling_mode
 
       # Expect not editable
-      start_date.within_modal do
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--start-date-field')}[disabled]")
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--due-date-field')}[disabled]")
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: "Cancel")
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: "Save")
-      end
+      datepicker.expect_start_date "", disabled: true
+      datepicker.expect_due_date "", disabled: true
+      datepicker.expect_cancel_button_enabled
+      datepicker.expect_save_button_enabled
 
-      start_date.toggle_scheduling_mode
+      # Toggle to manual scheduling mode
+      datepicker.toggle_scheduling_mode
 
-      # Expect editable
-      start_date.within_modal do
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--start-date-field')}:not([disabled])", visible: :hidden)
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--due-date-field')}:not([disabled])")
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: "Cancel")
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: "Save")
-      end
+      # Expect editable in single mode with due date field visible
+      datepicker.expect_add_start_date_button_visible
+      datepicker.expect_due_date ""
+      datepicker.expect_cancel_button_enabled
+      datepicker.expect_save_button_enabled
 
-      start_date.cancel_by_click
+      # Close date picker by clicking on the Cancel button
+      datepicker.cancel!
 
       # Both are closed
-      start_date.expect_inactive!
-      due_date.expect_inactive!
+      start_date_field.expect_inactive!
+      due_date_field.expect_inactive!
 
       # Open second date, closes first
-      due_date.activate!
-      due_date.expect_active!
+      due_date_field.activate!
+      datepicker.expect_visible
 
-      # Close with escape
-      due_date.cancel_by_click
+      # Close date picker by clicking on the Cancel button
+      datepicker.cancel!
 
-      start_date.activate!
-      start_date.expect_automatic_scheduling_mode
-
-      # Expect not editable
-      start_date.within_modal do
-        expect(page).to have_css('input[name="work_package[start_date]"][disabled]')
-        expect(page).to have_css('input[name="work_package[due_date]"][disabled]')
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: "Cancel")
-        expect(page).to have_css("#{test_selector('op-datepicker-modal--action')}:not([disabled])", text: "Save")
-      end
-
-      start_date.toggle_scheduling_mode
-      start_date.expect_calendar
+      # Open datepicker again
+      start_date_field.activate!
+      datepicker.expect_automatic_scheduling_mode
 
       # Expect not editable
-      start_date.within_modal do
-        page.find_test_selector("wp-datepicker--show-start-date").click
-        fill_in "work_package[start_date]", with: "2020-07-20"
-        fill_in "work_package[due_date]", with: "2020-07-25"
-      end
+      datepicker.expect_start_date "", disabled: true
+      datepicker.expect_due_date "", disabled: true
+      datepicker.expect_cancel_button_enabled
+      datepicker.expect_save_button_enabled
 
-      # Wait for the debounce to be done
-      sleep 1
+      # Toggle to manual scheduling mode
+      datepicker.toggle_scheduling_mode
 
-      start_date.save!
-      start_date.expect_state_text "07/20/2020"
-      due_date.expect_state_text "07/25/2020"
+      # Enable start date then set dates
+      datepicker.expect_add_start_date_button_visible
+      datepicker.enable_start_date
+      datepicker.set_start_date "2020-07-20"
+      datepicker.set_due_date "2020-07-25"
+      datepicker.save!
+
+      start_date_field.expect_state_text "07/20/2020"
+      due_date_field.expect_state_text "07/25/2020"
 
       parent.reload
       expect(parent).to be_schedule_manually

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -123,8 +123,16 @@ module Components
       container.click_button cancel_button_label
     end
 
+    def expect_save_button_enabled
+      expect(container).to have_button(save_button_label, disabled: false)
+    end
+
     def expect_save_button_disabled
       expect(container).to have_button(save_button_label, disabled: true)
+    end
+
+    def expect_cancel_button_enabled
+      expect(container).to have_button(cancel_button_label, disabled: false)
     end
 
     ##

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -101,6 +101,10 @@ module Components
       end
     end
 
+    def expect_add_start_date_button_visible
+      expect(container).to have_link("Start date")
+    end
+
     def enable_due_date
       retry_block do
         page.find_test_selector("wp-datepicker--show-due-date").click
@@ -236,7 +240,7 @@ module Components
     def input_aria_related_element(input_element, describedby:)
       input_element["aria-describedby"]
         .split
-        .find { _1.start_with?("#{describedby}-") }
+        .find { it.start_with?("#{describedby}-") }
         &.then { |id| find(id:, visible: :all) }
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63296

> [!WARNING]  
> This PR is based on PR #18594 which should be reviewed and merged first.

# What are you trying to accomplish?

A work package being a child of another package needs to consider both its own soonest start and its new parent soonest start, and take the max of both. Old parent soonest start is not relevant.

Before it was considering only the dates of its new parent to calculate the new start date, and that could lead to a "Start date can only be set to yyyy-mm-dd or later so as not to violate the work package's relationships." error if the soonest date of the parent was violating constraints of the child.

## Screenshots

See linked ticket.

# What approach did you choose and why?

Take max of parent and child soonest start

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
