### PR TITLE
[#63674] "Meeting updated" flash does not work correctly with series backlogs

### DIFF
--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -274,7 +274,7 @@ module Meetings
         move_item_via_turbo_stream(meeting_agenda_item:)
 
         # Update the header for updated timestamp
-        update_header_component_via_turbo_stream
+        update_header_component_via_turbo_stream unless @meeting_agenda_item.meeting_section.backlog?
 
         # update the displayed time slots of all other items in the section
         update_show_items_of_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section)

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -52,130 +52,225 @@ RSpec.describe "Meetings CRUD",
               .and_return(0)
     end
 
-    it do
-      flash_component = ".op-primer-flash--item"
+    context "for meeting related actions" do
+      it do
+        flash_component = ".op-primer-flash--item"
 
-      ## Add agenda item
-      show_page.visit!
-
-      first_window = current_window
-      second_window = open_new_window
-
-      within_window(second_window) do
+        ## Add agenda item
         show_page.visit!
 
-        show_page.add_agenda_item do
-          fill_in "Title", with: "Update toast test item"
+        first_window = current_window
+        second_window = open_new_window
+
+        within_window(second_window) do
+          show_page.visit!
+
+          retry_block do
+            show_page.add_agenda_item do
+              fill_in "Title", with: "Update toast test item"
+            end
+          end
+        end
+
+        # Expect notification in window1
+        within_window(first_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_css(flash_component, wait: 5)
+          expect(page).to have_text I18n.t(:notice_meeting_updated)
+          page.within(flash_component) { click_on "Reload" }
+          sleep 1
+        end
+
+        # Expect no notification in window2
+        within_window(second_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+        end
+
+        ## Edit agenda item
+        within_window(first_window) do
+          item = MeetingAgendaItem.find_by(title: "Update toast test item")
+
+          show_page.edit_agenda_item(item) do
+            fill_in "Title", with: "Updated title"
+            click_on "Save"
+          end
+
+          # Expect no notification in window1
+          show_page.trigger_change_poll
+          expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+        end
+
+        # Expect notification in window2
+        within_window(second_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_css(flash_component, wait: 5)
+          expect(page).to have_text I18n.t(:notice_meeting_updated)
+
+          page.within(flash_component) { click_on "Reload" }
+          sleep 1
+
+          ## Add section
+          show_page.add_section do
+            fill_in "Title", with: "First section"
+            click_on "Save"
+          end
+
+          show_page.expect_section(title: "First section")
+          show_page.visit!
+          expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+        end
+
+        # Expect notification in window1
+        within_window(first_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_css(flash_component, wait: 5)
+          expect(page).to have_text I18n.t(:notice_meeting_updated)
+          page.within(flash_component) { click_on "Reload" }
+          sleep 1
+        end
+
+        # Expect no notification in window2
+        within_window(second_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+        end
+
+        ## Edit meeting details
+        within_window(first_window) do
+          find_test_selector("edit-meeting-details-button").click
+          fill_in "meeting_duration", with: "2.5"
+          click_link_or_button "Save"
+
+          # Expect updated duration
+          expect(page).to have_text "2 hrs, 30 mins"
+
+          # Expect no notification in window1
+          show_page.trigger_change_poll
+          expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+        end
+
+        # Expect notification in window2
+        within_window(second_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_text I18n.t(:notice_meeting_updated)
+
+          page.within(flash_component) { click_on "Reload" }
+          sleep 1
+
+          ## Close meeting
+          find_test_selector("close-meeting-button").click
+          expect(page).to have_text "This meeting is in progress."
+          find_test_selector("close-meeting-button").click
+          expect(page).to have_text "This meeting is closed."
+
+          show_page.visit!
+          expect(page).to have_text "This meeting is closed."
+        end
+
+        # Expect notification in window1
+        within_window(first_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_css(flash_component, wait: 5)
+          expect(page).to have_text I18n.t(:notice_meeting_updated)
+          page.within(flash_component) { click_on "Reload" }
+          sleep 1
+        end
+
+        # Expect no notification in window2
+        within_window(second_window) do
+          show_page.trigger_change_poll
+          expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+        end
+
+        second_window.close
+      end
+    end
+
+    context "for backlog related actions" do
+      context "for one-time meetings" do
+        it do
+          show_page.visit!
+          first_window = current_window
+          second_window = open_new_window
+
+          # Add item to backlog - expect no flash in both windows
+          within_window(first_window) do
+            show_page.add_agenda_item_to_backlog do
+              fill_in "Title", with: "Backlog agenda item"
+            end
+
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+          end
+
+          within_window(second_window) do
+            show_page.visit!
+
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+
+            # Edit item in backlog - expect no flash in both windows
+            item = MeetingAgendaItem.find_by(title: "Backlog agenda item")
+            show_page.edit_agenda_item(item) do
+              fill_in "Title", with: "Edited title"
+              click_on "Save"
+            end
+
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+          end
+
+          within_window(first_window) do
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+            show_page.reload!
+
+            # Reorder items in backlog - expect no flash in both windows
+            show_page.add_agenda_item_to_backlog do
+              fill_in "Title", with: "Second item"
+            end
+            item = MeetingAgendaItem.find_by(title: "Edited title")
+            retry_block do
+              show_page.select_action(item, I18n.t(:label_agenda_item_move_to_bottom))
+            end
+
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+          end
+
+          within_window(second_window) do
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+
+            # Delete item in backlog - expect no flash in both windows
+            item = MeetingAgendaItem.find_by(title: "Edited title")
+            show_page.remove_agenda_item(item)
+
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+          end
+
+          within_window(first_window) do
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+
+            # Clear backlog - expect no flash in both windows
+            show_page.clear_backlog
+
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+          end
+
+          within_window(second_window) do
+            show_page.trigger_change_poll
+            expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+          end
+
+          second_window.close
         end
       end
 
-      # Expect notification in window1
-      within_window(first_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_css(flash_component, wait: 5)
-        expect(page).to have_text I18n.t(:notice_meeting_updated)
-        page.within(flash_component) { click_on "Reload" }
-      end
-
-      # Expect no notification in window2
-      within_window(second_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_no_text I18n.t(:notice_meeting_updated)
-      end
-
-      ## Edit agenda item
-      within_window(first_window) do
-        item = MeetingAgendaItem.find_by(title: "Update toast test item")
-
-        show_page.edit_agenda_item(item) do
-          fill_in "Title", with: "Updated title"
-          click_on "Save"
-        end
-
-        # Expect no notification in window1
-        show_page.trigger_change_poll
-        expect(page).to have_no_text I18n.t(:notice_meeting_updated)
-      end
-
-      # Expect notification in window2
-      within_window(second_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_css(flash_component, wait: 5)
-        expect(page).to have_text I18n.t(:notice_meeting_updated)
-
-        page.within(flash_component) { click_on "Reload" }
-
-        ## Add section
-        show_page.add_section do
-          fill_in "Title", with: "First section"
-          click_on "Save"
-        end
-
-        show_page.expect_section(title: "First section")
-        show_page.visit!
-        expect(page).to have_no_text I18n.t(:notice_meeting_updated)
-      end
-
-      # Expect notification in window1
-      within_window(first_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_css(flash_component, wait: 5)
-        expect(page).to have_text I18n.t(:notice_meeting_updated)
-        page.within(flash_component) { click_on "Reload" }
-      end
-
-      # Expect no notification in window2
-      within_window(second_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_no_text I18n.t(:notice_meeting_updated)
-      end
-
-      ## Edit meeting details
-      within_window(first_window) do
-        find_test_selector("edit-meeting-details-button").click
-        fill_in "meeting_duration", with: "2.5"
-        click_link_or_button "Save"
-
-        # Expect updated duration
-        expect(page).to have_text "2 hrs, 30 mins"
-
-        # Expect no notification in window1
-        show_page.trigger_change_poll
-        expect(page).to have_no_text I18n.t(:notice_meeting_updated)
-      end
-
-      # Expect notification in window2
-      within_window(second_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_text I18n.t(:notice_meeting_updated)
-
-        page.within(flash_component) { click_on "Reload" }
-
-        ## Close meeting
-        find_test_selector("close-meeting-button").click
-        expect(page).to have_text "This meeting is in progress."
-        find_test_selector("close-meeting-button").click
-        expect(page).to have_text "This meeting is closed."
-
-        show_page.visit!
-        expect(page).to have_text "This meeting is closed."
-      end
-
-      # Expect notification in window1
-      within_window(first_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_css(flash_component, wait: 5)
-        expect(page).to have_text I18n.t(:notice_meeting_updated)
-        page.within(flash_component) { click_on "Reload" }
-      end
-
-      # Expect no notification in window2
-      within_window(second_window) do
-        show_page.trigger_change_poll
-        expect(page).to have_no_text I18n.t(:notice_meeting_updated)
-      end
-
-      second_window.close
     end
   end
 end

--- a/modules/meeting/spec/features/structured_meetings/update_flash_shared_examples.rb
+++ b/modules/meeting/spec/features/structured_meetings/update_flash_shared_examples.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.shared_examples "no flash appears when interacting with backlog in multiple windows" do
+  it do
+    show_page.visit!
+    first_window = current_window
+    second_window = open_new_window
+
+    within_window(first_window) do
+      show_page.add_agenda_item_to_backlog do
+        fill_in "Title", with: "Backlog agenda item"
+      end
+
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+    end
+
+    within_window(second_window) do
+      show_page.visit!
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+
+      item = MeetingAgendaItem.find_by(title: "Backlog agenda item")
+      show_page.edit_agenda_item(item) do
+        fill_in "Title", with: "Edited title"
+        click_on "Save"
+      end
+
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+    end
+
+    within_window(first_window) do
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+      show_page.reload!
+
+      show_page.add_agenda_item_to_backlog do
+        fill_in "Title", with: "Second item"
+      end
+
+      item = MeetingAgendaItem.find_by(title: "Edited title")
+      retry_block do
+        show_page.select_action(item, I18n.t(:label_agenda_item_move_to_bottom))
+      end
+
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+    end
+
+    within_window(second_window) do
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+
+      item = MeetingAgendaItem.find_by(title: "Edited title")
+      show_page.remove_agenda_item(item)
+
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+    end
+
+    within_window(first_window) do
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+
+      show_page.clear_backlog
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+    end
+
+    within_window(second_window) do
+      show_page.trigger_change_poll
+      expect(page).to have_no_text I18n.t(:notice_meeting_updated)
+    end
+
+    second_window.close
+  end
+end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -391,12 +391,10 @@ module Pages::Meetings
     end
 
     def clear_backlog
-      retry_block do
-        select_backlog_action(I18n.t("label_backlog_clear"))
-        expect(page).to have_modal(I18n.t("label_backlog_clear"))
-        page.within_modal(I18n.t("label_backlog_clear")) do
-          click_on "Clear all"
-        end
+      select_backlog_action(I18n.t("label_backlog_clear"))
+      expect(page).to have_modal(I18n.t("label_backlog_clear"), wait: 3)
+      page.within_modal(I18n.t("label_backlog_clear")) do
+        click_on "Clear all"
       end
     end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/63674

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
- [x] The flash shows in a second window of the same occurrence when an item is moved in/out of the backlog
- [x] The flash does not show anywhere when items are modified inside the backlog (other windows of the same meeting + other occurrences in the series):
   - Adding an agenda item
   - Editing an agenda item
   - Deleting an agenda item
   - Reordering agenda items within the backlog
   - Reordering agenda items via drag and drop within the backlog
- [x] The flash does not show anywhere when the backlog is cleared (other windows of the same meeting + other occurrences in the series)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
