### PR TITLE
Fix omission in token exchange implementation

### DIFF
--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -34,8 +34,6 @@ module OpenIDConnect
 
     has_many :remote_identities, as: :auth_source, dependent: :destroy
 
-    TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
-
     OIDC_PROVIDERS = %w[google microsoft_entra custom].freeze
     DISCOVERABLE_STRING_ATTRIBUTES_MANDATORY = %i[authorization_endpoint
                                                   userinfo_endpoint
@@ -118,7 +116,7 @@ module OpenIDConnect
     def token_exchange_capable?
       return false if grant_types_supported.blank?
 
-      grant_types_supported.include?(TOKEN_EXCHANGE_GRANT_TYPE)
+      grant_types_supported.include?(OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE)
     end
 
     def icon

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/token_request.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/token_request.rb
@@ -45,8 +45,9 @@ module OpenIDConnect
 
       def exchange(access_token, audience)
         request_token(form: {
-                        grant_type: OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE,
+                        grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE,
                         subject_token: access_token,
+                        subject_token_type: OpenProject::OpenIDConnect::ACCESS_TOKEN_TYPE,
                         audience:
                       })
       end

--- a/modules/openid_connect/lib/open_project/openid_connect.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect.rb
@@ -34,6 +34,9 @@ require "open_project/openid_connect/engine"
 
 module OpenProject
   module OpenIDConnect
+    ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+    TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
     def self.configuration
       providers = ::OpenIDConnect::Provider.where(available: true)
 

--- a/modules/openid_connect/spec/factories/oidc_provider_factory.rb
+++ b/modules/openid_connect/spec/factories/oidc_provider_factory.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
     trait :token_exchange_capable do
       callback(:after_build) do |provider|
         provider.options["grant_types_supported"] ||= []
-        provider.options["grant_types_supported"] << OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE
+        provider.options["grant_types_supported"] << OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE
       end
     end
   end

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
     user.oidc_user_tokens.create!(access_token: idp_access_token, audiences: [OpenIDConnect::UserToken::IDP_AUDIENCE])
     user.oidc_user_tokens.create!(access_token:, refresh_token:, audiences: [existing_audience])
     stub_request(:post, provider.token_endpoint)
-      .with(body: hash_including(grant_type: OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE))
+      .with(body: hash_including(grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE))
       .to_return(**exchange_response)
   end
 

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/token_request_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/token_request_spec.rb
@@ -121,7 +121,12 @@ RSpec.describe OpenIDConnect::UserTokens::TokenRequest, :webmock do
     it "uses a properly formatted request body" do
       subject
       expect(WebMock).to have_requested(:post, provider.token_endpoint)
-        .with(body: { grant_type: OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE, subject_token: token, audience: })
+        .with(body: {
+                grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+                subject_token: token,
+                subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+                audience:
+              })
     end
 
     it "authenticates the request via HTTP Basic auth using Client ID and Client Secret" do

--- a/modules/storages/spec/common/storages/peripherals/connection_validators/nextcloud/authentication_validator_spec.rb
+++ b/modules/storages/spec/common/storages/peripherals/connection_validators/nextcloud/authentication_validator_spec.rb
@@ -178,12 +178,13 @@ module Storages
 
                 context "when the server supports token exchange" do
                   let(:oidc_provider) { create(:oidc_provider, :token_exchange_capable, scope: "offline_access") }
-                  let(:exchangeable_token) { create(:oidc_user_token, user:, refresh_token: nil) }
+                  let!(:exchangeable_token) { create(:oidc_user_token, user:, refresh_token: nil) }
 
                   it "favors token exchange when refreshing" do
                     exchange_request = stub_request(:post, oidc_provider.token_endpoint)
-                                         .with(body: { audience: storage.audience, subject_token: exchangeable_token.access_token,
-                                                       grant_type: OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE })
+                                         .with(body: hash_including(
+                                           grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE
+                                         ))
                                          .and_return_json(status: 200, body: { access_token: "NEW_TOKEN" })
 
                     expect(validator.call).to be_success
@@ -192,8 +193,9 @@ module Storages
 
                   it "fails if the exchange is met with an unexpected body" do
                     exchange_request = stub_request(:post, oidc_provider.token_endpoint)
-                                         .with(body: { audience: storage.audience, subject_token: exchangeable_token.access_token,
-                                                       grant_type: OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE })
+                                         .with(body: hash_including(
+                                           grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE
+                                         ))
                                          .and_return_json(status: 200, body: { error: "failed " })
 
                     result = validator.call
@@ -205,8 +207,9 @@ module Storages
 
                   it "fails if the exchange fails" do
                     exchange_request = stub_request(:post, oidc_provider.token_endpoint)
-                                         .with(body: { audience: storage.audience, subject_token: exchangeable_token.access_token,
-                                                       grant_type: OpenIDConnect::Provider::TOKEN_EXCHANGE_GRANT_TYPE })
+                                         .with(body: hash_including(
+                                           grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE
+                                         ))
                                          .and_return(status: 401)
 
                     result = validator.call


### PR DESCRIPTION
Providing a subject_token_type is required according to RFC 8693, but we left it out so far. New versions of Keycloak fail the token exchange request if that parameter is missing.

Since this required introducing another urn-constant, I've decided to move all of them to a common location.

# Ticket
https://community.openproject.org/wp/64117

# Checklist

* [x] updated specs
* [x] manually tested with Keycloak 26.2
* [x] manually tested with Keycloak 26.1