### PR TITLE
Update structured_warnings gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,7 +151,7 @@ gem "gon", "~> 6.4.0"
 gem "lograge", "~> 0.14.0"
 
 # Structured warnings to selectively disable them in production
-gem "structured_warnings", "~> 0.4.0"
+gem "structured_warnings", "~> 0.5.0"
 
 # catch exceptions and send them to any airbrake compatible backend
 # don't require by default, instead load on-demand when actually configured

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1166,7 +1166,7 @@ GEM
       activerecord (>= 6.1)
     stringex (2.8.6)
     stringio (3.1.6)
-    structured_warnings (0.4.0)
+    structured_warnings (0.5.0)
     svg-graph (2.2.2)
     swd (2.0.3)
       activesupport (>= 3)
@@ -1464,7 +1464,7 @@ DEPENDENCIES
   stackprof
   store_attribute (~> 2.0)
   stringex (~> 2.8.5)
-  structured_warnings (~> 0.4.0)
+  structured_warnings (~> 0.5.0)
   svg-graph (~> 2.2.0)
   sys-filesystem (~> 1.5.0)
   table_print (~> 1.5.6)
@@ -1888,7 +1888,7 @@ CHECKSUMS
   store_attribute (2.0.0) sha256=3399d9baa20776ec9dcb266cff407aac82bf99791678d6266ea617703e4b0e28
   stringex (2.8.6) sha256=c7b382d2b2a47a1e1646f256df201c48d487d6296fbb289d76802f67f5e929c4
   stringio (3.1.6) sha256=292c495d1657adfcdf0a32eecf12a60e6691317a500c3112ad3b2e31068274f5
-  structured_warnings (0.4.0) sha256=ff9a59278e3ad8d18f742e677b764ce374f16e52c7993c0ff7d76900e93383ad
+  structured_warnings (0.5.0) sha256=864aca5a4d6b63cd3a948f9dcd7f5498af1cf42bcf4fd75e2c315b7d77a30583
   svg-graph (2.2.2) sha256=f928866403055e6539afdfdab5f6268d108b2abc9f002e0fc51b16511809513a
   swd (2.0.3) sha256=4cdbe2a4246c19f093fce22e967ec3ebdd4657d37673672e621bf0c7eb770655
   sys-filesystem (1.5.3) sha256=17b561d1be683c34bc53946461ea9d67012d8f395e7297db8c63b9018cb30ece


### PR DESCRIPTION
This should fix compatibility issues with our currently used Ruby
version that causes errors when rendering warnings in some
cases.

# Ticket
https://community.openproject.org/wp/62764

