### PR TITLE
Replace format_time_as_date with format_date

### DIFF
--- a/app/components/work_packages/reminder/modal_body_component.rb
+++ b/app/components/work_packages/reminder/modal_body_component.rb
@@ -120,7 +120,7 @@ module WorkPackages
       end
 
       def time_as_date(time)
-        format_time_as_date(time, format: "%Y-%m-%d")
+        format_date(time, format: "%Y-%m-%d")
       end
 
       def attribute_blank?(attribute)

--- a/app/models/exports/concerns/csv.rb
+++ b/app/models/exports/concerns/csv.rb
@@ -84,7 +84,7 @@ module Exports
       def csv_export_filename
         sane_filename(
           "#{Setting.app_title} #{title} \
-          #{format_time_as_date(Time.zone.now, format: '%Y-%m-%d')}.csv"
+          #{format_date(Time.zone.now, format: '%Y-%m-%d')}.csv"
         )
       end
     end

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -69,10 +69,27 @@ module Redmine
       ("%.2f" % hours.to_f)
     end
 
-    def format_date(date)
-      return nil unless date
+    # Formats the given date or datetime as a date string according to the user's time zone
+    # and optional specified or system default format.
+    #
+    # @param date_or_time [Date|Time] The date or time object to format.
+    # @param time_zone [ActiveSupport::TimeZone] Use a different time zone than the current users's.
+    #   If provided, will output the time zone identifier
+    # @param format [String, nil] The strftime format to use for the date. If nil, the default
+    #   date format from `Setting.date_format` is used.
+    def format_date(date_or_time, time_zone: nil, format: Setting.date_format)
+      return nil unless date_or_time
 
-      Setting.date_format.blank? ? ::I18n.l(date.to_date) : date.strftime(Setting.date_format)
+      local =
+        if time_zone
+          date_or_time.in_time_zone(time_zone).to_date
+        elsif date_or_time.instance_of?(Date) # Important not to use is_a? as it will match DateTime
+          date_or_time
+        else
+          in_user_zone(time).to_date
+        end
+
+      format.blank? ? ::I18n.l(local) : date.strftime(format)
     end
 
     ##
@@ -116,25 +133,6 @@ module Redmine
     #   - `name`
     def link_regex
       /(\[(.+?)\]\((.+?)\))/
-    end
-
-    # Formats the given time as a date string according to the user's time zone and
-    # optional specified format.
-    #
-    # @param time [Time] The time to format.
-    # @param format [String, nil] The strftime format to use for the date. If nil, the default
-    #   date format from `Setting.date_format` is used.
-    # @return [String, nil] The formatted date string, or nil if the time is not provided.
-    def format_time_as_date(time, format: nil)
-      return nil unless time
-
-      local_date = in_user_zone(time).to_date
-
-      if format
-        local_date.strftime(format)
-      else
-        format_date(local_date)
-      end
     end
 
     # Formats the given time as a time string according to the user's time zone

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -86,10 +86,10 @@ module Redmine
         elsif date_or_time.instance_of?(Date) # Important not to use is_a? as it will match DateTime
           date_or_time
         else
-          in_user_zone(time).to_date
+          in_user_zone(date_or_time).to_date
         end
 
-      format.blank? ? ::I18n.l(local) : date.strftime(format)
+      format.present? ? ::I18n.l(local, format:) : ::I18n.l(local)
     end
 
     ##

--- a/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
@@ -43,7 +43,7 @@ module OpenProject::Bim::BcfXml
 
       sane_filename(
         "#{Setting.app_title} #{I18n.t(:label_work_package_plural)} \
-        #{format_time_as_date(Time.current, format: '%Y-%m-%d')}.bcf"
+        #{format_date(Time.current, format: '%Y-%m-%d')}.bcf"
       )
     end
 

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -60,7 +60,7 @@ module Meetings
       else
         safe_join(
           [
-            helpers.format_time_as_date(model.start_time),
+            helpers.format_date(model.start_time),
             helpers.format_time(model.start_time, include_date: false)
           ],
           " "

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -50,7 +50,7 @@
           details.with_row do
             render_meeting_attribute_row(:calendar) do
               render(Primer::Beta::Text.new) do
-                format_time_as_date(@meeting.start_time)
+                format_date(@meeting.start_time)
               end
             end
           end

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
@@ -47,7 +47,7 @@ module Meetings
     private
 
     def start_date_initial_value
-      format_time_as_date(@meeting.start_time, format: "%Y-%m-%d")
+      format_date(@meeting.start_time, format: "%Y-%m-%d")
     end
 
     def start_time_initial_value

--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -112,7 +112,7 @@ module Meeting::VirtualStartTime
   end
 
   def update_derived_fields
-    @start_date = format_time_as_date(start_time, format: "%Y-%m-%d")
+    @start_date = format_date(start_time, format: "%Y-%m-%d")
     @start_time_hour = format_time(start_time, include_date: false, format: "%H:%M")
   end
 

--- a/modules/meeting/app/views/meeting_mailer/cancelled.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/cancelled.html.erb
@@ -59,7 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
             </td>
             <td style="<%= placeholder_text_styles %>">
               <s>
-                <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
+                <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
                 -
                 <%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
               </s>

--- a/modules/meeting/app/views/meeting_mailer/cancelled.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/cancelled.text.erb
@@ -44,4 +44,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= @meeting.project.name %>: <%= @meeting.title %>
 <%= @meeting.author %>
-<%= t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
+<%= t :label_meeting_date_time %>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)

--- a/modules/meeting/app/views/meeting_mailer/icalendar_notification.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/icalendar_notification.html.erb
@@ -4,7 +4,7 @@
 <p><%= t(:text_notificiation_invited) %></p>
 
 <ul>
-<li><%= t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)</li>
+<li><%= t :label_meeting_date_time %>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)</li>
 <li><%= Meeting.human_attribute_name(:location) %>: <%= @meeting.location %></li>
 <li><%= Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %></li>
 <li><%= Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %></li>

--- a/modules/meeting/app/views/meeting_mailer/icalendar_notification.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/icalendar_notification.text.erb
@@ -3,7 +3,7 @@
 
 <%= t(:text_notificiation_invited) %>
 
-<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
+<%=t :label_meeting_date_time %>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
 <%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
 <%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
 <%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/modules/meeting/app/views/meeting_mailer/invited.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.html.erb
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
               <%= I18n.t(:label_meeting_date_time) %>
             </td>
             <td style="<%= placeholder_text_styles %>">
-              <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
+              <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>
               -
               <%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
             </td>

--- a/modules/meeting/app/views/meeting_mailer/invited.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.text.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= @meeting.project.name %>: <%= @meeting.title %> (<%= meeting_url(@meeting) %>)
 <%= @meeting.author %>
 
-<%=t :label_meeting_date_time %>: <%= format_time_as_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
+<%=t :label_meeting_date_time %>: <%= format_date @meeting.start_time %> <%= format_time @meeting.start_time, include_date: false %>-<%= format_time @meeting.end_time, include_date: false %> (<%= formatted_time_zone_offset %>)
 <%= Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
 <%= Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
 <%= Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/modules/meeting/app/views/meeting_mailer/rescheduled.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/rescheduled.html.erb
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
             </td>
             <td style="<%= placeholder_text_styles %>">
               <s>
-                <%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %>
+                <%= format_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %>
                 -
                 <%= format_time (@changes[:old_start] + @changes[:old_duration].hours), include_date: false %> (<%= formatted_time_zone_offset %>)
               </s>
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
               <%= t("meeting.email.rescheduled.new_date_time") %>
             </td>
             <td style="<%= placeholder_text_styles("font-weight": "bold") %>">
-              <%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %>
+              <%= format_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %>
               -
               <%= format_time (@changes[:new_start] + @changes[:new_duration].hours), include_date: false %> (<%= formatted_time_zone_offset %>)
             </td>

--- a/modules/meeting/app/views/meeting_mailer/rescheduled.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/rescheduled.text.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
     ) %>
 
 <%= t("meeting.email.rescheduled.old_date_time") %>:
-<%= format_time_as_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %> - <%= format_time (@changes[:old_start] + @changes[:old_duration]), include_date: false %> (<%= formatted_time_zone_offset %>}
+<%= format_date @changes[:old_start] %> <%= format_time @changes[:old_start], include_date: false %> - <%= format_time (@changes[:old_start] + @changes[:old_duration]), include_date: false %> (<%= formatted_time_zone_offset %>}
 
 <%= t("meeting.email.rescheduled.new_date_time") %>:
-<%= format_time_as_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %> - <%= format_time (@changes[:new_start] + @changes[:new_duration]), include_date: false %> (<%= formatted_time_zone_offset %>}
+<%= format_date @changes[:new_start] %> <%= format_time @changes[:new_start], include_date: false %> - <%= format_time (@changes[:new_start] + @changes[:new_duration]), include_date: false %> (<%= formatted_time_zone_offset %>}

--- a/modules/meeting/app/views/meeting_series_mailer/template_completed.html.erb
+++ b/modules/meeting/app/views/meeting_series_mailer/template_completed.html.erb
@@ -54,7 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
               <%= I18n.t(:label_recurring_meeting_next_occurrence) %>
             </td>
             <td style="<%= placeholder_text_styles %>">
-              <%= format_time_as_date @next_occurrence %> <%= format_time @next_occurrence, include_date: false %>
+              <%= format_date @next_occurrence %> <%= format_time @next_occurrence, include_date: false %>
               (<%= formatted_time_zone_offset %>)
             </td>
           </tr>

--- a/modules/xls_export/app/models/xls_export/concerns/spreadsheet_builder.rb
+++ b/modules/xls_export/app/models/xls_export/concerns/spreadsheet_builder.rb
@@ -79,7 +79,7 @@ module XlsExport
       def xls_export_filename
         sane_filename(
           "#{Setting.app_title} #{spreadsheet_title} \
-          #{format_time_as_date(Time.zone.now, format: '%Y-%m-%d')}.xls"
+          #{format_date(Time.zone.now, format: '%Y-%m-%d')}.xls"
         )
       end
     end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -37,7 +37,7 @@ module OpenProject
     let(:format) { "%d/%m/%Y" }
     let(:user) { build_stubbed(:user) }
 
-    describe "#format_time_as_date" do
+    describe "#format_date with time" do
       current_user { build_stubbed(:user, preferences: { time_zone: user_time_zone }) }
 
       describe "with user time zone" do
@@ -45,12 +45,12 @@ module OpenProject
 
         it "returns a date string in the user timezone for a utc timestamp" do
           time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format:)).to eq "01/07/2013"
+          expect(format_date(time, format:)).to eq "01/07/2013"
         end
 
         it "returns a date string in the user timezone for a non-utc timestamp" do
           time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format:)).to eq "01/07/2013"
+          expect(format_date(time, format:)).to eq "01/07/2013"
         end
       end
 
@@ -59,12 +59,12 @@ module OpenProject
 
         it "returns a date string in the utc timezone for a utc timestamp" do
           time = ActiveSupport::TimeZone["UTC"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format:)).to eq "30/06/2013"
+          expect(format_date(time, format:)).to eq "30/06/2013"
         end
 
         it "returns a date string in the utc timezone for a non-utc timestamp" do
           time = ActiveSupport::TimeZone["Berlin"].local(2013, 6, 30, 23, 59)
-          expect(format_time_as_date(time, format:)).to eq "30/06/2013"
+          expect(format_date(time, format:)).to eq "30/06/2013"
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/63911/activity


<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Provide a consistent interface to format dates with `format_date` to work the same as `format_time`.
