### PR TITLE
Adjustments for enterprise banner on activity settings

### DIFF
--- a/app/components/settings/project_work_packages/header_component.html.erb
+++ b/app/components/settings/project_work_packages/header_component.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
       tab_nav.with_tab(selected: selected?(:activities), href: project_settings_work_packages_activities_path) do |tab|
-        tab.with_text { t("label_activity") }
+        tab.with_text { activity_title }
       end
     end
   end

--- a/app/components/settings/project_work_packages/header_component.rb
+++ b/app/components/settings/project_work_packages/header_component.rb
@@ -58,6 +58,14 @@ module Settings
       def show_custom_fields?
         User.current.allowed_in_project?(:select_custom_fields, @project)
       end
+
+      def activity_title
+        label = t("label_activity").html_safe
+        if !EnterpriseToken.allows_to?(:comments_with_restricted_visibility)
+          label << render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons", classes: "upsale-colored", ml: 2))
+        end
+        label
+      end
     end
   end
 end

--- a/app/components/settings/project_work_packages/header_component.rb
+++ b/app/components/settings/project_work_packages/header_component.rb
@@ -61,7 +61,7 @@ module Settings
 
       def activity_title
         label = t("label_activity").html_safe
-        if !EnterpriseToken.allows_to?(:comments_with_restricted_visibility)
+        unless EnterpriseToken.allows_to?(:comments_with_restricted_visibility)
           label << render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons", classes: "upsale-colored", ml: 2))
         end
         label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2101,7 +2101,7 @@ en:
           or if you don’t want to give that person access to OpenProject but still want to track tasks assigned to them.
       comments_with_restricted_visibility:
         title: "For your eyes only"
-        description: "Restricted-visibilty comments allow an internal team to communicate amongst themselves privately. These are only visible to certain project roles and will never be visible publicly. Available only through the enterprise professional plan."
+        description: "Restricted-visibilty comments allow an internal team to communicate amongst themselves privately. These are only visible to certain project roles and will never be visible publicly."
   enumeration_activities: "Time tracking activities"
   enumeration_work_package_priorities: "Work package priorities"
   enumeration_reported_project_statuses: "Reported project status"
@@ -4047,7 +4047,7 @@ en:
       not_allowed_text: "You do not have the necessary permissions to view this page."
       activities:
         enable_comments_with_restricted_visibility: "Enable restricted visibility comments"
-        helper_text: "Restricted comments allow an internal team to communicate amongst themselves privately. These are only visible to select roles that have the necessary permissions and will not be visible publicly. %{link}"
+        helper_text: "Restricted comments allow an internal team to communicate amongst themselves privately. These are only visible to selected roles that have the necessary permissions and will not be visible publicly. %{link}"
 
   text_formatting:
     markdown: "Markdown"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/61061

# What are you trying to accomplish?
- Add the enterprise icon to the activity settings tab
- Adjust translations

## Screenshots
![image](https://github.com/user-attachments/assets/d0ef35e4-12c7-48e7-a884-33e0494b4220)
