### PR TITLE
bug/61544 Activity Tab renders the same turbo frame multiple times inside of itself

### DIFF
--- a/app/components/concerns/work_packages/activities_tab/stimulus_controllers.rb
+++ b/app/components/concerns/work_packages/activities_tab/stimulus_controllers.rb
@@ -31,11 +31,13 @@
 module WorkPackages
   module ActivitiesTab
     module StimulusControllers
+      module_function
+
       def index_stimulus_controller(suffix = nil) = "work-packages--activities-tab--index#{suffix}"
       def internal_comment_stimulus_controller(suffix = nil) = "work-packages--activities-tab--internal-comment#{suffix}"
       def quote_comments_stimulus_controller(suffix = nil) = "work-packages--activities-tab--quote-comment#{suffix}"
 
-      def items_index_selector = "##{WorkPackages::ActivitiesTab::IndexComponent.wrapper_key}"
+      def index_stimulus_controller_outlet_selector = "##{WorkPackages::ActivitiesTab::IndexComponent.index_content_wrapper_key}"
 
       def add_comment_selector
         "##{WorkPackages::ActivitiesTab::IndexComponent.add_comment_wrapper_key}"

--- a/app/components/concerns/work_packages/activities_tab/stimulus_controllers.rb
+++ b/app/components/concerns/work_packages/activities_tab/stimulus_controllers.rb
@@ -39,7 +39,7 @@ module WorkPackages
 
       def index_stimulus_controller_outlet_selector = "##{WorkPackages::ActivitiesTab::IndexComponent.index_content_wrapper_key}"
 
-      def add_comment_selector
+      def internal_comment_stimulus_controller_outlet_selector
         "##{WorkPackages::ActivitiesTab::IndexComponent.add_comment_wrapper_key}"
       end
     end

--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -12,7 +12,7 @@
           )
         end
 
-        activities_tab_wrapper_container.with_row(data: wrapper_data_attributes) do
+        activities_tab_wrapper_container.with_row(id: index_content_wrapper_key, data: wrapper_data_attributes) do
           flex_layout do |activities_tab_container|
             activities_tab_container.with_row(mb: 2) do
               render(

--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -4,45 +4,46 @@
       WorkPackages::ActivitiesTab::Journals::IndexComponent.new(work_package:, filter:, deferred:)
     )
   else
-    content_tag("turbo-frame", id: "work-package-activities-tab-content") do
-      flex_layout(classes: "work-packages-activities-tab-index-component") do |activties_tab_wrapper_container|
-        activties_tab_wrapper_container.with_row(classes: "work-packages-activities-tab-index-component--errors") do
+    component_wrapper(tag: "turbo-frame") do
+      flex_layout(classes: "work-packages-activities-tab-index-component") do |activities_tab_wrapper_container|
+        activities_tab_wrapper_container.with_row(classes: "work-packages-activities-tab-index-component--errors") do
           render(
             WorkPackages::ActivitiesTab::ErrorStreamComponent.new
           )
         end
-        activties_tab_wrapper_container.with_row do
-          component_wrapper(data: wrapper_data_attributes) do
-            flex_layout do |activties_tab_container|
-              activties_tab_container.with_row(mb: 2) do
+
+        activities_tab_wrapper_container.with_row(data: wrapper_data_attributes) do
+          flex_layout do |activities_tab_container|
+            activities_tab_container.with_row(mb: 2) do
+              render(
+                WorkPackages::ActivitiesTab::Journals::FilterAndSortingComponent.new(
+                  work_package:,
+                  filter:
+                )
+              )
+            end
+
+            activities_tab_container.with_row(flex_layout: true, classes: "work-packages-activities-tab-index-component--content-container", mt: 3) do |journals_wrapper_container|
+              journals_wrapper_container.with_row(
+                classes: "work-packages-activities-tab-index-component--journals-container work-packages-activities-tab-index-component--journals-container_with-initial-input-compensation",
+                data: { "work-packages--activities-tab--index-target": "journalsContainer" }
+              ) do
                 render(
-                  WorkPackages::ActivitiesTab::Journals::FilterAndSortingComponent.new(
-                    work_package:,
-                    filter:
-                  )
+                  WorkPackages::ActivitiesTab::Journals::IndexComponent.new(work_package:, filter:)
                 )
               end
-              activties_tab_container.with_row(flex_layout: true, classes: "work-packages-activities-tab-index-component--content-container", mt: 3) do |journals_wrapper_container|
+
+              if adding_comment_allowed?
                 journals_wrapper_container.with_row(
-                  classes: "work-packages-activities-tab-index-component--journals-container work-packages-activities-tab-index-component--journals-container_with-initial-input-compensation",
-                  data: { "work-packages--activities-tab--index-target": "journalsContainer" }
+                  id: add_comment_wrapper_key,
+                  classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
+                  p: 3,
+                  bg: :subtle,
+                  data: add_comment_wrapper_data_attributes
                 ) do
                   render(
-                    WorkPackages::ActivitiesTab::Journals::IndexComponent.new(work_package:, filter:)
+                    WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:)
                   )
-                end
-                if adding_comment_allowed?
-                  journals_wrapper_container.with_row(
-                    id: add_comment_wrapper_key,
-                    classes: "work-packages-activities-tab-index-component--input-container work-packages-activities-tab-index-component--input-container_sort-#{journal_sorting}",
-                    p: 3,
-                    bg: :subtle,
-                    data: add_comment_wrapper_data_attributes
-                  ) do
-                    render(
-                      WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:)
-                    )
-                  end
                 end
               end
             end

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -49,6 +49,8 @@ module WorkPackages
       def self.add_comment_wrapper_key = "work-packages-activities-tab-add-comment-component"
       delegate :add_comment_wrapper_key, to: :class
 
+      def wrapper_key = "work-package-activities-tab-content"
+
       private
 
       attr_reader :work_package, :filter, :last_server_timestamp, :deferred

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -46,10 +46,10 @@ module WorkPackages
         @deferred = deferred
       end
 
+      def self.wrapper_key = "work-package-activities-tab-content"
+      def self.index_content_wrapper_key = WorkPackages::ActivitiesTab::StimulusControllers.index_stimulus_controller
       def self.add_comment_wrapper_key = "work-packages-activities-tab-add-comment-component"
-      delegate :add_comment_wrapper_key, to: :class
-
-      def wrapper_key = "work-package-activities-tab-content"
+      delegate :index_content_wrapper_key, :add_comment_wrapper_key, to: :class
 
       private
 

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -82,7 +82,7 @@ module WorkPackages
           action: index_stimulus_controller(":onSubmit-end@window->#{internal_comment_stimulus_controller}#onSubmitEnd"),
           internal_comment_stimulus_controller("-highlight-class") => "work-packages-activities-tab-journals-new-component--journal-notes-body__internal-comment", # rubocop:disable Layout/LineLength
           internal_comment_stimulus_controller("-hidden-class") => "d-none",
-          internal_comment_stimulus_controller("-#{index_stimulus_controller}-outlet") => "##{wrapper_key}",
+          internal_comment_stimulus_controller("-#{index_stimulus_controller}-outlet") => index_stimulus_controller_outlet_selector, # rubocop:disable Layout/LineLength
           internal_comment_stimulus_controller("-is-internal-value") => false # Initial value
         }
       end

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -166,7 +166,7 @@ module WorkPackages
             quote_comments_stimulus_controller("-is-internal-param") => journal.internal?,
             quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
             quote_comments_stimulus_controller("-#{index_stimulus_controller}-outlet") => index_stimulus_controller_outlet_selector, # rubocop:disable Layout/LineLength
-            quote_comments_stimulus_controller("-#{internal_comment_stimulus_controller}-outlet") => add_comment_selector,
+            quote_comments_stimulus_controller("-#{internal_comment_stimulus_controller}-outlet") => internal_comment_stimulus_controller_outlet_selector, # rubocop:disable Layout/LineLength
             test_selector: "op-wp-journal-#{journal.id}-quote"
           }
         end

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -165,7 +165,7 @@ module WorkPackages
             quote_comments_stimulus_controller("-user-name-param") => journal.user.name,
             quote_comments_stimulus_controller("-is-internal-param") => journal.internal?,
             quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
-            quote_comments_stimulus_controller("-#{index_stimulus_controller}-outlet") => items_index_selector,
+            quote_comments_stimulus_controller("-#{index_stimulus_controller}-outlet") => index_stimulus_controller_outlet_selector, # rubocop:disable Layout/LineLength
             quote_comments_stimulus_controller("-#{internal_comment_stimulus_controller}-outlet") => add_comment_selector,
             test_selector: "op-wp-journal-#{journal.id}-quote"
           }

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -338,11 +338,6 @@ module Components
         page.uncheck("Internal comment")
       end
 
-      def uncheck_internal_comment_checkbox
-        expect(page).to have_test_selector("op-work-package-journal-internal-comment-checkbox")
-        page.uncheck("Internal comment")
-      end
-
       def dismiss_comment_editor_with_esc
         page.find_test_selector("op-work-package-journal-form-element").send_keys(:escape)
       end


### PR DESCRIPTION
https://community.openproject.org/work_packages/61544

Move the `component_wrapper` to the top level so that the turbo (stream) replace target is applied directly on the top-level turbo frame element. The target is derived from the component wrapper_key

(see [OpTurbo::Streamable#render_as_turbo_stream](https://github.com/opf/openproject/blob/03c8db36bf7aaa379663ef439d3127441ef33886/app/components/concerns/op_turbo/streamable.rb#L48))


https://github.com/user-attachments/assets/19a47068-a7f6-4122-89f0-3c93f28e1c29

