### PR TITLE
Raise an error when trying to call the banner with a feature that does not exist

### DIFF
--- a/app/components/enterprise_edition/plan_for_feature.rb
+++ b/app/components/enterprise_edition/plan_for_feature.rb
@@ -64,18 +64,25 @@ module EnterpriseEdition
     end
 
     def features
-      return @features if defined?(@features)
+      defined?(@features) || begin
+        @features = I18n.t(:features, scope: i18n_scope, default: nil)&.values
+      end
 
       @features = I18n.t(:features, scope: i18n_scope, default: nil)&.values
     end
 
     def plan
-      @plan ||= OpenProject::Token.lowest_plan_for(feature_key)&.capitalize
+      defined?(@plan) || begin
+        @plan = OpenProject::Token.lowest_plan_for(feature_key)
+        raise ArgumentError, "#{feature_key} is not a valid feature, as no plan mapped to it." if @plan.nil?
+      end
+
+      @plan
     end
 
     def plan_text
       plan_name = render(Primer::Beta::Text.new(font_weight: :bold, classes: "upsell-colored")) do
-        I18n.t("ee.upsell.plan_name", plan:)
+        I18n.t("ee.upsell.plan_name", plan: plan.capitalize)
       end
 
       I18n.t("ee.upsell.plan_text_html", plan_name:).html_safe

--- a/spec/components/enterprise_edition/banner_component_spec.rb
+++ b/spec/components/enterprise_edition/banner_component_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
   let(:href) { "https://www.example.org" }
   let(:component_test_selector) { "op-enterprise-banner" }
   let(:features) { nil }
+  let(:plan) { :basic }
   let(:enforce_available_locales) { I18n.config.enforce_available_locales }
   let(:i18n_upsell) do
     {
@@ -83,6 +84,11 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
     allow(OpenProject::Static::Links)
       .to receive(:links)
             .and_return(static_links)
+
+    allow(OpenProject::Token)
+      .to receive(:lowest_plan_for)
+      .with(:some_enterprise_feature)
+      .and_return(plan)
 
     I18n.config.enforce_available_locales = !enforce_available_locales
 


### PR DESCRIPTION
Make life easier for other developers to spot, when a feature key is incorrect by raising an error