### PR TITLE
implementation/64103 Extend API V3 to cover Emoji reactions on work package comments (read) and extend documentation

### DIFF
--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -57,7 +57,7 @@ module Reactable
         .select(emoji_reactions_group_selection_sql)
         .joins(:user)
         .where(reactable_id:, reactable_type:)
-        .group("emoji_reactions.reactable_id, emoji_reactions.reaction")
+        .group("emoji_reactions.reactable_type, emoji_reactions.reactable_id, emoji_reactions.reaction")
         .order("first_created_at ASC")
     end
 
@@ -65,7 +65,7 @@ module Reactable
 
     def emoji_reactions_group_selection_sql
       <<~SQL.squish
-        emoji_reactions.reactable_id, emoji_reactions.reaction,
+        emoji_reactions.reactable_id, emoji_reactions.reactable_type, emoji_reactions.reaction,
         COUNT(emoji_reactions.id) as reactions_count,
         json_agg(
           json_build_array(users.id, #{user_name_concat_format_sql})

--- a/app/models/concerns/reactable.rb
+++ b/app/models/concerns/reactable.rb
@@ -56,6 +56,7 @@ module Reactable
       EmojiReaction
         .select(emoji_reactions_group_selection_sql)
         .joins(:user)
+        .includes(:reactable)
         .where(reactable_id:, reactable_type:)
         .group("emoji_reactions.reactable_type, emoji_reactions.reactable_id, emoji_reactions.reaction")
         .order("first_created_at ASC")

--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -53,4 +53,8 @@ class EmojiReaction < ApplicationRecord
   def self.emoji(reaction)
     EMOJI_MAP[reaction.to_sym]
   end
+
+  def emoji
+    self.class.emoji(reaction)
+  end
 end

--- a/docs/api/apiv3/components/examples/activity_response.yml
+++ b/docs/api/apiv3/components/examples/activity_response.yml
@@ -21,6 +21,11 @@ value:
       id: 207
       _type: WorkPackage
       _hint: Work package resource shortened for brevity.
+    emojiReactions:
+      _type: Collection
+      total: 1
+      count: 1
+      _hint: Emoji reactions resource shortened for brevity.
   _links:
     attachments:
       href: "/api/v3/activities/1478/attachments"

--- a/docs/api/apiv3/components/schemas/activity_model.yml
+++ b/docs/api/apiv3/components/schemas/activity_model.yml
@@ -40,10 +40,14 @@ properties:
           - $ref: './work_package_model.yml'
           - description: |-
               The work package this activity belongs to
-              
+
               # Conditions
-              
+
               Only embedded when the `journable` of the activity is a work package
+      emojiReactions:
+        allOf:
+          - $ref: './emoji_reactions_model.yml'
+          - description: Collection of emoji reactions for this activity
   _links:
     type: object
     properties:
@@ -87,9 +91,16 @@ properties:
 
               # Conditions
 
-              **Permissions**: 
+              **Permissions**:
               - `add_work_package_comments`
               - for internal comments: `add_internal_comments`
+      emojiReactions:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The emoji reactions collection of this activity
+
+              **Resource**: EmojiReactions
 example:
   id: 1
   _type: Activity::Comment
@@ -133,6 +144,47 @@ example:
       _links:
         self:
           href: "/api/v3/activities/79090/attachments"
+    emojiReactions:
+      _type: Collection
+      total: 2
+      count: 2
+      _embedded:
+        elements:
+          - _type: "EmojiReaction"
+            id: "1-thumbs_up"
+            reaction: "thumbs_up"
+            emoji: "👍"
+            reactionsCount: 3
+            firstReactionAt: "2024-04-08T15:37:19.275Z"
+            _links:
+              self:
+                href: "/api/v3/emoji_reactions/1-thumbs_up"
+              reactable:
+                href: "/api/v3/activities/1"
+              reactingUsers:
+                - href: "/api/v3/users/435"
+                  title: "John Doe"
+                - href: "/api/v3/users/436"
+                  title: "Jane Smith"
+                - href: "/api/v3/users/437"
+                  title: "Bob Johnson"
+          - _type: "EmojiReaction"
+            id: "1-heart"
+            reaction: "heart"
+            emoji: "❤️"
+            reactionsCount: 1
+            firstReactionAt: "2024-04-08T15:38:19.275Z"
+            _links:
+              self:
+                href: "/api/v3/emoji_reactions/1-heart"
+              reactable:
+                href: "/api/v3/activities/1"
+              reactingUsers:
+                - href: "/api/v3/users/435"
+                  title: "John Doe"
+      _links:
+        self:
+          href: "/api/v3/activities/1/emoji_reactions"
     workPackage:
       _type: WorkPackage
       id: 10403
@@ -181,6 +233,8 @@ example:
       title: John Sheppard - admin
     attachments:
       href: "/api/v3/activities/1/attachments"
+    emojiReactions:
+      href: "/api/v3/activities/1/emoji_reactions"
     addAttachment:
       href: "/api/v3/activities/1/attachments"
       method: post

--- a/docs/api/apiv3/components/schemas/emoji_reaction_model.yml
+++ b/docs/api/apiv3/components/schemas/emoji_reaction_model.yml
@@ -1,0 +1,65 @@
+# Schema: EmojiReactionModel
+---
+type: object
+properties:
+  _type:
+    type: string
+    enum:
+      - "EmojiReaction"
+  id:
+    type: string
+    description: "Emoji reaction id (format: reactable_id-reaction)"
+    example: "1-thumbs_up"
+  reaction:
+    type: string
+    description: The reaction identifier
+    example: "thumbs_up"
+  emoji:
+    type: string
+    description: The emoji character
+    example: "👍"
+  reactionsCount:
+    type: integer
+    description: Number of users who reacted with this emoji
+    minimum: 1
+    example: 3
+  firstReactionAt:
+    type: string
+    format: date-time
+    description: Time of the first reaction
+  _links:
+    type: object
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: This emoji reaction
+      reactable:
+        allOf:
+          - $ref: './link.yml'
+          - description: The activity this emoji reaction belongs to
+      reactingUsers:
+        type: array
+        items:
+          allOf:
+            - $ref: './link.yml'
+            - description: The users who reacted with this emoji
+example:
+  _type: "EmojiReaction"
+  id: "1-thumbs_up"
+  reaction: "thumbs_up"
+  emoji: "👍"
+  reactionsCount: 3
+  firstReactionAt: "2024-04-08T15:37:19.275Z"
+  _links:
+    self:
+      href: "/api/v3/emoji_reactions/1-thumbs_up"
+    reactable:
+      href: "/api/v3/activities/1"
+    reactingUsers:
+      - href: "/api/v3/users/435"
+        title: "John Doe"
+      - href: "/api/v3/users/436"
+        title: "Jane Smith"
+      - href: "/api/v3/users/437"
+        title: "Bob Johnson"

--- a/docs/api/apiv3/components/schemas/emoji_reactions_model.yml
+++ b/docs/api/apiv3/components/schemas/emoji_reactions_model.yml
@@ -1,0 +1,71 @@
+# Schema: EmojiReactionsModel
+---
+type: object
+properties:
+  _type:
+    type: string
+    enum:
+      - "Collection"
+  total:
+    type: integer
+    description: Total number of emoji reactions
+    minimum: 0
+  count:
+    type: integer
+    description: Number of emoji reactions in this response
+    minimum: 0
+  _embedded:
+    type: object
+    properties:
+      elements:
+        type: array
+        items:
+          $ref: './emoji_reaction_model.yml'
+  _links:
+    type: object
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: This collection
+example:
+  _type: "Collection"
+  total: 2
+  count: 2
+  _embedded:
+    elements:
+      - _type: "EmojiReaction"
+        id: "1-thumbs_up"
+        reaction: "thumbs_up"
+        emoji: "👍"
+        reactionsCount: 3
+        firstReactionAt: "2024-04-08T15:37:19.275Z"
+        _links:
+          self:
+            href: "/api/v3/emoji_reactions/1-thumbs_up"
+          reactable:
+            href: "/api/v3/activities/1"
+          reactingUsers:
+            - href: "/api/v3/users/435"
+              title: "John Doe"
+            - href: "/api/v3/users/436"
+              title: "Jane Smith"
+            - href: "/api/v3/users/437"
+              title: "Bob Johnson"
+      - _type: "EmojiReaction"
+        id: "1-heart"
+        reaction: "heart"
+        emoji: "❤️"
+        reactionsCount: 1
+        firstReactionAt: "2024-04-08T15:38:19.275Z"
+        _links:
+          self:
+            href: "/api/v3/emoji_reactions/1-heart"
+          reactable:
+            href: "/api/v3/activities/1"
+          reactingUsers:
+            - href: "/api/v3/users/435"
+              title: "John Doe"
+  _links:
+    self:
+      href: "/api/v3/activities/1/emoji_reactions"

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -172,6 +172,8 @@ paths:
     "$ref": "./paths/activity.yml"
   "/api/v3/activities/{id}/attachments":
     "$ref": "./paths/activity_attachments.yml"
+  "/api/v3/activities/{id}/emoji_reactions":
+    "$ref": "./paths/activity_emoji_reactions.yml"
   "/api/v3/attachments":
     "$ref": "./paths/attachments.yml"
   "/api/v3/attachments/{id}":
@@ -472,6 +474,8 @@ paths:
     "$ref": "./paths/work_package.yml"
   "/api/v3/work_packages/{id}/activities":
     "$ref": "./paths/work_package_activities.yml"
+  "/api/v3/work_packages/{id}/activities_emoji_reactions":
+    "$ref": "./paths/work_package_activities_emoji_reactions.yml"
   "/api/v3/work_packages/{id}/attachments":
     "$ref": "./paths/work_package_attachments.yml"
   "/api/v3/work_packages/{id}/available_assignees":
@@ -935,6 +939,10 @@ components:
       "$ref": "./components/schemas/work_package_activities_model.yml"
     Work_PackagesModel:
       "$ref": "./components/schemas/work_packages_model.yml"
+    EmojiReactionModel:
+      "$ref": "./components/schemas/emoji_reaction_model.yml"
+    EmojiReactions_Model:
+      "$ref": "./components/schemas/emoji_reactions_model.yml"
   securitySchemes:
     BasicAuth:
       type: http

--- a/docs/api/apiv3/paths/activity_emoji_reactions.yml
+++ b/docs/api/apiv3/paths/activity_emoji_reactions.yml
@@ -1,0 +1,45 @@
+# /api/v3/activities/{id}/emoji_reactions
+---
+get:
+  summary: List emoji reactions by activity
+  operationId: list_activity_emoji_reactions
+  tags:
+    - Activities
+    - EmojiReactions
+  description: List all emoji reactions of a single activity.
+  parameters:
+    - name: id
+      description: ID of the activity whose emoji reactions will be listed
+      in: path
+      required: true
+      schema:
+        type: integer
+      example: '1'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/emoji_reactions_model.yml'
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the activity does not exist or the client does not have sufficient permissions
+        to see it.
+
+        **Required permission:**
+        - `view_work_packages`
+        - for internal comments: `view_internal_comments`
+
+        *Note: A client without sufficient permissions shall not be able to test for the existence of an activity.
+        That's why a 404 is returned here, even if a 403 might be more appropriate.*

--- a/docs/api/apiv3/paths/work_package_activities_emoji_reactions.yml
+++ b/docs/api/apiv3/paths/work_package_activities_emoji_reactions.yml
@@ -1,0 +1,46 @@
+# /api/v3/work_packages/{id}/activities_emoji_reactions
+---
+get:
+  summary: List emoji reactions by work package activities
+  operationId: list_work_package_activities_emoji_reactions
+  tags:
+    - WorkPackages
+    - Activities
+    - EmojiReactions
+  description: List all emoji reactions of all activities of a single work package.
+  parameters:
+    - name: id
+      description: ID of the work package whose activities' emoji reactions will be listed
+      in: path
+      required: true
+      schema:
+        type: integer
+      example: '1'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/emoji_reactions_model.yml'
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the work package does not exist or the client does not have sufficient permissions
+        to see it.
+
+        **Required permission:**
+        - `view_work_packages`
+        - for internal comments: `view_internal_comments`
+
+        *Note: A client without sufficient permissions shall not be able to test for the existence of a work package.
+        That's why a 404 is returned here, even if a 403 might be more appropriate.*

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -58,6 +58,7 @@ module API
                                                           .mount
 
             mount ::API::V3::Attachments::AttachmentsByActivityCommentAPI
+            mount ::API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI
           end
         end
       end

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -62,6 +62,12 @@ module API
           }
         end
 
+        link :emojiReactions do
+          {
+            href: api_v3_paths.emoji_reactions_by_activity_comment(represented.id)
+          }
+        end
+
         property :id,
                  render_nil: true
 

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -82,6 +82,12 @@ module API
                  if: ->(*) { embed_links },
                  uncacheable: true
 
+        property :emoji_reactions,
+                 embedded: true,
+                 exec_context: :decorator,
+                 if: ->(*) { embed_links },
+                 uncacheable: true
+
         date_time_property :created_at
         date_time_property :updated_at
 
@@ -100,6 +106,16 @@ module API
             .create(represented.journable,
                     current_user: current_user,
                     embed_links: false)
+        end
+
+        def emoji_reactions
+          return unless represented.journable.is_a?(WorkPackage)
+
+          emoji_reactions = Journal.grouped_emoji_reactions(reactable_id: represented.id, reactable_type: "Journal")
+          API::V3::EmojiReactions::EmojiReactionCollectionRepresenter
+            .new(emoji_reactions,
+                 self_link: api_v3_paths.emoji_reactions_by_activity_comment(represented.id),
+                 current_user:)
         end
 
         private

--- a/lib/api/v3/emoji_reactions/emoji_reaction_collection_representer.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reaction_collection_representer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module EmojiReactions
+      class EmojiReactionCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+        def model_count(models)
+          # Since models is a grouped ActiveRecord relation, we count resulting collection
+          models.to_a.size
+        end
+
+        property :count,
+                 getter: ->(*) { model_count(represented) },
+                 exec_context: :decorator
+      end
+    end
+  end
+end

--- a/lib/api/v3/emoji_reactions/emoji_reaction_representer.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reaction_representer.rb
@@ -34,7 +34,6 @@ module API
       class EmojiReactionRepresenter < ::API::Decorators::Single
         include API::Decorators::DateProperty
         include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
 
         def self.associated_reactable_getter
           ->(*) {
@@ -57,21 +56,7 @@ module API
           }
         end
 
-        def initialize(model, current_user:, embed_links: false)
-          raise "no represented object passed" if model_required? && model.nil?
-
-          # EmojiReaction#updated_at is set to the first created_at timestamp of the reaction.
-          #
-          # This is done to ensure that the updated_at timestamp is always present for caching purposes.
-          model.updated_at = model.first_created_at
-
-          super
-        end
-
-        cached_representer key_parts: %i[reactable]
-
-        links :reactingUsers,
-              uncacheable: true do
+        links :reactingUsers do
           represented.reacting_users.map do |(id, name)|
             {
               href: api_v3_paths.user(id),

--- a/lib/api/v3/emoji_reactions/emoji_reaction_representer.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reaction_representer.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module EmojiReactions
+      class EmojiReactionRepresenter < ::API::Decorators::Single
+        include API::Decorators::DateProperty
+        include API::Decorators::LinkedResource
+        include API::Caching::CachedRepresenter
+
+        def self.associated_reactable_getter
+          ->(*) {
+            next unless embed_links && reactable_representer
+
+            reactable_representer
+              .create(represented.reactable, current_user:)
+          }
+        end
+
+        def self.associated_reactable_link
+          ->(*) {
+            return nil unless v3_reactable_name == "nil_class" || api_v3_paths.respond_to?(v3_reactable_name)
+
+            ::API::Decorators::LinkObject
+              .new(represented,
+                   path: v3_reactable_name,
+                   property_name: :reactable)
+              .to_hash
+          }
+        end
+
+        def initialize(model, current_user:, embed_links: false)
+          raise "no represented object passed" if model_required? && model.nil?
+
+          # EmojiReaction#updated_at is set to the first created_at timestamp of the reaction.
+          #
+          # This is done to ensure that the updated_at timestamp is always present for caching purposes.
+          model.updated_at = model.first_created_at
+
+          super
+        end
+
+        cached_representer key_parts: %i[reactable]
+
+        links :reactingUsers,
+              uncacheable: true do
+          represented.reacting_users.map do |(id, name)|
+            {
+              href: api_v3_paths.user(id),
+              title: name
+            }
+          end
+        end
+
+        property :id,
+                 exec_context: :decorator,
+                 getter: ->(*) { "#{represented.reactable_id}-#{represented.reaction}" }
+        property :reaction
+        property :emoji,
+                 exec_context: :decorator,
+                 getter: ->(*) { ::EmojiReaction.emoji(represented.reaction) }
+        property :reactions_count
+
+        date_time_property :first_created_at, as: :firstReactionAt
+
+        associated_resource :reactable,
+                            getter: associated_reactable_getter,
+                            link: associated_reactable_link
+
+        def _type
+          "EmojiReaction"
+        end
+
+        def reactable_representer
+          name = v3_reactable_name.camelcase
+
+          "::API::V3::#{name.pluralize}::#{name}Representer".constantize
+        rescue NameError
+          nil
+        end
+
+        def v3_reactable_name
+          ar_name = represented.reactable_type.underscore
+
+          ::API::Utilities::PropertyNameConverter.from_ar_name_with_aliases(ar_name, "journal" => "activity").underscore
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/emoji_reactions/emoji_reaction_representer.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reaction_representer.rb
@@ -84,9 +84,7 @@ module API
                  exec_context: :decorator,
                  getter: ->(*) { "#{represented.reactable_id}-#{represented.reaction}" }
         property :reaction
-        property :emoji,
-                 exec_context: :decorator,
-                 getter: ->(*) { ::EmojiReaction.emoji(represented.reaction) }
+        property :emoji
         property :reactions_count
 
         date_time_property :first_created_at, as: :firstReactionAt

--- a/lib/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module EmojiReactions
+      class EmojiReactionsByActivityCommentAPI < ::API::OpenProjectAPI
+        resource :emoji_reactions do
+          helpers do
+            def reactable
+              @activity
+            end
+
+            def get_emoji_reactions_self_path
+              api_v3_paths.emoji_reactions_by_activity_comment(reactable.id)
+            end
+          end
+
+          get do
+            emoji_reactions = Journal.grouped_emoji_reactions(reactable_id: reactable.id, reactable_type: "Journal")
+            EmojiReactionCollectionRepresenter.new(emoji_reactions,
+                                                   self_link: get_emoji_reactions_self_path,
+                                                   current_user: User.current)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/emoji_reactions/emoji_reactions_by_work_package_comments_api.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reactions_by_work_package_comments_api.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module EmojiReactions
+      class EmojiReactionsByWorkPackageCommentsAPI < ::API::OpenProjectAPI
+        resource :activities_emoji_reactions do
+          helpers do
+            def reactable
+              @work_package
+            end
+
+            def get_emoji_reactions_self_path
+              api_v3_paths.emoji_reactions_by_work_package_comments(reactable.id)
+            end
+          end
+
+          get do
+            emoji_reactions = Journal.grouped_emoji_reactions(
+              reactable_id: reactable.journals.internal_visible.select(:id).pluck(:id),
+              reactable_type: "Journal"
+            )
+            EmojiReactionCollectionRepresenter.new(emoji_reactions,
+                                                   self_link: get_emoji_reactions_self_path,
+                                                   current_user: User.current)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -581,7 +581,7 @@ module API
           end
 
           def self.work_package_activities_emoji_reactions(id)
-            "#{work_package_activities(id)}/emoji_reactions"
+            "#{work_package_activities(id)}/activities_emoji_reactions"
           end
 
           def self.work_package_activities(id)

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -162,6 +162,14 @@ module API
             "#{root}/attachments/#{attachment_id}/uploaded"
           end
 
+          def self.emoji_reactions_by_activity_comment(id)
+            "#{root}/activities/#{id}/emoji_reactions"
+          end
+
+          def self.emoji_reactions_by_work_package_comments(work_package_id)
+            "#{work_package(work_package_id)}/activities_emoji_reactions"
+          end
+
           def self.available_assignees_in_project(project_id)
             "#{project(project_id)}/available_assignees"
           end
@@ -570,6 +578,10 @@ module API
 
           def self.work_package_schema(project_id, type_id)
             "#{root}/work_packages/schemas/#{project_id}-#{type_id}"
+          end
+
+          def self.work_package_activities_emoji_reactions(id)
+            "#{work_package_activities(id)}/emoji_reactions"
           end
 
           def self.work_package_activities(id)

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -99,6 +99,7 @@ module API
             mount ::API::V3::WorkPackages::AvailableRelationCandidatesAPI
             mount ::API::V3::WorkPackages::WorkPackageRelationsAPI
             mount ::API::V3::Reminders::RemindersAPI
+            mount ::API::V3::EmojiReactions::EmojiReactionsByWorkPackageCommentsAPI
           end
 
           mount ::API::V3::WorkPackages::CreateFormAPI

--- a/spec/models/emoji_reaction_spec.rb
+++ b/spec/models/emoji_reaction_spec.rb
@@ -89,4 +89,11 @@ RSpec.describe EmojiReaction do
       expect(described_class.emoji("rock_on")).to be_nil
     end
   end
+
+  describe "#emoji" do
+    it "returns the emoji for the reaction" do
+      emoji_reaction = build_stubbed(:emoji_reaction, reaction: :thumbs_up)
+      expect(emoji_reaction.emoji).to eq("👍")
+    end
+  end
 end

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -216,6 +216,24 @@ RSpec.describe API::V3::Activities::ActivitiesAPI, content_type: :json do
         end
 
         it_behaves_like "valid activity request", "Activity::Comment"
+
+        context "and an emoji reaction" do
+          let!(:emoji_reaction) do
+            create(:emoji_reaction, reactable: activity, user: current_user)
+          end
+
+          it "returns the emoji reactions" do
+            get get_path
+
+            expect(last_response.body)
+              .to be_json_eql("#{activity.id}-#{emoji_reaction.reaction}".to_json)
+              .at_path("_embedded/emojiReactions/_embedded/elements/0/id")
+
+            expect(last_response.body)
+              .to be_json_eql(emoji_reaction.emoji.to_json)
+              .at_path("_embedded/emojiReactions/_embedded/elements/0/emoji")
+          end
+        end
       end
 
       context "for a internal journal" do

--- a/spec/requests/api/v3/emoji_reactions/emoji_reaction_representer_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reaction_representer_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::V3::EmojiReactions::EmojiReactionRepresenter do
+  let(:user) { create(:user) }
+  let(:reactable) { create(:work_package_journal) }
+  let(:emoji_reaction) do
+    create(:emoji_reaction,
+           reactable: reactable,
+           user: user,
+           reaction: "thumbs_up")
+    Journal.grouped_emoji_reactions(reactable_id: reactable.id, reactable_type: "Journal").first
+  end
+  let(:current_user) { user }
+  let(:representer) { described_class.new(emoji_reaction, current_user: current_user) }
+  let(:json) { representer.to_json }
+  let(:parsed) { JSON.parse(json) }
+
+  it "renders the id as reactable_id-reaction" do
+    expect(parsed["id"]).to eq "#{reactable.id}-thumbs_up"
+  end
+
+  it "renders the reaction" do
+    expect(parsed["reaction"]).to eq "thumbs_up"
+  end
+
+  it "renders the emoji" do
+    expect(parsed["emoji"]).to eq EmojiReaction.emoji("thumbs_up")
+  end
+
+  it "renders the reactionsCount" do
+    expect(parsed["reactionsCount"]).to eq 1
+  end
+
+  it "renders the firstReactionAt" do
+    expect(parsed["firstReactionAt"]).to eq emoji_reaction.first_created_at.iso8601(3)
+  end
+
+  it "renders the _type" do
+    expect(parsed["_type"]).to eq "EmojiReaction"
+  end
+
+  it "renders the reactingUsers link" do
+    expect(parsed["_links"]["reactingUsers"]).to be_an(Array)
+    expect(parsed["_links"]["reactingUsers"].first["href"]).to include("/api/v3/users/#{user.id}")
+    expect(parsed["_links"]["reactingUsers"].first["title"]).to eq user.name
+  end
+
+  it "renders the reactable link" do
+    expect(parsed["_links"]).to have_key("reactable")
+    expect(parsed["_links"]["reactable"]["href"]).to include("/api/v3/activities/#{reactable.id}")
+  end
+end

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { work_package.project }
+  let(:work_package) { create(:work_package) }
+  let(:current_user) do
+    create(:user, member_with_roles: { project => role })
+  end
+  let(:admin) { create(:admin) }
+  let(:role) { create(:project_role, permissions:) }
+  let(:permissions) do
+    %i(view_work_packages add_work_package_comments view_internal_comments)
+  end
+  let(:activity) { create(:work_package_journal, journable: work_package, user: admin, version: 2) }
+  let!(:emoji_reaction) { create(:emoji_reaction, reactable: activity, user: current_user) }
+
+  before do
+    allow(User).to receive(:current).and_return(current_user)
+  end
+
+  describe "GET /api/v3/activities/:id/emoji_reactions" do
+    context "when user has permission to view work package" do
+      before do
+        get api_v3_paths.emoji_reactions_by_activity_comment(activity.id)
+      end
+
+      it "succeeds" do
+        expect(last_response).to have_http_status :ok
+      end
+
+      it "returns the emoji reactions" do # rubocop:disable RSpec/ExampleLength
+        expect(last_response.body)
+          .to be_json_eql(1.to_json)
+          .at_path("total")
+
+        expect(last_response.body)
+          .to be_json_eql(1.to_json)
+          .at_path("count")
+
+        expect(last_response.body)
+          .to be_json_eql("Collection".to_json)
+          .at_path("_type")
+
+        expect(last_response.body)
+          .to be_json_eql("#{activity.id}-#{emoji_reaction.reaction}".to_json)
+          .at_path("_embedded/elements/0/id")
+
+        expect(last_response.body)
+          .to be_json_eql(emoji_reaction.emoji.to_json)
+          .at_path("_embedded/elements/0/emoji")
+
+        expect(last_response.body)
+          .to be_json_eql(emoji_reaction.reaction.to_json)
+          .at_path("_embedded/elements/0/reaction")
+
+        expect(last_response.body)
+          .to be_json_eql(1.to_json)
+          .at_path("_embedded/elements/0/reactionsCount")
+
+        expect(last_response.body)
+          .to be_json_eql(api_v3_paths.emoji_reactions_by_activity_comment(activity.id).to_json)
+          .at_path("_links/self/href")
+
+        expect(last_response.body)
+          .to be_json_eql(api_v3_paths.activity(activity.id).to_json)
+          .at_path("_embedded/elements/0/_links/reactable/href")
+      end
+    end
+
+    context "when user does not have permission to view work package" do
+      let(:current_user) { create(:user) }
+
+      before do
+        get api_v3_paths.emoji_reactions_by_activity_comment(activity.id)
+      end
+
+      it "fails with HTTP Not Found" do
+        expect(last_response).to have_http_status :not_found
+      end
+    end
+
+    context "when the activity is internal" do
+      let(:internal_comment) do
+        work_package.add_journal(user: current_user, notes: "Internal comment", internal: true)
+        work_package.save(validate: false)
+        work_package.journals.last
+      end
+      let!(:internal_emoji_reaction) { create(:emoji_reaction, reactable: internal_comment, user: current_user) }
+
+      before do
+        project.enabled_internal_comments = true
+        project.save!
+      end
+
+      context "and user has permission to view internal comments" do
+        before do
+          get api_v3_paths.emoji_reactions_by_activity_comment(internal_comment.id)
+        end
+
+        it "succeeds" do
+          expect(last_response).to have_http_status :ok
+        end
+
+        it "returns the emoji reactions" do
+          expect(last_response.body)
+            .to be_json_eql(1.to_json)
+            .at_path("total")
+
+          expect(last_response.body)
+            .to be_json_eql(internal_emoji_reaction.emoji.to_json)
+            .at_path("_embedded/elements/0/emoji")
+
+          expect(last_response.body)
+            .to be_json_eql(internal_emoji_reaction.reaction.to_json)
+            .at_path("_embedded/elements/0/reaction")
+        end
+      end
+
+      context "and user does not have permission to view internal comments" do
+        before do
+          role.role_permissions
+            .find_by(permission: "view_internal_comments")
+            .destroy
+          get api_v3_paths.emoji_reactions_by_activity_comment(internal_comment.id)
+        end
+
+        it "fails with HTTP Not Found" do
+          expect(last_response).to have_http_status :not_found
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
         expect(last_response).to have_http_status :ok
       end
 
-      it "returns the emoji reactions" do # rubocop:disable RSpec/ExampleLength
+      it "returns the emoji reactions" do
         expect(last_response.body)
           .to be_json_eql(1.to_json)
           .at_path("total")
@@ -81,22 +81,6 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
         expect(last_response.body)
           .to be_json_eql(emoji_reaction.emoji.to_json)
           .at_path("_embedded/elements/0/emoji")
-
-        expect(last_response.body)
-          .to be_json_eql(emoji_reaction.reaction.to_json)
-          .at_path("_embedded/elements/0/reaction")
-
-        expect(last_response.body)
-          .to be_json_eql(1.to_json)
-          .at_path("_embedded/elements/0/reactionsCount")
-
-        expect(last_response.body)
-          .to be_json_eql(api_v3_paths.emoji_reactions_by_activity_comment(activity.id).to_json)
-          .at_path("_links/self/href")
-
-        expect(last_response.body)
-          .to be_json_eql(api_v3_paths.activity(activity.id).to_json)
-          .at_path("_embedded/elements/0/_links/reactable/href")
       end
     end
 

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_work_package_comments_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_work_package_comments_api_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe API::V3::EmojiReactions::EmojiReactionsByWorkPackageCommentsAPI do
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { work_package.project }
+  let(:work_package) { create(:work_package) }
+  let(:current_user) do
+    create(:user, member_with_roles: { project => role })
+  end
+  let(:admin) { create(:admin) }
+  let(:role) { create(:project_role, permissions:) }
+  let(:permissions) do
+    %i(view_work_packages add_work_package_comments view_internal_comments)
+  end
+
+  let(:activity) { work_package.journals.first }
+  let!(:emoji_reaction) { create(:emoji_reaction, reactable: activity, user: current_user) }
+
+  before do
+    allow(User).to receive(:current).and_return(current_user)
+  end
+
+  describe "GET /api/v3/work_packages/:id/activities/emoji_reactions" do
+    context "when user has permission to view work package" do
+      before do
+        get api_v3_paths.emoji_reactions_by_work_package_comments(work_package.id)
+      end
+
+      it "succeeds" do
+        expect(last_response).to have_http_status :ok
+      end
+
+      it "returns the emoji reactions" do # rubocop:disable RSpec/ExampleLength
+        expect(last_response.body)
+          .to be_json_eql(1.to_json)
+          .at_path("total")
+
+        expect(last_response.body)
+          .to be_json_eql(1.to_json)
+          .at_path("count")
+
+        expect(last_response.body)
+          .to be_json_eql("Collection".to_json)
+          .at_path("_type")
+
+        expect(last_response.body)
+          .to be_json_eql("#{activity.id}-#{emoji_reaction.reaction}".to_json)
+          .at_path("_embedded/elements/0/id")
+
+        expect(last_response.body)
+          .to be_json_eql(emoji_reaction.emoji.to_json)
+          .at_path("_embedded/elements/0/emoji")
+
+        expect(last_response.body)
+          .to be_json_eql(emoji_reaction.reaction.to_json)
+          .at_path("_embedded/elements/0/reaction")
+
+        expect(last_response.body)
+          .to be_json_eql(1.to_json)
+          .at_path("_embedded/elements/0/reactionsCount")
+
+        expect(last_response.body)
+          .to be_json_eql(api_v3_paths.emoji_reactions_by_work_package_comments(work_package.id).to_json)
+          .at_path("_links/self/href")
+
+        expect(last_response.body)
+          .to be_json_eql(api_v3_paths.activity(activity.id).to_json)
+          .at_path("_embedded/elements/0/_links/reactable/href")
+      end
+    end
+
+    context "when user does not have permission to view work package" do
+      let(:current_user) { create(:user) }
+
+      before do
+        get api_v3_paths.emoji_reactions_by_work_package_comments(work_package.id)
+      end
+
+      it "fails with HTTP Not Found" do
+        expect(last_response).to have_http_status :not_found
+      end
+    end
+
+    context "when the work package has internal activities" do
+      let(:internal_comment) do
+        work_package.add_journal(user: current_user, notes: "Internal comment", internal: true)
+        work_package.save(validate: false)
+        work_package.journals.last
+      end
+      let!(:internal_emoji_reaction) { create(:emoji_reaction, reactable: internal_comment, user: current_user) }
+
+      before do
+        project.enabled_internal_comments = true
+        project.save!
+      end
+
+      context "and user has permission to view internal comments" do
+        before do
+          get api_v3_paths.emoji_reactions_by_work_package_comments(work_package.id)
+        end
+
+        it "succeeds" do
+          expect(last_response).to have_http_status :ok
+        end
+
+        it "returns all emoji reactions including internal ones" do
+          expect(last_response.body)
+            .to be_json_eql(2.to_json)
+            .at_path("total")
+
+          expect(last_response.body)
+            .to be_json_eql(internal_emoji_reaction.emoji.to_json)
+            .at_path("_embedded/elements/1/emoji")
+
+          expect(last_response.body)
+            .to be_json_eql(internal_emoji_reaction.reaction.to_json)
+            .at_path("_embedded/elements/1/reaction")
+        end
+      end
+
+      context "and user does not have permission to view internal comments" do
+        before do
+          role.role_permissions
+            .find_by(permission: "view_internal_comments")
+            .destroy
+          get api_v3_paths.emoji_reactions_by_work_package_comments(work_package.id)
+        end
+
+        it "succeeds but only returns non-internal emoji reactions" do
+          expect(last_response).to have_http_status :ok
+          expect(last_response.body)
+            .to be_json_eql(1.to_json)
+            .at_path("total")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_work_package_comments_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_work_package_comments_api_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByWorkPackageCommentsAPI d
         expect(last_response).to have_http_status :ok
       end
 
-      it "returns the emoji reactions" do # rubocop:disable RSpec/ExampleLength
+      it "returns the emoji reactions" do
         expect(last_response.body)
           .to be_json_eql(1.to_json)
           .at_path("total")
@@ -82,22 +82,6 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByWorkPackageCommentsAPI d
         expect(last_response.body)
           .to be_json_eql(emoji_reaction.emoji.to_json)
           .at_path("_embedded/elements/0/emoji")
-
-        expect(last_response.body)
-          .to be_json_eql(emoji_reaction.reaction.to_json)
-          .at_path("_embedded/elements/0/reaction")
-
-        expect(last_response.body)
-          .to be_json_eql(1.to_json)
-          .at_path("_embedded/elements/0/reactionsCount")
-
-        expect(last_response.body)
-          .to be_json_eql(api_v3_paths.emoji_reactions_by_work_package_comments(work_package.id).to_json)
-          .at_path("_links/self/href")
-
-        expect(last_response.body)
-          .to be_json_eql(api_v3_paths.activity(activity.id).to_json)
-          .at_path("_embedded/elements/0/_links/reactable/href")
       end
     end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/64103

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- [x] Add _embedded emoji reactions to Activities
- [x] Add `GET /api/v3/activities/:id/emoji_reactions`
- [x] Add `GET /api/v3/work_packages/:id/activities_emoji_reactions` *collection endpoint for all work package comments emoji reaction
- [x] Add API documentation

_Visit /api/docs_

<img width="1461" alt="Screenshot 2025-05-21 at 5 40 36 PM" src="https://github.com/user-attachments/assets/3bc1bfee-4b12-4898-bde3-0afda2059f49" />


# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
