### PR TITLE
[chore] fix pattern attribute matcher

### DIFF
--- a/frontend/src/stimulus/controllers/pattern-input.controller.ts
+++ b/frontend/src/stimulus/controllers/pattern-input.controller.ts
@@ -444,7 +444,7 @@ export default class PatternInputController extends Controller {
         key,
         label: group.title,
         values: group.tokens
-          .filter((token) => token.key.includes(word) || token.label.includes(word) || word === '*')
+          .filter((token) => token.key.includes(word) || token.label.toLowerCase().includes(word) || word === '*')
           .map((token) => ({ prop: token.key, value: token.label })),
       };
     }).filter((group) => group.values.length > 0);


### PR DESCRIPTION
# What are you trying to accomplish?
- searching for words in custom field names must work

# What approach did you choose and why?
- label must be cast to lowercase for search matches
