### PR TITLE
[#63660] show attribute name in resolved subject

### DIFF
--- a/app/components/work_packages/types/pattern_input.html.erb
+++ b/app/components/work_packages/types/pattern_input.html.erb
@@ -34,7 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
       classes: "pattern-input",
       "data-controller": "pattern-input",
       "data-pattern-input-pattern-initial-value": @value,
-      "data-pattern-input-heading-locales-value": heading_locales,
       "data-pattern-input-insert-as-text-template-value": I18n.t("types.edit.subject_configuration.pattern.insert_as_text"),
       "data-pattern-input-suggestions-initial-value": suggestions_for_stimulus
     )

--- a/app/components/work_packages/types/pattern_input.rb
+++ b/app/components/work_packages/types/pattern_input.rb
@@ -46,13 +46,6 @@ module WorkPackages
         @suggestions_for_stimulus ||= @suggestions.to_json
       end
 
-      def heading_locales
-        @suggestions.keys.reduce({}) do |acc, key|
-          acc[key] = I18n.t("types.edit.subject_configuration.pattern.headings.#{key}")
-          acc
-        end.to_json
-      end
-
       def suggestions_list_component
         @suggestions_list_component ||= Primer::Alpha::ActionList.new(
           role: :list,

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -63,9 +63,38 @@ module WorkPackages
         ::Types::Forms::SubjectConfigurationFormModel.new(
           subject_configuration: values[:subject_configuration],
           pattern: values[:pattern],
-          suggestions: ::Types::Patterns::TokenPropertyMapper.new.tokens_for_type(model),
+          suggestions: sort_attributes(supported_attributes),
           validation_errors: model.errors
         )
+      end
+
+      def supported_attributes
+        attribute_tokens = ::Types::Patterns::TokenPropertyMapper.new.tokens_for_type(model)
+
+        result = {
+          work_package: {
+            title: I18n.t("types.edit.subject_configuration.token.context.work_package"),
+            tokens: []
+          },
+          parent: {
+            title: I18n.t("types.edit.subject_configuration.token.context.parent"),
+            tokens: []
+          },
+          project: {
+            title: I18n.t("types.edit.subject_configuration.token.context.project"),
+            tokens: []
+          }
+        }
+
+        attribute_tokens.each_with_object(result) do |token, obj|
+          token_hash = { key: token.key, label: token.label, label_with_context: token.label_with_context }
+          obj[token.context][:tokens] << token_hash
+        end
+      end
+
+      def sort_attributes(attributes)
+        attributes.each_value { |group| group[:tokens] = group[:tokens].sort_by { |a| a[:label] } }
+        attributes
       end
 
       def subject_configuration_form_values

--- a/app/contracts/types/base_contract.rb
+++ b/app/contracts/types/base_contract.rb
@@ -109,7 +109,7 @@ module Types
       valid_tokens = flat_valid_token_list
       invalid_tokens = blueprint.scan(PatternResolver::TOKEN_REGEX)
                                 .reduce([]) do |acc, match|
-        token = Patterns::Token.build(match).key
+        token = Patterns::PatternToken.build(match).key
         valid_tokens.include?(token) ? acc : acc << token
       end
 

--- a/app/models/types/pattern_resolver.rb
+++ b/app/models/types/pattern_resolver.rb
@@ -40,6 +40,8 @@ module Types
     end
 
     def resolve(work_package)
+      @token_resolver = @mapper.tokens_for_type(work_package.type)
+
       @tokens.inject(@pattern) do |pattern, token|
         pattern.gsub(token.pattern, get_value(work_package, token))
       end
@@ -49,17 +51,32 @@ module Types
 
     def get_value(work_package, token)
       context = token.context == :work_package ? work_package : work_package.public_send(token.context)
+      return ATTRIBUTE_PLACEHOLDER if context.nil?
 
-      stringify(@mapper[token.context_key].call(context))
+      attribute_resolver = @token_resolver.detect { |t| t.key == token.key }
+      return ATTRIBUTE_PLACEHOLDER if attribute_resolver.nil?
+
+      stringify(attribute_resolver.call(context), nil_replacement(attribute_resolver))
     end
 
-    def stringify(value)
+    def nil_replacement(attribute_resolver)
+      if attribute_resolver.context == :work_package
+        "[#{attribute_resolver.label}]"
+      else
+        "[#{attribute_resolver.label_with_context}]"
+      end
+    end
+
+    def stringify(value, nil_fallback)
       case value
       when Date, Time, DateTime
         value.strftime("%Y-%m-%d")
       when Array
-        value.join(", ")
+        compact = value.compact
+        compact.empty? ? nil_fallback : compact.join(", ")
       when NilClass
+        nil_fallback
+      when :attribute_not_available
         ATTRIBUTE_PLACEHOLDER
       else
         value.to_s

--- a/app/models/types/patterns/attribute_resolver.rb
+++ b/app/models/types/patterns/attribute_resolver.rb
@@ -30,11 +30,14 @@
 
 module Types
   module Patterns
-    Token = Data.define(:pattern, :key) do
-      private_class_method :new
+    AttributeResolver = Data.define(:key, :label, :resolve_fn) do
+      def label_with_context
+        attribute_context = I18n.t("types.edit.subject_configuration.token.context.#{context}")
+        I18n.t("types.edit.subject_configuration.token.label_with_context", attribute_context:, attribute_label: label)
+      end
 
-      def self.build(pattern)
-        new(pattern, pattern.tr("{}", "").to_sym)
+      def call(*)
+        resolve_fn.call(*)
       end
 
       def context

--- a/app/models/types/patterns/attribute_token.rb
+++ b/app/models/types/patterns/attribute_token.rb
@@ -30,7 +30,7 @@
 
 module Types
   module Patterns
-    AttributeResolver = Data.define(:key, :label, :resolve_fn) do
+    AttributeToken = Data.define(:key, :label, :resolve_fn) do
       def label_with_context
         attribute_context = I18n.t("types.edit.subject_configuration.token.context.#{context}")
         I18n.t("types.edit.subject_configuration.token.label_with_context", attribute_context:, attribute_label: label)

--- a/app/models/types/patterns/pattern_token.rb
+++ b/app/models/types/patterns/pattern_token.rb
@@ -30,7 +30,7 @@
 
 module Types
   module Patterns
-    Token = Data.define(:pattern, :key) do
+    PatternToken = Data.define(:pattern, :key) do
       private_class_method :new
 
       def self.build(pattern)

--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -31,88 +31,82 @@
 module Types
   module Patterns
     class TokenPropertyMapper
-      DEFAULT_FUNCTION = ->(key, context) do
-        return nil if context.nil?
-        return nil unless context.respond_to?(key.to_sym)
-
-        context.public_send(key.to_sym)
-      end.curry
-
-      TOKEN_PROPERTY_MAP = IceNine.deep_freeze(
-        {
-          id: { fn: ->(wp) { wp.id }, label: -> { WorkPackage.human_attribute_name(:id) } },
-          accountable: { fn: ->(wp) { wp.responsible&.name }, label: -> { WorkPackage.human_attribute_name(:responsible) } },
-          assignee: { fn: ->(wp) { wp.assigned_to&.name }, label: -> { WorkPackage.human_attribute_name(:assigned_to) } },
-          author: { fn: ->(wp) { wp.author&.name }, label: -> { WorkPackage.human_attribute_name(:author) } },
-          category: { fn: ->(wp) { wp.category&.name }, label: -> { WorkPackage.human_attribute_name(:category) } },
-          creation_date: { fn: ->(wp) { wp.created_at }, label: -> { WorkPackage.human_attribute_name(:created_at) } },
-          estimated_time: { fn: ->(wp) { wp.estimated_hours }, label: -> { WorkPackage.human_attribute_name(:estimated_hours) } },
-          remaining_time: { fn: ->(wp) { wp.remaining_hours }, label: -> { WorkPackage.human_attribute_name(:remaining_hours) } },
-          finish_date: { fn: ->(wp) { wp.due_date }, label: -> { WorkPackage.human_attribute_name(:due_date) } },
-          parent_id: { fn: ->(wp) { wp.parent&.id }, label: -> { WorkPackage.human_attribute_name(:id) } },
-          parent_assignee: { fn: ->(wp) { wp.parent&.assigned_to&.name }, label: -> {
-            WorkPackage.human_attribute_name(:assigned_to)
-          } },
-          parent_author: { fn: ->(wp) { wp.parent&.author&.name }, label: -> { WorkPackage.human_attribute_name(:author) } },
-          parent_category: { fn: ->(wp) { wp.parent&.category&.name },
-                             label: -> { WorkPackage.human_attribute_name(:category) } },
-          parent_creation_date: { fn: ->(wp) { wp.parent&.created_at },
-                                  label: -> { WorkPackage.human_attribute_name(:created_at) } },
-          parent_estimated_time: { fn: ->(wp) { wp.parent&.estimated_hours },
-                                   label: -> { WorkPackage.human_attribute_name(:estimated_hours) } },
-          parent_remaining_time: { fn: ->(wp) { wp.parent&.remaining_hours },
-                                   label: -> { WorkPackage.human_attribute_name(:remaining_hours) } },
-          parent_finish_date: { fn: ->(wp) { wp.parent&.due_date },
-                                label: -> { WorkPackage.human_attribute_name(:due_date) } },
-          parent_priority: { fn: ->(wp) { wp.parent&.priority }, label: -> { WorkPackage.human_attribute_name(:priority) } },
-          parent_subject: { fn: ->(wp) { wp.parent&.subject }, label: -> { WorkPackage.human_attribute_name(:subject) } },
-          priority: { fn: ->(wp) { wp.priority }, label: -> { WorkPackage.human_attribute_name(:priority) } },
-          project: { fn: ->(wp) { wp.project_id }, label: -> { WorkPackage.human_attribute_name(:project) } },
-          project_active: { fn: ->(wp) { wp.project&.active? }, label: -> { Project.human_attribute_name(:active) } },
-          project_name: { fn: ->(wp) { wp.project&.name }, label: -> { Project.human_attribute_name(:name) } },
-          project_status: { fn: ->(wp) { wp.project&.status_code }, label: -> { Project.human_attribute_name(:status_code) } },
-          project_parent: { fn: ->(wp) { wp.project&.parent_id }, label: -> { Project.human_attribute_name(:parent) } },
-          project_public: { fn: ->(wp) { wp.project&.public? }, label: -> { Project.human_attribute_name(:public) } },
-          start_date: { fn: ->(wp) { wp.start_date }, label: -> { WorkPackage.human_attribute_name(:start_date) } },
-          status: { fn: ->(wp) { wp.status&.name }, label: -> { WorkPackage.human_attribute_name(:status) } },
-          type: { fn: ->(wp) { wp.type&.name }, label: -> { WorkPackage.human_attribute_name(:type) } }
-        }
-      )
-
-      def fetch(key)
-        TOKEN_PROPERTY_MAP.dig(key, :fn) || DEFAULT_FUNCTION.call(key)
-      end
-
-      alias :[] :fetch
+      # rubocop:disable Layout/LineLength
+      BASE_ATTRIBUTE_TOKENS = [
+        AttributeResolver.new(:id, WorkPackage.human_attribute_name(:id), ->(wp) { wp.id }),
+        AttributeResolver.new(:accountable, WorkPackage.human_attribute_name(:responsible), ->(wp) { wp.responsible&.name }),
+        AttributeResolver.new(:assignee, WorkPackage.human_attribute_name(:assigned_to), ->(wp) { wp.assigned_to&.name }),
+        AttributeResolver.new(:author, WorkPackage.human_attribute_name(:author), ->(wp) { wp.author&.name }),
+        AttributeResolver.new(:category, WorkPackage.human_attribute_name(:category), ->(wp) { wp.category&.name }),
+        AttributeResolver.new(:creation_date, WorkPackage.human_attribute_name(:created_at), ->(wp) { wp.created_at }),
+        AttributeResolver.new(:estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(wp) { wp.estimated_hours }),
+        AttributeResolver.new(:remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(wp) { wp.remaining_hours }),
+        AttributeResolver.new(:finish_date, WorkPackage.human_attribute_name(:due_date), ->(wp) { wp.due_date }),
+        AttributeResolver.new(:parent_id, WorkPackage.human_attribute_name(:id), ->(parent) { parent.id }),
+        AttributeResolver.new(:parent_assignee, WorkPackage.human_attribute_name(:assigned_to), ->(parent) { parent.assigned_to&.name }),
+        AttributeResolver.new(:parent_author, WorkPackage.human_attribute_name(:author), ->(parent) { parent.author&.name }),
+        AttributeResolver.new(:parent_category, WorkPackage.human_attribute_name(:category), ->(parent) { parent.category&.name }),
+        AttributeResolver.new(:parent_creation_date, WorkPackage.human_attribute_name(:created_at), ->(parent) { parent.created_at }),
+        AttributeResolver.new(:parent_estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(parent) { parent.estimated_hours }),
+        AttributeResolver.new(:parent_remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(parent) { parent.remaining_hours }),
+        AttributeResolver.new(:parent_finish_date, WorkPackage.human_attribute_name(:due_date), ->(parent) { parent.due_date }),
+        AttributeResolver.new(:parent_priority, WorkPackage.human_attribute_name(:priority), ->(parent) { parent.priority }),
+        AttributeResolver.new(:parent_subject, WorkPackage.human_attribute_name(:subject), ->(parent) { parent.subject }),
+        AttributeResolver.new(:priority, WorkPackage.human_attribute_name(:priority), ->(wp) { wp.priority }),
+        AttributeResolver.new(:project, WorkPackage.human_attribute_name(:project_id), ->(wp) { wp.project }),
+        AttributeResolver.new(:project_active, Project.human_attribute_name(:active), ->(project) { project.active? }),
+        AttributeResolver.new(:project_name, Project.human_attribute_name(:name), ->(project) { project.name }),
+        AttributeResolver.new(:project_status, Project.human_attribute_name(:status_code), ->(project) { project.status_code }),
+        AttributeResolver.new(:project_parent, Project.human_attribute_name(:parent), ->(project) { project.parent_id }),
+        AttributeResolver.new(:project_public, Project.human_attribute_name(:public), ->(project) { project.public? }),
+        AttributeResolver.new(:start_date, WorkPackage.human_attribute_name(:start_date), ->(wp) { wp.start_date }),
+        AttributeResolver.new(:status, WorkPackage.human_attribute_name(:status), ->(wp) { wp.status&.name }),
+        AttributeResolver.new(:type, WorkPackage.human_attribute_name(:type), ->(wp) { wp.type&.name })
+      ].freeze
+      # rubocop:enable Layout/LineLength
 
       def tokens_for_type(type)
-        base = default_tokens
-        base[:work_package].merge!(tokenize(work_package_cfs_for(type)))
-        base[:project].merge!(tokenize(project_attributes, "project_"))
-        base[:parent].merge!(tokenize(all_work_package_cfs, "parent_"))
-
-        base.transform_values { _1.sort_by(&:last).to_h }
+        [
+          *BASE_ATTRIBUTE_TOKENS,
+          *tokenize(work_package_cfs_for(type)),
+          *tokenize(project_attributes, "project_"),
+          *tokenize(all_work_package_cfs, "parent_")
+        ]
       end
 
       private
 
       def default_tokens
-        TOKEN_PROPERTY_MAP.keys.each_with_object({ work_package: {}, project: {}, parent: {} }) do |key, obj|
-          label = TOKEN_PROPERTY_MAP.dig(key, :label).call
-
-          case key.to_s
+        BASE_ATTRIBUTE_TOKENS.each_with_object({ work_package: {}, project: {}, parent: {} }) do |token, obj|
+          case token.key.to_s
           when /^project_/
-            obj[:project][key] = label
+            obj[:project][token.key] = token
           when /^parent_/
-            obj[:parent][key] = label
+            obj[:parent][token.key] = token
           else
-            obj[:work_package][key] = label
+            obj[:work_package][token.key] = token
           end
         end
       end
 
+      def prefixed_label(context, attribute_label)
+        attribute_context = I18n.t("types.edit.subject_configuration.token.context.#{context}")
+        I18n.t("types.edit.subject_configuration.token.label_with_context", attribute_context:, attribute_label:)
+      end
+
       def tokenize(custom_field_scope, prefix = nil)
-        custom_field_scope.pluck(:name, :id).to_h { |name, id| [:"#{prefix}custom_field_#{id}", name] }
+        custom_field_scope.pluck(:name, :id).map do |name, id|
+          AttributeResolver.new(
+            :"#{prefix}custom_field_#{id}",
+            name,
+            ->(context) do
+              key = :"custom_field_#{id}"
+              return :attribute_not_available unless context.respond_to?(key)
+
+              context.public_send(key)
+            end
+          )
+        end
       end
 
       def work_package_cfs_for(type)

--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -33,35 +33,35 @@ module Types
     class TokenPropertyMapper
       # rubocop:disable Layout/LineLength
       BASE_ATTRIBUTE_TOKENS = [
-        AttributeResolver.new(:id, WorkPackage.human_attribute_name(:id), ->(wp) { wp.id }),
-        AttributeResolver.new(:accountable, WorkPackage.human_attribute_name(:responsible), ->(wp) { wp.responsible&.name }),
-        AttributeResolver.new(:assignee, WorkPackage.human_attribute_name(:assigned_to), ->(wp) { wp.assigned_to&.name }),
-        AttributeResolver.new(:author, WorkPackage.human_attribute_name(:author), ->(wp) { wp.author&.name }),
-        AttributeResolver.new(:category, WorkPackage.human_attribute_name(:category), ->(wp) { wp.category&.name }),
-        AttributeResolver.new(:creation_date, WorkPackage.human_attribute_name(:created_at), ->(wp) { wp.created_at }),
-        AttributeResolver.new(:estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(wp) { wp.estimated_hours }),
-        AttributeResolver.new(:remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(wp) { wp.remaining_hours }),
-        AttributeResolver.new(:finish_date, WorkPackage.human_attribute_name(:due_date), ->(wp) { wp.due_date }),
-        AttributeResolver.new(:parent_id, WorkPackage.human_attribute_name(:id), ->(parent) { parent.id }),
-        AttributeResolver.new(:parent_assignee, WorkPackage.human_attribute_name(:assigned_to), ->(parent) { parent.assigned_to&.name }),
-        AttributeResolver.new(:parent_author, WorkPackage.human_attribute_name(:author), ->(parent) { parent.author&.name }),
-        AttributeResolver.new(:parent_category, WorkPackage.human_attribute_name(:category), ->(parent) { parent.category&.name }),
-        AttributeResolver.new(:parent_creation_date, WorkPackage.human_attribute_name(:created_at), ->(parent) { parent.created_at }),
-        AttributeResolver.new(:parent_estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(parent) { parent.estimated_hours }),
-        AttributeResolver.new(:parent_remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(parent) { parent.remaining_hours }),
-        AttributeResolver.new(:parent_finish_date, WorkPackage.human_attribute_name(:due_date), ->(parent) { parent.due_date }),
-        AttributeResolver.new(:parent_priority, WorkPackage.human_attribute_name(:priority), ->(parent) { parent.priority }),
-        AttributeResolver.new(:parent_subject, WorkPackage.human_attribute_name(:subject), ->(parent) { parent.subject }),
-        AttributeResolver.new(:priority, WorkPackage.human_attribute_name(:priority), ->(wp) { wp.priority }),
-        AttributeResolver.new(:project, WorkPackage.human_attribute_name(:project_id), ->(wp) { wp.project }),
-        AttributeResolver.new(:project_active, Project.human_attribute_name(:active), ->(project) { project.active? }),
-        AttributeResolver.new(:project_name, Project.human_attribute_name(:name), ->(project) { project.name }),
-        AttributeResolver.new(:project_status, Project.human_attribute_name(:status_code), ->(project) { project.status_code }),
-        AttributeResolver.new(:project_parent, Project.human_attribute_name(:parent), ->(project) { project.parent_id }),
-        AttributeResolver.new(:project_public, Project.human_attribute_name(:public), ->(project) { project.public? }),
-        AttributeResolver.new(:start_date, WorkPackage.human_attribute_name(:start_date), ->(wp) { wp.start_date }),
-        AttributeResolver.new(:status, WorkPackage.human_attribute_name(:status), ->(wp) { wp.status&.name }),
-        AttributeResolver.new(:type, WorkPackage.human_attribute_name(:type), ->(wp) { wp.type&.name })
+        AttributeToken.new(:id, WorkPackage.human_attribute_name(:id), ->(wp) { wp.id }),
+        AttributeToken.new(:accountable, WorkPackage.human_attribute_name(:responsible), ->(wp) { wp.responsible&.name }),
+        AttributeToken.new(:assignee, WorkPackage.human_attribute_name(:assigned_to), ->(wp) { wp.assigned_to&.name }),
+        AttributeToken.new(:author, WorkPackage.human_attribute_name(:author), ->(wp) { wp.author&.name }),
+        AttributeToken.new(:category, WorkPackage.human_attribute_name(:category), ->(wp) { wp.category&.name }),
+        AttributeToken.new(:creation_date, WorkPackage.human_attribute_name(:created_at), ->(wp) { wp.created_at }),
+        AttributeToken.new(:estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(wp) { wp.estimated_hours }),
+        AttributeToken.new(:remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(wp) { wp.remaining_hours }),
+        AttributeToken.new(:finish_date, WorkPackage.human_attribute_name(:due_date), ->(wp) { wp.due_date }),
+        AttributeToken.new(:parent_id, WorkPackage.human_attribute_name(:id), ->(parent) { parent.id }),
+        AttributeToken.new(:parent_assignee, WorkPackage.human_attribute_name(:assigned_to), ->(parent) { parent.assigned_to&.name }),
+        AttributeToken.new(:parent_author, WorkPackage.human_attribute_name(:author), ->(parent) { parent.author&.name }),
+        AttributeToken.new(:parent_category, WorkPackage.human_attribute_name(:category), ->(parent) { parent.category&.name }),
+        AttributeToken.new(:parent_creation_date, WorkPackage.human_attribute_name(:created_at), ->(parent) { parent.created_at }),
+        AttributeToken.new(:parent_estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(parent) { parent.estimated_hours }),
+        AttributeToken.new(:parent_remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(parent) { parent.remaining_hours }),
+        AttributeToken.new(:parent_finish_date, WorkPackage.human_attribute_name(:due_date), ->(parent) { parent.due_date }),
+        AttributeToken.new(:parent_priority, WorkPackage.human_attribute_name(:priority), ->(parent) { parent.priority }),
+        AttributeToken.new(:parent_subject, WorkPackage.human_attribute_name(:subject), ->(parent) { parent.subject }),
+        AttributeToken.new(:priority, WorkPackage.human_attribute_name(:priority), ->(wp) { wp.priority }),
+        AttributeToken.new(:project, WorkPackage.human_attribute_name(:project_id), ->(wp) { wp.project }),
+        AttributeToken.new(:project_active, Project.human_attribute_name(:active), ->(project) { project.active? }),
+        AttributeToken.new(:project_name, Project.human_attribute_name(:name), ->(project) { project.name }),
+        AttributeToken.new(:project_status, Project.human_attribute_name(:status_code), ->(project) { project.status_code }),
+        AttributeToken.new(:project_parent, Project.human_attribute_name(:parent), ->(project) { project.parent_id }),
+        AttributeToken.new(:project_public, Project.human_attribute_name(:public), ->(project) { project.public? }),
+        AttributeToken.new(:start_date, WorkPackage.human_attribute_name(:start_date), ->(wp) { wp.start_date }),
+        AttributeToken.new(:status, WorkPackage.human_attribute_name(:status), ->(wp) { wp.status&.name }),
+        AttributeToken.new(:type, WorkPackage.human_attribute_name(:type), ->(wp) { wp.type&.name })
       ].freeze
       # rubocop:enable Layout/LineLength
 
@@ -69,7 +69,7 @@ module Types
         [
           *BASE_ATTRIBUTE_TOKENS,
           *tokenize(work_package_cfs_for(type)),
-          *tokenize(project_attributes, "project_"),
+          *tokenize(project_cfs, "project_"),
           *tokenize(all_work_package_cfs, "parent_")
         ]
       end
@@ -96,7 +96,7 @@ module Types
 
       def tokenize(custom_field_scope, prefix = nil)
         custom_field_scope.pluck(:name, :id).map do |name, id|
-          AttributeResolver.new(
+          AttributeToken.new(
             :"#{prefix}custom_field_#{id}",
             name,
             ->(context) do
@@ -117,7 +117,7 @@ module Types
         WorkPackageCustomField.where.not(field_format: %w[text bool link empty]).order(:name)
       end
 
-      def project_attributes
+      def project_cfs
         ProjectCustomField.where.not(field_format: %w[text bool link empty])
                           .where(admin_only: false, multi_value: false).order(:name)
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -687,13 +687,15 @@ en:
         automatically_generated_subjects:
           label: "Automatically generated subjects"
           caption: "Define a pattern using referenced attributes and text to automatically generate work package subjects. Users will not be able to manually edit subjects."
-        pattern:
-          label: "Subject pattern"
-          caption: "Add text or type / to search for an attribute. You can add spaces to separate them."
-          headings:
+        token:
+          label_with_context: "%{attribute_context}: %{attribute_label}"
+          context:
             work_package: "Work package"
             parent: "Parent"
             project: "Project"
+        pattern:
+          label: "Subject pattern"
+          caption: "Add text or type / to search for an attribute. You can add spaces to separate them."
           insert_as_text: "No attributes found. Add as text: \"%{word}\""
       export_configuration:
         tab: "Generate PDF"

--- a/frontend/src/stimulus/controllers/pattern-input.controller.ts
+++ b/frontend/src/stimulus/controllers/pattern-input.controller.ts
@@ -33,11 +33,13 @@ import { Controller } from '@hotwired/stimulus';
 // internal type used to filter suggestions
 type FilteredSuggestions = Array<{
   key:string;
+  label:string;
   values:Array<{ prop:string; value:string; }>;
 }>;
 
 type TokenElement = HTMLElement&{ dataset:{ role:'token', prop:string } };
 type ListElement = HTMLElement&{ dataset:{ role:'list_item', prop:string } };
+type AttributeToken = { key:string, label:string, label_with_context:string };
 
 const COMPLETION_CHARACTER = '/';
 const TOKEN_REGEX = /{{([0-9A-Za-z_]+)}}/g;
@@ -73,21 +75,19 @@ export default class PatternInputController extends Controller {
 
   static values = {
     patternInitial: String,
-    headingLocales: Object,
     suggestionsInitial: Object,
     insertAsTextTemplate: String,
   };
 
   declare readonly patternInitialValue:string;
-  declare readonly suggestionsInitialValue:Record<string, Record<string, string>>;
-  declare readonly headingLocalesValue:Record<string, string>;
+  declare readonly suggestionsInitialValue:Record<string, { title:string, tokens:AttributeToken[] }>;
   declare readonly insertAsTextTemplateValue:string;
 
-  validTokenMap:Record<string, string> = {};
+  validTokenMap:Record<string, AttributeToken> = {};
   currentRange:Range|undefined = undefined;
 
   connect() {
-    this.validTokenMap = this.flatLocalizedTokenMap();
+    this.validTokenMap = this.flatTokensKeyToLabelWithContext();
     this.contentTarget.innerHTML = this.toHtml(this.patternInitialValue) || ' ';
     this.tagInvalidTokens();
     this.clearSuggestionsFilter();
@@ -212,17 +212,12 @@ export default class PatternInputController extends Controller {
     this.clearSuggestionsFilter();
   }
 
-  private flatLocalizedTokenMap():Record<string, string> {
+  private flatTokensKeyToLabelWithContext():Record<string, AttributeToken> {
     return Object.entries(this.suggestionsInitialValue)
-      .reduce((acc, [groupKey, attributes]) => {
-        if (groupKey !== 'work_package') {
-          Object.entries(attributes).forEach(([key, value]) => {
-            attributes[key] = `${this.tokenPrefix(groupKey)} ${value}`;
-          });
-        }
-
-        return { ...acc, ...attributes };
-      }, {});
+      .reduce((acc, [_, token_group]) => {
+        token_group.tokens.forEach((t) => { acc[t.key] = t; });
+        return acc;
+      }, {} as Record<string, AttributeToken>);
   }
 
   private updateFormInputValue():void {
@@ -361,9 +356,9 @@ export default class PatternInputController extends Controller {
     if (textContent === null) { return null; }
 
     if (this.isToken(parent)) {
-      const key = parent.dataset.prop;
-      const prefix = this.tokenPrefix(key.slice(0, key.indexOf('_')));
-      const start = prefix && textContent.startsWith(`${prefix} `) ? prefix.length + 1 : 0;
+      const token = this.validTokenMap[parent.dataset.prop];
+      const prefix = token.label_with_context.replace(token.label, '');
+      const start = prefix && textContent.startsWith(prefix) ? prefix.length : 0;
 
       return textContent.slice(start, selection.anchorOffset);
     }
@@ -393,7 +388,7 @@ export default class PatternInputController extends Controller {
       if (groupHeader) {
         const headerElement = groupHeader.querySelector('h2');
         if (headerElement) {
-          headerElement.innerText = this.headingLocalesValue[group.key];
+          headerElement.innerText = group.label;
         }
 
         this.suggestionsTarget.appendChild(groupHeader);
@@ -447,9 +442,10 @@ export default class PatternInputController extends Controller {
       const group = this.suggestionsInitialValue[key];
       return {
         key,
-        values: Object.entries(group).filter(([prop, value]) => {
-          return value.toLowerCase().includes(word.toLowerCase()) || prop.toLowerCase().includes(word.toLowerCase()) || word === '*';
-        }).map(([prop, value]) => ({ prop, value })),
+        label: group.title,
+        values: group.tokens
+          .filter((token) => token.key.includes(word) || token.label.includes(word) || word === '*')
+          .map((token) => ({ prop: token.key, value: token.label })),
       };
     }).filter((group) => group.values.length > 0);
   }
@@ -485,11 +481,11 @@ export default class PatternInputController extends Controller {
     }
   }
 
-  private createToken(value:string):TokenElement {
+  private createToken(key:string):TokenElement {
     const templateTarget = this.tokenTemplateTarget.content?.cloneNode(true) as DocumentFragment;
     const contentElement = templateTarget.firstElementChild as TokenElement;
-    contentElement.dataset.prop = value;
-    contentElement.innerText = this.validTokenMap[value] || value;
+    contentElement.dataset.prop = key;
+    contentElement.innerText = this.tokenText(key);
     return contentElement;
   }
 
@@ -499,11 +495,11 @@ export default class PatternInputController extends Controller {
         this.setStyle(node, 'accent');
 
         const key = node.dataset.prop;
-        if (node.textContent !== this.validTokenMap[key]) {
+        if (node.textContent !== this.tokenText(key)) {
           if (this.containsCursor(node)) {
             this.setStyle(node, 'secondary');
           } else {
-            node.innerText = this.validTokenMap[key] || key;
+            node.innerText = this.tokenText(key);
           }
         }
 
@@ -521,6 +517,20 @@ export default class PatternInputController extends Controller {
         }
       }
     });
+  }
+
+  private tokenText(key:string):string {
+    const token = this.validTokenMap[key];
+
+    if (!token) {
+      return key;
+    }
+
+    if (token.key.startsWith('parent_') || token.key.startsWith('project_')) {
+      return token.label_with_context;
+    }
+
+    return token.label;
   }
 
   private toHtml(blueprint:string):string {
@@ -549,11 +559,6 @@ export default class PatternInputController extends Controller {
       .reduce((acc, index) => {
         return `${acc.slice(0, index)}${CONTROL_SPACE}${acc.slice(index)}`;
       }, blueprint);
-  }
-
-  private tokenPrefix(groupKey:string):string {
-    const locale = this.headingLocalesValue[groupKey];
-    return locale ? `${locale}:` : '';
   }
 
   private toBlueprint():string {

--- a/spec/models/types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/types/patterns/token_property_mapper_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Types::Patterns::TokenPropertyMapper do
     cf = string_custom_field
     tokens = described_class.new.tokens_for_type(work_package.type)
 
-    expect(tokens.first).to be_a(Types::Patterns::AttributeResolver)
+    expect(tokens.first).to be_a(Types::Patterns::AttributeToken)
     expect(detect(tokens, :project_status).label).to eq(Project.human_attribute_name(:status_code))
     expect(detect(tokens, :"custom_field_#{cf.id}").label).to eq(cf.name)
   end


### PR DESCRIPTION
# Ticket
[OP#63660](https://community.openproject.org/work_packages/63660)

# What are you trying to accomplish?
- show attribute name in resolved subject

# What approach did you choose and why?
- return array of token resolver objects from property mapper
- resolver reacts on absent context
- different reaction to nil values and not resolvable attributes

### More information

- the first commit contains the change regarding the pattern resolver and the underlying property mapper utility class. Those changes need to be reflected in the pattern input component, which will be part of a next commit.