### PR TITLE
Limit angular dependabot updates to the current major version.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       fullcalendar:
         patterns:
           - '@fullcalendar*'
+    ignore:
+      dependency-name: "@angular*"
+      update-types: ["version-update:semver-major"]
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Dependabot tries to update angular to 19, however that is a major version change and it would require significant effort to do so. The solution for now is to limit angular to version 17.

# What approach did you choose and why?
Limit the dependabot config to angular 17.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
