### PR TITLE
bug/63897 Missing target element "internalCheckbox" error when internal comments feature is disabled

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
@@ -51,8 +51,12 @@ export default class InternalCommentController extends Controller {
 
   declare isInternalValue:boolean;
 
+  declare hasInternalCheckboxTarget:boolean;
+
   onSubmitEnd(_event:CustomEvent):void {
-    this.toggleInternal();
+    if (this.hasInternalCheckboxTarget) {
+      this.toggleInternal();
+    }
   }
 
   toggleInternal():void {


### PR DESCRIPTION
https://community.openproject.org/wp/63897

When the Internal comments feature is disabled, the internalCommentCheckboxTarget does not exist, causing a warning from Stimulus; the InternalCommentController listens to form submit end events from the activities IndexController which manages comment form submission- it is then able to update the UI state on form close. E.g. Ensuring that the background color is reset https://github.com/opf/openproject/commit/e4270942f935c127bf322955933c7bb81b93192b

<img width="1631" alt="Screenshot 2025-05-08 at 4 48 47 PM" src="https://github.com/user-attachments/assets/7f174ac1-4ad0-4e62-b476-ea375b8aad9c" />
