### PR TITLE
Increase wait time for custom action title assertion

### DIFF
--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
     within(".custom-actions") do
       # When hovering over the button, the description is displayed
       expect(page)
-        .to have_button("Unassign", title: "Removes the assignee")
+        .to have_button("Unassign", title: "Removes the assignee", wait: 10)
     end
 
     wp_page.click_custom_action("Unassign")


### PR DESCRIPTION
There seems to be a delay in when the title is updated to the custom action description

https://github.com/opf/openproject/actions/runs/14464585412/job/40563898557?pr=18537