### PR TITLE
[#64023] Meeting occurrence blankslate disappears if item from the backlog is added and removed before other user refreshes the page  

### DIFF
--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -295,7 +295,12 @@ module Meetings
           update_section_header_via_turbo_stream(meeting_section: old_section)
 
           if old_section.agenda_items.empty?
-            update_section_via_turbo_stream(meeting_section: old_section)
+            if old_section.title.blank?
+              # Special case when the only item is being moved out of current meeting
+              update_list_via_turbo_stream
+            else
+              update_section_via_turbo_stream(meeting_section: old_section)
+            end
           else
             update_show_items_of_section_via_turbo_stream(meeting_section: old_section)
           end

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -166,7 +166,11 @@ class MeetingAgendaItemsController < ApplicationController
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
         remove_item_via_turbo_stream(clear_slate: @meeting.agenda_items.empty?)
-        update_section_header_via_turbo_stream(meeting_section: section) if section&.reload.present?
+
+        # If section is deleted via an after_destroy/after_update action, it needs to be handled separately
+        if MeetingSection.exists?(section.id) && section&.reload.present?
+          update_section_header_via_turbo_stream(meeting_section: section)
+        end
       end
     else
       generic_call_failure_response(call)


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/64023
https://community.openproject.org/wp/63422

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

A hidden section is created as soon as the first agenda item is added/moved to a meeting. Before, this hidden section was not deleted automatically when the last agenda item in it was moved out/deleted, resulting in some edge cases and buggy behaviour. 

This PR changes that by implementing the pending method to automatically destroy the default section if its last agenda item is removed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
