### PR TITLE
bug/63637 After clicking on "Make public" once, subsequent "cancel" actions do not retain the "Internal comment" checked state

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
@@ -130,6 +130,7 @@ export default class InternalCommentController extends Controller {
   }
 
   private askForConfirmation():Promise<boolean> {
+    this.confirmationDialogTarget.returnValue = ''; // Reset the return value on every confirmation dialog
     this.confirmationDialogTarget.showModal();
 
     return new Promise((resolve) => {


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/63637

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Ensure the confirm dialog cancel/confirm actions always result in the correct "Internal comment" state.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

_Before_


https://github.com/user-attachments/assets/6bc456b2-9053-4977-8b9d-9b26da0ba8e4


_After_


https://github.com/user-attachments/assets/ca3d1b4b-07ce-4c59-84a7-4f3fb1fc3dc2



# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Reset the confirmation dialog [returnValue](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue) on every showDialog() instance so that the state is always "fresh"

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
