### PR TITLE
Change typo "occured" to "occurred" in storage locales

### DIFF
--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -81,7 +81,7 @@ en:
     edit_project_folder:
       label: Edit project folder
     open:
-      remote_identity_error: An unexpected error occured while connecting to the storage.
+      remote_identity_error: An unexpected error occurred while connecting to the storage.
     project_folder_mode:
       automatic: Automatically managed
       inactive: No specific folder


### PR DESCRIPTION
No WP created for this
