### PR TITLE
[64123] Project attribute page shows the same button twice on mobile

### DIFF
--- a/app/components/settings/project_custom_fields/header_component.html.erb
+++ b/app/components/settings/project_custom_fields/header_component.html.erb
@@ -9,24 +9,32 @@
 
   <%=
     render Primer::OpenProject::SubHeader.new do |subheader|
-      subheader.with_action_button(leading_icon: :plus,
-                                   label: t("settings.project_attributes.label_new_section"),
-                                   tag: :a,
-                                   id: "dialog-show-project-custom-field-section-dialog",
-                                   href: new_link_admin_settings_project_custom_field_sections_path,
-                                   data: { controller: "async-dialog" }) do
-        t("settings.project_attributes.label_new_section")
-      end
-
-      subheader.with_action_button(
-        tag: :a,
-        href: new_admin_settings_project_custom_field_path(type: "ProjectCustomField"),
-        scheme: :primary,
+      subheader.with_action_menu(
         leading_icon: :plus,
-        label: t("settings.project_attributes.label_new_attribute"),
-        data: { turbo: "false", test_selector: "new-project-custom-field-button" },
-      ) do
-        t("settings.project_attributes.label_new_attribute")
+        trailing_icon: :"triangle-down",
+        label: I18n.t(:button_add),
+        anchor_align: :end,
+        button_arguments: {
+          scheme: :primary,
+          aria: { label: I18n.t(:button_add) },
+          test_selector: "project-attributes-add-menu-button"
+        }
+      ) do |menu|
+        menu.with_item(
+          label: t("settings.project_attributes.label_new_section"),
+          id: "dialog-show-project-custom-field-section-dialog",
+          tag: :a,
+          href: new_link_admin_settings_project_custom_field_sections_path,
+          content_arguments: { data: { controller: "async-dialog" } }
+        )
+
+        menu.with_item(
+          label: t("settings.project_attributes.label_new_attribute"),
+          tag: :a,
+          href: new_admin_settings_project_custom_field_path(type: "ProjectCustomField"),
+          content_arguments: { data: { turbo: "false",
+                                       test_selector: "new-project-custom-field-button" } }
+        )
       end
     end
   %>

--- a/spec/features/admin/project_custom_fields/list_spec.rb
+++ b/spec/features/admin/project_custom_fields/list_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe "List project custom fields", :js do
 
     it "allows to create a new section" do
       within "#settings-project-custom-fields-header-component" do
+        page.find_test_selector("project-attributes-add-menu-button").click
         click_on("dialog-show-project-custom-field-section-dialog")
       end
 
@@ -211,14 +212,15 @@ RSpec.describe "List project custom fields", :js do
       end
 
       it "redirects to the custom field new page via header menu button" do
-        page.find("[data-test-selector='new-project-custom-field-button']").click
+        page.find_test_selector("project-attributes-add-menu-button").click
+        page.find_test_selector("new-project-custom-field-button").click
 
         expect(page).to have_current_path(new_admin_settings_project_custom_field_path(type: "ProjectCustomField"))
       end
 
       it "redirects to the custom field new page via button in empty sections" do
         within_project_custom_field_section_container(section_for_multi_select_fields) do
-          expect(page).to have_no_css("[data-test-selector='new-project-custom-field-button']")
+          expect(page).not_to have_test_selector("new-project-custom-field-button")
         end
 
         multi_list_project_custom_field.destroy
@@ -228,7 +230,7 @@ RSpec.describe "List project custom fields", :js do
         visit admin_settings_project_custom_fields_path
 
         within_project_custom_field_section_container(section_for_multi_select_fields) do
-          page.find("[data-test-selector='new-project-custom-field-button']").click
+          page.find_test_selector("new-project-custom-field-button").click
         end
 
         expect(page).to have_current_path(new_admin_settings_project_custom_field_path(
@@ -241,14 +243,14 @@ RSpec.describe "List project custom fields", :js do
 
   # helper methods:
 
-  def within_project_custom_field_section_container(section, &block)
-    within("[data-test-selector='project-custom-field-section-container-#{section.id}']", &block)
+  def within_project_custom_field_section_container(section, &)
+    within_test_selector("project-custom-field-section-container-#{section.id}", &)
   end
 
-  def within_project_custom_field_section_menu(section, &block)
+  def within_project_custom_field_section_menu(section, &)
     within_project_custom_field_section_container(section) do
-      page.find("[data-test-selector='project-custom-field-section-action-menu']").click
-      within("anchored-position", &block)
+      page.find_test_selector("project-custom-field-section-action-menu").click
+      within("anchored-position", &)
     end
   end
 
@@ -259,14 +261,14 @@ RSpec.describe "List project custom fields", :js do
     sleep 0.5 # quick fix: allow the brower to process the action
   end
 
-  def within_project_custom_field_container(custom_field, &block)
-    within("[data-test-selector='project-custom-field-container-#{custom_field.id}']", &block)
+  def within_project_custom_field_container(custom_field, &)
+    within_test_selector("project-custom-field-container-#{custom_field.id}", &)
   end
 
-  def within_project_custom_field_menu(section, &block)
+  def within_project_custom_field_menu(section, &)
     within_project_custom_field_container(section) do
-      page.find("[data-test-selector='project-custom-field-action-menu']").click
-      within("anchored-position", &block)
+      page.find_test_selector("project-custom-field-action-menu").click
+      within("anchored-position", &)
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64123

# What are you trying to accomplish?
Transform the two "add" buttons into a single action menu

## Screenshots

<img width="965" alt="Bildschirmfoto 2025-05-21 um 14 04 34" src="https://github.com/user-attachments/assets/67875cc3-c206-4fd9-b5c1-175531dc2fe5" />

<img width="424" alt="Bildschirmfoto 2025-05-21 um 14 04 44" src="https://github.com/user-attachments/assets/b5a0160a-daba-45e0-a372-e41ca139e11b" />


