### PR TITLE
`OpenProject::TextFormatting` code improvements and documentation

### DIFF
--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -40,7 +40,7 @@ module RepositoriesHelper
   ##
   # Format revision commits with plain formatter
   def format_revision_text(commit_message)
-    format_text(commit_message, format: "plain")
+    format_text(commit_message, format: :plain)
   end
 
   def truncate_at_line_break(text, length = 255)

--- a/app/views/account/_user_consent_check.html.erb
+++ b/app/views/account/_user_consent_check.html.erb
@@ -1,6 +1,6 @@
 <section class="form--section op-user-consent-form">
   <p>
-    <%= format_text(user_consent_instructions(::I18n.locale), { target: "_blank" }) %>
+    <%= format_text(user_consent_instructions(::I18n.locale), target: "_blank") %>
   </p>
 
   <label class="form--label-with-check-box -required -no-ellipsis op-user-consent-form--agreement">

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
 <div class="forum-message">
   <p class="author additional-information"><%= authoring @topic.created_at, @topic.author %></p>
   <div class="wiki op-uc-container">
-    <%= format_text(@topic.content, object: @topic, attachments: @topic.attachments) %>
+    <%= format_text(@topic, :content, attachments: @topic.attachments) %>
   </div>
 
   <% resource = message_attachment_representer(@topic) %>

--- a/app/views/news/_news.html.erb
+++ b/app/views/news/_news.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="comment">
     <% if news.summary.present? %>
       <div class="summary">
-        <%= format_text(news.summary, object: news) %>
+        <%= format_text(news, :summary) %>
       </div>
     <% end %>
     <%= "(#{t(:label_x_comments, count: news.comments_count)})" if news.comments_count > 0 %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -82,12 +82,12 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 <% if @news.summary.present? %>
   <div class="summary">
-    <%= format_text(@news.summary, object: @news) %>
+    <%= format_text(@news, :summary) %>
   </div>
 <% end %>
   <p class="author additional-information"><%= authoring @news.created_at, @news.author %></p>
 <div class="op-uc-container">
-  <%= format_text(@news.description, object: @news) %>
+  <%= format_text(@news, :description) %>
 </div>
 <br>
 <div id="comments" class="news--comments comments">
@@ -105,7 +105,7 @@ See COPYRIGHT and LICENSE files for more details.
                                     alt: t(:button_delete) %>
         </div>
         <h4 class="author additional-information"><%= avatar(comment.author) %><%= authoring comment.created_at, comment.author %></h4>
-        <%= format_text(comment.comments, object: comment) %>
+        <%= format_text(comment, :comments) %>
       </div>
     <% end %>
   </div>

--- a/app/views/work_package_mailer/_work_package_details.html.erb
+++ b/app/views/work_package_mailer/_work_package_details.html.erb
@@ -47,4 +47,4 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 </ul>
 
-<%= format_text(work_package.description, attribute: :description, only_path: false, object: work_package, project: work_package.project) %>
+<%= format_text(work_package, :description, only_path: false) %>

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -90,7 +90,7 @@ module OpenProject
       else
         raise ArgumentError, "invalid arguments to format_text"
       end
-      return "" if text.blank?
+      return "".html_safe if text.blank?
 
       project ||= @project || object.try(:project)
 

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -93,12 +93,11 @@ module OpenProject
       return "" if text.blank?
 
       project ||= @project || object.try(:project)
-      plain = Formats.plain?(format)
 
       Renderer.format_text(
         text,
         **,
-        plain:,
+        format:,
         object:,
         request: try(:request),
         current_user:,

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -27,13 +27,55 @@
 #++
 
 module OpenProject
+  # This module provides high-level text formatting functionality.
+  #
+  # @!method request
+  #   Expected to be defined in the including class.
+  #   @return [ActionDispatch::Request] the current request context.
+  #
+  # @note
+  #   The including class should implement {#request} if {#format_text} is
+  #   called within a request cycle.
   module TextFormatting
     include ::OpenProject::TextFormatting::Truncation
 
-    # Formats text according to system settings.
-    # 2 ways to call this method:
-    # * with a String: format_text(text, options)
-    # * with an object and one of its attribute: format_text(issue, :description, options)
+    # @!macro format_text_options
+    #   @param [Hash] options a customizable set of options.
+    #   @option options [Project] :project (@project, object#project)
+    #     a Project context.
+    #   @option options [Boolean] :only_path (true)
+    #     whether to generate links with relative URLs.
+    #   @option options [User] :current_user (User.current)
+    #     the current user context.
+    #   @option options [:plain, :rich] :format (:rich)
+    #     the text format.
+    #     `:plain` will return plain text.
+    #     `:rich` will render raw Markdown as HTML.
+
+    ##
+    # Formats text according to system settings and provided options.
+    #
+    # @overload format_text(text, options = {})
+    #   @param [String] text the raw text to be formatted, typically Markdown.
+    #   @macro format_text_options
+    #   @option options [Object] :object an object context.
+    #
+    #   @example Setting a project context explicitly
+    #     format_text("## Hello world", project: current_project)
+    #   @example Generating links with full URLs
+    #     format_text("[Projects](/projects)", only_path: false)
+    #
+    # @overload format_text(object, attribute, options = {})
+    #   @param [Object] object an object, typically a model
+    #     (i.e. `ActiveRecord::Base` descendent).
+    #   @param [Symbol] attribute the method on that object.
+    #     `#to_s` will be called on the return value.
+    #   @macro format_text_options
+    #
+    #   @example
+    #     format_text(issue, :description, options)
+    #
+    # @return [String] the formatted text as an HTML-safe String.
     def format_text(*args)
       options = args.last.is_a?(Hash) ? args.pop : {}
       case args.size

--- a/lib/open_project/text_formatting/formats.rb
+++ b/lib/open_project/text_formatting/formats.rb
@@ -52,10 +52,6 @@ module OpenProject::TextFormatting
       def supported?(name)
         [plain, rich].map(&:format).include?(name.to_sym)
       end
-
-      def plain?(name)
-        name && plain.format == name.to_sym
-      end
     end
   end
 end

--- a/lib/open_project/text_formatting/renderer.rb
+++ b/lib/open_project/text_formatting/renderer.rb
@@ -32,6 +32,15 @@ module OpenProject::TextFormatting
   module Renderer
     module_function
 
+    # @note
+    #   Consider the {OpenProject::TextFormatting#format_text} convenience
+    #   method instead, particularly if you are formatting model attributes.
+    #
+    # @param [String] text the raw text to be formatted, typically Markdown.
+    # @param (see .formatter_for)
+    # @param [Hash] context context arguments to pass to underlying rendering
+    #   pipeline (see {Formats::BaseFormatter#initialize}).
+    # @return [String] the formatted text as an HTML-safe String.
     def format_text(text, format: :rich, **context)
       return "" if text.blank?
 
@@ -40,6 +49,8 @@ module OpenProject::TextFormatting
         .to_html(text)
     end
 
+    # @param [:plain, :rich] format the text format.
+    # @return [Formats::BaseFormatter] a formatter implementation.
     def formatter_for(format)
       case format.to_sym
       when :plain

--- a/lib/open_project/text_formatting/renderer.rb
+++ b/lib/open_project/text_formatting/renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,19 +32,20 @@ module OpenProject::TextFormatting
   module Renderer
     module_function
 
-    def format_text(text, options = {})
+    def format_text(text, format: :rich, **context)
       return "" if text.blank?
 
-      formatter(plain: options.delete(:plain))
-        .new(options)
+      formatter_for(format)
+        .new(context)
         .to_html(text)
     end
 
-    def formatter(plain: false)
-      if plain
-        OpenProject::TextFormatting::Formats.plain_formatter
+    def formatter_for(format)
+      case format.to_sym
+      when :plain
+        Formats.plain_formatter
       else
-        OpenProject::TextFormatting::Formats.rich_formatter
+        Formats.rich_formatter
       end
     end
   end

--- a/lib/open_project/text_formatting/truncation.rb
+++ b/lib/open_project/text_formatting/truncation.rb
@@ -54,7 +54,7 @@ module OpenProject
       # @see ActionView::Helpers::TextHelper#truncate
       # @return [String] an HTML-safe safe string as single-line.
       def truncate_single_line(text, *)
-        truncate(text, *).gsub(%r{[\r\n]+}m, " ").html_safe
+        truncate(text, *).gsub(%r{[\r\n]+}m, " ").html_safe # rubocop:disable Rails/OutputSafety
       end
     end
   end

--- a/lib/open_project/text_formatting/truncation.rb
+++ b/lib/open_project/text_formatting/truncation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,9 +34,27 @@ module OpenProject
       # Used for truncation
       include ActionView::Helpers::TextHelper
 
+      ##
       # Truncates and returns the string as a single line
-      def truncate_single_line(string, *)
-        truncate(string.to_s, *).gsub(%r{[\r\n]+}m, " ").html_safe
+      #
+      # @overload truncate_single_line(text, options = {}, &block)
+      #   @param [String] text the string to truncate.
+      #   @param [Hash] options
+      #   @option options [Number] :length (30)
+      #     The maximum number of characters that should be returned, excluding
+      #     any extra content from the block.
+      #   @option options [String] :omission ("...")
+      #     The string to append after truncating.
+      #   @option options [String, RegExp] :separator
+      #     A string or regexp used to find a breaking point at which to
+      #     truncate. By default, truncation can occur at any character in text.
+      #   @option options [Boolean] :escape (true)
+      #     Whether to escape the result.
+      #
+      # @see ActionView::Helpers::TextHelper#truncate
+      # @return [String] an HTML-safe safe string as single-line.
+      def truncate_single_line(text, *)
+        truncate(text, *).gsub(%r{[\r\n]+}m, " ").html_safe
       end
     end
   end

--- a/modules/documents/app/views/documents/_document.html.erb
+++ b/modules/documents/app/views/documents/_document.html.erb
@@ -31,5 +31,5 @@ See COPYRIGHT and LICENSE files for more details.
 <p class="document-category-elements--date"><em><%= format_time(document.updated_at) %></em></p>
 
 <div class="wiki op-uc-container">
-  <%= format_text(document.description) %>
+  <%= format_text(document, :description) %>
 </div>

--- a/spec/lib/open_project/text_formatting/markdown/expected_markdown.rb
+++ b/spec/lib/open_project/text_formatting/markdown/expected_markdown.rb
@@ -15,7 +15,7 @@ end
 
 RSpec.shared_examples_for "format_text produces" do
   let(:passed_options) { defined?(options) ? options : {} }
-  subject { format_text(raw, passed_options) }
+  subject { format_text(raw, **passed_options) }
 
   it "the expected output" do
     expect(subject)

--- a/spec/lib/open_project/text_formatting/renderer_spec.rb
+++ b/spec/lib/open_project/text_formatting/renderer_spec.rb
@@ -27,36 +27,20 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+require "spec_helper"
 
-module OpenProject::TextFormatting
-  module Renderer
-    module_function
-
-    # @note
-    #   Consider the {OpenProject::TextFormatting#format_text} convenience
-    #   method instead, particularly if you are formatting model attributes.
-    #
-    # @param [String] text the raw text to be formatted, typically Markdown.
-    # @param (see .formatter_for)
-    # @param [Hash] context context arguments to pass to underlying rendering
-    #   pipeline (see {Formats::BaseFormatter#initialize}).
-    # @return [String] the formatted text as an HTML-safe String.
-    def format_text(text, format: :rich, **context)
-      return "".html_safe if text.blank?
-
-      formatter_for(format)
-        .new(context)
-        .to_html(text)
+RSpec.describe OpenProject::TextFormatting::Renderer do
+  describe "HTML safety" do
+    context "with blank strings" do
+      it "always returns HTML-safe strings" do
+        expect(described_class.format_text("")).to be_html_safe
+        expect(described_class.format_text(" ")).to be_html_safe
+      end
     end
 
-    # @param [:plain, :rich] format the text format.
-    # @return [Formats::BaseFormatter] a formatter implementation.
-    def formatter_for(format)
-      case format.to_sym
-      when :plain
-        Formats.plain_formatter
-      else
-        Formats.rich_formatter
+    context "with non-blank strings" do
+      it "always returns HTML-safe strings" do
+        expect(described_class.format_text("abc")).to be_html_safe
       end
     end
   end

--- a/spec/lib/open_project/text_formatting/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/text_formatting_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe OpenProject::TextFormatting do
       end
 
       it "allows plain format of options, if specified" do
-        expect(format_text("*Stars!*", format: "plain")).to be_html_eql("<p>*Stars!*</p>")
+        expect(format_text("*Stars!*", format: :plain)).to be_html_eql("<p>*Stars!*</p>")
       end
     end
   end

--- a/spec/lib/open_project/text_formatting/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/text_formatting_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe OpenProject::TextFormatting do
                                     ))
   end
 
+  describe "HTML safety" do
+    context "with blank strings" do
+      it "always returns HTML-safe strings" do
+        expect(format_text("")).to be_html_safe
+        expect(format_text(" ")).to be_html_safe
+      end
+    end
+
+    context "with non-blank strings" do
+      it "always returns HTML-safe strings" do
+        expect(format_text("abc")).to be_html_safe
+      end
+    end
+  end
+
   describe "options" do
     describe "#format" do
       it "uses format of Settings, if nothing is specified" do

--- a/spec/lib/open_project/text_formatting/truncation_spec.rb
+++ b/spec/lib/open_project/text_formatting/truncation_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "spec_helper"
+
+RSpec.describe OpenProject::TextFormatting::Truncation do
+  subject do
+    extend(described_class)
+  end
+
+  describe "#truncate_single_line" do
+    describe "HTML safety" do
+      it "always returns HTML-safe strings" do
+        expect(subject.truncate_single_line("")).to be_html_safe
+        expect(subject.truncate_single_line("ABC" * 99)).to be_html_safe
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

* Add comprehensive docs for `OpenProject::TextFormatting`, `OpenProject::TextFormatting::Renderer` and `OpenProject::TextFormatting::Truncation` using YARD.
* Rewrites `#format_text` to use keyword arguments.
* HTML-safety fixes for blank strings.

## Screenshots

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/216829d6-a73b-4e31-9757-b0cc9d47bd1d" />

# What approach did you choose and why?

Keyword arguments reduce the number of LOC to process options and improve the visibility of default values.

Similar to #18791 - came across lack of documentation while working on another PR (#18933).

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
