### PR TITLE
[64068] Tooltip in Enterprise banners is floating out of box

### DIFF
--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
@@ -1,6 +1,6 @@
 <div
   [attr.data-tooltip]="trialRequested ? text.confirmation_info(created, email) : ''"
-  [ngClass]="{'tooltip--top': trialRequested}">
+  [ngClass]="{'tooltip--right': trialRequested}">
   <button
     type="button"
     [disabled]="trialRequested"


### PR DESCRIPTION
Open the tooltip to the right because there is most of the times more space. This is an intermediate fix until the button is primerized

# Ticket
https://community.openproject.org/projects/openproject/work_packages/64068/github?query_id=5722

## Screenshots
**Before**

<img width="526" alt="Bildschirmfoto 2025-05-16 um 11 16 18" src="https://github.com/user-attachments/assets/ef6125ea-eb50-4369-8ce2-430892e23910" />

**After**

<img width="1133" alt="Bildschirmfoto 2025-05-16 um 11 36 41" src="https://github.com/user-attachments/assets/8ecacb55-18c7-4af7-b664-4488a458b975" />

