### PR TITLE
[63521] Do nothing if relation to delete does not exist anymore

### DIFF
--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -33,7 +33,7 @@ class WorkPackageRelationsController < ApplicationController
   include OpTurbo::DialogStreamHelper
 
   before_action :set_work_package
-  before_action :set_relation, except: %i[new create]
+  before_action :set_relation, only: %i[edit update]
   before_action :authorize
 
   def new
@@ -90,7 +90,13 @@ class WorkPackageRelationsController < ApplicationController
   end
 
   def destroy
-    service_result = Relations::DeleteService.new(user: current_user, model: @relation).call
+    @relation = @work_package.relations.find_by(id: params[:id])
+    service_result =
+      if @relation
+        Relations::DeleteService.new(user: current_user, model: @relation).call
+      else
+        ServiceResult.success
+      end
 
     respond_with_relations_tab_update(service_result)
   end

--- a/spec/controllers/work_package_relations_controller_spec.rb
+++ b/spec/controllers/work_package_relations_controller_spec.rb
@@ -165,5 +165,18 @@ RSpec.describe WorkPackageRelationsController do
         .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
       expect { relation.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "does nothing if the given relation does not exist" do
+      deleted_relation_id = relation.id
+      relation.destroy
+      delete("destroy", params: { work_package_id: work_package.id, id: deleted_relation_id }, as: :turbo_stream)
+
+      expect(response).to be_successful
+
+      expect(WorkPackageRelationsTab::IndexComponent).to have_received(:new)
+        .with(work_package:)
+      expect(controller).to have_received(:replace_via_turbo_stream)
+        .with(component: an_instance_of(WorkPackageRelationsTab::IndexComponent))
+    end
   end
 end

--- a/spec/features/types/form_configuration_query_spec.rb
+++ b/spec/features/types/form_configuration_query_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "form query configuration", :js do
     it "can save an empty query group" do
       form.add_query_group("Empty test", :children)
       form.save_changes
-      expect_flash(message: "Successful update.")
+      expect_and_dismiss_flash(message: "Successful update.")
       type_bug.reload
 
       query_group = type_bug.attribute_groups.detect { |x| x.is_a?(Type::QueryGroup) }
@@ -107,7 +107,7 @@ RSpec.describe "form query configuration", :js do
       form.add_query_group("Subtasks", :children)
       # Save changed query
       form.save_changes
-      expect_flash(message: "Successful update.")
+      expect_and_dismiss_flash(message: "Successful update.")
 
       # Visit wp_table
       wp_table.visit!
@@ -133,7 +133,7 @@ RSpec.describe "form query configuration", :js do
         form.add_query_group("Subtasks", :children)
         # Save changed query
         form.save_changes
-        expect_flash(message: "Successful update.")
+        expect_and_dismiss_flash(message: "Successful update.")
 
         # Visit new wp page
         visit new_project_work_packages_path(project)
@@ -147,18 +147,16 @@ RSpec.describe "form query configuration", :js do
       let!(:archived) { create(:project, name: "To be archived") }
 
       it "uses the valid subset of the query (Regression #40324)" do
-        form.add_query_group("Archived project", :children)
-        form.edit_query_group("Archived project")
-
-        # Select the soon archived project
-        modal.switch_to "Filters"
-        filters.expect_filter_count 1
-        filters.add_filter_by("Project", "is (OR)", archived.name)
-        filters.expect_filter_count 2
-        filters.save
+        form.add_query_group("Archived project", :children) do |modal|
+          # Select the soon archived project
+          modal.switch_to "Filters"
+          filters.expect_filter_count 1
+          filters.add_filter_by("Project", "is (OR)", archived.name)
+          filters.expect_filter_count 2
+        end
 
         form.save_changes
-        expect_flash message: "Successful update."
+        expect_and_dismiss_flash(message: "Successful update.")
 
         archived.update_attribute(:active, false)
 
@@ -172,21 +170,19 @@ RSpec.describe "form query configuration", :js do
     end
 
     it "can modify and keep changed columns (Regression #27604)" do
-      form.add_query_group("Columns Test", :children)
-      form.edit_query_group("Columns Test")
+      form.add_query_group("Columns Test", :children) do |modal|
+        # Restrict filters to type_task
+        modal.switch_to "Columns"
 
-      # Restrict filters to type_task
-      modal.switch_to "Columns"
-
-      columns.assume_opened
-      columns.uncheck_all save_changes: false
-      columns.add "ID", save_changes: false
-      columns.add "Subject", save_changes: false
-      columns.apply
+        columns.assume_opened
+        columns.uncheck_all save_changes: false
+        columns.add "ID", save_changes: false
+        columns.add "Subject", save_changes: false
+      end
 
       # Save changed query
       form.save_changes
-      expect_flash(message: "Successful update.")
+      expect_and_dismiss_flash(message: "Successful update.")
 
       type_bug.reload
       query = type_bug.attribute_groups.detect { |x| x.key == "Columns Test" }
@@ -195,20 +191,18 @@ RSpec.describe "form query configuration", :js do
       column_names = query.attributes.columns.map(&:name).sort
       expect(column_names).to eq %i[id subject]
 
-      form.add_query_group("Second query", :children)
-      form.edit_query_group("Second query")
+      form.add_query_group("Second query", :children) do |modal|
+        # Restrict filters to type_task
+        modal.switch_to "Columns"
 
-      # Restrict filters to type_task
-      modal.switch_to "Columns"
-
-      columns.assume_opened
-      columns.uncheck_all save_changes: false
-      columns.add "ID", save_changes: false
-      columns.apply
+        columns.assume_opened
+        columns.uncheck_all save_changes: false
+        columns.add "ID", save_changes: false
+      end
 
       # Save changed query
       form.save_changes
-      expect_flash(message: "Successful update.")
+      expect_and_dismiss_flash(message: "Successful update.")
 
       type_bug.reload
       query = type_bug.attribute_groups.detect { |x| x.key == "Columns Test" }
@@ -239,23 +233,21 @@ RSpec.describe "form query configuration", :js do
 
     shared_examples_for "query group" do
       it do
-        form.add_query_group("Subtasks", frontend_relation_type)
-        form.edit_query_group("Subtasks")
+        form.add_query_group("Subtasks", frontend_relation_type) do |modal|
+          # Expect disabled tabs for timelines and display mode
+          modal.expect_disabled_tab "Gantt chart"
+          modal.expect_disabled_tab "Display settings"
 
-        # Expect disabled tabs for timelines and display mode
-        modal.expect_disabled_tab "Gantt chart"
-        modal.expect_disabled_tab "Display settings"
-
-        # Restrict filters to type_task
-        modal.expect_open
-        modal.switch_to "Filters"
-        # the templated filter should be hidden in the Filters tab
-        filters.expect_filter_count 1
-        filters.add_filter_by("Type", "is (OR)", type_task.name)
-        filters.save
+          # Restrict filters to type_task
+          modal.expect_open
+          modal.switch_to "Filters"
+          # the templated filter should be hidden in the Filters tab
+          filters.expect_filter_count 1
+          filters.add_filter_by("Type", "is (OR)", type_task.name)
+        end
 
         form.save_changes
-        expect_flash(message: "Successful update.")
+        expect_and_dismiss_flash(message: "Successful update.")
 
         # Visit work package with that type
         wp_page.visit!

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -157,6 +157,7 @@ module Components
             expect(page).to have_text(label)
           end
         end
+        yield modal if block_given?
         modal.save
 
         input = find(".group-edit-in-place--input")


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63521

# What are you trying to accomplish?

When the same relation is deleted in two different browser tabs, it produces an invisible 500 error. There is no message on the UI but we see the error in AppSignal.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

If the relation can't be found, do like if we managed to delete it.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
