### PR TITLE
Only accept access tokens of enabled OAuth applications

### DIFF
--- a/app/seeders/oauth_applications_seeder.rb
+++ b/app/seeders/oauth_applications_seeder.rb
@@ -41,7 +41,7 @@ class OAuthApplicationsSeeder < Seeder
   end
 
   def applicable?
-    Doorkeeper::Application.find_by(id: OPENPROJECT_MOBILE_APP_UID).nil?
+    Doorkeeper::Application.find_by(uid: OPENPROJECT_MOBILE_APP_UID).nil?
   end
 
   def not_applicable_message

--- a/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
+++ b/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "doorkeeper/grape/authorization_decorator"
 
 module OpenProject
@@ -12,10 +14,10 @@ module OpenProject
           def valid?
             access_token = ::Doorkeeper::OAuth::Token
                              .from_request(decorated_request, *Doorkeeper.configuration.access_token_methods)
-            
+
             # No access token found, so invalid strategy.
             return false if access_token.blank?
-            
+
             # We don't want JWT as our OAuth Bearer token
             JWT.decode(access_token, nil, false)
             false
@@ -28,6 +30,7 @@ module OpenProject
                                                                    *Doorkeeper.configuration.access_token_methods)
             return fail_with_header!(error: "invalid_token") if access_token.blank?
             return fail_with_header!(error: "invalid_token") if access_token.expired? || access_token.revoked?
+            return fail_with_header!(error: "invalid_token") unless access_token.application.enabled?
             return fail_with_header!(error: "insufficient_scope") if !access_token.includes_scope?(scope)
 
             if access_token.resource_owner_id.nil?

--- a/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
+++ b/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
@@ -28,26 +28,21 @@ module OpenProject
           def authenticate!
             access_token = ::Doorkeeper::OAuth::Token.authenticate(decorated_request,
                                                                    *Doorkeeper.configuration.access_token_methods)
-            return fail_with_header!(error: "invalid_token") if access_token.blank?
-            return fail_with_header!(error: "invalid_token") if access_token.expired? || access_token.revoked?
-            return fail_with_header!(error: "invalid_token") unless access_token.application.enabled?
+            return fail_with_header!(error: "invalid_token") if access_token_invalid?(access_token)
             return fail_with_header!(error: "insufficient_scope") if !access_token.includes_scope?(scope)
 
-            if access_token.resource_owner_id.nil?
-              user_id = ::Doorkeeper::Application
-                          .where(id: access_token.application_id)
-                          .where.not(client_credentials_user_id: nil)
-                          .pick(:client_credentials_user_id)
-              authenticate_user(user_id) if user_id
-            else
-              authenticate_user(access_token.resource_owner_id)
-            end
+            user_id = access_token.resource_owner_id || access_token.application.client_credentials_user_id
+            authenticate_user(user_id) if user_id
           end
 
           private
 
+          def access_token_invalid?(access_token)
+            access_token.blank? || access_token.expired? || access_token.revoked? || !access_token.application.enabled?
+          end
+
           def authenticate_user(id)
-            user = User.find_by(id:)
+            user = id && User.find_by(id:)
             if user
               success!(user)
             else

--- a/spec/factories/oauth_access_token_factory.rb
+++ b/spec/factories/oauth_access_token_factory.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
     end
 
     after(:build) do |token, evaluator|
-      token.resource_owner_id = evaluator.resource_owner.id
+      token.resource_owner_id = evaluator.resource_owner.id if evaluator.resource_owner
     end
 
     application factory: :oauth_application

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe "API V3 Authentication" do
       end
     end
 
+    context "when the token's application is disabled" do
+      let(:token) { create(:oauth_access_token, resource_owner: user, application: create(:oauth_application, enabled: false)) }
+      let(:oauth_access_token) { token.plaintext_token }
+
+      it "returns unauthorized" do
+        expect(last_response).to have_http_status :unauthorized
+        expect(last_response.header["WWW-Authenticate"]).to eq('Bearer realm="OpenProject API", error="invalid_token"')
+        expect(JSON.parse(last_response.body)).to eq(error_response_body)
+      end
+    end
+
     context "with an expired access token" do
       let(:token) { create(:oauth_access_token, resource_owner: user) }
       let(:oauth_access_token) { token.plaintext_token }

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -122,8 +122,9 @@ RSpec.describe "API V3 Authentication" do
       end
     end
 
-    context "with not found user" do
-      let(:token) { create(:oauth_access_token, resource_owner: user) }
+    context "when the token's resource owner can't be found" do
+      let(:token) { create(:oauth_access_token, resource_owner: user, application:) }
+      let(:application) { create(:oauth_application) }
       let(:oauth_access_token) { token.plaintext_token }
 
       around do |ex|
@@ -135,6 +136,43 @@ RSpec.describe "API V3 Authentication" do
         expect(last_response).to have_http_status :unauthorized
         expect(last_response.header["WWW-Authenticate"]).to eq('Bearer realm="OpenProject API", error="invalid_token"')
         expect(JSON.parse(last_response.body)).to eq(error_response_body)
+      end
+
+      context "when the application has a client credentials user configured" do
+        let(:application) { create(:oauth_application, client_credentials_user_id: create(:user).id) }
+
+        it "returns unauthorized" do
+          expect(last_response).to have_http_status :unauthorized
+          expect(last_response.header["WWW-Authenticate"]).to eq('Bearer realm="OpenProject API", error="invalid_token"')
+          expect(JSON.parse(last_response.body)).to eq(error_response_body)
+        end
+      end
+    end
+
+    context "when there is no resource owner on the token" do
+      let(:token) { create(:oauth_access_token, resource_owner: nil, application:) }
+      let(:application) { create(:oauth_application) }
+      let(:oauth_access_token) { token.plaintext_token }
+
+      # Note: This is just caused by DoorkeeperOauth rejecting to handle this case and auth falling through to basic auth
+      # more specific examples can be found at spec/requests/oauth/client_credentials_flow_spec.rb
+      let(:expected_message) { "You need to be authenticated to access this resource." }
+
+      it "returns unauthorized" do
+        expect(last_response).to have_http_status :unauthorized
+
+        # Note: This is just caused by DoorkeeperOauth rejecting to handle this case and auth falling through to basic auth
+        # more specific examples can be found at spec/requests/oauth/client_credentials_flow_spec.rb
+        expect(last_response.header["WWW-Authenticate"]).to eq('Basic realm="OpenProject API"')
+        expect(JSON.parse(last_response.body)).to eq(error_response_body)
+      end
+
+      context "when the application has a client credentials user configured" do
+        let(:application) { create(:oauth_application, client_credentials_user_id: user.id) }
+
+        it "authenticates successfully" do
+          expect(last_response).to have_http_status :ok
+        end
       end
     end
   end


### PR DESCRIPTION
We introduced the ability to disable doorkeeper applications in the past, but apparently we didn't check that an application whose token we validate is also enabled.

Now we make sure that only tokens of enabled applications are accepted.

# Ticket
https://community.openproject.org/wp/64258