### PR TITLE
Fix extra relations visible when user adds any other type of relations

### DIFF
--- a/spec/models/relations/scopes/visible_spec.rb
+++ b/spec/models/relations/scopes/visible_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe Relations::Scopes::Visible do
 
         admin = create(:admin)
         User.execute_as(admin) do
-          expect(red.relations.visible).to contain_exactly(red.relations)
-          expect(green.relations.visible).to contain_exactly(green.relations)
-          expect(blue.relations.visible).to contain_exactly(blue.relations)
+          expect(red.relations.visible).to match_array(red.relations)
+          expect(green.relations.visible).to match_array(green.relations)
+          expect(blue.relations.visible).to match_array(blue.relations)
         end
       end
     end

--- a/spec/models/relations/scopes/visible_spec.rb
+++ b/spec/models/relations/scopes/visible_spec.rb
@@ -87,5 +87,28 @@ RSpec.describe Relations::Scopes::Visible do
           .to be_empty
       end
     end
+
+    context "when multiple relations exists between 3 work packages" do
+      # In this setup, each work package has a related_to relation to the 2 other work packages
+      let_work_packages(<<~TABLE)
+        subject | related to
+        red     | green
+        green   | blue
+        blue    | red
+      TABLE
+
+      it "returns only the relations directly related to the work package (Bug #62587)" do
+        expect(red.relations.visible).to be_empty
+        expect(green.relations.visible).to be_empty
+        expect(blue.relations.visible).to be_empty
+
+        admin = create(:admin)
+        User.execute_as(admin) do
+          expect(red.relations.visible).to contain_exactly(red.relations)
+          expect(green.relations.visible).to contain_exactly(green.relations)
+          expect(blue.relations.visible).to contain_exactly(blue.relations)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62587

# What are you trying to accomplish?

Some relations unrelated to the work package are visible in the relations tab.

# Explanation of the bug

It's related to the way the sql query generated by `Relation.visible` works: it gathers all relations of the work package, take the ids of all work packages of those relations, filter them by user's visibility, and then get all relations where both `to` and `from` are from that list of work packages.

That means that if we have the following work packages:
- work package "Red", id 1
- work package "Green", id 2
- work package "Blue", id 3

And each of them has a relation to the other, we have those relations:
- [1, 2]
- [2, 3]
- [3, 1]

When wanting to display all relations of work package "Red":
- it takes all relations related to "1": [1, 2] and [3, 1]
- it takes all work package ids: [1, 2, 3]
- it checks that they are all visible, and then takes all relations where `from_id` and `to_id` are in [1, 2, 3]
=> that includes [2, 3], even if it's not originally related to work package 1.

That's the bug.

## Screenshots



# What approach did you choose and why?

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
