### PR TITLE
Make diff_format_revisions frozen string compatible

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -174,8 +174,8 @@ class Repository < ApplicationRecord
 
   def diff_format_revisions(cs, cs_to, sep = ":")
     text = ""
-    text << (cs_to.format_identifier + sep) if cs_to
-    text << cs.format_identifier if cs
+    text += (cs_to.format_identifier + sep) if cs_to
+    text += cs.format_identifier if cs
     text
   end
 


### PR DESCRIPTION
Replaced `<<` with `+=`, so that strings are not changed in-place anymore.

# Ticket
[<!-- Provide the link to respective work package -->](https://community.openproject.org/projects/openproject/work_packages/63604/activity)

# What are you trying to accomplish?
Fix error 500 when diffing between revisions or commits.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
