### PR TITLE
More time tracking calendar layout fixes

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -100,7 +100,7 @@ export default class MyTimeTrackingController extends Controller {
       eventClassNames(arg) {
         return [
           'calendar-time-entry-event',
-          `__hl_status_${arg.event.extendedProps.statusId}`,
+          `__hl_type_${arg.event.extendedProps.typeId}`,
           '__hl_border_top',
           'ellipsis',
         ];

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -92,7 +92,6 @@ export default class MyTimeTrackingController extends Controller {
       dayMaxEventRows: 4, // 3 + more link
       eventMinHeight: 30,
       eventMaxStack: 2,
-      eventShortHeight: 31,
       nowIndicator: true,
       businessHours: { daysOfWeek: this.workingDaysValue, startTime: '00:00', endTime: '24:00' },
       hiddenDays: this.hiddenDays(),

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -90,6 +90,7 @@ export default class MyTimeTrackingController extends Controller {
       defaultTimedEventDuration: this.DEFAULT_TIMED_EVENT_DURATION,
       allDayContent: '',
       dayMaxEventRows: 4, // 3 + more link
+      eventShortHeight: 45,
       eventMinHeight: 30,
       eventMaxStack: 2,
       nowIndicator: true,

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -90,7 +90,9 @@ export default class MyTimeTrackingController extends Controller {
       defaultTimedEventDuration: this.DEFAULT_TIMED_EVENT_DURATION,
       allDayContent: '',
       dayMaxEventRows: 4, // 3 + more link
-      eventShortHeight: 45,
+      // We want everything including 90 minutes to be short style ... If we set it to 90,
+      // 2 hours is also considered short ... So, magic number at 80 ... Don't ask me why
+      eventShortHeight: 80,
       eventMinHeight: 30,
       eventMaxStack: 2,
       nowIndicator: true,
@@ -118,7 +120,7 @@ export default class MyTimeTrackingController extends Controller {
 
         if (!arg.event.allDay) {
           const time = `${toMoment(arg.event.start!, this.calendar).format('LT')} - ${toMoment(arg.event.end!, this.calendar).format('LT')}`;
-          timeDetails = `<div class="color-fg-muted mt-2" title="${time}">${time}</div>`;
+          timeDetails = `<div class="fc-entry-time color-fg-muted mt-2" title="${time}">${time}</div>`;
         }
 
         return {
@@ -131,7 +133,7 @@ export default class MyTimeTrackingController extends Controller {
                     ${arg.event.extendedProps.workPackageSubject}
                   </a>
                </div>
-               <div class="color-fg-muted" title="${arg.event.extendedProps.projectName}">${arg.event.extendedProps.projectName}</div>
+               <div class="fc-project-name color-fg-muted" title="${arg.event.extendedProps.projectName}">${arg.event.extendedProps.projectName}</div>
                ${timeDetails}
              </div>
            </div>`,

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -107,6 +107,14 @@ export default class MyTimeTrackingController extends Controller {
       },
       eventContent: (arg) => {
         let timeDetails = '';
+        let duration = arg.event.extendedProps.hours as number;
+
+        if (arg.isResizing && arg.event.start && arg.event.end) {
+          const startMoment = toMoment(arg.event.start, this.calendar);
+          const endMoment = toMoment(arg.event.end, this.calendar);
+
+         duration = moment.duration(endMoment.diff(startMoment)).asHours();
+        }
 
         if (!arg.event.allDay) {
           const time = `${toMoment(arg.event.start!, this.calendar).format('LT')} - ${toMoment(arg.event.end!, this.calendar).format('LT')}`;
@@ -116,7 +124,7 @@ export default class MyTimeTrackingController extends Controller {
         return {
           html: `
            <div class="fc-event-main-frame">
-             <div class="fc-event-time mb-1">${this.displayDuration(arg.event.extendedProps.hours as number)}</div>
+             <div class="fc-event-time mb-1">${this.displayDuration(duration)}</div>
              <div class="fc-event-title-container">
                 <div class="fc-event-title mb-2" title="${arg.event.extendedProps.workPackageSubject}">
                   <a class="Link--primary Link" href="${this.pathHelper.workPackageShortPath(arg.event.extendedProps.workPackageId as string)}">

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -1,5 +1,5 @@
 import { ActionEvent, Controller } from '@hotwired/stimulus';
-import { Calendar } from '@fullcalendar/core';
+import { Calendar, EventApi } from '@fullcalendar/core';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
@@ -99,27 +99,24 @@ export default class MyTimeTrackingController extends Controller {
       businessHours: { daysOfWeek: this.workingDaysValue, startTime: '00:00', endTime: '24:00' },
       hiddenDays: this.hiddenDays(),
       firstDay: this.startOfWeekValue,
-      eventClassNames(arg) {
+      eventClassNames(info) {
         return [
           'calendar-time-entry-event',
-          `__hl_type_${arg.event.extendedProps.typeId}`,
+          `__hl_type_${info.event.extendedProps.typeId}`,
           '__hl_border_top',
           'ellipsis',
         ];
       },
-      eventContent: (arg) => {
+      eventContent: (info) => {
         let timeDetails = '';
-        let duration = arg.event.extendedProps.hours as number;
+        let duration = info.event.extendedProps.hours as number;
 
-        if (arg.isResizing && arg.event.start && arg.event.end) {
-          const startMoment = toMoment(arg.event.start, this.calendar);
-          const endMoment = toMoment(arg.event.end, this.calendar);
-
-         duration = moment.duration(endMoment.diff(startMoment)).asHours();
+        if (info.isResizing && info.event.start && info.event.end) {
+          duration = this.calculateHours(info.event);
         }
 
-        if (!arg.event.allDay) {
-          const time = `${toMoment(arg.event.start!, this.calendar).format('LT')} - ${toMoment(arg.event.end!, this.calendar).format('LT')}`;
+        if (!info.event.allDay) {
+          const time = `${toMoment(info.event.start!, this.calendar).format('LT')} - ${toMoment(info.event.end!, this.calendar).format('LT')}`;
           timeDetails = `<div class="fc-entry-time color-fg-muted mt-2" title="${time}">${time}</div>`;
         }
 
@@ -128,12 +125,12 @@ export default class MyTimeTrackingController extends Controller {
            <div class="fc-event-main-frame">
              <div class="fc-event-time mb-1">${this.displayDuration(duration)}</div>
              <div class="fc-event-title-container">
-                <div class="fc-event-title mb-2" title="${arg.event.extendedProps.workPackageSubject}">
-                  <a class="Link--primary Link" href="${this.pathHelper.workPackageShortPath(arg.event.extendedProps.workPackageId as string)}">
-                    ${arg.event.extendedProps.workPackageSubject}
+                <div class="fc-event-title mb-2" title="${info.event.extendedProps.workPackageSubject}">
+                  <a class="Link--primary Link" href="${this.pathHelper.workPackageShortPath(info.event.extendedProps.workPackageId as string)}">
+                    ${info.event.extendedProps.workPackageSubject}
                   </a>
                </div>
-               <div class="fc-project-name color-fg-muted" title="${arg.event.extendedProps.projectName}">${arg.event.extendedProps.projectName}</div>
+               <div class="fc-project-name color-fg-muted" title="${info.event.extendedProps.projectName}">${info.event.extendedProps.projectName}</div>
                ${timeDetails}
              </div>
            </div>`,
@@ -163,9 +160,7 @@ export default class MyTimeTrackingController extends Controller {
         }
 
         const startMoment = toMoment(info.event.start, this.calendar);
-        const endMoment = toMoment(info.event.end, this.calendar);
-
-        const newEventHours = moment.duration(endMoment.diff(startMoment)).asHours();
+        const newEventHours = this.calculateHours(info.event);
 
         info.event.setExtendedProp('hours', newEventHours);
 
@@ -389,6 +384,20 @@ export default class MyTimeTrackingController extends Controller {
       return `${minutes}m`;
     }
     return `${hours}h ${minutes}m`;
+  }
+
+  calculateHours(event:EventApi):number {
+    const start = event.start;
+    const end = event.end;
+
+    if (!start || !end) {
+      return 0;
+    }
+
+    const startMoment = toMoment(start, this.calendar);
+    const endMoment = toMoment(end, this.calendar);
+
+    return moment.duration(endMoment.diff(startMoment)).asHours();
   }
 
   calendarView():string {

--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -90,9 +90,7 @@ export default class MyTimeTrackingController extends Controller {
       defaultTimedEventDuration: this.DEFAULT_TIMED_EVENT_DURATION,
       allDayContent: '',
       dayMaxEventRows: 4, // 3 + more link
-      // We want everything including 90 minutes to be short style ... If we set it to 90,
-      // 2 hours is also considered short ... So, magic number at 80 ... Don't ask me why
-      eventShortHeight: 80,
+      eventShortHeight: 60,
       eventMinHeight: 30,
       eventMaxStack: 2,
       nowIndicator: true,
@@ -117,20 +115,20 @@ export default class MyTimeTrackingController extends Controller {
 
         if (!info.event.allDay) {
           const time = `${toMoment(info.event.start!, this.calendar).format('LT')} - ${toMoment(info.event.end!, this.calendar).format('LT')}`;
-          timeDetails = `<div class="fc-entry-time color-fg-muted mt-2" title="${time}">${time}</div>`;
+          timeDetails = `<div class="fc-event-times" title="${time}">${time}</div>`;
         }
 
         return {
           html: `
            <div class="fc-event-main-frame">
-             <div class="fc-event-time mb-1">${this.displayDuration(duration)}</div>
+             <div class="fc-event-time">${this.displayDuration(duration)}</div>
              <div class="fc-event-title-container">
-                <div class="fc-event-title mb-2" title="${info.event.extendedProps.workPackageSubject}">
+                <div class="fc-event-title fc-event-wp" title="${info.event.extendedProps.workPackageSubject}">
                   <a class="Link--primary Link" href="${this.pathHelper.workPackageShortPath(info.event.extendedProps.workPackageId as string)}">
                     ${info.event.extendedProps.workPackageSubject}
                   </a>
                </div>
-               <div class="fc-project-name color-fg-muted" title="${info.event.extendedProps.projectName}">${info.event.extendedProps.projectName}</div>
+               <div class="fc-event-project" title="${info.event.extendedProps.projectName}">${info.event.extendedProps.projectName}</div>
                ${timeDetails}
              </div>
            </div>`,

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -34,12 +34,13 @@
       .fc-event-time
         font-weight: normal
 
-    .fc-day
-      &.fc-day-past
-        background-color: var(--fc-page-bg-color) !important
+    .fc-col-header
+      .fc-day
+        &.fc-day-past
+          background-color: var(--fc-page-bg-color) !important
 
-      &.fc-day-future
-        background-color: var(--fc-page-bg-color) !important
+        &.fc-day-future
+          background-color: var(--fc-page-bg-color) !important
 
     .fc-timegrid-more-link
       background: var(--fc-page-bg-color) !important

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -12,7 +12,8 @@
     .calendar-time-entry-event
       display: flex
       user-select: none
-      border: 1px solid var(--borderColor-default)
+      border: none
+      box-shadow: 1px 1px 3px 0px var(--borderColor-default)
       border-radius: 5px
       background: var(--body-background)
       color: var(--body-font-color)

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -10,41 +10,77 @@
       justify-content: center
 
     .calendar-time-entry-event
-      display: flex
       user-select: none
       border: none
       box-shadow: var(--shadow-floating-small)
-      border-radius: 5px
       background: var(--body-background)
       color: var(--body-font-color)
-      font-size: var(--body-font-size)
+      border-radius: 5px
+      padding-top: 8px
+      padding-right: 4px
+      padding-bottom: 8px
+      padding-left: 4px
+      line-height: var(--text-body-lineHeight-small)
+      font-size: var(--text-body-size-small)
 
       .fc-event-time
-        color: var(--fgColor-default)
+        font-size: var(--text-body-size-small) !important
 
+      .fc-event-main
+        padding: 0
+
+      .fc-event-title-container
+        line-height: var(--text-body-lineHeight-small) !important
+
+      .fc-event-time, .fc-event-times
+        color: var(--fgColor-muted, var(--color-fg-subtle))
+        font-style: normal
+        font-weight: normal
+
+      // special short display version
       &.fc-timegrid-event-short, &.fc-daygrid-block-event
-        // background: hotpink !important
+        padding-top: 5px
+        padding-bottom: 5px
+
+        .fc-event-title-container
+          padding-top: 0
+
+        .fc-event-time
+          padding-top: 0
+          padding-right: 2px
+
         .fc-event-time::after
           content: ''
           display: none
 
-        .fc-project-name
+        .fc-event-title
+          font-size: var(--text-body-size-small)
+
+        .fc-event-project
           display: none
 
-        .fc-entry-time
+        .fc-event-times
           display: none
 
     .fc-popover
       background: var(--fc-page-bg-color) !important
 
+    // event in the normal calendar area
+    .fc-timegrid-event
+      .fc-event-title-container
+        margin: 0 !important
+        padding-top: 4px
+
+        .fc-event-project, .fc-event-times
+          color: var(--fgColor-muted, var(--color-fg-subtle))
+          padding-top: 4px
+
+    // event in the the all day area
     .fc-daygrid-event
       background: var(--body-background) !important
 
       .fc-event-title-container
         margin: 0 !important
-
-      .fc-event-time
-        font-weight: normal
 
     .fc-col-header
       .fc-day

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -4,6 +4,11 @@
   .op-fc-wrapper
     flex-grow: 1
 
+    .fc-daygrid-day-bottom
+      display: flex
+      align-items: center
+      justify-content: center
+
     .calendar-time-entry-event
       display: flex
       user-select: none

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -34,6 +34,13 @@
       .fc-event-time
         font-weight: normal
 
+    .fc-day
+      &.fc-day-past
+        background-color: var(--fc-page-bg-color) !important
+
+      &.fc-day-future
+        background-color: var(--fc-page-bg-color) !important
+
     .fc-timegrid-more-link
       background: var(--fc-page-bg-color) !important
       border: 1px solid var(--borderColor-default)

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -13,7 +13,7 @@
       display: flex
       user-select: none
       border: none
-      box-shadow: 1px 1px 3px 0px var(--borderColor-default)
+      box-shadow: var(--shadow-floating-small)
       border-radius: 5px
       background: var(--body-background)
       color: var(--body-font-color)

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -4,11 +4,6 @@
   .op-fc-wrapper
     flex-grow: 1
 
-    .fc-timegrid-event-short
-      .fc-event-time::after
-        content: ''
-        display: none
-
     .calendar-time-entry-event
       display: flex
       user-select: none
@@ -21,6 +16,18 @@
 
       .fc-event-time
         color: var(--fgColor-default)
+
+      &.fc-timegrid-event-short, &.fc-daygrid-block-event
+        // background: hotpink !important
+        .fc-event-time::after
+          content: ''
+          display: none
+
+        .fc-project-name
+          display: none
+
+        .fc-entry-time
+          display: none
 
     .fc-popover
       background: var(--fc-page-bg-color) !important

--- a/modules/costs/app/components/my/time_tracking/calendar_component.sass
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.sass
@@ -16,10 +16,7 @@
       background: var(--body-background)
       color: var(--body-font-color)
       border-radius: 5px
-      padding-top: 8px
-      padding-right: 4px
-      padding-bottom: 8px
-      padding-left: 4px
+      padding: 4px
       line-height: var(--text-body-lineHeight-small)
       font-size: var(--text-body-size-small)
 
@@ -39,8 +36,8 @@
 
       // special short display version
       &.fc-timegrid-event-short, &.fc-daygrid-block-event
-        padding-top: 5px
-        padding-bottom: 5px
+        padding-top: 4px
+        padding-bottom: 4px
 
         .fc-event-title-container
           padding-top: 0
@@ -69,11 +66,9 @@
     .fc-timegrid-event
       .fc-event-title-container
         margin: 0 !important
-        padding-top: 4px
 
         .fc-event-project, .fc-event-times
           color: var(--fgColor-muted, var(--color-fg-subtle))
-          padding-top: 4px
 
     // event in the the all day area
     .fc-daygrid-event

--- a/modules/costs/app/components/my/time_tracking/list_component.rb
+++ b/modules/costs/app/components/my/time_tracking/list_component.rb
@@ -100,6 +100,8 @@ module My
       end
 
       def collapsed?(date)
+        return false if mode == :day
+
         date.past?
       end
 

--- a/modules/costs/app/components/my/time_tracking/sub_header_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/sub_header_component.html.erb
@@ -25,6 +25,6 @@
         href: dialog_time_entries_path(onlyMe: true)
       ) do |button|
         button.with_leading_visual_icon(icon: "plus")
-        t(:button_log_time)
+        t(:button_add_time_entry)
       end
     end %>

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
   button_log_costs: "Log unit costs"
   button_log_time: "Log"
   button_add_activity: "Activity"
+  button_add_time_entry: "Log time"
 
   caption_booked_on_project: "Booked on project"
   caption_default: "Default"

--- a/modules/costs/lib/full_calendar/time_entry_event.rb
+++ b/modules/costs/lib/full_calendar/time_entry_event.rb
@@ -50,7 +50,7 @@ module FullCalendar
     def additional_attributes
       {
         hours: time_entry.hours,
-        statusId: time_entry.work_package.status_id,
+        typeId: time_entry.work_package.type_id,
         workPackageId: time_entry.work_package.id,
         workPackageSubject: time_entry.work_package.subject,
         projectId: time_entry.project.id,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/63706
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63787
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63563
# What are you trying to accomplish?
Fix some stylings according to figma

- [x] Remove border and add a drop shadow
- [x] Use WP type and not status for the color on the header
- [x] Style the header in white
- [x] [Style "all day" and short (<1h events) in small style](https://www.figma.com/design/xRFTkBJYxQJxwAf9fd3oM1/Log-time?node-id=2857-42179&t=Mu0vcx427f8HlWf8-4)
- [x] Time is not updated while resizing an event
- [x] [Style normal events correctly ](https://www.figma.com/design/xRFTkBJYxQJxwAf9fd3oM1/Log-time?node-id=2857-42102&t=5jnmuEVY5gB8PUyg-4)
- [x] center "+ x more" link
- [x] day+list view is always expanded even if it is in the past


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
