### PR TITLE
fix apache example config

### DIFF
--- a/docs/installation-and-operations/installation/packaged/openproject-apache-example.conf
+++ b/docs/installation-and-operations/installation/packaged/openproject-apache-example.conf
@@ -39,9 +39,6 @@
     ProxyRequests off
     # Forward the original host name to the proxy
     ProxyPreserveHost On
-    ProxyPass / http://127.0.0.1:6000/ retry=0
-    ProxyPassReverse / http://127.0.0.1:6000/
-
 
     # Disallow internal API for external use
     # (used for repository authenticiation, if any)
@@ -83,6 +80,9 @@
 
     # Enabling compression for common text formats
     AddOutputFilterByType DEFLATE text/html text/css application/x-javascript application/javascript
+
+    ProxyPass / http://127.0.0.1:6000/ retry=0
+    ProxyPassReverse / http://127.0.0.1:6000/
 
     ErrorLog    /var/log/apache2/openproject.example.com-error.log
 </VirtualHost>


### PR DESCRIPTION
For the apache config to work correctly the following lines need to be declered before the general `ProxyPass /`:

```
Alias /assets /opt/openproject/public/assets
ProxyPass /assets/ !
```