### PR TITLE
implementation/64104 Extend API V3 to cover Emoji reactions on work package comments (toggle) and extend documentation

### DIFF
--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -149,17 +149,10 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def toggle_reaction # rubocop:disable Metrics/AbcSize
-    emoji_reaction_service =
-      if @journal.emoji_reactions.exists?(user: User.current, reaction: params[:reaction])
-        EmojiReactions::DeleteService
-         .new(user: User.current,
-              model: @journal.emoji_reactions.find_by(user: User.current, reaction: params[:reaction]))
-         .call
-      else
-        EmojiReactions::CreateService
-         .new(user: User.current)
-         .call(user: User.current, reactable: @journal, reaction: params[:reaction])
-      end
+    emoji_reaction_service = EmojiReactions::ToggleEmojiReactionService
+      .call(user: User.current,
+            reactable: @journal,
+            reaction: params[:reaction])
 
     emoji_reaction_service.on_success do
       update_via_turbo_stream(

--- a/app/services/emoji_reactions/toggle_emoji_reaction_service.rb
+++ b/app/services/emoji_reactions/toggle_emoji_reaction_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module EmojiReactions
+  module ToggleEmojiReactionService
+    def self.call(user:, reactable:, reaction:)
+      if reactable.emoji_reactions.exists?(user:, reaction:)
+        EmojiReactions::DeleteService
+         .new(user:,
+              model: reactable.emoji_reactions.find_by(user:, reaction:))
+         .call
+      else
+        EmojiReactions::CreateService
+         .new(user:)
+         .call(user:, reactable:, reaction:)
+      end
+    end
+  end
+end

--- a/docs/api/apiv3/paths/activity_emoji_reactions.yml
+++ b/docs/api/apiv3/paths/activity_emoji_reactions.yml
@@ -43,3 +43,94 @@ get:
 
         *Note: A client without sufficient permissions shall not be able to test for the existence of an activity.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
+
+patch:
+  summary: Toggle emoji reaction for an activity
+  operationId: toggle_activity_emoji_reaction
+  tags:
+    - Activities
+    - EmojiReactions
+  description: |-
+    Toggle an emoji reaction for a given activity. If the user has already reacted with the given emoji,
+    the reaction will be removed. Otherwise, a new reaction will be created.
+
+    **Required permission:**
+    - `add_work_package_comments`
+    - for internal comments: `add_internal_comments`
+
+  parameters:
+    - name: id
+      description: ID of the activity to toggle emoji reaction for
+      in: path
+      required: true
+      schema:
+        type: integer
+      example: '1'
+  requestBody:
+    required: true
+    content:
+      application/hal+json:
+        schema:
+          type: object
+          required:
+            - reaction
+          properties:
+            reaction:
+              type: string
+              description: The emoji reaction identifier
+              example: "thumbs_up"
+              enum:
+                - thumbs_up
+                - thumbs_down
+                - grinning_face_with_smiling_eyes
+                - confused_face
+                - heart
+                - party_popper
+                - rocket
+                - eyes
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/emoji_reaction_model.yml'
+    '400':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:BadRequest
+                message: "Bad request: reaction does not have a valid value"
+      description: Returned if the request is invalid. For example, if the reaction is not valid.
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: "You are not authorized to access this resource."
+      description: |-
+        Returned if the client does not have sufficient permissions to toggle the emoji reaction for the activity.
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the activity does not exist or the client does not have sufficient permissions
+        to see it.

--- a/docs/api/apiv3/paths/activity_emoji_reactions.yml
+++ b/docs/api/apiv3/paths/activity_emoji_reactions.yml
@@ -54,6 +54,8 @@ patch:
     Toggle an emoji reaction for a given activity. If the user has already reacted with the given emoji,
     the reaction will be removed. Otherwise, a new reaction will be created.
 
+    **Note:** The response contains the complete collection of all emoji reactions for this activity.
+
     **Required permission:**
     - `add_work_package_comments`
     - for internal comments: `add_internal_comments`

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
@@ -239,11 +239,6 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
       let(:path) { api_v3_paths.emoji_reactions_by_activity_comment(internal_comment.id) }
       let(:reaction) { "thumbs_up" }
 
-      before do
-        project.enabled_internal_comments = true
-        project.save!
-      end
-
       context "and user has permission to create internal comments" do
         let(:reaction) { "rocket" }
         let(:permissions) { %i(view_work_packages add_work_package_comments view_internal_comments add_internal_comments) }

--- a/spec/services/emoji_reactions/toggle_emoji_reaction_service_spec.rb
+++ b/spec/services/emoji_reactions/toggle_emoji_reaction_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe EmojiReactions::ToggleEmojiReactionService do
+  shared_let(:user) { create(:user, admin: true) }
+  shared_let(:work_package) { create(:work_package) }
+  shared_let(:reactable) do
+    create(:work_package_journal, user: user, notes: "A Note", journable: work_package, version: 2)
+  end
+
+  let(:reaction) { "thumbs_up" }
+
+  before do
+    allow(EmojiReactions::CreateService).to receive(:new).and_call_original
+    allow(EmojiReactions::DeleteService).to receive(:new).and_call_original
+  end
+
+  describe ".call" do
+    it "toggles the reaction" do
+      aggregate_failures "creates if not exists" do
+        expect do
+          described_class.call(user:, reactable:, reaction:)
+        end.to change(EmojiReaction, :count).by(1)
+
+        expect(EmojiReactions::CreateService).to have_received(:new).with(user:)
+      end
+
+      emoji_reaction = EmojiReaction.last
+
+      aggregate_failures "deletes if exists" do
+        expect do
+          described_class.call(user:, reactable:, reaction:)
+        end.to change(EmojiReaction, :count).by(-1)
+
+        expect(EmojiReactions::DeleteService).to have_received(:new).with(user:, model: emoji_reaction)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/64104

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Add emoji reaction toggle endpoint- `PATCH /api/v3/activities/{id}/emoji_reactions`

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1959" alt="Screenshot 2025-05-26 at 1 19 59 PM" src="https://github.com/user-attachments/assets/c78855f7-3263-404c-a565-af881e5581d2" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The toggle endpoint serves as combination of create/delete operations as emoji reactions are largely seen a "compound" resource.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
