### PR TITLE
[#63676] Use a boolean instead of CSS classes to check state for the collapsible header in meetings stimulus controllers

### DIFF
--- a/frontend/src/stimulus/helpers/collapsible-helper.ts
+++ b/frontend/src/stimulus/helpers/collapsible-helper.ts
@@ -35,7 +35,7 @@ export function appendCollapsedState(
   const header = document.querySelector(headerSelector);
 
   if (header) {
-    const collapsed = header.classList.contains('CollapsibleHeader--collapsed');
+    const collapsed = header.hasAttribute('data-collapsed');
     target.append('collapsed', collapsed.toString());
   }
 }

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -315,10 +315,10 @@ module Pages::Meetings
       expect(page).to have_css(".CollapsibleHeader", text: I18n.t("label_agenda_backlog"))
 
       if collapsed
-        expect(page).to have_css(".CollapsibleHeader.CollapsibleHeader--collapsed")
+        expect(page).to have_css(".CollapsibleHeader[data-collapsed]")
         expect(page).to have_no_text(I18n.t("text_agenda_backlog"))
       else
-        expect(page).to have_no_css(".CollapsibleHeader.CollapsibleHeader--collapsed")
+        expect(page).to have_no_css(".CollapsibleHeader[data-collapsed]")
         expect(page).to have_text(I18n.t("text_agenda_backlog"))
       end
     end
@@ -327,10 +327,10 @@ module Pages::Meetings
       expect(page).to have_css(".CollapsibleHeader", text: I18n.t("label_series_backlog"))
 
       if collapsed
-        expect(page).to have_css(".CollapsibleHeader.CollapsibleHeader--collapsed")
+        expect(page).to have_css(".CollapsibleHeader[data-collapsed]")
         expect(page).to have_no_text(I18n.t("text_series_backlog"))
       else
-        expect(page).to have_no_css(".CollapsibleHeader.CollapsibleHeader--collapsed")
+        expect(page).to have_no_css(".CollapsibleHeader[data-collapsed]")
         expect(page).to have_text(I18n.t("text_series_backlog"))
       end
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/63676

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Check the collapsed state via the already implemented boolean instead of using CSS classes

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
