### PR TITLE
Fix wrong calculation for time entries without start&end times

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -246,7 +246,7 @@ export default class MyTimeTrackingController extends Controller {
       if (!eventStart) return;
 
       // Format event date for comparison
-      const eventDateStr = eventStart.toISOString().slice(0, 10);
+      const eventDateStr = moment(eventStart).format('YYYY-MM-DD');
 
       if (eventDateStr === dayStr && event.extendedProps && event.extendedProps.hours) {
         totalHours += event.extendedProps.hours as number;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/63690

## Screenshots
see ticket

# What approach did you choose and why?
- [x] Use the correct date and not UTC. Especially for the events that we handle as all day events, the UTC date is wrong
- [x] Fix an error that showed up in the console, that when we drag or resize events, the backend is trying to close the dialog but we don't have one 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
