### PR TITLE
[62823] NoMethodError in WorkPackages::DatePickerController#show 

### DIFF
--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -236,6 +236,8 @@ class WorkPackages::DatePickerController < ApplicationController
             .slice(*allowed_touched_params)
             .merge(schedule_manually:, date_mode:, triggering_field: params[:triggering_field])
             .permit!
+    else
+      {}
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62823/activity

# What are you trying to accomplish?
Sometimes the daepicker_controler throws a `undefined method '[]' for nil` error. Since we did not manage to reproduce the issue itself, this is a cheap "fix" by preventing that `nil` case

