### PR TITLE
Fix custom action title flaky spec by fetching titles on initialization.

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
@@ -74,6 +74,7 @@ export class WpCustomActionComponent extends UntilDestroyedMixin implements OnIn
         this.untilDestroyed(),
       )
       .subscribe(() => this.cdRef.detectChanges());
+    this.fetchAction();
   }
 
   private fetchAction() {


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Fix flaky spec

```
1) Custom actions viewing workflow buttons
     Failure/Error:
       expect(page)
         .to have_button("Unassign", title: "Removes the assignee")

       expected to find button "Unassign" that is not disabled with title Removes the assignee within #

rspec ./spec/features/work_packages/custom_actions/custom_actions_spec.rb:140 # Custom actions viewing workflow buttons
```

## Screenshots
<details><summary>The bug</summary>
<p>

![button-bug](https://github.com/user-attachments/assets/d750aecd-56ce-446a-a7d6-1f5bb0d8051a)


</p>
</details> 

<details><summary>The fix</summary>
<p>

![button-fix](https://github.com/user-attachments/assets/6a489427-514c-4327-b226-4eeb48fc8fb0)

</p>
</details> 

# What approach did you choose and why?
The issue is, the Custom action resource holding the title is not being fetched unless [the custom action button is hovered](https://github.com/opf/openproject/blob/584f6768b0ad8cc3b90d24f64f094b74fe1dad34/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts#L132-L134). The fix is to fetch the resource earlier in the initialize method of the `wp-custom-action` component.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
