### PR TITLE
Restrict emoji reactions (toggle) API to activity comments

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4574,6 +4574,8 @@ en:
       code_500: "An internal error has occurred."
       code_500_outbound_request_failure: "An outbound request to another resource has failed with status code %{status_code}."
       code_500_missing_enterprise_token: "The request can not be handled due to invalid or missing Enterprise token."
+      bad_request:
+        emoji_reactions_activity_type_not_supported: "This activity type does not support emoji reactions."
       not_found:
         work_package: "The work package you are looking for cannot be found or has been deleted."
       expected:

--- a/docs/api/apiv3/paths/activity_emoji_reactions.yml
+++ b/docs/api/apiv3/paths/activity_emoji_reactions.yml
@@ -43,3 +43,94 @@ get:
 
         *Note: A client without sufficient permissions shall not be able to test for the existence of an activity.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
+
+patch:
+  summary: Toggle emoji reaction for an activity
+  operationId: toggle_activity_emoji_reaction
+  tags:
+    - Activities
+    - EmojiReactions
+  description: |-
+    Toggle an emoji reaction for a given activity. If the user has already reacted with the given emoji,
+    the reaction will be removed. Otherwise, a new reaction will be created.
+
+    **Required permission:**
+    - `add_work_package_comments`
+    - for internal comments: `add_internal_comments`
+
+  parameters:
+    - name: id
+      description: ID of the activity to toggle emoji reaction for
+      in: path
+      required: true
+      schema:
+        type: integer
+      example: '1'
+  requestBody:
+    required: true
+    content:
+      application/hal+json:
+        schema:
+          type: object
+          required:
+            - reaction
+          properties:
+            reaction:
+              type: string
+              description: The emoji reaction identifier
+              example: "thumbs_up"
+              enum:
+                - thumbs_up
+                - thumbs_down
+                - grinning_face_with_smiling_eyes
+                - confused_face
+                - heart
+                - party_popper
+                - rocket
+                - eyes
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/emoji_reaction_model.yml'
+    '400':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:BadRequest
+                message: "Bad request: reaction does not have a valid value"
+      description: Returned if the request is invalid. For example, if the reaction is not valid.
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: "You are not authorized to access this resource."
+      description: |-
+        Returned if the client does not have sufficient permissions to toggle the emoji reaction for the activity.
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: '../components/schemas/error_response.yml'
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the activity does not exist or the client does not have sufficient permissions
+        to see it.

--- a/lib/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api.rb
@@ -42,22 +42,12 @@ module API
               api_v3_paths.emoji_reactions_by_activity_comment(reactable.id)
             end
 
-            def ensure_emoji_reactions_enabled!
-              return if activity_comment?
-
-              raise ::API::Errors::BadRequest.new(
-                I18n.t("api_v3.errors.bad_request.emoji_reactions_activity_type_not_supported")
-              )
-            end
-
             def activity_comment?
               reactable.notes.present?
             end
           end
 
           get do
-            ensure_emoji_reactions_enabled!
-
             emoji_reactions = Journal.grouped_emoji_reactions(reactable_id: reactable.id, reactable_type: "Journal")
             EmojiReactionCollectionRepresenter.new(emoji_reactions,
                                                    self_link: get_emoji_reactions_self_path,
@@ -70,7 +60,11 @@ module API
           end
 
           patch do
-            ensure_emoji_reactions_enabled!
+            unless activity_comment?
+              raise ::API::Errors::BadRequest.new(
+                I18n.t("api_v3.errors.bad_request.emoji_reactions_activity_type_not_supported")
+              )
+            end
 
             toggle_service = ::EmojiReactions::ToggleEmojiReactionService.call(
               user: current_user,

--- a/lib/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api.rb
+++ b/lib/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api.rb
@@ -45,7 +45,9 @@ module API
             def ensure_emoji_reactions_enabled!
               return if activity_comment?
 
-              raise ::API::Errors::BadRequest.new("This activity type does not support emoji reactions.")
+              raise ::API::Errors::BadRequest.new(
+                I18n.t("api_v3.errors.bad_request.emoji_reactions_activity_type_not_supported")
+              )
             end
 
             def activity_comment?

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
     allow(User).to receive(:current).and_return(current_user)
   end
 
+  shared_examples "restricts API to activity comments" do
+    context "when the activity is not a comment" do
+      let(:non_comment_activity) { work_package.journals.first }
+
+      it "returns 422 Unprocessable Entity" do
+        expect(last_response).to have_http_status :bad_request
+
+        expect(last_response.body)
+          .to be_json_eql("Bad request: This activity type does not support emoji reactions.".to_json)
+          .at_path("message")
+      end
+    end
+  end
+
   describe "GET /api/v3/activities/:id/emoji_reactions" do
     context "when user has permission to view work package" do
       before do
@@ -139,6 +153,12 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
         it "fails with HTTP Not Found" do
           expect(last_response).to have_http_status :not_found
         end
+      end
+    end
+
+    it_behaves_like "restricts API to activity comments" do
+      before do
+        get api_v3_paths.emoji_reactions_by_activity_comment(non_comment_activity.id)
       end
     end
   end
@@ -276,6 +296,13 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
           make_request
           expect(last_response).to have_http_status :forbidden
         end
+      end
+    end
+
+    it_behaves_like "restricts API to activity comments" do
+      before do
+        patch api_v3_paths.emoji_reactions_by_activity_comment(non_comment_activity.id), { reaction: }.to_json,
+              headers
       end
     end
 

--- a/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
+++ b/spec/requests/api/v3/emoji_reactions/emoji_reactions_by_activity_comment_api_spec.rb
@@ -260,11 +260,6 @@ RSpec.describe API::V3::EmojiReactions::EmojiReactionsByActivityCommentAPI do
       let(:path) { api_v3_paths.emoji_reactions_by_activity_comment(internal_comment.id) }
       let(:reaction) { "thumbs_up" }
 
-      before do
-        project.enabled_internal_comments = true
-        project.save!
-      end
-
       context "and user has permission to create internal comments" do
         let(:reaction) { "rocket" }
         let(:permissions) { %i(view_work_packages add_work_package_comments view_internal_comments add_internal_comments) }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/64256

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

EmojiReactions are not yet supported for "non-comment" journals.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

A simple guard clause- I would have liked to use a grape "before/after_validation" hook but since the emoji reactions is a mounted sub-resource, this did not work. Open to better ideas here. 🙂 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
