### PR TITLE
[chore] add subject pattern attribute wp versions

### DIFF
--- a/app/models/types/pattern_resolver.rb
+++ b/app/models/types/pattern_resolver.rb
@@ -56,16 +56,16 @@ module Types
       attribute_token = @tokens.detect { |t| t.key == pattern_token.key }
       return ATTRIBUTE_PLACEHOLDER if attribute_token.nil?
 
-      stringify(attribute_token.call(context), nil_replacement(attribute_token))
+      I18n.with_locale(Setting.default_language) do
+        stringify(attribute_token.call(context), nil_replacement(attribute_token))
+      end
     end
 
     def nil_replacement(attribute_resolver)
-      I18n.with_locale(Setting.default_language) do
-        if attribute_resolver.context == :work_package
-          "[#{attribute_resolver.label}]"
-        else
-          "[#{attribute_resolver.label_with_context}]"
-        end
+      if attribute_resolver.context == :work_package
+        "[#{attribute_resolver.label}]"
+      else
+        "[#{attribute_resolver.label_with_context}]"
       end
     end
 

--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -54,16 +54,18 @@ module Types
         AttributeToken.new(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
         AttributeToken.new(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status&.name }),
         AttributeToken.new(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type&.name }),
+        AttributeToken.new(:parent_version, -> { WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.version&.name }),
         AttributeToken.new(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
         AttributeToken.new(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
         AttributeToken.new(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
         AttributeToken.new(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project.name }),
-        AttributeToken.new(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code }),
+        AttributeToken.new(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code.nil? ? nil : I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") }),
         AttributeToken.new(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id }),
         AttributeToken.new(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? }),
         AttributeToken.new(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }),
         AttributeToken.new(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status&.name }),
-        AttributeToken.new(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type&.name })
+        AttributeToken.new(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type&.name }),
+        AttributeToken.new(:version, -> { WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.version&.name })
       ].freeze
       # rubocop:enable Layout/LineLength
 

--- a/app/models/types/patterns/token_property_mapper.rb
+++ b/app/models/types/patterns/token_property_mapper.rb
@@ -59,7 +59,7 @@ module Types
         AttributeToken.new(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
         AttributeToken.new(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
         AttributeToken.new(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project.name }),
-        AttributeToken.new(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code.nil? ? nil : I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") }),
+        AttributeToken.new(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") }),
         AttributeToken.new(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id }),
         AttributeToken.new(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? }),
         AttributeToken.new(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }),

--- a/spec/models/types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/types/patterns/token_property_mapper_spec.rb
@@ -33,6 +33,7 @@ require "spec_helper"
 RSpec.describe Types::Patterns::TokenPropertyMapper do
   shared_let(:responsible) { create(:user, firstname: "Responsible") }
   shared_let(:assignee) { create(:user, firstname: "Assignee") }
+  shared_let(:version) { create(:version) }
   shared_let(:parent_assignee) { create(:user, firstname: "Parent", lastname: "Assignee") }
 
   shared_let(:category) { create(:category) }
@@ -41,13 +42,13 @@ RSpec.describe Types::Patterns::TokenPropertyMapper do
 
   shared_let(:work_package_parent) do
     create(:work_package, project:, category:, start_date: Date.yesterday, estimated_hours: 120,
-                          remaining_hours: 80, due_date: 3.months.from_now, assigned_to: parent_assignee)
+                          remaining_hours: 80, due_date: 3.months.from_now, assigned_to: parent_assignee, version:)
   end
 
   shared_let(:work_package) do
     create(:work_package, responsible:, project:, category:, due_date: 1.month.from_now, assigned_to: assignee,
                           parent: work_package_parent, start_date: Time.zone.today, estimated_hours: 30,
-                          remaining_hours: 25)
+                          remaining_hours: 25, version:)
   end
 
   shared_let(:string_custom_field) do


### PR DESCRIPTION
# What are you trying to accomplish?
- add work package versions as supported attributes
- use localized project status instead of status code

### Open for discussion

- if we think it is a bad idea using i18n in the resolver functions, speak now (or be silent forever - muhahahahaha)