### PR TITLE
Freeze string literals in the meetings module

### DIFF
--- a/modules/meeting/app/components/authors/autocomplete_item_component.rb
+++ b/modules/meeting/app/components/authors/autocomplete_item_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/base_errors_component.rb
+++ b/modules/meeting/app/components/base_errors_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_agenda_items/item_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/edit_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/edit_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_agenda_items/new_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/combined_filter_component.rb
+++ b/modules/meeting/app/components/meetings/combined_filter_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/header_infoline_component.rb
+++ b/modules/meeting/app/components/meetings/header_infoline_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/history_component.rb
+++ b/modules/meeting/app/components/meetings/history_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Meetings
   class HistoryComponent < ApplicationComponent
     include ApplicationHelper

--- a/modules/meeting/app/components/meetings/index/dialog_component.rb
+++ b/modules/meeting/app/components/meetings/index/dialog_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/index/form_component.rb
+++ b/modules/meeting/app/components/meetings/index/form_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/show_component.rb
+++ b/modules/meeting/app/components/meetings/show_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel/attachments_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/attachments_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel/details_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel/details_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_dialog_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel/participants_dialog.rb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_dialog.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/side_panel_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/table_footer_component.rb
+++ b/modules/meeting/app/components/meetings/table_footer_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/meetings/update_flash_component.rb
+++ b/modules/meeting/app/components/meetings/update_flash_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_dialog_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_dialog_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/heading_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/heading_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/index_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/index_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/list_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/list_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_agenda_items/base_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/base_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_agenda_items/delete_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/delete_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_agenda_items/modifiable_item.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/modifiable_item.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_agenda_items/update_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/update_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_sections/base_contract.rb
+++ b/modules/meeting/app/contracts/meeting_sections/base_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_sections/delete_contract.rb
+++ b/modules/meeting/app/contracts/meeting_sections/delete_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_sections/modifiable_item.rb
+++ b/modules/meeting/app/contracts/meeting_sections/modifiable_item.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_sections/move_contract.rb
+++ b/modules/meeting/app/contracts/meeting_sections/move_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_sections/update_contract.rb
+++ b/modules/meeting/app/contracts/meeting_sections/update_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meetings/base_contract.rb
+++ b/modules/meeting/app/contracts/meetings/base_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/meetings/delete_contract.rb
+++ b/modules/meeting/app/contracts/meetings/delete_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/recurring_meetings/base_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/base_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/contracts/recurring_meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/create_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/controllers/concerns/meetings/work_package_meetings_tab_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/work_package_meetings_tab_component_streams.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/controllers/meetings/menus_controller.rb
+++ b/modules/meeting/app/controllers/meetings/menus_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RecurringMeetings
   class ScheduleController < ApplicationController
     authorize_with_permission :create_meetings, global: true

--- a/modules/meeting/app/forms/meeting/copied_from.rb
+++ b/modules/meeting/app/forms/meeting/copied_from.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/copy_attachments.rb
+++ b/modules/meeting/app/forms/meeting/copy_attachments.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/copy_items.rb
+++ b/modules/meeting/app/forms/meeting/copy_items.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/copy_participants.rb
+++ b/modules/meeting/app/forms/meeting/copy_participants.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/email_participants.rb
+++ b/modules/meeting/app/forms/meeting/email_participants.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/location.rb
+++ b/modules/meeting/app/forms/meeting/location.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/lock_version.rb
+++ b/modules/meeting/app/forms/meeting/lock_version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/project_autocompleter.rb
+++ b/modules/meeting/app/forms/meeting/project_autocompleter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/time_group.rb
+++ b/modules/meeting/app/forms/meeting/time_group.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting/title.rb
+++ b/modules/meeting/app/forms/meeting/title.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/duration.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/duration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_section_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_section_form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/notes.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/notes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/presenter.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/presenter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/submit.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/submit.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/title.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/title.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_agenda_item/work_package.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/work_package.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_section/submit.rb
+++ b/modules/meeting/app/forms/meeting_section/submit.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/meeting_section/title.rb
+++ b/modules/meeting/app/forms/meeting_section/title.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/recurring_meeting/end_after.rb
+++ b/modules/meeting/app/forms/recurring_meeting/end_after.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/recurring_meeting/interval.rb
+++ b/modules/meeting/app/forms/recurring_meeting/interval.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/recurring_meeting/iterations.rb
+++ b/modules/meeting/app/forms/recurring_meeting/iterations.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/forms/recurring_meeting/specific_date.rb
+++ b/modules/meeting/app/forms/recurring_meeting/specific_date.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/mailers/meeting_series_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_series_mailer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/activities/meeting_activity_provider.rb
+++ b/modules/meeting/app/models/activities/meeting_activity_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/activities/meeting_event_mapper.rb
+++ b/modules/meeting/app/models/activities/meeting_event_mapper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/journal/meeting_content_journal.rb
+++ b/modules/meeting/app/models/journal/meeting_content_journal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/journal/meeting_journal.rb
+++ b/modules/meeting/app/models/journal/meeting_journal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting/chronic_duration.rb
+++ b/modules/meeting/app/models/meeting/chronic_duration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting/journalized.rb
+++ b/modules/meeting/app/models/meeting/journalized.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting/virtual_start_time.rb
+++ b/modules/meeting/app/models/meeting/virtual_start_time.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting_agenda.rb
+++ b/modules/meeting/app/models/meeting_agenda.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting_content.rb
+++ b/modules/meeting/app/models/meeting_content.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting_minutes.rb
+++ b/modules/meeting/app/models/meeting_minutes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/meeting_section.rb
+++ b/modules/meeting/app/models/meeting_section.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings.rb
+++ b/modules/meeting/app/models/queries/meetings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/attended_user_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/attended_user_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/author_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/author_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/dates_interval_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/dates_interval_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/invited_user_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/invited_user_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/meeting_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/meeting_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/project_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/project_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/recurring_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/recurring_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
+++ b/modules/meeting/app/models/queries/meetings/filters/time_filter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,8 +29,8 @@
 #++
 
 class Queries::Meetings::Filters::TimeFilter < Queries::Meetings::Filters::MeetingFilter
-  PAST_VALUE = "past".freeze
-  FUTURE_VALUE = "future".freeze
+  PAST_VALUE = "past"
+  FUTURE_VALUE = "future"
 
   validate :validate_only_single_value
 

--- a/modules/meeting/app/models/queries/meetings/meeting_query.rb
+++ b/modules/meeting/app/models/queries/meetings/meeting_query.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/queries/meetings/orders/default_order.rb
+++ b/modules/meeting/app/models/queries/meetings/orders/default_order.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/models/scheduled_meeting.rb
+++ b/modules/meeting/app/models/scheduled_meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_agenda_items_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_agenda_items_seeder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_agenda_items/after_perform_hook.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/after_perform_hook.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_agenda_items/create_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/create_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_agenda_items/delete_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/delete_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_agenda_items/drop_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/drop_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_agenda_items/set_attributes_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/set_attributes_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_agenda_items/update_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/update_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_notification_service.rb
+++ b/modules/meeting/app/services/meeting_notification_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class MeetingNotificationService
   attr_reader :meeting, :content_type
 

--- a/modules/meeting/app/services/meeting_sections/create_service.rb
+++ b/modules/meeting/app/services/meeting_sections/create_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_sections/delete_service.rb
+++ b/modules/meeting/app/services/meeting_sections/delete_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_sections/set_attributes_service.rb
+++ b/modules/meeting/app/services/meeting_sections/set_attributes_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_sections/update_service.rb
+++ b/modules/meeting/app/services/meeting_sections/update_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meetings/ical_helpers.rb
+++ b/modules/meeting/app/services/meetings/ical_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meetings/ical_service.rb
+++ b/modules/meeting/app/services/meetings/ical_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/meetings/update_service.rb
+++ b/modules/meeting/app/services/meetings/update_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/recurring_meetings/ical_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/ical_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/services/recurring_meetings/with_template.rb
+++ b/modules/meeting/app/services/recurring_meetings/with_template.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
+++ b/modules/meeting/app/workers/recurring_meetings/init_next_occurrence_job.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,7 +33,7 @@ module RecurringMeetings
     include GoodJob::ActiveJobExtensions::Concurrency
     discard_on ActiveJob::DeserializationError
 
-    CONCURRENCY_KEY_BASE = "RecurringMeetings::InitNextOccurrenceJob-".freeze
+    CONCURRENCY_KEY_BASE = "RecurringMeetings::InitNextOccurrenceJob-"
 
     good_job_control_concurrency_with(
       # Allow the running job to enqueue the next one

--- a/modules/meeting/db/migrate/20180323135408_to_v710_aggregated_meeting_migrations.rb
+++ b/modules/meeting/db/migrate/20180323135408_to_v710_aggregated_meeting_migrations.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/db/migrate/20230816141222_create_meeting_agenda_items.rb
+++ b/modules/meeting/db/migrate/20230816141222_create_meeting_agenda_items.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateMeetingAgendaItems < ActiveRecord::Migration[5.1]
   def change
     create_table :meeting_agenda_items do |t|

--- a/modules/meeting/db/migrate/20230823113310_add_work_package_to_meeting_agenda_items.rb
+++ b/modules/meeting/db/migrate/20230823113310_add_work_package_to_meeting_agenda_items.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddWorkPackageToMeetingAgendaItems < ActiveRecord::Migration[5.1]
   def change
     add_reference :meeting_agenda_items, :work_package, index: true

--- a/modules/meeting/db/migrate/20230829122717_add_state_to_meetings.rb
+++ b/modules/meeting/db/migrate/20230829122717_add_state_to_meetings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddStateToMeetings < ActiveRecord::Migration[5.1]
   def change
     add_column :meetings, :state, :integer, default: 0, null: false

--- a/modules/meeting/db/migrate/20230911102918_add_type_to_meeting.rb
+++ b/modules/meeting/db/migrate/20230911102918_add_type_to_meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddTypeToMeeting < ActiveRecord::Migration[7.0]
   def change
     add_column :meetings, :type, :string, default: "Meeting", null: false

--- a/modules/meeting/db/migrate/20230918135247_change_meeting_agenda_item_description_to_notes.rb
+++ b/modules/meeting/db/migrate/20230918135247_change_meeting_agenda_item_description_to_notes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ChangeMeetingAgendaItemDescriptionToNotes < ActiveRecord::Migration[7.0]
   def change
     rename_column :meeting_agenda_items, :description, :notes

--- a/modules/meeting/db/migrate/20240313102951_add_presenter_to_meeting.rb
+++ b/modules/meeting/db/migrate/20240313102951_add_presenter_to_meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddPresenterToMeeting < ActiveRecord::Migration[7.1]
   def change
     add_reference :meeting_agenda_items, :presenter, type: :bigint, foreign_key: { to_table: :users }, index: true

--- a/modules/meeting/db/migrate/20240408161233_add_state_to_meeting_journal.rb
+++ b/modules/meeting/db/migrate/20240408161233_add_state_to_meeting_journal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddStateToMeetingJournal < ActiveRecord::Migration[7.1]
   def change
     add_column :meeting_journals, :state, :integer, default: 0, null: false

--- a/modules/meeting/db/migrate/20240418110249_set_author_as_presenter.rb
+++ b/modules/meeting/db/migrate/20240418110249_set_author_as_presenter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SetAuthorAsPresenter < ActiveRecord::Migration[7.1]
   def up
     execute "UPDATE meeting_agenda_items SET presenter_id = author_id WHERE presenter_id IS NULL"

--- a/modules/meeting/db/migrate/20240426073948_create_recurring_meetings.rb
+++ b/modules/meeting/db/migrate/20240426073948_create_recurring_meetings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateRecurringMeetings < ActiveRecord::Migration[7.1]
   def change
     create_table :recurring_meetings do |t|

--- a/modules/meeting/db/migrate/20240516102219_fix_untitled_meetings.rb
+++ b/modules/meeting/db/migrate/20240516102219_fix_untitled_meetings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class FixUntitledMeetings < ActiveRecord::Migration[7.1]
   def up
     MeetingSection.where(title: "Untitled").update_all(title: "")

--- a/modules/meeting/db/migrate/20241122143600_add_interval_to_recurring_meeting.rb
+++ b/modules/meeting/db/migrate/20241122143600_add_interval_to_recurring_meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class AddIntervalToRecurringMeeting < ActiveRecord::Migration[7.1]
   def change
     add_column :recurring_meetings, :interval, :integer,

--- a/modules/meeting/db/migrate/20241128190428_create_scheduled_meetings.rb
+++ b/modules/meeting/db/migrate/20241128190428_create_scheduled_meetings.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateScheduledMeetings < ActiveRecord::Migration[7.1]
   def change
     create_table :scheduled_meetings do |t|

--- a/modules/meeting/lib/api/v3/attachments/attachments_by_meeting_api.rb
+++ b/modules/meeting/lib/api/v3/attachments/attachments_by_meeting_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/attachments/attachments_by_meeting_content_api.rb
+++ b/modules/meeting/lib/api/v3/attachments/attachments_by_meeting_content_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meetings/meeting_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_collection_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meetings/meeting_contents_api.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_contents_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meetings/meetings_api.rb
+++ b/modules/meeting/lib/api/v3/meetings/meetings_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/agenda_item_diff.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/agenda_item_diff.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/agenda_item_duration.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/agenda_item_duration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/agenda_item_position.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/agenda_item_position.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/agenda_item_title.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/agenda_item_title.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/meeting_start_time.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/meeting_start_time.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/meeting_state.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/meeting_state.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/journal_formatter/meeting_work_package_id.rb
+++ b/modules/meeting/lib/open_project/journal_formatter/meeting_work_package_id.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/meeting.rb
+++ b/modules/meeting/lib/open_project/meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/meeting/patches/api/work_package_representer.rb
+++ b/modules/meeting/lib/open_project/meeting/patches/api/work_package_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module OpenProject::Meeting
   module Patches
     module API

--- a/modules/meeting/lib/open_project/meeting/patches/project_patch.rb
+++ b/modules/meeting/lib/open_project/meeting/patches/project_patch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/open_project/meeting/patches/setting_seeder_patch.rb
+++ b/modules/meeting/lib/open_project/meeting/patches/setting_seeder_patch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/lib/openproject-meeting.rb
+++ b/modules/meeting/lib/openproject-meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/openproject-meeting.gemspec
+++ b/modules/meeting/openproject-meeting.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "openproject-meeting"

--- a/modules/meeting/spec/factories/meeting_agenda_item_journal_factory.rb
+++ b/modules/meeting/spec/factories/meeting_agenda_item_journal_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/factories/meeting_journal_factory.rb
+++ b/modules/meeting/spec/factories/meeting_journal_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/factories/meeting_participant_factory.rb
+++ b/modules/meeting/spec/factories/meeting_participant_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/factories/scheduled_meeting_factory.rb
+++ b/modules/meeting/spec/factories/scheduled_meeting_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/features/meetings_activity_spec.rb
+++ b/modules/meeting/spec/features/meetings_activity_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_create_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/lib/open_project/markdown_formatting_spec.rb
+++ b/modules/meeting/spec/lib/open_project/markdown_formatting_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/permitted_params_spec.rb
+++ b/modules/meeting/spec/models/permitted_params_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/project/activity_spec.rb
+++ b/modules/meeting/spec/models/project/activity_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/queries/meeting_query_spec.rb
+++ b/modules/meeting/spec/models/queries/meeting_query_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/queries/meetings/filters/dates_interval_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/meetings/filters/dates_interval_filter_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 require_module_spec_helper
 

--- a/modules/meeting/spec/requests/api/v3/attachments/meetings_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/attachments/meetings_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_index_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_index_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/services/meetings/create_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/create_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/services/meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/ical_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/services/meetings/update_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/update_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/services/recurring_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/ical_service_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/spec_helper.rb
+++ b/modules/meeting/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/support/pages/meetings/base.rb
+++ b/modules/meeting/spec/support/pages/meetings/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/support/pages/meetings/edit.rb
+++ b/modules/meeting/spec/support/pages/meetings/edit.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/support/pages/recurring_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/recurring_meeting/show.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
+++ b/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH


### PR DESCRIPTION
Achieved through

    rubocop -A --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment,Style/RedundantFreeze modules/meeting

Part of freezing string literals across the application step-by-step to be well prepared for future Ruby releases.