### PR TITLE
Request scope during token exchange

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2997,6 +2997,7 @@ en:
   label_query_new: "New query"
   label_query_plural: "Custom queries"
   label_read: "Read..."
+  label_read_documentation: "Read documentation"
   label_register: "Create a new account"
   label_register_with_developer: "Register as developer"
   label_registered_on: "Registered on"

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/exchange_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/exchange_service.rb
@@ -46,8 +46,9 @@ module OpenIDConnect
 
       attr_reader :user
 
-      def initialize(user:)
+      def initialize(user:, scope: nil)
         @user = user
+        @scope = scope
       end
 
       def call(audience)
@@ -85,7 +86,7 @@ module OpenIDConnect
       end
 
       def exchange_token_request(idp_token, audience)
-        TokenRequest.new(provider:).exchange(idp_token, audience).alt_map do
+        TokenRequest.new(provider:).exchange(idp_token, audience, @scope).alt_map do
           it.with(code: :"token_exchange_#{it.code}", source: self.class)
         end
       end

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/fetch_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/fetch_service.rb
@@ -43,8 +43,9 @@ module OpenIDConnect
       attr_reader :user
 
       def initialize(user:,
+                     exchange_scope: nil,
                      jwt_parser: JwtParser.new(verify_audience: false, verify_expiration: false),
-                     token_exchange: ExchangeService.new(user:),
+                     token_exchange: ExchangeService.new(user:, scope: exchange_scope),
                      token_refresh: RefreshService.new(user:, token_exchange:))
         @user = user
         @token_exchange = token_exchange

--- a/modules/openid_connect/app/services/openid_connect/user_tokens/token_request.rb
+++ b/modules/openid_connect/app/services/openid_connect/user_tokens/token_request.rb
@@ -43,13 +43,16 @@ module OpenIDConnect
         request_token(form: { grant_type: :refresh_token, refresh_token: })
       end
 
-      def exchange(access_token, audience)
-        request_token(form: {
-                        grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE,
-                        subject_token: access_token,
-                        subject_token_type: OpenProject::OpenIDConnect::ACCESS_TOKEN_TYPE,
-                        audience:
-                      })
+      def exchange(access_token, audience, scope)
+        parameters = {
+          grant_type: OpenProject::OpenIDConnect::TOKEN_EXCHANGE_GRANT_TYPE,
+          subject_token: access_token,
+          subject_token_type: OpenProject::OpenIDConnect::ACCESS_TOKEN_TYPE,
+          audience:
+        }
+        parameters[:scope] = scope unless scope.nil?
+
+        request_token(form: parameters)
       end
 
       private

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/exchange_service_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe OpenIDConnect::UserTokens::ExchangeService, :webmock do
         .with(body: hash_including(subject_token: idp_access_token))
     end
 
+    it "doesn't request any scopes" do
+      subject
+      expect(WebMock).to(have_requested(:post, provider.token_endpoint).with { |req| expect(req.body).not_to include("scope") })
+    end
+
+    context "when configuring a scope" do
+      let(:service) { described_class.new(user:, scope:) }
+      let(:scope) { "scope-a scope-b" }
+
+      it "requests the scopes during token exchange" do
+        subject
+        expect(WebMock).to have_requested(:post, provider.token_endpoint)
+          .with(body: hash_including(scope:))
+      end
+    end
+
     context "when the response has no expires_in" do
       let(:exchange_response) do
         {

--- a/modules/openid_connect/spec/services/openid_connect/user_tokens/token_request_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/user_tokens/token_request_spec.rb
@@ -107,10 +107,11 @@ RSpec.describe OpenIDConnect::UserTokens::TokenRequest, :webmock do
   end
 
   describe "#exchange" do
-    subject { service.exchange(token, audience) }
+    subject { service.exchange(token, audience, scope) }
 
     let(:token) { "a-refresh-token" }
     let(:audience) { "target-audience" }
+    let(:scope) { nil }
 
     it { is_expected.to be_success }
 
@@ -150,6 +151,22 @@ RSpec.describe OpenIDConnect::UserTokens::TokenRequest, :webmock do
           _, credentials = auth_header.split
           expect(Base64.decode64(credentials)).to eq "https%3A%2F%2Fopenproject.local:a-secret%2Fwith%3Aspecial-characters"
         end)
+      end
+    end
+
+    context "when passing a scope" do
+      let(:scope) { "scope-a scope-b" }
+
+      it "includes the scope in the request body" do
+        subject
+        expect(WebMock).to have_requested(:post, provider.token_endpoint)
+          .with(body: {
+                  grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+                  subject_token: token,
+                  subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+                  audience:,
+                  scope:
+                })
       end
     end
 

--- a/modules/storages/app/common/storages/peripherals/connection_validators/nextcloud/authentication_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/connection_validators/nextcloud/authentication_validator.rb
@@ -104,7 +104,7 @@ module Storages
           end
 
           def token_negotiable
-            service = OpenIDConnect::UserTokens::FetchService.new(user: @user)
+            service = OpenIDConnect::UserTokens::FetchService.new(user: @user, exchange_scope: @storage.storage_scope)
 
             result = service.access_token_for(audience: @storage.audience)
             return pass_check(:token_negotiable) if result.success?

--- a/modules/storages/app/common/storages/peripherals/connection_validators/nextcloud/authentication_validator.rb
+++ b/modules/storages/app/common/storages/peripherals/connection_validators/nextcloud/authentication_validator.rb
@@ -104,7 +104,7 @@ module Storages
           end
 
           def token_negotiable
-            service = OpenIDConnect::UserTokens::FetchService.new(user: @user, exchange_scope: @storage.storage_scope)
+            service = OpenIDConnect::UserTokens::FetchService.new(user: @user, exchange_scope: @storage.token_exchange_scope)
 
             result = service.access_token_for(audience: @storage.audience)
             return pass_check(:token_negotiable) if result.success?

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/sso_user_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/sso_user_token.rb
@@ -43,7 +43,7 @@ module Storages
 
           def call(storage:, http_options: {}, &)
             OpenIDConnect::UserTokens::FetchService
-              .new(user: @user, exchange_scope: storage.storage_scope)
+              .new(user: @user, exchange_scope: storage.token_exchange_scope)
               .access_token_for(audience: storage.audience)
               .either(
                 ->(token) do

--- a/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/sso_user_token.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_interaction/authentication_strategies/sso_user_token.rb
@@ -43,7 +43,7 @@ module Storages
 
           def call(storage:, http_options: {}, &)
             OpenIDConnect::UserTokens::FetchService
-              .new(user: @user)
+              .new(user: @user, exchange_scope: storage.storage_scope)
               .access_token_for(audience: storage.audience)
               .either(
                 ->(token) do

--- a/modules/storages/app/components/storages/admin/forms/storage_audience_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/storage_audience_form_component.html.erb
@@ -42,13 +42,15 @@ See COPYRIGHT and LICENSE files for more details.
       ) do |form|
         flex_layout do |general_info_row|
           general_info_row.with_row(mb: 3) do
-            concat(render(Primer::Beta::Text.new(color: :subtle)) { "#{t('storages.storage_audience.documentation_intro')} " })
-            concat(
-              render(Primer::Beta::Link.new(href: OpenProject::Static::Links.url_for(:storage_docs, :nextcloud_sso))) do |link|
-                link.with_trailing_visual_icon(icon: "link-external")
-                I18n.t(:label_more_information)
-              end
-            )
+            render(Primer::Alpha::Banner.new(icon: :info, scheme: :default)) do |component|
+              component.with_action_button(
+                size: :medium,
+                tag: :a,
+                href: OpenProject::Static::Links.url_for(:storage_docs, :nextcloud_sso)
+              ) { I18n.t(:label_read_documentation) }
+
+              t('storages.storage_audience.documentation_intro')
+            end
           end
 
           general_info_row.with_row(mb: 3) do

--- a/modules/storages/app/components/storages/admin/storage_audience_info_component.erb
+++ b/modules/storages/app/components/storages/admin/storage_audience_info_component.erb
@@ -31,12 +31,12 @@ See COPYRIGHT and LICENSE files for more details.
   component_wrapper(tag: 'turbo-frame') do
     grid_layout('op-storage-view--row', tag: :div, align_items: :center) do |grid|
       grid.with_area(:item, tag: :div, mr: 3) do
-        concat(render(Primer::Beta::Text.new(font_weight: :bold, mr: 1, test_selector: 'storage-audience-label')) { I18n.t('storages.file_storage_view.storage_audience') })
+        concat(render(Primer::Beta::Text.new(font_weight: :bold, mr: 1, test_selector: 'storage-audience-label')) { I18n.t('storages.file_storage_view.token_exchange') })
         concat(configuration_check_label_for(:storage_audience_configured))
       end
 
       grid.with_area(:description, tag: :div, color: :subtle, test_selector: 'storage-audience-description') do
-        concat(render(Primer::Beta::Text.new) { audience_summary })
+        concat(render(Primer::Beta::Text.new) { token_exchange_summary })
       end
 
       if editable_storage?
@@ -49,7 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
                   tag: :a,
                   scheme: :invisible,
                   href: edit_storage_audience_admin_settings_storage_path(storage),
-                  aria: { label: I18n.t('storages.label_edit_storage_audience') },
+                  aria: { label: I18n.t('storages.label_edit_token_exchange') },
                   test_selector: 'storage-edit-storage-audience-button',
                   data: { turbo_stream: true }
                 )

--- a/modules/storages/app/components/storages/admin/storage_audience_info_component.rb
+++ b/modules/storages/app/components/storages/admin/storage_audience_info_component.rb
@@ -33,7 +33,7 @@ module Storages
     class StorageAudienceInfoComponent < StorageInfoComponent
       def self.wrapper_key = :storage_audience_section
 
-      def audience_summary
+      def token_exchange_summary
         case storage.storage_audience
         when "", nil
           I18n.t("storages.file_storage_view.storage_audience_blank")

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -82,6 +82,10 @@ class Storages::Admin::StoragesController < ApplicationController
 
   def upsell; end
 
+  def edit
+    @wizard = storage_wizard(@storage)
+  end
+
   def create
     service_result = Storages::Storages::CreateService
                        .new(
@@ -110,10 +114,6 @@ class Storages::Admin::StoragesController < ApplicationController
     else
       redirect_to(edit_admin_settings_storage_path(@storage), status: :see_other)
     end
-  end
-
-  def edit
-    @wizard = storage_wizard(@storage)
   end
 
   def edit_host
@@ -242,20 +242,21 @@ class Storages::Admin::StoragesController < ApplicationController
   # update parameters are correctly set.
   def permitted_storage_params(model_parameter_name = storage_provider_parameter_name)
     params
-      .require(model_parameter_name)
-      .permit("name",
-              "provider_type",
-              "host",
-              "authentication_method",
-              "audience_configuration",
-              "storage_audience",
-              "storage_scope",
-              "oauth_client_id",
-              "oauth_client_secret",
-              "tenant_id",
-              "drive_id",
-              "automatic_management_enabled",
-              "health_notifications_enabled")
+      .expect(model_parameter_name => %i[
+                audience_configuration
+                authentication_method
+                automatic_management_enabled
+                drive_id
+                health_notifications_enabled
+                host
+                name
+                oauth_client_id
+                oauth_client_secret
+                provider_type
+                storage_audience
+                storage_scope
+                tenant_id
+              ])
   end
 
   def storage_provider_parameter_name

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -249,6 +249,7 @@ class Storages::Admin::StoragesController < ApplicationController
               "authentication_method",
               "audience_configuration",
               "storage_audience",
+              "storage_scope",
               "oauth_client_id",
               "oauth_client_secret",
               "tenant_id",

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -254,8 +254,8 @@ class Storages::Admin::StoragesController < ApplicationController
                 oauth_client_secret
                 provider_type
                 storage_audience
-                storage_scope
                 tenant_id
+                token_exchange_scope
               ])
   end
 

--- a/modules/storages/app/forms/storages/admin/storage_audience_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/storage_audience_input_form.rb
@@ -62,10 +62,10 @@ module Storages::Admin
         )
 
         toggleable_group.text_field(
-          name: :storage_scope,
-          label: I18n.t("activerecord.attributes.storages/nextcloud_storage.storage_scope"),
+          name: :token_exchange_scope,
+          label: I18n.t("activerecord.attributes.storages/nextcloud_storage.token_exchange_scope"),
           required: false,
-          caption: I18n.t("storages.instructions.nextcloud.storage_scope"),
+          caption: I18n.t("storages.instructions.nextcloud.token_exchange_scope"),
           input_width: :large
         )
       end

--- a/modules/storages/app/forms/storages/admin/storage_audience_input_form.rb
+++ b/modules/storages/app/forms/storages/admin/storage_audience_input_form.rb
@@ -60,6 +60,14 @@ module Storages::Admin
           data: { "storages--storage-audience-target": "audienceInput" },
           value: prefilled_audience
         )
+
+        toggleable_group.text_field(
+          name: :storage_scope,
+          label: I18n.t("activerecord.attributes.storages/nextcloud_storage.storage_scope"),
+          required: false,
+          caption: I18n.t("storages.instructions.nextcloud.storage_scope"),
+          input_width: :large
+        )
       end
     end
 

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -49,7 +49,7 @@ module Storages
     store_attribute :provider_fields, :group_folder, :string
     store_attribute :provider_fields, :authentication_method, :string, default: "two_way_oauth2"
     store_attribute :provider_fields, :storage_audience, :string
-    store_attribute :provider_fields, :storage_scope, :string
+    store_attribute :provider_fields, :token_exchange_scope, :string
 
     def oauth_configuration
       Peripherals::OAuthConfigurations::NextcloudConfiguration.new(self)

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -49,6 +49,7 @@ module Storages
     store_attribute :provider_fields, :group_folder, :string
     store_attribute :provider_fields, :authentication_method, :string, default: "two_way_oauth2"
     store_attribute :provider_fields, :storage_audience, :string
+    store_attribute :provider_fields, :storage_scope, :string
 
     def oauth_configuration
       Peripherals::OAuthConfigurations::NextcloudConfiguration.new(self)

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -352,9 +352,9 @@ en:
         integration: Nextcloud Administration / OpenProject
         oauth_configuration: Copy these values from %{application_link_text}.
         provider_configuration: Please make sure you have administration privileges in your Nextcloud instance and the %{application_link_text} is installed before doing the setup.
-        storage_audience: Please enter the Client ID that the Nextcloud instance uses to communicate with the identity provider.
+        storage_audience: The client ID that the Nextcloud instance uses to communicate with the identity provider.
         storage_audience_placeholder: e.g. nextcloud
-        storage_scope: Enter scopes that should be requested during token exchange. Multiple scopes can be separated by a space.
+        storage_scope: The scopes that should be requested during token exchange, each one separated by a space.
       no_specific_folder: By default, each user will start at their own home folder when they upload a file.
       no_storage_set_up: There are no file storages set up yet.
       not_logged_into_storage: To select a project folder, please first login
@@ -482,13 +482,13 @@ en:
       description: Deactivating this option will hide the attachments list on the work packages files tab. The files attached in the description of a work package will still be uploaded in the internal attachments storage.
       label: Show attachments in the work packages files tab
     storage_audience:
-      documentation_intro: Details on the following options and what needs to be configured in the identity provider can be found in our documentation.
+      documentation_intro: Please read our documentation for details on the following options and configuration of the identity provider.
       idp:
-        helptext: OpenProject will use the access token received by the identity provider during the user's log in to authenticate requests to the storage. It will not try to obtain another token.
-        label: Use access token obtained during user's log in
+        helptext: OpenProject will use the access token received by the identity provider during log in to authenticate requests to the storage. It will not try to obtain another token.
+        label: Use access token obtained during user log in
       manual:
-        helptext: Allows you to set the audience of the storage. OpenProject will try to exchange a token for the given audience from the identity provider.
-        label: Specify audience for which to exchange access token
+        helptext: OpenProject will exchange a token with the identity provider for the given audience.
+        label: Manually specify audience for which to exchange access token
     storage_list_blank_slate:
       description: Add a storage to see them here.
       heading: You don't have any storages yet.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -227,12 +227,12 @@ en:
       openproject_oauth: OpenProject OAuth
       project_folders: Project folders
       redirect_uri: Redirect URI
-      storage_audience: Storage Audience
       storage_audience_blank: No audience has been configured.
-      storage_audience_description: Obtaining tokens for audience "%{audience}".
-      storage_audience_idp: Using first access token received by identity provider, regardless of audience.
+      storage_audience_description: Exchanging tokens for audience "%{audience}".
+      storage_audience_idp: Using access token obtained by identity provider during login, regardless of audience.
       storage_oauth: Nextcloud OAuth
       storage_provider: Storage provider
+      token_exchange: Token Exchange
     health:
       actions:
         download_report: Download
@@ -386,9 +386,9 @@ en:
     label_creator: Creator
     label_delete_storage: Delete storage
     label_edit_storage_access_management: Edit storage access management
-    label_edit_storage_audience: Edit Storage Audience
     label_edit_storage_automatically_managed_folders: Edit storage automatically managed folders
     label_edit_storage_host: Edit storage host
+    label_edit_token_exchange: Edit token exchange configuration
     label_existing_manual_folder: Existing folder with manually managed permissions
     label_file_storage: File storage
     label_host: Host URL
@@ -484,11 +484,11 @@ en:
     storage_audience:
       documentation_intro: Details on the following options and what needs to be configured in the identity provider can be found in our documentation.
       idp:
-        helptext: OpenProject will use the first access token received by the identity provider to authenticate requests to the storage. It will not try to obtain another token.
-        label: Use first access token obtained by identity provider
+        helptext: OpenProject will use the access token received by the identity provider during the user's log in to authenticate requests to the storage. It will not try to obtain another token.
+        label: Use access token obtained during user's log in
       manual:
-        helptext: Allows you to set the audience of the storage. OpenProject will try to obtain a token for the given audience from the identity provider.
-        label: Define storage audience manually
+        helptext: Allows you to set the audience of the storage. OpenProject will try to exchange a token for the given audience from the identity provider.
+        label: Specify audience for which to exchange access token
     storage_list_blank_slate:
       description: Add a storage to see them here.
       heading: You don't have any storages yet.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
           oauth2_sso_with_two_way_oauth2_fallback: Single-Sign-On with Two-Way OAuth 2.0 as fallback
           two_way_oauth2: Two-way OAuth 2.0 authorization code flow
         storage_audience: Storage Audience
-        storage_scope: Storage Scope
+        token_exchange_scope: Storage Scope
       storages/project_storage:
         project_folder: Project folder
         project_folder_mode: Project folder mode
@@ -354,7 +354,7 @@ en:
         provider_configuration: Please make sure you have administration privileges in your Nextcloud instance and the %{application_link_text} is installed before doing the setup.
         storage_audience: The client ID that the Nextcloud instance uses to communicate with the identity provider.
         storage_audience_placeholder: e.g. nextcloud
-        storage_scope: The scopes that should be requested during token exchange, each one separated by a space.
+        token_exchange_scope: The scopes that should be requested during token exchange, each one separated by a space.
       no_specific_folder: By default, each user will start at their own home folder when they upload a file.
       no_storage_set_up: There are no file storages set up yet.
       not_logged_into_storage: To select a project folder, please first login

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
           oauth2_sso_with_two_way_oauth2_fallback: Single-Sign-On with Two-Way OAuth 2.0 as fallback
           two_way_oauth2: Two-way OAuth 2.0 authorization code flow
         storage_audience: Storage Audience
+        storage_scope: Storage Scope
       storages/project_storage:
         project_folder: Project folder
         project_folder_mode: Project folder mode
@@ -353,6 +354,7 @@ en:
         provider_configuration: Please make sure you have administration privileges in your Nextcloud instance and the %{application_link_text} is installed before doing the setup.
         storage_audience: Please enter the Client ID that the Nextcloud instance uses to communicate with the identity provider.
         storage_audience_placeholder: e.g. nextcloud
+        storage_scope: Enter scopes that should be requested during token exchange. Multiple scopes can be separated by a space.
       no_specific_folder: By default, each user will start at their own home folder when they upload a file.
       no_storage_set_up: There are no file storages set up yet.
       not_logged_into_storage: To select a project folder, please first login

--- a/modules/storages/spec/components/storages/admin/storage_audience_info_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/storage_audience_info_component_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe Storages::Admin::StorageAudienceInfoComponent, type: :component d
     render_component
 
     expect(page).to have_test_selector("storage-audience-label")
-    expect(page).to have_content("Storage Audience")
+    expect(page).to have_content("Token Exchange")
   end
 
   it "indicates the name of the selected audience" do
     render_component
-    expect(page).to have_content('Obtaining tokens for audience "Alice".')
+    expect(page).to have_content('Exchanging tokens for audience "Alice".')
   end
 
   context "when audience is empty string" do
@@ -74,7 +74,7 @@ RSpec.describe Storages::Admin::StorageAudienceInfoComponent, type: :component d
 
     it "indicates that the IDP audience has been selected" do
       render_component
-      expect(page).to have_content("Using first access token received by identity provider, regardless of audience.")
+      expect(page).to have_content("Using access token obtained by identity provider during login, regardless of audience.")
     end
   end
 end

--- a/modules/storages/spec/features/storages/admin/create_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/create_storage_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "Admin Create a new file storage",
         end
 
         expect(page).to have_test_selector("label-storage_audience_configured-status", text: "Completed")
-        expect(page).to have_test_selector("storage-audience-description", text: "Obtaining tokens for audience \"nextcloud\"")
+        expect(page).to have_test_selector("storage-audience-description", text: "Exchanging tokens for audience \"nextcloud\"")
       end
 
       aggregate_failures "Automatically managed project folders" do

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe "Admin Edit File storage",
       aggregate_failures "Token Exchange" do
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page).to have_checked_field("Specify audience for which to exchange access token")
+          expect(page).to have_checked_field("Manually specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience")
 
           click_on "Save and continue"
@@ -310,9 +310,9 @@ RSpec.describe "Admin Edit File storage",
 
           fill_in "Storage Audience", with: "schmaudience"
 
-          choose("Use access token obtained during user's log in")
+          choose("Use access token obtained during user log in")
           expect(page).to have_no_field("Storage Audience")
-          choose("Specify audience for which to exchange access token")
+          choose("Manually specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience", with: "schmaudience")
 
           click_on "Save and continue"
@@ -326,10 +326,10 @@ RSpec.describe "Admin Edit File storage",
 
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page).to have_checked_field("Specify audience for which to exchange access token")
+          expect(page).to have_checked_field("Manually specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience", with: "schmaudience")
 
-          choose("Use access token obtained during user's log in")
+          choose("Use access token obtained during user log in")
           click_on "Save and continue"
         end
 
@@ -341,10 +341,10 @@ RSpec.describe "Admin Edit File storage",
 
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page).to have_checked_field("Use access token obtained during user's log in")
+          expect(page).to have_checked_field("Use access token obtained during user log in")
           expect(page).to have_no_field("Storage Audience")
 
-          choose("Specify audience for which to exchange access token")
+          choose("Manually specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience", with: "")
         end
       end

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -274,8 +274,8 @@ RSpec.describe "Admin Edit File storage",
         expect(page).to have_test_selector("label-host_name_configured-status", text: "Completed")
         expect(page).to have_test_selector("storage-description", text: "Nextcloud - #{storage.name} - #{storage.host}")
 
-        # Storage audience
-        expect(page).to have_test_selector("storage-audience-label", text: "Storage Audience")
+        # Token Exchange
+        expect(page).to have_test_selector("storage-audience-label", text: "Token Exchange")
         expect(page).to have_test_selector("label-storage_audience_configured-status", text: "Incomplete")
         expect(page).to have_test_selector("storage-audience-description", text: "No audience has been configured")
 
@@ -299,10 +299,10 @@ RSpec.describe "Admin Edit File storage",
         end
       end
 
-      aggregate_failures "Storage Audience" do
+      aggregate_failures "Token Exchange" do
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page).to have_checked_field("Define storage audience manually")
+          expect(page).to have_checked_field("Specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience")
 
           click_on "Save and continue"
@@ -310,38 +310,41 @@ RSpec.describe "Admin Edit File storage",
 
           fill_in "Storage Audience", with: "schmaudience"
 
-          choose("Use first access token obtained by identity provider")
+          choose("Use access token obtained during user's log in")
           expect(page).to have_no_field("Storage Audience")
-          choose("Define storage audience manually")
+          choose("Specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience", with: "schmaudience")
 
-          click_on "Save and continue"
-        end
-
-        expect(page).to have_test_selector("label-storage_audience_configured-status", text: "Completed")
-        expect(page).to have_test_selector("storage-audience-description", text: "Obtaining tokens for audience \"schmaudience\"")
-
-        find_test_selector("storage-edit-storage-audience-button").click
-        within_test_selector("storage-audience-form") do
-          expect(page).to have_checked_field("Define storage audience manually")
-          expect(page).to have_field("Storage Audience", with: "schmaudience")
-
-          choose("Use first access token obtained by identity provider")
           click_on "Save and continue"
         end
 
         expect(page).to have_test_selector("label-storage_audience_configured-status", text: "Completed")
         expect(page).to have_test_selector(
           "storage-audience-description",
-          text: "Using first access token received by identity provider, regardless of audience."
+          text: "Exchanging tokens for audience \"schmaudience\""
         )
 
         find_test_selector("storage-edit-storage-audience-button").click
         within_test_selector("storage-audience-form") do
-          expect(page).to have_checked_field("Use first access token obtained by identity provider")
+          expect(page).to have_checked_field("Specify audience for which to exchange access token")
+          expect(page).to have_field("Storage Audience", with: "schmaudience")
+
+          choose("Use access token obtained during user's log in")
+          click_on "Save and continue"
+        end
+
+        expect(page).to have_test_selector("label-storage_audience_configured-status", text: "Completed")
+        expect(page).to have_test_selector(
+          "storage-audience-description",
+          text: "Using access token obtained by identity provider during login, regardless of audience."
+        )
+
+        find_test_selector("storage-edit-storage-audience-button").click
+        within_test_selector("storage-audience-form") do
+          expect(page).to have_checked_field("Use access token obtained during user's log in")
           expect(page).to have_no_field("Storage Audience")
 
-          choose("Define storage audience manually")
+          choose("Specify audience for which to exchange access token")
           expect(page).to have_field("Storage Audience", with: "")
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64121

# What are you trying to accomplish?
Allowing to specify scopes requested during Token Exchange. This is effectively required with the latest Keycloak version, because the scope parameter allows to ask for any `Optional` scopes, thus it allows to extend the scope beyond the scope of the original token. On the other hand the `audience` parameter can only be used to reduce the token's existing audiences to the one requested. This means exchanging a login token with audience `A` for a token with audience `B` requires to add a scope that will result in an extension of the audience, while at the same time filtering out all other audiences using the `audience` parameter.

To make the forms more consistent, the framing of "storage audience" has been changed to "token exchange", where the audience is just one aspect of it.

## Screenshots

![image](https://github.com/user-attachments/assets/b504db44-60c3-43af-bdf5-ef1d705287ff)

![image](https://github.com/user-attachments/assets/f6ff5301-ba5e-4e3a-8159-8cd0f161fb90)
