### PR TITLE
Allow forcing a feature flag to be active

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1334,6 +1334,8 @@ module Settings
       # @param [nil] env_alias Alternative for the default env name to also look up. E.g. with the alias set to
       #  `OPENPROJECT_2FA` for a definition with the name `two_factor_authentication`, the value is fetched
       #  from the ENV OPENPROJECT_2FA as well.
+      # @param [TrueClass|FalseClass] disallow_override Disables the usual possibility of overriding the value
+      #   from ENV or configuration file.
       def add(name,
               default:,
               default_by_env: {},
@@ -1342,7 +1344,8 @@ module Settings
               writable: true,
               allowed: nil,
               env_alias: nil,
-              string_values: false)
+              string_values: false,
+              disallow_override: false)
         name = name.to_sym
         return if exists?(name)
 
@@ -1355,7 +1358,7 @@ module Settings
                          allowed:,
                          env_alias:,
                          string_values:)
-        override_value(definition)
+        override_value(definition) unless disallow_override
         all[name] = definition
       end
 

--- a/lib_static/open_project/feature_decisions.rb
+++ b/lib_static/open_project/feature_decisions.rb
@@ -60,10 +60,10 @@ module OpenProject
   module FeatureDecisions
     module_function
 
-    def add(flag_name, description: nil)
+    def add(flag_name, description: nil, force_active: false)
       all << flag_name
       define_flag_methods(flag_name)
-      define_setting_definition(flag_name, description:)
+      define_setting_definition(flag_name, description:, force_active:)
     end
 
     def active
@@ -80,10 +80,12 @@ module OpenProject
       end
     end
 
-    def define_setting_definition(flag_name, description: nil)
+    def define_setting_definition(flag_name, description: nil, force_active: false)
       Settings::Definition.add :"feature_#{flag_name}_active",
                                description:,
-                               default: Rails.env.development?
+                               default: force_active || Rails.env.development?,
+                               writable: !force_active,
+                               disallow_override: force_active
     end
   end
 end

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -972,4 +972,33 @@ RSpec.describe Settings::Definition, :settings_reset do
       end
     end
   end
+
+  describe ".add" do
+    context "when overriding from ENV",
+            with_env: {
+              "OPENPROJECT_BOGUS_SETTING" => "true"
+            } do
+      it "allows overriding configuration" do
+        described_class.add "bogus_setting",
+                            default: false
+
+        expect(described_class.all[:bogus_setting].value)
+          .to be true
+      end
+    end
+
+    context "when overriding from ENV with disallow_override set to true",
+            with_env: {
+              "OPENPROJECT_BOGUS_SETTING" => "true"
+            } do
+      it "allows overriding configuration" do
+        described_class.add "bogus_setting",
+                            default: false,
+                            disallow_override: true
+
+        expect(described_class.all[:bogus_setting].value)
+          .to be false
+      end
+    end
+  end
 end

--- a/spec/lib/open_project/feature_decisions_spec.rb
+++ b/spec/lib/open_project/feature_decisions_spec.rb
@@ -32,21 +32,21 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
 
   include_context "with clean feature decisions"
 
-  shared_context "when adding without env variable" do
+  shared_context "when adding the feature flag" do
     before do
       described_class.add flag_name
     end
   end
 
-  shared_context "when adding the given feature flag" do
+  shared_context "when adding the feature flag as always active" do
     before do
-      described_class.add flag_name
+      described_class.add flag_name, force_active: true
     end
   end
 
   describe "`flag_name`_active?" do
     context "without an ENV variable" do
-      include_context "when adding without env variable"
+      include_context "when adding the feature flag"
 
       it "is false by default" do
         expect(described_class.send(:"#{flag_name}_active?"))
@@ -54,9 +54,28 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
       end
     end
 
+    context "without an ENV variable but set to active" do
+      include_context "when adding the feature flag as always active"
+
+      it "is true by default" do
+        expect(described_class.send(:"#{flag_name}_active?"))
+          .to be true
+      end
+    end
+
     context "with an ENV variable (set to true)",
             with_env: { "OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE" => "true" } do
-      include_context "when adding the given feature flag"
+      include_context "when adding the feature flag"
+
+      it "is true" do
+        expect(described_class.send(:"#{flag_name}_active?"))
+          .to be true
+      end
+    end
+
+    context "with a flag defined that is disabled via env and set to active",
+            with_env: { "OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE" => "false" } do
+      include_context "when adding the feature flag as always active"
 
       it "is true" do
         expect(described_class.send(:"#{flag_name}_active?"))
@@ -74,7 +93,7 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
     end
 
     context "with a flag defined but not enabled" do
-      include_context "when adding without env variable"
+      include_context "when adding the feature flag"
 
       it "returns an empty array" do
         expect(described_class.active)
@@ -82,11 +101,30 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
       end
     end
 
+    context "without an ENV variable but set to active" do
+      include_context "when adding the feature flag as always active"
+
+      it "is an array with the flag included" do
+        expect(described_class.active)
+          .to eq [flag_name.to_s]
+      end
+    end
+
     context "with a flag defined that is enabled via env",
             with_env: { "OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE" => "true" } do
-      include_context "when adding the given feature flag"
+      include_context "when adding the feature flag"
 
-      it "returns an empty array" do
+      it "is an array with the flag included" do
+        expect(described_class.active)
+          .to eq [flag_name.to_s]
+      end
+    end
+
+    context "with a flag defined that is disabled via env and set to active",
+            with_env: { "OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE" => "false" } do
+      include_context "when adding the feature flag as always active"
+
+      it "is an array with the flag included" do
         expect(described_class.active)
           .to eq [flag_name.to_s]
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63846

# What are you trying to accomplish?

- Developers can set a feature flag to be active by default
- Users cannot disable such a feature flag on the /admin/settings/experimental page
- The feature flag cannot be disabled via ENV variable or configuration file.

# Merge checklist

- [x] Added/updated tests
