### PR TITLE
Deprecate outdated API link

### DIFF
--- a/docs/api/apiv3/components/schemas/project_storage_model.yml
+++ b/docs/api/apiv3/components/schemas/project_storage_model.yml
@@ -81,15 +81,18 @@ properties:
           - $ref: './link.yml'
           - description: |-
               A link to OpenProject strorage.
+
+              # Conditions
+
+              If the storage has not been configured(oauth client is missing, for instance), then the link is null.
       openWithConnectionEnsured:
         allOf:
           - $ref: './link.yml'
           - description: |-
               A link to OpenProject storage with making sure user has access to it.
 
-              # Conditions
-
-              If the storage has not been configured(oauth client is missing, for instance), then the link is null.
+              **Deprecated:** Use `open` instead, which returns a link that will ensure the user's connection to the storage
+              as well, but properly works for all kinds of storage configurations.
 example:
   _type: 'ProjectStorage'
   id: 1337
@@ -113,4 +116,4 @@ example:
     open:
       href: '/api/v3/storages/81/open'
     openWithConnectionEnsured:
-      href: '/oauth_clients/123/ensure_connection?destination_url=https%3A%2F%2Fopenproject.local%2Fprojects%2Fdeath-star%2Fproject_storages%2F23%2Fopen&storage_id=81'
+      href: '/api/v3/storages/81/open'

--- a/frontend/src/app/core/state/project-storages/project-storage.model.ts
+++ b/frontend/src/app/core/state/project-storages/project-storage.model.ts
@@ -35,7 +35,6 @@ export interface IProjectStorageHalResourceLinks extends IHalResourceLinks {
   creator:IHalResourceLink;
   projectFolder?:IHalOptionalTitledLink;
   open?:IHalResourceLink;
-  openWithConnectionEnsured?:IHalResourceLink;
 }
 
 export interface IProjectStorage {

--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -216,7 +216,7 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
   };
 
   public get openStorageLink() {
-    return this.projectStorage._links.openWithConnectionEnsured?.href || this.projectStorage._links.open?.href;
+    return this.projectStorage._links.open?.href;
   }
 
   constructor(

--- a/modules/storages/app/models/storages/project_storage.rb
+++ b/modules/storages/app/models/storages/project_storage.rb
@@ -96,19 +96,6 @@ module Storages
       end
     end
 
-    # TODO: This method should be removed, callers should refer to the project_storages_controller and its "open" action
-    #       directly, which already takes care of ensuring the connection when needed.
-    def open_with_connection_ensured
-      return unless storage.configured?
-      return open_project_storage_url if storage.authenticate_via_idp?
-
-      OpenProject::StaticRouting::StaticRouter.new.url_helpers.oauth_clients_ensure_connection_path(
-        oauth_client_id: storage.oauth_client.client_id,
-        storage_id: storage.id,
-        destination_url: open_project_storage_url
-      )
-    end
-
     def open_project_storage_url
       OpenProject::StaticRouting::StaticRouter.new.url_helpers.open_project_storage_url(project_id: project.identifier, id:)
     end

--- a/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
+++ b/modules/storages/lib/api/v3/project_storages/project_storage_representer.rb
@@ -57,7 +57,7 @@ module API::V3::ProjectStorages
     link :openWithConnectionEnsured do
       next unless show_open_storage_links
 
-      { href: represented.open_with_connection_ensured }
+      { href: api_v3_paths.project_storage_open(represented.id) }
     end
 
     associated_resource :storage, skip_render: ->(*) { true }, skip_link: ->(*) { false }

--- a/modules/storages/spec/lib/api/v3/project_storages/project_storage_representer_spec.rb
+++ b/modules/storages/spec/lib/api/v3/project_storages/project_storage_representer_spec.rb
@@ -96,20 +96,9 @@ RSpec.describe API::V3::ProjectStorages::ProjectStorageRepresenter do
       let(:href) { api_v3_paths.project_storage_open(project_storage.id) }
     end
 
-    context "when storage is not configured" do
-      it_behaves_like "has an untitled link" do
-        let(:link) { "openWithConnectionEnsured" }
-        let(:href) { nil }
-      end
-    end
-
-    context "when storage is configured" do
-      before { project_storage.storage = create(:nextcloud_storage_configured) }
-
-      it_behaves_like "has an untitled link" do
-        let(:link) { "openWithConnectionEnsured" }
-        let(:href) { ensure_connection_path(project_storage) }
-      end
+    it_behaves_like "has an untitled link" do
+      let(:link) { "openWithConnectionEnsured" }
+      let(:href) { api_v3_paths.project_storage_open(project_storage.id) }
     end
 
     context "when user does not have read_files permission" do


### PR DESCRIPTION
Having a separate "ensure connection" link does not add any value, because even the original "open" link does redirect unconnected users properly. On the other hand, immediately returning an ensure_connection URL is only possible if the storage was configured for mutual OAuth 2 authentication, not for authentication through an SSO provider.

# Ticket
https://community.openproject.org/wp/63691