### PR TITLE
[#64091] Turbo requests can trigger pointless browser's Basic auth pop-up

### DIFF
--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -14,6 +14,15 @@ export class TurboRequestsService {
     html:string,
     headers:Headers
   }> {
+    const defaultHeaders = {
+      'X-Authentication-Scheme': 'Session',
+    };
+
+    init.headers = {
+      ...defaultHeaders,
+      ...init.headers,
+    };
+
     return fetch(url, init)
       .then((response) => {
         return response.text().then((html) => ({
@@ -59,7 +68,6 @@ export class TurboRequestsService {
         body: formData,
         headers: {
           'X-CSRF-Token': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement).content,
-          'X-Authentication-Scheme': 'Session',
         },
       },
       true,
@@ -71,7 +79,6 @@ export class TurboRequestsService {
       method: 'GET',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
-        'X-Authentication-Scheme': 'Session',
       },
       credentials: 'same-origin',
     });

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -59,6 +59,7 @@ export class TurboRequestsService {
         body: formData,
         headers: {
           'X-CSRF-Token': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement).content,
+          'X-Authentication-Scheme': 'Session',
         },
       },
       true,
@@ -68,7 +69,10 @@ export class TurboRequestsService {
   public requestStream(url:string):Promise<{ html:string, headers:Headers }> {
     return this.request(url, {
       method: 'GET',
-      headers: { Accept: 'text/vnd.turbo-stream.html' },
+      headers: {
+        Accept: 'text/vnd.turbo-stream.html',
+        'X-Authentication-Scheme': 'Session',
+      },
       credentials: 'same-origin',
     });
   }

--- a/frontend/src/stimulus/controllers/async-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.ts
@@ -47,6 +47,7 @@ export default class AsyncDialogController extends ApplicationController {
       method: this.method,
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
+        'X-Authentication-Scheme': 'Session',
       },
     }).then((r) => r.text())
       .then((html) => {

--- a/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
@@ -59,7 +59,6 @@ export default class OpMeetingsFormController extends ApplicationController {
         {
           headers: {
             Accept: 'text/vnd.turbo-stream.html',
-            'X-Authentication-Scheme': 'Session',
           },
         },
       );

--- a/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/form.controller.ts
@@ -57,7 +57,10 @@ export default class OpMeetingsFormController extends ApplicationController {
       .request(
         `${this.pathHelper.staticBase}/meetings/fetch_timezone?${urlSearchParams.toString()}`,
         {
-          headers: { Accept: 'text/vnd.turbo-stream.html' },
+          headers: {
+            Accept: 'text/vnd.turbo-stream.html',
+            'X-Authentication-Scheme': 'Session',
+          },
         },
       );
   }

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
@@ -27,7 +27,6 @@ export default class OpRecurringMeetingsFormController extends ApplicationContro
         {
           headers: {
             Accept: 'text/vnd.turbo-stream.html',
-            'X-Authentication-Scheme': 'Session',
           },
         },
       );

--- a/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/recurring-meetings/form.controller.ts
@@ -25,7 +25,10 @@ export default class OpRecurringMeetingsFormController extends ApplicationContro
       .request(
         `${this.pathHelper.staticBase}/recurring_meetings/humanize_schedule?${urlSearchParams.toString()}`,
         {
-          headers: { Accept: 'text/vnd.turbo-stream.html' },
+          headers: {
+            Accept: 'text/vnd.turbo-stream.html',
+            'X-Authentication-Scheme': 'Session',
+          },
         },
       );
   }

--- a/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
+++ b/frontend/src/stimulus/controllers/poll-for-changes.controller.ts
@@ -76,6 +76,7 @@ export default class PollForChangesController extends ApplicationController {
     void fetch(`${this.urlValue}?reference=${this.buildReference()}`, {
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
+        'X-Authentication-Scheme': 'Session',
       },
     }).then(async (r) => {
       if (r.status === 200) {

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -31,6 +31,7 @@ export function addTurboEventListeners() {
     const headers = event.detail.fetchOptions.headers as Record<string, string>;
     headers['Turbo-Referrer'] = window.location.href;
     headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') || '';
+    headers['X-Authentication-Scheme'] = 'Session';
   });
 
   // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces


### PR DESCRIPTION
# Ticket

- [BUG 1 on work package activity polling](https://community.openproject.org/work_packages/64091) 
- [BUG 2 on meeting agenda polling](https://community.openproject.org/work_packages/64088)
- The topic is [pressing at openDesk](https://project.opendesk.family/notifications/details/1555/) as for whatever reason it seems that sessions expire more often.

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When OpenProject's frontend is polling for upstream updates it should provide the HTTP header `X-Authenticate-Scheme` to be `Session`. If we don't do that then a failing authentication will trigger a basic auth login form that is pretty useless (in a SSO setup you need to login to the IdP and not do some basic auth agains OP). We set those headers already for requests from Angular to API/V3 but we don't do it for turbo requests. This PR changes that.

The problem is not only an issue for turbo based polling. Also other, user triggered scenarios are problematic. Imagine you have a meeting agenda open in a tab, then close the computer until the browser session has expired, open the computer, and click "Add agenda item". This also trriggers a roundtrip to the backend. And if that roundtrip does not have that HTTP header set, it will also show the basic auth login dialog.

## Screenshots
![image](https://github.com/user-attachments/assets/14cbdaaa-c5ce-41df-a05a-f5b31040e178)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

This PR extends the HTTP headers of (hopefully) all turbo requests with `X-Authenticate-Scheme: Session`. Turbo uses the native API. That is why our JQuery `ajaxSend` where we already sent the correct headers does not affect Turbo requests. Further, we have to extend not only FETCH (e.g. when polling for updates) requests but also GET requests when extending meeting agenda forms.

## Out of sccope

- I had to add the HTTP header at multiple places as that problem touches multiple scenarios and all of them already had independent HTTP header configuration. Ideally we would somehow DRY that up. But I chose to not introduce and DRY efforts as the intention of this PR is fixing a high prio BUG.
- Having more sophisticated error handling and UX as we have in the work package table for instance. There, when session times out, we show a red flash banner that a user can dismiss. Ideally we would also have something like that when users are interacting with the page. During the polling I prefer not to show any error messages at all as errors happend far too often and resolve themselves pretty often (Network outages, maintenance down times, ...)


# Merge checklist

- [ ] Review by people knowing all the other places for which this PR changes the HTTP headers. Ideally with more turbo experience than me.
- [ ] Probably a good QA on those 
- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
