### PR TITLE
feature/61309 Trigger browser confirmation dialog when clicking on 'Mark all as read' and disable it when there are no notifications for the current filter

### DIFF
--- a/app/components/notifications/index_sub_header_component.html.erb
+++ b/app/components/notifications/index_sub_header_component.html.erb
@@ -23,7 +23,9 @@
         href: mark_all_read_notifications_path(**current_filters),
         data: { method: :post, confirm: I18n.t("js.notifications.center.mark_all_read_confirmation") },
         size: :medium,
-        aria: { label: I18n.t("js.notifications.center.mark_all_read") }
+        aria: { label: I18n.t("js.notifications.center.mark_all_read") },
+        disabled: !unread_notifications?,
+        test_selector: "mark-all-as-read-button"
       ) do |button|
         button.with_leading_visual_icon(icon: :"op-read-all")
         I18n.t("js.notifications.center.mark_all_read")

--- a/app/components/notifications/index_sub_header_component.html.erb
+++ b/app/components/notifications/index_sub_header_component.html.erb
@@ -21,7 +21,7 @@
       subheader.with_action_button(
         tag: :a,
         href: mark_all_read_notifications_path(**current_filters),
-        data: { method: :post },
+        data: { method: :post, confirm: I18n.t("js.notifications.center.mark_all_read_confirmation") },
         size: :medium,
         aria: { label: I18n.t("js.notifications.center.mark_all_read") }
       ) do |button|

--- a/app/components/notifications/index_sub_header_component.rb
+++ b/app/components/notifications/index_sub_header_component.rb
@@ -45,5 +45,25 @@ module Notifications
     def current_filters
       @current_filters ||= { filter: @filter_type, name: @filter_name }.compact
     end
+
+    def unread_notifications?
+      unread_notifications_query.valid? && unread_notifications_query.results.any?
+    end
+
+    private
+
+    def unread_notifications_query
+      @unread_notifications_query ||= Queries::Notifications::NotificationQuery.new(user: User.current).tap do |query|
+        query.where(:read_ian, "=", "f")
+
+        case filter_type
+        when "project"
+          id = filter_name.to_i
+          query.where(:project_id, "=", [id])
+        when "reason"
+          query.where(:reason, "=", [filter_name])
+        end
+      end
+    end
   end
 end

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -695,7 +695,7 @@ en:
         no_results:
           at_all: "New notifications will appear here when there is activity that concerns you."
           with_current_filter: "There are no notifications in this view at the moment"
-        mark_all_read: "Clear all"
+        mark_all_read: "Mark all as read"
         mark_as_read: "Mark as read"
         mark_all_read_confirmation: "This will mark all notifications in this view as read. Are you sure you want to do this?"
         text_update_date_by: "%{date} by"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -695,8 +695,9 @@ en:
         no_results:
           at_all: "New notifications will appear here when there is activity that concerns you."
           with_current_filter: "There are no notifications in this view at the moment"
-        mark_all_read: "Mark all as read"
+        mark_all_read: "Clear all"
         mark_as_read: "Mark as read"
+        mark_all_read_confirmation: "This will mark all notifications in this view as read. Are you sure you want to do this?"
         text_update_date_by: "%{date} by"
         total_count_warning: "Showing the %{newest_count} most recent notifications. %{more_count} more are not displayed."
         empty_state:

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe "Notification center",
         wait_for_network_idle
 
         center.expect_bell_count 0
+        center.expect_mark_all_as_read_button_disabled
         side_menu.expect_item_with_no_count "Inbox"
         side_menu.expect_item_with_no_count "Mentioned"
         side_menu.expect_item_with_no_count "Watcher"

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -41,7 +41,7 @@ module Pages
 
       def mark_all_read
         accept_confirm do
-          click_link_or_button "Clear all"
+          click_on "Mark all as read"
         end
       end
 

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -40,7 +40,9 @@ module Pages
       end
 
       def mark_all_read
-        click_link_or_button "Mark all as read"
+        accept_confirm do
+          click_link_or_button "Clear all"
+        end
       end
 
       def mark_notification_as_read(notification)

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -140,6 +140,10 @@ module Pages
         end
       end
 
+      def expect_mark_all_as_read_button_disabled
+        expect(page).to have_css('[data-test-selector="mark-all-as-read-button"][disabled]', text: "Mark all as read")
+      end
+
       def bell_element
         page.find('opce-in-app-notification-bell [data-test-selector="op-ian-bell"]')
       end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/61309

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- [x] Add browser confirmation dialog for "Mark all as read" button
- [x] Disable "Mark all as read" button when there are no notifications for the current filter

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/5157b3ce-4446-4577-b92d-c2dbce87afc1

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
