### PR TITLE
Add link to documentation for supported attributes

### DIFF
--- a/app/forms/work_packages/types/subject_configuration_form.rb
+++ b/app/forms/work_packages/types/subject_configuration_form.rb
@@ -56,7 +56,7 @@ module WorkPackages
             value: model.pattern,
             suggestions: model.suggestions,
             label: I18n.t("types.edit.subject_configuration.pattern.label"),
-            caption: I18n.t("types.edit.subject_configuration.pattern.caption"),
+            caption: pattern_input_caption,
             required: true,
             validation_message: validation_message_for(:patterns)
           )
@@ -81,6 +81,20 @@ module WorkPackages
 
       def validation_message_for(attribute)
         model.validation_errors.messages_for(attribute).to_sentence.presence
+      end
+
+      def pattern_input_caption
+        I18n.t(
+          "types.edit.subject_configuration.pattern.caption_with_supported_attributes_link",
+          link: make_link(
+            ::OpenProject::Static::Links.url_for(:enterprise_features, :work_package_subject_generation),
+            I18n.t("types.edit.subject_configuration.pattern.supported_attributes_link")
+          )
+        ).html_safe
+      end
+
+      def make_link(href, link_text)
+        render(Primer::Beta::Link.new(href:, target: "_blank")) { link_text }
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,8 +695,9 @@ en:
             project: "Project"
         pattern:
           label: "Subject pattern"
-          caption: "Add text or type / to search for an attribute. You can add spaces to separate them."
+          caption_with_supported_attributes_link: Create patterns by adding text, or type "/" to search for %{link}.
           insert_as_text: "No attributes found. Add as text: \"%{word}\""
+          supported_attributes_link: "supported attributes"
       export_configuration:
         tab: "Generate PDF"
         intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."


### PR DESCRIPTION
This allows the user to directly see which attributes we support for subject patterns.

# Ticket
https://community.openproject.org/wp/62368

## Screenshots

![image](https://github.com/user-attachments/assets/838bf4f8-4bd4-47f6-886a-d942b968790e)
