### PR TITLE
Hide enterprise banner frame in boards if has enterprise edition

### DIFF
--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="(board$ | async) as board">
   <div
-    *ngIf="!needEnterpriseEdition"
+    *ngIf="!needEnterpriseEdition; else enterpriseBanner"
     class="boards-list--container"
     [ngClass]="{ '-free' : board.isFree }"
     #container
@@ -38,9 +38,12 @@
       </div>
     </div>
   </div>
-  <op-enterprise-banner-frame
-    class="boards-list--enterprise-banner"
-    feature="board_view"
-    [dismissable]="true"
-  ></op-enterprise-banner-frame>
+
+  <ng-template #enterpriseBanner>
+    <op-enterprise-banner-frame
+      class="boards-list--enterprise-banner"
+      feature="board_view"
+      [dismissable]="true"
+    ></op-enterprise-banner-frame>
+  </ng-template>
 </ng-container>

--- a/spec/support/matchers/has_enterprise_banner.rb
+++ b/spec/support/matchers/has_enterprise_banner.rb
@@ -46,15 +46,17 @@ RSpec::Matchers.define :have_enterprise_banner do |**args|
 
   failure_message do
     <<~MESSAGE
-      Expected page to have Enterprise edition banner, but it does not:
-      #{@error}
+      Expected page to have Enterprise banner, but it is absent or invisible.
     MESSAGE
   end
 
   failure_message_when_negated do
+    puts Capybara::Screenshot.screenshot_and_save_page
+    banner_text = page.find(test_selector("op-enterprise-banner")).text
     <<~MESSAGE
-      Expected page not to have Enterprise edition banner, but it does:
-      #{@error}
+      Expected page not to have Enterprise banner, but it is present and visible.
+      Enterprise banner text:
+        #{banner_text.gsub("\n", "\n  ")}
     MESSAGE
   end
 end


### PR DESCRIPTION
In boards module, basic boards do not need the enterprise banner. Yet it's there. Out of the viewport but present.
It can be made visible by pressing "Tab" until the button "Start trial" is focused.

See this video taken from the not-so-flaky spec that was failing:

[enterprise-banner-hidden-but-there.webm](https://github.com/user-attachments/assets/b86d6356-e76a-403d-8e11-b7de13f057d1)

I alter found that it can be focused with tab:

![image](https://github.com/user-attachments/assets/fe200ca9-819d-4f70-8d5a-feb7edf044dd)

This PR hides this banner if enterprise plan is not needed.

Seen through a flaky spec: `modules/boards/spec/features/board_enterprise_spec.rb:63` on job https://github.com/opf/openproject/actions/runs/14512895098/job/40715394915 on PR https://github.com/opf/openproject/pull/18658

It should have been always failing, but was passing anyway most of the time because of the time it takes to load the enterprise banner.

Reproduction command that worked on my machine:

```
OPENPROJECT_TESTING_NO_HEADLESS=1 CI=true rspec -fd './modules/boards/spec/features/board_enterprise_spec.rb[1:1:2]' './modules/calendar/spec/features/calendar_widget_spec.rb[1:5:2:1]' --seed 61699
```

I also fixed some test helpers where `@error` was used but was not defined.