### PR TITLE
[63014] The "Create meeting" drop down in the Meetings subheader is too wide

### DIFF
--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -13,7 +13,7 @@
 
       if render_create_button?
         subheader.with_action_component do
-          render Primer::Alpha::ActionMenu.new(anchor_align: :end, size: :medium) do |menu|
+          render Primer::Alpha::ActionMenu.new(anchor_align: :end, size: :small) do |menu|
             menu.with_show_button(
               scheme: :primary,
               test_selector: "add-meeting-button",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/63014/activity#comment-1044830

# What are you trying to accomplish?
Use smaller variant for meetings create dropdown

## Screenshots
<img width="376" alt="Bildschirmfoto 2025-04-14 um 10 51 11" src="https://github.com/user-attachments/assets/f127a762-d125-4f15-9881-debe914522d2" />
