### PR TITLE
[#62318] submit inline create work packages conditionally

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
@@ -140,7 +140,6 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
         this.showing.emit(this.canAdd || this.canReference);
       });
 
-
     // Register callback on newly created work packages
     this.registerCreationCallback();
 
@@ -240,9 +239,8 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
         change
           .state
           ?.values$()
-          .pipe(
-            filter(() => !!this.currentWorkPackage),
-          ).subscribe((form) => {
+          .pipe(filter(() => !!this.currentWorkPackage))
+          .subscribe((form) => {
             if (!this.isActive) {
               this.insertRow(wp);
             } else {
@@ -255,11 +253,16 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
 
   private insertRow(wp:WorkPackageResource) {
     // Actually render the row
-    const form = this.workPackageEditForm = this.renderInlineCreateRow(wp);
+    this.workPackageEditForm = this.renderInlineCreateRow(wp);
+    const form = this.workPackageEditForm;
 
     setTimeout(() => {
       // Activate any required fields
-      form.activateMissingFields();
+      void form.activateMissingFields().then((activeFields) => {
+        if (activeFields.length === 0) {
+          void form.submit();
+        }
+      });
 
       // Hide the button row
       this.hideRow();

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
@@ -42,6 +42,7 @@ import { HalResourceNotificationService } from 'core-app/features/hal/services/h
 import { ErrorResource } from 'core-app/features/hal/resources/error-resource';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { HalError } from 'core-app/features/hal/services/hal-error';
+import { FormResource } from 'core-app/features/hal/resources/form-resource';
 
 export const activeFieldContainerClassName = 'inline-edit--active-field';
 export const activeFieldClassName = 'inline-edit--field';
@@ -145,14 +146,18 @@ export abstract class EditForm<T extends HalResource = HalResource> {
   /**
    * Activate all fields that are returned in validation errors
    */
-  public activateMissingFields() {
-    this.change.getForm().then((form:any) => {
-      _.each(form.validationErrors, (val:any, key:string) => {
+  public async activateMissingFields():Promise<unknown[]> {
+    return this.change.getForm().then((form:FormResource) => {
+      const activateFields:Promise<unknown>[] = [];
+
+      _.each(form.validationErrors, (_:ErrorResource, key:string) => {
         if (key === 'id') {
           return;
         }
-        this.activateWhenNeeded(key);
+        activateFields.push(this.activateWhenNeeded(key));
       });
+
+      return Promise.all(activateFields);
     });
   }
 


### PR DESCRIPTION
# Ticket
[OP#62318](https://community.openproject.org/wp/62318)

# What are you trying to accomplish?
- when inline creating a wp of a type with generated subjects, the creation must be instantaneous, if no field is missing

# What approach did you choose and why?
- inline create component now submits the form after creating the row, if the form has no validation errors - i.e. no fields are active anymore.
