### PR TITLE
Disable `RSpec/IncludeExamples` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -204,6 +204,10 @@ RSpec/DescribeClass:
     - 'spec/features/**/*.rb'
     - 'modules/*/spec/features/**/*.rb'
 
+# Nothing wrong with `include_examples` when used properly.
+RSpec/IncludeExamples:
+  Enabled: false
+
 # Allow number HTTP status codes in specs
 RSpecRails/HttpStatus:
   Enabled: false


### PR DESCRIPTION
There is nothing wrong with using `include_examples` when used properly.

See https://community.openproject.org/meetings/5253#item-14193 for more details about the decision.
