### PR TITLE
[64236] Accessibility, Focus issues with WP primary button

### DIFF
--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -85,7 +85,7 @@ a.button
       border-color: var(--button--primary-background-hover-color)
 
     &:focus-visible
-      box-shadow: inset 0 0 0 3px var(--fgColor-onEmphasis,var(--color-fg-on-emphasis))
+      box-shadow: inset 0 0 0 3px var(--fgColor-onEmphasis,var(--fgColor-white))
 
   &.-highlight-inverted
     @include button-style(var(--button-default-bgColor-rest), var(--button-default-bgColor-hover), var(--button-default-fgColor-rest))

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -84,6 +84,9 @@ a.button
     &:hover, &:focus
       border-color: var(--button--primary-background-hover-color)
 
+    &:focus-visible
+      box-shadow: inset 0 0 0 3px var(--fgColor-onEmphasis,var(--color-fg-on-emphasis))
+
   &.-highlight-inverted
     @include button-style(var(--button-default-bgColor-rest), var(--button-default-bgColor-hover), var(--button-default-fgColor-rest))
     @include button-style(var(--button-default-bgColor-rest), var(--button-default-bgColor-hover), var(--button-default-fgColor-rest))


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64236

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add box-shadow for primary button in focus-visible state

## Screenshots
Before:
![Screenshot 2025-05-26 at 09 18 52](https://github.com/user-attachments/assets/75a17509-a3ee-475c-aa1f-cabb96eb3859)

After:
![Screenshot 2025-05-26 at 09 17 55](https://github.com/user-attachments/assets/27f3fed0-8fc5-4e0a-8788-e4a676887e41)