### PR TITLE
[#62231] PDF Export: Strikethrough formatting in tables is not applied

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,8 +157,8 @@ gem "structured_warnings", "~> 0.5.0"
 # don't require by default, instead load on-demand when actually configured
 gem "airbrake", "~> 13.0.0", require: false
 
-gem "markly", "~> 0.10" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "66893683b94a5fe8f1dc9a60600773307209cdd2"
+gem "markly", "~> 0.13" # another markdown parser like commonmarker, but with AST support used in PDF export
+gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "67d14c6c7a13f918d158bde1a51ef1067a8cf724"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,16 +19,16 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: 66893683b94a5fe8f1dc9a60600773307209cdd2
-  ref: 66893683b94a5fe8f1dc9a60600773307209cdd2
+  revision: 67d14c6c7a13f918d158bde1a51ef1067a8cf724
+  ref: 67d14c6c7a13f918d158bde1a51ef1067a8cf724
   specs:
-    md_to_pdf (0.2.0)
+    md_to_pdf (0.2.1)
       base64 (~> 0.2)
       bigdecimal (~> 3.1)
       color_conversion (~> 0.1)
       front_matter_parser (~> 1.0)
       json-schema (~> 4.3)
-      markly (~> 0.10)
+      markly (~> 0.13)
       matrix (~> 0.4)
       nokogiri (~> 1.18)
       prawn (~> 2.4)
@@ -1359,7 +1359,7 @@ DEPENDENCIES
   lograge (~> 0.14.0)
   lookbook (~> 2.3.4)
   mail (= 2.8.1)
-  markly (~> 0.10)
+  markly (~> 0.13)
   matrix (~> 0.4.2)
   md_to_pdf!
   meta-tags (~> 2.22.0)
@@ -1699,7 +1699,7 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   markly (0.13.0) sha256=326a232c876cd95093d110b8d184be8effeadd776c3ffcefd59bdc8de7f59e0d
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
-  md_to_pdf (0.2.0)
+  md_to_pdf (0.2.1)
   messagebird-rest (1.4.2) sha256=1501e16ad76c87558f20f3b26cb39d05f587b349b44b8bf8056b040e9b495301
   meta-tags (2.22.1) sha256=e5ae1febbd320d396c7226d7edb868e5d63466c14b9c8b06622a1a74e6dce354
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5

--- a/app/models/work_package/pdf_export/export/markdown.rb
+++ b/app/models/work_package/pdf_export/export/markdown.rb
@@ -45,6 +45,9 @@ module WorkPackage::PDFExport::Export::Markdown
     def draw_markdown(markdown, pdf, image_loader)
       @pdf = pdf
       @image_loader = image_loader
+      @pdf.stroke_color = "000000"
+      @pdf.line_width = 1
+      @pdf.fill_color = "000000"
       root = parse_markdown(markdown)
       begin
         draw_node(root, pdf_root_options(@styles.page), true)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/openproject/work_packages/62231/

# What are you trying to achieve?

Support HTML formatting, e.g. `<s>strike</s>` in HTML tables, which were not applied in the PDF exports.

# What approach did you choose and why?

bump md-to-pdf to v0.2.1 (Implement support for HTML formatting in HTML tables)

+ contribution by @prathamesh-vic (Thanks a lot!)

# Screenshots

In editor
<img width="559" alt="editor" src="https://github.com/user-attachments/assets/d8c891c9-e7bf-4bcf-9abb-d8d69093aa64" />

In PDF
<img width="259" alt="pdf" src="https://github.com/user-attachments/assets/bcee3500-eddf-42a6-8866-18a05faba381" />


# Merge checklist

- [x] Added/updated tests (in [md-to-pdf](https://github.com/opf/md-to-pdf/commit/b2dbb05b0e785171d057523c983cf9ffa9f774d2))

