### PR TITLE
[62992] Show single date work packages in the calendar

### DIFF
--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -400,11 +400,11 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       const startDate = this.workPackagesCalendar.eventDate(workPackage, 'start');
       const endDate = this.workPackagesCalendar.eventDate(workPackage, 'due');
 
-      const exclusiveEnd = moment(endDate).add(1, 'days').format('YYYY-MM-DD');
+      const exclusiveEnd = endDate && moment(endDate).add(1, 'days').format('YYYY-MM-DD');
 
       return {
         title: workPackage.subject,
-        start: startDate,
+        start: startDate || endDate,
         editable: this.workPackagesCalendar.dateEditable(workPackage),
         durationEditable: this.workPackagesCalendar.eventDurationEditable(workPackage),
         end: exclusiveEnd,

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -401,10 +401,14 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       const endDate = this.workPackagesCalendar.eventDate(workPackage, 'due');
 
       const exclusiveEnd = endDate && moment(endDate).add(1, 'days').format('YYYY-MM-DD');
+      // An event is visible on the calendar only if it has a start date.
+      // That's why the end date is used as event start date if the work package
+      // does not have a proper start date.
+      const visibleStart = startDate || endDate;
 
       return {
         title: workPackage.subject,
-        start: startDate || endDate,
+        start: visibleStart,
         editable: this.workPackagesCalendar.dateEditable(workPackage),
         durationEditable: this.workPackagesCalendar.eventDurationEditable(workPackage),
         end: exclusiveEnd,

--- a/modules/calendar/spec/features/calendars_spec.rb
+++ b/modules/calendar/spec/features/calendars_spec.rb
@@ -29,33 +29,33 @@
 require "spec_helper"
 
 RSpec.describe "Work package calendars", :js do
-  let(:project) { create(:project) }
-  let(:user) do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) do
     create(:user,
            member_with_permissions: { project => %i[view_work_packages view_calendar manage_calendars] })
   end
-  let!(:current_work_package) do
+  shared_let(:current_work_package) do
     create(:work_package,
            subject: "Current work package",
            project:,
            start_date: Time.zone.today.at_beginning_of_month + 15.days,
            due_date: Time.zone.today.at_beginning_of_month + 15.days)
   end
-  let!(:another_current_work_package) do
+  shared_let(:another_current_work_package) do
     create(:work_package,
            subject: "Another current work package",
            project:,
            start_date: Time.zone.today.at_beginning_of_month + 12.days,
            due_date: Time.zone.today.at_beginning_of_month + 18.days)
   end
-  let!(:future_work_package) do
+  shared_let(:future_work_package) do
     create(:work_package,
            subject: "Future work package",
            project:,
            start_date: Time.zone.today.at_beginning_of_month.next_month + 15.days,
            due_date: Time.zone.today.at_beginning_of_month.next_month + 15.days)
   end
-  let!(:another_future_work_package) do
+  shared_let(:another_future_work_package) do
     create(:work_package,
            subject: "Another future work package",
            project:,
@@ -199,5 +199,48 @@ RSpec.describe "Work package calendars", :js do
     expect(page)
       .to have_css ".fc-event-title", text: current_work_package.subject, wait: 20
     current_wp_split_screen.expect_closed
+  end
+
+  context "when work packages have only one date set (start or due date)" do
+    shared_let(:wp_start_date_only) do
+      create(:work_package,
+             subject: "Start date only",
+             project:,
+             start_date: Time.zone.today.at_beginning_of_month + 8.days)
+    end
+    shared_let(:wp_due_date_only) do
+      create(:work_package,
+             subject: "Due date only",
+             project:,
+             due_date: Time.zone.today.at_beginning_of_month + 8.days)
+    end
+    shared_let(:wp_no_dates) do
+      create(:work_package,
+             subject: "No dates at all",
+             project:)
+    end
+
+    it "shows the event on the calendar" do
+      visit project_path(project)
+
+      within "#main-menu" do
+        click_link "Calendars"
+      end
+
+      # Expect empty index
+      expect(page).to have_text "There is currently nothing to display."
+
+      # Open a new calendar from there
+      find('[data-test-selector="add-calendar-button"]', text: "Calendar").click
+
+      loading_indicator_saveguard
+
+      expect(page)
+        .to have_css ".fc-event-title", text: wp_start_date_only.subject
+      expect(page)
+        .to have_css ".fc-event-title", text: wp_due_date_only.subject
+      expect(page)
+        .to have_no_css ".fc-event-title", text: wp_no_dates.subject
+    end
   end
 end

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -350,11 +350,12 @@ module Components
       end
 
       def remove_child(work_package)
-        child_wp_row = find_row(work_package)
-
-        within(child_wp_row) do
-          relatable_action_menu(work_package).click
-          relatable_delete_button(work_package).click
+        retry_block do
+          child_wp_row = find_row(work_package)
+          within(child_wp_row) do
+            relatable_action_menu(work_package).click
+            relatable_delete_button(work_package).click
+          end
         end
 
         expect_no_row(work_package)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62992

# What are you trying to accomplish?

In calendar module, show work packages even if they only have 1 date set.

# What approach did you choose and why?

For work package with end date only: use end date as start date if start date is absent.
For work package with start date only: they were already visible so nothing particular.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
