### PR TITLE
[63379] Show self-registration warning on click

### DIFF
--- a/app/views/admin/settings/authentication_settings/_registration.html.erb
+++ b/app/views/admin/settings/authentication_settings/_registration.html.erb
@@ -28,32 +28,43 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  admin_settings_primer_form_with(scope: :settings,
-                                  url: admin_settings_authentication_path(tab: params[:tab]),
-                                  data: { turbo_method: :patch },
-                                  method: :patch) do |f|
+  admin_settings_primer_form_with(
+    scope: :settings,
+    url: admin_settings_authentication_path(tab: params[:tab]),
+    data: {
+      turbo_method: :patch,
+      application_target: "dynamic",
+      controller: "admin--registration",
+      admin__registration_target: "selfRegistrationRadioGroup",
+      admin__registration_activation_by_email_value: Setting::SelfRegistration.value(key: :activation_by_email),
+      admin__registration_automatic_activation_value: Setting::SelfRegistration.value(key: :automatic_activation)
+    },
+    method: :patch
+  ) do |f|
     render_inline_settings_form(f) do |form|
       form.check_box(
         name: :login_required,
-        caption: I18n.t(:setting_login_required_caption),
+        caption: I18n.t(:setting_login_required_caption)
       )
 
       form.radio_button_group(
         name: :self_registration,
         label: I18n.t(:setting_self_registration),
         caption: I18n.t(:setting_self_registration_caption),
-        values: Setting::SelfRegistration::VALUES.map { |name, value| { name:, value: } }
+        values: Setting::SelfRegistration::VALUES.map { |name, value| { name:, value: } },
+        button_options: {
+          data: { action: "admin--registration#updateWarningVisibility" }
+        }
       )
 
-      if Setting::SelfRegistration.unsupervised_registration?
-        form.html_content do
-          render Primer::Alpha::Banner.new(
-            scheme: :warning,
-            icon: :alert,
-            my: 2
-          ) do
-            I18n.t(:setting_self_registration_warning)
-          end
+      form.html_content do
+        render Primer::Alpha::Banner.new(
+          scheme: :warning,
+          data: { admin__registration_target: "warningToast" },
+          hidden: !Setting::SelfRegistration.unsupervised_registration?,
+          my: 2
+        ) do
+          I18n.t(:setting_self_registration_warning)
         end
       end
 
@@ -64,7 +75,7 @@ See COPYRIGHT and LICENSE files for more details.
         input_width: :small,
         trailing_visual: { text: { text: I18n.t("datetime.units.day.other") } },
         name: :invitation_expiration_days,
-        caption: I18n.t(:setting_invitation_expiration_days_caption),
+        caption: I18n.t(:setting_invitation_expiration_days_caption)
       )
 
       form.multi_language_text_select(name: :registration_footer)

--- a/frontend/src/stimulus/controllers/dynamic/admin/registration.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/registration.controller.ts
@@ -1,0 +1,71 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class RegistrationController extends Controller {
+  static values = {
+    activationByEmail: String,
+    automaticActivation: String,
+  };
+
+  static targets = [
+    'selfRegistrationRadioGroup',
+    'warningToast',
+  ];
+
+  declare readonly activationByEmailValue:string;
+  declare readonly automaticActivationValue:string;
+
+  declare readonly selfRegistrationRadioGroupTarget:HTMLElement;
+  declare readonly warningToastTarget:HTMLElement;
+
+  connect() {
+    this.updateWarningVisibility();
+  }
+
+  updateWarningVisibility() {
+    if (this.isUnsupervisedRegistration()) {
+      this.warningToastTarget.hidden = false;
+    } else {
+      this.warningToastTarget.hidden = true;
+    }
+  }
+
+  isUnsupervisedRegistration():boolean {
+    const selectedOption = this.getSelectedOption();
+    return selectedOption === this.activationByEmailValue || selectedOption === this.automaticActivationValue;
+  }
+
+  getSelectedOption() {
+    const checkedRadio = this.selfRegistrationRadioGroupTarget.querySelector('input[type="radio"]:checked') as HTMLInputElement;
+    return checkedRadio?.value || '';
+  }
+}

--- a/spec/support/pages/admin/authentication/registration.rb
+++ b/spec/support/pages/admin/authentication/registration.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module Admin
+    module Authentication
+      class Registration < ::Pages::Page
+        attr_reader :id, :individual_principal
+
+        def path
+          admin_settings_authentication_path(tab: "registration")
+        end
+
+        def save
+          click_button "Save"
+          # wait for the save to be processed
+          expect_and_dismiss_flash(message: "Successful update.")
+        end
+
+        def expect_self_registration_selected(key)
+          expect(page).to have_field("settings[self_registration]",
+                                     with: Setting::SelfRegistration.value(key:))
+        end
+
+        def expect_visible_unsupervised_self_registration_warning
+          expect(page).to have_text(I18n.t(:setting_self_registration_warning))
+        end
+
+        def expect_hidden_unsupervised_self_registration_warning
+          expect(page).to have_no_text(I18n.t(:setting_self_registration_warning))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

This is a follow-up of 63379 which had status "test failed".

https://community.openproject.org/wp/63379

# What are you trying to accomplish?

The ticket was rejected by QA because the warning was shown only after choosing a new value for self-registration and saving. The admin could easily miss the warning. And even without missing it, it's cumbersome to choose a new value, see a warning, and then having to revert.

The idea here is to show or hide the warning each time an option for self-registration is selected

## Screenshots

Before 

[self-registration-before.webm](https://github.com/user-attachments/assets/7e46c0a9-280d-46b9-95f9-ca5cd8f3cf89)

After

[self-registration-after.webm](https://github.com/user-attachments/assets/46e802c2-2c80-46c9-8ccf-a9714dea418b)

# What approach did you choose and why?

Similar to warning on progress tracking admin page: the warning is always there, and its visibility is set with the `hidden` property on first render, and updated with a stimulus controller each time the option changes.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
