### PR TITLE
[62847] Remove project filter from hierarchy query link

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service.ts
@@ -28,8 +28,6 @@
 
 import { Injectable } from '@angular/core';
 import * as URI from 'urijs';
-import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
@@ -37,29 +35,22 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 export class HierarchyQueryLinkHelperService {
   constructor(
-    private apiV3Service:ApiV3Service,
     private pathHelper:PathHelperService,
   ) {}
 
   public addHref(link:HTMLAnchorElement, resource:HalResource):void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (resource && resource.id && resource.project) {
+    if (resource && resource.id) {
       const wpID = resource.id.toString();
-      this.apiV3Service.projects.id(resource.project as ProjectResource).get().subscribe(
-        (project:ProjectResource) => {
-          const props = {
-            c: ['id', 'subject', 'type', 'status', 'estimatedTime', 'remainingTime', 'percentageDone'],
-            hi: true,
-            is: true,
-            f: [{ n: 'parent', o: '=', v: [wpID] }],
-          };
-          const href = URI(this.pathHelper.projectWorkPackagesPath(project.identifier as string))
-            .query({ query_props: JSON.stringify(props) })
-            .toString();
-
-          link.href = href;
-        },
-      );
+      const props = {
+        c: ['id', 'subject', 'type', 'status', 'estimatedTime', 'remainingTime', 'percentageDone'],
+        hi: true,
+        is: true,
+        f: [{ n: 'parent', o: '=', v: [wpID] }],
+      };
+      link.href = URI(this.pathHelper.workPackagesPath())
+        .query({ query_props: JSON.stringify(props) })
+        .toString();
     }
   }
 }

--- a/spec/features/work_packages/display_fields/work_display_spec.rb
+++ b/spec/features/work_packages/display_fields/work_display_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Work display", :js do
   end
 
   describe "link to detailed view" do
-    let_work_packages(<<~TABLE)
+    shared_let_work_packages(<<~TABLE)
       hierarchy          | work |
       parent             |   5h |
         child 1          |   0h |
@@ -212,6 +212,21 @@ RSpec.describe "Work display", :js do
         within(:table) do
           expect(page).to have_columnheader("Work")
           expect(page).to have_columnheader("Remaining work")
+        end
+      end
+
+      context "when one of the children is in a different project" do
+        let(:other_project) { create(:project) }
+
+        before do
+          child1.update!(project: other_project)
+        end
+
+        it "still shows it (Bug #62847)" do
+          click_on("Σ 20h")
+
+          wp_table.expect_work_package_count(4)
+          wp_table.expect_work_package_listed(parent, child1, child2, child3)
         end
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/62847

# What are you trying to accomplish?

Make it so that when clicking the link "Σ 25h" in "5h•Σ 25h", it shows all children, even if they are not part of current project or its sub projects.

## Screenshots

None

# What approach did you choose and why?

Remove the project from the hierarchy link path to make the query consider work packages from all visible projects.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
