### PR TITLE
[63913] Work package subject can overflow on list view

### DIFF
--- a/app/components/op_primer/border_box_table_component.sass
+++ b/app/components/op_primer/border_box_table_component.sass
@@ -3,6 +3,9 @@
 .op-border-box-grid
   display: grid
 
+  &--row-item
+    word-break: break-word
+
   &--row-action
     align-items: center
     justify-content: flex-end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63913/activity

# What are you trying to accomplish?
Wrap long words in the borderBoxTable

## Screenshots
**Before**
<img width="500" alt="Bildschirmfoto 2025-05-09 um 10 47 17" src="https://github.com/user-attachments/assets/a7a4952c-2d51-44db-9836-56919bbf748b" />

**After**
<img width="500" alt="Bildschirmfoto 2025-05-09 um 10 47 05" src="https://github.com/user-attachments/assets/777787e2-7c95-4ea3-b235-da4281b9de7d" />


