### PR TITLE
Remove params argument from BaseCallable#perform

### DIFF
--- a/app/services/attachments/delete_service.rb
+++ b/app/services/attachments/delete_service.rb
@@ -30,8 +30,9 @@ class Attachments::DeleteService < BaseServices::Delete
   include Attachments::TouchContainer
 
   def call(params = {})
+    self.params = params
     in_context(model.container || model) do
-      perform(params)
+      perform
     end
   end
 

--- a/app/services/attachments/finish_direct_upload_service.rb
+++ b/app/services/attachments/finish_direct_upload_service.rb
@@ -46,13 +46,13 @@ module Attachments
       in_context(attachment.container, send_notifications:, &)
     end
 
-    def validate_params(_params)
+    def validate_params
       super.tap do |call|
         validate_local_file_exists(call)
       end
     end
 
-    def before_perform(*)
+    def before_perform(_)
       super.tap do
         set_attachment_parameters
       end

--- a/app/services/base_services/base_callable.rb
+++ b/app/services/base_services/base_callable.rb
@@ -39,7 +39,7 @@ module BaseServices
       self.params = extract_options!(args).deep_symbolize_keys
 
       run_callbacks(:call) do
-        perform(*args, **params)
+        perform(*args)
       end
     end
 

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -54,13 +54,13 @@ module BaseServices
       in_context(model, send_notifications:, &)
     end
 
-    def perform(params = {})
-      params, send_notifications = extract(params, :send_notifications)
+    def perform
+      self.params, send_notifications = extract(params, :send_notifications)
       service_context(send_notifications:) do
-        service_call = validate_params(params)
-        service_call = before_perform(params, service_call) if service_call.success?
+        service_call = validate_params
+        service_call = before_perform(service_call) if service_call.success?
         service_call = validate_contract(service_call) if service_call.success?
-        service_call = after_validate(params, service_call) if service_call.success?
+        service_call = after_validate(service_call) if service_call.success?
         service_call = persist(service_call) if service_call.success?
         service_call = after_perform(service_call) if service_call.success?
 
@@ -69,19 +69,19 @@ module BaseServices
     end
 
     def extract(params, attribute)
-      params = params ? params.dup : {}
-      [params, params.delete(attribute)]
+      params ||= {}
+      [params, params[attribute]]
     end
 
-    def validate_params(_params)
+    def validate_params
       ServiceResult.success(result: model)
     end
 
-    def before_perform(*)
+    def before_perform(_)
       ServiceResult.success(result: model)
     end
 
-    def after_validate(_params, contract_call)
+    def after_validate(contract_call)
       contract_call
     end
 

--- a/app/services/base_services/delete.rb
+++ b/app/services/base_services/delete.rb
@@ -33,8 +33,8 @@ module BaseServices
       super(user:, contract_class:, contract_options:)
     end
 
-    def persist(service_result)
-      service_result = super(service_result) # rubocop:disable Style/SuperArguments
+    def persist(_service_result)
+      service_result = super
 
       unless destroy(service_result.result)
         service_result.errors = service_result.result.errors

--- a/app/services/base_services/set_attributes.rb
+++ b/app/services/base_services/set_attributes.rb
@@ -40,8 +40,8 @@ module BaseServices
       self.contract_options = contract_options
     end
 
-    def perform(params = {})
-      set_attributes(params || {})
+    def perform
+      set_attributes(params)
 
       validate_and_result
     end

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -30,8 +30,8 @@ module BaseServices
   class Write < BaseContracted
     protected
 
-    def persist(service_result)
-      service_result = super(service_result) # rubocop:disable Style/SuperArguments
+    def persist(_service_result)
+      service_result = super
 
       unless service_result.result.save
         service_result.errors = service_result.result.errors
@@ -47,7 +47,7 @@ module BaseServices
       service_result
     end
 
-    def before_perform(params, _service_result)
+    def before_perform(_service_result)
       set_attributes(params)
     end
 

--- a/app/services/bulk_services/project_mappings/base_create_service.rb
+++ b/app/services/bulk_services/project_mappings/base_create_service.rb
@@ -41,7 +41,7 @@ module BulkServices
         @mapping_context = mapping_context
       end
 
-      def perform(params = {})
+      def perform
         service_call = validate_permissions
         service_call = validate_contract(service_call, params) if service_call.success?
         service_call = perform_bulk_create(service_call) if service_call.success?

--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -79,7 +79,7 @@ module Copy
       errors.full_messages.join(". ")
     end
 
-    def perform(params:)
+    def perform
       begin
         copy_dependency(params:)
       rescue StandardError => e

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -38,7 +38,7 @@ module CustomFields
       nil
     end
 
-    def perform(params)
+    def perform
       super
     rescue StandardError => e
       ServiceResult.failure(message: e.message)

--- a/app/services/groups/concerns/membership_manipulation.rb
+++ b/app/services/groups/concerns/membership_manipulation.rb
@@ -30,9 +30,7 @@ module Groups::Concerns
   module MembershipManipulation
     extend ActiveSupport::Concern
 
-    def after_validate(params, _call)
-      params ||= {}
-
+    def after_validate(_call)
       with_error_handled do
         ::Group.transaction do
           send_notifications = params.fetch(:send_notifications, Journal::NotificationConfiguration.active?)

--- a/app/services/members/cleanup_service.rb
+++ b/app/services/members/cleanup_service.rb
@@ -37,7 +37,7 @@ module Members
 
     protected
 
-    def perform(*)
+    def perform
       prune_watchers
       unassign_categories
 

--- a/app/services/oauth_clients/create_service.rb
+++ b/app/services/oauth_clients/create_service.rb
@@ -36,7 +36,7 @@ module OAuthClients
   class CreateService < ::BaseServices::Create
     protected
 
-    def after_validate(params, contract_call)
+    def after_validate(contract_call)
       OAuthClient.where(integration: params[:integration]).delete_all
       super
     end

--- a/app/services/project_custom_field_project_mappings/bulk_update_service.rb
+++ b/app/services/project_custom_field_project_mappings/bulk_update_service.rb
@@ -35,7 +35,7 @@ module ProjectCustomFieldProjectMappings
       @project_custom_field_section = project_custom_field_section
     end
 
-    def perform(params)
+    def perform
       service_call = validate_permissions
       service_call = perform_bulk_edit(service_call, params) if service_call.success?
 

--- a/app/services/project_custom_fields/drop_service.rb
+++ b/app/services/project_custom_fields/drop_service.rb
@@ -34,7 +34,7 @@ module ProjectCustomFields
       @project_custom_field = project_custom_field
     end
 
-    def perform(params)
+    def perform
       service_call = validate_permissions
       service_call = perform_drop(service_call, params) if service_call.success?
 

--- a/app/services/project_phases/set_attributes_service.rb
+++ b/app/services/project_phases/set_attributes_service.rb
@@ -28,7 +28,7 @@
 
 module ProjectPhases
   class SetAttributesService < ::BaseServices::SetAttributes
-    def perform(*)
+    def perform
       super.tap do
         set_calculated_duration
       end

--- a/app/services/project_queries/publish_service.rb
+++ b/app/services/project_queries/publish_service.rb
@@ -30,7 +30,7 @@ module ProjectQueries
   class PublishService < BaseServices::Update
     private
 
-    def after_validate(params, service_call)
+    def after_validate(service_call)
       model.public = params[:public]
 
       service_call

--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -30,13 +30,13 @@ module Projects::Concerns
   module NewProjectService
     private
 
-    def before_perform(params, service_call)
+    def before_perform(service_call)
       super.tap do |super_call|
         reject_section_scoped_validation(super_call.result)
       end
     end
 
-    def after_validate(params, service_call)
+    def after_validate(service_call)
       super.tap do |super_call|
         build_missing_project_custom_field_project_mappings(super_call.result)
       end

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -86,7 +86,7 @@ module Projects
         .merge(target_project_params)
     end
 
-    def before_perform(params, service_call)
+    def before_perform(service_call)
       super.tap do |super_call|
         # Retain values after the set attributes service
         retain_attributes(source, super_call.result)

--- a/app/services/projects/enabled_modules_service.rb
+++ b/app/services/projects/enabled_modules_service.rb
@@ -38,7 +38,7 @@ module Projects
 
     private
 
-    def before_perform(params, _service_result)
+    def before_perform(_service_result)
       model.enabled_module_names = params[:enabled_modules]
       super
     end

--- a/app/services/projects/enqueue_copy_service.rb
+++ b/app/services/projects/enqueue_copy_service.rb
@@ -39,7 +39,7 @@ module Projects
 
     private
 
-    def perform(params)
+    def perform
       call = test_copy(params)
 
       if call.success?

--- a/app/services/projects/schedule_deletion_service.rb
+++ b/app/services/projects/schedule_deletion_service.rb
@@ -39,7 +39,7 @@ module Projects
 
     private
 
-    def before_perform(_params, service_result)
+    def before_perform(service_result)
       return service_result if model.archived?
 
       Projects::ArchiveService

--- a/app/services/relations/create_service.rb
+++ b/app/services/relations/create_service.rb
@@ -32,8 +32,10 @@ class Relations::CreateService < Relations::BaseService
     self.contract_class = Relations::CreateContract
   end
 
-  def perform(send_notifications: nil, **attributes)
-    in_user_context(send_notifications:) do
+  def perform
+    attributes = params.except(:send_notifications)
+
+    in_user_context(send_notifications: params[:send_notifications]) do
       update_relation ::Relation.new, attributes
     end
   end

--- a/app/services/relations/delete_service.rb
+++ b/app/services/relations/delete_service.rb
@@ -29,7 +29,7 @@
 class Relations::DeleteService < BaseServices::Delete
   include Relations::Concerns::Rescheduling
 
-  def after_perform(_result)
+  def after_perform(_call)
     result = super
     if result.success? && deleted_relation.follows?
       reschedule_result = reschedule_successor(deleted_relation)

--- a/app/services/relations/update_service.rb
+++ b/app/services/relations/update_service.rb
@@ -35,9 +35,9 @@ class Relations::UpdateService < Relations::BaseService
     self.contract_class = Relations::UpdateContract
   end
 
-  def perform(attributes)
-    in_user_context(send_notifications: attributes[:send_notifications]) do
-      update_relation model, attributes
+  def perform
+    in_user_context(send_notifications: params[:send_notifications]) do
+      update_relation model, params
     end
   end
 end

--- a/app/services/reminders/set_attributes_service.rb
+++ b/app/services/reminders/set_attributes_service.rb
@@ -30,7 +30,7 @@
 
 module Reminders
   class SetAttributesService < ::BaseServices::SetAttributes
-    def perform(params = {})
+    def perform
       remind_at_params = params.extract!(:remind_at_date, :remind_at_time)
 
       build_remind_at_from_params(params, remind_at_params) unless params.key?(:remind_at)

--- a/app/services/roles/create_service.rb
+++ b/app/services/roles/create_service.rb
@@ -29,7 +29,7 @@
 class Roles::CreateService < BaseServices::Create
   private
 
-  def perform(params)
+  def perform
     copy_workflow_id = params.delete(:copy_workflow_from)
 
     super_call = super

--- a/app/services/roles/update_service.rb
+++ b/app/services/roles/update_service.rb
@@ -29,7 +29,7 @@
 class Roles::UpdateService < BaseServices::Update
   private
 
-  def before_perform(params, service_call)
+  def before_perform(service_call)
     @permissions_old = service_call.result.permissions
     super
   end

--- a/app/services/settings/working_days_and_hours_update_service.rb
+++ b/app/services/settings/working_days_and_hours_update_service.rb
@@ -35,7 +35,7 @@ class Settings::WorkingDaysAndHoursUpdateService < Settings::UpdateService
     super
   end
 
-  def validate_params(params)
+  def validate_params
     contract = Settings::WorkingDaysAndHoursParamsContract.new(model, user, params:)
     ServiceResult.new success: contract.valid?,
                       errors: contract.errors,

--- a/app/services/user_preferences/update_service.rb
+++ b/app/services/user_preferences/update_service.rb
@@ -32,7 +32,7 @@ module UserPreferences
 
     attr_accessor :notifications
 
-    def validate_params(params)
+    def validate_params
       contract = ParamsContract.new(model, user, params:)
 
       ServiceResult.new success: contract.valid?,
@@ -40,7 +40,7 @@ module UserPreferences
                         result: model
     end
 
-    def before_perform(params, _service_result)
+    def before_perform(_service_result)
       self.notifications = params&.delete(:notification_settings)
 
       super

--- a/app/services/users/update_service.rb
+++ b/app/services/users/update_service.rb
@@ -32,7 +32,7 @@ module Users
 
     protected
 
-    def before_perform(params, _service_result)
+    def before_perform(_service_result)
       call_hook :service_update_user_before_save,
                 params:,
                 user: model
@@ -40,8 +40,8 @@ module Users
       super
     end
 
-    def persist(service_result)
-      service_result = super(service_result) # rubocop:disable Style/SuperArguments
+    def persist(_service_result)
+      service_result = super
 
       if service_result.success?
         service_result.success = model.pref.save

--- a/app/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service.rb
+++ b/app/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service.rb
@@ -36,12 +36,9 @@ module WorkPackages
 
         ATTACHMENT_CSS_SELECTOR = "img.op-uc-image"
 
-        def perform(params = {})
-          super(
-            params.reverse_merge(
-              attachment_ids: collect_attachment_ids_from_notes
-            )
-          )
+        def perform
+          self.params = params.reverse_merge(attachment_ids: collect_attachment_ids_from_notes)
+          super
         end
 
         private

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -40,8 +40,11 @@ class WorkPackages::CreateService < BaseServices::BaseCallable
     @contract_class = contract_class
   end
 
-  def perform(work_package: WorkPackage.new, send_notifications: nil, **attributes)
-    in_user_context(send_notifications:) do
+  def perform
+    attributes = params.except(:send_notifications, :work_package)
+    work_package = params[:work_package] || WorkPackage.new
+
+    in_user_context(send_notifications: params[:send_notifications]) do
       create(attributes, work_package)
     end
   end

--- a/docs/release-notes/16-2-0/README.md
+++ b/docs/release-notes/16-2-0/README.md
@@ -1,0 +1,45 @@
+---
+title: OpenProject 16.2.0
+sidebar_navigation:
+    title: 16.2.0
+release_version: 16.2.0
+release_date: 2025-07-16
+---
+
+# OpenProject 16.2.0
+
+Release date: 2025-07-16
+
+TODO
+
+## Important technical changes
+
+### Breaking: Interface changes to BaseCallable and BaseContracted
+
+The method signatures shared between `BaseServices::BaseCallable`, `BaseServices::BaseContracted` and their subclasses (this includes `BaseServices::Create` and `BaseServices::Update` among others) have been changed.
+The method argument `params` was removed, to encourage consistently using the `params` attribute accessor instead. Previously it was
+unclear whether using the argument or the accessor should be used, that should be more clear and consistent now.
+
+For plugin developers this means that signatures of the following methods have to be updated accordingly,
+if they are defined in a subclass of `BaseServices::BaseContracted`:
+
+* `validate_params(params)` becomes `validate_params`
+* `before_perform(params, call)` becomes `before_perform(call)`
+* `after_validate(params, call)` becomes `after_validate(call)`
+
+Subclasses of `BaseServices::BaseContracted` need to change `perform` if it previously only accepted keyword-arguments, which are not
+passed to `perform` anymore. Positional arguments are still passed as before. Examples:
+
+* `perform(params = {})` becomes `perform` (this is the case for all subclasses of `BaseContracted`)
+* `perform(a, b:)` becomes `perform(a)`
+
+## Bug fixes and changes
+
+<!-- Warning: Anything within the below lines will be automatically removed by the release script -->
+<!-- BEGIN AUTOMATED SECTION -->
+<!-- END AUTOMATED SECTION -->
+<!-- Warning: Anything above this line will be automatically removed by the release script -->
+
+## Contributions
+
+TODO

--- a/modules/auth_saml/app/services/saml/providers/update_metadata.rb
+++ b/modules/auth_saml/app/services/saml/providers/update_metadata.rb
@@ -29,7 +29,7 @@
 module Saml
   module Providers
     module UpdateMetadata
-      def after_validate(_params, call)
+      def after_validate(call)
         model = call.result
         return call unless model&.metadata_updated?
 

--- a/modules/bim/app/services/bim/bcf/comments/create_service.rb
+++ b/modules/bim/app/services/bim/bcf/comments/create_service.rb
@@ -31,15 +31,15 @@ module Bim::Bcf
     class CreateService < ::BaseServices::Create
       private
 
-      def before_perform(params, service_result)
+      def before_perform(service_result)
         journal_call = create_journal(params[:issue].work_package,
                                       params[:comment])
         return journal_call if journal_call.failure?
 
-        input = { journal: journal_call.result }
-                  .merge(params)
-                  .slice(*::Bim::Bcf::Comment::CREATE_ATTRIBUTES)
-        super(input, service_result)
+        self.params = { journal: journal_call.result }
+                        .merge(params)
+                        .slice(*::Bim::Bcf::Comment::CREATE_ATTRIBUTES)
+        super
       end
 
       def create_journal(work_package, comment)

--- a/modules/bim/app/services/bim/bcf/comments/update_service.rb
+++ b/modules/bim/app/services/bim/bcf/comments/update_service.rb
@@ -31,11 +31,12 @@ module Bim::Bcf
     class UpdateService < ::BaseServices::Update
       private
 
-      def before_perform(params, service_result)
+      def before_perform(service_result)
         journal_call = update_journal(params[:original_comment].journal, params[:comment])
         return journal_call if journal_call.failure?
 
-        super(params.slice(*::Bim::Bcf::Comment::UPDATE_ATTRIBUTES), service_result)
+        self.params = params.slice(*::Bim::Bcf::Comment::UPDATE_ATTRIBUTES)
+        super
       end
 
       def update_journal(journal, comment)

--- a/modules/bim/app/services/bim/bcf/issues/create_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/create_service.rb
@@ -31,11 +31,12 @@ module Bim::Bcf
     class CreateService < ::BaseServices::Create
       private
 
-      def before_perform(params, service_result)
+      def before_perform(service_result)
         wp_call = get_work_package params
         return wp_call if wp_call.failure?
 
-        super(issue_params(work_package: wp_call.result, params:), service_result)
+        self.params = issue_params(work_package: wp_call.result, params:)
+        super
       end
 
       def issue_params(work_package:, params:)

--- a/modules/bim/app/services/bim/bcf/issues/delete_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/delete_service.rb
@@ -31,7 +31,7 @@ module Bim::Bcf
     class DeleteService < ::BaseServices::Delete
       private
 
-      def after_validate(params, contract_call)
+      def after_validate(contract_call)
         wp_call = work_package_delete_call(params)
 
         if wp_call.success?

--- a/modules/bim/app/services/bim/bcf/issues/update_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/update_service.rb
@@ -31,7 +31,7 @@ module Bim::Bcf
     class UpdateService < ::BaseServices::Update
       private
 
-      def before_perform(params, service_result)
+      def before_perform(service_result)
         wp_call = ::WorkPackages::UpdateService
           .new(model: model.work_package,
                user:,
@@ -39,9 +39,9 @@ module Bim::Bcf
           .call(**params)
 
         if wp_call.success?
-          issue_params = params.slice(*Bim::Bcf::Issue::SETTABLE_ATTRIBUTES)
+          self.params = params.slice(*Bim::Bcf::Issue::SETTABLE_ATTRIBUTES)
 
-          super(issue_params, service_result)
+          super
         else
           wp_call
         end

--- a/modules/bim/app/services/bim/ifc_models/update_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/update_service.rb
@@ -31,7 +31,7 @@ module Bim
     class UpdateService < ::BaseServices::Update
       protected
 
-      def before_perform(params, _service_result)
+      def before_perform(_service_result)
         @ifc_attachment_updated = params[:ifc_attachment].present?
 
         super

--- a/modules/boards/app/services/boards/base_create_service.rb
+++ b/modules/boards/app/services/boards/base_create_service.rb
@@ -13,14 +13,15 @@ module Boards
       )
     end
 
-    def before_perform(params, _service_result)
+    def before_perform(_service_result)
       return super if no_widgets_initially?
 
       create_query_result = create_query(params)
 
       return create_query_result if create_query_result.failure?
 
-      super(params.merge(query_id: create_query_result.result.id), create_query_result)
+      params[:query_id] = create_query_result.result.id
+      super(create_query_result)
     end
 
     def set_attributes_params(params)

--- a/modules/boards/app/services/boards/version_board_create_service.rb
+++ b/modules/boards/app/services/boards/version_board_create_service.rb
@@ -4,7 +4,7 @@ module Boards
   class VersionBoardCreateService < BaseCreateService
     protected
 
-    def before_perform(params, _service_result)
+    def before_perform(_service_result)
       create_queries_results = create_queries(params)
 
       return create_queries_results.find(&:failure?) if create_queries_results.any?(&:failure?)

--- a/modules/calendar/app/services/calendar/create_ical_service.rb
+++ b/modules/calendar/app/services/calendar/create_ical_service.rb
@@ -33,7 +33,9 @@ module Calendar
     include ActionView::Helpers::SanitizeHelper
     include TextFormattingHelper
 
-    def perform(work_packages:, calendar_name:)
+    def perform
+      work_packages = params.fetch(:work_packages)
+      calendar_name = params.fetch(:calendar_name)
       ical_string = create_ical_string(work_packages, calendar_name)
 
       ServiceResult.success(result: ical_string)

--- a/modules/calendar/app/services/calendar/ical_response_service.rb
+++ b/modules/calendar/app/services/calendar/ical_response_service.rb
@@ -35,7 +35,9 @@ module Calendar
       self.contract_class = Queries::ICalSharingContract
     end
 
-    def perform(ical_token_string:, query_id:)
+    def perform
+      ical_token_string = params.fetch(:ical_token_string)
+      query_id = params.fetch(:query_id)
       ical_token_instance = resolve_ical_token(ical_token_string)
 
       user = ical_token_instance.user

--- a/modules/calendar/app/services/calendar/resolve_ical_token_service.rb
+++ b/modules/calendar/app/services/calendar/resolve_ical_token_service.rb
@@ -28,7 +28,8 @@
 
 module Calendar
   class ResolveICalTokenService < ::BaseServices::BaseCallable
-    def perform(ical_token_string:)
+    def perform
+      ical_token_string = params.fetch(:ical_token_string)
       if ical_token_string.blank?
         raise ActiveRecord::RecordNotFound
       end

--- a/modules/calendar/app/services/calendar/resolve_work_packages_service.rb
+++ b/modules/calendar/app/services/calendar/resolve_work_packages_service.rb
@@ -28,7 +28,8 @@
 
 module Calendar
   class ResolveWorkPackagesService < ::BaseServices::BaseCallable
-    def perform(query:)
+    def perform
+      query = params.fetch(:query)
       raise ActiveRecord::RecordNotFound if query.nil?
 
       query.remove_filter(:dates_interval)

--- a/modules/grids/app/services/grids/update_service.rb
+++ b/modules/grids/app/services/grids/update_service.rb
@@ -29,8 +29,8 @@
 class Grids::UpdateService < BaseServices::Update
   protected
 
-  def perform(attributes)
-    set_type_for_error_message(attributes.delete(:scope))
+  def perform
+    set_type_for_error_message(params.delete(:scope))
 
     super
   end

--- a/modules/meeting/app/services/meeting_agenda_items/drop_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/drop_service.rb
@@ -38,7 +38,7 @@ module MeetingAgendaItems
       @meeting = meeting_agenda_item.meeting
     end
 
-    def perform(params)
+    def perform
       service_call = validate_permission
       service_call = validate_meeting_existence if service_call.success?
       service_call = validate_meeting_agenda_item_editable if service_call.success?

--- a/modules/meeting/app/services/meetings/delete_service.rb
+++ b/modules/meeting/app/services/meetings/delete_service.rb
@@ -32,7 +32,7 @@ module Meetings
   class DeleteService < ::BaseServices::Delete
     protected
 
-    def after_validate(_, call)
+    def after_validate(call)
       send_cancellation_mail(model)
       cancel_scheduled_meeting(model)
 

--- a/modules/meeting/app/services/recurring_meetings/delete_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/delete_service.rb
@@ -36,7 +36,7 @@ module RecurringMeetings
       Meetings::DeleteContract
     end
 
-    def after_validate(_, call)
+    def after_validate(call)
       send_cancellation_mail(model)
 
       call

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -41,7 +41,8 @@ module RecurringMeetings
 
     protected
 
-    def perform(start_time:)
+    def perform
+      start_time = params.fetch(:start_time)
       in_context(recurring_meeting, send_notifications: false) do
         call = instantiate(start_time)
         create_schedule(call) if call.success?

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -34,7 +34,7 @@ module RecurringMeetings
 
     protected
 
-    def validate_params(*)
+    def validate_params
       @old_schedule = model.full_schedule_in_words
       super
     end

--- a/modules/meeting/app/services/recurring_meetings/with_template.rb
+++ b/modules/meeting/app/services/recurring_meetings/with_template.rb
@@ -34,7 +34,7 @@ module RecurringMeetings
     included do
       attr_accessor :template_params
 
-      def before_perform(params, _)
+      def before_perform(_)
         @template_params = extract_template_params(params)
 
         super

--- a/modules/openid_connect/app/services/openid_connect/providers/update_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/providers/update_service.rb
@@ -50,7 +50,7 @@ module OpenIDConnect
         @fetch_metadata = fetch_metadata
       end
 
-      def after_validate(_params, call)
+      def after_validate(call)
         model = call.result
         metadata_url = get_metadata_url(model)
         return call if metadata_url.blank? || !@fetch_metadata

--- a/spec/services/base/base_callable_spec.rb
+++ b/spec/services/base/base_callable_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe BaseServices::BaseCallable, type: :model do
   let(:test_service) do
     Class.new(BaseServices::BaseCallable) do
-      def perform(*)
+      def perform
         state.test = "foo"
         ServiceResult.success(result: "something")
       end
@@ -42,7 +42,7 @@ RSpec.describe BaseServices::BaseCallable, type: :model do
 
   let(:test_service2) do
     Class.new(BaseServices::BaseCallable) do
-      def perform(*)
+      def perform
         state.test2 = "foo"
         ServiceResult.success(result: "something")
       end

--- a/spec/services/reminders/set_attributes_service_spec.rb
+++ b/spec/services/reminders/set_attributes_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reminders::SetAttributesService do
         creator: user
       }
 
-      service.perform(params)
+      service.call(params)
 
       expect(model_instance).to have_attributes(
         remind_at: current_user.time_zone.parse("2023-10-01 12:00"),
@@ -75,7 +75,7 @@ RSpec.describe Reminders::SetAttributesService do
           creator: user
         }
 
-        model_result = service.perform(params).result
+        model_result = service.call(params).result
 
         expect(model_result).to have_attributes(
           remind_at: current_user.time_zone.parse("2027-10-01 08:00"),
@@ -89,17 +89,17 @@ RSpec.describe Reminders::SetAttributesService do
     context "when remind_at_date or remind_at_time is not provided" do
       it "does not set the remind_at attribute" do
         aggregate_failures "one is nil" do
-          service.perform(remind_at_date: nil, remind_at_time: "12:00")
+          service.call(remind_at_date: nil, remind_at_time: "12:00")
           expect(model_instance.remind_at).to be_nil
         end
 
         aggregate_failures "both are nil" do
-          service.perform(remind_at_date: nil, remind_at_time: nil)
+          service.call(remind_at_date: nil, remind_at_time: nil)
           expect(model_instance.remind_at).to be_nil
         end
 
         aggregate_failures "none provided" do
-          service.perform({})
+          service.call({})
           expect(model_instance.remind_at).to be_nil
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe Reminders::SetAttributesService do
 
       context "and neither remind_at, remind_at_date nor remind_at_time are provided" do
         it "does not change the remind_at attribute" do
-          contract_call = service.perform({})
+          contract_call = service.call({})
 
           model_result = contract_call.result
           expect(model_result.remind_at).to eq(model_instance.remind_at)
@@ -125,7 +125,7 @@ RSpec.describe Reminders::SetAttributesService do
 
     context "with remind_at blank active model error" do
       it "adds blank errors for `remind_at_date` and `remind_at_time` attributes" do
-        result = service.perform({})
+        result = service.call({})
 
         expect(result).to be_failure
         expect(result.errors.messages).to include(
@@ -140,7 +140,7 @@ RSpec.describe Reminders::SetAttributesService do
       let(:remind_at_time) { 1.hour.ago.strftime("%H:%M") }
 
       it "adds errors for `remind_at_date` and `remind_at_time` attributes" do
-        result = service.perform(remind_at_date:, remind_at_time:)
+        result = service.call(remind_at_date:, remind_at_time:)
 
         expect(result).to be_failure
         expect(result.errors.messages).to include(

--- a/spec/services/work_package_types/set_attributes_service_spec.rb
+++ b/spec/services/work_package_types/set_attributes_service_spec.rb
@@ -42,18 +42,18 @@ module WorkPackageTypes
       let(:params) { { patterns: "vader_s_rubber_duck" } }
 
       it "fails" do
-        result = service.perform(params)
+        result = service.call(params)
 
         expect(result).to be_failure
       end
 
       it "adds an error on the patterns atrribute" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result.errors.details).to eq(patterns: [{ error: :is_invalid }])
       end
 
       it "does not override the already existing value on the model" do
-        service.perform(params)
+        service.call(params)
         expect(model).not_to be_changed
       end
     end
@@ -62,17 +62,17 @@ module WorkPackageTypes
       let(:params) { { patterns: { subject: { blueprint: "{{author}}" } } } }
 
       it "fails" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result).to be_failure
       end
 
       it "adds an error on the patterns attribute" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result.errors.details).to eq(patterns: [{ error: "Enabled is missing" }])
       end
 
       it "does not override the already existing value on the model" do
-        service.perform(params)
+        service.call(params)
         expect(model).not_to be_changed
       end
     end
@@ -81,11 +81,11 @@ module WorkPackageTypes
       let(:params) { { patterns: nil } }
 
       it "succeeds" do
-        expect(service.perform(params)).to be_success
+        expect(service.call(params)).to be_success
       end
 
       it "sets the patterns to an empty collection" do
-        service.perform(params)
+        service.call(params)
         expect(model.patterns).to eq(Types::Patterns::Collection.empty)
       end
     end
@@ -94,17 +94,17 @@ module WorkPackageTypes
       let(:params) { { copy_workflow_from: "1337" } }
 
       it "fails" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result).to be_failure
       end
 
       it "adds an error on the copy_workflow_from attribute" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result.errors.details).to eq(copy_workflow_from: [{ error: "Type for workflow copy not found." }])
       end
 
       it "does not override the already existing value on the model" do
-        service.perform(params)
+        service.call(params)
         expect(model).not_to be_changed
       end
     end
@@ -114,17 +114,17 @@ module WorkPackageTypes
       let(:params) { { copy_workflow_from: wp_type.id.to_s } }
 
       it "fails" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result).to be_failure
       end
 
       it "adds an error on the copy_workflow_from attribute" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result.errors.details).to eq(copy_workflow_from: [{ error: "Type for workflow copy has no own workflow." }])
       end
 
       it "does not override the already existing value on the model" do
-        service.perform(params)
+        service.call(params)
         expect(model).not_to be_changed
       end
     end
@@ -134,17 +134,17 @@ module WorkPackageTypes
       let(:params) { { project_ids: [project.id.to_s, "1337"] } }
 
       it "fails" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result).to be_failure
       end
 
       it "adds an error on the project_ids attribute" do
-        result = service.perform(params)
+        result = service.call(params)
         expect(result.errors.details).to eq(project_ids: [{ error: "Projects with ids 1337 do not exist." }])
       end
 
       it "does not override the already existing value on the model" do
-        service.perform(params)
+        service.call(params)
         expect(model).not_to be_changed
       end
     end


### PR DESCRIPTION
This is making the interface of BaseCallable more consistent. Previously it was unclear, whether the params passed to perform should be used to reference parameters or whether the attribute accessor should be used. Different code used different approaches.

To apply this change more consistently, BaseContracted also removed params from the methods called inside its own perform method, e.g. before_perform or after_validate.

At a later point we might consider removing this argument from other large inheritors as well, for example `BaseServices::SetAttributes#set_attributes`.

# Ticket
Initially intended as prework for https://community.openproject.org/work_packages/62516, though now it's independent cleanup.