### PR TITLE
[63434] Fix user with a particular set of permissions seeing errors when updating work packages dates

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -218,9 +218,9 @@ module WorkPackages
         permitted_params = params.merge(date_mode: "range", focused_field:).permit!
 
         if params[:action] == "new"
-          new_work_package_datepicker_dialog_content_path(permitted_params)
+          new_date_picker_path(permitted_params)
         else
-          work_package_datepicker_dialog_content_path(permitted_params)
+          work_package_date_picker_path(permitted_params)
         end
       end
 

--- a/app/components/work_packages/date_picker/date_form_component.rb
+++ b/app/components/work_packages/date_picker/date_form_component.rb
@@ -167,7 +167,7 @@ module WorkPackages
 
       def field_value(name)
         errors = @work_package.errors.where(name)
-        if (user_value = errors.map { |error| error.options[:value] }.find { !_1.nil? })
+        if (user_value = errors.map { |error| error.options[:value] }.find { !it.nil? })
           user_value
         else
           @work_package.public_send(name)

--- a/app/components/work_packages/date_picker/form_component.rb
+++ b/app/components/work_packages/date_picker/form_component.rb
@@ -61,9 +61,11 @@ module WorkPackages
 
       def submit_path
         if work_package.new_record?
-          datepicker_dialog_content_path
+          # create: get json of selected dates
+          date_picker_path
         else
-          work_package_datepicker_dialog_content_path(work_package)
+          # update dates of work package
+          work_package_date_picker_path(work_package)
         end
       end
 
@@ -72,9 +74,9 @@ module WorkPackages
                               .merge(schedule_manually:)
                               .permit!
         if work_package.new_record?
-          new_work_package_datepicker_dialog_content_path("new", dialog_params)
+          new_date_picker_path(dialog_params)
         else
-          work_package_datepicker_dialog_content_path(work_package, dialog_params)
+          work_package_date_picker_path(work_package, dialog_params)
         end
       end
 

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -199,7 +199,7 @@ class WorkPackages::DatePickerController < ApplicationController
                    "start_date_touched",
                    "due_date_touched",
                    "duration_touched")
-            .transform_values { _1 == "true" }
+            .transform_values { it == "true" }
             .permit!
     else
       {}
@@ -242,7 +242,7 @@ class WorkPackages::DatePickerController < ApplicationController
   end
 
   def allowed_touched_params
-    allowed_params.filter { touched?(_1) }
+    allowed_params.filter { touched?(it) }
   end
 
   def allowed_params

--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -269,8 +269,16 @@ class WorkPackages::DatePickerController < ApplicationController
       WorkPackages::SetAttributesService
         .new(user: current_user,
              model: @work_package,
-             contract_class: WorkPackages::CreateContract)
+             contract_class:)
         .call(wp_params)
+    end
+  end
+
+  def contract_class
+    if @work_package.new_record?
+      WorkPackages::CreateContract
+    else
+      WorkPackages::UpdateContract
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -664,10 +664,10 @@ Rails.application.routes.draw do
 
     resources :children_relations, only: %i[new create destroy], controller: "work_package_children_relations"
 
-    resource :progress, only: %i[new edit update], controller: "work_packages/progress"
+    resource :progress, only: %i[edit update], controller: "work_packages/progress"
     collection do
       resource :progress,
-               only: :create,
+               only: %i[create new],
                controller: "work_packages/progress",
                as: :work_package_progress
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -672,15 +672,15 @@ Rails.application.routes.draw do
                as: :work_package_progress
     end
 
-    resource :datepicker_dialog_content,
-             only: %i[show new edit update],
+    resource :date_picker,
+             only: %i[show edit update],
              controller: "work_packages/date_picker",
-             on: :member,
-             as: "datepicker_dialog_content"
+             as: "date_picker"
     collection do
-      resource :datepicker_dialog_content,
-               only: :create,
-               controller: "work_packages/date_picker"
+      resource :date_picker,
+               only: %i[create new],
+               controller: "work_packages/date_picker",
+               as: "date_picker"
     end
 
     resources :relations_tab, only: %i[index], controller: "work_package_relations_tab"

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -298,7 +298,7 @@ export class PathHelperService {
 
   public workPackageProgressModalPath(workPackageId:string|number) {
     if (workPackageId === 'new') {
-      return `${this.workPackagePath(workPackageId)}/progress/new`;
+      return `${this.workPackagesPath()}/progress/new`;
     }
 
     return `${this.workPackagePath(workPackageId)}/progress/edit`;

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -314,10 +314,10 @@ export class PathHelperService {
 
   public workPackageDatepickerDialogContentPath(workPackageId:string|number):string {
     if (workPackageId === 'new') {
-      return `${this.workPackagePath(workPackageId)}/datepicker_dialog_content/new`;
+      return `${this.workPackagesPath()}/date_picker/new`;
     }
 
-    return `${this.workPackagePath(workPackageId)}/datepicker_dialog_content`;
+    return `${this.workPackagePath(workPackageId)}/date_picker`;
   }
 
   // Work Package Bulk paths

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -309,21 +309,12 @@ export default class PreviewController extends DialogPreviewController {
     this.updateFlatpickrCalendar();
   }
 
-  // Ensures that on create forms, there is an "id" for the un-persisted
-  // work package when sending requests to the edit action for previews.
   ensureValidPathname(formAction:string):string {
-    const wpPath = new URL(formAction);
-
-    if (wpPath.pathname.endsWith('/work_packages/datepicker_dialog_content')) {
-      // Replace /work_packages/date_picker with /work_packages/new/date_picker
-      wpPath.pathname = wpPath.pathname.replace('/work_packages/datepicker_dialog_content', '/work_packages/new/datepicker_dialog_content');
-    }
-
-    return wpPath.toString();
+    return formAction;
   }
 
   ensureValidWpAction(wpPath:string):string {
-    return wpPath.endsWith('/work_packages/new/datepicker_dialog_content') ? 'new' : 'edit';
+    return wpPath.endsWith('/work_packages/date_picker') ? 'new' : 'edit';
   }
 
   afterRendering() {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -309,14 +309,6 @@ export default class PreviewController extends DialogPreviewController {
     this.updateFlatpickrCalendar();
   }
 
-  ensureValidPathname(formAction:string):string {
-    return formAction;
-  }
-
-  ensureValidWpAction(wpPath:string):string {
-    return wpPath.endsWith('/work_packages/date_picker') ? 'new' : 'edit';
-  }
-
   afterRendering() {
     this.readCurrentValues();
     this.updateFlatpickrCalendar();

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -138,15 +138,18 @@ export abstract class DialogPreviewController extends Controller {
       });
     }
 
-    const wpPath = this.ensureValidPathname(form.action);
-    const wpAction = this.ensureValidWpAction(wpPath);
-
-    const editUrl = `${wpPath}/${wpAction}?${new URLSearchParams(wpParams).toString()}`;
+    const wpAction = this.isUpdatingWorkPackage(form.action) ? 'edit' : 'new';
+    const previewUrl = `${form.action}/${wpAction}?${new URLSearchParams(wpParams).toString()}`;
     const turboFrame = this.formTarget.closest('turbo-frame') as HTMLTurboFrameElement;
 
     if (turboFrame) {
-      turboFrame.src = editUrl;
+      turboFrame.src = previewUrl;
     }
+  }
+
+  private isUpdatingWorkPackage(formPath:string):boolean {
+    const workPackagePathRegex = /\/work_packages\/\d+\//;
+    return workPackagePathRegex.test(formPath);
   }
 
   protected focusAndSetCursorPositionToEndOfInput(field:HTMLInputElement) {
@@ -158,10 +161,6 @@ export abstract class DialogPreviewController extends Controller {
       );
     }
   }
-
-  abstract ensureValidPathname(formAction:string):string;
-
-  abstract ensureValidWpAction(path:string):string;
 
   abstract afterRendering():void;
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview.controller.ts
@@ -59,23 +59,6 @@ export default class PreviewController extends DialogPreviewController {
     // Do nothing;
   }
 
-  // Ensures that on create forms, there is an "id" for the un-persisted
-  // work package when sending requests to the edit action for previews.
-  ensureValidPathname(formAction:string):string {
-    const wpPath = new URL(formAction);
-
-    if (wpPath.pathname.endsWith('/work_packages/progress')) {
-      // Replace /work_packages/progress with /work_packages/new/progress
-      wpPath.pathname = wpPath.pathname.replace('/work_packages/progress', '/work_packages/new/progress');
-    }
-
-    return wpPath.toString();
-  }
-
-  ensureValidWpAction(wpPath:string):string {
-    return wpPath.endsWith('/work_packages/new/progress') ? 'new' : 'edit';
-  }
-
   markFieldAsTouched(event:{ target:HTMLInputElement }) {
     this.targetFieldName = event.target.name.replace(/^work_package\[([^\]]+)\]$/, '$1');
     this.markTouched(this.targetFieldName);

--- a/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
+++ b/spec/components/work_packages/date_picker/dialog_content_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WorkPackages::DatePicker::DialogContentComponent, type: :componen
 
   subject(:dialog_content) do
     with_controller_class(WorkPackages::DatePickerController) do
-      with_request_url("/work_packages/:work_package_id/datepicker_dialog_content") do
+      with_request_url("/work_packages/:work_package_id/date_picker") do
         render_inline(described_class.new(work_package:, schedule_manually:))
       end
     end

--- a/spec/controllers/work_packages/date_picker_controller_spec.rb
+++ b/spec/controllers/work_packages/date_picker_controller_spec.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::DatePickerController do
+  shared_let(:week_days) { week_with_saturday_and_sunday_as_weekend }
+  shared_let(:work_package) do
+    create(:work_package,
+           start_date: "2025-04-01",
+           due_date: "2025-04-07",
+           duration: 5)
+  end
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: {
+             work_package.project => %i[add_work_packages edit_work_packages view_work_packages]
+           })
+  end
+
+  current_user { user }
+
+  def date_errors(work_package)
+    work_package.errors.group_by_attribute.slice(:start_date, :due_date, :duration)
+  end
+
+  describe "GET /work_packages/date_picker/new" do
+    # the parameters as they are sent when the date picker is opened again
+    # from the new work package page after a due date has been entered.
+    let(:params_from_first_display_of_date_picker) do
+      {
+        "field" => "combinedDate",
+        "work_package" => {
+          "start_date" => "",
+          "due_date" => "2025-04-18",
+          "duration" => "",
+          "ignore_non_working_days" => "false",
+          "initial" => {
+            "start_date" => "",
+            "due_date" => "2025-04-18",
+            "duration" => "",
+            "ignore_non_working_days" => "false"
+          }
+        }
+      }
+    end
+    # the parameters used to re-render the date picker after changing values is
+    # enriched by the stimulus preview controller. Here nothing is changed yet,
+    # each test uses this as a basis to update the values.
+    # captured on 2025-04-17.
+    let(:params_after_changing_values) do
+      {
+        "field" => "work_package[due_date]",
+        "date_mode" => "single",
+        "triggering_field" => "",
+        "work_package" => {
+          "start_date" => "",
+          "due_date" => "2025-04-18",
+          "duration" => "",
+          "ignore_non_working_days" => "0",
+          "schedule_manually" => "true",
+          "initial" => {
+            "start_date" => "",
+            "due_date" => "2025-04-18",
+            "duration" => "",
+            "ignore_non_working_days" => "false",
+            "schedule_manually" => "true"
+          },
+          "start_date_touched" => "false",
+          "due_date_touched" => "false",
+          "duration_touched" => "false",
+          "ignore_non_working_days_touched" => "false",
+          "schedule_manually_touched" => "false"
+        }
+      }
+    end
+
+    it "assigns work package initialized with initial values" do
+      get("new", params: params_from_first_display_of_date_picker)
+
+      assigned_work_package = assigns(:work_package)
+      expect(assigned_work_package).to be_new_record
+      expect(assigned_work_package.start_date).to be_nil
+      expect(assigned_work_package.due_date).to eq(Date.parse("2025-04-18"))
+      expect(assigned_work_package.duration).to be_nil
+      expect(assigned_work_package.ignore_non_working_days).to be(false)
+      expect(assigned_work_package.schedule_manually).to be(true) # the default value
+      expect(date_errors(assigned_work_package)).to be_empty
+    end
+
+    context "when values for untouched fields are received (like derived values)" do
+      let(:params_with_due_date_value_but_untouched) do
+        params_after_changing_values.deep_merge(
+          "work_package" => {
+            "start_date" => "2025-01-01",
+            "start_date_touched" => "false",
+            "due_date" => "2025-04-21",
+            "due_date_touched" => "false"
+          }
+        )
+      end
+
+      it "keeps the initial value for untouched fields in the assigned work package" do
+        get("new", params: params_with_due_date_value_but_untouched)
+
+        assigned_work_package = assigns(:work_package)
+        # initial values are used for untouched fields
+        expect(assigned_work_package.start_date).to be_nil
+        expect(assigned_work_package.due_date).to eq(Date.parse("2025-04-18"))
+      end
+    end
+
+    context "when the user edits the dates" do
+      let(:params_after_editing_due_date) do
+        params_after_changing_values.deep_merge(
+          "work_package" => {
+            "start_date" => "2025-04-14",
+            "start_date_touched" => "true",
+            "due_date" => "2025-04-21",
+            "due_date_touched" => "true"
+          }
+        )
+      end
+
+      it "assigns work package updated with touched and derived values" do
+        get("new", params: params_after_editing_due_date)
+
+        assigned_work_package = assigns(:work_package)
+        expect(assigned_work_package).to be_new_record
+        expect(assigned_work_package.start_date).to eq(Date.parse("2025-04-14"))
+        expect(assigned_work_package.due_date).to eq(Date.parse("2025-04-21"))
+        expect(assigned_work_package.duration).to eq(6)
+        expect(date_errors(assigned_work_package)).to be_empty
+      end
+
+      context "when the user does not have 'Add work packages' permission" do
+        before do
+          RolePermission.where(permission: "add_work_packages").delete_all
+        end
+
+        it "displays read-only errors" do
+          get("new", params: params_after_editing_due_date)
+
+          assigned_work_package = assigns(:work_package)
+          expect(date_errors(assigned_work_package)).to match(
+            start_date: [have_attributes(class: ActiveModel::Error, type: :error_readonly)],
+            due_date: [have_attributes(class: ActiveModel::Error, type: :error_readonly)]
+          )
+        end
+      end
+
+      context "when the user edits fields and does not have 'Edit work packages' permission" do
+        before do
+          RolePermission.where(permission: "edit_work_packages").delete_all
+        end
+
+        it "does not display any errors" do
+          get("new", params: params_after_editing_due_date)
+
+          assigned_work_package = assigns(:work_package)
+          expect(date_errors(assigned_work_package)).to be_empty
+        end
+      end
+    end
+  end
+
+  describe "GET /work_packages/:id/progress" do
+    let(:params_from_first_display_of_date_picker) do
+      {
+        "field" => "combinedDate",
+        "work_package_id" => work_package.id,
+        "work_package" => {
+          "start_date" => "2025-04-01",
+          "due_date" => "2025-04-07",
+          "duration" => "P5D",
+          "ignore_non_working_days" => "",
+          "initial" => {
+            "start_date" => "2025-04-01",
+            "due_date" => "2025-04-07",
+            "duration" => "P5D",
+            "ignore_non_working_days" => ""
+          }
+        }
+      }
+    end
+    let(:params_after_changing_values) do
+      {
+        "field" => "work_package[due_date]",
+        "date_mode" => "range",
+        "triggering_field" => "combined_date",
+        "work_package_id" => work_package.id,
+        "work_package" => {
+          "start_date" => "2025-04-01",
+          "due_date" => "2025-04-17",
+          "duration" => "5",
+          "ignore_non_working_days" => "0",
+          "schedule_manually" => "true",
+          "initial" => {
+            "start_date" => "2025-04-01",
+            "due_date" => "2025-04-07",
+            "duration" => "5",
+            "ignore_non_working_days" => "false",
+            "schedule_manually" => "true"
+          },
+          "start_date_touched" => "false",
+          "due_date_touched" => "true",
+          "duration_touched" => "false",
+          "ignore_non_working_days_touched" => "false",
+          "schedule_manually_touched" => "false"
+        }
+      }
+    end
+
+    it "assigns work package initialized with initial values" do
+      get("edit", params: params_from_first_display_of_date_picker)
+
+      assigned_work_package = assigns(:work_package)
+      expect(assigned_work_package).to be_persisted
+      expect(assigned_work_package.start_date).to eq(Date.parse("2025-04-01"))
+      expect(assigned_work_package.due_date).to eq(Date.parse("2025-04-07"))
+      expect(assigned_work_package.duration).to eq(5)
+      expect(assigned_work_package.ignore_non_working_days).to be(false)
+      expect(assigned_work_package.schedule_manually).to be(true) # default value
+      expect(date_errors(assigned_work_package)).to be_empty
+    end
+
+    context "when the user edits the dates" do
+      let(:params_after_editing_due_date) do
+        params_after_changing_values.deep_merge(
+          "work_package" => {
+            "start_date" => "2025-04-03",
+            "start_date_touched" => "true",
+            "due_date" => "2025-04-15",
+            "due_date_touched" => "true",
+            "duration" => "3" # it was 3 before changing due date; will be derived (because not touched)
+          }
+        )
+      end
+
+      it "assigns work package updated with touched and derived values" do
+        get("edit", params: params_after_editing_due_date)
+
+        assigned_work_package = assigns(:work_package)
+        expect(assigned_work_package).to be_persisted
+        expect(assigned_work_package.start_date).to eq(Date.parse("2025-04-03"))
+        expect(assigned_work_package.due_date).to eq(Date.parse("2025-04-15"))
+        expect(assigned_work_package.duration).to eq(9)
+        expect(date_errors(assigned_work_package)).to be_empty
+      end
+
+      context "when the user does not have 'Add work packages' permission" do
+        before do
+          RolePermission.where(permission: "add_work_packages").delete_all
+        end
+
+        it "does not display any errors" do
+          get("edit", params: params_after_editing_due_date)
+
+          assigned_work_package = assigns(:work_package)
+          expect(date_errors(assigned_work_package)).to be_empty
+        end
+      end
+
+      context "when the user does not have 'Edit work packages' permission" do
+        before do
+          RolePermission.where(permission: "edit_work_packages").delete_all
+        end
+
+        it "display read-only errors" do
+          get("edit", params: params_after_editing_due_date)
+
+          assigned_work_package = assigns(:work_package)
+          expect(date_errors(assigned_work_package)).to match(
+            start_date: [have_attributes(class: ActiveModel::Error, type: :error_readonly)],
+            due_date: [have_attributes(class: ActiveModel::Error, type: :error_readonly)]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/work_packages/progress_controller_spec.rb
+++ b/spec/controllers/work_packages/progress_controller_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe WorkPackages::ProgressController do
   describe "GET /work_packages/progress/new" do
     let(:params) do
       {
-        "work_package_id" => work_package.id,
         "work_package" => {
           "initial" => {
             "estimated_hours" => "7.0",

--- a/spec/controllers/work_packages/progress_controller_spec.rb
+++ b/spec/controllers/work_packages/progress_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe WorkPackages::ProgressController do
     work_package.errors.group_by_attribute.slice(:estimated_hours, :remaining_hours, :done_ratio)
   end
 
-  describe "GET /work_packages/new/progress/new" do
+  describe "GET /work_packages/progress/new" do
     let(:params) do
       {
         "work_package_id" => work_package.id,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63434

# What are you trying to accomplish?

The wrong permissions are checked in the date picker. It always checks for `add_work_packages`, but it should also check for `edit_work_packages` when it's an update.

## Screenshots

![image](https://github.com/user-attachments/assets/d7d82c79-6ec5-443b-9311-e83a37141937)

# What approach did you choose and why?

Use correct contract when calling `SetAttributesService`: either `UpdateContract` when editing an existing work package or `CreateContract` when being with a new work package.

I also revised the routing as there was something odd going on when trying to add a controller spec for `DatePickerController`. I kept having some "no route exists" for `new` action, so I made it a bit more sane by:
* changing route path from `.../datepicker_dialog_content` to `.../date_picker` to match controller name and make things easier to find when navigating code.
* moving `new` action for `date_picker` to the collection level of work_packages scope.
* moving `new` action for `progress` to the collection level of work_packages scope.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
