### PR TITLE
Fix meeting time zone handling

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
@@ -33,8 +33,8 @@ import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 export default class extends ApplicationController {
-  private turboRequests:TurboRequestsService;
-  private pathHelper:PathHelperService;
+  protected turboRequests:TurboRequestsService;
+  protected pathHelper:PathHelperService;
 
   async connect() {
     const context = await window.OpenProject.getPluginContext();

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
@@ -10,7 +10,13 @@ export default class OpRecurringMeetingsFormController extends OpMeetingsFormCon
   updateFrequencyText():void {
     const data = new FormData(this.element as HTMLFormElement);
     const urlSearchParams = new URLSearchParams();
-    ['start_date', 'start_time_hour', 'frequency', 'interval'].forEach((name) => {
+    [
+      'start_date',
+      'start_time_hour',
+      'frequency',
+      'interval',
+      'time_zone',
+    ].forEach((name) => {
       const key = `meeting[${name}]`;
       urlSearchParams.append(key, data.get(key) as string);
     });

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
@@ -1,16 +1,11 @@
-import { ApplicationController } from 'stimulus-use';
-import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import OpMeetingsFormController from 'core-stimulus/controllers/dynamic/meetings/form.controller';
 
-export default class OpRecurringMeetingsFormController extends ApplicationController {
-  private turboRequests:TurboRequestsService;
-  private pathHelper:PathHelperService;
+export default class OpRecurringMeetingsFormController extends OpMeetingsFormController {
+  static values = {
+    persisted: Boolean,
+  };
 
-  async connect() {
-    const context = await window.OpenProject.getPluginContext();
-    this.turboRequests = context.services.turboRequests;
-    this.pathHelper = context.services.pathHelperService;
-  }
+  declare persistedValue:boolean;
 
   updateFrequencyText():void {
     const data = new FormData(this.element as HTMLFormElement);
@@ -30,5 +25,14 @@ export default class OpRecurringMeetingsFormController extends ApplicationContro
           },
         },
       );
+  }
+
+  updateTimezoneText() {
+    // We don't update the timezone text on editing recurring meetings
+    if (this.persistedValue) {
+      return;
+    }
+
+    super.updateTimezoneText();
   }
 }

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -36,6 +36,7 @@
     "paths": {
       "@ng-select/ng-select": ["../node_modules/@ng-select/ng-select/"],
       "core-app/*": ["./app/*"],
+      "core-stimulus/*": ["./stimulus/*"],
       "core-typings/*": [
         "./typings/*"
       ],

--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -7,10 +7,10 @@
       data: {
         turbo: true,
         controller: [
-          "meetings--form",
           "show-when-value-selected",
           @meeting.is_a?(RecurringMeeting) ? "recurring-meetings--form" : nil
-        ].compact.join(" ")
+        ].compact.join(" "),
+        "recurring-meetings--form-persisted-value": @meeting.persisted?
       },
       html: {
         id: "meeting-form"

--- a/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
@@ -8,6 +8,7 @@ module RecurringMeetings
 
     def humanize_schedule
       text = @recurring_meeting.human_frequency_schedule
+
       respond_to do |format|
         format.html { render plain: text }
         format.turbo_stream do
@@ -28,9 +29,7 @@ module RecurringMeetings
     end
 
     def schedule_params
-      params
-        .require(:meeting)
-        .permit(:start_date, :start_time_hour, :frequency, :interval)
+      params.expect(meeting: %i[start_date start_time_hour frequency interval time_zone])
     end
   end
 end

--- a/modules/meeting/app/forms/meeting/time_group.rb
+++ b/modules/meeting/app/forms/meeting/time_group.rb
@@ -98,6 +98,8 @@ class Meeting::TimeGroup < ApplicationForm
   end
 
   def timezone_caption
+    return if @meeting.is_a?(RecurringMeeting) && @meeting.persisted?
+
     friendly_timezone_name(User.current.time_zone, period: @meeting.start_time)
   end
 end

--- a/modules/meeting/app/forms/meeting/time_group.rb
+++ b/modules/meeting/app/forms/meeting/time_group.rb
@@ -42,6 +42,11 @@ class Meeting::TimeGroup < ApplicationForm
           )
         ) { I18n.t("recurring_meeting.time_zone_difference_banner.title") }
       end
+
+      meeting_form.hidden(
+        name: :time_zone,
+        value: @meeting.time_zone.name
+      )
     end
 
     meeting_form.group(layout: :horizontal) do |group|

--- a/modules/meeting/app/forms/meeting/time_group.rb
+++ b/modules/meeting/app/forms/meeting/time_group.rb
@@ -31,6 +31,19 @@ class Meeting::TimeGroup < ApplicationForm
   include Redmine::I18n
 
   form do |meeting_form|
+    if editing_recurring? && User.current.time_zone != @meeting.time_zone
+      meeting_form.html_content do
+        render(
+          Primer::Alpha::Banner.new(
+            description: I18n.t("recurring_meeting.time_zone_difference_banner.description",
+                                actual_zone: friendly_timezone_name(@meeting.time_zone),
+                                user_zone: friendly_timezone_name(User.current.time_zone)),
+            scheme: :warning
+          )
+        ) { I18n.t("recurring_meeting.time_zone_difference_banner.title") }
+      end
+    end
+
     meeting_form.group(layout: :horizontal) do |group|
       group.text_field(
         name: :start_date,
@@ -98,8 +111,12 @@ class Meeting::TimeGroup < ApplicationForm
   end
 
   def timezone_caption
-    return if @meeting.is_a?(RecurringMeeting) && @meeting.persisted?
+    return if editing_recurring?
 
     friendly_timezone_name(User.current.time_zone, period: @meeting.start_time)
+  end
+
+  def editing_recurring?
+    @meeting.is_a?(RecurringMeeting) && @meeting.persisted?
   end
 end

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -167,6 +167,12 @@ class Meeting < ApplicationRecord
     !!template
   end
 
+  # One-time meeting time zone
+  # is always in the user's time zone
+  def time_zone
+    User.current.time_zone
+  end
+
   # Returns true if user or current user is allowed to view the meeting
   def visible?(user = User.current)
     user.allowed_in_project?(:view_meetings, project)

--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -112,8 +113,8 @@ module Meeting::VirtualStartTime
   end
 
   def update_derived_fields
-    @start_date = format_date(start_time, format: "%Y-%m-%d")
-    @start_time_hour = format_time(start_time, include_date: false, format: "%H:%M")
+    @start_date = format_date(start_time, time_zone:, format: "%Y-%m-%d")
+    @start_time_hour = format_time(start_time, time_zone:, include_date: false, format: "%H:%M")
   end
 
   ##

--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -50,7 +50,7 @@ module Meeting::VirtualStartTime
   ##
   # Actually sets the aggregated start_time attribute.
   def update_start_time!
-    write_attribute(:start_time, start_time)
+    self[:start_time] = start_time
   end
 
   ##
@@ -80,7 +80,7 @@ module Meeting::VirtualStartTime
 
     return if date.nil? || time.nil?
 
-    Time.zone.local(
+    time_zone.local(
       date.year,
       date.month,
       date.day,
@@ -92,7 +92,7 @@ module Meeting::VirtualStartTime
   def set_initial_values
     # set defaults
     # Start date is set to tomorrow at 10 AM (Current users local time)
-    write_attribute(:start_time, User.current.time_zone.now.at_midnight + 34.hours) if start_time.nil?
+    self[:start_time] = time_zone.now.at_midnight + 34.hours if start_time.nil?
     update_derived_fields
   end
 

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -142,9 +142,15 @@ class RecurringMeeting < ApplicationRecord
     super&.in_time_zone(time_zone)
   end
 
+  def time_zone_differs?
+    time_zone != User.current.time_zone
+  end
+
   def time_zone
-    time_zone_string = super || User.current.time_zone
-    ActiveSupport::TimeZone[time_zone_string]
+    time_zone_string = super
+    zone = ActiveSupport::TimeZone[time_zone_string] if time_zone_string.present?
+
+    zone || User.current.time_zone
   end
 
   def schedule
@@ -193,9 +199,11 @@ class RecurringMeeting < ApplicationRecord
   end
 
   def human_frequency_schedule
+    formatted_time = format_time(start_time, time_zone:, include_date: false)
+    time = time_zone_differs? ? "#{formatted_time} (#{friendly_timezone_name(time_zone)})" : formatted_time
     I18n.t("recurring_meeting.in_words.frequency",
            base: base_schedule,
-           time: format_time(start_time, include_date: false))
+           time:)
   end
 
   def reschedule_required?(previous: false)

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -143,7 +143,7 @@ class RecurringMeeting < ApplicationRecord
   end
 
   def time_zone
-    time_zone_string = super || Setting.user_default_timezone.presence || "Etc/UTC"
+    time_zone_string = super || User.current.time_zone
     ActiveSupport::TimeZone[time_zone_string]
   end
 

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -95,7 +95,7 @@ module RecurringMeetings
 
       schedule_meetings.each do |scheduled|
         # Ensure we treat the start_time as a local time of the series
-        start_time = scheduled.start_time.in_zone(recurring_meeting.time_zone)
+        start_time = scheduled.start_time.in_time_zone(recurring_meeting.time_zone)
         # so that we change the correct hour/minute
         new_time = start_time.change(
           hour: recurring_meeting.start_time.hour,

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -94,7 +94,10 @@ module RecurringMeetings
       schedule_meetings = recurring_meeting.scheduled_meetings
 
       schedule_meetings.each do |scheduled|
-        new_time = scheduled.start_time.change(
+        # Ensure we treat the start_time as a local time of the series
+        start_time = scheduled.start_time.in_zone(recurring_meeting.time_zone)
+        # so that we change the correct hour/minute
+        new_time = start_time.change(
           hour: recurring_meeting.start_time.hour,
           min: recurring_meeting.start_time.min
         )
@@ -169,7 +172,7 @@ module RecurringMeetings
       GoodJob::Job.where(finished_at: nil, concurrency_key:).delete_all
 
       # Ensure we init the next meeting directly
-      InitNextOccurrenceJob.perform_now(recurring_meeting, recurring_meeting.next_occurrence.to_time)
+      InitNextOccurrenceJob.perform_now(recurring_meeting, recurring_meeting.next_occurrence)
     end
 
     def should_reschedule?(recurring_meeting)

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -57,7 +57,7 @@ module RecurringMeetings
 
     def perform(recurring_meeting, scheduled_time)
       self.recurring_meeting = recurring_meeting
-      self.scheduled_time = scheduled_time.in_zone(recurring_meeting.time_zone)
+      self.scheduled_time = scheduled_time.in_time_zone(recurring_meeting.time_zone)
 
       # Schedule the next job
       schedule_next_job

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -57,7 +57,7 @@ module RecurringMeetings
 
     def perform(recurring_meeting, scheduled_time)
       self.recurring_meeting = recurring_meeting
-      self.scheduled_time = scheduled_time
+      self.scheduled_time = scheduled_time.in_zone(recurring_meeting.time_zone)
 
       # Schedule the next job
       schedule_next_job

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -289,6 +289,11 @@ en:
 
 
   recurring_meeting:
+    time_zone_difference_banner:
+      title: "Time zone difference"
+      description: >
+        The dates below are referencing the time zone of the meeting series (%{actual_zone}),
+        not your local time zone (%{user_zone}).
     ended_blankslate:
         title: "Meeting series ended"
         message: "This meeting series has come to an end. There are no upcoming meetings. "

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -162,15 +162,7 @@ RSpec.describe Meeting do
     end
 
     context "other timezone set" do
-      let!(:old_time_zone) { Time.zone }
-
-      before do
-        Time.zone = "EST"
-      end
-
-      after do
-        Time.zone = old_time_zone.name
-      end
+      current_user { build_stubbed(:user, preferences: { time_zone: "EST" }) }
 
       it_behaves_like "uses that zone", "EST"
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62375/activity
https://community.openproject.org/work_packages/63549/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Ensure consistent handling of the user's time zone and the stored meeting's time zone, so that when:

1. A meeting is rescheduled, we do not accidentally compute the new time from the current user's time zone

2. When a meeting is edited in a different time zone than the current user's, a warning is shown that this is happening.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
