### PR TITLE
Avoid SystemStackError on project eager loading wrapper

### DIFF
--- a/lib/api/v3/projects/project_eager_loading_wrapper.rb
+++ b/lib/api/v3/projects/project_eager_loading_wrapper.rb
@@ -51,16 +51,15 @@ module API
           end
 
           def ancestor_projects(projects)
-            ancestor_selector = projects[1..].inject(ancestor_project_select(projects[0])) do |select, project|
-              select.or(ancestor_project_select(project))
-            end
-            Project.where(ancestor_selector).to_a
+            projects[1..].inject(ancestor_projects_of(projects[0])) do |select, project|
+              select.or(ancestor_projects_of(project))
+            end.to_a
           end
 
-          def ancestor_project_select(project)
+          def ancestor_projects_of(project)
             projects_table = Project.arel_table
 
-            projects_table[:lft].lt(project.lft).and(projects_table[:rgt].gt(project.rgt))
+            Project.where(projects_table[:lft].lt(project.lft).and(projects_table[:rgt].gt(project.rgt)))
           end
 
           def custom_fields_from_projects


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63498

# What are you trying to accomplish?

Avoid SystemStackError when fetching a larger list of projects via the API v3. The problem arises when having 1000 projects in the system (could also happen sooner) and fetching those via the API by specifying `pageSize=1000`.

For all of the projects, the ancestors are prefetched for efficient rendering in the representer. 

Before, this was done by constructing an AREL object that had a structure like this:

```
Grouping
  OR
    Grouping
      OR
```

So a grouping and an OR was added for every project to the statement.

This crashed but using a similar approach with AR does not seem to be affected by the same problem. This was tested for 2000 projects which ran through without problems.  


