### PR TITLE
Upgrade development Keycloak to 26.2

### DIFF
--- a/docker/dev/keycloak/docker-compose.yml
+++ b/docker/dev/keycloak/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - POSTGRES_PASSWORD=keycloak
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.1
+    image: quay.io/keycloak/keycloak:26.2
     command:
     - "start-dev"
     - "--proxy-headers"
@@ -36,7 +36,6 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - KC_DB_SCHEMA=public
       - KC_HOSTNAME=keycloak.local
-      - KC_FEATURES=token-exchange,admin-fine-grained-authz
       - KC_TRANSACTION_XA_ENABLED=false
     volumes:
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro


### PR DESCRIPTION
This version adds official support for token exchange, so we can drop usage of preview features.

# Ticket
https://community.openproject.org/wp/64114