### PR TITLE
[58011] Allow negative lag for predecessor/successor relations

### DIFF
--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -1,15 +1,15 @@
 <%= component_wrapper do %>
-  <%= primer_form_with(
-    id: FORM_ID,
+<%= primer_form_with(
+      id: FORM_ID,
       model: @relation,
       **submit_url_options,
       data: {
         turbo: true,
         update_work_package: true
       }
-    ) do |f| %>
-    <%# Form fields section %>
-    <%= flex_layout(mb: 3) do |flex|
+    ) do |f|
+      # Form fields section
+      flex_layout(mb: 3) do |flex|
         flex.with_row do
           if @base_errors&.any?
             render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @base_errors.join("\n") }
@@ -51,7 +51,7 @@
                   focusDirectly: true,
                   dropdownPosition: "bottom",
                   appendTo: "##{DIALOG_ID}",
-                  data: { test_selector: TO_ID_FIELD_TEST_SELECTOR}
+                  data: { test_selector: TO_ID_FIELD_TEST_SELECTOR }
                 }
               )
             end
@@ -66,7 +66,8 @@
               my_form.text_field(
                 name: :lag,
                 type: :number,
-                min: 0,
+                min: Relation::MIN_LAG,
+                max: Relation::MAX_LAG,
                 label: I18n.t("work_package_relations_tab.lag.subject"),
                 caption: I18n.t("work_package_relations_tab.lag.caption"),
                 input_width: :small,
@@ -75,6 +76,6 @@
             end
           end
         end
-      end %>
-  <% end %>
+      end
+    end %>
 <% end %>

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -101,6 +101,9 @@ class Relation < ApplicationRecord
 
   ORDERED_TYPES = [*TYPES.keys, TYPE_PARENT, TYPE_CHILD].freeze
 
+  MAX_LAG = 2_000
+  MIN_LAG = -MAX_LAG
+
   include ::Scopes::Scoped
 
   scopes :used_for_scheduling_of,
@@ -127,8 +130,8 @@ class Relation < ApplicationRecord
 
   validates :lag, numericality: {
     allow_nil: true,
-    less_than_or_equal_to: 2_147_483_647,
-    greater_than_or_equal_to: 0
+    less_than_or_equal_to: MAX_LAG,
+    greater_than_or_equal_to: MIN_LAG
   }
 
   validates :to, uniqueness: { scope: :from }
@@ -176,7 +179,7 @@ class Relation < ApplicationRecord
   def successor_soonest_start
     if follows? && predecessor_date
       days = WorkPackages::Shared::WorkingDays.new
-      days.add_lag(predecessor_date, lag)
+      days.with_lag(predecessor_date, lag)
     end
   end
 

--- a/app/services/work_packages/shared/all_days.rb
+++ b/app/services/work_packages/shared/all_days.rb
@@ -43,9 +43,9 @@ module WorkPackages
         WorkingDays.new.lag(predecessor_date, successor_date)
       end
 
-      def add_lag(date, lag)
+      def with_lag(date, lag)
         # lag is *always* excluding non-working days (at least for now)
-        WorkingDays.new.add_lag(date, lag)
+        WorkingDays.new.with_lag(date, lag)
       end
 
       def start_date(due_date, duration)

--- a/app/services/work_packages/shared/working_days.rb
+++ b/app/services/work_packages/shared/working_days.rb
@@ -51,16 +51,15 @@ module WorkPackages
         duration(predecessor_date + 1.day, successor_date - 1.day)
       end
 
-      def add_lag(date, lag)
+      def with_lag(date, lag)
         return nil unless date
 
-        date_after_lag = date + 1.day
         lag ||= 0
-        while lag > 0
-          lag -= 1 if working?(date_after_lag)
-          date_after_lag += 1
+        if lag >= 0
+          add_lag(date, lag)
+        else
+          remove_lag(date, -lag)
         end
-        date_after_lag
       end
 
       def start_date(due_date, duration)
@@ -109,6 +108,26 @@ module WorkPackages
 
       def assert_strictly_positive_duration(duration)
         raise ArgumentError, "duration must be strictly positive" if duration.is_a?(Integer) && duration <= 0
+      end
+
+      def add_lag(date, lag)
+        date_with_lag = date.next_day
+        while lag != 0
+          lag -= 1 if working?(date_with_lag)
+          date_with_lag += 1
+        end
+        date_with_lag
+      end
+
+      def remove_lag(date, lag)
+        date_with_lag = date
+        while lag != 0
+          lag -= 1 if working?(date_with_lag)
+          next if lag == 0
+
+          date_with_lag -= 1
+        end
+        date_with_lag
       end
 
       def latest_working_day(date)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -830,7 +830,9 @@ en:
     label_add_description: "Add description"
     lag:
       subject: "Lag"
-      caption: "The minimum number of working days to keep in between the two work packages."
+      caption: |-
+        The minimum number of working days to keep in between the two work packages.
+        It can also be negative.
     relations:
       label_new_child_created: "New work package created and added as a child"
       label_relates_singular: "related to"
@@ -1418,10 +1420,6 @@ en:
             from_id:
               error_not_found: "not found or not visible."
               error_readonly: "cannot be changed for existing relations."
-            lag:
-              greater_than_or_equal_to:
-                zero: "cannot be negative."
-              less_than_or_equal_to: "is too high."
         repository:
           not_available: "SCM vendor is not available"
           not_whitelisted: "is not allowed by the configuration."

--- a/spec/components/work_package_relations_tab/closest_relation_spec.rb
+++ b/spec/components/work_package_relations_tab/closest_relation_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe WorkPackageRelationsTab::ClosestRelation do
       expect(described_class.of(work_package, relations)).to eq(relations.last)
     end
 
+    it "is correct even when there is negative lag" do
+      relations = [
+        follows_relation(due_date: 4.days.ago),
+        follows_relation(due_date: 3.days.ago, lag: -2) # 3.days.ago - 2.days = 5.days.ago
+      ]
+      expect(described_class.of(work_package, relations)).to eq(relations.first)
+
+      relations = [
+        follows_relation(due_date: 3.days.ago, lag: -3),
+        follows_relation(due_date: 3.days.ago, lag: -1)
+      ]
+      expect(described_class.of(work_package, relations)).to eq(relations.second)
+    end
+
     it "ignores relations not being 'follows' relations" do
       relations = [
         follows_relation(due_date: 4.days.ago),
@@ -228,7 +242,6 @@ RSpec.describe WorkPackageRelationsTab::ClosestRelation do
 
       context "with a negative lag" do
         it "returns the combined due date and lag" do
-          pending "negative lags are not yet implemented"
           expect(closest_relation(lag: -2, due_date:).soonest_start).to eq(Date.new(2020, 7, 13))
         end
       end
@@ -251,7 +264,6 @@ RSpec.describe WorkPackageRelationsTab::ClosestRelation do
 
       context "with a negative lag" do
         it "returns the combined start date and lag" do
-          pending "negative lags are not yet implemented (Feature OP#38606)"
           expect(closest_relation(lag: -2, start_date:).soonest_start).to eq(Date.new(2020, 7, 13))
         end
       end

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -38,24 +38,10 @@ RSpec.describe Relation do
   let(:relation) { build(:relation, from:, to:, relation_type: type) }
 
   it "validates lag numericality" do
-    relation.lag = nil
-    expect(relation).to be_valid
-    relation.lag = -1
-    expect(relation).to be_valid
-    relation.lag = 2_000
-    expect(relation).to be_valid
-    relation.lag = -2_000
-    expect(relation).to be_valid
-
-    relation.lag = 2_001
-    expect(relation).not_to be_valid
-    expect(relation.errors[:lag])
-      .to eq(["must be less than or equal to #{Relation::MAX_LAG}."])
-
-    relation.lag = -2_001
-    expect(relation).not_to be_valid
-    expect(relation.errors[:lag])
-      .to eq(["must be greater than or equal to #{Relation::MIN_LAG}."])
+    expect(relation).to validate_numericality_of(:lag)
+      .is_greater_than_or_equal_to(Relation::MIN_LAG)
+      .is_less_than_or_equal_to(Relation::MAX_LAG)
+      .allow_nil
   end
 
   it "validates relation uniqueness on both from_id and to_id" do

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -38,17 +38,24 @@ RSpec.describe Relation do
   let(:relation) { build(:relation, from:, to:, relation_type: type) }
 
   it "validates lag numericality" do
+    relation.lag = nil
+    expect(relation).to be_valid
     relation.lag = -1
+    expect(relation).to be_valid
+    relation.lag = 2_000
+    expect(relation).to be_valid
+    relation.lag = -2_000
+    expect(relation).to be_valid
+
+    relation.lag = 2_001
     expect(relation).not_to be_valid
     expect(relation.errors[:lag])
-      .to include(I18n.t(:"activerecord.errors.models.relation.attributes.lag.greater_than_or_equal_to.zero"))
+      .to eq(["must be less than or equal to #{Relation::MAX_LAG}."])
 
-    relation.lag = 2_147_483_648
+    relation.lag = -2_001
     expect(relation).not_to be_valid
-    expect(relation.errors[:lag]).to include(I18n.t(:"activerecord.errors.models.relation.attributes.lag.less_than_or_equal_to"))
-
-    relation.lag = 1_000
-    expect(relation).to be_valid
+    expect(relation.errors[:lag])
+      .to eq(["must be greater than or equal to #{Relation::MIN_LAG}."])
   end
 
   it "validates relation uniqueness on both from_id and to_id" do

--- a/spec/services/work_packages/shared/all_days_spec.rb
+++ b/spec/services/work_packages/shared/all_days_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe WorkPackages::Shared::AllDays do
       end
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       it "considers all days as working days and returns the number of days between two dates, inclusive" do
         expect(subject.duration(sunday_2022_07_31, sunday_2022_07_31 + 6)).to eq(7)
         expect(subject.duration(sunday_2022_07_31, sunday_2022_07_31 + 50)).to eq(51)
@@ -94,7 +94,7 @@ RSpec.describe WorkPackages::Shared::AllDays do
       expect(subject.start_date(sunday_2022_07_31, nil)).to be_nil
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "start_date", due_date: sunday_2022_07_31, duration: 1, expected: sunday_2022_07_31
       include_examples "start_date", due_date: sunday_2022_07_31, duration: 5, expected: sunday_2022_07_31 - 4.days
       include_examples "start_date", due_date: sunday_2022_07_31, duration: 10, expected: sunday_2022_07_31 - 9.days
@@ -127,7 +127,7 @@ RSpec.describe WorkPackages::Shared::AllDays do
       expect(subject.due_date(sunday_2022_07_31, nil)).to be_nil
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "due_date", start_date: sunday_2022_07_31, duration: 1, expected: sunday_2022_07_31
       include_examples "due_date", start_date: sunday_2022_07_31, duration: 5, expected: sunday_2022_07_31 + 4.days
       include_examples "due_date", start_date: sunday_2022_07_31, duration: 10, expected: sunday_2022_07_31 + 9.days
@@ -148,7 +148,7 @@ RSpec.describe WorkPackages::Shared::AllDays do
       expect(subject.soonest_working_day(nil)).to be_nil
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       it "returns the given day" do
         expect(subject.soonest_working_day(sunday_2022_07_31)).to eq(sunday_2022_07_31)
       end

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -136,7 +136,7 @@ RSpec.shared_examples "lag computation excluding non-working days" do
       end
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "it returns lag", 0, sunday_2022_07_31, monday_2022_08_01
       include_examples "it returns lag", 4, sunday_2022_07_31, Date.new(2022, 8, 5) # Friday
       include_examples "it returns lag", 5, sunday_2022_07_31, Date.new(2022, 8, 6) # Saturday
@@ -209,7 +209,7 @@ RSpec.shared_examples "add lag to a date" do
         .not_to raise_error
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "it adds lag", date: saturday_2022_07_30, lag: 0, expected_result: sunday_2022_07_31
       include_examples "it adds lag", date: saturday_2022_07_30, lag: 1, expected_result: Date.new(2022, 8, 2)
       include_examples "it adds lag", date: saturday_2022_07_30, lag: -1, expected_result: Date.new(2022, 7, 29) # previous Friday

--- a/spec/services/work_packages/shared/shared_examples_days.rb
+++ b/spec/services/work_packages/shared/shared_examples_days.rb
@@ -78,7 +78,7 @@ RSpec.shared_examples "it adds lag" do |date:, lag:, expected_result:|
      "with lag #{lag} " \
      "=> #{expected_result.to_fs(:wday_date)}" \
   do
-    expect(subject.add_lag(date, lag)).to eq(expected_result)
+    expect(subject.with_lag(date, lag)).to eq(expected_result)
   end
 end
 
@@ -178,40 +178,56 @@ RSpec.shared_examples "lag computation excluding non-working days" do
 end
 
 RSpec.shared_examples "add lag to a date" do
-  describe "#add_lag" do
+  describe "#with_lag" do
     saturday_2022_07_30 = Date.new(2022, 7, 30)
     sunday_2022_07_31 = Date.new(2022, 7, 31)
     monday_2022_08_01 = Date.new(2022, 8, 1)
 
-    it "returns the soonest date after the given date where the number of working days in between equals the given lag" do
-      expect(subject.add_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
-      expect(subject.add_lag(sunday_2022_07_31, 1)).to eq(Date.new(2022, 8, 2))
-      expect(subject.add_lag(sunday_2022_07_31, 5)).to eq(Date.new(2022, 8, 6))
-      expect(subject.add_lag(sunday_2022_07_31, 6)).to eq(Date.new(2022, 8, 7))
+    context "when lag is positive" do
+      it "returns the soonest date after the given date where the number of working days in between equals the given lag" do
+        expect(subject.with_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
+        expect(subject.with_lag(sunday_2022_07_31, 1)).to eq(Date.new(2022, 8, 2))
+        expect(subject.with_lag(sunday_2022_07_31, 5)).to eq(Date.new(2022, 8, 6))
+        expect(subject.with_lag(sunday_2022_07_31, 6)).to eq(Date.new(2022, 8, 7))
+      end
     end
 
-    it "returns the day after the given date when lag is negative (like lag = 0)" do
-      expect(subject.add_lag(sunday_2022_07_31, -100)).to eq(monday_2022_08_01)
-      expect(subject.add_lag(sunday_2022_07_31, -1)).to eq(monday_2022_08_01)
-      expect(subject.add_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
+    context "when lag is negative" do
+      it "returns the latest day before the given date where the number of working days between " \
+         "both dates, inclusive, is equal to the given lag (but negative)" do
+        expect(subject.with_lag(saturday_2022_07_30, -1)).to eq(saturday_2022_07_30)
+
+        expect(subject.with_lag(sunday_2022_07_31, -100)).to eq(sunday_2022_07_31 - 99.days)
+        expect(subject.with_lag(sunday_2022_07_31, -1)).to eq(sunday_2022_07_31)
+        expect(subject.with_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
+      end
     end
 
     it "works with big lag value like 100_000" do
       # Ensure implementation is not recursive and won't fail with SystemStackError: stack level too deep
-      expect { subject.add_lag(sunday_2022_07_31, 100_000) }
+      expect { subject.with_lag(sunday_2022_07_31, 100_000) }
         .not_to raise_error
     end
 
     context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
       include_examples "it adds lag", date: saturday_2022_07_30, lag: 0, expected_result: sunday_2022_07_31
       include_examples "it adds lag", date: saturday_2022_07_30, lag: 1, expected_result: Date.new(2022, 8, 2)
+      include_examples "it adds lag", date: saturday_2022_07_30, lag: -1, expected_result: Date.new(2022, 7, 29) # previous Friday
 
       include_examples "it adds lag", date: sunday_2022_07_31, lag: 0, expected_result: monday_2022_08_01
       include_examples "it adds lag", date: sunday_2022_07_31, lag: 1, expected_result: Date.new(2022, 8, 2)
       include_examples "it adds lag", date: sunday_2022_07_31, lag: 4, expected_result: Date.new(2022, 8, 5) # Friday
       include_examples "it adds lag", date: sunday_2022_07_31, lag: 5, expected_result: Date.new(2022, 8, 6) # Saturday
       include_examples "it adds lag", date: sunday_2022_07_31, lag: 6, expected_result: Date.new(2022, 8, 9) # Tuesday
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: -1, expected_result: Date.new(2022, 7, 29) # previous Friday
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: -2, expected_result: Date.new(2022, 7, 28) # previous Thursday
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: -5, expected_result: Date.new(2022, 7, 25) # previous Monday
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: -6, expected_result: Date.new(2022, 7, 22)
+      include_examples "it adds lag", date: sunday_2022_07_31, lag: -7, expected_result: Date.new(2022, 7, 21)
 
+      include_examples "it adds lag", date: monday_2022_08_01, lag: -2, expected_result: Date.new(2022, 7, 29) # previous Friday
+      include_examples "it adds lag", date: monday_2022_08_01, lag: -1, expected_result: Date.new(2022, 8, 1) # Monday
+      include_examples "it adds lag", date: monday_2022_08_01, lag: 0, expected_result: Date.new(2022, 8, 2) # Tuesday
       include_examples "it adds lag", date: monday_2022_08_01, lag: 3, expected_result: Date.new(2022, 8, 5) # Friday
       include_examples "it adds lag", date: monday_2022_08_01, lag: 4, expected_result: Date.new(2022, 8, 6) # Saturday
       include_examples "it adds lag", date: monday_2022_08_01, lag: 5, expected_result: Date.new(2022, 8, 9) # Tuesday
@@ -222,18 +238,24 @@ RSpec.shared_examples "add lag to a date" do
       include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 1, expected_result: Date.new(2022, 12, 27)
       include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 6, expected_result: Date.new(2023, 1, 1)
       include_examples "it adds lag", date: Date.new(2022, 12, 24), lag: 7, expected_result: Date.new(2023, 1, 3)
+
+      include_examples "it adds lag", date: Date.new(2022, 12, 25), lag: -1, expected_result: Date.new(2022, 12, 24)
+      include_examples "it adds lag", date: Date.new(2022, 12, 26), lag: -1, expected_result: Date.new(2022, 12, 26)
+      include_examples "it adds lag", date: Date.new(2022, 12, 26), lag: -2, expected_result: Date.new(2022, 12, 24)
+      include_examples "it adds lag", date: Date.new(2023, 1, 2), lag: -7, expected_result: Date.new(2022, 12, 26)
+      include_examples "it adds lag", date: Date.new(2023, 1, 2), lag: -8, expected_result: Date.new(2022, 12, 24)
     end
 
     context "with nil date" do
       it "returns nil" do
-        expect(subject.add_lag(nil, 5)).to be_nil
+        expect(subject.with_lag(nil, 5)).to be_nil
       end
     end
 
     context "with nil lag" do
       it "returns the day after the given date when lag is nil (like lag = 0)" do
-        expect(subject.add_lag(sunday_2022_07_31, nil)).to eq(monday_2022_08_01)
-        expect(subject.add_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
+        expect(subject.with_lag(sunday_2022_07_31, nil)).to eq(monday_2022_08_01)
+        expect(subject.with_lag(sunday_2022_07_31, 0)).to eq(monday_2022_08_01)
       end
     end
   end

--- a/spec/services/work_packages/shared/working_days_spec.rb
+++ b/spec/services/work_packages/shared/working_days_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
       end
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "it returns duration", 0, sunday_2022_07_31, sunday_2022_07_31
       include_examples "it returns duration", 5, sunday_2022_07_31, Date.new(2022, 8, 5)
       include_examples "it returns duration", 5, sunday_2022_07_31, Date.new(2022, 8, 6)
@@ -124,7 +124,7 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
       end
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "start_date", due_date: monday_2022_08_01, duration: 1, expected: monday_2022_08_01
       include_examples "start_date", due_date: monday_2022_08_01, duration: 5, expected: monday_2022_08_01 - 6.days
       include_examples "start_date", due_date: wednesday_2022_08_03, duration: 10, expected: wednesday_2022_08_03 - 13.days
@@ -168,7 +168,7 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
       end
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "due_date", start_date: monday_2022_08_01, duration: 1, expected: monday_2022_08_01
       include_examples "due_date", start_date: monday_2022_08_01, duration: 5, expected: monday_2022_08_01 + 4.days
       include_examples "due_date", start_date: wednesday_2022_08_03, duration: 10, expected: wednesday_2022_08_03 + 13.days
@@ -194,7 +194,7 @@ RSpec.describe WorkPackages::Shared::WorkingDays do
       expect(subject.soonest_working_day(nil)).to be_nil
     end
 
-    context "with weekend days (Saturday and Sunday)", :weekend_saturday_sunday do
+    context "with Saturday and Sunday being non-working days", :weekend_saturday_sunday do
       include_examples "soonest working day", date: friday_2022_07_29, expected: friday_2022_07_29
       include_examples "soonest working day", date: saturday_2022_07_30, expected: monday_2022_08_01
       include_examples "soonest working day", date: sunday_2022_07_31, expected: monday_2022_08_01


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/58011

# What are you trying to accomplish?

Allow negative lag for a predecessor/successor relation.

This makes it possible to have a follower starting the same day a predecessor ends, or at the same time as a predecessor starts.

## Screenshots

![image](https://github.com/user-attachments/assets/e2e03725-316c-4393-b6f1-a6e026e5fd1d)

# What approach did you choose and why?

* Allow negative number and adapt calculation
* Add limits to lag: -2000 to +2000 days

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
