### PR TITLE
implementation/63384 On work package comment edit set attachment replacements

### DIFF
--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -129,6 +129,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
       call = update_journal_service_call
 
       if call.success? && call.result
+        claim_journal_attachments_for(call.result)
         update_item_show_component(journal: call.result, grouped_emoji_reactions: grouped_emoji_reactions_for_journal)
       else
         handle_failed_create_or_update_call(call)


### PR DESCRIPTION
When a comment is updated, replace attachments.

https://community.openproject.org/wp/63384

