### PR TITLE
have project phase changes show up on wp activity

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -58,6 +58,7 @@ class Journal < ApplicationRecord
   register_journal_formatter OpenProject::JournalFormatter::MeetingWorkPackageId
   register_journal_formatter OpenProject::JournalFormatter::ProjectPhaseActive
   register_journal_formatter OpenProject::JournalFormatter::ProjectPhaseDates
+  register_journal_formatter OpenProject::JournalFormatter::ProjectPhaseDefinition
   register_journal_formatter OpenProject::JournalFormatter::ProjectStatusCode
   register_journal_formatter OpenProject::JournalFormatter::ScheduleManually
   register_journal_formatter OpenProject::JournalFormatter::SubprojectNamedAssociation

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -100,6 +100,7 @@ module WorkPackage::Journalized
     register_journal_formatted_fields "ignore_non_working_days", formatter_key: :ignore_non_working_days
     register_journal_formatted_fields "cause", formatter_key: :cause
     register_journal_formatted_fields /file_links_?\d+/, formatter_key: :file_link
+    register_journal_formatted_fields "project_phase_definition_id", formatter_key: :project_phase_definition
 
     # Joined
     register_journal_formatted_fields :parent_id, :project_id,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1673,12 +1673,13 @@ en:
       work_package: "Work packages"
     project_phase:
       activated: "activated"
-      deactivated: "deactivated"
       added_date: "set to %{date}"
       changed_date: "changed from %{from} to %{to}"
-      removed_date: "date deleted %{date}"
-      phase_and_one_gate: "%{phase_message}. %{gate_message}"
+      deactivated: "deactivated"
+      deleted_project_phase: "Deleted project phase"
       phase_and_both_gates: "%{phase_message}. %{start_gate_message}, and %{finish_gate_message}"
+      phase_and_one_gate: "%{phase_message}. %{gate_message}"
+      removed_date: "date deleted %{date}"
 
   # common attributes of all models
   attributes:

--- a/lib/open_project/journal_formatter/project_phase_definition.rb
+++ b/lib/open_project/journal_formatter/project_phase_definition.rb
@@ -32,7 +32,9 @@ class OpenProject::JournalFormatter::ProjectPhaseDefinition < JournalFormatter::
   private
 
   def associated_object_name(object)
-    if phase_active?(object)
+    if object.nil?
+      I18n.t(:"activity.project_phase.deleted_project_phase")
+    elsif phase_active?(object)
       super
     else
       "#{super} (#{I18n.t(:label_inactive)})"
@@ -40,8 +42,11 @@ class OpenProject::JournalFormatter::ProjectPhaseDefinition < JournalFormatter::
   end
 
   def phase_active?(definition)
-    phase = @journal.journable.project.phases.detect { |phase| phase.definition_id == definition.id } if definition
-
-    phase&.active
+    @journal
+      .journable
+      .project
+      .phases
+      .detect { |phase| phase.definition_id == definition.id }
+      &.active
   end
 end

--- a/lib/open_project/journal_formatter/project_phase_definition.rb
+++ b/lib/open_project/journal_formatter/project_phase_definition.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class OpenProject::JournalFormatter::ProjectPhaseDefinition < JournalFormatter::NamedAssociation
+  private
+
+  def associated_object_name(object)
+    if phase_active?(object)
+      super
+    else
+      "#{super} (#{I18n.t(:label_inactive)})"
+    end
+  end
+
+  def phase_active?(definition)
+    phase = @journal.journable.project.phases.detect { |phase| phase.definition_id == definition.id } if definition
+
+    phase&.active
+  end
+end

--- a/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib_static/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -53,17 +53,15 @@ module JournalFormatter
       klass = class_from_field(key)
 
       values.map do |value|
-        if klass && value
-          record = associated_object(klass, value.to_i, cache:)
-          if record
-            if record.respond_to? :name
-              record.name
-            else
-              record.subject
-            end
-          end
-        end
+        next unless klass && value
+
+        record = associated_object(klass, value.to_i, cache:)
+        associated_object_name(record)
       end
+    end
+
+    def associated_object_name(object)
+      object&.name
     end
 
     def associated_object(klass, id, cache:)

--- a/spec/features/work_packages/project_phases/linking_spec.rb
+++ b/spec/features/work_packages/project_phases/linking_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "Linking projects phases and work packages", :js, with_flag: { st
   current_user { user }
 
   let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
+  let(:activity_tab) { Components::WorkPackages::Activities.new(work_package) }
 
   it "allows seeing and editing linked phases" do
     work_package_page.visit!
@@ -57,6 +58,12 @@ RSpec.describe "Linking projects phases and work packages", :js, with_flag: { st
     work_package_page.expect_attributes(project_phase: executing_phase_definition.name)
 
     work_package_page.set_attributes({ projectPhase: initiating_phase_definition.name })
+
+    activity_tab.within_journal_entry(work_package.journals.last) do
+      activity_tab.expect_journal_changed_attribute(
+        text: "Project phase changed from #{executing_phase_definition.name} to #{initiating_phase_definition.name}"
+      )
+    end
 
     work_package_page.expect_and_dismiss_toaster(message: "Successful update.")
 

--- a/spec/lib/open_project/journal_formatter/project_phase_definition_spec.rb
+++ b/spec/lib/open_project/journal_formatter/project_phase_definition_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::JournalFormatter::ProjectPhaseDefinition do
+  describe "#render" do
+    let(:project_phase) { build_stubbed(:project_phase) }
+    let(:other_project_phase) { build_stubbed(:project_phase) }
+    let(:project_phases) { [project_phase, other_project_phase] }
+    let(:project) { build_stubbed(:project, phases: project_phases) }
+    let(:work_package) { build_stubbed(:work_package, project:) }
+    let(:journal) { build_stubbed(:work_package_journal, journable: work_package) }
+    let(:instance) { described_class.new(journal) }
+
+    before do
+      project_phases.each do |phase|
+        allow(Project::PhaseDefinition)
+          .to receive(:find_by)
+          .with(id: phase.definition_id)
+          .and_return(phase.definition)
+      end
+    end
+
+    shared_examples_for "renders project phase definition change" do
+      it { expect(instance.render(:project_phase_definition, [old_value, new_value])).to eq(expected) }
+    end
+
+    context "when setting an active phase" do
+      let(:old_value) { nil }
+      let(:new_value) { project_phase.definition_id.to_s }
+      let(:expected) do
+        I18n.t(:text_journal_set_to,
+               label: "<strong>Project phase</strong>",
+               value: "<i>#{project_phase.name}</i>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when changing between two active phases" do
+      let(:old_value) { other_project_phase.definition_id.to_s }
+      let(:new_value) { project_phase.definition_id.to_s }
+      let(:expected) do
+        I18n.t(:text_journal_changed_plain,
+               label: "<strong>Project phase</strong>",
+               linebreak: nil,
+               old: "<i>#{other_project_phase.name}</i>",
+               new: "<i>#{project_phase.name}</i>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when deleting an active phase" do
+      let(:old_value) { project_phase.definition_id.to_s }
+      let(:new_value) { nil }
+      let(:expected) do
+        I18n.t(:text_journal_deleted,
+               label: "<strong>Project phase</strong>",
+               old: "<strike><i>#{project_phase.name}</i></strike>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when setting an inactive phase" do
+      let(:project_phase) { build_stubbed(:project_phase, active: false) }
+      let(:old_value) { nil }
+      let(:new_value) { project_phase.definition_id.to_s }
+      let(:expected) do
+        I18n.t(:text_journal_set_to,
+               label: "<strong>Project phase</strong>",
+               value: "<i>#{project_phase.name} (Inactive)</i>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when changing between two inactive phases" do
+      let(:project_phase) { build_stubbed(:project_phase, active: false) }
+      let(:other_project_phase) { build_stubbed(:project_phase, active: false) }
+      let(:old_value) { other_project_phase.definition_id.to_s }
+      let(:new_value) { project_phase.definition_id.to_s }
+      let(:expected) do
+        I18n.t(:text_journal_changed_plain,
+               label: "<strong>Project phase</strong>",
+               linebreak: nil,
+               old: "<i>#{other_project_phase.name} (Inactive)</i>",
+               new: "<i>#{project_phase.name} (Inactive)</i>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when deleting an inactive phase" do
+      let(:project_phase) { build_stubbed(:project_phase, active: false) }
+      let(:old_value) { project_phase.definition_id.to_s }
+      let(:new_value) { nil }
+      let(:expected) do
+        I18n.t(:text_journal_deleted,
+               label: "<strong>Project phase</strong>",
+               old: "<strike><i>#{project_phase.name} (Inactive)</i></strike>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when setting a phase not configured for the project" do
+      let(:project) { build_stubbed(:project, phases: []) }
+      let(:old_value) { nil }
+      let(:new_value) { project_phase.definition_id.to_s }
+      let(:expected) do
+        I18n.t(:text_journal_set_to,
+               label: "<strong>Project phase</strong>",
+               value: "<i>#{project_phase.name} (Inactive)</i>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when changing between two phases not configured for the project" do
+      let(:project) { build_stubbed(:project, phases: []) }
+      let(:old_value) { other_project_phase.definition_id.to_s }
+      let(:new_value) { project_phase.definition_id.to_s }
+      let(:expected) do
+        I18n.t(:text_journal_changed_plain,
+               label: "<strong>Project phase</strong>",
+               linebreak: nil,
+               old: "<i>#{other_project_phase.name} (Inactive)</i>",
+               new: "<i>#{project_phase.name} (Inactive)</i>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+
+    context "when deleting a phase not configured for the project" do
+      let(:project) { build_stubbed(:project, phases: []) }
+      let(:old_value) { project_phase.definition_id.to_s }
+      let(:new_value) { nil }
+      let(:expected) do
+        I18n.t(:text_journal_deleted,
+               label: "<strong>Project phase</strong>",
+               old: "<strike><i>#{project_phase.name} (Inactive)</i></strike>")
+      end
+
+      it_behaves_like "renders project phase definition change"
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62983

# What are you trying to accomplish?

This PR introduces functionality to journalize changes to project phase definitions associated with work packages. It uses the default state changes of journals (e.g. 'Project phase set to abc'). The difference is just in the way the values are displayed. Since project phases can both be inactive in the project as well not being configured in it at all, the formatter checks for the active state of the phase in the project. If it is inactive or not configured, "(Inactive)" is appended to the name of the definition.

## Screenshots

<img width="711" alt="image" src="https://github.com/user-attachments/assets/84453fff-75d9-4478-8f44-032dd99b0549" />

# Merge checklist

- [x] Added/updated tests
