### PR TITLE
adjust width wp select autocomplete on baord view

### DIFF
--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.sass
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.sass
@@ -3,3 +3,7 @@ ng-select.wp-inline-create--reference-autocompleter
 
   .ng-clear-wrapper
     display: none
+
+.ng-dropdown-panel.wp-inline-create--reference-autocompleter
+  max-width: 75vw !important
+  width: 500px !important

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -144,7 +144,7 @@
   </ng-container>
 
   <ng-container *ngSwitchCase="resource === 'work_packages' || resource === 'parent-child'">
-    <div class="op-autocompleter--option-wrapper">
+    <div class="op-autocompleter--option-wrapper" title="{{ item.subject }}">
       <op-principal
         class="op-autocompleter--option-principal"
         *ngIf="item.author && item.author.href"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58702

# What are you trying to accomplish?

Make the input wider so that it's easier to read the list of work packages

## Screenshots

Wider search results
![image](https://github.com/user-attachments/assets/71b6cf1b-7574-4b23-a8cb-681c713e8fbb)

Title property (tooltip)
![image](https://github.com/user-attachments/assets/f43e4222-256d-4b3b-8682-f55a01833b23)


