### PR TITLE
Use certificate fingerprint as a fallback only

### DIFF
--- a/modules/auth_saml/app/models/saml/provider/hash_builder.rb
+++ b/modules/auth_saml/app/models/saml/provider/hash_builder.rb
@@ -26,22 +26,22 @@ module Saml
     end
 
     def idp_cert_options_hash
-      if idp_cert_fingerprint.present?
-        return { idp_cert_fingerprint: }
-      end
-
       if idp_cert.present?
         certificates = loaded_idp_certificates.map(&:to_pem)
         if certificates.count > 1
-          {
+          return {
             idp_cert_multi: {
               signing: certificates,
               encryption: certificates
             }
           }
         else
-          { idp_cert: certificates.first }
+          return { idp_cert: certificates.first }
         end
+      end
+
+      if idp_cert_fingerprint.present?
+        { idp_cert_fingerprint: }
       else
         {}
       end


### PR DESCRIPTION
As far as I can tell from existing code and forms, we only want to use the fingerprint as a fallback and not as a primary means of authentication.

However, the HashBuilder would have only returned the fingerprint, if both a fingerprint and a certificate were present, which sadly always seems to be the case, because even when creating a new provider, we fill the fingerprint from the provided certificate.

Since the omniauth configuration happens from the provider hash, this means that we so far only ever used the fingerprint for validation.

### Ticket

* https://community.openproject.org/wp/63612

### Considerations

I don't have a local setup for Saml authentication, so I wasn't yet able to validate my changes. However, this seems like a plausible explanation for the described problem.