### PR TITLE
Do not assign time zone, when there is no user

### DIFF
--- a/modules/costs/app/services/time_entries/set_attributes_service.rb
+++ b/modules/costs/app/services/time_entries/set_attributes_service.rb
@@ -45,7 +45,7 @@ module TimeEntries
 
       # move the timezone from the user
       model.change_by_system do
-        model.time_zone = model.user.time_zone.name
+        model.time_zone = model.user.time_zone.name if model.user
       end
 
       # Set start time for ongoing time entries

--- a/modules/costs/spec/services/time_entries/set_attributes_service_spec.rb
+++ b/modules/costs/spec/services/time_entries/set_attributes_service_spec.rb
@@ -135,6 +135,26 @@ RSpec.describe TimeEntries::SetAttributesService, type: :model do
       expect(attributes_of_interest)
         .to eql(expected)
     end
+
+    context "with an existing record and params including an empty user" do
+      let(:params) do
+        {
+          user_id: ""
+        }
+      end
+
+      before do
+        allow(time_entry_instance).to receive(:new_record?).and_return(false)
+      end
+
+      it "runs correctly and not raise an error trying to assign the timezone (Reggression #63843)" do
+        expect do
+          subject
+        end.not_to raise_error
+
+        expect(time_entry_instance.user).to be_nil
+      end
+    end
   end
 
   context "with a user with a defined timezone" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/63843

# What are you trying to accomplish?
Unsetting the user in the form is possible, when this is done, we cannot update the timezone. The form will show an error anyways (as the user cannot be empty), but we don't even get to the validation because it fails in the service already. So we just let this happen here.

I have added a regression test with it

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests