### PR TITLE
[64019] 'Make project public' modal has to be scrolled to be read in full

### DIFF
--- a/app/components/projects/settings/toggle_public_dialog_component.html.erb
+++ b/app/components/projects/settings/toggle_public_dialog_component.html.erb
@@ -31,8 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     Primer::OpenProject::DangerDialog.new(
       id: "projects_toggle_public_confirmation",
+      size: :medium_portrait,
       title: t(:title, scope: i18n_scope),
-      confirm_button_text: t(:'js.button_confirm'),
+      confirm_button_text: t(:"js.button_confirm"),
       form_arguments: {
         action: toggle_public_project_settings_general_path(@project),
         method: :post,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/64019/activity

⚠️ Do not merge for version 16.0!

# What are you trying to accomplish?
Increase size of Dialog to avoid scrolling

## Screenshots
<img width="540" alt="Bildschirmfoto 2025-05-20 um 11 16 44" src="https://github.com/user-attachments/assets/0c94614f-2470-406f-9ad7-0eef83249e54" />

