### PR TITLE
Fix behavior of wrong entries in edit modal when switching timezones

### DIFF
--- a/modules/costs/app/components/time_entries/days_and_hours_form.rb
+++ b/modules/costs/app/components/time_entries/days_and_hours_form.rb
@@ -49,7 +49,7 @@ module TimeEntries
                        type: "time",
                        required: start_and_end_time_required?,
                        label: TimeEntry.human_attribute_name(:start_time),
-                       value: model.start_timestamp&.strftime("%H:%M"),
+                       value: start_time_in_local_time,
                        show_clear_button: true,
                        data: {
                          "time-entry-target" => "startTimeInput",
@@ -60,7 +60,7 @@ module TimeEntries
                        type: "time",
                        required: start_and_end_time_required?,
                        label: TimeEntry.human_attribute_name(:end_time),
-                       value: model.end_timestamp&.strftime("%H:%M"),
+                       value: end_time_in_local_time,
                        show_clear_button: true,
                        caption: end_time_caption,
                        data: {
@@ -79,6 +79,26 @@ module TimeEntries
     end
 
     private
+
+    def start_time_in_local_time
+      return if model.start_timestamp.blank?
+
+      if model.user == User.current
+        model.start_timestamp.in_time_zone(User.current.time_zone)
+      else
+        model.start_timestamp
+      end.strftime("%H:%M")
+    end
+
+    def end_time_in_local_time
+      return if model.end_timestamp.blank?
+
+      if model.user == User.current
+        model.end_timestamp.in_time_zone(User.current.time_zone)
+      else
+        model.end_timestamp
+      end.strftime("%H:%M")
+    end
 
     def show_start_and_end_time_fields?
       TimeEntry.can_track_start_and_end_time?

--- a/modules/costs/app/components/time_entries/days_and_hours_form.rb
+++ b/modules/costs/app/components/time_entries/days_and_hours_form.rb
@@ -83,21 +83,13 @@ module TimeEntries
     def start_time_in_local_time
       return if model.start_timestamp.blank?
 
-      if model.user == User.current
-        model.start_timestamp.in_time_zone(User.current.time_zone)
-      else
-        model.start_timestamp
-      end.strftime("%H:%M")
+      model.start_timestamp.in_time_zone(model.user.time_zone).strftime("%H:%M")
     end
 
     def end_time_in_local_time
       return if model.end_timestamp.blank?
 
-      if model.user == User.current
-        model.end_timestamp.in_time_zone(User.current.time_zone)
-      else
-        model.end_timestamp
-      end.strftime("%H:%M")
+      model.end_timestamp.in_time_zone(model.user.time_zone).strftime("%H:%M")
     end
 
     def show_start_and_end_time_fields?

--- a/modules/costs/app/components/time_entries/user_form.rb
+++ b/modules/costs/app/components/time_entries/user_form.rb
@@ -30,6 +30,8 @@
 
 module TimeEntries
   class UserForm < ApplicationForm
+    include Redmine::I18n
+
     def initialize(visible: true)
       super()
       @visible = visible
@@ -43,6 +45,7 @@ module TimeEntries
           name: :user_id,
           id: "time_entry_user_id",
           label: TimeEntry.human_attribute_name(:user),
+          caption: caption,
           required: true,
           autocomplete_options: {
             defaultData: true,
@@ -83,6 +86,14 @@ module TimeEntries
       end
 
       filters
+    end
+
+    def caption
+      if model.user.time_zone == User.current.time_zone
+        nil
+      else
+        I18n.t("notice_different_time_zones", tz: friendly_timezone_name(model.user.time_zone))
+      end
     end
   end
 end

--- a/modules/costs/app/controllers/time_entries_controller.rb
+++ b/modules/costs/app/controllers/time_entries_controller.rb
@@ -132,6 +132,8 @@ class TimeEntriesController < ApplicationController
       form_component = TimeEntries::TimeEntryFormComponent.new(time_entry: @time_entry, **form_config_options)
       update_via_turbo_stream(component: form_component, status: :bad_request)
     end
+
+    respond_with_turbo_streams(status: call.success? ? :ok : :bad_request)
   end
 
   private


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63812/activity
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63817/activity

# What are you trying to accomplish?
Cecile identified another weird behavior.

- Set user TZ to Europe/Berlin
- Create a time entry for 10:00-13:00
- Switch timezone to something like America/New_York
- Go to my time tracking
- Calendar entry is correctly shown at 4:00-7:00 (since we are displaying everything in the user's new TZ)
- Clicking on the time entry opens the modal and this still shows 10:00-13:00

To be consistent, we also need to adjust the times in the modal. But only when editing your own entries.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
