### PR TITLE
limit Projects tab to work packages and project custom fields

### DIFF
--- a/app/components/admin/custom_fields/edit_form_header_component.rb
+++ b/app/components/admin/custom_fields/edit_form_header_component.rb
@@ -52,12 +52,15 @@ module Admin
           }
         end
 
-        tabs <<
-          {
-            name: "custom_field_projects",
-            path: custom_field_projects_path(@custom_field),
-            label: t(:label_project_plural)
-          }
+        if @custom_field.is_a?(WorkPackageCustomField) ||
+          @custom_field.is_a?(ProjectCustomField)
+          tabs <<
+            {
+              name: "custom_field_projects",
+              path: custom_field_projects_path(@custom_field),
+              label: t(:label_project_plural)
+            }
+        end
 
         tabs
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63900

# What are you trying to accomplish?

Only show the 'Projects' tab for custom fields on projects and work packages.