### PR TITLE
[#63482] Create Project Status Button Component

### DIFF
--- a/app/components/op_primer/status_button_component.rb
+++ b/app/components/op_primer/status_button_component.rb
@@ -36,6 +36,11 @@ module OpPrimer
     def initialize(current_status:, items:, readonly: false, disabled: false, button_arguments: {}, menu_arguments: {})
       super
 
+      menu_arguments[:classes] = class_names(
+        menu_arguments[:classes],
+        "op-status-button"
+      )
+
       @current_status = current_status
       @items = items
       @readonly = readonly

--- a/app/components/projects/settings/general/show_component.html.erb
+++ b/app/components/projects/settings/general/show_component.html.erb
@@ -58,8 +58,9 @@ See COPYRIGHT and LICENSE files for more details.
         concat(
           render(
             Primer::Forms::FormList.new(
+              Projects::StatusButtonComponent.new(project:, user: current_user),
               Projects::Settings::StatusForm.new(f),
-              Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_status"))
+              Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_status_description"))
             )
           )
         )

--- a/app/components/projects/settings/general/show_component.rb
+++ b/app/components/projects/settings/general/show_component.rb
@@ -36,7 +36,7 @@ module Projects
         include OpPrimer::ComponentHelpers
         include OpTurbo::Streamable
 
-        options :project
+        options :project, :current_user
       end
     end
   end

--- a/app/components/projects/settings/general/show_component.rb
+++ b/app/components/projects/settings/general/show_component.rb
@@ -36,7 +36,14 @@ module Projects
         include OpPrimer::ComponentHelpers
         include OpTurbo::Streamable
 
-        options :project, :current_user
+        attr_reader :project, :current_user
+
+        def initialize(project:, current_user:)
+          super()
+
+          @project = project
+          @current_user = current_user
+        end
       end
     end
   end

--- a/app/components/projects/status_button_component.rb
+++ b/app/components/projects/status_button_component.rb
@@ -87,7 +87,7 @@ class Projects::StatusButtonComponent < ApplicationComponent
       tag: :a,
       href: project_status_path(project, status_code: status.value),
       content_arguments: {
-        data: { turbo_method: :put },
+        data: { turbo_method: status.value ? :put : :delete },
         aria: { current: (true if status == @status) }
       }
     )

--- a/app/components/projects/status_button_component.rb
+++ b/app/components/projects/status_button_component.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Projects::StatusButtonComponent < ApplicationComponent
+  include ApplicationHelper
+  include OpTurbo::Streamable
+  include OpPrimer::ComponentHelpers
+  include ProjectStatusHelper
+
+  attr_reader :project, :user
+
+  def initialize(project:, user:, size: :medium)
+    super
+
+    @project = project
+    @user = user
+    @size = size
+
+    @status = find_status(project.status_code)
+  end
+
+  def call
+    component_wrapper do
+      render(
+        OpPrimer::StatusButtonComponent.new(
+          current_status: build_item(@status),
+          items: build_items,
+          readonly: !edit_enabled?,
+          disabled: !edit_enabled?,
+          button_arguments: {
+            title: t("projects.status.button_edit"),
+            size: @size
+          }
+        )
+      )
+    end
+  end
+
+  private
+
+  def edit_enabled?
+    user.allowed_in_project?(:edit_project, project)
+  end
+
+  def find_status(code)
+    Projects::Statuses::AVAILABLE.find(-> { Projects::Statuses::NOT_SET }) { it.code&.to_s == code }
+  end
+
+  def build_items
+    Projects::Statuses::AVAILABLE.map { build_item(it) }
+  end
+
+  def build_item(status)
+    OpPrimer::StatusButtonOption.new(
+      name: project_status_name(status.code),
+      color_namespace: :project_status,
+      color_ref: status.id,
+      icon: status.icon,
+      item_id: status.id,
+      tag: :a,
+      href: project_status_path(project, status_code: status.value),
+      content_arguments: {
+        data: { turbo_method: :put },
+        aria: { current: (true if status == @status) }
+      }
+    )
+  end
+end

--- a/app/constants/projects/statuses.rb
+++ b/app/constants/projects/statuses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,25 +28,30 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module ProjectStatusHelper
-  def project_status_css_class(status_code)
-    code = project_status_ensure_default_code(status_code)
-    "-#{code.dasherize}"
-  end
+module Projects
+  module Statuses
+    Status = Data.define(:code, :color, :icon) do
+      def id = code&.to_s || :none
+      def value = code.to_s
+    end
 
-  def project_status_name(status_code)
-    code = project_status_ensure_default_code(status_code)
-    project_status_name_for_code(code)
-  end
+    NOT_SET = Status.new(code: nil, color: Color.new(hexcode: "#24292F"), icon: "issue-draft")
+    ON_TRACK = Status.new(code: :on_track, color: Color.new(hexcode: "#1F883D"), icon: "issue-opened")
+    AT_RISK = Status.new(code: :at_risk, color: Color.new(hexcode: "#BC4C00"), icon: "alert")
+    OFF_TRACK = Status.new(code: :off_track, color: Color.new(hexcode: "#CF222E"), icon: "stop")
+    NOT_STARTED = Status.new(code: :not_started, color: Color.new(hexcode: "#0969DA"), icon: "circle")
+    FINISHED = Status.new(code: :finished, color: Color.new(hexcode: "#8250DF"), icon: "issue-closed")
+    DISCONTINUED = Status.new(code: :discontinued, color: Color.new(hexcode: "#9A6700"), icon: "no-entry")
 
-  def project_status_name_for_code(code)
-    code ||= "not_set"
-    I18n.t("js.grid.widgets.project_status.#{code}")
-  end
+    VALID = [
+      ON_TRACK,
+      AT_RISK,
+      OFF_TRACK,
+      NOT_STARTED,
+      FINISHED,
+      DISCONTINUED
+    ].freeze
 
-  private
-
-  def project_status_ensure_default_code(status_code)
-    status_code || "not_set"
+    AVAILABLE = [NOT_SET, *VALID].freeze
   end
 end

--- a/app/constants/projects/statuses.rb
+++ b/app/constants/projects/statuses.rb
@@ -32,7 +32,7 @@ module Projects
   module Statuses
     Status = Data.define(:code, :color, :icon) do
       def id = code&.to_s || :none
-      def value = code.to_s
+      def value = code&.to_s
     end
 
     NOT_SET = Status.new(code: nil, color: Color.new(hexcode: "#24292F"), icon: "issue-draft")

--- a/app/controllers/projects/status_controller.rb
+++ b/app/controllers/projects/status_controller.rb
@@ -36,9 +36,19 @@ class Projects::StatusController < ApplicationController
   before_action :authorize
 
   def update
+    change_status_action(params.fetch(:status_code).presence)
+  end
+
+  def destroy
+    change_status_action(nil)
+  end
+
+  private
+
+  def change_status_action(status_code)
     call = Projects::UpdateService
       .new(model: @project, user: current_user)
-      .call(status_code: params.fetch(:status_code).presence)
+      .call(status_code:)
 
     if call.success?
       @project = call.result
@@ -50,8 +60,6 @@ class Projects::StatusController < ApplicationController
       end
     end
   end
-
-  private
 
   def respond_with_update_status_button
     message = t(:notice_successful_update)

--- a/app/forms/projects/settings/status_form.rb
+++ b/app/forms/projects/settings/status_form.rb
@@ -30,30 +30,7 @@
 module Projects
   module Settings
     class StatusForm < ApplicationForm
-      include ProjectStatusHelper
-
       form do |f|
-        f.autocompleter(
-          name: :status_code,
-          label: attribute_name(:status_code),
-          include_blank: true,
-          autocomplete_options: {
-            decorated: true,
-            clearable: false,
-            focusDirectly: false,
-            data: { qa_field_name: "status" }
-          }
-        ) do |select|
-          [nil, *Project.status_codes.keys].map do |status_code|
-            select.option(
-              label: project_status_name(status_code),
-              value: status_code,
-              classes: "project-status--name #{project_status_css_class(status_code)}",
-              selected: model.status_code == status_code
-            )
-          end
-        end
-
         f.rich_text_area(
           name: :status_explanation,
           label: attribute_name(:status_explanation),

--- a/app/helpers/project_status_helper.rb
+++ b/app/helpers/project_status_helper.rb
@@ -30,11 +30,24 @@
 
 module ProjectStatusHelper
   NOT_SET = "not_set"
+  private_constant :NOT_SET
 
+  ##
+  # Returns the CSS class (BEM modifier) for the Project Status.
+  # Can be used in conjunction with `.project-status--name` or
+  # `.project-status--bulb` (BEM element) classes.
+  #
+  # @param status_code [String | Symbol | nil] Project Status code
+  # @return [String] the CSS class.
   def project_status_css_class(status_code)
     "-#{(status_code&.to_s || NOT_SET).dasherize}"
   end
 
+  ##
+  # Returns the localized Project Status name.
+  #
+  # @param status_code [String | Symbol | nil] Project Status code
+  # @return [String] the localized name.
   def project_status_name(status_code)
     I18n.t(status_code || NOT_SET, scope: "js.grid.widgets.project_status")
   end

--- a/app/helpers/project_status_helper.rb
+++ b/app/helpers/project_status_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,24 +29,13 @@
 #++
 
 module ProjectStatusHelper
+  NOT_SET = "not_set"
+
   def project_status_css_class(status_code)
-    code = project_status_ensure_default_code(status_code)
-    "-#{code.dasherize}"
+    "-#{(status_code&.to_s || NOT_SET).dasherize}"
   end
 
   def project_status_name(status_code)
-    code = project_status_ensure_default_code(status_code)
-    project_status_name_for_code(code)
-  end
-
-  def project_status_name_for_code(code)
-    code ||= "not_set"
-    I18n.t("js.grid.widgets.project_status.#{code}")
-  end
-
-  private
-
-  def project_status_ensure_default_code(status_code)
-    status_code || "not_set"
+    I18n.t(status_code || NOT_SET, scope: "js.grid.widgets.project_status")
   end
 end

--- a/app/models/queries/projects/filters/project_status_filter.rb
+++ b/app/models/queries/projects/filters/project_status_filter.rb
@@ -31,7 +31,7 @@ class Queries::Projects::Filters::ProjectStatusFilter < Queries::Projects::Filte
 
   def allowed_values
     @allowed_values ||= Project.status_codes.map do |code, id|
-      [project_status_name_for_code(code), id.to_s]
+      [project_status_name(code), id.to_s]
     end
   end
 

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -9,6 +9,10 @@
 <%= resource_color_css("meeting_status", meeting_status) %>
 <% end %>
 
+<% Projects::Statuses::AVAILABLE.each do |project_status| %>
+<%= resource_color_css("project_status", project_status) %>
+<% end %>
+
 <%= color_css %>
 
 <%# usage classes %>

--- a/app/views/projects/settings/general/show.html.erb
+++ b/app/views/projects/settings/general/show.html.erb
@@ -48,4 +48,4 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<%= render Projects::Settings::General::ShowComponent.new(project: @project) %>
+<%= render Projects::Settings::General::ShowComponent.new(project: @project, current_user:) %>

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -104,7 +104,7 @@ Rails.application.reloader.to_prepare do
                        "projects/settings/work_packages/internal_comments": %i[show update],
                        "projects/templated": %i[create destroy],
                        "projects/identifier": %i[show update],
-                       "projects/status": %i[update]
+                       "projects/status": %i[update destroy]
                      },
                      permissible_on: :project,
                      require: :member,

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -103,7 +103,8 @@ Rails.application.reloader.to_prepare do
                        "projects/settings/work_packages": %i[show],
                        "projects/settings/work_packages/internal_comments": %i[show update],
                        "projects/templated": %i[create destroy],
-                       "projects/identifier": %i[show update]
+                       "projects/identifier": %i[show update],
+                       "projects/status": %i[update]
                      },
                      permissible_on: :project,
                      require: :member,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -459,6 +459,8 @@ en:
         no_results_title_text: There is no additional recorded disk space consumed by this project.
       work_package_priorities:
         new_label: "New priority"
+    status:
+      button_edit: Edit project status
   project_phase:
     working_days_count:
       one: "Duration: %{count} working day"
@@ -3429,6 +3431,7 @@ en:
   notice_successful_cancel: "Successful cancellation."
   notice_successful_update: "Successful update."
   notice_unsuccessful_update: "Update failed."
+  notice_unsuccessful_update_with_reason: "Update failed: %{reason}"
   notice_successful_update_custom_fields_added_to_project: |
     Successful update. The custom fields of the activated types are automatically activated
     on the work package form. <a href="%{url}" target="_blank">See more</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,7 +391,7 @@ en:
       header_status: Project status
       header_relations: Project relations
       button_update_details: Update details
-      button_update_status: Update status
+      button_update_status_description: Update status description
       button_update_parent_project: Update parent project
       public_warning: >
         This project is public.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,6 +293,7 @@ Rails.application.routes.draw do
       resource :templated, only: %i[create destroy], controller: "templated"
       resource :archive, only: %i[create destroy], controller: "archive"
       resource :identifier, only: %i[show update], controller: "identifier"
+      resource :status, only: %i[update], controller: "status"
     end
 
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,7 +293,7 @@ Rails.application.routes.draw do
       resource :templated, only: %i[create destroy], controller: "templated"
       resource :archive, only: %i[create destroy], controller: "archive"
       resource :identifier, only: %i[show update], controller: "identifier"
-      resource :status, only: %i[update], controller: "status"
+      resource :status, only: %i[update destroy], controller: "status"
     end
 
     member do

--- a/lookbook/previews/open_project/projects/status_button_component_preview.rb
+++ b/lookbook/previews/open_project/projects/status_button_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OpenProject::Projects
+  # @logical_path OpenProject/Projects
+  class StatusButtonComponentPreview < ViewComponent::Preview
+    # !! Currently nothing happens when changing the status!!
+    # @display min_height 400px
+    # @param size [Symbol] select [small, medium, large]
+    def playground(size: :medium)
+      user = FactoryBot.build_stubbed(:admin)
+      project = FactoryBot.build_stubbed(:project, :with_status)
+      render(Projects::StatusButtonComponent.new(project:, user:, size:))
+    end
+  end
+end

--- a/spec/components/projects/settings/general/show_component_spec.rb
+++ b/spec/components/projects/settings/general/show_component_spec.rb
@@ -32,9 +32,12 @@ require "rails_helper"
 
 RSpec.describe Projects::Settings::General::ShowComponent, type: :component do
   let(:project) { build_stubbed(:project) }
+  let(:user) { build_stubbed(:user) }
+
+  current_user { user }
 
   def render_component(**params)
-    render_inline(described_class.new(project:, **params))
+    render_inline(described_class.new(project:, current_user:, **params))
     page
   end
 
@@ -67,10 +70,7 @@ RSpec.describe Projects::Settings::General::ShowComponent, type: :component do
   describe "Project status" do
     it_behaves_like "section with heading", "Project status"
 
-    it "renders fields" do
-      expect(render_component).to have_element "opce-autocompleter",
-                                               "data-input-name": "\"project[status_code]\""
-
+    it "renders field" do
       expect(render_component).to have_element "opce-ckeditor-augmented-textarea",
                                                "data-test-selector": "augmented-text-area-description"
     end

--- a/spec/components/projects/settings/general/show_component_spec.rb
+++ b/spec/components/projects/settings/general/show_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Projects::Settings::General::ShowComponent, type: :component do
 
     it "renders field" do
       expect(render_component).to have_element "opce-ckeditor-augmented-textarea",
-                                               "data-test-selector": "augmented-text-area-description"
+                                               "data-test-selector": "augmented-text-area-status_explanation"
     end
   end
 

--- a/spec/components/projects/status_button_component_spec.rb
+++ b/spec/components/projects/status_button_component_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::StatusButtonComponent, type: :component do
+  let(:project) { build_stubbed(:project, status_code:) }
+  let(:status_code) { nil }
+
+  let(:user) { build_stubbed(:user) }
+
+  current_user { user }
+
+  subject do
+    render_inline(described_class.new(project:, user:))
+    page
+  end
+
+  shared_examples "component wrapper" do |id|
+    it "renders component wrapper" do
+      expect(subject).to have_xpath "//*[@id='#{id}']", count: 1
+    end
+  end
+
+  it_behaves_like "component wrapper", "projects-status-button-component"
+
+  context "when the user has no project edit permissions" do
+    context "when status code is not set" do
+      it "renders a disabled button" do
+        expect(subject).to have_button "Not set", disabled: true
+      end
+    end
+
+    context "when status code is set" do
+      let(:status_code) { :off_track }
+
+      it "renders a disabled button" do
+        expect(subject).to have_button "Off track", disabled: true
+      end
+    end
+
+    it "does not render a Primer ActionMenu" do
+      expect(subject).not_to have_element "action-menu"
+    end
+  end
+
+  context "when the user has project edit permissions" do
+    let(:user) { build_stubbed(:admin) }
+
+    context "when status code is not set" do
+      it "renders an enabled button" do
+        expect(subject).to have_button "Not set", disabled: false, aria: { label: "Edit project status" }
+      end
+
+      it "renders a Primer ActionMenu (single variant)" do
+        expect(subject).to have_element "action-menu", "data-select-variant": "none"
+        expect(subject).to have_element "action-menu", class: "op-status-button"
+      end
+
+      it "renders project status options" do
+        subject
+
+        expect(page).to have_menu do
+          expect(page).to have_selector :menuitem, count: 7
+          expect(page).to have_selector :menuitem, text: "Not set", aria: { current: true }
+          expect(page).to have_selector :menuitem, text: "On track"
+          expect(page).to have_selector :menuitem, text: "At risk"
+          expect(page).to have_selector :menuitem, text: "Not started"
+          expect(page).to have_selector :menuitem, text: "Finished"
+          expect(page).to have_selector :menuitem, text: "Discontinued"
+          expect(page).to have_selector :menuitem, text: "Off track"
+        end
+      end
+    end
+
+    context "when status code is set" do
+      let(:status_code) { :on_track }
+
+      it "renders an enabled button" do
+        expect(subject).to have_button "On track", disabled: false, aria: { label: "Edit project status" }
+      end
+
+      it "renders a Primer ActionMenu (single variant)" do
+        expect(subject).to have_element "action-menu", "data-select-variant": "none"
+        expect(subject).to have_element "action-menu", class: "op-status-button"
+      end
+
+      it "renders project status options" do
+        subject
+
+        expect(page).to have_menu do
+          expect(page).to have_selector :menuitem, count: 7
+          expect(page).to have_selector :menuitem, text: "Not set"
+          expect(page).to have_selector :menuitem, text: "On track", aria: { current: true }
+          expect(page).to have_selector :menuitem, text: "At risk"
+          expect(page).to have_selector :menuitem, text: "Not started"
+          expect(page).to have_selector :menuitem, text: "Finished"
+          expect(page).to have_selector :menuitem, text: "Discontinued"
+          expect(page).to have_selector :menuitem, text: "Off track"
+        end
+      end
+    end
+  end
+end

--- a/spec/components/projects/status_button_component_spec.rb
+++ b/spec/components/projects/status_button_component_spec.rb
@@ -89,7 +89,9 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
 
         expect(page).to have_menu do
           expect(page).to have_selector :menuitem, count: 7
-          expect(page).to have_selector :menuitem, text: "Not set", aria: { current: true }
+          expect(page).to (have_selector :menuitem, text: "Not set", aria: { current: true } do |link|
+            expect(link[:"data-turbo-method"]).to eq "delete"
+          end)
           expect(page).to have_selector :menuitem, text: "On track"
           expect(page).to have_selector :menuitem, text: "At risk"
           expect(page).to have_selector :menuitem, text: "Not started"
@@ -118,7 +120,9 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
         expect(page).to have_menu do
           expect(page).to have_selector :menuitem, count: 7
           expect(page).to have_selector :menuitem, text: "Not set"
-          expect(page).to have_selector :menuitem, text: "On track", aria: { current: true }
+          expect(page).to (have_selector :menuitem, text: "On track", aria: { current: true } do |link|
+            expect(link[:"data-turbo-method"]).to eq "put"
+          end)
           expect(page).to have_selector :menuitem, text: "At risk"
           expect(page).to have_selector :menuitem, text: "Not started"
           expect(page).to have_selector :menuitem, text: "Finished"

--- a/spec/controllers/projects/status_controller_spec.rb
+++ b/spec/controllers/projects/status_controller_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::StatusController do
+  shared_let(:user) { create(:admin) }
+  current_user { user }
+
+  describe "PUT #update" do
+    let(:project) { build_stubbed(:project) }
+    let(:service_result) { ServiceResult.success(result: project) }
+
+    before do
+      allow(Project)
+        .to receive(:find)
+              .with(project.identifier)
+              .and_return(project)
+
+      update_service = instance_double(Projects::UpdateService, call: service_result)
+
+      allow(Projects::UpdateService)
+        .to receive(:new)
+              .with(user:, model: project)
+              .and_return(update_service)
+    end
+
+    context "when service call succeeds" do
+      context "with valid status_code param" do
+        context "with a text/html request" do
+          it "redirects back or to project show" do
+            put :update, params: { project_id: project, status_code: :foo }
+
+            expect(response).to redirect_to project_path(project)
+            expect(flash[:notice]).to eq I18n.t(:notice_successful_update)
+          end
+        end
+
+        context "with a turbo stream request" do
+          it "renders turbo streams updating Projects::StatusButtonComponent and flash action" do
+            put :update, params: { project_id: project, status_code: :foo }, format: :turbo_stream
+
+            expect(response).to be_successful
+            expect(assigns(:project)).to eq project
+            expect(response).to have_turbo_stream action: "update", target: "projects-status-button-component"
+            expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+          end
+        end
+      end
+
+      context "with valid empty status_code param" do
+        context "when service call succeeds" do
+          context "with a text/html request" do
+            it "redirects back or to project show" do
+              put :update, params: { project_id: project, status_code: "" }
+
+              expect(response).to redirect_to project_path(project)
+              expect(flash[:notice]).to eq I18n.t(:notice_successful_update)
+            end
+          end
+
+          context "with a turbo stream request" do
+            it "renders turbo streams updating Projects::StatusButtonComponent and flash action" do
+              put :update, params: { project_id: project, status_code: "" }, format: :turbo_stream
+
+              expect(response).to be_successful
+              expect(assigns(:project)).to eq project
+              expect(response).to have_turbo_stream action: "update", target: "projects-status-button-component"
+              expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+            end
+          end
+        end
+      end
+    end
+
+    context "when service call fails" do
+      let(:service_result) { ServiceResult.failure(result: project, message: "Custom Field 1 must not be blank") }
+
+      context "with a text/html request" do
+        it "redirects back or to project show" do
+          put :update, params: { project_id: project, status_code: :foo }
+
+          expect(response).to redirect_to project_path(project)
+          expect(flash[:error]).to start_with I18n.t(:notice_unsuccessful_update_with_reason, reason: "")
+        end
+      end
+
+      context "with a turbo stream request" do
+        it "renders turbo stream flash action" do
+          put :update, params: { project_id: project, status_code: :foo }, format: :turbo_stream
+
+          expect(response).not_to be_successful
+          expect(response).to have_http_status :unprocessable_entity
+          expect(assigns(:project)).to eq project
+          expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        end
+      end
+    end
+
+    context "with invalid params" do
+      it "invalid params" do
+        put :update, params: { project_id: project, not_status_code: "something" }, format: :turbo_stream
+
+        expect(response).not_to be_successful
+        expect(response).to have_http_status :bad_request
+      end
+    end
+  end
+end

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Projects", "editing settings", :js do
   end
 
   shared_let(:project) do
-    create(:project, :with_status, name: "Foo project", identifier: "foo-project")
+    create(:project, name: "Foo project", identifier: "foo-project")
   end
 
   it "hides the field whose functionality is presented otherwise" do
@@ -117,39 +117,71 @@ RSpec.describe "Projects", "editing settings", :js do
   end
 
   describe "editing project status" do
-    let(:status_field) { FormFields::SelectFormField.new :status }
-
     before do
       Pages::Projects::Settings::General.new(project).visit!
     end
 
-    it "updates the project status and description" do
+    it "sets the project status" do
       within_section "Project status" do
-        status_field.select_option "At risk"
-        fill_in_rich_text "Project status description", with: "Light-years behind 🥺"
+        click_on "Edit project status"
 
-        click_on "Update status"
+        within :menu, "Not set" do
+          find(:menuitem, "Not started").click
+        end
       end
 
       expect_and_dismiss_flash type: :success, message: "Successful update."
 
       within_section "Project status" do
-        status_field.expect_selected "AT RISK"
-        expect(page).to have_selector :rich_text, "Project status description", text: "Light-years behind 🥺"
+        button = find_button("Edit project status")
+        expect(button).to have_text "Not started"
+        button.click
+
+        expect(find(:menu, "Not started")).to have_selector :menuitem, "Not started", aria: { current: true }
       end
     end
 
     it "unsets the project status" do
       within_section "Project status" do
-        status_field.select_option "Not set"
+        click_on "Edit project status"
 
-        click_on "Update status"
+        within :menu, "Not set" do
+          find(:menuitem, "Finished").click
+        end
       end
 
       expect_and_dismiss_flash type: :success, message: "Successful update."
 
       within_section "Project status" do
-        status_field.expect_selected "NOT SET"
+        click_on "Edit project status"
+
+        within :menu, "Finished" do
+          find(:menuitem, "Not set").click
+        end
+      end
+
+      expect_and_dismiss_flash type: :success, message: "Successful update."
+
+      within_section "Project status" do
+        button = find_button("Edit project status")
+        expect(button).to have_text "Not set"
+        button.click
+
+        expect(find(:menu, "Not set")).to have_selector :menuitem, "Not set", aria: { current: true }
+      end
+    end
+
+    it "updates the project status description" do
+      within_section "Project status" do
+        fill_in_rich_text "Project status description", with: "Light-years behind 🥺"
+
+        click_on "Update status description"
+      end
+
+      expect_and_dismiss_flash type: :success, message: "Successful update."
+
+      within_section "Project status" do
+        expect(page).to have_selector :rich_text, "Project status description", text: "Light-years behind 🥺"
       end
     end
   end

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -75,15 +75,12 @@ RSpec.describe "Projects status administration", :js do
     # Check that the status has been set correctly
     visit project_settings_general_path(project_id: "new-project")
 
-    status_field.expect_selected "ON TRACK"
     status_description.expect_value "Everything is fine at the start"
 
-    status_field.select_option "Off track"
     status_description.set_markdown "Oh no"
 
-    click_button "Update status"
+    click_button "Update status description"
 
-    status_field.expect_selected "OFF TRACK"
     status_description.expect_value "Oh no"
   end
 end

--- a/spec/forms/projects/settings/status_form_spec.rb
+++ b/spec/forms/projects/settings/status_form_spec.rb
@@ -35,19 +35,6 @@ RSpec.describe Projects::Settings::StatusForm, type: :forms do
 
   let(:model) { build_stubbed(:project, status_explanation: "example status info") }
 
-  it "renders status field" do
-    expect(page).to have_element "opce-autocompleter", "data-input-name": "\"project[status_code]\""
-    expect(page).to have_element "opce-autocompleter", "data-qa-field-name": "status" do |elem|
-      expect(elem["data-items"]).to have_json_size(7)
-      expect(elem["data-items"]).to include_json(
-        %{{"id":null,"name":"Not set","classes":"project-status--name -not-set"}}
-      ).including(:id)
-      expect(elem["data-items"]).to include_json(
-        %{{"id":"on_track","name":"On track","classes":"project-status--name -on-track"}}
-      ).including(:id)
-    end
-  end
-
   it "renders status description field" do
     expect(page).to have_field "Project status description", with: "example status info", visible: :hidden
     expect(page).to have_element "opce-ckeditor-augmented-textarea",

--- a/spec/helpers/project_status_helper_spec.rb
+++ b/spec/helpers/project_status_helper_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe ProjectStatusHelper do
+  describe "#project_status_css_class" do
+    context "when status_code is nil" do
+      it "returns '-not-set' css class" do
+        expect(helper.project_status_css_class(nil)).to eq("-not-set")
+      end
+    end
+
+    context "when status_code is set" do
+      it "returns the css class", :aggregate_failures do
+        expect(helper.project_status_css_class(:off_track)).to eq("-off-track")
+        expect(helper.project_status_css_class("finished")).to eq("-finished")
+      end
+    end
+  end
+
+  describe "#project_status_name" do
+    context "when status_code is nil" do
+      it "returns 'not set' name" do
+        expect(helper.project_status_name(nil)).to eq I18n.t("js.grid.widgets.project_status.not_set")
+      end
+    end
+
+    context "when status_code is set" do
+      it "returns the localized name", :aggregate_failures do
+        expect(helper.project_status_name(:on_track)).to eq I18n.t("js.grid.widgets.project_status.on_track")
+        expect(helper.project_status_name("discontinued")).to eq I18n.t("js.grid.widgets.project_status.discontinued")
+      end
+    end
+  end
+end

--- a/spec/permissions/edit_projects_spec.rb
+++ b/spec/permissions/edit_projects_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "support/permission_specs"
+
+# rubocop:disable RSpec/EmptyExampleGroup
+RSpec.describe "edit_project permission", type: :controller do
+  include PermissionSpecs
+
+  describe Projects::SettingsController do
+    describe Projects::Settings::GeneralController do
+      check_permission_required_for("projects/settings/general#show", :edit_project)
+      check_permission_required_for("projects/settings/general#update", :edit_project)
+      check_permission_required_for("projects/settings/general#toggle_public", :edit_project)
+      check_permission_required_for("projects/settings/general#toggle_public_dialog", :edit_project)
+    end
+
+    describe Projects::Settings::StorageController do
+      check_permission_required_for("projects/settings/storage#show", :edit_project)
+    end
+
+    describe Projects::Settings::WorkPackagesController do
+      check_permission_required_for("projects/settings/work_packages#show", :edit_project)
+
+      describe Projects::Settings::WorkPackages::InternalCommentsController do
+        check_permission_required_for("projects/settings/work_packages/internal_comments#show", :edit_project)
+        check_permission_required_for("projects/settings/work_packages/internal_comments#update", :edit_project)
+      end
+    end
+  end
+
+  describe Projects::TemplatedController do
+    check_permission_required_for("projects/templated#create", :edit_project)
+    check_permission_required_for("projects/templated#destroy", :edit_project)
+  end
+
+  describe Projects::IdentifierController do
+    check_permission_required_for("projects/identifier#show", :edit_project)
+    check_permission_required_for("projects/identifier#update", :edit_project)
+  end
+
+  describe Projects::StatusController do
+    check_permission_required_for("projects/status#update", :edit_project)
+    check_permission_required_for("projects/status#destroy", :edit_project)
+  end
+end
+# rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/routing/project_status_routing_spec.rb
+++ b/spec/routing/project_status_routing_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe Projects::StatusController do
       )
     end
   end
+
+  describe "destroy" do
+    it do
+      expect(delete("/projects/123/status")).to route_to(
+        controller: "projects/status", action: "destroy", project_id: "123"
+      )
+    end
+  end
 end

--- a/spec/routing/project_status_routing_spec.rb
+++ b/spec/routing/project_status_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,25 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module ProjectStatusHelper
-  def project_status_css_class(status_code)
-    code = project_status_ensure_default_code(status_code)
-    "-#{code.dasherize}"
-  end
+require "spec_helper"
 
-  def project_status_name(status_code)
-    code = project_status_ensure_default_code(status_code)
-    project_status_name_for_code(code)
-  end
-
-  def project_status_name_for_code(code)
-    code ||= "not_set"
-    I18n.t("js.grid.widgets.project_status.#{code}")
-  end
-
-  private
-
-  def project_status_ensure_default_code(status_code)
-    status_code || "not_set"
+RSpec.describe Projects::StatusController do
+  describe "update" do
+    it do
+      expect(put("/projects/123/status")).to route_to(
+        controller: "projects/status", action: "update", project_id: "123"
+      )
+    end
   end
 end

--- a/spec/support/turbo/turbo_matchers.rb
+++ b/spec/support/turbo/turbo_matchers.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Adapted for RSpec from turbo-rails
+# See: https://github.com/hotwired/turbo-rails/blob/main/lib/turbo/test_assertions.rb
+#
+RSpec::Matchers.define :have_turbo_stream do |action:, target: nil, targets: nil, count: 1|
+  description { "contain a `<turbo-stream>` element" }
+  failure_message { rescued_exception.message }
+  failure_message_when_negated do
+    "Expected no elements matching #{@selector.inspect}, found at least 1."
+  end
+
+  match_unless_raises ActiveSupport::TestCase::Assertion do |_|
+    @selector =  %(turbo-stream[action="#{action}"])
+    @selector << %([target="#{target.respond_to?(:to_key) ? dom_id(target) : target}"]) if target
+    @selector << %([targets="#{targets}"]) if targets
+
+    assert_select(@selector, count:, &block_arg)
+  end
+end

--- a/spec/views/projects/settings/general/show.html.erb_spec.rb
+++ b/spec/views/projects/settings/general/show.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,64 +32,35 @@ require "spec_helper"
 
 RSpec.describe "projects/settings/general/show" do
   include TestSelectorFinders
-  let(:project) { build_stubbed(:project) }
 
-  describe "project copy permission" do
-    before do
-      assign(:project, project)
-      allow(view).to receive(:labelled_tabular_form_for).and_return("")
+  let(:project) { build_stubbed(:project, public:) }
+  let(:user) { build_stubbed(:admin) }
+
+  before do
+    assign(:project, project)
+
+    without_partial_double_verification do
+      allow(view)
+        .to receive(:current_user)
+        .and_return(user)
     end
 
-    context "when project copy is allowed" do
-      before do
-        allow(project).to receive(:copy_allowed?).and_return(true)
-        render
-      end
+    render
+  end
 
-      it "the copy link should be visible" do
-        expect(rendered).to have_test_selector "project-settings--copy"
-      end
-    end
+  context "when project is not public" do
+    let(:public) { false }
 
-    context "when project copy is not allowed" do
-      before do
-        allow(project).to receive(:copy_allowed?).and_return(false)
-        render
-      end
-
-      it "the copy link should not be visible" do
-        expect(rendered).to have_no_css "a.copy"
-      end
+    it "does not show warning banner" do
+      expect(rendered).not_to have_test_selector "op-projects-public-warning"
     end
   end
 
-  context "User.current is admin" do
-    let(:admin) { build_stubbed(:admin) }
+  context "when project is public" do
+    let(:public) { true }
 
-    before do
-      assign(:project, project)
-      allow(User).to receive(:current).and_return(admin)
-      render
-    end
-
-    it "show delete and archive buttons" do
-      expect(rendered).to have_test_selector "project-settings--archive"
-      expect(rendered).to have_test_selector "project-settings--delete"
-    end
-  end
-
-  context "User.current is non-admin" do
-    let(:non_admin) { build_stubbed(:user) }
-
-    before do
-      assign(:project, project)
-      allow(User).to receive(:current).and_return(non_admin)
-      render
-    end
-
-    it "hide delete and archive buttons" do
-      expect(rendered).to have_no_css("li.toolbar-item span.button--text", text: "Archive project")
-      expect(rendered).to have_no_css("li.toolbar-item span.button--text", text: "Delete project")
+    it "shows warning banner" do
+      expect(rendered).to have_test_selector "op-projects-public-warning"
     end
   end
 end


### PR DESCRIPTION
⚠️ **~~This PR is based on #18478. Please review/merge first.~~**

# Ticket

https://community.openproject.org/wp/63482

# What are you trying to accomplish?

Implements a Project Status Button Component based on the existing OP Primer Status Component. Integrates the Status Button Component on the Project Settings > Information page.

In detail:

* Introduces `Projects::StatusButtonComponent` and its Lookbook Preview.
* Defines colours, icons as (Ruby) constants nested under `Project::Statuses` (c.f. `Meetings::Statuses`).
* Adds `Projects::StatusController` with `#update` action, routes and accompanying permissions.

## Screenshots

<img width="701" alt="Screenshot 2025-04-28 at 21 12 03" src="https://github.com/user-attachments/assets/114dd202-1315-4eb1-b280-5f009fd9337c" />
<img width="705" alt="Screenshot 2025-04-28 at 21 11 11" src="https://github.com/user-attachments/assets/a4e2d19f-57a7-4067-9057-6e6dd3ef81f0" />
<img width="700" alt="Screenshot 2025-04-28 at 21 11 02" src="https://github.com/user-attachments/assets/03b04953-2639-4f3a-b63a-41c7e729f04d" />
<img width="702" alt="Screenshot 2025-04-28 at 21 10 53" src="https://github.com/user-attachments/assets/68d13ebb-cf9a-4bc5-9ba9-11ece58f2c12" />

# What approach did you choose and why?

The implementation is based on the Meeting Status Button.

# Merge checklist

- [x] Added/updated tests
- [X] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
