### PR TITLE
[62604] Marking a notification as read automatically selects the first notification

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -255,7 +255,15 @@ export class IanCenterService extends UntilDestroyedMixin {
           return;
         }
         if (notifications[0][0]._links.resource || notifications[this.selectedNotificationIndex][0]._links.resource) {
-          const wpId = idFromLink(notifications[this.selectedNotificationIndex >= notifications.length ? 0 : this.selectedNotificationIndex][0]._links.resource.href);
+          let index:number;
+          if (this.selectedNotificationIndex === notifications.length) {
+            // If the last notification is marked as read, we do not jump to the top, but rather show the new last notification
+            index = notifications.length - 1;
+          } else {
+            index = this.selectedNotificationIndex > notifications.length ? 0 : this.selectedNotificationIndex;
+          }
+
+          const wpId = idFromLink(notifications[index][0]._links.resource.href);
           this.openSplitScreen(wpId);
         }
       });


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/62604/activity

# What are you trying to accomplish?
Show the above notification when the last notification is marked as read (instead of jumping to the top)


