### PR TITLE
Parameterize `attachments_storage_path` based on `TEST_ENV_NUMBER`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,5 +93,5 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::Assertions
   config.include ActiveJob::TestHelper
 
-  OpenProject::Configuration["attachments_storage_path"] = "tmp/files"
+  OpenProject::Configuration["attachments_storage_path"] = "tmp/files#{ENV.fetch('TEST_ENV_NUMBER', nil)}"
 end


### PR DESCRIPTION
Failing spec is `./modules/meeting/spec/services/meetings/copy_service_integration_spec.rb:173`
job run is https://github.com/opf/openproject/actions/runs/15107490046/job/42459184256

This spec failed in CI, but not locally, even with correct `--seed`, commit SHA + merge commit SHA, time zone, locale, and `CI=true`.

We suppose the flakiness came from the fact that the storage path is not parameterized. Here is the reasoning:

Tests are run in parallel. The test `copy_service_integration_spec.rb` creates an attachment, saved in something like
`tmp/files/attachment/file/187/file-1.test`. It could be possible that another test from another parallel run creates a similar attachment with an identical id and filename, and deletes it. If that's the case, then the first test relying on that attachment can not copy it, and so the test fails.

To fix this, the storage path is made unique for each parallel rspec runner based on `TEST_ENV_NUMBER`. This way, each job gets its own storage path and cannot interfere with others.

Even if that's not the root cause, it's a good practice for each runner to have its own storage path.
