### PR TITLE
Make feature tests more stable

### DIFF
--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -226,9 +226,8 @@ module Pages::Meetings
           page.find_test_selector("op-meeting-agenda-actions").click
         end
         page.find(".Overlay")
+        page.within(".Overlay", &)
       end
-
-      page.within(".Overlay", &)
     end
 
     def select_outcome_action(action)
@@ -367,10 +366,9 @@ module Pages::Meetings
       retry_block do
         click_on_backlog_menu
         page.find(".Overlay")
-      end
-
-      page.within(".Overlay") do
-        click_on action
+        page.within(".Overlay") do
+          click_on action
+        end
       end
     end
 

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -30,6 +30,19 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "new", over
     # Disable "Select your search engine screen"
     options.add_argument("--disable-search-engine-choice-screen")
 
+    # Disable timers being throttled in background pages/tabs. Useful for
+    # parallel test runs.
+    options.add_argument("disable-background-timer-throttling")
+
+    # Normally, Chrome will treat a 'foreground' tab instead as backgrounded if
+    # the surrounding window is occluded (aka visually covered) by another
+    # window. This flag disables that. Useful for parallel test runs.
+    options.add_argument("disable-backgrounding-occluded-windows")
+
+    # This disables non-foreground tabs from getting a lower process priority.
+    # Useful for parallel test runs.
+    options.add_argument("disable-renderer-backgrounding")
+
     options.add_preference(:download,
                            directory_upgrade: true,
                            prompt_for_download: false,

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -86,7 +86,17 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       lang: language,
       "accept-lang": language,
       "no-sandbox": nil,
-      "disable-smooth-scrolling": true
+      "disable-smooth-scrolling": true,
+      # Disable timers being throttled in background pages/tabs. Useful for
+      # parallel test runs.
+      "disable-background-timer-throttling": nil,
+      # Normally, Chrome will treat a 'foreground' tab instead as backgrounded
+      # if the surrounding window is occluded (aka visually covered) by another
+      # window. This flag disables that. Useful for parallel test runs.
+      "disable-backgrounding-occluded-windows": nil,
+      # This disables non-foreground tabs from getting a lower process priority.
+      # Useful for parallel test runs.
+      "disable-renderer-backgrounding": nil
     }
 
     if ENV["OPENPROJECT_TESTING_AUTO_DEVTOOLS"].present?


### PR DESCRIPTION
Following advices on https://github.com/teamcapybara/capybara/issues/2796

This occurs sometimes that some tests are failing in headless mode: the DOM is not correctly reflecting the state of the page until a screenshot is taken.

This happened in ./spec/features/work_packages/table/queries/query_menu_refresh_spec.rb:44 in job https://github.com/opf/openproject/actions/runs/14965572620/job/42034828494

The screenshot shows that the query menu item is here, but before the screenshot is taken, capybara cannot find it.

This is a shot in the dark. I have no idea if that will really fix the issue mentioned above.
