### PR TITLE
[#63535] Users without the manage meeting minutes permission still see the "Add outcome" option  

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -63,7 +63,8 @@ module MeetingAgendaItems
       @meeting_agenda_item.editable? &&
         @meeting.in_progress? &&
         !@meeting_agenda_item.outcomes.exists? &&
-        !@meeting_agenda_item.in_backlog?
+        !@meeting_agenda_item.in_backlog? &&
+        User.current.allowed_in_project?(:manage_outcomes, @meeting.project)
     end
 
     def first?

--- a/modules/meeting/spec/features/meeting_outcomes_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_outcomes_crud_spec.rb
@@ -167,6 +167,10 @@ RSpec.describe "Meeting Outcomes CRUD", :js do
       show_page.expect_outcome "Existing outcome"
       show_page.expect_no_outcome_actions
       show_page.expect_no_outcome_button
+
+      # Fixes #63535
+      item = MeetingAgendaItem.find_by(id: wp_agenda_item.id)
+      show_page.expect_no_outcome_action(item)
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/63535

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
