### PR TITLE
[63499] Fix possible SystemStackError

### DIFF
--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -117,9 +117,23 @@ class WorkPackages::ScheduleDependency
     # All needed data is already loaded.
     @descendants ||= {}
     @descendants[work_package] ||= begin
-      children = children_by_parent_id(work_package.id)
+      work_packages_to_process = [work_package]
+      result = []
+      processed_ids = Set.new
 
-      children + children.flat_map { |child| descendants(child) }
+      while current = work_packages_to_process.shift
+        processed_ids.add(current.id)
+
+        children = children_by_parent_id(current.id)
+
+        # Avoid cycles by rejecting children that have already been processed
+        children.reject! { |child| processed_ids.include?(child.id) }
+
+        result.concat(children)
+        work_packages_to_process.concat(children)
+      end
+
+      result
     end
   end
 

--- a/spec/services/work_packages/schedule_dependency_spec.rb
+++ b/spec/services/work_packages/schedule_dependency_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::ScheduleDependency do
+  create_shared_association_defaults_for_work_package_factory
+
+  describe "#descendants" do
+    shared_let(:work_package) { create(:work_package) }
+    let(:schedule_dependency) { described_class.new(work_package) }
+
+    context "with a simple hierarchy" do
+      let!(:child1) { create(:work_package, parent: work_package) }
+      let!(:child2) { create(:work_package, parent: work_package) }
+
+      it "returns all direct children" do
+        expect(schedule_dependency.descendants(work_package)).to contain_exactly(child1, child2)
+      end
+    end
+
+    context "with multiple levels" do
+      let!(:child) { create(:work_package, parent: work_package) }
+      let!(:grandchild) { create(:work_package, parent: child) }
+      let!(:great_grandchild) { create(:work_package, parent: grandchild) }
+
+      it "returns all descendants at all levels" do
+        expect(schedule_dependency.descendants(work_package)).to contain_exactly(child, grandchild, great_grandchild)
+      end
+    end
+
+    context "with multiple branches" do
+      let!(:child1) { create(:work_package, parent: work_package) }
+      let!(:child2) { create(:work_package, parent: work_package) }
+      let!(:grandchild1) { create(:work_package, parent: child1) }
+      let!(:grandchild2) { create(:work_package, parent: child2) }
+
+      it "returns all descendants from all branches" do
+        expect(schedule_dependency.descendants(work_package)).to contain_exactly(
+          child1, child2, grandchild1, grandchild2
+        )
+      end
+    end
+
+    context "with caching" do
+      let!(:child) { create(:work_package, parent: work_package) }
+
+      it "caches the result" do
+        expect(schedule_dependency.descendants(work_package)).to contain_exactly(child)
+
+        # Create a new child after the first call
+        create(:work_package, parent: work_package)
+
+        # Should still return the cached result
+        expect(schedule_dependency.descendants(work_package)).to contain_exactly(child)
+      end
+    end
+
+    context "with a cycle in the hierarchy" do
+      let!(:child) { create(:work_package, parent: work_package) }
+
+      before do
+        # Create a cycle by making the work package a child of its child
+        work_package.update_column(:parent_id, child.id)
+      end
+
+      it "handles the cycle gracefully" do
+        expect { schedule_dependency.descendants(work_package) }.not_to raise_error
+        expect(schedule_dependency.descendants(work_package)).to contain_exactly(child)
+      end
+    end
+
+    context "with no children" do
+      it "returns an empty array" do
+        expect(schedule_dependency.descendants(work_package)).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION


# Ticket

https://community.openproject.org/wp/63499

# What are you trying to accomplish?

When there is a cycle in the hierarchy, for instance when drag and dropping a parent work package to its children from work packages list, or by bulk editing work packages and setting one of them as the parent, the scheduling computation would enter an infinite loop (when computing dates of parent from its children).

## Screenshots

[SystemStackError dragging parent into children.webm](https://github.com/user-attachments/assets/636f0758-1d92-4aea-acc5-94a0b3cab393)


# What approach did you choose and why?

In `WorkPackages::ScheduleDependency#descendants`, replace recursive call by a stack-based approach, and store processed items ids so that children that have already been processed can be rejected on next iterations.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
