### PR TITLE
Do not add a click handler to the label if there is no label

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -291,7 +291,10 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   private setLabel() {
-    const label = document.querySelector<HTMLLabelElement>(`label[for=${this.textAreaId}]`)!;
+    const label = document.querySelector<HTMLLabelElement>(`label[for=${this.textAreaId}]`);
+    if (!label) {
+      return;
+    }
 
     const ckContent = this.element.querySelector<HTMLElement>('.ck-content')!;
 


### PR DESCRIPTION

# Ticket

None

# What are you trying to accomplish?

When going to the activity feed of a work package, the ckeditor does not have an associated label and this is throwing an error in the JS console of DevTools.

As I noticed it today, I fixed it.


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Return early if no label was found after calling `document.querySelector<HTMLLabelElement>(`label[for=${this.textAreaId}]`)`.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
