### PR TITLE
Fix not_builtin scope

### DIFF
--- a/app/models/principals/scopes/not_builtin.rb
+++ b/app/models/principals/scopes/not_builtin.rb
@@ -40,7 +40,8 @@ module Principals::Scopes
       def not_builtin
         where.not(type: [SystemUser.name,
                          AnonymousUser.name,
-                         DeletedUser.name])
+                         DeletedUser.name,
+                         ServiceAccount.name])
       end
     end
   end

--- a/spec/models/principals/scopes/not_builtin_spec.rb
+++ b/spec/models/principals/scopes/not_builtin_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Principals::Scopes::NotBuiltin do
     let!(:group) { create(:group) }
     let!(:user) { create(:user) }
     let!(:placeholder_user) { create(:placeholder_user) }
+    let!(:service_account) { create(:service_account) }
 
     subject { Principal.not_builtin }
 


### PR DESCRIPTION
This scope could have returned ServiceAccounts, even though we count them as builtin users for other purposes.

The error could not have manifested in productive deployments so far, because there is no code that creates service accounts yet. It is therefore also not testable in a QA environment or similar.

I noticed it locally when trying to setup Nextcloud as IDP, because it would try to link the Nextcloud user to a service account, which should have been impossible.