### PR TITLE
Change permissions to 775 and GID to 0 for /tmp/op_uploaded_files

### DIFF
--- a/docker/prod/setup/postinstall-common.sh
+++ b/docker/prod/setup/postinstall-common.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 # Ensure we can write in /tmp/op_uploaded_files (cf. #29112)
-mkdir -p /tmp/op_uploaded_files/ && chown -R $APP_USER:$APP_USER /tmp/op_uploaded_files/
+mkdir -p /tmp/op_uploaded_files/ && chmod 775 /tmp/op_uploaded_files && chown -R $APP_USER:0 /tmp/op_uploaded_files/
 
 # Remove any existing config/database.yml
 rm -f ./config/database.yml


### PR DESCRIPTION
The /tmp/op_uploaded_files directory was previously owned by app:app and mode 755, but Openshift and OKD execute pods by default as an ephemeral UID with GID 0.

# Ticket
[64037](https://community.openproject.org/projects/openproject/work_packages/64037)

# What are you trying to accomplish?
Modify permissions in the Docker image to allow Openshift/OKD to upload attachments by default

# What approach did you choose and why?
This is a minor change - extending write permissions to GID 0 inside a docker image.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
