### PR TITLE
Add index for user_id on the sessions table

### DIFF
--- a/db/migrate/20250423123519_add_index_to_sessions.rb
+++ b/db/migrate/20250423123519_add_index_to_sessions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToSessions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :sessions, :user_id, algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/63587

# What are you trying to accomplish?
On the `tokens` table we do have an index on `user_id` on sessions, we don't. This causes the My::Sessions#index page to load for a long time. The page does not have much throughput, but when it is opened, it takes between 10-15 seconds to load.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
