### PR TITLE
exclude ongoing timers from my time tracking page

### DIFF
--- a/modules/costs/app/controllers/my/time_tracking_controller.rb
+++ b/modules/costs/app/controllers/my/time_tracking_controller.rb
@@ -125,7 +125,7 @@ module My
       @time_entries = TimeEntry
         .includes(:project, :activity, { work_package: :status })
         .where(project_id: Project.visible.select(:id))
-        .where(user: User.current, spent_on: time_scope)
+        .where(user: User.current, spent_on: time_scope, ongoing: false)
         .order(:spent_on, :start_time, :hours)
     end
 

--- a/modules/costs/spec/controllers/my/time_tracking_controller_spec.rb
+++ b/modules/costs/spec/controllers/my/time_tracking_controller_spec.rb
@@ -97,6 +97,16 @@ RSpec.describe My::TimeTrackingController do
         end
       end
     end
+
+    context "with an ongoing timer" do
+      let!(:time_entry) { create(:time_entry, user: user, spent_on: Date.current, hours: 1.5) }
+      let!(:time_entry_ongoing) { create(:time_entry, user: user, spent_on: Date.current, ongoing: true) }
+
+      it "does not include the ongoing timer in the my time tracking page (Regression: #64173)" do
+        get :index
+        expect(assigns(:time_entries)).to contain_exactly(time_entry)
+      end
+    end
   end
 
   describe "GET /my/time-tracking/day" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/64173

# What are you trying to accomplish?
Ongoing timers do not have hours set yet, so we can not include them in sums, etc. 

## Screenshots

# What approach did you choose and why?
We can easily exclude it

# Merge checklist

- [x] Added/updated tests
