### PR TITLE
Feature/59180 activation service that reschedules instead of plain upsert

### DIFF
--- a/app/contracts/project_life_cycle_steps/activation_contract.rb
+++ b/app/contracts/project_life_cycle_steps/activation_contract.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectLifeCycleSteps
+  class ActivationContract < ::ModelContract
+    alias_method :project, :model
+
+    validate :validate_select_project_phases_permission
+
+    def validate_select_project_phases_permission
+      return if user.allowed_in_project?(:select_project_phases, project)
+
+      errors.add :base, :error_unauthorized
+    end
+
+    protected
+
+    def validate_model?
+      false
+    end
+  end
+end

--- a/app/controllers/projects/settings/life_cycle_steps_controller.rb
+++ b/app/controllers/projects/settings/life_cycle_steps_controller.rb
@@ -40,17 +40,17 @@ class Projects::Settings::LifeCycleStepsController < Projects::SettingsControlle
   def toggle
     definition = Project::PhaseDefinition.where(id: params[:id])
 
-    upsert_steps(definition, active: params["value"])
+    set_steps_active_status(definition, active: params["value"])
   end
 
   def disable_all
-    upsert_steps(@life_cycle_definitions, active: false)
+    set_steps_active_status(@life_cycle_definitions, active: false)
 
     redirect_to action: :index
   end
 
   def enable_all
-    upsert_steps(@life_cycle_definitions, active: true)
+    set_steps_active_status(@life_cycle_definitions, active: true)
 
     redirect_to action: :index
   end
@@ -65,18 +65,9 @@ class Projects::Settings::LifeCycleStepsController < Projects::SettingsControlle
     deny_access(not_found: true) unless OpenProject::FeatureDecisions.stages_and_gates_active?
   end
 
-  def upsert_steps(definitions, active:)
-    Project::Phase.upsert_all(
-      definitions.map do |definition|
-        {
-          project_id: @project.id,
-          definition_id: definition.id,
-          active:
-        }
-      end,
-      unique_by: %i[project_id definition_id]
-    )
-
-    @project.touch_and_save_journals
+  def set_steps_active_status(definitions, active:)
+    ::ProjectLifeCycleSteps::ActivationService
+      .new(user: current_user, project: @project, definitions:)
+      .call(active:)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -88,7 +88,7 @@ class Project < ApplicationRecord
   has_many :storages, through: :project_storages
   has_many :phases, class_name: "Project::Phase", dependent: :destroy
   has_many :available_phases,
-           -> { visible.eager_load(:definition).order(position: :asc) },
+           -> { visible.order_by_position },
            class_name: "Project::Phase",
            inverse_of: :project
 

--- a/app/services/project_life_cycle_steps/activation_service.rb
+++ b/app/services/project_life_cycle_steps/activation_service.rb
@@ -47,10 +47,8 @@ module ProjectLifeCycleSteps
 
       upsert(active:)
 
-      first_changed_phase = project.phases.find_by(definition_id: definitions.min_by(&:position)&.id)
-
-      if first_changed_phase
-        UpdateService.new(user:, model: first_changed_phase).call
+      if (first_phase = find_first_phase)
+        UpdateService.new(user:, model: first_phase).call
       else
         project.touch_and_save_journals
 
@@ -69,6 +67,13 @@ module ProjectLifeCycleSteps
         end,
         unique_by: %i[project_id definition_id]
       )
+    end
+
+    def find_first_phase
+      definition_id = definitions.min_by(&:position)&.id
+      return unless definition_id
+
+      project.phases.find_by(definition_id:)
     end
 
     def default_contract_class

--- a/app/services/project_life_cycle_steps/activation_service.rb
+++ b/app/services/project_life_cycle_steps/activation_service.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ProjectLifeCycleSteps
+  class ActivationService < ::BaseServices::BaseContracted
+    alias_method :project, :model
+
+    attr_reader :definitions
+
+    def initialize(user:, project:, definitions:, contract_class: nil, contract_options: {})
+      super(user:, contract_class:, contract_options:)
+      self.model = project
+      @definitions = definitions
+    end
+
+    private
+
+    def persist(service_call)
+      active = params[:active]
+
+      upsert(active:)
+
+      first_changed_phase = project.phases.find_by(definition_id: definitions.min_by(&:position)&.id)
+
+      if first_changed_phase
+        UpdateService.new(user:, model: first_changed_phase).call
+      else
+        project.touch_and_save_journals
+
+        service_call
+      end
+    end
+
+    def upsert(active:)
+      Project::Phase.upsert_all(
+        definitions.map do |definition|
+          {
+            project_id: project.id,
+            definition_id: definition.id,
+            active:
+          }
+        end,
+        unique_by: %i[project_id definition_id]
+      )
+    end
+
+    def default_contract_class
+      ProjectLifeCycleSteps::ActivationContract
+    end
+  end
+end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -158,6 +158,7 @@ Rails.application.reloader.to_prepare do
                      },
                      permissible_on: :project,
                      require: :member,
+                     dependencies: :edit_project_phases,
                      visible: -> { OpenProject::FeatureDecisions.stages_and_gates_active? }
 
       map.permission :manage_members,

--- a/modules/overviews/app/components/overviews/project_phases/show_component.rb
+++ b/modules/overviews/app/components/overviews/project_phases/show_component.rb
@@ -39,7 +39,7 @@ module Overviews
         super
 
         @project = project
-        @phases = @project.available_phases
+        @phases = @project.available_phases.eager_load(:definition)
       end
     end
   end

--- a/spec/contracts/project_life_cycle_steps/activation_contract_spec.rb
+++ b/spec/contracts/project_life_cycle_steps/activation_contract_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe ProjectLifeCycleSteps::ActivationContract do
+  include_context "ModelContract shared context"
+
+  let(:user) { build_stubbed(:user) }
+
+  subject(:contract) { described_class.new(project, user) }
+
+  context "with authorized user" do
+    let(:project) { build_stubbed(:project) }
+
+    before do
+      mock_permissions_for(user) do |mock|
+        mock.allow_in_project(:select_project_phases, project:)
+      end
+    end
+
+    it_behaves_like "contract is valid"
+    it_behaves_like "contract reuses the model errors"
+
+    context "when project is invalid" do
+      let(:project) { build_stubbed(:project, name: "") }
+
+      it_behaves_like "contract is valid"
+    end
+  end
+
+  context "with unauthorized user" do
+    let(:project) { build_stubbed(:project) }
+
+    it_behaves_like "contract user is unauthorized"
+  end
+end

--- a/spec/contracts/project_life_cycle_steps/update_contract_spec.rb
+++ b/spec/contracts/project_life_cycle_steps/update_contract_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ProjectLifeCycleSteps::UpdateContract do
   subject(:contract) { described_class.new(phase, user) }
 
   context "with authorized user" do
-    let(:phase) { build_stubbed(:project_phase) }
+    let(:phase) { create(:project_phase) }
     let(:project) { phase.project }
     let(:date) { Date.current }
 
@@ -69,13 +69,13 @@ RSpec.describe ProjectLifeCycleSteps::UpdateContract do
     end
 
     describe "#validate_start_after_preceeding_phases" do
-      def build_phase(**) = build_stubbed(:project_phase, project:, **)
+      def create_phase(**) = create(:project_phase, project:, **)
 
-      let(:project) { build_stubbed(:project) }
+      let(:project) { create(:project) }
       let(:phases) { [preceding, phase, following] }
-      let(:phase) { build_phase(date_range:, active:) }
-      let(:preceding) { build_phase(date_range: preceding_date_range) }
-      let(:following) { build_phase(date_range: following_date_range) }
+      let(:phase) { create_phase(date_range:, active:) }
+      let(:preceding) { create_phase(date_range: preceding_date_range) }
+      let(:following) { create_phase(date_range: following_date_range) }
       let(:active) { true }
       let(:date_range) { date - 1..date + 1 }
       let(:preceding_date_range) { date - 6..date - 5 }

--- a/spec/factories/project_phase_factory.rb
+++ b/spec/factories/project_phase_factory.rb
@@ -36,7 +36,13 @@ FactoryBot.define do
 
     start_date { Date.current - 2.days }
     finish_date { Date.current + 2.days }
-    duration { start_date && finish_date ? finish_date - start_date + 1 : nil }
+
+    # calculate duration by diffing start and finish dates unless duration is set explicitly
+    callback(:after_build, :after_stub) do |phase, context|
+      next if context.__override_names__.include?(:duration)
+
+      phase.duration = phase.range_set? ? phase.finish_date - phase.start_date + 1 : nil
+    end
 
     trait :skip_validate do
       to_create { |instance| instance.save(validate: false) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe Project do
                     .class_name("Project::Phase")
                     .inverse_of(:project)
                     .dependent(nil)
-                    .order(position: :asc)
+                    .order("project_phase_definitions.position ASC")
     end
 
     it "checks for active flag" do

--- a/spec/services/project_life_cycle_steps/activation_service_spec.rb
+++ b/spec/services/project_life_cycle_steps/activation_service_spec.rb
@@ -1,0 +1,388 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe ProjectLifeCycleSteps::ActivationService, type: :model do
+  shared_let(:user) { create(:user) }
+  shared_let(:project) { create(:project) }
+  shared_let(:definitions) { create_list(:project_phase_definition, 3) }
+
+  let(:service) { described_class.new(user:, project:, definitions:) }
+
+  before do
+    allow(project).to receive(:touch_and_save_journals)
+  end
+
+  def create_phase(**) = create(:project_phase, project:, **)
+
+  describe "initialization" do
+    it "exposes user" do
+      expect(service.user).to eq(user)
+    end
+
+    it "uses ProjectLifeCycleSteps::ActivationContract as the default contract" do
+      expect(service.contract_class).to eq(ProjectLifeCycleSteps::ActivationContract)
+    end
+  end
+
+  describe "contract validation" do
+    context "when the contract is valid" do
+      before do
+        mock_permissions_for(user) do |mock|
+          mock.allow_in_project(:select_project_phases, :edit_project_phases, project:)
+        end
+      end
+
+      it "calls the service successfully" do
+        expect(service.call(active: true)).to be_success
+      end
+    end
+
+    context "when the contract is invalid" do
+      it "fails the service call" do
+        expect(service.call(active: true)).to be_failure
+      end
+
+      it "doesn't touch phases" do
+        expect do
+          service.call(active: true)
+        end.not_to change { project.phases.count }
+      end
+    end
+  end
+
+  describe "activation/deactivation" do
+    before do
+      mock_permissions_for(user) do |mock|
+        mock.allow_in_project(:select_project_phases, :edit_project_phases, project:)
+      end
+    end
+
+    context "when no phases exist" do
+      it "creates active phases for every definition" do
+        service.call(active: true)
+
+        expect(project.phases).to match_array(definitions.map { have_attributes(active: true, definition_id: it.id) })
+      end
+
+      it "creates inactive phases for every definition" do
+        service.call(active: false)
+
+        expect(project.phases).to match_array(definitions.map { have_attributes(active: false, definition_id: it.id) })
+      end
+    end
+
+    context "when some phases exist" do
+      let!(:phase1) { create_phase(definition: definitions[1], active: true) }
+      let!(:phase2) { create_phase(definition: definitions[2], active: false) }
+
+      it "creates active phases for every definition" do
+        service.call(active: true)
+
+        expect(project.phases).to match_array(definitions.map { have_attributes(active: true, definition_id: it.id) })
+      end
+
+      it "creates inactive phases for every definition" do
+        service.call(active: false)
+
+        expect(project.phases).to match_array(definitions.map { have_attributes(active: false, definition_id: it.id) })
+      end
+    end
+  end
+
+  describe "rescheduling" do
+    let(:date) { Date.new(2025, 4, 9) }
+
+    current_user { user }
+
+    before do
+      mock_permissions_for(user) do |mock|
+        mock.allow_in_project(:select_project_phases, :edit_project_phases, :view_project_phases, project:)
+      end
+
+      allow(Project).to receive(:allowed_to).and_call_original
+      allow(Project).to receive(:allowed_to).with(user, :view_project_phases).and_return(Project.all)
+    end
+
+    context "when changing all" do
+      let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date + 1) }
+      let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 1..date + 1) }
+      let!(:phase2) { create_phase(definition: definitions[2], date_range: date - 9..date - 1) }
+
+      it "doesn't reschedule when deactivating" do
+        service.call(active: false)
+
+        expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date + 1, active: false)
+        expect(phase1.reload).to have_attributes(start_date: date + 1, finish_date: date + 1, active: false)
+        expect(phase2.reload).to have_attributes(start_date: date - 9, finish_date: date - 1, active: false)
+      end
+
+      it "reschedules when activating" do
+        service.call(active: true)
+
+        expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date + 1, active: true)
+        expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 2, active: true)
+        expect(phase2.reload).to have_attributes(start_date: date + 3, finish_date: date + 11, active: true)
+      end
+    end
+
+    context "when activating one phase" do
+      context "having preceding phases with date range" do
+        let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
+        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+          end
+        end
+
+        context "when already activated" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: false) }
+
+          it "doesn't reschedule" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+            expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+          end
+        end
+      end
+
+      context "having inactive preceding phases with date range" do
+        let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: false) }
+        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: false)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+          end
+        end
+
+        context "when already activated" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: false)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: false) }
+
+          it "doesn't reschedule" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: false)
+            expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+          end
+        end
+      end
+
+      context "having preceding phases without date range" do
+        let!(:phase0) { create_phase(definition: definitions[0], date_range: nil, active: true) }
+        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+          end
+        end
+
+        context "when already activated" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: false) }
+
+          it "doesn't reschedule" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+          end
+        end
+      end
+
+      context "having no preceding phases" do
+        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[0]]) }
+
+        context "with date range" do
+          let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: false) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+          end
+        end
+
+        context "when already activated" do
+          let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
+
+          it "reschedules following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase0) { create_phase(definition: definitions[0], date_range: nil, active: false) }
+
+          it "doesn't reschedule" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+          end
+        end
+      end
+    end
+
+    context "when deactivating one phase" do
+      let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
+      let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+
+      let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+
+      context "with date range" do
+        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+
+        it "reschedules following phases using dates of that phase" do
+          service.call(active: false)
+
+          expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+          expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: false)
+          expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+        end
+      end
+
+      context "when already deactivated" do
+        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+
+        it "reschedules following phases using dates of that phase" do
+          service.call(active: false)
+
+          expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+          expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: false)
+          expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+        end
+      end
+
+      context "without date range" do
+        let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: true) }
+
+        it "doesn't reschedule" do
+          service.call(active: false)
+
+          expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
+          expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: false)
+          expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+        end
+      end
+    end
+  end
+
+  describe "journaling" do
+    before do
+      mock_permissions_for(user) do |mock|
+        mock.allow_in_project(:select_project_phases, :edit_project_phases, project:)
+      end
+    end
+
+    it "journals the project" do
+      service.call(active: true)
+
+      expect(project).to have_received(:touch_and_save_journals)
+    end
+  end
+end

--- a/spec/services/project_life_cycle_steps/activation_service_spec.rb
+++ b/spec/services/project_life_cycle_steps/activation_service_spec.rb
@@ -164,24 +164,24 @@ RSpec.describe ProjectLifeCycleSteps::ActivationService, type: :model do
         context "with date range" do
           let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
 
-          it "reschedules following phases" do
+          it "reschedules that and following phases" do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
           end
         end
 
         context "when already activated" do
           let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
 
-          it "reschedules following phases" do
+          it "reschedules that and following phases" do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
+            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
           end
         end
 

--- a/spec/services/project_life_cycle_steps/activation_service_spec.rb
+++ b/spec/services/project_life_cycle_steps/activation_service_spec.rb
@@ -140,295 +140,295 @@ RSpec.describe ProjectLifeCycleSteps::ActivationService, type: :model do
       it "doesn't reschedule when deactivating" do
         service.call(active: false)
 
-        expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date + 1, active: false)
-        expect(phase1.reload).to have_attributes(start_date: date + 1, finish_date: date + 1, active: false)
-        expect(phase2.reload).to have_attributes(start_date: date - 9, finish_date: date - 1, active: false)
+        expect(phase0.reload).to have_attributes(active: false, start_date: date - 1, finish_date: date + 1)
+        expect(phase1.reload).to have_attributes(active: false, start_date: date + 1, finish_date: date + 1)
+        expect(phase2.reload).to have_attributes(active: false, start_date: date - 9, finish_date: date - 1)
       end
 
       it "reschedules when activating" do
         service.call(active: true)
 
-        expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date + 1, active: true)
-        expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 2, active: true)
-        expect(phase2.reload).to have_attributes(start_date: date + 3, finish_date: date + 11, active: true)
+        expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
+        expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 2)
+        expect(phase2.reload).to have_attributes(active: true, start_date: date + 3, finish_date: date + 11)
       end
     end
 
     context "when activating one phase" do
       context "having preceding phases with date range" do
-        let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
-        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, date_range: date - 1..date - 1) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
         let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
         context "with date range" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: date + 2..date + 3) }
 
           it "reschedules that and following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
           end
         end
 
         context "when already activated" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: date + 2..date + 3) }
 
           it "reschedules that and following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
           end
         end
 
         context "without date range" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: false) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: nil) }
 
           it "doesn't reschedule" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 7, finish_date: date + 9)
           end
         end
       end
 
       context "having multiple preceding phases with date range" do
-        let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
-        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, date_range: date - 1..date - 1) }
+        let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: date + 2..date + 3) }
 
         let(:service) { described_class.new(user:, project:, definitions: [definitions[2]]) }
 
         context "with date range" do
-          let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: false) }
+          let!(:phase2) { create_phase(definition: definitions[2], active: false, date_range: date + 7..date + 9) }
 
           it "reschedules starting from last preceding phase" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
           end
         end
 
         context "when already activated" do
-          let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+          let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
           it "reschedules starting from last preceding phase" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
           end
         end
       end
 
       context "having multiple preceding phases with date range, some inactive" do
-        let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
-        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, date_range: date - 1..date - 1) }
+        let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: date + 2..date + 3) }
 
         let(:service) { described_class.new(user:, project:, definitions: [definitions[2]]) }
 
         context "with date range" do
-          let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: false) }
+          let!(:phase2) { create_phase(definition: definitions[2], active: false, date_range: date + 7..date + 9) }
 
           it "reschedules starting from last preceding phase" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: false)
-            expect(phase2.reload).to have_attributes(start_date: date, finish_date: date + 2, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
           end
         end
 
         context "when already activated" do
-          let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+          let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
           it "reschedules starting from last preceding phase" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: false)
-            expect(phase2.reload).to have_attributes(start_date: date, finish_date: date + 2, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
           end
         end
       end
 
       context "having inactive preceding phases with date range" do
-        let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: false) }
-        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+        let!(:phase0) { create_phase(definition: definitions[0], active: false, date_range: date - 1..date - 1) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
         let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
         context "with date range" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: date + 2..date + 3) }
 
           it "reschedules following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: false)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase0.reload).to have_attributes(active: false, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
           end
         end
 
         context "when already activated" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: date + 2..date + 3) }
 
           it "reschedules following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: false)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase0.reload).to have_attributes(active: false, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
           end
         end
 
         context "without date range" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: false) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: nil) }
 
           it "doesn't reschedule" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: false)
-            expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+            expect(phase0.reload).to have_attributes(active: false, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 7, finish_date: date + 9)
           end
         end
       end
 
       context "having preceding phases without date range" do
-        let!(:phase0) { create_phase(definition: definitions[0], date_range: nil, active: true) }
-        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, date_range: nil) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
         let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
         context "with date range" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: date + 2..date + 3) }
 
           it "reschedules following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
           end
         end
 
         context "when already activated" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: date + 2..date + 3) }
 
           it "reschedules following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 4, finish_date: date + 6, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
           end
         end
 
         context "without date range" do
-          let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: false) }
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: nil) }
 
           it "doesn't reschedule" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 7, finish_date: date + 9)
           end
         end
       end
 
       context "having no preceding phases" do
-        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
-        let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+        let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: date + 2..date + 3) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
         let(:service) { described_class.new(user:, project:, definitions: [definitions[0]]) }
 
         context "with date range" do
-          let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: false) }
+          let!(:phase0) { create_phase(definition: definitions[0], active: false, date_range: date - 1..date - 1) }
 
           it "reschedules following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
           end
         end
 
         context "when already activated" do
-          let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
+          let!(:phase0) { create_phase(definition: definitions[0], active: true, date_range: date - 1..date - 1) }
 
           it "reschedules following phases" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date, finish_date: date + 1, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
           end
         end
 
         context "without date range" do
-          let!(:phase0) { create_phase(definition: definitions[0], date_range: nil, active: false) }
+          let!(:phase0) { create_phase(definition: definitions[0], active: false, date_range: nil) }
 
           it "doesn't reschedule" do
             service.call(active: true)
 
-            expect(phase0.reload).to have_attributes(start_date: nil, finish_date: nil, active: true)
-            expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: true)
-            expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 7, finish_date: date + 9)
           end
         end
       end
     end
 
     context "when deactivating one phase" do
-      let!(:phase0) { create_phase(definition: definitions[0], date_range: date - 1..date - 1, active: true) }
-      let!(:phase2) { create_phase(definition: definitions[2], date_range: date + 7..date + 9, active: true) }
+      let!(:phase0) { create_phase(definition: definitions[0], active: true, date_range: date - 1..date - 1) }
+      let!(:phase2) { create_phase(definition: definitions[2], active: true, date_range: date + 7..date + 9) }
 
       let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
       context "with date range" do
-        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: true) }
+        let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: date + 2..date + 3) }
 
         it "reschedules following phases using dates of that phase" do
           service.call(active: false)
 
-          expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-          expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: false)
-          expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+          expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+          expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+          expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
         end
       end
 
       context "when already deactivated" do
-        let!(:phase1) { create_phase(definition: definitions[1], date_range: date + 2..date + 3, active: false) }
+        let!(:phase1) { create_phase(definition: definitions[1], active: false, date_range: date + 2..date + 3) }
 
         it "reschedules following phases using dates of that phase" do
           service.call(active: false)
 
-          expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-          expect(phase1.reload).to have_attributes(start_date: date + 2, finish_date: date + 3, active: false)
-          expect(phase2.reload).to have_attributes(start_date: date + 2, finish_date: date + 4, active: true)
+          expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+          expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+          expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
         end
       end
 
       context "without date range" do
-        let!(:phase1) { create_phase(definition: definitions[1], date_range: nil, active: true) }
+        let!(:phase1) { create_phase(definition: definitions[1], active: true, date_range: nil) }
 
         it "doesn't reschedule" do
           service.call(active: false)
 
-          expect(phase0.reload).to have_attributes(start_date: date - 1, finish_date: date - 1, active: true)
-          expect(phase1.reload).to have_attributes(start_date: nil, finish_date: nil, active: false)
-          expect(phase2.reload).to have_attributes(start_date: date + 7, finish_date: date + 9, active: true)
+          expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+          expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
+          expect(phase2.reload).to have_attributes(active: true, start_date: date + 7, finish_date: date + 9)
         end
       end
     end


### PR DESCRIPTION
# Ticket
[OP#63893](https://community.openproject.org/wp/63893) (part of [OP#59180](https://community.openproject.org/wp/59180), follows #18523)

# What are you trying to accomplish?
Automatic rescheduling after activation/deactivation of one or multiple phases

# What approach did you choose and why?

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
