### PR TITLE
[#63353, #63108] Meeting layout fixes

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.sass
@@ -21,7 +21,6 @@ $meeting-agenda-item--presenter-width--mobile: 150px
 
   &--content
     overflow-wrap: anywhere
-    min-height: 32px
 
   &--presenter
     max-width: $meeting-agenda-item--presenter-width

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/base_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/base_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   component_wrapper do
     if show_outcome?
-      grid_layout("op-meeting-outcome", tag: :div, id: "outcome-#{@meeting_agenda_item.id}", mt: 2) do |grid|
+      grid_layout("op-meeting-outcome", tag: :div, id: "outcome-#{@meeting_agenda_item.id}", mt: margin_top) do |grid|
         if @edit
           grid.with_area(:notes) do
             render(MeetingAgendaItems::Outcomes::InputComponent.new(meeting: @meeting, meeting_agenda_item: @meeting_agenda_item, meeting_outcome: @meeting_outcome))

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/base_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/base_component.rb
@@ -57,5 +57,9 @@ module MeetingAgendaItems
     def show_outcome?
       @meeting.in_progress? || @meeting_outcome.present?
     end
+
+    def margin_top
+      @meeting_agenda_item.notes.present? ? 3 : 2
+    end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/63353
https://community.openproject.org/wp/63108

# Note
This PR removes the min-height I had earlier set on `content` to prevent the agenda item boxes from growing in height when toggling between meeting states due to the height of the icon, but this is less relevant now that the '+ Outcome' button gets added in and greatly expands the boxes anyway 🤷‍♂️