### PR TITLE
Remove query behaviour of clearing columns if they match default

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -289,11 +289,6 @@ class Query < ApplicationRecord
                 .compact_blank
                 .map(&:to_sym)
 
-    # Set column_names to blank/nil if it is equal to the default columns
-    if col_names.map(&:to_s) == Setting.work_package_list_default_columns
-      col_names.clear
-    end
-
     write_attribute(:column_names, col_names)
   end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/64062

# What are you trying to accomplish?

When an array of columns was provided that match the default columns setting, the columns used to be cleared so that when next the query is loaded, the default columns are used. This granted the setting reign also over already existing columns.

At the same time, this behaviour leads to surprising side effects. E.g. by removing a column the default columns might be matched suddenly so that then the columns change if the default ones are changed afterwards. Additionally, it becomes impossible to remove the project column from the global work package list. It can also be argued that users would be surprised if the columns for their stored queries change by changing the default columns. However, that might be the only valid use case for the removed code. 

The intend of relying on the default columns is still working for newly created queries as well as for default column (e.g. "all open").