### PR TITLE
[64021] Medium Enterprise Banners look weird in Dark mode

### DIFF
--- a/app/components/enterprise_edition/banner_component.html.erb
+++ b/app/components/enterprise_edition/banner_component.html.erb
@@ -1,8 +1,9 @@
 <%=
   component_wrapper(tag: "turbo-frame") do
-    grid_layout("op-enterprise-banner",
-                **@system_arguments) do |grid|
-
+    grid_layout(
+      "op-enterprise-banner",
+      **@system_arguments
+    ) do |grid|
       if inline?
         grid.with_area(:visual) do
           render(Primer::Beta::Octicon.new(icon: :"op-enterprise-addons", classes: "op-enterprise-banner--icon"))
@@ -15,9 +16,13 @@
             if medium?
               flex_layout(align_items: :center, mb: 3) do |title_flex|
                 title_flex.with_column do
-                  render(Primer::Beta::Octicon.new(icon: :"op-enterprise-addons",
-                                                   size: :medium,
-                                                   classes: "upsell-colored"))
+                  render(
+                    Primer::Beta::Octicon.new(
+                      icon: :"op-enterprise-addons",
+                      size: :medium,
+                      classes: "upsell-colored"
+                    )
+                  )
                 end
 
                 title_flex.with_column(ml: 2) do
@@ -36,7 +41,7 @@
 
           if features.present?
             flex.with_row do
-              content_tag(:ul) { safe_join features.map { |text| render(Primer::Beta::Text.new(tag: :li)) { text } } }
+              content_tag(:ul) { safe_join(features.map { |text| render(Primer::Beta::Text.new(tag: :li)) { text } }) }
             end
           end
 
@@ -44,6 +49,10 @@
             render EnterpriseEdition::UpsellButtonsComponent.new(feature_key)
           end
         end
+      end
+
+      if medium?
+        grid.with_area(:image, **@image_arguments)
       end
 
       if @dismissable

--- a/app/components/enterprise_edition/banner_component.rb
+++ b/app/components/enterprise_edition/banner_component.rb
@@ -89,10 +89,8 @@ module EnterpriseEdition
     end
 
     def before_render
-      @system_arguments[:style] = join_style_arguments(
-        @system_arguments[:style],
-        medium? ? "background-image: url(#{helpers.image_path(@image)})" : nil
-      )
+      @image_arguments = {}
+      @image_arguments[:style] = @image.present? ? "background-image: url(#{helpers.image_path(@image)})" : nil
     end
 
     def medium?

--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -43,20 +43,15 @@ $op-enterprise-banner-fixed-height: 220px
   overflow: hidden
 
   &_medium
+    position: relative
     padding: 0
     grid-template-areas: "content graphic"
     grid-template-columns: 2fr 1fr
     height: $op-enterprise-banner-fixed-height
-    background-repeat: no-repeat
-    background-position: center right
 
     @media screen and (max-width: $breakpoint-lg)
       grid-template-columns: 1fr
-      background-image: none !important
       height: auto
-
-    @media screen and (max-width: $breakpoint-xl)
-      background-size: cover
 
   &_medium &
     padding: 0
@@ -64,13 +59,12 @@ $op-enterprise-banner-fixed-height: 220px
     grid-template-columns: 1fr 1fr
 
     &--content
+      z-index: 1
       align-self: center
       padding: var(--base-size-16)
 
   &--image
-    width: 100%
-    height: 100%
-    object-fit: cover
+    @include upsell-image
 
   &--visual
     display: grid

--- a/app/views/homescreen/blocks/_upsell.html.erb
+++ b/app/views/homescreen/blocks/_upsell.html.erb
@@ -1,12 +1,15 @@
-<div class="widget-box--blocks--upsell-container"
-     style="background-image: url(<%= image_path("enterprise/homescreen.png") %>)">
+<div class="widget-box--blocks--upsell-container">
   <div class="widget-box--blocks--upsell-text">
     <%=
       render(Primer::OpenProject::FlexLayout.new(align_items: :center, mb: 3)) do |title_flex|
         title_flex.with_column do
-          render(Primer::Beta::Octicon.new(icon: :"op-enterprise-addons",
-                                           size: :medium,
-                                           classes: "upsell-colored"))
+          render(
+            Primer::Beta::Octicon.new(
+              icon: :"op-enterprise-addons",
+              size: :medium,
+              classes: "upsell-colored"
+            )
+          )
         end
 
         title_flex.with_column(ml: 2) do
@@ -21,6 +24,9 @@
     <p class="widget-box--blocks--upsell-description">
       <%= t("ee.upsell.homescreen_subline") %>
     </p>
+
+    <%= render EnterpriseEdition::UpsellButtonsComponent.new(nil) %>
   </div>
-  <%= render EnterpriseEdition::UpsellButtonsComponent.new(nil) %>
+  <div class="widget-box--blocks--upsell-image"
+       style="background-image: url(<%= image_path("enterprise/homescreen.png") %>)"></div>
 </div>

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -23,17 +23,9 @@
     background: var(--body-background)
 
 .widget-box--blocks--upsell-container
+  position: relative
   padding: 20px
   height: 250px
-  background-size: contain
-  background-repeat: no-repeat
-  background-position: center right
-
-  @media screen and (max-width: $breakpoint-lg)
-    background-image: none !important
-
-  @media screen and (max-width: $breakpoint-xl)
-    background-size: cover
 
 .upsell-colored
   color: var(--enterprise-upsell-color) !important
@@ -49,15 +41,16 @@
   display: flex
 
 .widget-box--blocks--upsell-text
-  width: 50%
+  width: 60%
+  position: relative
+  z-index: 1
 
   @media screen and (max-width: $breakpoint-lg)
     width: 100%
 
+.widget-box--blocks--upsell-image
+  @include upsell-image
+
 .widget-box--blocks--upsell-description
   margin: 10px 0 10px 0
   display: flex
-
-.widget-box--blocks--upsell-image
-  width: 200px
-  margin: auto

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -363,6 +363,15 @@ $scrollbar-size: 10px
   @media screen and (max-width: $breakpoint-xl)
     background-size: cover
 
+  &:after
+    content: ""
+    position: absolute
+    bottom: 0
+    left: 0
+    right: 0
+    height: 100%
+    background: linear-gradient(to left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%)
+
   body[data-color-mode="dark"] &
     filter: invert(100%)
     -webkit-filter: invert(100%)

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -346,3 +346,23 @@ $scrollbar-size: 10px
 @mixin op-uc-table-header-styles
   border-color: var(--borderColor-default)
   background-color: var(--bgColor-muted)
+
+@mixin upsell-image
+  position: absolute
+  left: 0
+  right: 0
+  top: 0
+  bottom: 0
+  background-repeat: no-repeat
+  background-position: center right
+  background-size: contain
+
+  @media screen and (max-width: $breakpoint-lg)
+    background-image: none !important
+
+  @media screen and (max-width: $breakpoint-xl)
+    background-size: cover
+
+  body[data-color-mode="dark"] &
+    filter: invert(100%)
+    -webkit-filter: invert(100%)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64021
https://community.openproject.org/wp/63733
https://community.openproject.org/wp/63731


# What are you trying to accomplish?
Change the implementation of the image background of medium EE banners, to

- [x] invert the image in dark mode
- [x] Create a fading effect to increase the readability of the text

## Screenshots

<img width="1195" alt="Bildschirmfoto 2025-05-13 um 09 10 55" src="https://github.com/user-attachments/assets/b2d77b9f-65c6-4b76-94ff-f45281472362" />
<img width="954" alt="Bildschirmfoto 2025-05-13 um 09 11 46" src="https://github.com/user-attachments/assets/e49da94c-bd26-4e52-98b5-d8cbcac43542" />
<img width="1025" alt="Bildschirmfoto 2025-05-13 um 09 11 54" src="https://github.com/user-attachments/assets/f3473e7b-4e4c-4795-8533-dfc54565d084" />


