### PR TITLE
[64136] Add missing translation for Host in GitHub integration

### DIFF
--- a/modules/github_integration/config/locales/en.yml
+++ b/modules/github_integration/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     github_avatar_url: "Avatar URL"
     github_updated_at: "Updated at"
     github_login: "GitHub login"
+    host: "Host"
     labels: "Labels"
     repository: "Repository"
     changed_files_count: "Changed files"

--- a/modules/github_integration/spec/features/admin_github_integration_spec.rb
+++ b/modules/github_integration/spec/features/admin_github_integration_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Admin GitHub Integration page" do
+  current_user { create(:admin) }
+
+  it "renders the page" do
+    visit deploy_targets_path
+
+    expect(page).to have_content("GitHub Integration")
+  end
+end


### PR DESCRIPTION
Please wait for 16.0.0 to be released before merging.

# Ticket

https://community.openproject.org/wp/64136

# What are you trying to accomplish?

In GitHub integration page, in the table, "Host" header is not translatable. This is causing exceptions in development to force us to add a translation (See [PR #18023 Raise when using humanize within human\_attribute\_name](https://github.com/opf/openproject/pull/18023) for details).

Add the missing translation.

## Screenshots

Untranslated Host:

![image](https://github.com/user-attachments/assets/f9d2d837-46e5-4325-b2f5-c0a76425ca8d)

# What approach did you choose and why?

Simply add the key to the translation file, and add a test to render the GitHub integration page. If there was already a proper test for this page, it would have been caught in #18023 and fixed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
