### PR TITLE
Freeze string literals, other Rubocop fixes for `OpenProject::TextFormatting` module

### DIFF
--- a/lib/open_project/text_formatting/filters/attachment_filter.rb
+++ b/lib/open_project/text_formatting/filters/attachment_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/autolink_filter.rb
+++ b/lib/open_project/text_formatting/filters/autolink_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/bem_css_filter.rb
+++ b/lib/open_project/text_formatting/filters/bem_css_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/bem_css_filter.rb
+++ b/lib/open_project/text_formatting/filters/bem_css_filter.rb
@@ -84,7 +84,7 @@ module OpenProject::TextFormatting
         if element["class"].present?
           # Avoid using element['class'].include?(css_class) as css_class can be a substring
           # of an existing class
-          element["class"] += " #{css_class}" unless element["class"].split.any? { |existing_class| existing_class == css_class }
+          element["class"] += " #{css_class}" unless element["class"].split.any?(css_class)
         else
           element["class"] = css_class
         end

--- a/lib/open_project/text_formatting/filters/figure_wrapped_filter.rb
+++ b/lib/open_project/text_formatting/filters/figure_wrapped_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/link_attribute_filter.rb
+++ b/lib/open_project/text_formatting/filters/link_attribute_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macro_filter.rb
+++ b/lib/open_project/text_formatting/filters/macro_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macro_filter.rb
+++ b/lib/open_project/text_formatting/filters/macro_filter.rb
@@ -39,7 +39,7 @@ module OpenProject::TextFormatting
         macros.each { |macro| registered << macro }
       end
 
-      def call
+      def call # rubocop:disable Metrics/AbcSize
         doc.search("macro").each do |macro|
           registered.each do |macro_class|
             next unless macro_applies?(macro_class, macro)

--- a/lib/open_project/text_formatting/filters/macro_filter.rb
+++ b/lib/open_project/text_formatting/filters/macro_filter.rb
@@ -83,7 +83,7 @@ module OpenProject::TextFormatting
       end
 
       def macro_applies?(macro_class, element)
-        ((element["class"] || "").split & Array(macro_class.identifier)).any?
+        (element["class"] || "").split.intersect?(Array(macro_class.identifier))
       end
     end
   end

--- a/lib/open_project/text_formatting/filters/macros/child_pages.rb
+++ b/lib/open_project/text_formatting/filters/macros/child_pages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,7 +30,7 @@
 
 module OpenProject::TextFormatting::Filters::Macros
   module ChildPages
-    HTML_CLASS = "child_pages".freeze
+    HTML_CLASS = "child_pages"
 
     module_function
 

--- a/lib/open_project/text_formatting/filters/macros/child_pages/child_pages_context.rb
+++ b/lib/open_project/text_formatting/filters/macros/child_pages/child_pages_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
+++ b/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
@@ -46,7 +46,7 @@ module OpenProject::TextFormatting::Filters::Macros
       macro.replace work_package_link(macro, context)
     end
 
-    def work_package_link(macro, context)
+    def work_package_link(macro, context) # rubocop:disable Metrics/AbcSize
       project = context[:project]
       raise I18n.t("macros.create_work_package_link.errors.no_project_context") if project.nil?
 

--- a/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
+++ b/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,7 +34,7 @@ module OpenProject::TextFormatting::Filters::Macros
       include OpenProject::StaticRouting::UrlHelpers
     end
 
-    HTML_CLASS = "create_work_package_link".freeze
+    HTML_CLASS = "create_work_package_link"
 
     module_function
 

--- a/lib/open_project/text_formatting/filters/macros/embedded_table.rb
+++ b/lib/open_project/text_formatting/filters/macros/embedded_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,8 +30,8 @@
 
 module OpenProject::TextFormatting::Filters::Macros
   module EmbeddedTable
-    CUSTOM_ELEMENT = "opce-macro-embedded-table".freeze
-    HTML_CLASS = "embedded-table".freeze
+    CUSTOM_ELEMENT = "opce-macro-embedded-table"
+    HTML_CLASS = "embedded-table"
 
     module_function
 

--- a/lib/open_project/text_formatting/filters/macros/github_pull_request.rb
+++ b/lib/open_project/text_formatting/filters/macros/github_pull_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,8 +30,8 @@
 
 module OpenProject::TextFormatting::Filters::Macros
   module GithubPullRequest
-    CUSTOM_ELEMENT = "opce-github-pull-request".freeze
-    HTML_CLASS = "github_pull_request".freeze
+    CUSTOM_ELEMENT = "opce-github-pull-request"
+    HTML_CLASS = "github_pull_request"
 
     module_function
 

--- a/lib/open_project/text_formatting/filters/macros/include_wiki_page.rb
+++ b/lib/open_project/text_formatting/filters/macros/include_wiki_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,7 +30,7 @@
 
 module OpenProject::TextFormatting::Filters::Macros
   module IncludeWikiPage
-    HTML_CLASS = "include_wiki_page".freeze
+    HTML_CLASS = "include_wiki_page"
 
     module_function
 

--- a/lib/open_project/text_formatting/filters/macros/toc.rb
+++ b/lib/open_project/text_formatting/filters/macros/toc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,7 +30,7 @@
 
 module OpenProject::TextFormatting::Filters::Macros
   module Toc
-    HTML_CLASS = "toc".freeze
+    HTML_CLASS = "toc"
 
     module_function
 

--- a/lib/open_project/text_formatting/filters/markdown_filter.rb
+++ b/lib/open_project/text_formatting/filters/markdown_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/mention_filter.rb
+++ b/lib/open_project/text_formatting/filters/mention_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/pattern_matcher_filter.rb
+++ b/lib/open_project/text_formatting/filters/pattern_matcher_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/plain_filter.rb
+++ b/lib/open_project/text_formatting/filters/plain_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/relative_link_filter.rb
+++ b/lib/open_project/text_formatting/filters/relative_link_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/syntax_highlight_filter.rb
+++ b/lib/open_project/text_formatting/filters/syntax_highlight_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -82,7 +82,7 @@ module OpenProject::TextFormatting
         parent_number == "" ? num_in_level.to_s : "#{parent_number}.#{num_in_level}"
       end
 
-      def render_nested(level = 0, parent_number = "")
+      def render_nested(level = 0, parent_number = "") # rubocop:disable Metrics/AbcSize
         result = "".html_safe
         num_in_level = 0
 

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -68,7 +68,7 @@ module OpenProject::TextFormatting
       # that prefix is used if it matches the calculated number.
       def process_item(node, number)
         text = node.text
-        return "".html_safe unless text.present?
+        return "".html_safe if text.blank?
 
         id = get_unique_id(text)
         add_header_link_class_and_id(node, id)
@@ -86,9 +86,9 @@ module OpenProject::TextFormatting
         result = "".html_safe
         num_in_level = 0
 
-        while headings.length > 0
+        while !headings.empty?
           node = headings.first
-          node_level = node.name[1,].to_i
+          node_level = node.name[1].to_i
 
           if level == node_level
             # We will render this node

--- a/lib/open_project/text_formatting/filters/task_list_filter.rb
+++ b/lib/open_project/text_formatting/filters/task_list_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/task_list_filter.rb
+++ b/lib/open_project/text_formatting/filters/task_list_filter.rb
@@ -58,7 +58,7 @@ module OpenProject::TextFormatting
       # Modifications apply to the parsed document directly.
       #
       # Returns nothing.
-      def filter!
+      def filter! # rubocop:disable Metrics/AbcSize
         list_items(doc).reverse_each do |li|
           next if list_items(li.parent).empty?
 

--- a/lib/open_project/text_formatting/formats.rb
+++ b/lib/open_project/text_formatting/formats.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/base_format.rb
+++ b/lib/open_project/text_formatting/formats/base_format.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/base_formatter.rb
+++ b/lib/open_project/text_formatting/formats/base_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/format.rb
+++ b/lib/open_project/text_formatting/formats/markdown/format.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/formatter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/helper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/plain/format.rb
+++ b/lib/open_project/text_formatting/formats/plain/format.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/plain/formatter.rb
+++ b/lib/open_project/text_formatting/formats/plain/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/plain/helper.rb
+++ b/lib/open_project/text_formatting/formats/plain/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/helpers/link_rewriter.rb
+++ b/lib/open_project/text_formatting/helpers/link_rewriter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/attribute_macros.rb
+++ b/lib/open_project/text_formatting/matchers/attribute_macros.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/base.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/base.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/base.rb
@@ -57,9 +57,7 @@ module OpenProject::TextFormatting::Matchers
         []
       end
 
-      def allowed_prefixes
-        self.class.allowed_prefixes
-      end
+      delegate :allowed_prefixes, to: :class
 
       ##
       # Test whether we should try to resolve the given link
@@ -76,9 +74,7 @@ module OpenProject::TextFormatting::Matchers
       end
 
       def oid
-        unless identifier.nil?
-          identifier.to_i
-        end
+        identifier&.to_i
       end
 
       delegate :identifier, to: :matcher

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -89,7 +89,7 @@ module OpenProject::TextFormatting::Matchers
         end
       end
 
-      def render_commit
+      def render_commit # rubocop:disable Metrics/AbcSize
         if project&.repository &&
            (changeset = Changeset.where(["repository_id = ? AND scmid LIKE ?", project.repository.id, "#{oid}%"]).first)
           link_to h("#{matcher.project_prefix}#{matcher.identifier}"),
@@ -100,7 +100,7 @@ module OpenProject::TextFormatting::Matchers
         end
       end
 
-      def render_source
+      def render_source # rubocop:disable Metrics/AbcSize
         if project&.repository
           matcher.identifier =~ %r{\A[/\\]*(.*?)(@([0-9a-f]+))?(#(L\d+))?\z}
           path = $1

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -166,7 +166,7 @@ module OpenProject::TextFormatting::Matchers
           .where(["LOWER(title) = :s", { s: oid.downcase }])
           .first
 
-        if meeting && meeting.visible?(User.current)
+        if meeting&.visible?(User.current)
           link_to meeting.title,
                   { only_path: context[:only_path], controller: "/meetings", action: "show", id: meeting.id },
                   class: "meeting"

--- a/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
@@ -68,7 +68,7 @@ module OpenProject::TextFormatting::Matchers
       end
 
       def render_document
-        if document = Document.visible.find_by_id(oid)
+        if document = Document.visible.find_by(id: oid)
           link_to document.title,
                   { only_path: context[:only_path],
                     controller: "/documents",
@@ -79,7 +79,7 @@ module OpenProject::TextFormatting::Matchers
       end
 
       def render_meeting
-        meeting = Meeting.find_by_id(oid)
+        meeting = Meeting.find_by(id: oid)
         if meeting&.visible?(User.current)
           link_to meeting.title,
                   { only_path: context[:only_path],

--- a/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
@@ -43,7 +43,7 @@ module OpenProject::TextFormatting::Matchers
       # Examples:
       #
       # r11, r13
-      def call
+      def call # rubocop:disable Metrics/AbcSize
         # don't handle link unless repository exists
         return nil unless project&.repository
 

--- a/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
@@ -45,7 +45,7 @@ module OpenProject::TextFormatting::Matchers
       # r11, r13
       def call
         # don't handle link unless repository exists
-        return nil unless project && project.repository
+        return nil unless project&.repository
 
         changeset = project.repository.find_changeset_by_name(matcher.identifier)
 

--- a/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
@@ -50,7 +50,7 @@ module OpenProject::TextFormatting::Matchers
         # prohibits links to things like #0123
         return if wp_id.to_s != matcher.identifier
 
-        if matcher.sep == "##" || matcher.sep == "###"
+        if ["##", "###"].include?(matcher.sep)
           render_work_package_macro(wp_id, detailed: (matcher.sep === "###"))
         else
           render_work_package_link(wp_id)

--- a/lib/open_project/text_formatting/matchers/regex_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/regex_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/regex_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/regex_matcher.rb
@@ -52,7 +52,7 @@ module OpenProject::TextFormatting
       ##
       # Process the node's html and possibly, replace it
       def self.process_node!(content, context)
-        return nil unless content.present?
+        return nil if content.blank?
 
         content.gsub!(regexp) do |matched_string|
           matchdata = Regexp.last_match

--- a/lib/open_project/text_formatting/matchers/resource_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/resource_links_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
@@ -150,7 +150,7 @@ module OpenProject::TextFormatting
 
         link_to h(wiki_title),
                 url,
-                class: ("wiki-page" + (wiki_page ? "" : " new"))
+                class: "wiki-page#{wiki_page ? '' : ' new'}"
       end
     end
   end

--- a/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
@@ -116,7 +116,7 @@ module OpenProject::TextFormatting
         link_from_match
       end
 
-      def link_from_match
+      def link_from_match # rubocop:disable Metrics/AbcSize
         # extract anchor
         anchor = nil
         if page =~ /\A(.+?)\#(.+)\z/


### PR DESCRIPTION
⚠️ **this PR is based on #19028: please review/merge that work first.**

# Ticket

N/A

# What are you trying to accomplish?

- Freeze String literals (e.g. #18898)
- Other Rubocop fixes.

## Screenshots


# What approach did you choose and why?


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
