### PR TITLE
Correctly handle users unable to authenticate at a storage

### DIFF
--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -52,8 +52,8 @@ module Storages::ProjectStorages::Members
     def status
       connection_result = storage_connection_status
       case connection_result
-      when :not_connected
-        helpers.op_icon("icon-warning -warning") +
+      when :not_connected_oauth2
+        warning_icon +
           content_tag(
             :span,
             I18n.t("storages.member_connection_status.not_connected",
@@ -61,6 +61,8 @@ module Storages::ProjectStorages::Members
           )
       when :not_connected_sso
         content_tag(:span, I18n.t("storages.member_connection_status.not_connected_sso"))
+      when :not_connectable
+        warning_icon + content_tag(:span, I18n.t("storages.member_connection_status.not_connectable"))
       else
         I18n.t("storages.member_connection_status.#{connection_result}")
       end
@@ -94,8 +96,9 @@ module Storages::ProjectStorages::Members
 
       selector = Storages::Peripherals::StorageInteraction::AuthenticationMethodSelector.new(user: member.principal, storage:)
       return :not_connected_sso if selector.sso?
+      return :not_connected_oauth2 if selector.storage_oauth?
 
-      :not_connected
+      :not_connectable
     end
 
     def storage_connected?
@@ -111,6 +114,10 @@ module Storages::ProjectStorages::Members
         oauth_client_id: storage.oauth_client.client_id,
         storage_id: storage.id
       )
+    end
+
+    def warning_icon
+      helpers.op_icon("icon-warning -warning")
     end
   end
 end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -411,6 +411,7 @@ en:
     member_connection_status:
       connected: Connected
       connected_no_permissions: User role has no storages permissions
+      not_connectable: Not connectable. The storage requires login through an SSO provider, but the user is not logging in through SSO.
       not_connected: Not connected. The user should login to the storage via the following %{link}.
       not_connected_sso: Not yet connected, SSO should automatically connect them, once looking at files.
     members_no_results: No members to display.

--- a/modules/storages/spec/features/view_project_storage_members_spec.rb
+++ b/modules/storages/spec/features/view_project_storage_members_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Project storage members connection status view", :js do
   let(:connected_user) { create(:user) }
   let(:connected_no_permissions_user) { create(:user) }
   let(:disconnected_user) { create(:user) }
+  let(:disconnected_sso_user) { create(:user, authentication_provider: create(:oidc_provider)) }
   let(:group_user) { create(:user) }
 
   let!(:storage) { create_nextcloud_storage_with_oauth_application }
@@ -80,6 +81,7 @@ RSpec.describe "Project storage members connection status view", :js do
         [connected_user, "Connected"],
         [connected_no_permissions_user, "User role has no storages permissions"],
         [disconnected_user, "Not connected. The user should login to the storage via the following link."],
+        [disconnected_sso_user, "Not connected. The user should login to the storage via the following link."],
         [group_user, "Not connected. The user should login to the storage via the following link."]
       ].each do |(principal, status)|
         expect(page).to have_css("#member-#{principal.id} .name", text: principal.name)
@@ -112,6 +114,43 @@ RSpec.describe "Project storage members connection status view", :js do
     expect(page).to have_text("No members to display.")
   end
 
+  context "when the storage authenticates through SSO" do
+    let!(:storage) { create(:nextcloud_storage, :as_automatically_managed, :oidc_sso_enabled) }
+
+    it "lists project members connection statuses" do
+      login_as user
+
+      # Go to Projects -> Settings -> File Storages
+      visit external_file_storages_project_settings_project_storages_path(project)
+
+      expect(page).to have_title("Files")
+      expect(page).to have_text(storage.name)
+      page.find(".icon.icon-group").click
+
+      # Members connection status page
+      expect(page).to have_current_path project_settings_project_storage_members_path(project_id: project,
+                                                                                      project_storage_id: project_storage)
+
+      not_connectable = "Not connectable. The storage requires login through an SSO provider, " \
+                        "but the user is not logging in through SSO."
+      aggregate_failures "Verifying Connection Statuses" do
+        [
+          [user, not_connectable],
+          [connected_user, "Connected"],
+          [disconnected_user, not_connectable],
+          [disconnected_sso_user, "Not yet connected, SSO should automatically connect them, once looking at files."]
+        ].each do |(principal, status)|
+          expect(page).to have_css("#member-#{principal.id} .name", text: principal.name)
+          expect(page).to have_css("#member-#{principal.id} .status", text: status)
+        end
+
+        [placeholder_user, group].each do |principal|
+          expect(page).to have_no_css("#member-#{principal.id} .name", text: principal.name)
+        end
+      end
+    end
+  end
+
   def create_project_with_storage_and_members
     role_can_read_files = create(:project_role, permissions: %i[manage_files_in_project read_files])
     role_cannot_read_files = create(:project_role, permissions: %i[manage_files_in_project])
@@ -122,6 +161,7 @@ RSpec.describe "Project storage members connection status view", :js do
                       connected_user => role_can_read_files,
                       connected_no_permissions_user => role_cannot_read_files,
                       disconnected_user => role_can_read_files,
+                      disconnected_sso_user => role_can_read_files,
                       placeholder_user => role_can_read_files,
                       group => role_can_read_files },
            enabled_module_names: %i[storages])


### PR DESCRIPTION
The previous code assumed that if the authentication method selector doesn't choose SSO, it must have chosen OAuth 2.0, which results in rendering an ensure connection link. However, it's also possible that the method selector chooses NO authentication method, because the user simply can't authenticate at the storage. In this case rendering an ensure connection link would fail.

This was not detected earlier due to missing tests.

# Ticket
https://community.openproject.org/wp/63909