### PR TITLE
Fix hours cannot see in Dark theme in time tracking calendar page.

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -106,7 +106,9 @@ export default class MyTimeTrackingController extends Controller {
         return {
           html: `
            <div class="fc-event-main-frame">
-             <div class="fc-event-time mb-1">${this.displayDuration(arg.event.extendedProps.hours as number)}</div>
+             <div class="fc-event-time mb-1" style="color: var(--fgColor-default)">
+               ${this.displayDuration(arg.event.extendedProps.hours as number)}
+             </div>
              <div class="fc-event-title-container">
                 <div class="fc-event-title mb-2" title="${arg.event.extendedProps.workPackageSubject}">
                   <a class="Link--primary Link" href="${this.pathHelper.workPackageShortPath(arg.event.extendedProps.workPackageId as string)}">


### PR DESCRIPTION
# What are you trying to accomplish?

Fix the text color in dark mode

## Screenshots

Before:
<img width="570" alt="image" src="https://github.com/user-attachments/assets/02b38629-a94a-491d-bdc9-f8c288c6ce34" />

After:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/4d08dda4-2232-4ddd-b0e1-8cefd09a7f83" />

# What approach did you choose and why?

The color `--fgColor-default` suggested in [Primer Guide](https://primer.style/product/primitives/color/#foreground).

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
