### PR TITLE
why was rb_sys added as dependency of pry 0.15.2?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -944,7 +944,6 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-      rb_sys (~> 0.9.109)
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)


### PR DESCRIPTION
Added in d099ed1efa6b (325424a5a0dc of opf/openproject#18528)
