### PR TITLE
Rename and unify some meeting permissions after classic meetings

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.rb
@@ -46,7 +46,7 @@ module MeetingAgendaItems::Outcomes
     end
 
     def render?
-      @meeting.in_progress? && User.current.allowed_in_project?(:create_meeting_minutes, @meeting.project)
+      @meeting.in_progress? && User.current.allowed_in_project?(:manage_outcomes, @meeting.project)
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.rb
@@ -44,7 +44,7 @@ module MeetingAgendaItems
     private
 
     def edit_enabled?
-      @meeting.in_progress? && User.current.allowed_in_project?(:create_meeting_minutes, @meeting.project)
+      @meeting.in_progress? && User.current.allowed_in_project?(:manage_outcomes, @meeting.project)
     end
 
     def edit_action_item(menu)

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -86,7 +86,7 @@
             item.with_leading_visual_icon(icon: :download)
           end
 
-          if @meeting.open? && User.current.allowed_in_project?(:send_meeting_agendas_notification, @meeting.project)
+          if @meeting.open? && User.current.allowed_in_project?(:send_meeting_invites_and_outcomes, @meeting.project)
             menu.with_item(
               label: t("meeting.label_mail_all_participants"),
               href: notify_project_meeting_path(@project, @meeting),

--- a/modules/meeting/app/components/meetings/side_panel/state_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.rb
@@ -44,7 +44,8 @@ module Meetings
     private
 
     def edit_enabled?
-      User.current.allowed_in_project?(:manage_agendas, @project)
+      User.current.allowed_in_project?(:manage_agendas, @project) ||
+        User.current.allowed_in_project?(:edit_meetings, @project)
     end
 
     def status_button

--- a/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
@@ -61,7 +61,7 @@ module Meetings
     private
 
     def edit_enabled?
-      User.current.allowed_in_project?(:close_meeting_agendas, @project)
+      User.current.allowed_in_project?(:manage_agendas, @project)
     end
 
     def current_status

--- a/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
@@ -61,7 +61,8 @@ module Meetings
     private
 
     def edit_enabled?
-      User.current.allowed_in_project?(:manage_agendas, @project)
+      User.current.allowed_in_project?(:manage_agendas, @project) ||
+        User.current.allowed_in_project?(:edit_meetings, @project)
     end
 
     def current_status

--- a/modules/meeting/app/contracts/meeting_outcomes/delete_contract.rb
+++ b/modules/meeting/app/contracts/meeting_outcomes/delete_contract.rb
@@ -33,7 +33,7 @@ module MeetingOutcomes
     include EditableItem
 
     delete_permission -> {
-      user.allowed_in_project?(:create_meeting_minutes, model.meeting_agenda_item.project)
+      user.allowed_in_project?(:manage_outcomes, model.meeting_agenda_item.project)
     }
   end
 end

--- a/modules/meeting/app/contracts/meeting_outcomes/editable_item.rb
+++ b/modules/meeting/app/contracts/meeting_outcomes/editable_item.rb
@@ -57,7 +57,7 @@ module MeetingOutcomes
     def user_allowed_to_add
       return unless visible?
 
-      unless user.allowed_in_project?(:create_meeting_minutes, model.meeting_agenda_item.project)
+      unless user.allowed_in_project?(:manage_outcomes, model.meeting_agenda_item.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -36,7 +36,6 @@ modules_permissions:
     - :view_meetings
     - :create_meeting_agendas
     - :manage_agendas
-    - :close_meeting_agendas
     - :send_meeting_agendas_notification
     - :send_meeting_agendas_icalendar
     - :create_meeting_minutes

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -37,7 +37,6 @@ modules_permissions:
     - :manage_agendas
     - :send_meeting_agendas_notification
     - :manage_outcomes
-    - :send_meeting_minutes_notification
     - :meetings_send_invite
   - role: :default_role_reader
     add:

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -34,7 +34,6 @@ modules_permissions:
     - :edit_meetings
     - :delete_meetings
     - :view_meetings
-    - :create_meeting_agendas
     - :manage_agendas
     - :send_meeting_agendas_notification
     - :send_meeting_agendas_icalendar

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -35,7 +35,6 @@ modules_permissions:
     - :delete_meetings
     - :view_meetings
     - :manage_agendas
-    - :send_meeting_agendas_notification
     - :manage_outcomes
     - :send_meeting_invites_and_outcomes
   - role: :default_role_reader

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -37,7 +37,7 @@ modules_permissions:
     - :manage_agendas
     - :send_meeting_agendas_notification
     - :manage_outcomes
-    - :meetings_send_invite
+    - :send_meeting_invites_and_outcomes
   - role: :default_role_reader
     add:
     - :view_meetings

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -38,7 +38,7 @@ modules_permissions:
     - :manage_agendas
     - :send_meeting_agendas_notification
     - :send_meeting_agendas_icalendar
-    - :create_meeting_minutes
+    - :manage_outcomes
     - :send_meeting_minutes_notification
     - :meetings_send_invite
   - role: :default_role_reader

--- a/modules/meeting/app/seeders/common.yml
+++ b/modules/meeting/app/seeders/common.yml
@@ -36,7 +36,6 @@ modules_permissions:
     - :view_meetings
     - :manage_agendas
     - :send_meeting_agendas_notification
-    - :send_meeting_agendas_icalendar
     - :manage_outcomes
     - :send_meeting_minutes_notification
     - :meetings_send_invite

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -369,7 +369,6 @@ en:
   permission_view_meetings: "View meetings"
   permission_manage_agendas: "Manage agendas"
   permission_manage_agendas_explanation: "Allows managing the Dynamic Meeting's agenda items."
-  permission_send_meeting_agendas_notification: "Send review notification for agendas"
   permission_manage_outcomes: "Manage outcomes"
   permission_send_meeting_invites_and_outcomes: "Send meeting invites and outcomes to participants"
 

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -367,8 +367,6 @@ en:
   permission_edit_meetings: "Edit meetings"
   permission_delete_meetings: "Delete meetings"
   permission_view_meetings: "View meetings"
-  permission_create_meeting_agendas: "Create meeting agendas"
-  permission_create_meeting_agendas_explanation: "Allows editing the Classic Meeting's agenda content."
   permission_manage_agendas: "Manage agendas"
   permission_manage_agendas_explanation: "Allows managing the Dynamic Meeting's agenda items."
   permission_send_meeting_agendas_notification: "Send review notification for agendas"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -371,7 +371,7 @@ en:
   permission_manage_agendas_explanation: "Allows managing the Dynamic Meeting's agenda items."
   permission_send_meeting_agendas_notification: "Send review notification for agendas"
   permission_manage_outcomes: "Manage outcomes"
-  permission_meetings_send_invite: "Invite users to meetings"
+  permission_send_meeting_invites_and_outcomes: "Send meeting invites and outcomes to participants"
 
   project_module_meetings: "Meetings"
 

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -372,7 +372,7 @@ en:
   permission_manage_agendas: "Manage agendas"
   permission_manage_agendas_explanation: "Allows managing the Dynamic Meeting's agenda items."
   permission_send_meeting_agendas_notification: "Send review notification for agendas"
-  permission_create_meeting_minutes: "Manage minutes"
+  permission_manage_outcomes: "Manage outcomes"
   permission_send_meeting_minutes_notification: "Send review notification for minutes"
   permission_meetings_send_invite: "Invite users to meetings"
   permission_send_meeting_agendas_icalendar: "Send meeting agenda as calendar entry"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -371,7 +371,6 @@ en:
   permission_create_meeting_agendas_explanation: "Allows editing the Classic Meeting's agenda content."
   permission_manage_agendas: "Manage agendas"
   permission_manage_agendas_explanation: "Allows managing the Dynamic Meeting's agenda items."
-  permission_close_meeting_agendas: "Close agendas"
   permission_send_meeting_agendas_notification: "Send review notification for agendas"
   permission_create_meeting_minutes: "Manage minutes"
   permission_send_meeting_minutes_notification: "Send review notification for minutes"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -373,7 +373,6 @@ en:
   permission_manage_outcomes: "Manage outcomes"
   permission_send_meeting_minutes_notification: "Send review notification for minutes"
   permission_meetings_send_invite: "Invite users to meetings"
-  permission_send_meeting_agendas_icalendar: "Send meeting agenda as calendar entry"
 
   project_module_meetings: "Meetings"
 

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -371,7 +371,6 @@ en:
   permission_manage_agendas_explanation: "Allows managing the Dynamic Meeting's agenda items."
   permission_send_meeting_agendas_notification: "Send review notification for agendas"
   permission_manage_outcomes: "Manage outcomes"
-  permission_send_meeting_minutes_notification: "Send review notification for minutes"
   permission_meetings_send_invite: "Invite users to meetings"
 
   project_module_meetings: "Meetings"

--- a/modules/meeting/db/migrate/20250428114958_cleanup_meeting_permissions.rb
+++ b/modules/meeting/db/migrate/20250428114958_cleanup_meeting_permissions.rb
@@ -39,6 +39,12 @@ class CleanupMeetingPermissions < ActiveRecord::Migration[7.1]
         'create_meeting_agendas'
       );
     SQL
+
+    execute <<-SQL.squish
+      UPDATE role_permissions
+      SET permission = 'send_meeting_invites_and_outcomes'
+      WHERE permission = 'meetings_send_invite'
+    SQL
   end
 
   # No-op

--- a/modules/meeting/db/migrate/20250428114958_cleanup_meeting_permissions.rb
+++ b/modules/meeting/db/migrate/20250428114958_cleanup_meeting_permissions.rb
@@ -28,27 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Meetings
-  class SidePanel::StateComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
-
-    def initialize(meeting:)
-      super
-
-      @meeting = meeting
-      @project = meeting.project
-    end
-
-    private
-
-    def edit_enabled?
-      User.current.allowed_in_project?(:manage_agendas, @project)
-    end
-
-    def status_button
-      render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting))
-    end
+class CleanupMeetingPermissions < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL.squish
+      DELETE FROM role_permissions
+      WHERE permission = 'close_meeting_agendas';
+    SQL
   end
+
+  # No-op
+  def down; end
 end

--- a/modules/meeting/db/migrate/20250428114958_cleanup_meeting_permissions.rb
+++ b/modules/meeting/db/migrate/20250428114958_cleanup_meeting_permissions.rb
@@ -32,7 +32,12 @@ class CleanupMeetingPermissions < ActiveRecord::Migration[7.1]
   def up
     execute <<-SQL.squish
       DELETE FROM role_permissions
-      WHERE permission = 'close_meeting_agendas';
+      WHERE permission IN (
+        'close_meeting_agendas',
+        'send_meeting_minutes_notification',
+        'send_meeting_agendas_icalendar',
+        'create_meeting_agendas'
+      );
     SQL
   end
 

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -103,10 +103,6 @@ module OpenProject::Meeting
                    },
                    permissible_on: :project,
                    require: :member
-        permission :send_meeting_minutes_notification,
-                   { meeting_minutes: %i[notify] },
-                   permissible_on: :project,
-                   require: :member
       end
 
       Redmine::Search.map do |search|

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -90,13 +90,6 @@ module OpenProject::Meeting
                    },
                    permissible_on: :project, # TODO: Change this to :meeting when MeetingRoles are available
                    require: :member
-        permission :send_meeting_agendas_notification,
-                   {
-                     meetings: [:notify],
-                     meeting_agendas: [:notify]
-                   },
-                   permissible_on: :project,
-                   require: :member
         permission :manage_outcomes,
                    {
                      meeting_outcomes: %i[new cancel_new create edit cancel_edit update destroy]

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -81,12 +81,6 @@ module OpenProject::Meeting
                    { meetings: [:icalendar] },
                    permissible_on: :project,
                    require: :member
-        permission :create_meeting_agendas,
-                   {
-                     meeting_agendas: %i[update preview]
-                   },
-                   permissible_on: :project,
-                   require: :member
         permission :manage_agendas,
                    {
                      meetings: %i[change_state],

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -107,9 +107,8 @@ module OpenProject::Meeting
                    { meeting_agendas: [:icalendar] },
                    permissible_on: :project,
                    require: :member
-        permission :create_meeting_minutes,
+        permission :manage_outcomes,
                    {
-                     meeting_minutes: %i[update preview],
                      meeting_outcomes: %i[new cancel_new create edit cancel_edit update destroy]
                    },
                    permissible_on: :project,

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -97,10 +97,6 @@ module OpenProject::Meeting
                    },
                    permissible_on: :project,
                    require: :member
-        permission :send_meeting_agendas_icalendar,
-                   { meeting_agendas: [:icalendar] },
-                   permissible_on: :project,
-                   require: :member
         permission :manage_outcomes,
                    {
                      meeting_outcomes: %i[new cancel_new create edit cancel_edit update destroy]

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -77,8 +77,8 @@ module OpenProject::Meeting
                    },
                    permissible_on: :project,
                    require: :member
-        permission :meetings_send_invite,
-                   { meetings: [:icalendar] },
+        permission :send_meeting_invites_and_outcomes,
+                   { meetings: %i[notify icalendar] },
                    permissible_on: :project,
                    require: :member
         permission :manage_agendas,

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -89,18 +89,12 @@ module OpenProject::Meeting
                    require: :member
         permission :manage_agendas,
                    {
+                     meetings: %i[change_state],
                      meeting_agenda_items: %i[new cancel_new create edit cancel_edit update destroy drop move
                                               move_to_next_meeting],
                      meeting_sections: %i[new cancel_new create edit cancel_edit update destroy drop move]
                    },
                    permissible_on: :project, # TODO: Change this to :meeting when MeetingRoles are available
-                   require: :member
-        permission :close_meeting_agendas,
-                   {
-                     meetings: %i[change_state],
-                     meeting_agendas: %i[close open]
-                   },
-                   permissible_on: :project,
                    require: :member
         permission :send_meeting_agendas_notification,
                    {

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -44,8 +44,6 @@ module OpenProject::Meeting
         permission :view_meetings,
                    {
                      meetings: %i[index show check_for_updates download_ics participants_dialog history],
-                     meeting_agendas: %i[history show diff],
-                     meeting_minutes: %i[history show diff],
                      "meetings/menus": %i[show],
                      work_package_meetings_tab: %i[index count],
                      recurring_meetings: %i[index show new create download_ics]

--- a/modules/meeting/spec/components/meetings/header_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/header_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Meetings::HeaderComponent, type: :component do
     context "when allowed" do
       before do
         mock_permissions_for(user) do |mock|
-          mock.allow_in_project(:send_meeting_agendas_notification, project:)
+          mock.allow_in_project(:send_meeting_invites_and_outcomes, project:)
         end
       end
 

--- a/modules/meeting/spec/contracts/meeting_outcomes/create_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_outcomes/create_contract_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MeetingOutcomes::CreateContract do
 
   context "with permission" do
     let(:user) do
-      create(:user, member_with_permissions: { project => %i[view_meetings create_meeting_minutes] })
+      create(:user, member_with_permissions: { project => %i[view_meetings manage_outcomes] })
     end
 
     context "when :meeting is 'in_progress'" do

--- a/modules/meeting/spec/contracts/meeting_outcomes/delete_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_outcomes/delete_contract_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MeetingOutcomes::DeleteContract do
 
   context "with permission" do
     let(:user) do
-      create(:user, member_with_permissions: { project => %i[view_meetings create_meeting_minutes] })
+      create(:user, member_with_permissions: { project => %i[view_meetings manage_outcomes] })
     end
 
     context "when :meeting is 'in_progress'" do

--- a/modules/meeting/spec/contracts/meeting_outcomes/update_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_outcomes/update_contract_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MeetingOutcomes::UpdateContract do
 
   context "with permission" do
     let(:user) do
-      create(:user, member_with_permissions: { project => %i[view_meetings create_meeting_minutes] })
+      create(:user, member_with_permissions: { project => %i[view_meetings manage_outcomes] })
     end
 
     context "when :meeting is 'in_progress'" do

--- a/modules/meeting/spec/features/structured_meetings/meeting_outcomes/meeting_outcomes_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/meeting_outcomes/meeting_outcomes_crud_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe "Meeting Outcomes CRUD", :js do
     create :user,
            lastname: "First",
            preferences: { time_zone: "Etc/UTC" },
-           member_with_permissions: { project => %i[view_meetings manage_agendas close_meeting_agendas create_meeting_minutes] }
+           member_with_permissions: { project => %i[view_meetings manage_agendas create_meeting_minutes] }
   end
   shared_let(:other_user) do
     create :user,
            lastname: "Second",
-           member_with_permissions: { project => %i[view_meetings manage_agendas close_meeting_agendas] }
+           member_with_permissions: { project => %i[view_meetings manage_agendas] }
   end
   shared_let(:meeting) do
     create :meeting,

--- a/modules/meeting/spec/features/structured_meetings/meeting_outcomes/meeting_outcomes_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/meeting_outcomes/meeting_outcomes_crud_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Meeting Outcomes CRUD", :js do
     create :user,
            lastname: "First",
            preferences: { time_zone: "Etc/UTC" },
-           member_with_permissions: { project => %i[view_meetings manage_agendas create_meeting_minutes] }
+           member_with_permissions: { project => %i[view_meetings manage_agendas manage_outcomes] }
   end
   shared_let(:other_user) do
     create :user,
@@ -64,7 +64,7 @@ RSpec.describe "Meeting Outcomes CRUD", :js do
     TextEditorField.new(page, "Outcome", selector: test_selector("meeting-outcome-input"))
   end
 
-  context "when a user has the necessary 'create_meeting_minutes' permission" do
+  context "when a user has the necessary 'manage_outcomes' permission" do
     before do
       meeting.update(state: state)
       login_as current_user

--- a/modules/meeting/spec/features/structured_meetings/mobile_structure_meeting_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/mobile_structure_meeting_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Meetings CRUD",
     create(:user,
            lastname: "First",
            member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
-                                                    close_meeting_agendas view_work_packages] }).tap do |u|
+                                                    view_work_packages] }).tap do |u|
       u.pref[:time_zone] = "Etc/UTC"
 
       u.save!

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_participant_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_participant_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Meetings participants",
     create(:user,
            lastname: "First",
            member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
-                                                    close_meeting_agendas view_work_packages] }).tap do |u|
+                                                    view_work_packages] }).tap do |u|
       u.pref[:time_zone] = "Etc/UTC"
 
       u.save!


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/62175



*   [x] Simpify the permissions into just these:
    *   [x] View meetings (keep)
    *   [x] Create meetings (keep)
    *   [x] Edit meetings (keep)
        *   [x] _this includes the ability to change status_
    *   [x] Delete meetings (keep)
    *   [x] Invite users to meetings (keep)
    *   [x] Manage agendas (keep but merge with the following:)
        *   [x] Create meeting agendas (remove)
        *   [x] Close agendas (remove)
    *   [x] Send meeting invites and outcomes to participants (keep and merge with the following:)
        *   [x] Send review notification for agendas (remove)
        *   [x] Send review notification for minutes (remove)
    *   [x] Manage outcomes (rename from &quot;Manage minutes&quot;)
        *   [x] Update translation key `permission_create_meeting_minutes`
        *   [x] Tie the ability to add/edit outcomes to this permission