### PR TITLE
update system guide (create new work package status page)

### DIFF
--- a/docs/system-admin-guide/manage-work-packages/work-package-status/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-status/README.md
@@ -33,12 +33,15 @@ A new window will open, where you will be able to specify the following:
 
    > [!TIP]
    > The value for % Complete can be set from 0 to 100. 
-   
+
 3. Define if the new work package status closes a work package (e.g. relevant when filtering for closed for packages), e.g. a work package status "rejected" will set a work package technically on closed and it will not appear in the default work package table with Open Work packages.
 
 4. Define if this status is set as default value when creating new work packages. BEWARE: If you decide to set the new status as default it will impact all work packages, existing and future ones. See more below.
 
 5. Check if this status sets a **work package in read-only mode**. This means no work package attributes can be changed except the status.
+
+   > [!NOTE]
+   > The read-only modus for work package statuses is an Enterprise add-on and only available for [Enterprise on-premises](https://www.openproject.org/enterprise-edition/) and [Enterprise cloud](https://www.openproject.org/enterprise-edition/#hosting-options) customers.
 
 6. Check **Exclude from calculation of totals in hierarchy** if you want work packages with this status to *not* be included in the calculation of totals in a hierarchy. This is useful for statuses like *rejected*.
 


### PR DESCRIPTION
Add a note that a read-only wp status is an Enterprise add-on

