### PR TITLE
Fix typo in sidebar navigation

### DIFF
--- a/docs/system-admin-guide/manage-work-packages/work-package-priorities/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-priorities/README.md
@@ -1,13 +1,13 @@
 ---
 sidebar_navigation:
-  title: Settings
+  title: Priorities
   priority: 966
 description: Work package priorities in OpenProject.
 keywords: work package priorities, work package configuration
 ---
 # Work package priorities
 
-To create or edit work package priorities in OpenProject, navigate to *Administration → Work packages → Priorities*. Here you will see all existing work package priorities. You can adjust the items within the list by using the options behind the **More (three dots)** menu on the right side. You can also rearrange the order by using the drag-and-drop handle on the left. 
+To create or edit work package priorities in OpenProject, navigate to *Administration → Work packages → Priorities*. Here you will see all existing work package priorities. You can adjust the items within the list by using the options behind the **More (three dots)** menu on the right side. You can also rearrange the order by using the drag-and-drop handle on the left.
 
 ![Work package priorities overview in OpenProject administration](openproject_system_guide_work_package_priorities_overview.png)
 


### PR DESCRIPTION
Should have been "Priorities", but duplicated the
navigation title from the Settings page.

## Screenshots
![image](https://github.com/user-attachments/assets/0db1bedb-43d3-46f6-b706-be0d91982ce9)
