### PR TITLE
[#63776] resolve language for subject patterns

### DIFF
--- a/app/contracts/types/base_contract.rb
+++ b/app/contracts/types/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -60,7 +62,7 @@ module Types
 
       seen = Set.new
       model.attribute_groups.each do |group|
-        errors.add(:attribute_groups, :group_without_name) unless group.key.present?
+        errors.add(:attribute_groups, :group_without_name) if group.key.blank?
         errors.add(:attribute_groups, :duplicate_group, group: group.key) if seen.add?(group.key).nil?
       end
     end
@@ -118,6 +120,6 @@ module Types
       end
     end
 
-    def flat_valid_token_list = Patterns::TokenPropertyMapper.new.tokens_for_type(model).values.map(&:keys).flatten
+    def flat_valid_token_list = Patterns::TokenPropertyMapper.new.tokens_for_type(model).map(&:key)
   end
 end

--- a/app/models/types/pattern_resolver.rb
+++ b/app/models/types/pattern_resolver.rb
@@ -60,10 +60,12 @@ module Types
     end
 
     def nil_replacement(attribute_resolver)
-      if attribute_resolver.context == :work_package
-        "[#{attribute_resolver.label}]"
-      else
-        "[#{attribute_resolver.label_with_context}]"
+      I18n.with_locale(Setting.default_language) do
+        if attribute_resolver.context == :work_package
+          "[#{attribute_resolver.label}]"
+        else
+          "[#{attribute_resolver.label_with_context}]"
+        end
       end
     end
 

--- a/app/models/types/patterns/attribute_token.rb
+++ b/app/models/types/patterns/attribute_token.rb
@@ -30,10 +30,14 @@
 
 module Types
   module Patterns
-    AttributeToken = Data.define(:key, :label, :resolve_fn) do
+    AttributeToken = Data.define(:key, :label_fn, :resolve_fn) do
       def label_with_context
         attribute_context = I18n.t("types.edit.subject_configuration.token.context.#{context}")
         I18n.t("types.edit.subject_configuration.token.label_with_context", attribute_context:, attribute_label: label)
+      end
+
+      def label(*)
+        label_fn.call(*)
       end
 
       def call(*)

--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -33,35 +33,35 @@ module Types
     class TokenPropertyMapper
       # rubocop:disable Layout/LineLength
       BASE_ATTRIBUTE_TOKENS = [
-        AttributeToken.new(:id, WorkPackage.human_attribute_name(:id), ->(wp) { wp.id }),
-        AttributeToken.new(:accountable, WorkPackage.human_attribute_name(:responsible), ->(wp) { wp.responsible&.name }),
-        AttributeToken.new(:assignee, WorkPackage.human_attribute_name(:assigned_to), ->(wp) { wp.assigned_to&.name }),
-        AttributeToken.new(:author, WorkPackage.human_attribute_name(:author), ->(wp) { wp.author&.name }),
-        AttributeToken.new(:category, WorkPackage.human_attribute_name(:category), ->(wp) { wp.category&.name }),
-        AttributeToken.new(:creation_date, WorkPackage.human_attribute_name(:created_at), ->(wp) { wp.created_at }),
-        AttributeToken.new(:estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(wp) { wp.estimated_hours }),
-        AttributeToken.new(:remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(wp) { wp.remaining_hours }),
-        AttributeToken.new(:finish_date, WorkPackage.human_attribute_name(:due_date), ->(wp) { wp.due_date }),
-        AttributeToken.new(:parent_id, WorkPackage.human_attribute_name(:id), ->(parent) { parent.id }),
-        AttributeToken.new(:parent_assignee, WorkPackage.human_attribute_name(:assigned_to), ->(parent) { parent.assigned_to&.name }),
-        AttributeToken.new(:parent_author, WorkPackage.human_attribute_name(:author), ->(parent) { parent.author&.name }),
-        AttributeToken.new(:parent_category, WorkPackage.human_attribute_name(:category), ->(parent) { parent.category&.name }),
-        AttributeToken.new(:parent_creation_date, WorkPackage.human_attribute_name(:created_at), ->(parent) { parent.created_at }),
-        AttributeToken.new(:parent_estimated_time, WorkPackage.human_attribute_name(:estimated_hours), ->(parent) { parent.estimated_hours }),
-        AttributeToken.new(:parent_remaining_time, WorkPackage.human_attribute_name(:remaining_hours), ->(parent) { parent.remaining_hours }),
-        AttributeToken.new(:parent_finish_date, WorkPackage.human_attribute_name(:due_date), ->(parent) { parent.due_date }),
-        AttributeToken.new(:parent_priority, WorkPackage.human_attribute_name(:priority), ->(parent) { parent.priority }),
-        AttributeToken.new(:parent_subject, WorkPackage.human_attribute_name(:subject), ->(parent) { parent.subject }),
-        AttributeToken.new(:priority, WorkPackage.human_attribute_name(:priority), ->(wp) { wp.priority }),
-        AttributeToken.new(:project, WorkPackage.human_attribute_name(:project_id), ->(wp) { wp.project }),
-        AttributeToken.new(:project_active, Project.human_attribute_name(:active), ->(project) { project.active? }),
-        AttributeToken.new(:project_name, Project.human_attribute_name(:name), ->(project) { project.name }),
-        AttributeToken.new(:project_status, Project.human_attribute_name(:status_code), ->(project) { project.status_code }),
-        AttributeToken.new(:project_parent, Project.human_attribute_name(:parent), ->(project) { project.parent_id }),
-        AttributeToken.new(:project_public, Project.human_attribute_name(:public), ->(project) { project.public? }),
-        AttributeToken.new(:start_date, WorkPackage.human_attribute_name(:start_date), ->(wp) { wp.start_date }),
-        AttributeToken.new(:status, WorkPackage.human_attribute_name(:status), ->(wp) { wp.status&.name }),
-        AttributeToken.new(:type, WorkPackage.human_attribute_name(:type), ->(wp) { wp.type&.name })
+        AttributeToken.new(:id, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id }),
+        AttributeToken.new(:accountable, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible&.name }),
+        AttributeToken.new(:assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to&.name }),
+        AttributeToken.new(:author, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author&.name }),
+        AttributeToken.new(:category, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category&.name }),
+        AttributeToken.new(:creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }),
+        AttributeToken.new(:estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }),
+        AttributeToken.new(:remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }),
+        AttributeToken.new(:finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }),
+        AttributeToken.new(:parent_id, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id }),
+        AttributeToken.new(:parent_assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to&.name }),
+        AttributeToken.new(:parent_author, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author&.name }),
+        AttributeToken.new(:parent_category, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category&.name }),
+        AttributeToken.new(:parent_creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }),
+        AttributeToken.new(:parent_estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }),
+        AttributeToken.new(:parent_remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }),
+        AttributeToken.new(:parent_finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }),
+        AttributeToken.new(:parent_priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority }),
+        AttributeToken.new(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
+        AttributeToken.new(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
+        AttributeToken.new(:project, -> { WorkPackage.human_attribute_name(:project_id) }, ->(wp) { wp.project }),
+        AttributeToken.new(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
+        AttributeToken.new(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project.name }),
+        AttributeToken.new(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code }),
+        AttributeToken.new(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id }),
+        AttributeToken.new(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? }),
+        AttributeToken.new(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }),
+        AttributeToken.new(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status&.name }),
+        AttributeToken.new(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type&.name })
       ].freeze
       # rubocop:enable Layout/LineLength
 
@@ -98,7 +98,7 @@ module Types
         custom_field_scope.pluck(:name, :id).map do |name, id|
           AttributeToken.new(
             :"#{prefix}custom_field_#{id}",
-            name,
+            -> { name },
             ->(context) do
               key = :"custom_field_#{id}"
               return :attribute_not_available unless context.respond_to?(key)

--- a/spec/contracts/types/base_contract_spec.rb
+++ b/spec/contracts/types/base_contract_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe Types::BaseContract do
 
   describe "#validation" do
     context "if subject generation patterns contains invalid tokens" do
-      let(:valid_tokens_hash) { { work_package: { assignee: "Assignee" } } }
+      let(:valid_tokens) { [Types::Patterns::AttributeToken.new(:assignee, nil, nil)] }
       let(:work_package_type) do
         Type.new(patterns: { subject: { blueprint: "Vacation {{vaders_toy}}", enabled: true } })
       end
 
       before do
         token_mapper_double = instance_double(Types::Patterns::TokenPropertyMapper)
-        allow(token_mapper_double).to receive(:tokens_for_type).and_return(valid_tokens_hash)
+        allow(token_mapper_double).to receive(:tokens_for_type).and_return(valid_tokens)
         allow(Types::Patterns::TokenPropertyMapper).to receive(:new).and_return(token_mapper_double)
       end
 


### PR DESCRIPTION
# Ticket
[OP#63776](https://community.openproject.org/work_packages/63776)

# What are you trying to accomplish?
- use user language in subject configuration form
- use system language for nil replacements in wp subjects

# What approach did you choose and why?
- label for an attribute token is now a callback (again)
- use default locale in pattern resolver for nil replacements
