### PR TITLE
[60904] Advanced accessibility for the datepicker

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -18,7 +18,7 @@
         end
 
         start_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label), aria: { live: :polite, atomic: true }))
+          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label)))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
           render_today_link(name: :start_date)
@@ -45,7 +45,7 @@
           end
 
           due_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date")), aria: { live: :polite, atomic: true }))
+            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date"))))
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
             render_today_link(name: :due_date)
@@ -54,7 +54,7 @@
       end
 
       body.with_column(classes: "wp-datepicker-dialog-date-form--duration") do
-        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration")), aria: { live: :polite, atomic: true }))
+        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration"))))
       end
     end
   end

--- a/app/components/work_packages/date_picker/date_form_component.html.erb
+++ b/app/components/work_packages/date_picker/date_form_component.html.erb
@@ -18,7 +18,7 @@
         end
 
         start_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label), aria: { live: :polite }))
+          render(Primer::Alpha::TextField.new(**text_field_options(name: :start_date, label: start_date_label), aria: { live: :polite, atomic: true }))
         end
         start_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
           render_today_link(name: :start_date)
@@ -45,7 +45,7 @@
           end
 
           due_date.with_row(classes: "wp-datepicker-dialog-date-form--text-field-container") do
-            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date")), aria: { live: :polite }))
+            render(Primer::Alpha::TextField.new(**text_field_options(name: :due_date, label: I18n.t("attributes.due_date")), aria: { live: :polite, atomic: true }))
           end
           due_date.with_row(classes: "wp-datepicker-dialog-set-today-link") do
             render_today_link(name: :due_date)
@@ -54,7 +54,7 @@
       end
 
       body.with_column(classes: "wp-datepicker-dialog-date-form--duration") do
-        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration")), aria: { live: :polite }))
+        render(Primer::Alpha::TextField.new(**text_field_options(name: :duration, label: WorkPackage.human_attribute_name("duration")), aria: { live: :polite, atomic: true }))
       end
     end
   end

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -81,7 +81,8 @@ module WorkPackages
           classes: "op-datepicker-modal--date-field #{'op-datepicker-modal--date-field_current' if @focused_field == name}",
           validation_message: validation_message(name),
           type: field_type(name),
-          placeholder: placeholder(name)
+          placeholder: placeholder(name),
+          aria: { live: :polite, atomic: true }
         )
 
         if duration_field?(name)

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -81,8 +81,7 @@ module WorkPackages
           classes: "op-datepicker-modal--date-field #{'op-datepicker-modal--date-field_current' if @focused_field == name}",
           validation_message: validation_message(name),
           type: field_type(name),
-          placeholder: placeholder(name),
-          aria: { live: :polite, atomic: true }
+          placeholder: placeholder(name)
         )
 
         if duration_field?(name)
@@ -212,7 +211,10 @@ module WorkPackages
           data[:focus] = "true"
         end
 
-        { data: }
+        {
+          data: data,
+          aria: { live: :polite, atomic: true }
+        }
       end
 
       def single_date_field_button_link(focused_field)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60904

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add aria-atomic=true on inputs to tell assistive technologies to announce the entire contents of a live region when any part of it changes — not just the changed portion

