### PR TITLE
Consistently use enterprise_banner test helper

### DIFF
--- a/spec/components/work_packages/types/subject_configuration_component_spec.rb
+++ b/spec/components/work_packages/types/subject_configuration_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
     it "shows no enterprise banner" do
       render_component
 
-      expect(page).not_to have_test_selector("op-enterprise-banner-work-package-subject-generation")
+      expect(page).not_to have_enterprise_banner
     end
 
     it "enables mode selectors", :aggregate_failures do
@@ -109,7 +109,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
     it "shows the enterprise banner" do
       render_component
 
-      expect(page).to have_enterprise_banner
+      expect(page).to have_enterprise_banner(:professional)
     end
 
     it "disables only automatic mode selector", :aggregate_failures do
@@ -125,7 +125,7 @@ RSpec.describe WorkPackages::Types::SubjectConfigurationComponent, type: :compon
       it "shows the enterprise banner" do
         render_component
 
-        expect(page).to have_enterprise_banner
+        expect(page).to have_enterprise_banner(:professional)
       end
 
       it "enables mode selectors", :aggregate_failures do


### PR DESCRIPTION
Also using it in negative test assertion and specifically requiring an enterprise banner for a plan when it is present.