### PR TITLE
Clean up test failure backtrace output of `script/github_pr_errors`

### DIFF
--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Rails
 require "rubygems"
 require "bundler"
 Bundler.setup(:default, :development)
@@ -32,6 +33,7 @@ class Options
     display_rerun_info: false,
     display_images: false,
     failed_jobs_logs: [],
+    full_backtrace: false,
     no_cache: false,
     run_id: nil,
     job_id: nil,
@@ -87,6 +89,10 @@ class Options
       options = {}
       opt_parser = OptionParser.new do |parser|
         parser.banner = BANNER
+
+        parser.on("-b", "--full-backtrace", "Output full backtrace of test failures") do
+          options[:full_backtrace] = true
+        end
 
         parser.on("-c", "--compact", "Output all failing rspec files on one line") do
           options[:compact] = true
@@ -523,7 +529,7 @@ class Formatter
     return if failures_explanation.nil? || failures_explanation.empty?
 
     warn "Failures explanation:".bold
-    warn failures_explanation
+    warn clean_failures_explanation(failures_explanation)
     warn ""
   end
 
@@ -551,6 +557,21 @@ class Formatter
   end
 
   private
+
+  # Remove test failure backtrace lines that are not useful.
+  # - rspec_retry and retriable lines
+  # - top level lines which are mostyl around blocks executing on each spec
+  # - make the spec file name bold
+  def clean_failures_explanation(failures_explanation)
+    return failures_explanation if Options.full_backtrace
+
+    failures_explanation
+      .split("\n")
+      .reject { |line| line.include?("spec/support/rspec_retry") || line.include?("/usr/local/bundle/gems/retriable") }
+      .reject { |line| line.include?("<top (required)>") && !line.include?("_spec.rb") }
+      .join("\n")
+      .gsub(/[.a-z_\/]+_spec.rb/, &:bold)
+  end
 
   def display_errors_compact(errors)
     puts errors.map { escaped_location(it) }.join(" ")
@@ -760,3 +781,5 @@ when "in_progress"
 when "error"
   formatter.display_errors_from_report(report)
 end
+
+# rubocop:enable Rails

--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -85,7 +85,7 @@ class Options
       options.merge!(parse_url(ARGV.first)) if ARGV.any?
     end
 
-    def parse_args
+    def parse_args # rubocop:disable Metrics/AbcSize
       options = {}
       opt_parser = OptionParser.new do |parser|
         parser.banner = BANNER


### PR DESCRIPTION
# What are you trying to accomplish?

I always struggle a bit to find the relevant bits in the rspec stacktrace output so I decided to remove the unrelevant lines when using `script/github_pr_errors`:

- Remove rspec_retry and retriable lines
- Remove top level lines which are mostly around blocks executing on each spec
- Make the spec file name bold (more visible)

The original full stack trace can still be shown with option `--full-backtrace`

## Screenshots

Before:

```
$ script/github_pr_errors https://github.com/opf/openproject/actions/runs/14519804438/job/40741624438
Looking for the workflow run with id 14519804438
  Branch: bug/62525-non-working-days-can-be-choosen-via-date-field-2
  Commit SHA: e83401e89467ecef514cf23a3de6ae3c4a534e27
  Commit message: Do not morph active element value in progress preview
  Last attempted run started at: 2025-04-17 19:06:52 +0200
  Pull Request: [62525] Non-working days can be choosen via date field (2) #18680 https://github.com/opf/openproject/pull/18680
  Looking for the job with id 40741624438
Failures explanation:

  1) scheduling mode can toggle the scheduling mode through the date modal
     Failure/Error: expect(container).to have_field("work_package[start_date]", with: value, **)
       expected to find visible field "work_package[start_date]" that is not disabled with value "2015-12-20" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/OPCE-MODAL-OVERLAY[1]/DIV[2]/NG-COMPONENT[1]/DIV[1]/TURBO-FRAME[1]/TURBO-FRAME[1]/DIV[1]"> but there were no matches. Also found "", which matched the selector but not all filters. Expected value to be "2015-12-20" but was ""
     # ./spec/support/components/datepicker/work_package_datepicker.rb:69:in 'Components::WorkPackageDatepicker#expect_start_date'
     # ./spec/support/edit_fields/date_edit_field.rb:144:in 'DateEditField#set_value'
     # ./spec/support/edit_fields/date_edit_field.rb:127:in 'block in DateEditField#update'
     # /usr/local/bundle/gems/retriable-3.1.2/lib/retriable.rb:61:in 'block in Retriable.retriable'
     # /usr/local/bundle/gems/retriable-3.1.2/lib/retriable.rb:56:in 'Retriable.retriable'
     # ./spec/support/rspec_retry.rb:84:in 'Object#retry_block'
     # ./spec/support/edit_fields/date_edit_field.rb:125:in 'DateEditField#update'
     # ./spec/features/work_packages/scheduling/scheduling_mode_spec.rb:231:in 'block (2 levels) in <top (required)>'
     # ./spec/support/capybara.rb:16:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:58:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:204:in 'block (2 levels) in <top (required)>'
     # ./spec/support/rspec_retry.rb:24:in 'block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:126:in 'block (2 levels) in <top (required)>'

Finished in 13 minutes 3 seconds (files took 36.59 seconds to load)
2618 examples, 1 failure, 15 pending

'./spec/features/work_packages/scheduling/scheduling_mode_spec.rb:139'
    ↳ html: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2025-04-17-17-24-42.472.html
    ↳ screenshot: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2025-04-17-17-24-42.472.png
```

After:
```
$ script/github_pr_errors https://github.com/opf/openproject/actions/runs/14519804438/job/40741624438
Looking for the workflow run with id 14519804438
  Branch: bug/62525-non-working-days-can-be-choosen-via-date-field-2
  Commit SHA: e83401e89467ecef514cf23a3de6ae3c4a534e27
  Commit message: Do not morph active element value in progress preview
  Last attempted run started at: 2025-04-17 19:06:52 +0200
  Pull Request: [62525] Non-working days can be choosen via date field (2) #18680 https://github.com/opf/openproject/pull/18680
  Looking for the job with id 40741624438
Failures explanation:

  1) scheduling mode can toggle the scheduling mode through the date modal
     Failure/Error: expect(container).to have_field("work_package[start_date]", with: value, **)
       expected to find visible field "work_package[start_date]" that is not disabled with value "2015-12-20" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/OPCE-MODAL-OVERLAY[1]/DIV[2]/NG-COMPONENT[1]/DIV[1]/TURBO-FRAME[1]/TURBO-FRAME[1]/DIV[1]"> but there were no matches. Also found "", which matched the selector but not all filters. Expected value to be "2015-12-20" but was ""
     # ./spec/support/components/datepicker/work_package_datepicker.rb:69:in 'Components::WorkPackageDatepicker#expect_start_date'
     # ./spec/support/edit_fields/date_edit_field.rb:144:in 'DateEditField#set_value'
     # ./spec/support/edit_fields/date_edit_field.rb:127:in 'block in DateEditField#update'
     # ./spec/support/edit_fields/date_edit_field.rb:125:in 'DateEditField#update'
     # ./spec/features/work_packages/scheduling/scheduling_mode_spec.rb:231:in 'block (2 levels) in <top (required)>'

Finished in 13 minutes 3 seconds (files took 36.59 seconds to load)
2618 examples, 1 failure, 15 pending

'./spec/features/work_packages/scheduling/scheduling_mode_spec.rb:139'
    ↳ html: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2025-04-17-17-24-42.472.html
    ↳ screenshot: https://openproject-ci-public-logs.s3-eu-west-1.amazonaws.com/screenshot_2025-04-17-17-24-42.472.png
```
