### PR TITLE
[#62293] PDF export does not export all embedded screenshots

### DIFF
--- a/app/models/work_package/pdf_export/common/attachments.rb
+++ b/app/models/work_package/pdf_export/common/attachments.rb
@@ -71,9 +71,11 @@ module WorkPackage::PDFExport::Common::Attachments
   end
 
   def attachment_by_api_content_src(_work_package, src)
-    # /attachments/#{id}/content
-    parts = src.split("/")
-    attachments_id = parts[-2]
+    attachment_regex = %r{/attachments/(\d+)/content}
+    return nil unless src&.match?(attachment_regex)
+
+    attachments_id = src.scan(attachment_regex).first.first
+
     # return nil if the src is not an attachment url
     return nil unless api_url_helpers.attachment_content(attachments_id) == src
 

--- a/app/models/work_package/pdf_export/common/attachments.rb
+++ b/app/models/work_package/pdf_export/common/attachments.rb
@@ -70,8 +70,21 @@ module WorkPackage::PDFExport::Common::Attachments
     resize_image(local_file.path)
   end
 
-  def attachment_by_api_content_src(work_package, src)
-    # find attachment by api-path
-    work_package.attachments.find { |a| api_url_helpers.attachment_content(a.id) == src }
+  def attachment_by_api_content_src(_work_package, src)
+    # /attachments/#{id}/content
+    parts = src.split("/")
+    attachments_id = parts[-2]
+    # return nil if the src is not an attachment url
+    return nil unless api_url_helpers.attachment_content(attachments_id) == src
+
+    attachment = Attachment.find_by(id: attachments_id.to_i)
+    return nil if attachment.nil?
+    return nil unless attachment.visible?
+
+    attachment
+  rescue StandardError
+    # if the attachment is not found or the id is invalid, we return nil
+    Rails.logger.error "Failed to access attachment #{src}"
+    nil
   end
 end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
         # simulate a null pointer exception
         # https://appsignal.com/openproject-gmbh/sites/62a6d833d2a5e482c1ef825d/exceptions/incidents/2326/samples/62a6d833d2a5e482c1ef825d-848752493603098719217252846401
         # where attachment data is in the database but the file is missing, corrupted or not accessible
-        allow_any_instance_of(Attachment).to receive(:file).and_return(nil)
+        allow_any_instance_of(Attachment).to receive(:file).and_return(nil) # rubocop:disable RSpec/AnyInstance
       end
 
       it "still finishes the export" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/62293

# What are you trying to achieve?

If an image attachment link in a description (wp A) is copied from another work package (wp B) description, the image file is not copied with it. The PDF export searches in the work package (wp A) but does not find it, the web app does, as it requests just the image src, regardless of the work package origin. PDF export should do the same.

# What approach did you choose and why?
Get the attachment id from the src and request the attachment directly instead of iterating through the attachments of the work package. An additional check is needed if the exporting user is allowed to see the attachment.

# Merge checklist

- [x] Added/updated tests
