### PR TITLE
Implementation/63015 pdf xls cvs exports of linked phases for work packages

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -338,6 +338,15 @@ class WorkPackage < ApplicationRecord
     duration ? duration * 24 : nil
   end
 
+  def project_phase
+    # This might look less efficient than using
+    # ProjectPhase.find_by(definition_id: project_phase_definition_id, project_id: project_id)
+    # as more phases are loaded.
+    # However, the expected number of phases per project is rather small and this way, a project
+    # loaded for multiple work packages can be reused.
+    project&.phases&.detect { |phase| phase.definition_id == project_phase_definition_id }
+  end
+
   # aliasing subject to name
   # using :alias is not possible as AR will add the subject method later
   def name

--- a/app/models/work_package/exports/formatters/project_phase.rb
+++ b/app/models/work_package/exports/formatters/project_phase.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+module WorkPackage::Exports
+  module Formatters
+    class ProjectPhase < ::Exports::Formatters::Default
+      def self.apply?(name, _export_format)
+        %i[project_phase].include?(name.to_sym)
+      end
+
+      def format(work_package, **)
+        phase = work_package.project_phase
+
+        phase.name if phase&.active?
+      end
+
+      def format_value(_value, _options)
+        # This method is not implemented (yet).
+        # As of now, it was not called from the codebase.
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/config/initializers/export_formats.rb
+++ b/config/initializers/export_formats.rb
@@ -36,17 +36,18 @@ Rails.application.configure do |application|
 
       single WorkPackage, WorkPackage::PDFExport::WorkPackageToPdf
 
-      formatter WorkPackage, WorkPackage::Exports::Formatters::CompoundHours
-      formatter WorkPackage, WorkPackage::Exports::Formatters::SpentUnits
-      formatter WorkPackage, WorkPackage::Exports::Formatters::Hours
-      formatter WorkPackage, WorkPackage::Exports::Formatters::Days
-      formatter WorkPackage, WorkPackage::Exports::Formatters::Currency
-      formatter WorkPackage, WorkPackage::Exports::Formatters::Costs
-      formatter WorkPackage, WorkPackage::Exports::Formatters::CompoundDoneRatio
-      formatter WorkPackage, WorkPackage::Exports::Formatters::DoneRatio
-      formatter WorkPackage, WorkPackage::Exports::Formatters::Date
       formatter WorkPackage, Exports::Formatters::CustomField
       formatter WorkPackage, Exports::Formatters::CustomFieldPdf
+      formatter WorkPackage, WorkPackage::Exports::Formatters::CompoundDoneRatio
+      formatter WorkPackage, WorkPackage::Exports::Formatters::CompoundHours
+      formatter WorkPackage, WorkPackage::Exports::Formatters::Costs
+      formatter WorkPackage, WorkPackage::Exports::Formatters::Currency
+      formatter WorkPackage, WorkPackage::Exports::Formatters::Date
+      formatter WorkPackage, WorkPackage::Exports::Formatters::Days
+      formatter WorkPackage, WorkPackage::Exports::Formatters::DoneRatio
+      formatter WorkPackage, WorkPackage::Exports::Formatters::Hours
+      formatter WorkPackage, WorkPackage::Exports::Formatters::ProjectPhase
+      formatter WorkPackage, WorkPackage::Exports::Formatters::SpentUnits
 
       list Project, Projects::Exports::CSV
       formatter Project, Exports::Formatters::CustomField

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -682,9 +682,7 @@ module API
         end
 
         def project_phase
-          @project_phase ||= represented.project&.phases&.detect do
-            it.definition_id == represented.project_phase_definition_id
-          end
+          @project_phase ||= represented.project_phase
         end
 
         def phase_set_and_active?

--- a/spec/models/work_package/exports/formatters/project_phase_spec.rb
+++ b/spec/models/work_package/exports/formatters/project_phase_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe WorkPackage::Exports::Formatters::ProjectPhase do
+  let(:formatter_instance) { described_class.new(:project_phase) }
+
+  describe ".apply?" do
+    it "returns true for :project_phase and pdf format" do
+      expect(described_class.apply?(:project_phase, :pdf)).to be true
+    end
+
+    it "returns false for other attributes" do
+      expect(described_class.apply?(:other_attribute, :pdf)).to be false
+    end
+
+    it "returns true for :project_phase and csv format" do
+      expect(described_class.apply?(:project_phase, :csv)).to be true
+    end
+
+    it "returns true for :project_phase and xls format" do
+      expect(described_class.apply?(:project_phase, :xls)).to be true
+    end
+  end
+
+  describe "#format" do
+    let(:work_package) do
+      build_stubbed(:work_package) do |wp|
+        allow(wp)
+          .to receive(:project_phase)
+                .and_return(project_phase)
+      end
+    end
+
+    context "when the phase is active" do
+      let(:project_phase) { build_stubbed(:project_phase, active: true) }
+
+      it "returns the name of the phase" do
+        expect(formatter_instance.format(work_package)).to eq(project_phase.name)
+      end
+    end
+
+    context "when the phase is inactive" do
+      let(:project_phase) { build_stubbed(:project_phase, active: false) }
+
+      it "returns nil" do
+        expect(formatter_instance.format(work_package)).to be_nil
+      end
+    end
+
+    context "when no phase is set" do
+      let(:project_phase) { nil }
+
+      it "returns nil" do
+        expect(formatter_instance.format(work_package)).to be_nil
+      end
+    end
+  end
+
+  describe "#format_value" do
+    it "is not implemented" do
+      expect { formatter_instance.format_value("abc", {}) }
+        .to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -878,4 +878,30 @@ RSpec.describe WorkPackage do
       expect(work_package.remaining_hours).to eq((3 * 8) + 1.5)
     end
   end
+
+  describe "#project_phase" do
+    let(:project_phase) { build_stubbed(:project_phase, definition: project_phase_definition) }
+    let(:project_phase_definition) { build_stubbed(:project_phase_definition) }
+    let(:project) { build_stubbed(:project, phases: [project_phase]) }
+    let(:work_package) do
+      build_stubbed(:work_package,
+                    project:,
+                    project_phase_definition: project_phase_definition)
+    end
+
+    describe "when the project phase exists in the project" do
+      it "returns the project phase definition" do
+        expect(work_package.project_phase).to eq(project_phase)
+      end
+    end
+
+    describe "when the project phase does not exist in the project (e.g. moved into the project)" do
+      # There is now only another project phase active in the project
+      let(:project_phase) { build_stubbed(:project_phase, definition: build_stubbed(:project_phase_definition)) }
+
+      it "returns nil" do
+        expect(work_package.project_phase).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63015

To get the full functionality, including exporting to xls, csv and list pdfs, #18851 will need to be merged first. But checking on a branch rebased on it looked solid.

# What are you trying to accomplish?

Enable exporting the project_phase column for work packages for the formats:
* [x] pdf
* [x] xls
* [x] csv

# Merge checklist

- [x] Added/updated tests
