### PR TITLE
[#63728] Project name/description, status and parent update fails silently if a required project attribute is created 

### DIFF
--- a/app/controllers/projects/settings/general_controller.rb
+++ b/app/controllers/projects/settings/general_controller.rb
@@ -49,7 +49,7 @@ class Projects::Settings::GeneralController < Projects::SettingsController
     redirect_to action: :show, status: :see_other
   end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     call = Projects::UpdateService
       .new(model: @project, user: current_user)
       .call(permitted_params.project)
@@ -60,6 +60,7 @@ class Projects::Settings::GeneralController < Projects::SettingsController
       flash[:notice] = I18n.t(:notice_successful_update)
       redirect_to project_settings_general_path(@project)
     else
+      flash[:error] = I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
       render action: :show, status: :unprocessable_entity
     end
   end

--- a/spec/controllers/projects/settings/general_controller_spec.rb
+++ b/spec/controllers/projects/settings/general_controller_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Projects::Settings::GeneralController do
         expect(response).not_to be_successful
         expect(response).to have_http_status :unprocessable_entity
         expect(assigns(:project)).not_to be_valid
+        expect(flash[:error]).to start_with I18n.t(:notice_unsuccessful_update_with_reason, reason: "")
         expect(response).to render_template "projects/settings/general/show"
       end
     end

--- a/spec/controllers/projects/settings/general_controller_spec.rb
+++ b/spec/controllers/projects/settings/general_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Projects::Settings::GeneralController do
     context "when service call succeeds" do
       let(:service_result) { ServiceResult.success(result: project) }
 
-      it "redirects to show" do
+      it "redirects to show", :aggregate_failures do
         patch :update, params: { project_id: project.identifier, project: { name: "new name" } }
 
         expect(response).to redirect_to action: :show
@@ -73,7 +73,7 @@ RSpec.describe Projects::Settings::GeneralController do
         project.name = ""
       end
 
-      it "renders show template with errors" do
+      it "renders show template with errors", :aggregate_failures do
         patch :update, params: { project_id: project.identifier, project: { name: "" } }
 
         expect(response).not_to be_successful


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63728

# What are you trying to accomplish?

This PR updates `GeneralController` to show an error flash message on an update failure. Previously updates could fail silently if the the failure was due to a validation errors on a fields/attributes not displayed on the Project Settings > Information field (e.g. project attributes).

## Screenshots

### Before

(before omitted since no flash message displayed)

### After

<img width="1269" alt="Screenshot 2025-05-16 at 11 52 10" src="https://github.com/user-attachments/assets/3dfdf849-2138-4669-9b83-3c269fe04966" />

<img width="1269" alt="Screenshot 2025-05-16 at 11 52 22" src="https://github.com/user-attachments/assets/2d620305-d50f-4643-a0a1-ccf5aa6c622d" />


# What approach did you choose and why?

This is a temporary solution while we consider how we surface errors to users generally. Ideally, since we are already displaying inline validations - and to avoid unnecessary noise in the UI, we would only display flash messages when there are fields/attributes with errors that are NOT visible to the user on this specific Project Settings>Information form, BUT that the user does have permissions to edit (albeit elsewhere in the application).

N.B. the flash messages and behaviour now match flash messages displayed on Project Status component change (BUT not Meeting Status component change).

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
