### PR TITLE
[62525] Non-working days can be choosen via date field (2)

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -331,6 +331,10 @@ export default class PreviewController extends DialogPreviewController {
     this.updateFlatpickrCalendar();
   }
 
+  ignoreActiveValueWhenMorphing():boolean {
+    return false;
+  }
+
   readInitialValues() {
     this.fieldInputTargets.forEach((inputField) => {
       this.assignReadValues(inputField);

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -75,10 +75,8 @@ export abstract class DialogPreviewController extends Controller {
     // assistive technologies. This is why morph cannot be used here.
     this.frameMorphRenderer = (event:CustomEvent<TurboBeforeFrameRenderEventDetail>) => {
       event.detail.render = (currentElement:HTMLElement, newElement:HTMLElement) => {
-        const ignoreActiveValue = false;
-
         Idiomorph.morph(currentElement, newElement, {
-          ignoreActiveValue,
+          ignoreActiveValue: this.ignoreActiveValueWhenMorphing(),
           callbacks: {
             beforeNodeMorphed: (oldNode:Element) => {
               // In case the element is an OpenProject custom dom element, morphing is prevented.
@@ -162,6 +160,9 @@ export abstract class DialogPreviewController extends Controller {
   abstract ensureValidWpAction(path:string):string;
 
   abstract afterRendering():void;
+
+  // Whether to ignore the active element value when morphing.
+  abstract ignoreActiveValueWhenMorphing():boolean;
 
   protected isBeingEdited(fieldName:string) {
     return fieldName === this.targetFieldName;

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/dialog/preview.controller.ts
@@ -75,10 +75,8 @@ export abstract class DialogPreviewController extends Controller {
     // assistive technologies. This is why morph cannot be used here.
     this.frameMorphRenderer = (event:CustomEvent<TurboBeforeFrameRenderEventDetail>) => {
       event.detail.render = (currentElement:HTMLElement, newElement:HTMLElement) => {
-        let ignoreActiveValue = false;
-        if (document.activeElement?.tagName === 'INPUT') {
-          ignoreActiveValue = true;
-        }
+        const ignoreActiveValue = false;
+
         Idiomorph.morph(currentElement, newElement, {
           ignoreActiveValue,
           callbacks: {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/progress/preview.controller.ts
@@ -55,6 +55,12 @@ export default class PreviewController extends DialogPreviewController {
     super.disconnect();
   }
 
+  // Must be true to avoid adding the unit to the active input field value while
+  // typing a duration or pressing backspace.
+  ignoreActiveValueWhenMorphing():boolean {
+    return true;
+  }
+
   afterRendering():void {
     // Do nothing;
   }

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
         # expect all journal entries
         activity_tab.expect_journal_notes(text: "First comment by admin")
         activity_tab.expect_journal_notes(text: "Second comment by admin")
-        activity_tab.expect_journal_changed_attribute(text: "Subject")
+        activity_tab.expect_journal_changed_attribute(text: "A new subject")
 
         activity_tab.filter_journals(:only_comments)
 

--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -45,13 +45,11 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
     create(:non_working_day,
            date: Time.zone.today.beginning_of_week.next_occurring(:tuesday))
   end
-  shared_let(:working_day_this_week) { Time.zone.today.beginning_of_week.next_occurring(:wednesday) }
 
   shared_let(:non_working_day_next_year) do
     create(:non_working_day,
            date: Time.zone.today.end_of_year.next_occurring(:tuesday))
   end
-  shared_let(:working_day_next_year) { Time.zone.today.end_of_year.next_occurring(:wednesday) }
 
   shared_examples "shows individual non working days" do
     let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
@@ -114,12 +112,12 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
       # Set the start date to a non working day
       datepicker.set_start_date non_working_day_this_week.date
       # The date is automatically updated to the next working day
-      datepicker.expect_start_date working_day_this_week
+      datepicker.expect_start_date non_working_day_this_week.date + 1.day
 
       # Set the due date to a non working day
       datepicker.set_due_date non_working_day_next_year.date
       # The date is automatically updated to the next working day
-      datepicker.expect_due_date working_day_next_year
+      datepicker.expect_due_date non_working_day_next_year.date + 1.day
     end
   end
 end

--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -45,11 +45,13 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
     create(:non_working_day,
            date: Time.zone.today.beginning_of_week.next_occurring(:tuesday))
   end
+  shared_let(:working_day_this_week) { Time.zone.today.beginning_of_week.next_occurring(:wednesday) }
 
   shared_let(:non_working_day_next_year) do
     create(:non_working_day,
            date: Time.zone.today.end_of_year.next_occurring(:tuesday))
   end
+  shared_let(:working_day_next_year) { Time.zone.today.end_of_year.next_occurring(:wednesday) }
 
   shared_examples "shows individual non working days" do
     let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
@@ -88,5 +90,36 @@ RSpec.describe "Datepicker modal individual non working days (WP #44453)", :js,
     let(:date_attribute) { :date }
 
     it_behaves_like "shows individual non working days"
+  end
+
+  context "when manually entering a date which is a non working day (regression #62525)" do
+    let(:work_package) { bug_wp }
+    let(:date_field) { work_packages_page.edit_field(:combinedDate) }
+    let(:datepicker) { date_field.datepicker }
+    let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
+
+    it "shows an error message" do
+      login_as user
+
+      work_packages_page.visit!
+      work_packages_page.ensure_page_loaded
+
+      date_field.activate!
+      date_field.expect_active!
+      # Wait for the datepicker to be initialized
+      datepicker.expect_visible
+
+      datepicker.enable_start_date
+
+      # Set the start date to a non working day
+      datepicker.set_start_date non_working_day_this_week.date
+      # The date is automatically updated to the next working day
+      datepicker.expect_start_date working_day_this_week
+
+      # Set the due date to a non working day
+      datepicker.set_due_date non_working_day_next_year.date
+      # The date is automatically updated to the next working day
+      datepicker.expect_due_date working_day_next_year
+    end
   end
 end

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -43,6 +43,7 @@ module Components
     def clear!
       set_field(container.find_field("work_package[start_date]"), "", wait_for_changes_to_be_applied: false)
       set_field(container.find_field("work_package[due_date]"), "", wait_for_changes_to_be_applied: false)
+      wait_for_changes_to_be_applied_after_setting_field
     end
 
     def expect_visible
@@ -229,9 +230,13 @@ module Components
       end
 
       if wait_for_changes_to_be_applied
-        sleep 0.75 # input debounce
-        wait_for_network_idle
+        wait_for_changes_to_be_applied_after_setting_field
       end
+    end
+
+    def wait_for_changes_to_be_applied_after_setting_field
+      sleep 0.75 # input debounce
+      wait_for_network_idle
     end
   end
 end

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -7,9 +7,8 @@ module Components
     include MonthRangeSelection
 
     def clear!
-      super
-
       set_field(duration_field, "", wait_for_changes_to_be_applied: false)
+      super
     end
 
     def expect_banner_text(text, **)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/openproject/work_packages/62525/activity


# What are you trying to accomplish?
This is an alternative approach to https://github.com/opf/openproject/pull/18611 which does not exclude active Element from the morhping to show when the SetAttributesService silently updated the date to the next non-working day

