### PR TITLE
[63831] Fix error 500 when bulk deleting related work packages

### DIFF
--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
            principal: user,
            roles: [role])
   end
-  shared_let(:work_package1) do
+  shared_let(:work_package1, refind: true) do
     create(:work_package,
            author: user,
            assigned_to: user,
@@ -91,7 +91,7 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
            custom_field_values: { custom_field1.id => custom_field_value },
            project: project1)
   end
-  shared_let(:work_package2) do
+  shared_let(:work_package2, refind: true) do
     create(:work_package,
            author: user,
            assigned_to: user,
@@ -101,7 +101,7 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
            custom_field_values: { custom_field1.id => custom_field_value },
            project: project1)
   end
-  shared_let(:work_package3) do
+  shared_let(:work_package3, refind: true) do
     create(:work_package,
            author: user,
            type:,
@@ -641,6 +641,24 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
         send_destroy_request
         expect(WorkPackage.count).to eq(0)
         expect(response).to redirect_to(project_work_packages_path(work_package1.project))
+      end
+    end
+
+    context "with children work packages following each other" do
+      before_all do
+        work_package1.update(subject: "parent", schedule_manually: false)
+        work_package2.update(subject: "predecessor child", parent: work_package1, schedule_manually: true)
+        work_package3.update(subject: "successor child", parent: work_package1, schedule_manually: false)
+        create(:follows_relation, predecessor: work_package2, successor: work_package3)
+      end
+
+      let(:params) { { "ids" => [work_package1.id, work_package2.id, work_package3.id] } }
+
+      it "deletes them all without errors" do
+        send_destroy_request
+
+        expect(WorkPackage.count).to eq(0)
+        expect(response).to redirect_to(project_work_packages_path(project1))
       end
     end
   end

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
       let(:params) { { "ids" => [work_package1.id, work_package2.id, work_package3.id] } }
 
       it "deletes them all without errors" do
-        send_destroy_request
+        expect { send_destroy_request }.not_to raise_error
 
         expect(WorkPackage.count).to eq(0)
         expect(response).to redirect_to(project_work_packages_path(project1))

--- a/spec/services/work_packages/delete_service_spec.rb
+++ b/spec/services/work_packages/delete_service_spec.rb
@@ -133,10 +133,14 @@ RSpec.describe WorkPackages::DeleteService do
 
   context "with descendants" do
     let(:child) do
-      build_stubbed(:work_package)
+      build_stubbed(:work_package).tap do |wp|
+        allow(wp).to receive(:reload).and_return(wp)
+      end
     end
     let(:grandchild) do
-      build_stubbed(:work_package)
+      build_stubbed(:work_package).tap do |wp|
+        allow(wp).to receive(:reload).and_return(wp)
+      end
     end
     let(:descendants) do
       [child, grandchild]


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63831

# What are you trying to accomplish?

Prevent 500 error which can occur when bulk deleting work packages.

It occurs for instance in this situation: 3 work packages. One parent and two children following each other.

## Screenshots

Not applicable

# What approach did you choose and why?

When bulk deleting work packages, successors of descendants are rescheduled, because as they have one less predecessor, they may need to be switched to manual scheduling mode.

Problem: if one of these successor to reschedule is also a child of the deleted work package, then it cannot be rescheduled: it's deleted. When trying to rescheduled and save it, the error
`ActiveRecord::StaleObjectError` is raised.

Solution: only reschedule successors that are not descendants of the deleted work package.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
