### PR TITLE
Freeze string literals in specs

### DIFF
--- a/spec/components/op_turbo/frame_component_spec.rb
+++ b/spec/components/op_turbo/frame_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/components/projects/row_component_spec.rb
+++ b/spec/components/projects/row_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/components/work_packages/activities_tab/journals/item_component/reactions_spec.rb
+++ b/spec/components/work_packages/activities_tab/journals/item_component/reactions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/attachments/create_contract_integration_spec.rb
+++ b/spec/contracts/attachments/create_contract_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/attachments/create_contract_spec.rb
+++ b/spec/contracts/attachments/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/attribute_help_texts/base_contract_spec.rb
+++ b/spec/contracts/attribute_help_texts/base_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
+++ b/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/backups/create_contract_spec.rb
+++ b/spec/contracts/backups/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/custom_actions/cu_contract_spec.rb
+++ b/spec/contracts/custom_actions/cu_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/custom_fields/create_contract_spec.rb
+++ b/spec/contracts/custom_fields/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/custom_fields/update_contract_spec.rb
+++ b/spec/contracts/custom_fields/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/emoji_reactions/delete_contract_spec.rb
+++ b/spec/contracts/emoji_reactions/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/groups/create_contract_spec.rb
+++ b/spec/contracts/groups/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/groups/shared_contract_examples.rb
+++ b/spec/contracts/groups/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/groups/update_contract_spec.rb
+++ b/spec/contracts/groups/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/members/create_contract_spec.rb
+++ b/spec/contracts/members/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/members/delete_from_project_contract_spec.rb
+++ b/spec/contracts/members/delete_from_project_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/members/delete_globally_contract_spec.rb
+++ b/spec/contracts/members/delete_globally_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/members/shared_contract_examples.rb
+++ b/spec/contracts/members/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/members/update_contract_spec.rb
+++ b/spec/contracts/members/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/messages/create_contract_spec.rb
+++ b/spec/contracts/messages/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/messages/shared_contract_examples.rb
+++ b/spec/contracts/messages/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/messages/update_contract_spec.rb
+++ b/spec/contracts/messages/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/news/create_contract_spec.rb
+++ b/spec/contracts/news/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/news/delete_contract_spec.rb
+++ b/spec/contracts/news/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/news/shared_contract_examples.rb
+++ b/spec/contracts/news/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/news/update_contract_spec.rb
+++ b/spec/contracts/news/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/notifications/create_contract_spec.rb
+++ b/spec/contracts/notifications/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/oauth_clients/create_contract_spec.rb
+++ b/spec/contracts/oauth_clients/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/oauth_clients/delete_contract_spec.rb
+++ b/spec/contracts/oauth_clients/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/placeholder_users/create_contract_spec.rb
+++ b/spec/contracts/placeholder_users/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/placeholder_users/delete_contract_spec.rb
+++ b/spec/contracts/placeholder_users/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/placeholder_users/shared_contract_examples.rb
+++ b/spec/contracts/placeholder_users/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/placeholder_users/update_contract_spec.rb
+++ b/spec/contracts/placeholder_users/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/project_queries/create_contract_spec.rb
+++ b/spec/contracts/project_queries/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/project_queries/shared_contract_examples.rb
+++ b/spec/contracts/project_queries/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/project_queries/update_contract_spec.rb
+++ b/spec/contracts/project_queries/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/archive_contract_spec.rb
+++ b/spec/contracts/projects/archive_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/base_contract_spec.rb
+++ b/spec/contracts/projects/base_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/create_contract_spec.rb
+++ b/spec/contracts/projects/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/delete_contract_spec.rb
+++ b/spec/contracts/projects/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/enabled_modules_contract_spec.rb
+++ b/spec/contracts/projects/enabled_modules_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/settings_contract_spec.rb
+++ b/spec/contracts/projects/settings_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/unarchive_contract_spec.rb
+++ b/spec/contracts/projects/unarchive_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/queries/base_contract_spec.rb
+++ b/spec/contracts/queries/base_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/queries/create_contract_spec.rb
+++ b/spec/contracts/queries/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/queries/ical_sharing_contract_spec.rb
+++ b/spec/contracts/queries/ical_sharing_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/queries/loading_contract_spec.rb
+++ b/spec/contracts/queries/loading_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/queries/shared_contract_examples.rb
+++ b/spec/contracts/queries/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/queries/update_contract_spec.rb
+++ b/spec/contracts/queries/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/relations/create_contract_spec.rb
+++ b/spec/contracts/relations/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/relations/shared_contract_examples.rb
+++ b/spec/contracts/relations/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/relations/update_contract_spec.rb
+++ b/spec/contracts/relations/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/reminders/delete_contract_spec.rb
+++ b/spec/contracts/reminders/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/roles/create_contract_spec.rb
+++ b/spec/contracts/roles/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/roles/shared_contract_examples.rb
+++ b/spec/contracts/roles/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/roles/update_contract_spec.rb
+++ b/spec/contracts/roles/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/settings/update_contract_spec.rb
+++ b/spec/contracts/settings/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/settings/working_days_and_hours_params_contract_spec.rb
+++ b/spec/contracts/settings/working_days_and_hours_params_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/shares/work_packages/create_contract_spec.rb
+++ b/spec/contracts/shares/work_packages/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/shares/work_packages/delete_contract_spec.rb
+++ b/spec/contracts/shares/work_packages/delete_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/shares/work_packages/shared_contract_examples.rb
+++ b/spec/contracts/shares/work_packages/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/shares/work_packages/update_contract_spec.rb
+++ b/spec/contracts/shares/work_packages/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/user_preferences/params_contract_spec.rb
+++ b/spec/contracts/user_preferences/params_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/user_preferences/update_contract_spec.rb
+++ b/spec/contracts/user_preferences/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/users/create_contract_spec.rb
+++ b/spec/contracts/users/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/users/shared_contract_examples.rb
+++ b/spec/contracts/users/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/versions/create_contract_spec.rb
+++ b/spec/contracts/versions/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/versions/shared_contract_examples.rb
+++ b/spec/contracts/versions/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/versions/update_contract_spec.rb
+++ b/spec/contracts/versions/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/views/create_contract_work_packages_table_spec.rb
+++ b/spec/contracts/views/create_contract_work_packages_table_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/views/shared_contract_examples.rb
+++ b/spec/contracts/views/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/views/update_contract_spec.rb
+++ b/spec/contracts/views/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/wiki_pages/create_contract_spec.rb
+++ b/spec/contracts/wiki_pages/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/wiki_pages/shared_contract_examples.rb
+++ b/spec/contracts/wiki_pages/shared_contract_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/work_packages/shared_base_contract.rb
+++ b/spec/contracts/work_packages/shared_base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/admin/settings/authentication_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/authentication_settings_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/admin/settings/new_project_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/new_project_settings_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/admin/settings/projects_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/projects_settings_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/admin/settings/working_days_and_hours_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/working_days_and_hours_settings_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe AnnouncementsController do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/attribute_help_texts_controller_spec.rb
+++ b/spec/controllers/attribute_help_texts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe AttributeHelpTextsController do

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/colors_controller_spec.rb
+++ b/spec/controllers/colors_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/concerns/auth_source_slo_spec.rb
+++ b/spec/controllers/concerns/auth_source_slo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/concerns/user_invitation_spec.rb
+++ b/spec/controllers/concerns/user_invitation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/custom_actions_controller_spec.rb
+++ b/spec/controllers/custom_actions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/custom_fields_controller_spec.rb
+++ b/spec/controllers/custom_fields_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/enterprises_controller_spec.rb
+++ b/spec/controllers/enterprises_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/homescreen_controller_spec.rb
+++ b/spec/controllers/homescreen_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/ldap_auth_sources_controller_spec.rb
+++ b/spec/controllers/ldap_auth_sources_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/news/comments_controller_spec.rb
+++ b/spec/controllers/news/comments_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/oauth/grants_controller_spec.rb
+++ b/spec/controllers/oauth/grants_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/omni_auth_login_controller_spec.rb
+++ b/spec/controllers/omni_auth_login_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/placeholder_users/memberships_controller_spec.rb
+++ b/spec/controllers/placeholder_users/memberships_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/placeholder_users_controller_spec.rb
+++ b/spec/controllers/placeholder_users_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/projects/identifier_controller_spec.rb
+++ b/spec/controllers/projects/identifier_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/projects/queries_controller_spec.rb
+++ b/spec/controllers/projects/queries_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/projects_settings_menu_controller_spec.rb
+++ b/spec/controllers/projects_settings_menu_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/users/memberships_controller_spec.rb
+++ b/spec/controllers/users/memberships_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/wiki_menu_authentication_spec.rb
+++ b/spec/controllers/wiki_menu_authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/wiki_menu_items_controller_spec.rb
+++ b/spec/controllers/wiki_menu_items_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/work_packages/activities_tab_controller_spec.rb
+++ b/spec/controllers/work_packages/activities_tab_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/work_packages/reports_controller_spec.rb
+++ b/spec/controllers/work_packages/reports_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/decorators/single_spec.rb
+++ b/spec/decorators/single_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/announcement_factory.rb
+++ b/spec/factories/announcement_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :announcement do
     text { "Announcement text" }

--- a/spec/factories/attachment_factory.rb
+++ b/spec/factories/attachment_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/attribute_help_text_factory.rb
+++ b/spec/factories/attribute_help_text_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :work_package_help_text, class: "AttributeHelpText::WorkPackage" do
     type { "AttributeHelpText::WorkPackage" }

--- a/spec/factories/backup_factory.rb
+++ b/spec/factories/backup_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/category_factory.rb
+++ b/spec/factories/category_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/changeset_factory.rb
+++ b/spec/factories/changeset_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/color_factory.rb
+++ b/spec/factories/color_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/comment_factory.rb
+++ b/spec/factories/comment_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_action_factory.rb
+++ b/spec/factories/custom_action_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_field_section.rb
+++ b/spec/factories/custom_field_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_fields_project_factory.rb
+++ b/spec/factories/custom_fields_project_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_option_factory.rb
+++ b/spec/factories/custom_option_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_style_factory.rb
+++ b/spec/factories/custom_style_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/custom_value_factory.rb
+++ b/spec/factories/custom_value_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/day_factory.rb
+++ b/spec/factories/day_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/design_color_factory.rb
+++ b/spec/factories/design_color_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/emoji_reactions_factory.rb
+++ b/spec/factories/emoji_reactions_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/enumerations_factory.rb
+++ b/spec/factories/enumerations_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/export_factory.rb
+++ b/spec/factories/export_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/file_factory.rb
+++ b/spec/factories/file_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/forum_factory.rb
+++ b/spec/factories/forum_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/global_role_factory.rb
+++ b/spec/factories/global_role_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/group_user_factory.rb
+++ b/spec/factories/group_user_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/ical_token_query_assignment_factory.rb
+++ b/spec/factories/ical_token_query_assignment_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/issue_priority_factory.rb
+++ b/spec/factories/issue_priority_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/attachable_journal_factory.rb
+++ b/spec/factories/journal/attachable_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/attachment_journal_factory.rb
+++ b/spec/factories/journal/attachment_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/changeset_journal_factory.rb
+++ b/spec/factories/journal/changeset_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/customizable_journal_factory.rb
+++ b/spec/factories/journal/customizable_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/message_journal_factory.rb
+++ b/spec/factories/journal/message_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/news_journal_factory.rb
+++ b/spec/factories/journal/news_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/project_journal_factory.rb
+++ b/spec/factories/journal/project_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/wiki_page_journal_factory.rb
+++ b/spec/factories/journal/wiki_page_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal/work_package_journal_factory.rb
+++ b/spec/factories/journal/work_package_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/journal_factory.rb
+++ b/spec/factories/journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/ldap_auth_source_factory.rb
+++ b/spec/factories/ldap_auth_source_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/member_factory.rb
+++ b/spec/factories/member_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/member_role_factory.rb
+++ b/spec/factories/member_role_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/menu_item_factory.rb
+++ b/spec/factories/menu_item_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/message_factory.rb
+++ b/spec/factories/message_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/news_factory.rb
+++ b/spec/factories/news_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/non_working_day_factory.rb
+++ b/spec/factories/non_working_day_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :non_working_day do
     sequence(:name) { "Non working on #{date} " }

--- a/spec/factories/notification_factory.rb
+++ b/spec/factories/notification_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :notification do
     subject { "MyText" }

--- a/spec/factories/notification_setting_factory.rb
+++ b/spec/factories/notification_setting_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :notification_setting do
     transient do

--- a/spec/factories/oauth_access_token_factory.rb
+++ b/spec/factories/oauth_access_token_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/oauth_application_factory.rb
+++ b/spec/factories/oauth_application_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/oauth_client_factory.rb
+++ b/spec/factories/oauth_client_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/placeholder_user_factory.rb
+++ b/spec/factories/placeholder_user_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/principal_factory.rb
+++ b/spec/factories/principal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/project_custom_field_project_mapping.rb
+++ b/spec/factories/project_custom_field_project_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/project_phase_definition_factory.rb
+++ b/spec/factories/project_phase_definition_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/project_role_factory.rb
+++ b/spec/factories/project_role_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/queries/project_query_factory.rb
+++ b/spec/factories/queries/project_query_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/query_factory.rb
+++ b/spec/factories/query_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/relation_factory.rb
+++ b/spec/factories/relation_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/reminders_factory.rb
+++ b/spec/factories/reminders_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/repository_factory.rb
+++ b/spec/factories/repository_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/token_factory.rb
+++ b/spec/factories/token_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/traits/skip_validations.rb
+++ b/spec/factories/traits/skip_validations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   trait :skip_validations do
     to_create { |model| model.save!(validate: false) }

--- a/spec/factories/user_password_factory.rb
+++ b/spec/factories/user_password_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/user_preference_factory.rb
+++ b/spec/factories/user_preference_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/user_session_factory.rb
+++ b/spec/factories/user_session_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/version_factory.rb
+++ b/spec/factories/version_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/view_factory.rb
+++ b/spec/factories/view_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/view_team_planner_factory.rb
+++ b/spec/factories/view_team_planner_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/watcher_factory.rb
+++ b/spec/factories/watcher_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/week_day_factory.rb
+++ b/spec/factories/week_day_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/wiki_factory.rb
+++ b/spec/factories/wiki_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/wiki_page_factory.rb
+++ b/spec/factories/wiki_page_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/wiki_redirect_factory.rb
+++ b/spec/factories/wiki_redirect_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/work_package_custom_field_factory.rb
+++ b/spec/factories/work_package_custom_field_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/work_packags_export_factory.rb
+++ b/spec/factories/work_packags_export_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/factories/workflow_factory.rb
+++ b/spec/factories/workflow_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/a11y/work_packages/work_package_query_spec.rb
+++ b/spec/features/a11y/work_packages/work_package_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/disabled_activity_spec.rb
+++ b/spec/features/activities/disabled_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/project_attributes_activity_spec.rb
+++ b/spec/features/activities/project_attributes_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/time_entry_activity_spec.rb
+++ b/spec/features/activities/time_entry_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/wiki_activity_spec.rb
+++ b/spec/features/activities/wiki_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/work_package/emoji_reactions_spec.rb
+++ b/spec/features/activities/work_package/emoji_reactions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/activities/work_package_activity_spec.rb
+++ b/spec/features/activities/work_package_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/attachments/quarantined_attachments_spec.rb
+++ b/spec/features/admin/attachments/quarantined_attachments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/backup_spec.rb
+++ b/spec/features/admin/backup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/custom_fields/custom_fields_project_spec.rb
+++ b/spec/features/admin/custom_fields/custom_fields_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/custom_fields/link_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/link_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/custom_fields/list_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/list_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
+++ b/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/custom_fields/user_custom_field_spec.rb
+++ b/spec/features/admin/custom_fields/user_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/enterprise/enterprise_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/enterprise/enterprise_trial_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_trial_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/languages_settings_spec.rb
+++ b/spec/features/admin/languages_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/menu_item_traversal_spec.rb
+++ b/spec/features/admin/menu_item_traversal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/oauth/oauth_applications_management_spec.rb
+++ b/spec/features/admin/oauth/oauth_applications_management_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/progress_tracking_spec.rb
+++ b/spec/features/admin/progress_tracking_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/project_custom_fields/create_spec.rb
+++ b/spec/features/admin/project_custom_fields/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/project_custom_fields/edit_spec.rb
+++ b/spec/features/admin/project_custom_fields/edit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/project_custom_fields/list_spec.rb
+++ b/spec/features/admin/project_custom_fields/list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/project_custom_fields/project_mappings_spec.rb
+++ b/spec/features/admin/project_custom_fields/project_mappings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/project_custom_fields/shared_context.rb
+++ b/spec/features/admin/project_custom_fields/shared_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/test_mail_notification_spec.rb
+++ b/spec/features/admin/test_mail_notification_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/admin/working_days_spec.rb
+++ b/spec/features/admin/working_days_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/api_docs/index_spec.rb
+++ b/spec/features/api_docs/index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/attachments/attachments_spec.rb
+++ b/spec/features/attachments/attachments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/auth_source_sso_login_spec.rb
+++ b/spec/features/auth/auth_source_sso_login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/auth_source_sso_logout_spec.rb
+++ b/spec/features/auth/auth_source_sso_logout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/auth_stages_spec.rb
+++ b/spec/features/auth/auth_stages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/consent_auth_stage_spec.rb
+++ b/spec/features/auth/consent_auth_stage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/login_spec.rb
+++ b/spec/features/auth/login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/logout_spec.rb
+++ b/spec/features/auth/logout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/lost_password_spec.rb
+++ b/spec/features/auth/lost_password_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/categories/categories_page.rb
+++ b/spec/features/categories/categories_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/categories/delete_spec.rb
+++ b/spec/features/categories/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/colors/color_administration_spec.rb
+++ b/spec/features/colors/color_administration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/custom_fields/activate_in_project_spec.rb
+++ b/spec/features/custom_fields/activate_in_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/custom_fields/create_bool_spec.rb
+++ b/spec/features/custom_fields/create_bool_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_fields/create_date_spec.rb
+++ b/spec/features/custom_fields/create_date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_fields/create_float_spec.rb
+++ b/spec/features/custom_fields/create_float_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_fields/create_int_spec.rb
+++ b/spec/features/custom_fields/create_int_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_fields/create_long_text_spec.rb
+++ b/spec/features/custom_fields/create_long_text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_fields/custom_fields_page.rb
+++ b/spec/features/custom_fields/custom_fields_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/custom_fields/custom_fields_spec.rb
+++ b/spec/features/custom_fields/custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 

--- a/spec/features/custom_fields/multi_version_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_version_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 

--- a/spec/features/custom_fields/non_open_version_custom_field_spec.rb
+++ b/spec/features/custom_fields/non_open_version_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 

--- a/spec/features/custom_fields/reorder_options_spec.rb
+++ b/spec/features/custom_fields/reorder_options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/pages/custom_fields/index_page"
 

--- a/spec/features/custom_styles/tabs_navigation_spec.rb
+++ b/spec/features/custom_styles/tabs_navigation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/errors/errors_handler_spec.rb
+++ b/spec/features/errors/errors_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Errors handling" do

--- a/spec/features/forums/attachment_upload_spec.rb
+++ b/spec/features/forums/attachment_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/forums/message_spec.rb
+++ b/spec/features/forums/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/forums/sticky_spec.rb
+++ b/spec/features/forums/sticky_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/global_roles/global_create_project_spec.rb
+++ b/spec/features/global_roles/global_create_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/global_roles/global_role_assignment_spec.rb
+++ b/spec/features/global_roles/global_role_assignment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/global_roles/global_role_crud_spec.rb
+++ b/spec/features/global_roles/global_role_crud_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/global_roles/global_role_update_spec.rb
+++ b/spec/features/global_roles/global_role_update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/global_roles/member_roles_spec.rb
+++ b/spec/features/global_roles/member_roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/global_roles/no_module_spec.rb
+++ b/spec/features/global_roles/no_module_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/groups/group_memberships_spec.rb
+++ b/spec/features/groups/group_memberships_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/groups/group_show_spec.rb
+++ b/spec/features/groups/group_show_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/groups/groups_spec.rb
+++ b/spec/features/groups/groups_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/groups/membership_spec.rb
+++ b/spec/features/groups/membership_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/homescreen/index_spec.rb
+++ b/spec/features/homescreen/index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/homescreen/robots_spec.rb
+++ b/spec/features/homescreen/robots_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/ldap_auth_sources/crud_spec.rb
+++ b/spec/features/ldap_auth_sources/crud_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/error_messages_spec.rb
+++ b/spec/features/members/error_messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/membership_filter_spec.rb
+++ b/spec/features/members/membership_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/membership_share_spec.rb
+++ b/spec/features/members/membership_share_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/pagination_spec.rb
+++ b/spec/features/members/pagination_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/members/roles_spec.rb
+++ b/spec/features/members/roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/help_menu_spec.rb
+++ b/spec/features/menu_items/help_menu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/menu_permissions_spec.rb
+++ b/spec/features/menu_items/menu_permissions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/query_menu_item_spec.rb
+++ b/spec/features/menu_items/query_menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/quick_add_menu_spec.rb
+++ b/spec/features/menu_items/quick_add_menu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/menu_items/wiki_menu_item_spec.rb
+++ b/spec/features/menu_items/wiki_menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/my/autologin_tokens_management_spec.rb
+++ b/spec/features/my/autologin_tokens_management_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/my/sessions_management_spec.rb
+++ b/spec/features/my/sessions_management_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/news/creation_and_commenting_spec.rb
+++ b/spec/features/news/creation_and_commenting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Notification center navigation", :js do

--- a/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 

--- a/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 

--- a/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_sidemenu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Notification center sidemenu",

--- a/spec/features/notifications/notification_center/notification_center_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Notification center",

--- a/spec/features/notifications/notification_center/split_screen_spec.rb
+++ b/spec/features/notifications/notification_center/split_screen_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Split screen in the notification center", :js do

--- a/spec/features/notifications/reminder_mail_spec.rb
+++ b/spec/features/notifications/reminder_mail_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_relative "../users/notifications/shared_examples"
 

--- a/spec/features/notifications/settings/immediate_reminder_spec.rb
+++ b/spec/features/notifications/settings/immediate_reminder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Immediate reminder settings", :js do

--- a/spec/features/notifications/settings/my_notifications_settings_spec.rb
+++ b/spec/features/notifications/settings/my_notifications_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require_relative "../../users/notifications/shared_examples"
 require "support/pages/my/notifications"

--- a/spec/features/notifications/settings/pause_reminder_settings_spec.rb
+++ b/spec/features/notifications/settings/pause_reminder_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Pause reminder settings", :js do

--- a/spec/features/notifications/settings/reminder_email_settings_spec.rb
+++ b/spec/features/notifications/settings/reminder_email_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_relative "../../users/notifications/shared_examples"
 

--- a/spec/features/notifications/settings/workdays_settings_spec.rb
+++ b/spec/features/notifications/settings/workdays_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Workday notification settings", :js do

--- a/spec/features/oauth/authorization_code_flow_spec.rb
+++ b/spec/features/oauth/authorization_code_flow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/oauth/pkce_spec.rb
+++ b/spec/features/oauth/pkce_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/onboarding/onboarding_tour_spec.rb
+++ b/spec/features/onboarding/onboarding_tour_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/page_objects/notification.rb
+++ b/spec/features/page_objects/notification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/placeholder_users/create_spec.rb
+++ b/spec/features/placeholder_users/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/placeholder_users/delete_spec.rb
+++ b/spec/features/placeholder_users/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/placeholder_users/edit_placeholder_users_spec.rb
+++ b/spec/features/placeholder_users/edit_placeholder_users_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/placeholder_users/index_spec.rb
+++ b/spec/features/placeholder_users/index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/placeholder_users/placeholder_user_memberships_spec.rb
+++ b/spec/features/placeholder_users/placeholder_user_memberships_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/principals/shared_memberships_examples.rb
+++ b/spec/features/principals/shared_memberships_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_context "principal membership management context" do
   shared_let(:project) do
     create(:project,

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/destroy_spec.rb
+++ b/spec/features/projects/destroy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/export_spec.rb
+++ b/spec/features/projects/export_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/favorite_spec.rb
+++ b/spec/features/projects/favorite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/life_cycle/active_in_project_spec.rb
+++ b/spec/features/projects/life_cycle/active_in_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/features/projects/life_cycle/overview_page/dialog/permission_spec.rb
+++ b/spec/features/projects/life_cycle/overview_page/dialog/permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/life_cycle/overview_page/shared_context.rb
+++ b/spec/features/projects/life_cycle/overview_page/shared_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/lists/columns_spec.rb
+++ b/spec/features/projects/lists/columns_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/features/projects/lists/gantt_spec.rb
+++ b/spec/features/projects/lists/gantt_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/features/projects/lists/table_spec.rb
+++ b/spec/features/projects/lists/table_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/features/projects/modules_spec.rb
+++ b/spec/features/projects/modules_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/navigation_spec.rb
+++ b/spec/features/projects/navigation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/permission_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/render_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/render_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/validation_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/validation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_custom_fields/settings/mapping_spec.rb
+++ b/spec/features/projects/project_custom_fields/settings/mapping_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/subproject_creation_spec.rb
+++ b/spec/features/projects/subproject_creation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/repositories/checkout_instructions_spec.rb
+++ b/spec/features/repositories/checkout_instructions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/repositories/create_repository_spec.rb
+++ b/spec/features/repositories/create_repository_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/repositories/repository_settings_page.rb
+++ b/spec/features/repositories/repository_settings_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/roles/create_spec.rb
+++ b/spec/features/roles/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/security/expire_sessions_spec.rb
+++ b/spec/features/security/expire_sessions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/security/plain_text_content_type.rb
+++ b/spec/features/security/plain_text_content_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/security/session_ttl_spec.rb
+++ b/spec/features/security/session_ttl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/statuses/read_only_statuses_spec.rb
+++ b/spec/features/statuses/read_only_statuses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/statuses/statuses_administration_spec.rb
+++ b/spec/features/statuses/statuses_administration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/support/components/attribute_help_text_modal.rb
+++ b/spec/features/support/components/attribute_help_text_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/support/components/danger_zone.rb
+++ b/spec/features/support/components/danger_zone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/support/components/ng_select_autocomplete.rb
+++ b/spec/features/support/components/ng_select_autocomplete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/support/work_package_table.rb
+++ b/spec/features/support/work_package_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/types/activate_in_project_spec.rb
+++ b/spec/features/types/activate_in_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/brute_force_spec.rb
+++ b/spec/features/users/brute_force_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/delete_spec.rb
+++ b/spec/features/users/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/edit_users_spec.rb
+++ b/spec/features/users/edit_users_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/invitation_spec.rb
+++ b/spec/features/users/invitation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/invite_user_modal/custom_fields_spec.rb
+++ b/spec/features/users/invite_user_modal/custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
+++ b/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/invite_user_modal/subproject_invite_spec.rb
+++ b/spec/features/users/invite_user_modal/subproject_invite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/notifications/shared_examples.rb
+++ b/spec/features/users/notifications/shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples "notification settings workflow" do
   describe "with another project the user can see",
            with_ee: %i[date_alerts] do

--- a/spec/features/users/notifications/user_notifications_settings_spec.rb
+++ b/spec/features/users/notifications/user_notifications_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require_relative "shared_examples"
 

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/self_registration_spec.rb
+++ b/spec/features/users/self_registration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/unaccent_user_filter_spec.rb
+++ b/spec/features/users/unaccent_user_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/users/user_memberships_spec.rb
+++ b/spec/features/users/user_memberships_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/versions/create_spec.rb
+++ b/spec/features/versions/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/versions/delete_spec.rb
+++ b/spec/features/versions/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/versions/edit_spec.rb
+++ b/spec/features/versions/edit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/versions/graph_spec.rb
+++ b/spec/features/versions/graph_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/versions/project_settings_index_spec.rb
+++ b/spec/features/versions/project_settings_index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/views/shared_examples.rb
+++ b/spec/features/views/shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/watching/toggle_watching_spec.rb
+++ b/spec/features/watching/toggle_watching_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/adding_editing_history_spec.rb
+++ b/spec/features/wiki/adding_editing_history_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/attachment_upload_spec.rb
+++ b/spec/features/wiki/attachment_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/child_pages_spec.rb
+++ b/spec/features/wiki/child_pages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/edit_new_page_spec.rb
+++ b/spec/features/wiki/edit_new_page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/rename_spec.rb
+++ b/spec/features/wiki/rename_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/restore_main_item_spec.rb
+++ b/spec/features/wiki/restore_main_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/wiki_page_external_link_spec.rb
+++ b/spec/features/wiki/wiki_page_external_link_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/wiki_page_navigation_spec.rb
+++ b/spec/features/wiki/wiki_page_navigation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_package_show_spec.rb
+++ b/spec/features/work_package_show_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/attribute_help_texts_spec.rb
+++ b/spec/features/work_packages/attribute_help_texts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/bulk/copy_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/copy_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 require "support/components/autocompleter/ng_select_autocomplete_helpers"

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 require "support/components/autocompleter/ng_select_autocomplete_helpers"

--- a/spec/features/work_packages/bulk/update_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/update_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 

--- a/spec/features/work_packages/cancel_editing_spec.rb
+++ b/spec/features/work_packages/cancel_editing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/custom_actions/custom_actions_link_value_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_link_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/custom_actions/custom_actions_me_value_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_me_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_non_working_day_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/datepicker/datepicker_parent_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_parent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/closed_status_and_version_spec.rb
+++ b/spec/features/work_packages/details/closed_status_and_version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Closed status and version in full view", :js do

--- a/spec/features/work_packages/details/context_menu_spec.rb
+++ b/spec/features/work_packages/details/context_menu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work package single context menu", :js, :selenium do

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/work_packages/work_packages_page"
 require "features/work_packages/details/inplace_editor/shared_examples"

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/details_refreshing_spec.rb
+++ b/spec/features/work_packages/details/details_refreshing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/details_toolbar_spec.rb
+++ b/spec/features/work_packages/details/details_toolbar_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples "as an accessible inplace editor" do
   it "triggers edit mode on click" do
     scroll_to_element(field.display_element)

--- a/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/subject_editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 require "features/work_packages/details/inplace_editor/shared_examples"

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/work_packages/details/inplace_editor/shared_examples"
 require "features/work_packages/shared_contexts"

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "features/work_packages/shared_contexts"

--- a/spec/features/work_packages/details/markdown/description_editor_spec.rb
+++ b/spec/features/work_packages/details/markdown/description_editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/markdown/todolist_spec.rb
+++ b/spec/features/work_packages/details/markdown/todolist_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/milestones_spec.rb
+++ b/spec/features/work_packages/details/milestones_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Milestones full screen v iew", :js do

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/relations/hierarchy_milestone_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_milestone_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/details/workdays_spec.rb
+++ b/spec/features/work_packages/details/workdays_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/display_fields/date_field_display_spec.rb
+++ b/spec/features/work_packages/display_fields/date_field_display_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/display_fields/spent_time_display_spec.rb
+++ b/spec/features/work_packages/display_fields/spent_time_display_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/display_fields/work_display_spec.rb
+++ b/spec/features/work_packages/display_fields/work_display_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/display_representations/switch_display_representations_on_mobile_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_on_mobile_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/edit_on_assign_version_permission_spec.rb
+++ b/spec/features/work_packages/edit_on_assign_version_permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 

--- a/spec/features/work_packages/edit_on_change_work_package_status_permission_spec.rb
+++ b/spec/features/work_packages/edit_on_change_work_package_status_permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "features/page_objects/notification"
 

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/generate_pdf_spec.rb
+++ b/spec/features/work_packages/generate_pdf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package highlighting fields",

--- a/spec/features/work_packages/index_sums_spec.rb
+++ b/spec/features/work_packages/index_sums_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_datepicker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/edit_fields/edit_field"
 require "features/work_packages/work_packages_page"

--- a/spec/features/work_packages/new/work_package_default_description_spec.rb
+++ b/spec/features/work_packages/new/work_package_default_description_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "support/edit_fields/edit_field"
 require "features/work_packages/work_packages_page"

--- a/spec/features/work_packages/pagination_spec.rb
+++ b/spec/features/work_packages/pagination_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/project_include/project_include_shared_examples.rb
+++ b/spec/features/work_packages/project_include/project_include_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/remaining_time_spec.rb
+++ b/spec/features/work_packages/remaining_time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/reports_spec.rb
+++ b/spec/features/work_packages/reports_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
+++ b/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/select/select_query_spec.rb
+++ b/spec/features/work_packages/select/select_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/select/select_work_package_row_spec.rb
+++ b/spec/features/work_packages/select/select_work_package_row_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/share/access_spec.rb
+++ b/spec/features/work_packages/share/access_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/share/notification_spec.rb
+++ b/spec/features/work_packages/share/notification_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/shared_contexts.rb
+++ b/spec/features/work_packages/shared_contexts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/sorting/manual_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/manual_sorting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/sorting/table_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/table_sorting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/switching_to_project_from_work_package_spec.rb
+++ b/spec/features/work_packages/switching_to_project_from_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Switching to project from work package", :js do

--- a/spec/features/work_packages/table/baseline/baseline_invisible_project_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_invisible_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/baseline/baseline_query_spec.rb
+++ b/spec/features/work_packages/table/baseline/baseline_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/configuration_modal/column_spec.rb
+++ b/spec/features/work_packages/table/configuration_modal/column_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table configuration modal columns spec", :js do

--- a/spec/features/work_packages/table/configuration_modal/filter_spec.rb
+++ b/spec/features/work_packages/table/configuration_modal/filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table configuration modal filters spec", :js do

--- a/spec/features/work_packages/table/configuration_modal/table_configuration_modal_spec.rb
+++ b/spec/features/work_packages/table/configuration_modal/table_configuration_modal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table configuration modal", :js do

--- a/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.shared_examples_for "provides a single WP context menu" do

--- a/spec/features/work_packages/table/context_menu/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require_relative "context_menu_shared_examples"
 

--- a/spec/features/work_packages/table/delete_work_packages_spec.rb
+++ b/spec/features/work_packages/table/delete_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/duration_field_spec.rb
+++ b/spec/features/work_packages/table/duration_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Duration field in the work package table", :js do

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Inline editing work packages", :js do

--- a/spec/features/work_packages/table/empty_filters_spec.rb
+++ b/spec/features/work_packages/table/empty_filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Empty query filters", :js do

--- a/spec/features/work_packages/table/group_by/group_by_boolean_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_boolean_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package group by boolean field", :js do

--- a/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package group by progress", :js, :selenium do

--- a/spec/features/work_packages/table/group_by/group_headers_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_headers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table group headers", :js do

--- a/spec/features/work_packages/table/hierarchy/hierarchy_indent_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_indent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table hierarchy and sorting", :js do

--- a/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table hierarchy parent below", :js do

--- a/spec/features/work_packages/table/hierarchy/hierarchy_sorting_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_sorting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table hierarchy and sorting", :js do

--- a/spec/features/work_packages/table/hierarchy/hierarchy_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table hierarchy", :js do

--- a/spec/features/work_packages/table/hierarchy/hierarchy_vs_grouping_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_vs_grouping_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/hierarchy/parent_column_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/parent_column_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table parent column", :js, :selenium do

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "inline create work package", :js, :selenium do

--- a/spec/features/work_packages/table/inline_create/inline_create_refresh_spec.rb
+++ b/spec/features/work_packages/table/inline_create/inline_create_refresh_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Refreshing in inline-create row", :flaky, :js do

--- a/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
+++ b/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Parallel work package creation spec", :js do

--- a/spec/features/work_packages/table/invalid_query_spec.rb
+++ b/spec/features/work_packages/table/invalid_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Invalid query spec", :js do

--- a/spec/features/work_packages/table/milestones_spec.rb
+++ b/spec/features/work_packages/table/milestones_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Inline editing milestones", :js do

--- a/spec/features/work_packages/table/queries/assignee_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/assignee_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/bool_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/bool_cf_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/default_queries_spec.rb
+++ b/spec/features/work_packages/table/queries/default_queries_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/filter_pagination_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_pagination_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/hierarchy_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/hierarchy_cf_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/id_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/me_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/me_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/query_history_spec.rb
+++ b/spec/features/work_packages/table/queries/query_history_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/query_menu_refresh_spec.rb
+++ b/spec/features/work_packages/table/queries/query_menu_refresh_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/query_menu_spec.rb
+++ b/spec/features/work_packages/table/queries/query_menu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
+++ b/spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/responsible_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/responsible_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/subject_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/subject_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/summary_spec.rb
+++ b/spec/features/work_packages/table/queries/summary_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/queries/user_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/user_cf_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/table/relations_spec.rb
+++ b/spec/features/work_packages/table/relations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Work Package table child relations",

--- a/spec/features/work_packages/table/subproject_filters_spec.rb
+++ b/spec/features/work_packages/table/subproject_filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Subproject filters", :js do

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Switching types in work package table", :js do

--- a/spec/features/work_packages/table/work_packages_table_project_include_spec.rb
+++ b/spec/features/work_packages/table/work_packages_table_project_include_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/tabs/activity_notifications_spec.rb
+++ b/spec/features/work_packages/tabs/activity_notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "features/work_packages/work_packages_page"

--- a/spec/features/work_packages/tabs/keep_tab_spec.rb
+++ b/spec/features/work_packages/tabs/keep_tab_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Watcher tab", :js, :selenium do

--- a/spec/features/work_packages/work_package_index_spec.rb
+++ b/spec/features/work_packages/work_package_index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/work_package_workflow_form_spec.rb
+++ b/spec/features/work_packages/work_package_workflow_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/work_packages_page.rb
+++ b/spec/features/work_packages/work_packages_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/work_packages/zen_mode_spec.rb
+++ b/spec/features/work_packages/zen_mode_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Zen mode", :js do

--- a/spec/features/workflows/copy_spec.rb
+++ b/spec/features/workflows/copy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/workflows/missing_for_sharing_wp_spec.rb
+++ b/spec/features/workflows/missing_for_sharing_wp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/autosave_spec.rb
+++ b/spec/features/wysiwyg/autosave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/bold_behavior_spec.rb
+++ b/spec/features/wysiwyg/bold_behavior_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/custom_css_classes_spec.rb
+++ b/spec/features/wysiwyg/custom_css_classes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/html_encoding_spec.rb
+++ b/spec/features/wysiwyg/html_encoding_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/linking_spec.rb
+++ b/spec/features/wysiwyg/linking_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/attribute_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/attribute_macros_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/child_pages_spec.rb
+++ b/spec/features/wysiwyg/macros/child_pages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/code_block_macro_spec.rb
+++ b/spec/features/wysiwyg/macros/code_block_macro_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/embedded_tables_spec.rb
+++ b/spec/features/wysiwyg/macros/embedded_tables_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/work_package_button_spec.rb
+++ b/spec/features/wysiwyg/macros/work_package_button_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/mentions_spec.rb
+++ b/spec/features/wysiwyg/mentions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/paragraphs_in_lists_spec.rb
+++ b/spec/features/wysiwyg/paragraphs_in_lists_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/tables_spec.rb
+++ b/spec/features/wysiwyg/tables_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/ui_localization_spec.rb
+++ b/spec/features/wysiwyg/ui_localization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/features/wysiwyg/work_package_linking_spec.rb
+++ b/spec/features/wysiwyg/work_package_linking_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/additional_url_helper_spec.rb
+++ b/spec/helpers/additional_url_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/angular_helper_spec.rb
+++ b/spec/helpers/angular_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/archived_projects_helper_spec.rb
+++ b/spec/helpers/archived_projects_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/colors_helper_spec.rb
+++ b/spec/helpers/colors_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/custom_styles_helper_spec.rb
+++ b/spec/helpers/custom_styles_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/error_message_helper_spec.rb
+++ b/spec/helpers/error_message_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/frontend_asset_helper_spec.rb
+++ b/spec/helpers/frontend_asset_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/hook_helper_spec.rb
+++ b/spec/helpers/hook_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/individual_principal_hooks_helper_spec.rb
+++ b/spec/helpers/individual_principal_hooks_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/no_results_helper_spec.rb
+++ b/spec/helpers/no_results_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/removed_js_helpers_helper_spec.rb
+++ b/spec/helpers/removed_js_helpers_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/security_badge_helper_spec.rb
+++ b/spec/helpers/security_badge_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/sort_helper_spec.rb
+++ b/spec/helpers/sort_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/tabs_helper_spec.rb
+++ b/spec/helpers/tabs_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/toolbar_helper_spec.rb
+++ b/spec/helpers/toolbar_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/types_helper_spec.rb
+++ b/spec/helpers/types_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/versions_helper_spec.rb
+++ b/spec/helpers/versions_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/wiki_pages/at_version_spec.rb
+++ b/spec/helpers/wiki_pages/at_version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/work_packages_filter_helper_spec.rb
+++ b/spec/helpers/work_packages_filter_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/httpx_spec.rb
+++ b/spec/httpx_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "webrick"
 require "httpx"
 

--- a/spec/jobs/attachments/virus_rescan_job_spec.rb
+++ b/spec/jobs/attachments/virus_rescan_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Attachments::VirusRescanJob,

--- a/spec/jobs/attachments/virus_scan_job_spec.rb
+++ b/spec/jobs/attachments/virus_scan_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Attachments::VirusScanJob,

--- a/spec/lib/acts_as_journalized/journal_formatter_cache_spec.rb
+++ b/spec/lib/acts_as_journalized/journal_formatter_cache_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/acts_as_journalized/journaled_spec.rb
+++ b/spec/lib/acts_as_journalized/journaled_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/acts_as_list/acts_as_list_patch_spec.rb
+++ b/spec/lib/acts_as_list/acts_as_list_patch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/acts_as_watchable/lib/open_project/acts/favorable/route_constraint_spec.rb
+++ b/spec/lib/acts_as_watchable/lib/open_project/acts/favorable/route_constraint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/acts_as_watchable/lib/open_project/acts/registry_methods_spec.rb
+++ b/spec/lib/acts_as_watchable/lib/open_project/acts/registry_methods_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/acts_as_watchable/lib/open_project/acts/watchable/route_constraint_spec.rb
+++ b/spec/lib/acts_as_watchable/lib/open_project/acts/watchable/route_constraint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/contracts/model_contract_spec.rb
+++ b/spec/lib/api/contracts/model_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/decorators/aggregation_group_spec.rb
+++ b/spec/lib/api/decorators/aggregation_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/decorators/formattable_spec.rb
+++ b/spec/lib/api/decorators/formattable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/decorators/link_object_spec.rb
+++ b/spec/lib/api/decorators/link_object_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/utilities/property_name_converter_spec.rb
+++ b/spec/lib/api/utilities/property_name_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/utilities/resource_link_parser_spec.rb
+++ b/spec/lib/api/utilities/resource_link_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/utilities/url_props_parsing_helper_spec.rb
+++ b/spec/lib/api/utilities/url_props_parsing_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/actions/action_sql_respresenter_rendering_spec.rb
+++ b/spec/lib/api/v3/actions/action_sql_respresenter_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/activities/activity_eager_loading_wrapper_spec.rb
+++ b/spec/lib/api/v3/activities/activity_eager_loading_wrapper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/activities/activity_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/activities/activity_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/attachments/attachment_metadata_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_metadata_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/attachments/attachment_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/capabilities/capability_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/capabilities/capability_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/capabilities/contexts/global_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/capabilities/contexts/global_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/categories/category_collection_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/categories/category_representer_spec.rb
+++ b/spec/lib/api/v3/categories/category_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/configuration/configuration_representer_spec.rb
+++ b/spec/lib/api/v3/configuration/configuration_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/custom_actions/custom_action_execute_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/custom_actions/custom_action_execute_representer_parsing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/custom_actions/custom_action_representer_generation_spec.rb
+++ b/spec/lib/api/v3/custom_actions/custom_action_representer_generation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/custom_options/custom_option_representer_spec.rb
+++ b/spec/lib/api/v3/custom_options/custom_option_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/days/day_collection_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/days/day_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/days/non_working_day_collection_representer_spec.rb
+++ b/spec/lib/api/v3/days/non_working_day_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/days/non_working_day_representer_spec.rb
+++ b/spec/lib/api/v3/days/non_working_day_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/days/week_day_collection_representer_spec.rb
+++ b/spec/lib/api/v3/days/week_day_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/days/week_day_representer_spec.rb
+++ b/spec/lib/api/v3/days/week_day_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/groups/group_collection_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/groups/group_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/groups/group_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/groups/group_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/help_texts/help_text_collection_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/memberships/membership_collection_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/memberships/membership_payload_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_payload_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/memberships/membership_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/memberships/schemas/membership_schema_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/schemas/membership_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/news/news_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/news/news_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
+++ b/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/notifications/notification_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/notifications/notification_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/notifications/property_factory_spec.rb
+++ b/spec/lib/api/v3/notifications/property_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/oauth/oauth_applications_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/oauth/oauth_applications_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/placeholder_users/placeholder_user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/placeholder_users/placeholder_user_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/placeholder_users/placeholder_user_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/placeholder_users/placeholder_user_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/placeholder_users/placeholder_user_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/placeholder_users/placeholder_user_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/posts/post_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/posts/post_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/principals/principal_representer_factory_spec.rb
+++ b/spec/lib/api/v3/principals/principal_representer_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/principals/principal_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/principals/principal_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/principals/principal_type_spec.rb
+++ b/spec/lib/api/v3/principals/principal_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/priorities/priority_collection_representer_spec.rb
+++ b/spec/lib/api/v3/priorities/priority_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/priorities/priority_representer_spec.rb
+++ b/spec/lib/api/v3/priorities/priority_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/copy/project_copy_payload_representer_spec.rb
+++ b/spec/lib/api/v3/projects/copy/project_copy_payload_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/copy/project_copy_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/copy/project_copy_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/project_collection_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
+++ b/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/project_sql_collection_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_sql_collection_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/projects/project_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/projects/statuses/status_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/statuses/status_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/columns/query_relation_of_type_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_of_type_column_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/columns/query_relation_to_type_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_to_type_column_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/filters/query_filter_representer_spec.rb
+++ b/spec/lib/api/v3/queries/filters/query_filter_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/group_bys/query_group_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/group_bys/query_group_by_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/ical_url/query_ical_url_representer_spec.rb
+++ b/spec/lib/api/v3/queries/ical_url/query_ical_url_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/operators/query_operator_representer_spec.rb
+++ b/spec/lib/api/v3/queries/operators/query_operator_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/queries_params_representer_spec.rb
+++ b/spec/lib/api/v3/queries/queries_params_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/query_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_parsing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/query_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/blocks_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/blocks_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/category_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/category_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/date_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/date_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/date_time_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/date_time_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/duplicated_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/duplicated_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/duplicates_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/duplicates_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/filter_dependency_representer_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/float_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/float_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/follows_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/follows_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/hierarchy_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/hierarchy_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/id_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/id_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/includes_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/includes_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/integer_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/integer_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/parent_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/parent_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/partof_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/partof_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/precedes_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/precedes_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/priority_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/priority_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/project_members_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/project_members_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/relates_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/relates_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/required_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/required_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/requires_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/requires_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/status_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/status_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/subproject_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/subproject_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/text_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/text_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/relations/relation_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/relations/relation_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/root_representer_spec.rb
+++ b/spec/lib/api/v3/root_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/shares/share_collection_representer_spec.rb
+++ b/spec/lib/api/v3/shares/share_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/shares/share_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/shares/share_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/statuses/status_collection_representer_spec.rb
+++ b/spec/lib/api/v3/statuses/status_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/statuses/status_representer_spec.rb
+++ b/spec/lib/api/v3/statuses/status_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/api_v3_collection.rb
+++ b/spec/lib/api/v3/support/api_v3_collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/api_v3_digest.rb
+++ b/spec/lib/api/v3/support/api_v3_digest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/api_v3_filter_dependency.rb
+++ b/spec/lib/api/v3/support/api_v3_filter_dependency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/api_v3_formattable.rb
+++ b/spec/lib/api/v3/support/api_v3_formattable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/collection_examples.rb
+++ b/spec/lib/api/v3/support/collection_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/date_time_examples.rb
+++ b/spec/lib/api/v3/support/date_time_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/link_examples.rb
+++ b/spec/lib/api/v3/support/link_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/property_examples.rb
+++ b/spec/lib/api/v3/support/property_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/types/type_representer_spec.rb
+++ b/spec/lib/api/v3/types/type_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/user_preferences/notification_setting_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/user_preferences/notification_setting_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_parsing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/users/unpaginated_user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/users/unpaginated_user_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/users/user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/users/user_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
+++ b/spec/lib/api/v3/utilities/date_time_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/utilities/resource_link_generator_spec.rb
+++ b/spec/lib/api/v3/utilities/resource_link_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/values/property_date_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/values/property_date_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/values/schemas/property_schema_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/values/schemas/property_schema_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/values/schemas/value_schema_factory_spec.rb
+++ b/spec/lib/api/v3/values/schemas/value_schema_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
+++ b/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/versions/version_collection_representer_spec.rb
+++ b/spec/lib/api/v3/versions/version_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/versions/version_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/versions/version_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/views/view_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/views/view_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/wiki_pages/wiki_page_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/wiki_pages/wiki_page_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/cost_eager_loading_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cost_eager_loading_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/custom_actions_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/custom_actions_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/eager_loading_mock_wrapper.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/eager_loading_mock_wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/principals_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/principals_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/form_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/specific_work_package_schema_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/typed_work_package_schema_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/update_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/update_form_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/work_package_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sql_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copied from https://gitlab.com/gitlab-org/ruby/gems/gitlab-chronic-duration
 # version 0.12.0
 #

--- a/spec/lib/core_extensions/squish_sql_spec.rb
+++ b/spec/lib/core_extensions/squish_sql_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/core_extensions/to_localized_slug_spec.rb
+++ b/spec/lib/core_extensions/to_localized_slug_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe CoreExtensions::String, "#to_localized_slug" do

--- a/spec/lib/database_spec.rb
+++ b/spec/lib/database_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/i18n/pluralization_spec.rb
+++ b/spec/lib/i18n/pluralization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/access_control/permission_spec.rb
+++ b/spec/lib/open_project/access_control/permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/authentication/strategies/warden/global_basic_auth_spec.rb
+++ b/spec/lib/open_project/authentication/strategies/warden/global_basic_auth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/changed_by_system_spec.rb
+++ b/spec/lib/open_project/changed_by_system_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/configuration/helpers_spec.rb
+++ b/spec/lib/open_project/configuration/helpers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/content_type_detector_spec.rb
+++ b/spec/lib/open_project/content_type_detector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/custom_field_format_dependent_spec.rb
+++ b/spec/lib/open_project/custom_field_format_dependent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/enterprise_spec.rb
+++ b/spec/lib/open_project/enterprise_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/feature_decisions_spec.rb
+++ b/spec/lib/open_project/feature_decisions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/file_command_content_type_detector_spec.rb
+++ b/spec/lib/open_project/file_command_content_type_detector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/files_spec.rb
+++ b/spec/lib/open_project/files_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/footer_spec.rb
+++ b/spec/lib/open_project/footer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/hook_spec.rb
+++ b/spec/lib/open_project/hook_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/active_status_spec.rb
+++ b/spec/lib/open_project/journal_formatter/active_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/attachment_spec.rb
+++ b/spec/lib/open_project/journal_formatter/attachment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/day_count_spec.rb
+++ b/spec/lib/open_project/journal_formatter/day_count_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/diff_spec.rb
+++ b/spec/lib/open_project/journal_formatter/diff_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/ignore_non_working_days_spec.rb
+++ b/spec/lib/open_project/journal_formatter/ignore_non_working_days_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/schedule_manually_spec.rb
+++ b/spec/lib/open_project/journal_formatter/schedule_manually_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/template_spec.rb
+++ b/spec/lib/open_project/journal_formatter/template_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/visibility_spec.rb
+++ b/spec/lib/open_project/journal_formatter/visibility_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/journal_formatter/wiki_diff_spec.rb
+++ b/spec/lib/open_project/journal_formatter/wiki_diff_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/logging/log_extender_spec.rb
+++ b/spec/lib/open_project/logging/log_extender_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/mime_type_spec.rb
+++ b/spec/lib/open_project/mime_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/notifications_spec.rb
+++ b/spec/lib/open_project/notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/omni_auth/authorization_spec.rb
+++ b/spec/lib/open_project/omni_auth/authorization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/passwords_spec.rb
+++ b/spec/lib/open_project/passwords_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/plugins/acts_as_op_engine_spec.rb
+++ b/spec/lib/open_project/plugins/acts_as_op_engine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/plugins/module_handler_spec.rb
+++ b/spec/lib/open_project/plugins/module_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/scm/manager_spec.rb
+++ b/spec/lib/open_project/scm/manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/static_routing_spec.rb
+++ b/spec/lib/open_project/static_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/storage_spec.rb
+++ b/spec/lib/open_project/storage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/blockquote_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/blockquote_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/child_pages_macro_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/code_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/embedded_table_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/embedded_table_macro_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/expected_markdown.rb
+++ b/spec/lib/open_project/text_formatting/markdown/expected_markdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_context "expected markdown modules" do
   include OpenProject::TextFormatting
   include ERB::Util

--- a/spec/lib/open_project/text_formatting/markdown/headings_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/headings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/images_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/images_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/in_tool_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/in_tool_links_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/include_wiki_page_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/include_wiki_page_macro_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/paragraphs_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/paragraphs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/tables_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/tables_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/toc_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/toc_macro_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/work_package_buttons_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/work_package_buttons_macro_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/plain_spec.rb
+++ b/spec/lib/open_project/text_formatting/plain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/text_formatting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/redmine/menu_manager/mapper_spec.rb
+++ b/spec/lib/redmine/menu_manager/mapper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/redmine/menu_manager/menu_helper_spec.rb
+++ b/spec/lib/redmine/menu_manager/menu_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/redmine/menu_manager/menu_item_spec.rb
+++ b/spec/lib/redmine/menu_manager/menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/redmine/menu_manager_spec.rb
+++ b/spec/lib/redmine/menu_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/lib/redmine/plugin_spec.rb
+++ b/spec/lib/redmine/plugin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/redmine/unified_diff_spec.rb
+++ b/spec/lib/redmine/unified_diff_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/representable_spec.rb
+++ b/spec/lib/representable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/announcement_mailer_spec.rb
+++ b/spec/mailers/announcement_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/previews/digest_mailer_preview.rb
+++ b/spec/mailers/previews/digest_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/previews/meeting_mailer_preview.rb
+++ b/spec/mailers/previews/meeting_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/previews/meeting_series_mailer_preview.rb
+++ b/spec/mailers/previews/meeting_series_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/previews/project_mailer_preview.rb
+++ b/spec/mailers/previews/project_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/previews/reminders/notification_mailer_preview.rb
+++ b/spec/mailers/previews/reminders/notification_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/previews/work_package_mailer_preview.rb
+++ b/spec/mailers/previews/work_package_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/reminders/notification_mailer_spec.rb
+++ b/spec/mailers/reminders/notification_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/shared_examples.rb
+++ b/spec/mailers/shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples_for "mail is sent" do
   let(:letters_sent_count) { 1 }
   let(:mail) { deliveries.first }

--- a/spec/mailers/smtp_settings_spec.rb
+++ b/spec/mailers/smtp_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/mailers/work_package_mailer_spec.rb
+++ b/spec/mailers/work_package_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/add_primary_key_to_custom_fields_projects_spec.rb
+++ b/spec/migrations/add_primary_key_to_custom_fields_projects_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/add_project_attribute_roles_spec.rb
+++ b/spec/migrations/add_project_attribute_roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/add_project_life_cycle_step_roles_spec.rb
+++ b/spec/migrations/add_project_life_cycle_step_roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/add_validity_period_to_journals_spec.rb
+++ b/spec/migrations/add_validity_period_to_journals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/change_default_value_of_alternative_color_spec.rb
+++ b/spec/migrations/change_default_value_of_alternative_color_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/create_custom_field_sections_spec.rb
+++ b/spec/migrations/create_custom_field_sections_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/fix_invalid_journals_spec.rb
+++ b/spec/migrations/fix_invalid_journals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/fix_untranslated_work_package_roles_spec.rb
+++ b/spec/migrations/fix_untranslated_work_package_roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/migrate_legacy_default_theme_to_light_theme_spec.rb
+++ b/spec/migrations/migrate_legacy_default_theme_to_light_theme_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/reduce_configurable_design_variables_spec.rb
+++ b/spec/migrations/reduce_configurable_design_variables_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/remove_hide_mail_from_user_preferences_spec.rb
+++ b/spec/migrations/remove_hide_mail_from_user_preferences_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/remove_incorrect_manage_own_reminders_permission_spec.rb
+++ b/spec/migrations/remove_incorrect_manage_own_reminders_permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/remove_project_details_widget_spec.rb
+++ b/spec/migrations/remove_project_details_widget_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/migrations/remove_totals_from_childless_work_packages_spec.rb
+++ b/spec/migrations/remove_totals_from_childless_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
+++ b/spec/migrations/rename_visible_to_admin_only_in_custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/reorder_project_children_spec.rb
+++ b/spec/migrations/reorder_project_children_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/restore_defaults_on_empty_settings_spec.rb
+++ b/spec/migrations/restore_defaults_on_empty_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/update_default_project_columns_spec.rb
+++ b/spec/migrations/update_default_project_columns_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/migrations/update_progress_calculation_spec.rb
+++ b/spec/migrations/update_progress_calculation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/actions/scopes/default_spec.rb
+++ b/spec/models/actions/scopes/default_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/activities/work_package_activity_provider_spec.rb
+++ b/spec/models/activities/work_package_activity_provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Announcement do

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe ApplicationRecord do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/capabilities/scopes/default_spec.rb
+++ b/spec/models/capabilities/scopes/default_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH

--- a/spec/models/concerns/reactable_spec.rb
+++ b/spec/models/concerns/reactable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/concerns/remindable_spec.rb
+++ b/spec/models/concerns/remindable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_action_spec.rb
+++ b/spec/models/custom_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/assigned_to_spec.rb
+++ b/spec/models/custom_actions/actions/assigned_to_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/date_spec.rb
+++ b/spec/models/custom_actions/actions/date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/done_ratio_spec.rb
+++ b/spec/models/custom_actions/actions/done_ratio_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/due_date_spec.rb
+++ b/spec/models/custom_actions/actions/due_date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/estimated_hours_spec.rb
+++ b/spec/models/custom_actions/actions/estimated_hours_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/notify_spec.rb
+++ b/spec/models/custom_actions/actions/notify_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/priority_spec.rb
+++ b/spec/models/custom_actions/actions/priority_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/project_spec.rb
+++ b/spec/models/custom_actions/actions/project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/responsible_spec.rb
+++ b/spec/models/custom_actions/actions/responsible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/start_date_spec.rb
+++ b/spec/models/custom_actions/actions/start_date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/status_spec.rb
+++ b/spec/models/custom_actions/actions/status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/actions/type_spec.rb
+++ b/spec/models/custom_actions/actions/type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/conditions/project_spec.rb
+++ b/spec/models/custom_actions/conditions/project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/conditions/role_spec.rb
+++ b/spec/models/custom_actions/conditions/role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/conditions/status_spec.rb
+++ b/spec/models/custom_actions/conditions/status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/conditions/type_spec.rb
+++ b/spec/models/custom_actions/conditions/type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_actions/shared_expectations.rb
+++ b/spec/models/custom_actions/shared_expectations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_option_spec.rb
+++ b/spec/models/custom_option_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_style_spec.rb
+++ b/spec/models/custom_style_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe CustomStyle do

--- a/spec/models/custom_value/bool_strategy_spec.rb
+++ b/spec/models/custom_value/bool_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/date_strategy_spec.rb
+++ b/spec/models/custom_value/date_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/float_strategy_spec.rb
+++ b/spec/models/custom_value/float_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/format_strategy_spec.rb
+++ b/spec/models/custom_value/format_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/int_strategy_spec.rb
+++ b/spec/models/custom_value/int_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/list_strategy_integration_spec.rb
+++ b/spec/models/custom_value/list_strategy_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/list_strategy_spec.rb
+++ b/spec/models/custom_value/list_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/string_strategy_spec.rb
+++ b/spec/models/custom_value/string_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/user_strategy_spec.rb
+++ b/spec/models/custom_value/user_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value/version_strategy_spec.rb
+++ b/spec/models/custom_value/version_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/custom_value_spec.rb
+++ b/spec/models/custom_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Day do

--- a/spec/models/db_and_ar_length_constraints_spec.rb
+++ b/spec/models/db_and_ar_length_constraints_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/deleted_user_spec.rb
+++ b/spec/models/deleted_user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/design_color_spec.rb
+++ b/spec/models/design_color_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe DesignColor do

--- a/spec/models/emoji_reaction_spec.rb
+++ b/spec/models/emoji_reaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/enabled_module_spec.rb
+++ b/spec/models/enabled_module_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/forum_spec.rb
+++ b/spec/models/forum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/global_role_spec.rb
+++ b/spec/models/global_role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/group_performance_spec.rb
+++ b/spec/models/group_performance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/issue_priority_spec.rb
+++ b/spec/models/issue_priority_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/journable/timestamps_spec.rb
+++ b/spec/models/journable/timestamps_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/journable/with_historic_attributes_spec.rb
+++ b/spec/models/journable/with_historic_attributes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/journal/notification_configuration_spec.rb
+++ b/spec/models/journal/notification_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/journal/project_journal_spec.rb
+++ b/spec/models/journal/project_journal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/journal/timestamps_spec.rb
+++ b/spec/models/journal/timestamps_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/ldap_auth_source_spec.rb
+++ b/spec/models/ldap_auth_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/mail_handler/user_creator_spec.rb
+++ b/spec/models/mail_handler/user_creator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/roles_diff_spec.rb
+++ b/spec/models/members/roles_diff_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/global_spec.rb
+++ b/spec/models/members/scopes/global_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/not_locked_spec.rb
+++ b/spec/models/members/scopes/not_locked_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/of_any_entity_spec.rb
+++ b/spec/models/members/scopes/of_any_entity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/of_any_project_spec.rb
+++ b/spec/models/members/scopes/of_any_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/of_any_work_package_spec.rb
+++ b/spec/models/members/scopes/of_any_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/of_anything_in_project_spec.rb
+++ b/spec/models/members/scopes/of_anything_in_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/of_project_spec.rb
+++ b/spec/models/members/scopes/of_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/of_work_package_spec.rb
+++ b/spec/models/members/scopes/of_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/visible_spec.rb
+++ b/spec/models/members/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/with_shared_work_packages_info_spec.rb
+++ b/spec/models/members/scopes/with_shared_work_packages_info_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/members/scopes/without_inherited_roles_spec.rb
+++ b/spec/models/members/scopes/without_inherited_roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/menu_items/wiki_menu_item_spec.rb
+++ b/spec/models/menu_items/wiki_menu_item_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/messages/acts_as_journalized_spec.rb
+++ b/spec/models/messages/acts_as_journalized_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/messages_spec.rb
+++ b/spec/models/messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/non_working_day_spec.rb
+++ b/spec/models/non_working_day_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe NonWorkingDay do

--- a/spec/models/notification_settings/scopes/applicable_spec.rb
+++ b/spec/models/notification_settings/scopes/applicable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/notifications/scopes/reminder_mail_unsent_spec.rb
+++ b/spec/models/notifications/scopes/reminder_mail_unsent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
+++ b/spec/models/notifications/scopes/unsent_reminders_before_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/notifications/scopes/visible_spec.rb
+++ b/spec/models/notifications/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/placeholder_users/placeholder_user_spec.rb
+++ b/spec/models/placeholder_users/placeholder_user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/placeholder_users/scopes/visible_spec.rb
+++ b/spec/models/placeholder_users/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/having_entity_membership_spec.rb
+++ b/spec/models/principals/scopes/having_entity_membership_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/human_spec.rb
+++ b/spec/models/principals/scopes/human_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/like_spec.rb
+++ b/spec/models/principals/scopes/like_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/not_builtin_spec.rb
+++ b/spec/models/principals/scopes/not_builtin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/ordered_by_name_spec.rb
+++ b/spec/models/principals/scopes/ordered_by_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/possible_assignee_spec.rb
+++ b/spec/models/principals/scopes/possible_assignee_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/possible_member_spec.rb
+++ b/spec/models/principals/scopes/possible_member_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/user_spec.rb
+++ b/spec/models/principals/scopes/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/principals/scopes/visible_spec.rb
+++ b/spec/models/principals/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/project/phase_spec.rb
+++ b/spec/models/project/phase_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/project_custom_field_project_mapping_spec.rb
+++ b/spec/models/project_custom_field_project_mapping_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/project_custom_field_spec.rb
+++ b/spec/models/project_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/project_queries/scopes/allowed_to_spec.rb
+++ b/spec/models/project_queries/scopes/allowed_to_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/project_role_spec.rb
+++ b/spec/models/project_role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/activity_spec.rb
+++ b/spec/models/projects/activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/allowed_to_scope_spec.rb
+++ b/spec/models/projects/allowed_to_scope_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/exporter/exportable_project_context.rb
+++ b/spec/models/projects/exporter/exportable_project_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/reorder_nested_set_spec.rb
+++ b/spec/models/projects/reorder_nested_set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/scopes/activated_in_storage_spec.rb
+++ b/spec/models/projects/scopes/activated_in_storage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/scopes/available_custom_fields_spec.rb
+++ b/spec/models/projects/scopes/available_custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/scopes/visible_spec.rb
+++ b/spec/models/projects/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/projects/storage_spec.rb
+++ b/spec/models/projects/storage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/capabilities/capability_query_spec.rb
+++ b/spec/models/queries/capabilities/capability_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/capabilities/filters/action_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/action_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/capabilities/filters/context_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/context_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/capabilities/filters/id_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/capabilities/filters/principal_id_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/principal_id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/days/day_query_spec.rb
+++ b/spec/models/queries/days/day_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/days/filters/dates_interval_filter_spec.rb
+++ b/spec/models/queries/days/filters/dates_interval_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/days/filters/working_filter_spec.rb
+++ b/spec/models/queries/days/filters/working_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/factory_project_query_spec.rb
+++ b/spec/models/queries/factory_project_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/filters/available_filters_spec.rb
+++ b/spec/models/queries/filters/available_filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/filters/base_spec.rb
+++ b/spec/models/queries/filters/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/also_project_member_filter_spec.rb
+++ b/spec/models/queries/members/filters/also_project_member_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/blocked_filter_spec.rb
+++ b/spec/models/queries/members/filters/blocked_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/created_at_filter_spec.rb
+++ b/spec/models/queries/members/filters/created_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/group_filter_spec.rb
+++ b/spec/models/queries/members/filters/group_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/name_filter_spec.rb
+++ b/spec/models/queries/members/filters/name_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/principal_filter_spec.rb
+++ b/spec/models/queries/members/filters/principal_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/project_filter_spec.rb
+++ b/spec/models/queries/members/filters/project_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/role_filter_spec.rb
+++ b/spec/models/queries/members/filters/role_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/status_filter_spec.rb
+++ b/spec/models/queries/members/filters/status_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/filters/updated_at_filter_spec.rb
+++ b/spec/models/queries/members/filters/updated_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/members/members_query_integration_spec.rb
+++ b/spec/models/queries/members/members_query_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/news/filters/project_filter_spec.rb
+++ b/spec/models/queries/news/filters/project_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/news/news_query_spec.rb
+++ b/spec/models/queries/news/news_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/non_working_days/filters/dates_interval_filter_spec.rb
+++ b/spec/models/queries/non_working_days/filters/dates_interval_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/non_working_days/non_working_day_query_spec.rb
+++ b/spec/models/queries/non_working_days/non_working_day_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/notifications/filters/id_filter_spec.rb
+++ b/spec/models/queries/notifications/filters/id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/notifications/filters/read_ian_filter_spec.rb
+++ b/spec/models/queries/notifications/filters/read_ian_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/notifications/filters/reason_filter_spec.rb
+++ b/spec/models/queries/notifications/filters/reason_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/notifications/notification_query_spec.rb
+++ b/spec/models/queries/notifications/notification_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/operators/custom_fields/hierarchies/equals_with_descendants_spec.rb
+++ b/spec/models/queries/operators/custom_fields/hierarchies/equals_with_descendants_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/operators/date_range_clauses_spec.rb
+++ b/spec/models/queries/operators/date_range_clauses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/operators/datetime_range_clauses_spec.rb
+++ b/spec/models/queries/operators/datetime_range_clauses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/placeholder_users/placeholder_user_query_spec.rb
+++ b/spec/models/queries/placeholder_users/placeholder_user_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/principals/principal_query_integrations_spec.rb
+++ b/spec/models/queries/principals/principal_query_integrations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/active_filter_spec.rb
+++ b/spec/models/queries/projects/filters/active_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/available_custom_fields_projects_filter_spec.rb
+++ b/spec/models/queries/projects/filters/available_custom_fields_projects_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/available_project_attributes_filter_spec.rb
+++ b/spec/models/queries/projects/filters/available_project_attributes_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/created_at_filter_spec.rb
+++ b/spec/models/queries/projects/filters/created_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/custom_field_filter_spec.rb
+++ b/spec/models/queries/projects/filters/custom_field_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/id_filter_spec.rb
+++ b/spec/models/queries/projects/filters/id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/latest_activity_at_filter_spec.rb
+++ b/spec/models/queries/projects/filters/latest_activity_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/name_and_identifier_filter_spec.rb
+++ b/spec/models/queries/projects/filters/name_and_identifier_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/name_filter_spec.rb
+++ b/spec/models/queries/projects/filters/name_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/parent_filter_spec.rb
+++ b/spec/models/queries/projects/filters/parent_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/principal_filter_spec.rb
+++ b/spec/models/queries/projects/filters/principal_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/project_status_filter_spec.rb
+++ b/spec/models/queries/projects/filters/project_status_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/public_filter_spec.rb
+++ b/spec/models/queries/projects/filters/public_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/type_filter_spec.rb
+++ b/spec/models/queries/projects/filters/type_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/user_action_filter_spec.rb
+++ b/spec/models/queries/projects/filters/user_action_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/filters/visible_filter_spec.rb
+++ b/spec/models/queries/projects/filters/visible_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/orders/custom_field_order_spec.rb
+++ b/spec/models/queries/projects/orders/custom_field_order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/orders/latest_activity_at_order_spec.rb
+++ b/spec/models/queries/projects/orders/latest_activity_at_order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/orders/required_disk_space_order_spec.rb
+++ b/spec/models/queries/projects/orders/required_disk_space_order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/project_query_custom_field_order_spec.rb
+++ b/spec/models/queries/projects/project_query_custom_field_order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/project_query_results_spec.rb
+++ b/spec/models/queries/projects/project_query_results_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/selects/custom_field_spec.rb
+++ b/spec/models/queries/projects/selects/custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/projects/selects/default_spec.rb
+++ b/spec/models/queries/projects/selects/default_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/queries/filters/project_filter_spec.rb
+++ b/spec/models/queries/queries/filters/project_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/queries/filters/updated_at_filter_spec.rb
+++ b/spec/models/queries/queries/filters/updated_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/queries/query_query_spec.rb
+++ b/spec/models/queries/queries/query_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/relations/filters/from_filter_spec.rb
+++ b/spec/models/queries/relations/filters/from_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/relations/filters/involved_filter_spec.rb
+++ b/spec/models/queries/relations/filters/involved_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/relations/filters/to_filter_spec.rb
+++ b/spec/models/queries/relations/filters/to_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/relations/relation_query_spec.rb
+++ b/spec/models/queries/relations/relation_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/roles/filters/grantable_filter_spec.rb
+++ b/spec/models/queries/roles/filters/grantable_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/roles/filters/unit_filter_spec.rb
+++ b/spec/models/queries/roles/filters/unit_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/scopes/visible_spec.rb
+++ b/spec/models/queries/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
+++ b/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/users/filters/group_filter_spec.rb
+++ b/spec/models/queries/users/filters/group_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/users/filters/name_filter_spec.rb
+++ b/spec/models/queries/users/filters/name_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/users/filters/status_filter_spec.rb
+++ b/spec/models/queries/users/filters/status_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/users/user_query_spec.rb
+++ b/spec/models/queries/users/user_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/versions/version_query_spec.rb
+++ b/spec/models/queries/versions/version_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/views/filters/type_filter_spec.rb
+++ b/spec/models/queries/views/filters/type_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/assignee_or_group_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assignee_or_group_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/attachment_content_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/attachment_content_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/attachment_file_name_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/attachment_file_name_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/author_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/author_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/blocked_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/blocked_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/blocks_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/blocks_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/category_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/category_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/comment_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/comment_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/created_at_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/created_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/custom_fields/contains_text_custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/contains_text_custom_field_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/dates_interval_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/dates_interval_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/description_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/description_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/done_ratio_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/done_ratio_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/due_date_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/due_date_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/duplicated_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/duplicated_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/duplicates_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/duplicates_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/duration_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/duration_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/estimated_hours_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/estimated_hours_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/follows_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/follows_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/group_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/group_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/id_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/includes_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/includes_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/manual_sort_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/manual_sort_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/milestone_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/milestone_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/parent_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/parent_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/partof_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/partof_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/precedes_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/precedes_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/principal_loader_spec.rb
+++ b/spec/models/queries/work_packages/filter/principal_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/priority_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/priority_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/project_filter_instance_spec.rb
+++ b/spec/models/queries/work_packages/filter/project_filter_instance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/project_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/project_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/relates_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/relates_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/required_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/required_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/requires_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/requires_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/responsible_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/responsible_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/role_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/role_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/search_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/search_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/shared_with_me_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/shared_with_me_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/shared_with_user_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/shared_with_user_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/start_date_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/start_date_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/status_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/status_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/subject_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/subject_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/subject_or_id_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/subject_or_id_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/subproject_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/subproject_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/type_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/type_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/updated_at_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/updated_at_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/version_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/version_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/watcher_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/watcher_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/manual_sorting_spec.rb
+++ b/spec/models/queries/work_packages/manual_sorting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/selects/property_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/property_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/selects/relation_of_type_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/relation_of_type_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/selects/relation_to_type_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/relation_to_type_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/selects/shared_query_select_specs.rb
+++ b/spec/models/queries/work_packages/selects/shared_query_select_specs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/queries/work_packages/selects/work_package_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/work_package_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/default_query_spec.rb
+++ b/spec/models/query/default_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/group_sums_custom_fields_spec.rb
+++ b/spec/models/query/group_sums_custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_cf_sorting_integration_spec.rb
+++ b/spec/models/query/results_cf_sorting_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_custom_field_filter_integration_spec.rb
+++ b/spec/models/query/results_custom_field_filter_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_filter_on_historic_data_spec.rb
+++ b/spec/models/query/results_filter_on_historic_data_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_project_filter_integration_spec.rb
+++ b/spec/models/query/results_project_filter_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_sort_intergration_spec.rb
+++ b/spec/models/query/results_sort_intergration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_subject_filter_integration_spec.rb
+++ b/spec/models/query/results_subject_filter_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_subproject_filter_integration_spec.rb
+++ b/spec/models/query/results_subproject_filter_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/results_version_integration_spec.rb
+++ b/spec/models/query/results_version_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/sort_criteria_spec.rb
+++ b/spec/models/query/sort_criteria_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/query/timestamps_spec.rb
+++ b/spec/models/query/timestamps_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/relations/scopes/visible_spec.rb
+++ b/spec/models/relations/scopes/visible_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/reminder_spec.rb
+++ b/spec/models/reminder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/reports_services_spec.rb
+++ b/spec/models/reports_services_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/sessions/active_record_sessions_spec.rb
+++ b/spec/models/sessions/active_record_sessions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/sessions/sql_bypass_sessions_spec.rb
+++ b/spec/models/sessions/sql_bypass_sessions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/system_user_spec.rb
+++ b/spec/models/system_user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/timestamp_spec.rb
+++ b/spec/models/timestamp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/token/base_token_spec.rb
+++ b/spec/models/token/base_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/token/hashed_token_spec.rb
+++ b/spec/models/token/hashed_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/token/ical_token_spec.rb
+++ b/spec/models/token/ical_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/types/scopes/milestone_spec.rb
+++ b/spec/models/types/scopes/milestone_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/user_passwords/sha1_spec.rb
+++ b/spec/models/user_passwords/sha1_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/allowed_scope_spec.rb
+++ b/spec/models/users/allowed_scope_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/default_timezone_spec.rb
+++ b/spec/models/users/default_timezone_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/permission_checks_spec.rb
+++ b/spec/models/users/permission_checks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/scopes/find_by_login_spec.rb
+++ b/spec/models/users/scopes/find_by_login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
+++ b/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/scopes/newest_spec.rb
+++ b/spec/models/users/scopes/newest_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/users/scopes/with_time_zone_spec.rb
+++ b/spec/models/users/scopes/with_time_zone_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/versions/scopes/order_by_semver_name_spec.rb
+++ b/spec/models/versions/scopes/order_by_semver_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Versions::Scopes::OrderBySemverName do

--- a/spec/models/versions/scopes/rolled_up_spec.rb
+++ b/spec/models/versions/scopes/rolled_up_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/versions/scopes/shared_with_spec.rb
+++ b/spec/models/versions/scopes/shared_with_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/watcher_spec.rb
+++ b/spec/models/watcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/week_day_spec.rb
+++ b/spec/models/week_day_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe WeekDay do

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/wiki_redirect_spec.rb
+++ b/spec/models/wiki_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/aggregate_ancestors_spec.rb
+++ b/spec/models/work_package/aggregate_ancestors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/ask_before_destruction_spec.rb
+++ b/spec/models/work_package/ask_before_destruction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/hooks_spec.rb
+++ b/spec/models/work_package/hooks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/openproject_notifications_spec.rb
+++ b/spec/models/work_package/openproject_notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/pdf_export/document_generator_spec.rb
+++ b/spec/models/work_package/pdf_export/document_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "text/hyphen"
 

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_acts_as_event_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_acts_as_searchable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_searchable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_acts_as_watchable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_watchable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_custom_actions_spec.rb
+++ b/spec/models/work_package/work_package_custom_actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_relations_spec.rb
+++ b/spec/models/work_package/work_package_relations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_scheduling_spec.rb
+++ b/spec/models/work_package/work_package_scheduling_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_status_spec.rb
+++ b/spec/models/work_package/work_package_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package/work_package_visibility_spec.rb
+++ b/spec/models/work_package/work_package_visibility_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package_custom_field_spec.rb
+++ b/spec/models/work_package_custom_field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_package_role_spec.rb
+++ b/spec/models/work_package_role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe WorkPackageRole do

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/blocks_relation_spec.rb
+++ b/spec/models/work_packages/blocks_relation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/derived_dates_spec.rb
+++ b/spec/models/work_packages/derived_dates_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/scopes/covering_dates_and_days_of_week_spec.rb
+++ b/spec/models/work_packages/scopes/covering_dates_and_days_of_week_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/scopes/directly_related_spec.rb
+++ b/spec/models/work_packages/scopes/directly_related_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/scopes/involving_user_spec.rb
+++ b/spec/models/work_packages/scopes/involving_user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/scopes/relatable_spec.rb
+++ b/spec/models/work_packages/scopes/relatable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/models/work_packages/search_spec.rb
+++ b/spec/models/work_packages/search_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/spent_time_spec.rb
+++ b/spec/models/work_packages/spent_time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/work_packages/work_package_duplicates_spec.rb
+++ b/spec/models/work_packages/work_package_duplicates_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/add_messages_spec.rb
+++ b/spec/permissions/add_messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/copy_projects_spec.rb
+++ b/spec/permissions/copy_projects_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/delete_work_packages_spec.rb
+++ b/spec/permissions/delete_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_messages_spec.rb
+++ b/spec/permissions/edit_messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_own_messages_spec.rb
+++ b/spec/permissions/edit_own_messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_own_work_package_comments.rb
+++ b/spec/permissions/edit_own_work_package_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_project_attributes_spec.rb
+++ b/spec/permissions/edit_project_attributes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_project_life_cycles_spec.rb
+++ b/spec/permissions/edit_project_life_cycles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_wiki_pages_spec.rb
+++ b/spec/permissions/edit_wiki_pages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/edit_work_package_comments.rb
+++ b/spec/permissions/edit_work_package_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/export_work_packages_spec.rb
+++ b/spec/permissions/export_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/manage_forums_spec.rb
+++ b/spec/permissions/manage_forums_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/manage_news_spec.rb
+++ b/spec/permissions/manage_news_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/manage_repositories_spec.rb
+++ b/spec/permissions/manage_repositories_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/select_project_custom_fields_spec.rb
+++ b/spec/permissions/select_project_custom_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/translations_spec.rb
+++ b/spec/permissions/translations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/view_project_attributes_spec.rb
+++ b/spec/permissions/view_project_attributes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/view_project_life_cycles_spec.rb
+++ b/spec/permissions/view_project_life_cycles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/view_work_packages_spec.rb
+++ b/spec/permissions/view_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/permissions/work_packages_bulk_spec.rb
+++ b/spec/permissions/work_packages_bulk_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/policies/query_policy_spec.rb
+++ b/spec/policies/query_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/policies/redirect_policy_spec.rb
+++ b/spec/policies/redirect_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/admin/attachments/quarantined_attachments_spec.rb
+++ b/spec/requests/admin/attachments/quarantined_attachments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/admin/attachments/virus_scanning_settings_spec.rb
+++ b/spec/requests/admin/attachments/virus_scanning_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/admin/token_domain_spec.rb
+++ b/spec/requests/admin/token_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/action_resource_spec.rb
+++ b/spec/requests/api/v3/action_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/attachments/forum_message_spec.rb
+++ b/spec/requests/api/v3/attachments/forum_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/attachments/wiki_page_spec.rb
+++ b/spec/requests/api/v3/attachments/wiki_page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/attachments/work_package_spec.rb
+++ b/spec/requests/api/v3/attachments/work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/attachments/work_packages_export_spec.rb
+++ b/spec/requests/api/v3/attachments/work_packages_export_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/attachments_spec.rb
+++ b/spec/requests/api/v3/attachments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/backups/backups_api_spec.rb
+++ b/spec/requests/api/v3/backups/backups_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/capabilities/contexts/global_resource_spec.rb
+++ b/spec/requests/api/v3/capabilities/contexts/global_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/capability_resource_spec.rb
+++ b/spec/requests/api/v3/capability_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/category_resource_spec.rb
+++ b/spec/requests/api/v3/category_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/configuration_resource_spec.rb
+++ b/spec/requests/api/v3/configuration_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/cors_header_spec.rb
+++ b/spec/requests/api/v3/cors_header_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/custom_actions/custom_actions_api_spec.rb
+++ b/spec/requests/api/v3/custom_actions/custom_actions_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/custom_options/custom_options_resource_spec.rb
+++ b/spec/requests/api/v3/custom_options/custom_options_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/days/day_spec.rb
+++ b/spec/requests/api/v3/days/day_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/days/non_working_days_index_resource_spec.rb
+++ b/spec/requests/api/v3/days/non_working_days_index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/days/non_working_days_show_resource_spec.rb
+++ b/spec/requests/api/v3/days/non_working_days_show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/days/week_show_resource_spec.rb
+++ b/spec/requests/api/v3/days/week_show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/days/week_spec.rb
+++ b/spec/requests/api/v3/days/week_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/locale_spec.rb
+++ b/spec/requests/api/v3/locale_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/memberships/available_projects_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/available_projects_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/memberships/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/create_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/memberships/schemas/membership_schema_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/schemas/membership_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/memberships/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/update_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/create_shared_examples.rb
+++ b/spec/requests/api/v3/news/create_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/index_resource_spec.rb
+++ b/spec/requests/api/v3/news/index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/news_api_create_spec.rb
+++ b/spec/requests/api/v3/news/news_api_create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/news_api_delete_spec.rb
+++ b/spec/requests/api/v3/news/news_api_delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/show_resource_examples.rb
+++ b/spec/requests/api/v3/news/show_resource_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/show_resource_spec.rb
+++ b/spec/requests/api/v3/news/show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/update_resource_examples.rb
+++ b/spec/requests/api/v3/news/update_resource_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news/update_resource_spec.rb
+++ b/spec/requests/api/v3/news/update_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/news_resource_spec.rb
+++ b/spec/requests/api/v3/news_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/details_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/details_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/show_resource_examples.rb
+++ b/spec/requests/api/v3/notifications/show_resource_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/show_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/create_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/create_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/create_shared_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/create_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/delete_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/index_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/show_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/show_resource_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/show_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/update_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/update_resource_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/update_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/update_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/posts_resource_spec.rb
+++ b/spec/requests/api/v3/posts_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/priority_resource_spec.rb
+++ b/spec/requests/api/v3/priority_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/available_assignees_api_spec.rb
+++ b/spec/requests/api/v3/projects/available_assignees_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/available_parents_resource_spec.rb
+++ b/spec/requests/api/v3/projects/available_parents_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/create_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/delete_resource_spec.rb
+++ b/spec/requests/api/v3/projects/delete_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/index_resource_spec.rb
+++ b/spec/requests/api/v3/projects/index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/schemas/project_schema_resource_spec.rb
+++ b/spec/requests/api/v3/projects/schemas/project_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/show_resource_spec.rb
+++ b/spec/requests/api/v3/projects/show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/statuses/project_status_resource_spec.rb
+++ b/spec/requests/api/v3/projects/statuses/project_status_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/update_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/projects/version_resource_spec.rb
+++ b/spec/requests/api/v3/projects/version_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/create_query_spec.rb
+++ b/spec/requests/api/v3/queries/create_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/filters/query_filters_resource_spec.rb
+++ b/spec/requests/api/v3/queries/filters/query_filters_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/group_bys/query_group_bys_resource_spec.rb
+++ b/spec/requests/api/v3/queries/group_bys/query_group_bys_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/ical_url/query_ical_url_api_spec.rb
+++ b/spec/requests/api/v3/queries/ical_url/query_ical_url_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/operators/query_operators_resource_spec.rb
+++ b/spec/requests/api/v3/queries/operators/query_operators_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/order/query_order_api_spec.rb
+++ b/spec/requests/api/v3/queries/order/query_order_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/queries_by_project_resource_spec.rb
+++ b/spec/requests/api/v3/queries/queries_by_project_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/query_resource_spec.rb
+++ b/spec/requests/api/v3/queries/query_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/schemas/query_filter_instance_schema_resource_spec.rb
+++ b/spec/requests/api/v3/queries/schemas/query_filter_instance_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/schemas/query_project_schema_resource_spec.rb
+++ b/spec/requests/api/v3/queries/schemas/query_project_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/schemas/query_schema_resource_spec.rb
+++ b/spec/requests/api/v3/queries/schemas/query_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/sort_bys/query_sort_bys_resource_spec.rb
+++ b/spec/requests/api/v3/queries/sort_bys/query_sort_bys_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/update_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/update_form_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/queries/update_query_spec.rb
+++ b/spec/requests/api/v3/queries/update_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/rack_deflater_spec.rb
+++ b/spec/requests/api/v3/rack_deflater_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/relations/relations_index_spec.rb
+++ b/spec/requests/api/v3/relations/relations_index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/relations_resource_spec.rb
+++ b/spec/requests/api/v3/relations_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/reminders/reminders_api_spec.rb
+++ b/spec/requests/api/v3/reminders/reminders_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/render_resource_spec.rb
+++ b/spec/requests/api/v3/render_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_by_work_package_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/repositories/revisions_resource_spec.rb
+++ b/spec/requests/api/v3/repositories/revisions_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/role_resource_spec.rb
+++ b/spec/requests/api/v3/role_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/root_resource_spec.rb
+++ b/spec/requests/api/v3/root_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/status_resource_spec.rb
+++ b/spec/requests/api/v3/status_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/string_objects_resource_spec.rb
+++ b/spec/requests/api/v3/string_objects_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/support/api_helper.rb
+++ b/spec/requests/api/v3/support/api_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/support/api_v3_collection_response.rb
+++ b/spec/requests/api/v3/support/api_v3_collection_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/support/authorization.rb
+++ b/spec/requests/api/v3/support/authorization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/types/type_resource_spec.rb
+++ b/spec/requests/api/v3/types/type_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/types/types_by_project_resource_spec.rb
+++ b/spec/requests/api/v3/types/types_by_project_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/create_user_common_examples.rb
+++ b/spec/requests/api/v3/user/create_user_common_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/create_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_user_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/filters_spec.rb
+++ b/spec/requests/api/v3/user/filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/schemas/user_schema_resource_spec.rb
+++ b/spec/requests/api/v3/user/schemas/user_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user/userlock_resource_spec.rb
+++ b/spec/requests/api/v3/user/userlock_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
+++ b/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/values/schemas/value_schema_resource_spec.rb
+++ b/spec/requests/api/v3/values/schemas/value_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # --copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/version_resource_spec.rb
+++ b/spec/requests/api/v3/version_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/versions/available_projects_resource_spec.rb
+++ b/spec/requests/api/v3/versions/available_projects_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/versions/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/create_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/versions/project_resource_spec.rb
+++ b/spec/requests/api/v3/versions/project_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/versions/schemas/version_schema_resource_spec.rb
+++ b/spec/requests/api/v3/versions/schemas/version_schema_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/versions/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/update_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/views/create_resource_spec.rb
+++ b/spec/requests/api/v3/views/create_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/views/index_resource_spec.rb
+++ b/spec/requests/api/v3/views/index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/views/show_resource_spec.rb
+++ b/spec/requests/api/v3/views/show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/wiki_pages_resource_spec.rb
+++ b/spec/requests/api/v3/wiki_pages_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/available_assignees_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_assignees_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/available_projects_on_edit_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_edit_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/by_project_create_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_project_create_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/by_project_index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_project_index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/create_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/delete_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/delete_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/index_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/auth/auth_source_sso_spec.rb
+++ b/spec/requests/auth/auth_source_sso_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/auth/ldap_sso_spec.rb
+++ b/spec/requests/auth/ldap_sso_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/auth/oauth_login_csp_spec.rb
+++ b/spec/requests/auth/oauth_login_csp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/auth/token_based_access_spec.rb
+++ b/spec/requests/auth/token_based_access_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/notifications/notifications_spec.rb
+++ b/spec/requests/notifications/notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/oauth/client_credentials_flow_spec.rb
+++ b/spec/requests/oauth/client_credentials_flow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/oauth/oauth_application_spec.rb
+++ b/spec/requests/oauth/oauth_application_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/oauth_clients/oauth_client_credentials_spec.rb
+++ b/spec/requests/oauth_clients/oauth_client_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/openid_google_provider_callback_spec.rb
+++ b/spec/requests/openid_google_provider_callback_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/rate_limiting/lost_password_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/lost_password_rate_limiting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/requests/wiki/menu_items_order_spec.rb
+++ b/spec/requests/wiki/menu_items_order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/account_spec.rb
+++ b/spec/routing/account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/activities_spec.rb
+++ b/spec/routing/activities_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/admin/incoming_mails_spec.rb
+++ b/spec/routing/admin/incoming_mails_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/admin/mail_notifications_spec.rb
+++ b/spec/routing/admin/mail_notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/admin_spec.rb
+++ b/spec/routing/admin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/attachments_spec.rb
+++ b/spec/routing/attachments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/attribute_help_text_spec.rb
+++ b/spec/routing/attribute_help_text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/categories_spec.rb
+++ b/spec/routing/categories_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/custom_actions_spec.rb
+++ b/spec/routing/custom_actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/enterprise_routing_spec.rb
+++ b/spec/routing/enterprise_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/errors_routing_spec.rb
+++ b/spec/routing/errors_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/forums_routing_spec.rb
+++ b/spec/routing/forums_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/groups_spec.rb
+++ b/spec/routing/groups_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/help_routing_spec.rb
+++ b/spec/routing/help_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/homescreen_spec.rb
+++ b/spec/routing/homescreen_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/journals_spec.rb
+++ b/spec/routing/journals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/members_spec.rb
+++ b/spec/routing/members_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/messages_spec.rb
+++ b/spec/routing/messages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/my_spec.rb
+++ b/spec/routing/my_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/news_comments_spec.rb
+++ b/spec/routing/news_comments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/news_spec.rb
+++ b/spec/routing/news_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/old_issue_2_wp_spec.rb
+++ b/spec/routing/old_issue_2_wp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/project_menu_routing_spec.rb
+++ b/spec/routing/project_menu_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/project_queries_routing_spec.rb
+++ b/spec/routing/project_queries_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/project_settings_routing_spec.rb
+++ b/spec/routing/project_settings_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/repositories_routing_spec.rb
+++ b/spec/routing/repositories_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/roles_spec.rb
+++ b/spec/routing/roles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/search_spec.rb
+++ b/spec/routing/search_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/settings_spec.rb
+++ b/spec/routing/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/short_uri_wp_spec.rb
+++ b/spec/routing/short_uri_wp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/status_routing_spec.rb
+++ b/spec/routing/status_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/types_spec.rb
+++ b/spec/routing/types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/user_memberships_routing_spec.rb
+++ b/spec/routing/user_memberships_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/versions_spec.rb
+++ b/spec/routing/versions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/watchers_spec.rb
+++ b/spec/routing/watchers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/wiki_routing_spec.rb
+++ b/spec/routing/wiki_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/work_package/auto_completes_routing_spec.rb
+++ b/spec/routing/work_package/auto_completes_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/work_package/reports_routing_spec.rb
+++ b/spec/routing/work_package/reports_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/work_package/shares_spec.rb
+++ b/spec/routing/work_package/shares_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/work_package_bulk_spec.rb
+++ b/spec/routing/work_package_bulk_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/work_packages_spec.rb
+++ b/spec/routing/work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/routing/workflows_spec.rb
+++ b/spec/routing/workflows_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/security/active_support_to_json_spec.rb
+++ b/spec/security/active_support_to_json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/seeders/setting_seeder_spec.rb
+++ b/spec/seeders/setting_seeder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/api/parser_struct_spec.rb
+++ b/spec/services/api/parser_struct_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/services/api/v3/parse_query_params_service_spec.rb
+++ b/spec/services/api/v3/parse_query_params_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/api/v3/update_query_from_v3_params_service_spec.rb
+++ b/spec/services/api/v3/update_query_from_v3_params_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/api/v3/work_package_collection_from_query_params_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_params_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/attachments/create_service_integration_spec.rb
+++ b/spec/services/attachments/create_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/attachments/delete_service_integration_spec.rb
+++ b/spec/services/attachments/delete_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/attachments/prepare_upload_service_integration_spec.rb
+++ b/spec/services/attachments/prepare_upload_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authentication/omniauth_service_spec.rb
+++ b/spec/services/authentication/omniauth_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/enterprise_service_spec.rb
+++ b/spec/services/authorization/enterprise_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/query_transformation_spec.rb
+++ b/spec/services/authorization/query_transformation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/query_transformations_spec.rb
+++ b/spec/services/authorization/query_transformations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/user_allowed_query_spec.rb
+++ b/spec/services/authorization/user_allowed_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/user_entity_roles_query_spec.rb
+++ b/spec/services/authorization/user_entity_roles_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/user_global_roles_query_spec.rb
+++ b/spec/services/authorization/user_global_roles_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization/user_permissible_service_spec.rb
+++ b/spec/services/authorization/user_permissible_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Authorization::UserPermissibleService do

--- a/spec/services/authorization/user_project_roles_query_spec.rb
+++ b/spec/services/authorization/user_project_roles_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/authorization_spec.rb
+++ b/spec/services/authorization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/backups/create_service_spec.rb
+++ b/spec/services/backups/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/base/base_callable_spec.rb
+++ b/spec/services/base/base_callable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/base_services/behaves_like_create_service.rb
+++ b/spec/services/base_services/behaves_like_create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/base_services/behaves_like_delete_service.rb
+++ b/spec/services/base_services/behaves_like_delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/base_services/behaves_like_update_service.rb
+++ b/spec/services/base_services/behaves_like_update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/create_type_service_spec.rb
+++ b/spec/services/create_type_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_actions/update_service_spec.rb
+++ b/spec/services/custom_actions/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_actions/update_work_package_service_spec.rb
+++ b/spec/services/custom_actions/update_work_package_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_fields/custom_field_projects/bulk_create_service_spec.rb
+++ b/spec/services/custom_fields/custom_field_projects/bulk_create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
+++ b/spec/services/custom_fields/custom_field_projects/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_fields/set_attributes_service_spec.rb
+++ b/spec/services/custom_fields/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/custom_fields/update_service_spec.rb
+++ b/spec/services/custom_fields/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/groups/add_users_service_integration_spec.rb
+++ b/spec/services/groups/add_users_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/groups/create_inherited_roles_service_integration_spec.rb
+++ b/spec/services/groups/create_inherited_roles_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/groups/set_attributes_service_spec.rb
+++ b/spec/services/groups/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/groups/update_roles_service_integration_spec.rb
+++ b/spec/services/groups/update_roles_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/groups/update_service_spec.rb
+++ b/spec/services/groups/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/ldap/import_user_list_service_integration_spec.rb
+++ b/spec/services/ldap/import_user_list_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Ldap::ImportUsersFromListService do

--- a/spec/services/ldap/import_users_from_filter_service_integration_spec.rb
+++ b/spec/services/ldap/import_users_from_filter_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Ldap::ImportUsersFromFilterService do

--- a/spec/services/ldap/post_login_sync_service_spec.rb
+++ b/spec/services/ldap/post_login_sync_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Ldap::PostLoginSyncService do

--- a/spec/services/ldap/synchronize_users_service_integration_spec.rb
+++ b/spec/services/ldap/synchronize_users_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Ldap::SynchronizeUsersService do

--- a/spec/services/members/cleanup_service_integration_spec.rb
+++ b/spec/services/members/cleanup_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/members/create_service_integration_spec.rb
+++ b/spec/services/members/create_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/members/create_service_spec.rb
+++ b/spec/services/members/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/members/delete_by_principal_service_spec.rb
+++ b/spec/services/members/delete_by_principal_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/members/delete_service_spec.rb
+++ b/spec/services/members/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/members/set_attributes_service_spec.rb
+++ b/spec/services/members/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/members/update_service_spec.rb
+++ b/spec/services/members/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/messages/create_service_spec.rb
+++ b/spec/services/messages/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/messages/set_attributes_service_spec.rb
+++ b/spec/services/messages/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/messages/update_service_spec.rb
+++ b/spec/services/messages/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/news/create_service_spec.rb
+++ b/spec/services/news/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/news/delete_service_spec.rb
+++ b/spec/services/news/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/news/set_attributes_service_spec.rb
+++ b/spec/services/news/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/news/update_service_spec.rb
+++ b/spec/services/news/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_from_journal_job_shared.rb
+++ b/spec/services/notifications/create_from_journal_job_shared.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_comment_spec.rb
+++ b/spec/services/notifications/create_from_model_service_comment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_message_spec.rb
+++ b/spec/services/notifications/create_from_model_service_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_news_spec.rb
+++ b/spec/services/notifications/create_from_model_service_news_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_wiki_spec.rb
+++ b/spec/services/notifications/create_from_model_service_wiki_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_service_intergration_spec.rb
+++ b/spec/services/notifications/create_service_intergration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/create_service_spec.rb
+++ b/spec/services/notifications/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/mail_service_mentioned_integration_spec.rb
+++ b/spec/services/notifications/mail_service_mentioned_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/mail_service_spec.rb
+++ b/spec/services/notifications/mail_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/mentioned_journals_shared.rb
+++ b/spec/services/notifications/mentioned_journals_shared.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/notifications/set_attributes_service_spec.rb
+++ b/spec/services/notifications/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/oauth_clients/create_service_spec.rb
+++ b/spec/services/oauth_clients/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/oauth_clients/delete_service_spec.rb
+++ b/spec/services/oauth_clients/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/oauth_clients/redirect_uri_from_state_service_spec.rb
+++ b/spec/services/oauth_clients/redirect_uri_from_state_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/oauth_clients/set_attributes_service_spec.rb
+++ b/spec/services/oauth_clients/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/params_to_query_service_capability_query_spec.rb
+++ b/spec/services/params_to_query_service_capability_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/params_to_query_service_project_query_spec.rb
+++ b/spec/services/params_to_query_service_project_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/parse_schema_filter_params_service_spec.rb
+++ b/spec/services/parse_schema_filter_params_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/placeholder_users/create_service_spec.rb
+++ b/spec/services/placeholder_users/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/placeholder_users/delete_service_spec.rb
+++ b/spec/services/placeholder_users/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/placeholder_users/set_attributes_service_spec.rb
+++ b/spec/services/placeholder_users/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/placeholder_users/update_service_spec.rb
+++ b/spec/services/placeholder_users/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/principals/replace_references_context.rb
+++ b/spec/services/principals/replace_references_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/principals/replace_references_service_call_integration_spec.rb
+++ b/spec/services/principals/replace_references_service_call_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_custom_field_project_mappings/bulk_create_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/bulk_create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_custom_field_project_mappings/bulk_update_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/bulk_update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_custom_field_project_mappings/delete_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_custom_field_project_mappings/toggle_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/toggle_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_queries/create_service_spec.rb
+++ b/spec/services/project_queries/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_queries/set_attributes_service_spec.rb
+++ b/spec/services/project_queries/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/project_queries/update_service_spec.rb
+++ b/spec/services/project_queries/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/archive_service_spec.rb
+++ b/spec/services/projects/archive_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/create_service_integration_spec.rb
+++ b/spec/services/projects/create_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/create_service_spec.rb
+++ b/spec/services/projects/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/delete_service_spec.rb
+++ b/spec/services/projects/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/gantt_query_generator_service_spec.rb
+++ b/spec/services/projects/gantt_query_generator_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/schedule_deletion_service_spec.rb
+++ b/spec/services/projects/schedule_deletion_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/set_attributes_service_integration_spec.rb
+++ b/spec/services/projects/set_attributes_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/unarchive_service_spec.rb
+++ b/spec/services/projects/unarchive_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/update_service_integration_spec.rb
+++ b/spec/services/projects/update_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/projects/update_service_spec.rb
+++ b/spec/services/projects/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/queries/create_service_spec.rb
+++ b/spec/services/queries/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/queries/filters_mapper_spec.rb
+++ b/spec/services/queries/filters_mapper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/queries/update_from_params_service_spec.rb
+++ b/spec/services/queries/update_from_params_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/queries/update_service_spec.rb
+++ b/spec/services/queries/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/relations/create_service_spec.rb
+++ b/spec/services/relations/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/relations/update_service_spec.rb
+++ b/spec/services/relations/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/roles/delete_service_spec.rb
+++ b/spec/services/roles/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/roles/set_attributes_service_spec.rb
+++ b/spec/services/roles/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/roles/update_service_spec.rb
+++ b/spec/services/roles/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/services/scm/checkout_instructions_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/scm/create_managed_repository_service_spec.rb
+++ b/spec/services/scm/create_managed_repository_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/scm/delete_managed_repository_service_spec.rb
+++ b/spec/services/scm/delete_managed_repository_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/scm/repository_factory_service_spec.rb
+++ b/spec/services/scm/repository_factory_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/services/create_service_spec.rb
+++ b/spec/services/services/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/set_localization_service_spec.rb
+++ b/spec/services/set_localization_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe SetLocalizationService do

--- a/spec/services/settings/shared/shared_call_examples.rb
+++ b/spec/services/settings/shared/shared_call_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/services/settings/update_service_spec.rb
+++ b/spec/services/settings/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/services/settings/working_days_and_hours_update_service_spec.rb
+++ b/spec/services/settings/working_days_and_hours_update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/services/shared/service_context_integration_spec.rb
+++ b/spec/services/shared/service_context_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/shared_type_service.rb
+++ b/spec/services/shared_type_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/shares/set_attributes_service_spec.rb
+++ b/spec/services/shares/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/update_projects_types_service_spec.rb
+++ b/spec/services/update_projects_types_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/update_query_from_params_service_spec.rb
+++ b/spec/services/update_query_from_params_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/user_preferences/update_service_integration_spec.rb
+++ b/spec/services/user_preferences/update_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/user_preferences/update_service_spec.rb
+++ b/spec/services/user_preferences/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/change_password_service_spec.rb
+++ b/spec/services/users/change_password_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/create_service_spec.rb
+++ b/spec/services/users/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/delete_service_integration_spec.rb
+++ b/spec/services/users/delete_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/delete_service_spec.rb
+++ b/spec/services/users/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/drop_tokens_service_spec.rb
+++ b/spec/services/users/drop_tokens_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/logout_service_spec.rb
+++ b/spec/services/users/logout_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/register_user_service_spec.rb
+++ b/spec/services/users/register_user_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/replace_mentions_service_integration_spec.rb
+++ b/spec/services/users/replace_mentions_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/set_attributes_service_integration_spec.rb
+++ b/spec/services/users/set_attributes_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/set_attributes_service_spec.rb
+++ b/spec/services/users/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/users/update_service_spec.rb
+++ b/spec/services/users/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/wiki_pages/copy_service_integration_spec.rb
+++ b/spec/services/wiki_pages/copy_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/wiki_pages/set_attributes_service_spec.rb
+++ b/spec/services/wiki_pages/set_attributes_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/delete_service_integration_spec.rb
+++ b/spec/services/work_packages/delete_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/delete_service_spec.rb
+++ b/spec/services/work_packages/delete_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_status_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_status_based_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
+++ b/spec/services/work_packages/set_attributes_service/derive_progress_values_work_based_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/shared/all_days_spec.rb
+++ b/spec/services/work_packages/shared/all_days_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/shared/days_spec.rb
+++ b/spec/services/work_packages/shared/days_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/shared/working_days_spec.rb
+++ b/spec/services/work_packages/shared/working_days_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/update_ancestors/loader_spec.rb
+++ b/spec/services/work_packages/update_ancestors/loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/work_packages/update_service_spec.rb
+++ b/spec/services/work_packages/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/services/workflows/bulk_update_service_integration_spec.rb
+++ b/spec/services/workflows/bulk_update_service_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/active_record_timestamps.rb
+++ b/spec/support/active_record_timestamps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/angular.rb
+++ b/spec/support/angular.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/api/v3/shared_available_principals_examples.rb
+++ b/spec/support/api/v3/shared_available_principals_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/api/v3/work_packages/work_package_representer_eager_loading.rb
+++ b/spec/support/api/v3/work_packages/work_package_representer_eager_loading.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/PerceivedComplexity
 def register_chrome(language, name: :"chrome_#{language}", headless: "new", override_time_zone: nil)
   Capybara.register_driver name do |app|

--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 def register_firefox(language, name: :"firefox_#{language}")

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 require "capybara/rspec"
 require "capybara-screenshot"

--- a/spec/support/capybara/block_requests_made_outside_of_test.rb
+++ b/spec/support/capybara/block_requests_made_outside_of_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # When test is finished, Capybara calls `Capybara.reset!` which in turn calls
 # `driver.reset!`. This one is responsible for stopping the browser by
 # navigating to about:blank page and waiting for pending requests to complete.

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/clean_feature_decisions.rb
+++ b/spec/support/clean_feature_decisions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/clear_notification_subscriptions.rb
+++ b/spec/support/clear_notification_subscriptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/component_specs.rb
+++ b/spec/support/component_specs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # spec/rails_helper.rb
 require "view_component/test_helpers"
 require "view_component/system_test_helpers"

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/attachments/attachments.rb
+++ b/spec/support/components/attachments/attachments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # JavaScript: HTML5 File attachments handling
 # requires a (hidden) input file field
 module Components

--- a/spec/support/components/attachments_list.rb
+++ b/spec/support/components/attachments_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Handles attachments list generally found under the wysiwyg editor.
 module Components
   class AttachmentsList

--- a/spec/support/components/autocompleter/autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/autocomplete_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/common/modal.rb
+++ b/spec/support/components/common/modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/common/submenu.rb
+++ b/spec/support/components/common/submenu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/confirmation_dialog.rb
+++ b/spec/support/components/confirmation_dialog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/datepicker/basic_datepicker.rb
+++ b/spec/support/components/datepicker/basic_datepicker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "datepicker"
 
 module Components

--- a/spec/support/components/datepicker/datepicker_modal.rb
+++ b/spec/support/components/datepicker/datepicker_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   class DatepickerModal < Datepicker
     def open_modal!

--- a/spec/support/components/datepicker/month_range_selection.rb
+++ b/spec/support/components/datepicker/month_range_selection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   module MonthRangeSelection
     ##

--- a/spec/support/components/datepicker/range_datepicker.rb
+++ b/spec/support/components/datepicker/range_datepicker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "basic_datepicker"
 
 module Components

--- a/spec/support/components/global_search.rb
+++ b/spec/support/components/global_search.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   class GlobalSearch
     include Capybara::DSL

--- a/spec/support/components/grids/grid_area.rb
+++ b/spec/support/components/grids/grid_area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   module Grids
     class GridArea

--- a/spec/support/components/html_title.rb
+++ b/spec/support/components/html_title.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/menu/dropdown.rb
+++ b/spec/support/components/menu/dropdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/menu/quick_add_menu.rb
+++ b/spec/support/components/menu/quick_add_menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/password_confirmation_dialog.rb
+++ b/spec/support/components/password_confirmation_dialog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/project_include_component.rb
+++ b/spec/support/components/project_include_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/projects/project_custom_fields/edit_dialog.rb
+++ b/spec/support/components/projects/project_custom_fields/edit_dialog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/projects/project_life_cycles/edit_dialog.rb
+++ b/spec/support/components/projects/project_life_cycles/edit_dialog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/sharing/project_queries/share_modal.rb
+++ b/spec/support/components/sharing/project_queries/share_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/sharing/share_modal.rb
+++ b/spec/support/components/sharing/share_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/sharing/work_packages/share_modal.rb
+++ b/spec/support/components/sharing/work_packages/share_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/table_pagination.rb
+++ b/spec/support/components/table_pagination.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/timelines/configuration_modal.rb
+++ b/spec/support/components/timelines/configuration_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/timelines/timeline_row.rb
+++ b/spec/support/components/timelines/timeline_row.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/baseline.rb
+++ b/spec/support/components/work_packages/baseline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/baseline_modal.rb
+++ b/spec/support/components/work_packages/baseline_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/columns.rb
+++ b/spec/support/components/work_packages/columns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/context_menu.rb
+++ b/spec/support/components/work_packages/context_menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/destroy_modal.rb
+++ b/spec/support/components/work_packages/destroy_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/emoji_reactions.rb
+++ b/spec/support/components/work_packages/emoji_reactions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/group_by.rb
+++ b/spec/support/components/work_packages/group_by.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/hierarchies.rb
+++ b/spec/support/components/work_packages/hierarchies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/primerized_tabs.rb
+++ b/spec/support/components/work_packages/primerized_tabs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   module WorkPackages
     class PrimerizedTabs

--- a/spec/support/components/work_packages/query_title.rb
+++ b/spec/support/components/work_packages/query_title.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/settings_menu.rb
+++ b/spec/support/components/work_packages/settings_menu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/sort_by.rb
+++ b/spec/support/components/work_packages/sort_by.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/table_configuration/filters.rb
+++ b/spec/support/components/work_packages/table_configuration/filters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/table_configuration/graph_general.rb
+++ b/spec/support/components/work_packages/table_configuration/graph_general.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/table_configuration/highlighting.rb
+++ b/spec/support/components/work_packages/table_configuration/highlighting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/work_packages/tabs_counter.rb
+++ b/spec/support/components/work_packages/tabs_counter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   module WorkPackages
     class Tabs

--- a/spec/support/components/work_packages/timer_button.rb
+++ b/spec/support/components/work_packages/timer_button.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Components
   class WysiwygEditor
     include Capybara::DSL

--- a/spec/support/contracts/shared.rb
+++ b/spec/support/contracts/shared.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_context "model contract" do
   shared_examples_for "is not writable" do
     before do

--- a/spec/support/download_list.rb
+++ b/spec/support/download_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DownloadList
   SHARED_PATH = Pathname.new(
     ENV.fetch("CAPYBARA_DOWNLOADED_FILE_DIR", Rails.root.join("tmp/test/downloads"))

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "edit_field"
 
 class DateEditField < EditField

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EditField
   include Capybara::DSL
   include Capybara::RSpecMatchers

--- a/spec/support/edit_fields/project_status_field.rb
+++ b/spec/support/edit_fields/project_status_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "support/components/autocompleter/ng_select_autocomplete_helpers"
 require_relative "edit_field"
 

--- a/spec/support/edit_fields/select_edit_field.rb
+++ b/spec/support/edit_fields/select_edit_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "edit_field"
 
 class SelectField < EditField

--- a/spec/support/edit_fields/spent_time_edit_field.rb
+++ b/spec/support/edit_fields/spent_time_edit_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "edit_field"
 
 class SpentTimeEditField < EditField

--- a/spec/support/edit_fields/text_area_field.rb
+++ b/spec/support/edit_fields/text_area_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "edit_field"
 
 class TextAreaField < EditField

--- a/spec/support/edit_fields/text_editor_field.rb
+++ b/spec/support/edit_fields/text_editor_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "edit_field"
 
 class TextEditorField < EditField

--- a/spec/support/edit_fields/work_package_status_field.rb
+++ b/spec/support/edit_fields/work_package_status_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "edit_field"
 
 class WorkPackageStatusField < EditField

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/finders/test_selector_finders.rb
+++ b/spec/support/finders/test_selector_finders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/flash.rb
+++ b/spec/support/flash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/flash/expectations.rb
+++ b/spec/support/flash/expectations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Flash
   module Expectations
     def expect_flash(message:, type: :success, wait: 20)

--- a/spec/support/focused_spec_circuit_breaker.rb
+++ b/spec/support/focused_spec_circuit_breaker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Add circuit breakers for CI builds, such as focused specs
 # that somehow elude linting

--- a/spec/support/form_fields/editor_form_field.rb
+++ b/spec/support/form_fields/editor_form_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "form_field"
 
 module FormFields

--- a/spec/support/form_fields/form_field.rb
+++ b/spec/support/form_fields/form_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FormFields
   class FormField
     include Capybara::DSL

--- a/spec/support/form_fields/input_form_field.rb
+++ b/spec/support/form_fields/input_form_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "form_field"
 
 module FormFields

--- a/spec/support/form_fields/primerized/editor_form_field.rb
+++ b/spec/support/form_fields/primerized/editor_form_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "form_field"
 
 module FormFields

--- a/spec/support/form_fields/primerized/form_field.rb
+++ b/spec/support/form_fields/primerized/form_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FormFields
   module Primerized
     class FormField < FormFields::FormField

--- a/spec/support/form_fields/primerized/input_field.rb
+++ b/spec/support/form_fields/primerized/input_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "form_field"
 
 module FormFields

--- a/spec/support/form_fields/select_form_field.rb
+++ b/spec/support/form_fields/select_form_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "form_field"
 
 module FormFields

--- a/spec/support/have_http_status_with_rack_response.rb
+++ b/spec/support/have_http_status_with_rack_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/i18n_lazy_loading.rb
+++ b/spec/support/i18n_lazy_loading.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/identical_ext.rb
+++ b/spec/support/identical_ext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/local_storage_cleanup.rb
+++ b/spec/support/local_storage_cleanup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/matchers/be_boolean.rb
+++ b/spec/support/matchers/be_boolean.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :be_boolean do
   match do |value|
     [true, false].include? value

--- a/spec/support/matchers/be_html_eql.rb
+++ b/spec/support/matchers/be_html_eql.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/matchers/eq_array.rb
+++ b/spec/support/matchers/eq_array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/matchers/has_conditional_selector.rb
+++ b/spec/support/matchers/has_conditional_selector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/matchers/has_focus_on.rb
+++ b/spec/support/matchers/has_focus_on.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/mocked_permission_helper.rb
+++ b/spec/support/mocked_permission_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -33,7 +35,7 @@
 class PermissionMock
   attr_reader :user, :permitted_entities, :allow_all_permissions
 
-  NIL_ERROR = "You tried to mock a permission on nil, this will not work! If you want to satisfy the `allow_in_any_project?` call, build an unused project and mock the permission on that.".freeze
+  NIL_ERROR = "You tried to mock a permission on nil, this will not work! If you want to satisfy the `allow_in_any_project?` call, build an unused project and mock the permission on that."
 
   def initialize(user)
     @user = user

--- a/spec/support/module_spec_helper.rb
+++ b/spec/support/module_spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/multi_json_issue_workaround.rb
+++ b/spec/support/multi_json_issue_workaround.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Multi_json issue #208 https://github.com/intridea/multi_json/issues/208
 # produces a `NoMethodError` with some tests like
 # modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb:277 where grape

--- a/spec/support/non_working_days.rb
+++ b/spec/support/non_working_days.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/noop_contract.rb
+++ b/spec/support/noop_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/notifications/navigation_helper.rb
+++ b/spec/support/notifications/navigation_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Notifications::NavigationHelper
   attr_reader :center,
               :notification,

--- a/spec/support/oauth_connections_helpers.rb
+++ b/spec/support/oauth_connections_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuthConnectionsHelpers
   def mock_one_drive_authorization_validation(with: {})
     me_response = {

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before :each, type: :feature do
     OmniAuth.config.mock_auth[:developer] = nil

--- a/spec/support/onboarding_helper.rb
+++ b/spec/support/onboarding_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/custom_actions/edit.rb
+++ b/spec/support/pages/admin/custom_actions/edit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/custom_actions/form.rb
+++ b/spec/support/pages/admin/custom_actions/form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/custom_actions/index.rb
+++ b/spec/support/pages/admin/custom_actions/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/custom_actions/new.rb
+++ b/spec/support/pages/admin/custom_actions/new.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
+++ b/spec/support/pages/admin/custom_fields/custom_fields_projects/custom_field_projects_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/individual_principals/edit.rb
+++ b/spec/support/pages/admin/individual_principals/edit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/ldap_auth_sources/index.rb
+++ b/spec/support/pages/admin/ldap_auth_sources/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/placeholder_users/index.rb
+++ b/spec/support/pages/admin/placeholder_users/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/settings/project_custom_fields/project_custom_field_mappings_index.rb
+++ b/spec/support/pages/admin/settings/project_custom_fields/project_custom_field_mappings_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/system_settings/general.rb
+++ b/spec/support/pages/admin/system_settings/general.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/users/edit.rb
+++ b/spec/support/pages/admin/users/edit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/custom_fields/index_page.rb
+++ b/spec/support/pages/custom_fields/index_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/custom_fields/new_page.rb
+++ b/spec/support/pages/custom_fields/new_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/form_filler.rb
+++ b/spec/support/pages/form_filler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/groups.rb
+++ b/spec/support/pages/groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/messages/base.rb
+++ b/spec/support/pages/messages/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/messages/create.rb
+++ b/spec/support/pages/messages/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/messages/index.rb
+++ b/spec/support/pages/messages/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/messages/show.rb
+++ b/spec/support/pages/messages/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/my/notifications.rb
+++ b/spec/support/pages/my/notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/my/password_page.rb
+++ b/spec/support/pages/my/password_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/my/reminders.rb
+++ b/spec/support/pages/my/reminders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/new_placeholder_user.rb
+++ b/spec/support/pages/new_placeholder_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/new_user.rb
+++ b/spec/support/pages/new_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/notifications/center.rb
+++ b/spec/support/pages/notifications/center.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/notifications/settings.rb
+++ b/spec/support/pages/notifications/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/projects/destroy.rb
+++ b/spec/support/pages/projects/destroy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/projects/settings/general.rb
+++ b/spec/support/pages/projects/settings/general.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/support/pages/projects/settings/life_cycle.rb
+++ b/spec/support/pages/projects/settings/life_cycle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/support/pages/projects/settings/modules.rb
+++ b/spec/support/pages/projects/settings/modules.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/support/pages/projects/settings/type.rb
+++ b/spec/support/pages/projects/settings/type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/support/pages/projects/settings/work_package_custom_fields.rb
+++ b/spec/support/pages/projects/settings/work_package_custom_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2010-2024 the OpenProject GmbH

--- a/spec/support/pages/projects/show.rb
+++ b/spec/support/pages/projects/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/reminders/settings.rb
+++ b/spec/support/pages/reminders/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/types/index.rb
+++ b/spec/support/pages/types/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/abstract_work_package_create.rb
+++ b/spec/support/pages/work_packages/abstract_work_package_create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/concerns/work_package_by_button_creator.rb
+++ b/spec/support/pages/work_packages/concerns/work_package_by_button_creator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/embedded_work_packages_table.rb
+++ b/spec/support/pages/work_packages/embedded_work_packages_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/full_work_package_create.rb
+++ b/spec/support/pages/work_packages/full_work_package_create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/primerized_split_work_package.rb
+++ b/spec/support/pages/work_packages/primerized_split_work_package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/split_work_package.rb
+++ b/spec/support/pages/work_packages/split_work_package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/split_work_package_create.rb
+++ b/spec/support/pages/work_packages/split_work_package_create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/work_package_card.rb
+++ b/spec/support/pages/work_packages/work_package_card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/pages/work_packages/work_packages_timeline.rb
+++ b/spec/support/pages/work_packages/work_packages_timeline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/parallel_helper.rb
+++ b/spec/support/parallel_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParallelHelper
   module_function
 

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/puffing_billy_proxy.rb
+++ b/spec/support/puffing_billy_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/queries/filters/shared_filter_examples.rb
+++ b/spec/support/queries/filters/shared_filter_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/queries/shared_get_individual_query_examples.rb
+++ b/spec/support/queries/shared_get_individual_query_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/repository_helpers.rb
+++ b/spec/support/repository_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/request_with_header.rb
+++ b/spec/support/request_with_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |c|
   ##
   # Session-based API authentication requires the X-requested-with header to be present.

--- a/spec/support/retryable.rb
+++ b/spec/support/retryable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/roles.rb
+++ b/spec/support/roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/rspec_cleanup.rb
+++ b/spec/support/rspec_cleanup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before do
     # Clear any mail deliveries

--- a/spec/support/rspec_disabled_specs.rb
+++ b/spec/support/rspec_disabled_specs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Loads two files automatically from plugins:
 #
 # 1. `spec/disable_specs.rbs` to disable specs which don't work in conjunction with the

--- a/spec/support/rspec_expect_it.rb
+++ b/spec/support/rspec_expect_it.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/rspec_mocks_ruby_3_2_fix_argument_forwarding.rb
+++ b/spec/support/rspec_mocks_ruby_3_2_fix_argument_forwarding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/rspec_request_specs.rb
+++ b/spec/support/rspec_request_specs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RackTestHelper
   include Rack::Test::Methods
 

--- a/spec/support/rspec_retry.rb
+++ b/spec/support/rspec_retry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/retry"
 require "retriable"
 

--- a/spec/support/schedule_reminder_mails.rb
+++ b/spec/support/schedule_reminder_mails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/scm/countable_repository.rb
+++ b/spec/support/scm/countable_repository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 RSpec.shared_examples_for "is a countable repository" do
   let(:cache_time) { 720 }

--- a/spec/support/scm/relocate_repository.rb
+++ b/spec/support/scm/relocate_repository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples_for "repository can be relocated" do |vendor|
   let(:job_call) do
     SCM::RelocateRepositoryJob.perform_now repository

--- a/spec/support/selector_helpers.rb
+++ b/spec/support/selector_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/selenium_hub_waiter.rb
+++ b/spec/support/selenium_hub_waiter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SeleniumHubWaiter
   module_function
 

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/acts_as_attachable.rb
+++ b/spec/support/shared/acts_as_attachable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/acts_as_customizable.rb
+++ b/spec/support/shared/acts_as_customizable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/acts_as_favorable.rb
+++ b/spec/support/shared/acts_as_favorable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/acts_as_watchable.rb
+++ b/spec/support/shared/acts_as_watchable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/as_user.rb
+++ b/spec/support/shared/as_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/audits.rb
+++ b/spec/support/shared/audits.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/become_member.rb
+++ b/spec/support/shared/become_member.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/clear_cache.rb
+++ b/spec/support/shared/clear_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/expect_page_reload.rb
+++ b/spec/support/shared/expect_page_reload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/forms_html.rb
+++ b/spec/support/shared/forms_html.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/loading_indicator_saveguard.rb
+++ b/spec/support/shared/loading_indicator_saveguard.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/permissions.rb
+++ b/spec/support/shared/permissions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/rake.rb
+++ b/spec/support/shared/rake.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/require_admin.rb
+++ b/spec/support/shared/require_admin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/scroll_into_view_helpers.rb
+++ b/spec/support/shared/scroll_into_view_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/selenium_workarounds.rb
+++ b/spec/support/shared/selenium_workarounds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/shoulda_matcher.rb
+++ b/spec/support/shared/shoulda_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     # Choose a test framework:

--- a/spec/support/shared/skip_csrf.rb
+++ b/spec/support/shared/skip_csrf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_2fa.rb
+++ b/spec/support/shared/with_2fa.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_blank_access_control_state.rb
+++ b/spec/support/shared/with_blank_access_control_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_config.rb
+++ b/spec/support/shared/with_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_direct_uploads.rb
+++ b/spec/support/shared/with_direct_uploads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_env.rb
+++ b/spec/support/shared/with_env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_flag.rb
+++ b/spec/support/shared/with_flag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/support/shared/with_good_job.rb
+++ b/spec/support/shared/with_good_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_mobile_screen.rb
+++ b/spec/support/shared/with_mobile_screen.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/support/shared/with_rack_attack.rb
+++ b/spec/support/shared/with_rack_attack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  OpenProject is an open source project management software.
 #  Copyright (C) the OpenProject GmbH
 #

--- a/spec/support/shared/with_settings.rb
+++ b/spec/support/shared/with_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared/with_test_ldap.rb
+++ b/spec/support/shared/with_test_ldap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/shared_let.rb
+++ b/spec/support/shared_let.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/table_helpers.rb
+++ b/spec/support/table_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/table_helpers/example_methods.rb
+++ b/spec/support/table_helpers/example_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/table_helpers/let_work_packages.rb
+++ b/spec/support/table_helpers/let_work_packages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/table_helpers/table.rb
+++ b/spec/support/table_helpers/table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/table_helpers/table_representer.rb
+++ b/spec/support/table_helpers/table_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/tempdir.rb
+++ b/spec/support/tempdir.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/toasts/expectations.rb
+++ b/spec/support/toasts/expectations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Toasts
   module Expectations
     def expect_toast(message:, type: :success, wait: 20)

--- a/spec/support/transactional_tests.rb
+++ b/spec/support/transactional_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   # Rails 5.1+ safely shares the database connection between the app and test
   # threads. So RSpec thread and Puma thread share the same db connection,

--- a/spec/support/uploaded_file.rb
+++ b/spec/support/uploaded_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UploadedFile
   attr_reader :pathname
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/work_packages.rb
+++ b/spec/support/work_packages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support/work_packages/pdf_export.rb
+++ b/spec/support/work_packages/pdf_export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "pdf/inspector"
 

--- a/spec/support/work_packages/work_package_cards.rb
+++ b/spec/support/work_packages/work_package_cards.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/support_spec/mocked_permission_helper_spec.rb
+++ b/spec/support_spec/mocked_permission_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/tasks/backup_spec.rb
+++ b/spec/tasks/backup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/tasks/seed_spec.rb
+++ b/spec/tasks/seed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/tasks/setting_spec.rb
+++ b/spec/tasks/setting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/validator/secure_context_uri_validator_spec.rb
+++ b/spec/validator/secure_context_uri_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/account/login.html.erb_spec.rb
+++ b/spec/views/account/login.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/account/register.html.erb_spec.rb
+++ b/spec/views/account/register.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/admin/enterprises/_current.html.erb_spec.rb
+++ b/spec/views/admin/enterprises/_current.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/layouts/admin.html.erb_spec.rb
+++ b/spec/views/layouts/admin.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/projects/settings/general/show.html.erb_spec.rb
+++ b/spec/views/projects/settings/general/show.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/repositories/stats.html.erb_spec.rb
+++ b/spec/views/repositories/stats.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/wiki/new.html.erb_spec.rb
+++ b/spec/views/wiki/new.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/views/work_package/auto_complete/index_spec.rb
+++ b/spec/views/work_package/auto_complete/index_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/application_job_spec.rb
+++ b/spec/workers/application_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/attachments/cleanup_uncontainered_job_integration_spec.rb
+++ b/spec/workers/attachments/cleanup_uncontainered_job_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
+++ b/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/backup_job_spec.rb
+++ b/spec/workers/backup_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/extract_fulltext_job_spec.rb
+++ b/spec/workers/extract_fulltext_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/journals/completed_job_spec.rb
+++ b/spec/workers/journals/completed_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/ldap/synchronization_job_spec.rb
+++ b/spec/workers/ldap/synchronization_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/member_created_job_spec.rb
+++ b/spec/workers/mails/member_created_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/member_updated_job_spec.rb
+++ b/spec/workers/mails/member_updated_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/reminder_job_spec.rb
+++ b/spec/workers/mails/reminder_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/reminders/notification_delivery_job_spec.rb
+++ b/spec/workers/mails/reminders/notification_delivery_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/shared/member_job.rb
+++ b/spec/workers/mails/shared/member_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/shared/watcher_job.rb
+++ b/spec/workers/mails/shared/watcher_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/watcher_added_job_spec.rb
+++ b/spec/workers/mails/watcher_added_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/mails/watcher_removed_job_spec.rb
+++ b/spec/workers/mails/watcher_removed_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job/alertable_work_packages_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
+++ b/spec/workers/notifications/create_date_alerts_notifications_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/notifications/group_member_altered_job_spec.rb
+++ b/spec/workers/notifications/group_member_altered_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/notifications/schedule_date_alerts_notifications_job_spec.rb
+++ b/spec/workers/notifications/schedule_date_alerts_notifications_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
+++ b/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/notifications/workflow_job_spec.rb
+++ b/spec/workers/notifications/workflow_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/reminders/schedule_reminder_job_spec.rb
+++ b/spec/workers/reminders/schedule_reminder_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/scm/create_local_repository_job_spec.rb
+++ b/spec/workers/scm/create_local_repository_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/user_job_spec.rb
+++ b/spec/workers/user_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/work_packages/apply_working_days_change_job_spec.rb
+++ b/spec/workers/work_packages/apply_working_days_change_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/work_packages/exports/export_job_integration_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/work_packages/progress/apply_statuses_change_job_spec.rb
+++ b/spec/workers/work_packages/progress/apply_statuses_change_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/work_packages/progress/apply_total_percent_complete_mode_change_job_spec.rb
+++ b/spec/workers/work_packages/progress/apply_total_percent_complete_mode_change_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/spec/workers/work_packages/progress/migrate_remove_totals_from_childless_work_packages_job_spec.rb
+++ b/spec/workers/work_packages/progress/migrate_remove_totals_from_childless_work_packages_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH


### PR DESCRIPTION
Rolling out frozen string literals further by freezing all string literals in core specs.

This follows seeing no further test failures in #18039. The risk of this PR is extra low, because it can't break any live code, just tests (which we would notice by running them).