### PR TITLE
Do not ellipsise member connection status

### DIFF
--- a/modules/storages/app/components/storages/project_storages/members/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/members/row_component.rb
@@ -45,6 +45,15 @@ module Storages::ProjectStorages::Members
       "member #{principal_class_name}".strip
     end
 
+    def column_css_class(column)
+      case column
+      when :status
+        "status -no-ellipsis"
+      else
+        super
+      end
+    end
+
     def name
       helpers.avatar principal, hide_name: false, size: :mini
     end


### PR DESCRIPTION
On small screen widths the text for unconnectable members was too long to be read.

# Ticket
https://community.openproject.org/wp/64063

# Screenshots

![image](https://github.com/user-attachments/assets/f2855938-889d-4d78-bf26-c7049f2802d5)
