### PR TITLE
Fix flaky custom_action spec

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.html
@@ -1,7 +1,7 @@
 <button
     (click)="update()"
     class="custom-action--button button -narrow hide-when-print"
-    title="{{action.description ? action.description : action.name}}"
+    [title]="title"
     [disabled]="change.inFlight"
     >
   {{action.name}}

--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
@@ -87,6 +87,10 @@ export class WpCustomActionComponent extends UntilDestroyedMixin implements OnIn
       });
   }
 
+  public get title():string {
+    return this.action.description || this.action.name;
+  }
+
   public get change():ResourceChangeset<WorkPackageResource> {
     return this.halEditing.changeFor(this.workPackage);
   }

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
     within(".custom-actions") do
       # When hovering over the button, the description is displayed
       expect(page)
-        .to have_button("Unassign", title: "Removes the assignee", wait: 10)
+        .to have_button("Unassign", title: "Removes the assignee")
     end
 
     wp_page.click_custom_action("Unassign")


### PR DESCRIPTION
Failing spec is spec/features/work_packages/custom_actions/custom_actions_spec.rb:140 on job run https://github.com/opf/openproject/actions/runs/14613189364/job/40995333431?pr=18684

It occurs because the custom actions stored in the cache are overwritten with some data after fetching the work package: when the work pacakge is fetched, it has a `links` property with multiple things, including a `customActions` array. This array of custom actions only has a name property, so when the cache is updated, the custom actions are overwritten with only the name property.

As there is only the name property, the description is lost and the title of the button is set to the name instead of being set to the description.

Sometimes it works because the work package is fetched before the action are fetched, and sometimes it doesn't.

The fix is to keep custom actions in the cache if they exist. This probably introduces bugs because if the custom actions array is very detailed, we want to override it, but that's a try.

So the fix applied here is absolutely not clean and should be revisited. It's a basis for a discussion about how we want to handle this.

cc @akabiru and @dombesz as you have already tried to fix this flaky spec in #18646.

I've reproduced it by moving the title property to the component so that we can set a debugger breakpoint. When reloading, you can see the title is correct at first, then the work package is fetched, and the title becomes incorrect. It becomes correct again later if the action is fetched again, like when hovering.

I suspect hovering was a workaround for this issue and that it will not be needed anymore once we find a proper way to preserve custom actions. 