### PR TITLE
Frozen string literals for storages and openid_connect

### DIFF
--- a/modules/storages/db/migrate/20220113144323_create_storage.rb
+++ b/modules/storages/db/migrate/20220113144323_create_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20220113144759_create_file_links.rb
+++ b/modules/storages/db/migrate/20220113144759_create_file_links.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20220121090847_create_projects_storages.rb
+++ b/modules/storages/db/migrate/20220121090847_create_projects_storages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20220712165928_add_storages_permissions_to_roles.rb
+++ b/modules/storages/db/migrate/20220712165928_add_storages_permissions_to_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20230123092649_make_containter_id_and_containter_type_optional_for_file_links.rb
+++ b/modules/storages/db/migrate/20230123092649_make_containter_id_and_containter_type_optional_for_file_links.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20230321194150_add_project_folder_to_projects_storages.rb
+++ b/modules/storages/db/migrate/20230321194150_add_project_folder_to_projects_storages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20230420063148_add_provider_fields_to_storages.rb
+++ b/modules/storages/db/migrate/20230420063148_add_provider_fields_to_storages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/modules/storages/db/migrate/20230420071113_migrate_storages_to_use_provider_type_as_sti_column.rb
+++ b/modules/storages/db/migrate/20230420071113_migrate_storages_to_use_provider_type_as_sti_column.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/modules/storages/db/migrate/20230512153303_change_storage_provider_fields_default.rb
+++ b/modules/storages/db/migrate/20230512153303_change_storage_provider_fields_default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/modules/storages/db/migrate/20230517075214_add_automatic_to_project_folder_modes.rb
+++ b/modules/storages/db/migrate/20230517075214_add_automatic_to_project_folder_modes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/modules/storages/db/migrate/20230601082746_create_last_project_folders.rb
+++ b/modules/storages/db/migrate/20230601082746_create_last_project_folders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20230721123022_remove_project_folder_mode_default.rb
+++ b/modules/storages/db/migrate/20230721123022_remove_project_folder_mode_default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20230802085026_rename_projects_storages_table.rb
+++ b/modules/storages/db/migrate/20230802085026_rename_projects_storages_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20230824130730_remove_not_null_constraint_for_storage_host.rb
+++ b/modules/storages/db/migrate/20230824130730_remove_not_null_constraint_for_storage_host.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20231009135807_remove_renamed_cronjobs.rb
+++ b/modules/storages/db/migrate/20231009135807_remove_renamed_cronjobs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/db/migrate/20231109080454_add_health_info_to_storages.rb
+++ b/modules/storages/db/migrate/20231109080454_add_health_info_to_storages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #

--- a/modules/storages/db/migrate/20231208143303_add_health_checked_at_to_storages.rb
+++ b/modules/storages/db/migrate/20231208143303_add_health_checked_at_to_storages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddHealthCheckedAtToStorages < ActiveRecord::Migration[7.0]
   def up
     add_column(:storages, :health_checked_at, :datetime, null: false, default: -> { "current_timestamp" })

--- a/modules/storages/db/migrate/20240610130953_rename_manage_storages_in_project_permission.rb
+++ b/modules/storages/db/migrate/20240610130953_rename_manage_storages_in_project_permission.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameManageStoragesInProjectPermission < ActiveRecord::Migration[7.1]
   def change
     RolePermission.where(permission: "manage_storages_in_project").update_all(permission: "manage_files_in_project")

--- a/modules/storages/lib/api/v3/file_links/file_link_collection_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_collection_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/file_links/file_link_payload_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_payload_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/file_links/file_link_relation_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_relation_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/file_links/file_link_representer.rb
+++ b/modules/storages/lib/api/v3/file_links/file_link_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/file_links/file_links_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/file_links/file_links_open_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_open_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/file_links/work_packages_file_links_create_endpoint.rb
+++ b/modules/storages/lib/api/v3/file_links/work_packages_file_links_create_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/oauth_client/oauth_client_credentials_api.rb
+++ b/modules/storages/lib/api/v3/oauth_client/oauth_client_credentials_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/project_storages/project_storage_collection_representer.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storage_collection_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/project_storages/project_storage_open_api.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storage_open_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/project_storages/project_storages_api.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storages_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/storage_files/storage_file_representer.rb
+++ b/modules/storages/lib/api/v3/storage_files/storage_file_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/storage_files/storage_files_representer.rb
+++ b/modules/storages/lib/api/v3/storage_files/storage_files_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/storage_files/storage_upload_link_representer.rb
+++ b/modules/storages/lib/api/v3/storage_files/storage_upload_link_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/api/v3/storages/storage_payload_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_payload_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/lib/open_project/storages.rb
+++ b/modules/storages/lib/open_project/storages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/openproject-storages.gemspec
+++ b/modules/storages/openproject-storages.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The comments in the files of this module will try to lift you from a
 # beginner's level to an intermediary level of Ruby on Rails in the context of
 # OpenProject.

--- a/modules/storages/spec/components/storages/admin/oauth_client_info_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/oauth_client_info_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/admin/side_panel/health_notifications_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/side_panel/health_notifications_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/admin/storage_list_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/storage_list_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/admin/storage_row_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/storage_row_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/admin/storages/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/storages/oauth_access_grant_nudge_modal_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/admin/storages/oauth_access_granted_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/storages/oauth_access_granted_modal_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/project_storages/destroy_confirmation_dialog_component_spec.rb
+++ b/modules/storages/spec/components/storages/project_storages/destroy_confirmation_dialog_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/project_storages/oauth_access_grant_nudge_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/project_storages/oauth_access_grant_nudge_modal_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/project_storages/oauth_access_granted_modal_component_spec.rb
+++ b/modules/storages/spec/components/storages/project_storages/oauth_access_granted_modal_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/components/storages/project_storages/row_component_spec.rb
+++ b/modules/storages/spec/components/storages/project_storages/row_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/file_links/create_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/file_links/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/file_links/delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/file_links/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/project_storages/create_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/project_storages/delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/storages/nextcloud_create_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/nextcloud_create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/storages/nextcloud_delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/nextcloud_delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/storages/nextcloud_update_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/nextcloud_update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/storages/one_drive_create_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/one_drive_create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/storages/one_drive_delete_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/one_drive_delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/contracts/storages/storages/one_drive_update_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/storages/one_drive_update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/factories/file_link_factory.rb
+++ b/modules/storages/spec/factories/file_link_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/factories/last_project_folder_factory.rb
+++ b/modules/storages/spec/factories/last_project_folder_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/factories/project_storage_factory.rb
+++ b/modules/storages/spec/factories/project_storage_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/factories/storage_file_info_factory.rb
+++ b/modules/storages/spec/factories/storage_file_info_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/factories/webdav_data_factory.rb
+++ b/modules/storages/spec/factories/webdav_data_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/models/queries/storages/projects/filter/storages_filter_spec.rb
+++ b/modules/storages/spec/models/queries/storages/projects/filter/storages_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/requests/api/v3/project_storages/project_storages_spec.rb
+++ b/modules/storages/spec/requests/api/v3/project_storages/project_storages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/requests/api/v3/work_packages/work_packages_linkable_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/work_packages/work_packages_linkable_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/requests/api/v3/work_packages/work_packages_linked_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/work_packages/work_packages_linked_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/requests/append_content_security_policy_spec.rb
+++ b/modules/storages/spec/requests/append_content_security_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/services/storages/file_links/copy_file_links_service_spec.rb
+++ b/modules/storages/spec/services/storages/file_links/copy_file_links_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/services/storages/last_project_folders/bulk_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/last_project_folders/bulk_create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/services/storages/project_storages/bulk_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/bulk_create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/services/storages/project_storages/notifications_service_spec.rb
+++ b/modules/storages/spec/services/storages/project_storages/notifications_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/support/components/file_picker_dialog.rb
+++ b/modules/storages/spec/support/components/file_picker_dialog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/support/nextcloud_group_user_helper.rb
+++ b/modules/storages/spec/support/nextcloud_group_user_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/storages/spec/support/pages/admin/storages/project_storages/project_storages_index.rb
+++ b/modules/storages/spec/support/pages/admin/storages/project_storages/project_storages_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH


### PR DESCRIPTION
Enforce frozen string literals across the storages module and the openid_connect module.

Starting to roll out wider usage of frozen string literals, after #18039 showed no further test failures.