### PR TITLE
Adjust label when moderating other user's comments

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -128,12 +128,20 @@ module WorkPackages
         end
 
         def edit_action_item(menu)
-          menu.with_item(label: t("js.label_edit_comment"),
+          menu.with_item(label: edit_action_label,
                          href: edit_work_package_activity_path(journal.journable, journal, filter:),
                          content_arguments: {
                            data: { turbo_stream: true, test_selector: "op-wp-journal-#{journal.id}-edit" }
                          }) do |item|
             item.with_leading_visual_icon(icon: :pencil)
+          end
+        end
+
+        def edit_action_label
+          if journal.user == User.current
+            t("js.label_edit_comment")
+          else
+            t("js.label_moderate_comment")
           end
         end
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -515,6 +515,7 @@ en:
     label_menu_collapse: "collapse"
     label_menu_expand: "expand"
     label_more_than_ago: "more than days ago"
+    label_moderate_comment: "Moderate comment"
     label_next: "Next"
     label_no_color: "No color"
     label_no_data: "No data to display"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/58511/activity

# What are you trying to accomplish?
Make label more informative for when moderating comments

## Screenshots
![image](https://github.com/user-attachments/assets/1b874b1c-bde1-4c97-ad36-d01d072de482)
