### PR TITLE
[#62689] Long code block breaks meeting outcome

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.sass
@@ -10,7 +10,10 @@
 .op-meeting-outcome-notes
   display: grid
   grid-template-columns: auto fit-content(40px)
-  grid-template-areas: "title actions" "content ."
+  grid-template-areas: "title actions" "content content"
+
+  &--content
+    overflow: auto
 
 
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/62689

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Before:
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/8cd37e1a-3758-4a92-9af4-d084ba79271d" />

### After: 
<img width="900" alt="image" src="https://github.com/user-attachments/assets/04c40157-68d1-4e63-836a-21e604b8c0ce" />


# Note
I also updated the grid layout as the outcome wasn't taking up the entire width of the container before
