### PR TITLE
add view for workweek and several bug fixes

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -25,6 +25,8 @@ export default class MyTimeTrackingController extends Controller {
     canEdit: Boolean,
     allowTimes: Boolean,
     forceTimes: Boolean,
+    workingDays: Array,
+    startOfWeek: Number,
   };
 
   declare readonly calendarTarget:HTMLElement;
@@ -38,6 +40,8 @@ export default class MyTimeTrackingController extends Controller {
   declare readonly forceTimesValue:boolean;
   declare readonly localeValue:string;
   declare readonly viewModeValue:string;
+  declare readonly workingDaysValue:number[];
+  declare readonly startOfWeekValue:number;
 
   private calendar:Calendar;
   private DEFAULT_TIMED_EVENT_DURATION = '01:00';
@@ -85,7 +89,9 @@ export default class MyTimeTrackingController extends Controller {
       eventMaxStack: 2,
       eventShortHeight: 31,
       nowIndicator: true,
-      businessHours: { daysOfWeek: [1, 2, 3, 4, 5], startTime: '00:00', endTime: '24:00' },
+      businessHours: { daysOfWeek: this.workingDaysValue, startTime: '00:00', endTime: '24:00' },
+      hiddenDays: this.hiddenDays(),
+      firstDay: this.startOfWeekValue,
       eventClassNames(arg) {
         return [
           'calendar-time-entry-event',
@@ -373,6 +379,7 @@ export default class MyTimeTrackingController extends Controller {
   calendarView():string {
     switch (this.modeValue) {
       case 'week':
+      case 'workweek':
         return 'timeGridWeek';
       case 'month':
         return 'dayGridMonth';
@@ -381,6 +388,23 @@ export default class MyTimeTrackingController extends Controller {
       default:
         return 'timeGridWeek';
     }
+  }
+
+  hiddenDays():number[] {
+    // if we are not in workweek mode we do not hide any days
+    if (this.modeValue !== 'workweek') {
+      return [];
+    }
+
+    const hiddenDays = [0, 1, 2, 3, 4, 5, 6];
+    this.workingDaysValue.forEach((day) => {
+      const index = hiddenDays.indexOf(day);
+      if (index > -1) {
+        hiddenDays.splice(index, 1);
+      }
+    });
+
+    return hiddenDays;
   }
 
   newTimeEntry(event:ActionEvent) {

--- a/modules/costs/app/components/my/time_tracking/calendar_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.html.erb
@@ -1,3 +1,4 @@
+<% helpers.html_title t(:label_my_time_tracking), "#{t("label_#{mode}")} #{t(:label_calendar)} #{I18n.l(date)}" -%>
 <%= flex_layout(data: wrapper_data, classes: "my-time-tracking-calendar-view") do |calendar_page| %>
   <% calendar_page.with_row { render(My::TimeTracking::HeaderComponent.new(mode:, date:, view_mode: :calendar)) } %>
   <% calendar_page.with_row { render(My::TimeTracking::SubHeaderComponent.new(mode:, date:, view_mode: :calendar)) } %>

--- a/modules/costs/app/components/my/time_tracking/calendar_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.html.erb
@@ -1,6 +1,7 @@
 <% helpers.html_title t(:label_my_time_tracking), "#{t("label_#{mode}")} #{t(:label_calendar)} #{I18n.l(date)}" -%>
 <%= flex_layout(data: wrapper_data, classes: "my-time-tracking-calendar-view") do |calendar_page| %>
   <% calendar_page.with_row { render(My::TimeTracking::HeaderComponent.new(mode:, date:, view_mode: :calendar)) } %>
+  <% calendar_page.with_row { render(My::TimeTracking::ViewModeSwitcherComponent.new(mode:, date:, view_mode: :calendar)) } %>
   <% calendar_page.with_row { render(My::TimeTracking::SubHeaderComponent.new(mode:, date:, view_mode: :calendar)) } %>
   <% calendar_page.with_row(classes: "op-fc-wrapper", data: { "my--time-tracking-target" => "calendar" }) %>
 

--- a/modules/costs/app/components/my/time_tracking/calendar_component.rb
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.rb
@@ -52,7 +52,9 @@ module My
           "my--time-tracking-can-edit-value" => User.current.allowed_in_any_project?(:edit_own_time_entries),
           "my--time-tracking-allow-times-value" => TimeEntry.can_track_start_and_end_time?,
           "my--time-tracking-force-times-value" => TimeEntry.must_track_start_and_end_time?,
-          "my--time-tracking-locale-value" => I18n.locale
+          "my--time-tracking-locale-value" => I18n.locale,
+          "my--time-tracking-start-of-week-value" => Setting.start_of_week,
+          "my--time-tracking-working-days-value" => working_days
         }
       end
 
@@ -67,6 +69,13 @@ module My
         total_str = DurationConverter.output(total_hours, format: :hours_and_minutes).presence || t("label_no_time")
 
         I18n.t(mode, scope: "total_times", hours: total_str)
+      end
+
+      def working_days
+        # Setting.working_days is mo=1, tu=2, we=3, th=4, fr=5, sa=6, su=7
+        # hiddenDays in fullcalendar is su=0, mo=1, tu=2, we=3, th=4, fr=5, sa=6
+
+        Setting.working_days.map { |day| day % 7 }.sort
       end
     end
   end

--- a/modules/costs/app/components/my/time_tracking/header_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/header_component.html.erb
@@ -7,25 +7,5 @@
         ]
       )
 
-      header.with_action_menu(
-        menu_arguments: { anchor_align: :end },
-        button_arguments: { button_block: view_mode_block }
-      ) do |menu|
-        menu.with_item(
-          label: t(:label_calendar),
-          tag: :a,
-          href: my_time_tracking_path(date: date, mode: mode, view_mode: "calendar")
-        ) do |item|
-          item.with_leading_visual_icon(icon: :calendar)
-        end
-        menu.with_item(
-          label: t(:label_list),
-          tag: :a,
-          href: my_time_tracking_path(date: date, mode: mode, view_mode: "list")
-        ) do |item|
-          item.with_leading_visual_icon(icon: "list-unordered")
-        end
-      end
-
       header.with_action_zen_mode_button
     end %>

--- a/modules/costs/app/components/my/time_tracking/list_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/list_component.html.erb
@@ -1,3 +1,4 @@
+<% helpers.html_title t(:label_my_time_tracking), "#{t("label_#{mode}")} #{t(:label_list)} #{I18n.l(date)}" -%>
 <%= component_wrapper(tag: "div", data: wrapper_data) do %>
   <%= render(My::TimeTracking::HeaderComponent.new(mode:, date:, view_mode: :list)) %>
   <%= render(My::TimeTracking::SubHeaderComponent.new(mode:, date:, view_mode: :list)) %>

--- a/modules/costs/app/components/my/time_tracking/list_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/list_component.html.erb
@@ -1,6 +1,7 @@
 <% helpers.html_title t(:label_my_time_tracking), "#{t("label_#{mode}")} #{t(:label_list)} #{I18n.l(date)}" -%>
 <%= component_wrapper(tag: "div", data: wrapper_data) do %>
   <%= render(My::TimeTracking::HeaderComponent.new(mode:, date:, view_mode: :list)) %>
+  <%= render(My::TimeTracking::ViewModeSwitcherComponent.new(mode:, date:, view_mode: :list)) %>
   <%= render(My::TimeTracking::SubHeaderComponent.new(mode:, date:, view_mode: :list)) %>
 
   <%= flex_layout(classes: ["my-time-tracking-list-view"]) do |flex| %>

--- a/modules/costs/app/components/my/time_tracking/list_component.rb
+++ b/modules/costs/app/components/my/time_tracking/list_component.rb
@@ -53,7 +53,8 @@ module My
         case mode
         when :day then [date]
         when :week then date.all_week
-        when :month then date.all_month.map(&:beginning_of_week).uniq
+        when :workweek then workweek_days
+        when :month then month_days
         end
       end
 
@@ -67,9 +68,26 @@ module My
 
       def date_title(date)
         if mode == :month
-          I18n.t(:label_specific_week, week: date.strftime("%W"))
+          I18n.t(:label_specific_week, week: week_number(date))
         else
           I18n.l(date, format: "%A %d")
+        end
+      end
+
+      def workweek_days
+        workdays_normalized  = Setting.working_days.map { |day| day % 7 }.sort
+        date.all_week.select { |d| workdays_normalized.include?(d.wday) }
+      end
+
+      def month_days
+        date.all_month.map(&:beginning_of_week).uniq
+      end
+
+      def week_number(date)
+        if Setting.start_of_week == 1 # monday
+          I18n.l(date, format: "%W")
+        else # 6 saturday, 7 sunday
+          I18n.l(date, format: "%U")
         end
       end
 

--- a/modules/costs/app/components/my/time_tracking/mode_switcher_component.rb
+++ b/modules/costs/app/components/my/time_tracking/mode_switcher_component.rb
@@ -36,17 +36,20 @@ module My
               :date
 
       def call
-        render(Primer::Alpha::SegmentedControl.new("aria-label": I18n.t(:label_meeting_date_time))) do |control|
-          %i[day week workweek month].each do |mode|
-            control.with_item(
-              tag: :a,
-              href: my_time_tracking_path(date:, view_mode:, mode:),
-              icon: icon_for_mode(mode),
-              label: t("label_#{mode}"),
-              title: t("label_#{mode}"),
-              selected: (current_mode == mode)
-            )
+        render(Primer::Alpha::ActionMenu.new(menu_id: "my-time-tracking-mode-switch")) do |menu|
+          menu.with_show_button do |button|
+            button.with_leading_visual_icon(icon: icon_for_mode(current_mode))
+            button.with_trailing_action_icon(icon: :"triangle-down")
+            t("label_#{current_mode}")
           end
+
+          %i[day week workweek month].each { menu_item_for_mode(menu, it) }
+        end
+      end
+
+      def menu_item_for_mode(menu, mode)
+        menu.with_item(tag: :a, href: my_time_tracking_path(date:, view_mode:, mode:), label: t("label_#{mode}")) do |item|
+          item.with_leading_visual_icon(icon: icon_for_mode(mode))
         end
       end
 

--- a/modules/costs/app/components/my/time_tracking/mode_switcher_component.rb
+++ b/modules/costs/app/components/my/time_tracking/mode_switcher_component.rb
@@ -43,7 +43,7 @@ module My
             t("label_#{current_mode}")
           end
 
-          %i[day week workweek month].each { menu_item_for_mode(menu, it) }
+          %i[day workweek week month].each { menu_item_for_mode(menu, it) }
         end
       end
 

--- a/modules/costs/app/components/my/time_tracking/mode_switcher_component.rb
+++ b/modules/costs/app/components/my/time_tracking/mode_switcher_component.rb
@@ -37,7 +37,7 @@ module My
 
       def call
         render(Primer::Alpha::SegmentedControl.new("aria-label": I18n.t(:label_meeting_date_time))) do |control|
-          %i[day week month].each do |mode|
+          %i[day week workweek month].each do |mode|
             control.with_item(
               tag: :a,
               href: my_time_tracking_path(date:, view_mode:, mode:),
@@ -56,6 +56,8 @@ module My
           "op-calendar-day"
         when :week
           "op-calendar-week"
+        when :workweek
+          "briefcase"
         else
           "calendar"
         end

--- a/modules/costs/app/components/my/time_tracking/sub_header_component.rb
+++ b/modules/costs/app/components/my/time_tracking/sub_header_component.rb
@@ -37,7 +37,7 @@ module My
         case mode
         when :day
           I18n.l(date, format: :long)
-        when :week
+        when :week, :workweek
           bow = date.beginning_of_week
           eow = date.end_of_week
 
@@ -62,6 +62,9 @@ module My
         when :day
           { href: my_time_tracking_path(date: date - 1.day, view_mode:, mode:),
             aria: { label: I18n.t(:label_previous_day) } }
+        when :workweek
+          { href: my_time_tracking_path(date: date - 1.week, view_mode:, mode:),
+            aria: { label: I18n.t(:label_previous_workweek) } }
         when :week
           { href: my_time_tracking_path(date: date - 1.week, view_mode:, mode:),
             aria: { label: I18n.t(:label_previous_week) } }
@@ -76,6 +79,9 @@ module My
         when :day
           { href: my_time_tracking_path(date: date + 1.day, view_mode:, mode:),
             aria: { label: I18n.t(:label_next_day) } }
+        when :workweek
+          { href: my_time_tracking_path(date: date + 1.week, view_mode:, mode:),
+            aria: { label: I18n.t(:label_next_workweek) } }
         when :week
           { href: my_time_tracking_path(date: date + 1.week, view_mode:, mode:),
             aria: { label: I18n.t(:label_next_week) } }

--- a/modules/costs/app/components/my/time_tracking/view_mode_switcher_component.rb
+++ b/modules/costs/app/components/my/time_tracking/view_mode_switcher_component.rb
@@ -30,8 +30,28 @@
 
 module My
   module TimeTracking
-    class HeaderComponent < ApplicationComponent
-      options :date, :mode, :view_mode
+    class ViewModeSwitcherComponent < ApplicationComponent
+      options :mode,
+              :view_mode,
+              :date
+
+      def call
+        render(Primer::Alpha::TabNav.new(label: I18n.l(:label_view_mode_switcher))) do |component|
+          component.with_tab(selected: view_mode == :calendar, href: link(:calendar)) do |tab|
+            tab.with_text { I18n.t(:label_calendar) }
+            tab.with_icon(icon: :calendar)
+          end
+
+          component.with_tab(selected: view_mode == :list, href: link(:list)) do |tab|
+            tab.with_text { I18n.t(:label_list) }
+            tab.with_icon(icon: "op-view-list")
+          end
+        end
+      end
+
+      def link(new_view_mode)
+        my_time_tracking_path(date: date, mode: mode, view_mode: new_view_mode)
+      end
     end
   end
 end

--- a/modules/costs/app/components/my/time_tracking/view_mode_switcher_component.rb
+++ b/modules/costs/app/components/my/time_tracking/view_mode_switcher_component.rb
@@ -36,7 +36,7 @@ module My
               :date
 
       def call
-        render(Primer::Alpha::TabNav.new(label: I18n.l(:label_view_mode_switcher))) do |component|
+        render(Primer::Alpha::TabNav.new(label: I18n.t(:label_view_mode_switcher))) do |component|
           component.with_tab(selected: view_mode == :calendar, href: link(:calendar)) do |tab|
             tab.with_text { I18n.t(:label_calendar) }
             tab.with_icon(icon: :calendar)

--- a/modules/costs/app/controllers/my/time_tracking_controller.rb
+++ b/modules/costs/app/controllers/my/time_tracking_controller.rb
@@ -75,8 +75,8 @@ module My
     end
 
     def workweek
-      workdays_normalized  = Setting.working_days.map { |day| day % 7 }.sort
-      date.all_week.select { |d| workdays_normalized.include?(d.wday) }
+      workdays_normalized = Setting.working_days.map { |day| day % 7 }.sort
+      date.all_week(week_start_day).select { |d| workdays_normalized.include?(d.wday) }
     end
 
     def parsed_date
@@ -116,7 +116,7 @@ module My
     def current_date
       case mode
       when :day then Time.zone.today
-      when :week, :workweek then Time.zone.today.beginning_of_week
+      when :week, :workweek then Time.zone.today.beginning_of_week(week_start_day)
       when :month then Time.zone.today.beginning_of_month
       end
     end
@@ -142,6 +142,14 @@ module My
           mode: mode,
           date: date
         )
+      end
+    end
+
+    def week_start_day
+      case Setting.start_of_week
+      when 6 then :saturday
+      when 7 then :sunday
+      else :monday
       end
     end
 

--- a/modules/costs/app/controllers/my/time_tracking_controller.rb
+++ b/modules/costs/app/controllers/my/time_tracking_controller.rb
@@ -93,7 +93,7 @@ module My
       if mobile?
         "day"
       else
-        "week"
+        "workweek"
       end
     end
 

--- a/modules/costs/app/controllers/my/time_tracking_controller.rb
+++ b/modules/costs/app/controllers/my/time_tracking_controller.rb
@@ -45,6 +45,7 @@ module My
     def index
       case mode
       when :day then load_time_entries(date)
+      when :workweek then load_time_entries(workweek)
       when :week then load_time_entries(date.all_week)
       when :month then load_time_entries(date.all_month)
       end
@@ -71,6 +72,11 @@ module My
 
     def date
       @date ||= parsed_date || current_date
+    end
+
+    def workweek
+      workdays_normalized  = Setting.working_days.map { |day| day % 7 }.sort
+      date.all_week.select { |d| workdays_normalized.include?(d.wday) }
     end
 
     def parsed_date
@@ -110,7 +116,7 @@ module My
     def current_date
       case mode
       when :day then Time.zone.today
-      when :week then Time.zone.today.beginning_of_week
+      when :week, :workweek then Time.zone.today.beginning_of_week
       when :month then Time.zone.today.beginning_of_month
       end
     end

--- a/modules/costs/app/views/admin/costs_settings/show.html.erb
+++ b/modules/costs/app/views/admin/costs_settings/show.html.erb
@@ -56,11 +56,11 @@ render(Primer::Alpha::TabPanels.new(label: I18n.t(:project_module_costs))) do |c
             end
           end
 
-          form.check_box(name: :allow_tracking_start_and_end_times)
-
           form.html_content do
             render(::EnterpriseEdition::BannerComponent.new(:time_entry_time_restrictions, dismissable: false))
           end
+
+          form.check_box(name: :allow_tracking_start_and_end_times)
           form.check_box(name: :enforce_tracking_start_and_end_times, disabled: !EnterpriseToken.allows_to?(:time_entry_time_restrictions))
 
           form.submit

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -170,8 +170,10 @@ en:
   label_no_time: "No time tracked"
   label_next_day: "Next day"
   label_next_week: "Next week"
+  label_next_workweek: "Next work week"
   label_next_month: "Next month"
   label_previous_day: "Previous day"
+  label_previous_workweek: "Previous work week"
   label_previous_week: "Previous week"
   label_previous_month: "Previous month"
   label_specific_day: "Day %{day}"
@@ -179,6 +181,7 @@ en:
   label_specific_month: "Month %{month}"
   label_list: "List"
   label_month: "Month"
+  label_workweek: "Work week"
   label_day: "Day"
   label_today_capitalized: "Today"
 

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -226,6 +226,7 @@ en:
   week: "week"
 
   total_times:
+    workweek: "Workweek Total: %{hours}"
     week: "Week Total: %{hours}"
     month: "Month Total: %{hours}"
     day: "Day Total: %{hours}"

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -210,10 +210,10 @@ en:
 
   project_module_costs: "Time and costs"
 
-  setting_allow_tracking_start_and_end_times: "Allow users to track start and end time on time records"
+  setting_allow_tracking_start_and_end_times: "Allow exact times tracking"
   setting_costs_currency: "Currency"
   setting_costs_currency_format: "Format of currency"
-  setting_enforce_tracking_start_and_end_times: "Force users to set start and end time on time records"
+  setting_enforce_tracking_start_and_end_times: "Require exact times"
 
   text_assign_time_and_cost_entries_to_project: "Assign reported hours and costs to the project"
   text_destroy_cost_entries_question: "%{cost_entries} were reported on the work packages you are about to delete. What do you want to do ?"

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
   label_workweek: "Work week"
   label_day: "Day"
   label_today_capitalized: "Today"
+  label_view_mode_switcher: "Change view"
 
   placeholder_activity_select_work_package_first: Work package selection is required first
 

--- a/modules/costs/config/routes.rb
+++ b/modules/costs/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
     get "/time-tracking/(:mode-:view_mode)(/:date)" => "time_tracking#index",
         as: :time_tracking,
         constraints: {
-          mode: /day|week|month/,
+          mode: /day|week|workweek|month/,
           view_mode: /list|calendar/,
           date: /\d{4}-\d{2}-\d{2}/
         }

--- a/modules/costs/spec/controllers/my/time_tracking_controller_spec.rb
+++ b/modules/costs/spec/controllers/my/time_tracking_controller_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe My::TimeTrackingController do
           allow(TimeEntry).to receive(:can_track_start_and_end_time?).and_return(true)
         end
 
-        it "renders the calendar week view" do
+        it "renders the work week view" do
           get :index
-          expect(assigns(:mode)).to eq(:week)
+          expect(assigns(:mode)).to eq(:workweek)
           expect(assigns(:view_mode)).to eq(:calendar)
         end
       end
@@ -60,9 +60,9 @@ RSpec.describe My::TimeTrackingController do
           allow(TimeEntry).to receive(:can_track_start_and_end_time?).and_return(false)
         end
 
-        it "renders the week list view" do
+        it "renders the work week list view" do
           get :index
-          expect(assigns(:mode)).to eq(:week)
+          expect(assigns(:mode)).to eq(:workweek)
           expect(assigns(:view_mode)).to eq(:list)
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63621
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63640
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63562
https://community.openproject.org/projects/openproject/work_packages/62624

# What are you trying to accomplish?
- [x] Add work week mode that only shows days defined as working days
- [x] mark non working days correctly (darker gray) in week and month mode
- [x] Change segmented control to dropdown
- [x] Change selector for calendar/list to tabs
- [x] Start of week setting is acknoweledged
- [x] My Time tracking has proper page title
- [x] Fix translations and layout of settings

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
