### PR TITLE
Don't show banner when active

### DIFF
--- a/config/initializers/homescreen.rb
+++ b/config/initializers/homescreen.rb
@@ -64,7 +64,7 @@ OpenProject::Static::Homescreen.manage :blocks do |blocks|
     },
     {
       partial: "upsell",
-      if: Proc.new { !EnterpriseToken.hide_banners? }
+      if: Proc.new { !(EnterpriseToken.active? || EnterpriseToken.hide_banners?) }
     }
   )
 end


### PR DESCRIPTION
The banner on homescreen is currently shown always if hide_banners? is true