### PR TITLE
Freeze string literals in the 2FA module

### DIFF
--- a/modules/two_factor_authentication/Gemfile
+++ b/modules/two_factor_authentication/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec

--- a/modules/two_factor_authentication/app/components/two_factor_authentication/devices/row_component.rb
+++ b/modules/two_factor_authentication/app/components/two_factor_authentication/devices/row_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module Devices
     class RowComponent < ::RowComponent

--- a/modules/two_factor_authentication/app/components/two_factor_authentication/devices/table_component.rb
+++ b/modules/two_factor_authentication/app/components/two_factor_authentication/devices/table_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module Devices
     class TableComponent < ::TableComponent

--- a/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/backup_codes.rb
+++ b/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/backup_codes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module BackupCodes
     extend ActiveSupport::Concern

--- a/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/remember_token.rb
+++ b/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/remember_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module RememberToken
     extend ActiveSupport::Concern

--- a/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/webauthn_relying_party.rb
+++ b/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/webauthn_relying_party.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module WebauthnRelyingParty
     extend ActiveSupport::Concern

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/authentication_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   class AuthenticationController < ApplicationController
     # Remember token functionality

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   class BaseController < ApplicationController
     include ::TwoFactorAuthentication::WebauthnRelyingParty

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module ForcedRegistration
     class TwoFactorDevicesController < ::TwoFactorAuthentication::BaseController

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/backup_codes_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/backup_codes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module My
     class BackupCodesController < ::ApplicationController

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/remember_cookie_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module My
     class RememberCookieController < ::ApplicationController

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module My
     class TwoFactorDevicesController < ::TwoFactorAuthentication::BaseController

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/two_factor_settings_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/two_factor_settings_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   class TwoFactorSettingsController < ApplicationController
     include EnterpriseTrialHelper

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/users/two_factor_devices_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::TwoFactorAuthentication
   module Users
     class TwoFactorDevicesController < ::TwoFactorAuthentication::BaseController

--- a/modules/two_factor_authentication/app/models/two_factor_authentication.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   def self.table_name_prefix
     "two_factor_authentication_"

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/backup_code.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/backup_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class BackupCode < ::Token::HashedToken
     class << self

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class Device < ApplicationRecord
     default_scope { order("id ASC") }

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device/sms.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device/sms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class Device::Sms < Device
     validates_presence_of :phone_number

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device/totp.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device/totp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rotp"
 
 module TwoFactorAuthentication

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device/webauthn.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device/webauthn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class Device::Webauthn < Device
     validates :webauthn_external_id, presence: true, uniqueness: { scope: :user_id }

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/remembered_auth_token.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/remembered_auth_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class RememberedAuthToken < ::Token::HashedToken
     include ::Token::ExpirableToken

--- a/modules/two_factor_authentication/app/services/two_factor_authentication/token_service.rb
+++ b/modules/two_factor_authentication/app/services/two_factor_authentication/token_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class TokenService
     attr_reader :user, :device, :strategy, :channel

--- a/modules/two_factor_authentication/app/services/two_factor_authentication/use_backup_code_service.rb
+++ b/modules/two_factor_authentication/app/services/two_factor_authentication/use_backup_code_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoFactorAuthentication
   class UseBackupCodeService
     attr_reader :user

--- a/modules/two_factor_authentication/config/routes.rb
+++ b/modules/two_factor_authentication/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   namespace "two_factor_authentication" do
     get :request, to: "authentication#request_otp"

--- a/modules/two_factor_authentication/db/migrate/20120214103300_aggregated_mobile_otp_migrations.rb
+++ b/modules/two_factor_authentication/db/migrate/20120214103300_aggregated_mobile_otp_migrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,14 +34,14 @@ require "open_project/plugins/migration_mapping"
 
 # This migration aggregates the migrations detailed in MIGRATION_FILES
 class AggregatedMobileOtpMigrations < ActiveRecord::Migration[5.0]
-  MIGRATION_FILES = <<-MIGRATIONS.freeze
+  MIGRATION_FILES = <<-MIGRATIONS
     001_add_user_phone.rb
     002_create_extended_tokens.rb
     003_remove_user_phone.rb
     004_add_user_verified_phone_unverified_phone.rb
   MIGRATIONS
 
-  OLD_PLUGIN_NAME = "redmine_two_factor_authentication_authentication".freeze
+  OLD_PLUGIN_NAME = "redmine_two_factor_authentication_authentication"
 
   def up
     migration_names = OpenProject::Plugins::MigrationMapping.migration_files_to_migration_names(MIGRATION_FILES, OLD_PLUGIN_NAME)

--- a/modules/two_factor_authentication/db/migrate/20130214130336_add_default_otp_channel_to_user.rb
+++ b/modules/two_factor_authentication/db/migrate/20130214130336_add_default_otp_channel_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/two_factor_authentication/db/migrate/20160331190036_change_default_channel.rb
+++ b/modules/two_factor_authentication/db/migrate/20160331190036_change_default_channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/two_factor_authentication/db/migrate/20171023190036_model_reorganization.rb
+++ b/modules/two_factor_authentication/db/migrate/20171023190036_model_reorganization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/two_factor_authentication/db/migrate/20230627133534_add_webauthn_fields_to_two_factor_table.rb
+++ b/modules/two_factor_authentication/db/migrate/20230627133534_add_webauthn_fields_to_two_factor_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddWebauthnFieldsToTwoFactorTable < ActiveRecord::Migration[7.0]
   def change
     add_column :two_factor_authentication_devices, :webauthn_external_id, :string, null: true

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject
   module TwoFactorAuthentication
     require "open_project/two_factor_authentication/engine"

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/engine.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open_project/plugins"
 require "webauthn"
 

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/patches.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject::TwoFactorAuthentication
   module Patches
   end

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/patches/user_patch.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/patches/user_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject::TwoFactorAuthentication::Patches
   module UserPatch
     def self.included(base)

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/base.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject::TwoFactorAuthentication
   module TokenStrategy
     class Base

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/developer.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/developer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject::TwoFactorAuthentication
   module TokenStrategy
     class Developer < Base

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/message_bird.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/message_bird.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "messagebird"
 
 module OpenProject::TwoFactorAuthentication

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/sns.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/sns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 require "aws-sdk-sns"
 

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/totp.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/totp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rotp"
 
 module OpenProject::TwoFactorAuthentication

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/webauthn.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/webauthn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "webauthn"
 
 module OpenProject::TwoFactorAuthentication

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy_manager.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject::TwoFactorAuthentication
   module TokenStrategyManager
     class << self

--- a/modules/two_factor_authentication/lib/openproject-two_factor_authentication.rb
+++ b/modules/two_factor_authentication/lib/openproject-two_factor_authentication.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "open_project/two_factor_authentication"

--- a/modules/two_factor_authentication/openproject-two_factor_authentication.gemspec
+++ b/modules/two_factor_authentication/openproject-two_factor_authentication.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = "openproject-two_factor_authentication"
   s.version     = "1.0.0"

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_shared_examples.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_shared_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 
 RSpec.shared_examples "immediate success login" do

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/authentication_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "authentication_controller_shared_examples"
 

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../spec_helper"
 require_relative "../authentication_controller_shared_examples"
 

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/remember_cookie_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/remember_cookie_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../spec_helper"
 require_relative "../authentication_controller_shared_examples"
 

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../spec_helper"
 require_relative "../authentication_controller_shared_examples"
 

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/users/two_factor_devices_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../../spec_helper"
 require_relative "../authentication_controller_shared_examples"
 

--- a/modules/two_factor_authentication/spec/factories/two_factor_authentication_device_factory.rb
+++ b/modules/two_factor_authentication/spec/factories/two_factor_authentication_device_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :two_factor_authentication_device_sms, class: "::TwoFactorAuthentication::Device::Sms" do
     user

--- a/modules/two_factor_authentication/spec/features/account_activation_spec.rb
+++ b/modules/two_factor_authentication/spec/features/account_activation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 require_relative "shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 RSpec.describe "Admin 2FA management", :js, :selenium, with_settings: {

--- a/modules/two_factor_authentication/spec/features/backup_codes/generate_backup_codes_spec.rb
+++ b/modules/two_factor_authentication/spec/features/backup_codes/generate_backup_codes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/backup_codes/login_with_backup_code_spec.rb
+++ b/modules/two_factor_authentication/spec/features/backup_codes/login_with_backup_code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/login/login_enforced_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_enforced_2fa_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/login/login_with_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_with_2fa_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/login/login_with_deleted_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_with_deleted_2fa_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/login/login_without_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_without_2fa_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/login/switch_available_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/switch_available_devices_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/my_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/my_two_factor_devices_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 RSpec.describe "My Account 2FA configuration",

--- a/modules/two_factor_authentication/spec/features/password_change_spec.rb
+++ b/modules/two_factor_authentication/spec/features/password_change_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 RSpec.describe "Password change with OTP", :js, with_settings: {

--- a/modules/two_factor_authentication/spec/features/remember_cookie/login_with_remember_cookie_spec.rb
+++ b/modules/two_factor_authentication/spec/features/remember_cookie/login_with_remember_cookie_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require_relative "../shared_two_factor_examples"
 

--- a/modules/two_factor_authentication/spec/features/shared_two_factor_examples.rb
+++ b/modules/two_factor_authentication/spec/features/shared_two_factor_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SharedTwoFactorExamples
   def first_login_step
     visit signin_path

--- a/modules/two_factor_authentication/spec/lib/token_strategies/message_bird_spec.rb
+++ b/modules/two_factor_authentication/spec/lib/token_strategies/message_bird_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../spec_helper"
 require "messagebird"
 

--- a/modules/two_factor_authentication/spec/lib/token_strategy_manager_spec.rb
+++ b/modules/two_factor_authentication/spec/lib/token_strategy_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 RSpec.describe OpenProject::TwoFactorAuthentication::TokenStrategyManager do

--- a/modules/two_factor_authentication/spec/models/device/default_device_spec.rb
+++ b/modules/two_factor_authentication/spec/models/device/default_device_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe "Default device" do

--- a/modules/two_factor_authentication/spec/models/device/totp_spec.rb
+++ b/modules/two_factor_authentication/spec/models/device/totp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "timecop"
 

--- a/modules/two_factor_authentication/spec/models/device/webauthn_spec.rb
+++ b/modules/two_factor_authentication/spec/models/device/webauthn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe TwoFactorAuthentication::Device::Webauthn do

--- a/modules/two_factor_authentication/spec/models/login_token_spec.rb
+++ b/modules/two_factor_authentication/spec/models/login_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 RSpec.describe TwoFactorAuthentication::LoginToken, :with_2fa_ee do

--- a/modules/two_factor_authentication/spec/models/user_spec.rb
+++ b/modules/two_factor_authentication/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 module OpenProject::TwoFactorAuthentication::Patches

--- a/modules/two_factor_authentication/spec/routing/two_factor_authentication/my/two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/routing/two_factor_authentication/my/two_factor_devices_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/two_factor_authentication/spec/routing/two_factor_authentication/users/two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/routing/two_factor_authentication/users/two_factor_devices_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/two_factor_authentication/spec/services/token_service_spec.rb
+++ b/modules/two_factor_authentication/spec/services/token_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../spec_helper"
 
 RSpec.describe TwoFactorAuthentication::TokenService do

--- a/modules/two_factor_authentication/spec/spec_helper.rb
+++ b/modules/two_factor_authentication/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- load spec_helper from OpenProject core
 require "spec_helper"
 require "webauthn/fake_client"


### PR DESCRIPTION
Achieved through

    rubocop -A --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment,Style/RedundantFreeze modules/two_factor_authentication

Part of freezing string literals across the application step-by-step to be well prepared for future Ruby releases.