### PR TITLE
[#64263] Add trial enterprise banner  

### DIFF
--- a/app/components/enterprise_edition/banner_component.rb
+++ b/app/components/enterprise_edition/banner_component.rb
@@ -55,7 +55,7 @@ module EnterpriseEdition
     # @param show_always [boolean] Always show the banner, regardless of the dismissed or feature state.
     # @param dismiss_key [String] Provide a string to identify this banner when being dismissed. Defaults to feature_key
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(feature_key, # rubocop:disable Metrics/AbcSize
+    def initialize(feature_key,
                    variant: DEFAULT_VARIANT,
                    image: nil,
                    video: nil,
@@ -122,9 +122,9 @@ module EnterpriseEdition
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
         "op-enterprise-banner",
-        @variant == :medium ? "op-enterprise-banner_medium" : nil,
-        @variant == :large ? "op-enterprise-banner_large" : nil,
-        trial_feature? ? "op-enterprise-banner_trial" : nil
+        "op-enterprise-banner_medium" => @variant == :medium,
+        "op-enterprise-banner_large" => @variant == :large,
+        "op-enterprise-banner_trial" => trial_feature?
       )
     end
 
@@ -136,11 +136,11 @@ module EnterpriseEdition
 
     def render?
       return true if @show_always
+      return false if dismissed?
+      return true if feature_available? && trial_feature?
+      return false if EnterpriseToken.hide_banners?
 
-      suppress_banner = EnterpriseToken.hide_banners? || feature_available? || dismissed?
-      allow_trial_exception = feature_available? && trial_feature? && !dismissed?
-
-      !suppress_banner || allow_trial_exception
+      !feature_available?
     end
 
     def feature_available?

--- a/app/components/enterprise_edition/banner_component.rb
+++ b/app/components/enterprise_edition/banner_component.rb
@@ -44,7 +44,7 @@ module EnterpriseEdition
     VARIANT_OPTIONS = %i[inline medium large].freeze
 
     # @param feature_key [Symbol, NilClass] The key of the feature to show the banner for.
-    # @param variant [Symbol, NilClass] The variant of the banner comopnent.
+    # @param variant [Symbol, NilClass] The variant of the banner component.
     # @param image [String, NilClass] Path to the image to show on the banner, or nil.
     #   Only applicable and required when variant is :medium.
     # @param video [String, NilClass] Path to the video to show on the banner, or nil.
@@ -123,7 +123,8 @@ module EnterpriseEdition
         @system_arguments[:classes],
         "op-enterprise-banner",
         @variant == :medium ? "op-enterprise-banner_medium" : nil,
-        @variant == :large ? "op-enterprise-banner_large" : nil
+        @variant == :large ? "op-enterprise-banner_large" : nil,
+        trial_feature? ? "op-enterprise-banner_trial" : nil
       )
     end
 

--- a/app/components/enterprise_edition/upsell_buttons_component.rb
+++ b/app/components/enterprise_edition/upsell_buttons_component.rb
@@ -66,7 +66,7 @@ module EnterpriseEdition
     end
 
     def free_trial_button
-      return if EnterpriseToken.active? && EnterpriseToken.trial?
+      return if EnterpriseToken.active?
       return unless User.current.admin?
 
       helpers.angular_component_tag(
@@ -76,7 +76,7 @@ module EnterpriseEdition
     end
 
     def buy_now_button
-      return unless EnterpriseToken.active? && EnterpriseToken.trial?
+      return unless EnterpriseToken.active?
       return unless User.current.admin?
 
       render(Primer::Beta::Button.new(

--- a/app/components/enterprise_edition/upsell_buttons_component.rb
+++ b/app/components/enterprise_edition/upsell_buttons_component.rb
@@ -58,6 +58,7 @@ module EnterpriseEdition
 
     def buttons
       [
+        buy_now_button,
         free_trial_button,
         upgrade_now_button,
         more_info_button
@@ -65,13 +66,27 @@ module EnterpriseEdition
     end
 
     def free_trial_button
-      return if EnterpriseToken.active?
+      return if EnterpriseToken.active? && EnterpriseToken.trial?
       return unless User.current.admin?
 
       helpers.angular_component_tag(
         "opce-free-trial-button",
         inputs: helpers.enterprise_angular_trial_inputs
       )
+    end
+
+    def buy_now_button
+      return unless EnterpriseToken.active? && EnterpriseToken.trial?
+      return unless User.current.admin?
+
+      render(Primer::Beta::Button.new(
+               classes: "upsell-colored-background",
+               tag: :a,
+               href: "/admin/subscriptions/new",
+               align_self: :center
+             )) do
+        I18n.t("ee.upsell.buy_now_button")
+      end
     end
 
     # Allow providing a custom upgrade now button

--- a/app/components/enterprise_edition/upsell_buttons_component.rb
+++ b/app/components/enterprise_edition/upsell_buttons_component.rb
@@ -82,7 +82,7 @@ module EnterpriseEdition
       render(Primer::Beta::Button.new(
                classes: "upsell-colored-background",
                tag: :a,
-               href: "/admin/subscriptions/new",
+               href: OpenProject::Enterprise.upgrade_path,
                align_self: :center
              )) do
         I18n.t("ee.upsell.buy_now_button")

--- a/app/components/settings/project_life_cycle_step_definitions/index_component.html.erb
+++ b/app/components/settings/project_life_cycle_step_definitions/index_component.html.erb
@@ -31,7 +31,14 @@ See COPYRIGHT and LICENSE files for more details.
   component_wrapper do
     flex_layout(data: wrapper_data_attributes) do |flex|
       flex.with_row do
-        if allowed_to_customize_life_cycle?
+        render EnterpriseEdition::BannerComponent.new(:customize_life_cycle,
+                                                      variant: :medium,
+                                                      image: "enterprise/project-lifecycle.png",
+                                                      mb: 3)
+      end
+
+      if allowed_to_customize_life_cycle?
+        flex.with_row do
           render(Primer::OpenProject::SubHeader.new) do |subheader|
             subheader.with_filter_input(
               name: "border-box-filter",
@@ -57,11 +64,6 @@ See COPYRIGHT and LICENSE files for more details.
               I18n.t("settings.project_phase_definitions.label_add")
             end
           end
-        else
-          render EnterpriseEdition::BannerComponent.new(:customize_life_cycle,
-                                                        variant: :medium,
-                                                        image: "enterprise/project-lifecycle.png",
-                                                        mb: 3)
         end
       end
 

--- a/app/components/shares/modal_body_component.html.erb
+++ b/app/components/shares/modal_body_component.html.erb
@@ -7,9 +7,8 @@
         end
       end
 
-      render(Shares::ProjectQueries::UpsellComponent.new(modal_content:))
-
-      render(strategy.manage_shares_component(modal_content:, errors:)) if EnterpriseToken.allows_to?(:project_list_sharing)
+      render(strategy.upsell_banner(modal_content:))
+      render(strategy.manage_shares_component(modal_content:, errors:)) if strategy.allow_feature?
     end
   end
 %>

--- a/app/components/shares/modal_body_component.html.erb
+++ b/app/components/shares/modal_body_component.html.erb
@@ -7,7 +7,9 @@
         end
       end
 
-      render(strategy.manage_shares_component(modal_content:, errors:))
+      render(Shares::ProjectQueries::UpsellComponent.new(modal_content:))
+
+      render(strategy.manage_shares_component(modal_content:, errors:)) if EnterpriseToken.allows_to?(:project_list_sharing)
     end
   end
 %>

--- a/app/components/shares/work_packages/modal_upsell_component.html.erb
+++ b/app/components/shares/work_packages/modal_upsell_component.html.erb
@@ -1,5 +1,7 @@
 <%=
   component_wrapper(tag: "turbo-frame") do
-    render(EnterpriseEdition::BannerComponent.new(:work_package_sharing))
+    modal_content.with_row do
+      render(EnterpriseEdition::BannerComponent.new(:work_package_sharing))
+    end
   end
 %>

--- a/app/components/shares/work_packages/modal_upsell_component.rb
+++ b/app/components/shares/work_packages/modal_upsell_component.rb
@@ -33,6 +33,14 @@ module Shares
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
+      def initialize(modal_content:)
+        super
+
+        @modal_content = modal_content
+      end
+
+      attr_reader :modal_content
+
       def self.wrapper_key
         "share_modal_body"
       end

--- a/app/controllers/concerns/projects/life_cycle_definition_helper.rb
+++ b/app/controllers/concerns/projects/life_cycle_definition_helper.rb
@@ -32,6 +32,6 @@ module Projects::LifeCycleDefinitionHelper
   private
 
   def allowed_to_customize_life_cycle?
-    EnterpriseToken.allows_to?(:customize_life_cycle)
+    EnterpriseToken.allows_to?(:customize_life_cycle) || EnterpriseToken.trialling?(:customize_life_cycle)
   end
 end

--- a/app/controllers/concerns/projects/life_cycle_definition_helper.rb
+++ b/app/controllers/concerns/projects/life_cycle_definition_helper.rb
@@ -32,6 +32,6 @@ module Projects::LifeCycleDefinitionHelper
   private
 
   def allowed_to_customize_life_cycle?
-    EnterpriseToken.allows_to?(:customize_life_cycle) || EnterpriseToken.trialling?(:customize_life_cycle)
+    EnterpriseToken.allows_to?(:customize_life_cycle)
   end
 end

--- a/app/controllers/my/enterprise_banners_controller.rb
+++ b/app/controllers/my/enterprise_banners_controller.rb
@@ -47,9 +47,13 @@ class My::EnterpriseBannersController < ApplicationController
 
   def dismiss
     pref = User.current.pref
-    pref.dismiss_banner(@feature_key)
+    pref.dismiss_banner(@dismiss_key)
     if pref.save
-      remove_via_turbo_stream(component: EnterpriseEdition::BannerComponent.new(@feature_key))
+      remove_via_turbo_stream(component: EnterpriseEdition::BannerComponent.new(
+        @feature_key,
+        dismiss_key: @dismiss_key,
+        show_always: true
+      ))
       respond_with_turbo_streams
     else
       respond_with_flash_error(message: call.message)
@@ -59,7 +63,11 @@ class My::EnterpriseBannersController < ApplicationController
   private
 
   def get_feature_key
-    @feature_key = params[:feature_key].to_sym
+    raw_key = params[:feature_key]
+
+    @dismiss_key = raw_key
+    @feature_key = raw_key.gsub(/_trial$/, "").to_sym
+
     render_400 unless OpenProject::Token.lowest_plan_for(@feature_key)
   end
 end

--- a/app/forms/statuses/form.rb
+++ b/app/forms/statuses/form.rb
@@ -86,10 +86,8 @@ module Statuses
         }
       )
 
-      if readonly_work_packages_restricted?
-        statuses_form.html_content do
-          render(EnterpriseEdition::BannerComponent.new(:readonly_work_packages))
-        end
+      statuses_form.html_content do
+        render(EnterpriseEdition::BannerComponent.new(:readonly_work_packages))
       end
 
       statuses_form.check_box(

--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -45,6 +45,10 @@ class EnterpriseToken < ApplicationRecord
       current && !current.expired?
     end
 
+    def trialling?(feature)
+      allows_to?(feature) && EnterpriseToken.current.trial?
+    end
+
     def hide_banners?
       OpenProject::Configuration.ee_hide_banners?
     end
@@ -88,6 +92,7 @@ class EnterpriseToken < ApplicationRecord
            :plan,
            :features,
            :version,
+           :trial?,
            to: :token_object
 
   def token_object

--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -45,6 +45,14 @@ class EnterpriseToken < ApplicationRecord
       current && !current.expired?
     end
 
+    def available_features
+      EnterpriseToken.current&.available_features || []
+    end
+
+    def trialling_features
+      available_features.select { |feature| trialling?(feature) }
+    end
+
     def trialling?(feature)
       allows_to?(feature) && EnterpriseToken.current.trial?
     end

--- a/app/models/sharing_strategies/project_query_strategy.rb
+++ b/app/models/sharing_strategies/project_query_strategy.rb
@@ -105,14 +105,6 @@ module SharingStrategies
       end
     end
 
-    def manage_shares_component(modal_content:, errors:)
-      if EnterpriseToken.allows_to?(:project_list_sharing)
-        super
-      else
-        Shares::ProjectQueries::UpsellComponent.new(modal_content:)
-      end
-    end
-
     def title
       I18n.t(:label_share_project_list)
     end

--- a/app/models/sharing_strategies/project_query_strategy.rb
+++ b/app/models/sharing_strategies/project_query_strategy.rb
@@ -109,6 +109,15 @@ module SharingStrategies
       I18n.t(:label_share_project_list)
     end
 
+    def upsell_banner(modal_content:)
+      Shares::ProjectQueries::UpsellComponent.new(modal_content:)
+    end
+
+    def allow_feature?
+      EnterpriseToken.allows_to?(:project_list_sharing) ||
+        EnterpriseToken.trialling?(:project_list_sharing)
+    end
+
     private
 
     def virtual_owner_share

--- a/app/models/sharing_strategies/work_package_strategy.rb
+++ b/app/models/sharing_strategies/work_package_strategy.rb
@@ -99,16 +99,17 @@ module SharingStrategies
       Shares::WorkPackages::DeleteContract
     end
 
-    def modal_body_component(errors)
-      if EnterpriseToken.allows_to?(:work_package_sharing)
-        super
-      else
-        Shares::WorkPackages::ModalUpsellComponent.new
-      end
-    end
-
     def title
       I18n.t(:label_share_work_package)
+    end
+
+    def upsell_banner(modal_content:)
+      Shares::WorkPackages::ModalUpsellComponent.new(modal_content:)
+    end
+
+    def allow_feature?
+      EnterpriseToken.allows_to?(:work_package_sharing) ||
+        EnterpriseToken.trialling?(:work_package_sharing)
     end
 
     private

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -46,8 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% content_controller "admin--custom-fields",
                       dynamic: true,
                       "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config,
-                      "admin--custom-fields-enterprise-edition-value": !EnterpriseToken.allows_to?(:custom_field_hierarchies) || EnterpriseToken.trialling?(:custom_field_hierarchies),
-                      "admin--custom-fields-hierarchy-enabled-value": EnterpriseToken.allows_to?(:custom_field_hierarchies) || EnterpriseToken.trialling?(:custom_field_hierarchies) %>
+                      "admin--custom-fields-hierarchy-enabled-value": EnterpriseToken.allows_to?(:custom_field_hierarchies) %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                                              url: custom_fields_path,

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -46,7 +46,8 @@ See COPYRIGHT and LICENSE files for more details.
 <% content_controller "admin--custom-fields",
                       dynamic: true,
                       "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config,
-                      "admin--custom-fields-enterprise-edition-value": EnterpriseToken.allows_to?(:custom_field_hierarchies) %>
+                      "admin--custom-fields-enterprise-edition-value": !EnterpriseToken.allows_to?(:custom_field_hierarchies) || EnterpriseToken.trialling?(:custom_field_hierarchies),
+                      "admin--custom-fields-hierarchy-enabled-value": EnterpriseToken.allows_to?(:custom_field_hierarchies) || EnterpriseToken.trialling?(:custom_field_hierarchies) %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,
                                              url: custom_fields_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2100,6 +2100,7 @@ en:
       work_package_sharing: Share work packages with external users
       work_package_subject_generation: Work Package Subject Generation
     upsell:
+      buy_now_button: "Buy now"
       plans_title: "Enterprise plans"
       title: "Enterprise add-on"
       plan_title: "Enterprise %{plan} add-on"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2094,7 +2094,6 @@ en:
       readonly_work_packages: Readonly Work Packages
       sso_auth_providers: Single sign-on
       team_planner_view: Team Planner View
-      two_factor_authentication: 2FA Authentication
       virus_scanning: Antivirus Scanning
       work_package_query_relation_columns: Work Package Query Relation Columns
       work_package_sharing: Share work packages with external users

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -150,6 +150,10 @@ export class ConfigurationService {
     return this.systemPreference<string[]>('availableFeatures');
   }
 
+  public get triallingFeatures():string[] {
+    return this.systemPreference<string[]>('triallingFeatures');
+  }
+
   private loadConfiguration() {
     return this
       .apiV3Service

--- a/frontend/src/app/core/enterprise/banners.service.ts
+++ b/frontend/src/app/core/enterprise/banners.service.ts
@@ -43,7 +43,19 @@ export class BannersService {
   }
 
   public showBannerFor(feature:string):boolean {
-    return !(this._bannersHidden || this.configuration.availableFeatures.includes(feature));
+    if (this._bannersHidden) {
+      return false;
+    }
+
+    return !this.allowsTo(feature) || this.trialling(feature);
+  }
+
+  public allowsTo(feature:string):boolean {
+    return this.configuration.availableFeatures.includes(feature);
+  }
+
+  public trialling(feature:string):boolean {
+    return this.configuration.triallingFeatures.includes(feature);
   }
 
   public getEnterPriseEditionUrl({ referrer, hash }:{ referrer?:string, hash?:string } = {}) {
@@ -59,13 +71,13 @@ export class BannersService {
     return url.toString();
   }
 
-  public async conditional(feature:string, bannersVisible?:() => void, bannersNotVisible?:() => void) {
+  public async conditional(feature:string, featureAvailable?:() => void, featureNotAvailable?:() => void) {
     await this.configuration.initialize();
 
-    if (this.showBannerFor(feature)) {
-      this.callMaybe(bannersVisible);
+    if (this.allowsTo(feature)) {
+      this.callMaybe(featureAvailable);
     } else {
-      this.callMaybe(bannersNotVisible);
+      this.callMaybe(featureNotAvailable);
     }
   }
 

--- a/frontend/src/app/core/enterprise/banners.service.ts
+++ b/frontend/src/app/core/enterprise/banners.service.ts
@@ -74,7 +74,7 @@ export class BannersService {
   public async conditional(feature:string, featureAvailable?:() => void, featureNotAvailable?:() => void) {
     await this.configuration.initialize();
 
-    if (this.allowsTo(feature)) {
+    if (!this.allowsTo(feature)) {
       this.callMaybe(featureAvailable);
     } else {
       this.callMaybe(featureNotAvailable);

--- a/frontend/src/app/core/enterprise/banners.service.ts
+++ b/frontend/src/app/core/enterprise/banners.service.ts
@@ -71,10 +71,10 @@ export class BannersService {
     return url.toString();
   }
 
-  public async conditional(feature:string, featureAvailable?:() => void, featureNotAvailable?:() => void) {
+  public async conditional(feature:string, featureNotAvailable?:() => void, featureAvailable?:() => void) {
     await this.configuration.initialize();
 
-    if (!this.allowsTo(feature)) {
+    if (this.allowsTo(feature)) {
       this.callMaybe(featureAvailable);
     } else {
       this.callMaybe(featureNotAvailable);

--- a/frontend/src/app/features/admin/types/type-banner.service.ts
+++ b/frontend/src/app/features/admin/types/type-banner.service.ts
@@ -7,7 +7,7 @@ import { ConfigurationService } from 'core-app/core/config/configuration.service
 
 @Injectable()
 export class TypeBannerService extends BannersService {
-  showBanners = this.showBannerFor('edit_attribute_groups');
+  eeAvailable = this.allowsTo('edit_attribute_groups');
 
   constructor(
     @Inject(DOCUMENT) protected documentElement:Document,

--- a/frontend/src/app/features/admin/types/type-form-configuration.html
+++ b/frontend/src/app/features/admin/types/type-form-configuration.html
@@ -10,7 +10,7 @@
         </button>
       </li>
       <li
-        *ngIf="!typeBanner.showBanners"
+        *ngIf="typeBanner.eeAvailable"
         class="toolbar-item drop-down">
         <a class="form-configuration--add-group button -primary" aria-haspopup="true">
           <op-icon icon-classes="button--icon icon-add"></op-icon>

--- a/frontend/src/app/features/boards/board/board-actions/board-actions-registry.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/board-actions-registry.service.ts
@@ -30,7 +30,7 @@ export class BoardActionsRegistryService {
       icon: '',
       description: '',
       image: '',
-      disabled: this.bannersService.showBannerFor('board_view'),
+      disabled: !this.bannersService.allowsTo('board_view'),
     }));
   }
 

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -1,6 +1,11 @@
 <ng-container *ngIf="(board$ | async) as board">
+  <op-enterprise-banner-frame
+    class="boards-list--enterprise-banner"
+    feature="board_view"
+    [dismissable]="true"
+  ></op-enterprise-banner-frame>
   <div
-    *ngIf="!needEnterpriseEdition; else enterpriseBanner"
+    *ngIf="available"
     class="boards-list--container"
     [ngClass]="{ '-free' : board.isFree }"
     #container
@@ -38,12 +43,4 @@
       </div>
     </div>
   </div>
-
-  <ng-template #enterpriseBanner>
-    <op-enterprise-banner-frame
-      class="boards-list--enterprise-banner"
-      feature="board_view"
-      [dismissable]="true"
-    ></op-enterprise-banner-frame>
-  </ng-template>
 </ng-container>

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -88,7 +88,7 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
 
   showHiddenListWarning:boolean = false;
 
-  needEnterpriseEdition = this.Banner.showBannerFor('board_view');
+  available = this.Banner.allowsTo('board_view');
 
   private currentQueryUpdatedMonitoring:Subscription;
 
@@ -126,7 +126,7 @@ readonly I18n:I18nService,
       );
 
     this.board$.subscribe((board) => {
-      this.needEnterpriseEdition = this.Banner.showBannerFor('board_view') && !board.isFree;
+      this.available = this.Banner.allowsTo('board_view') || board.isFree;
     });
 
     this.Boards.currentBoard$.next(id);

--- a/frontend/src/app/features/enterprise/enterprise-banner-frame.component.html
+++ b/frontend/src/app/features/enterprise/enterprise-banner-frame.component.html
@@ -1,5 +1,5 @@
 <turbo-frame
-  id="enterprise_banner_{{feature}}"
+  [id]="frameID"
   *ngIf="visible"
   [src]="frameURL"
 >

--- a/frontend/src/app/features/enterprise/enterprise-banner-frame.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-banner-frame.component.ts
@@ -43,6 +43,7 @@ export class EnterpriseBannerFrameComponent implements OnInit {
 
   visible:boolean;
   frameURL:string;
+  frameID:string;
 
   constructor(
     protected pathHelper:PathHelperService,
@@ -53,5 +54,8 @@ export class EnterpriseBannerFrameComponent implements OnInit {
   ngOnInit() {
     this.visible = this.banners.showBannerFor(this.feature);
     this.frameURL = this.pathHelper.bannerFramePath(this.feature, this.dismissable);
+
+    const trialSuffix = this.banners.trialling(this.feature) ? '_trial' : '';
+    this.frameID = `enterprise_banner_${this.feature}${trialSuffix}`;
   }
 }

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
@@ -119,7 +119,14 @@ export class ProjectSelectionComponent implements OnInit {
   }
 
   private setPlaceholderOption():void {
-    if (this.bannersService.showBannerFor('placeholder_users')) {
+    if (this.bannersService.allowsTo('placeholder_users')) {
+      this.typeOptions.push({
+        value: PrincipalType.Placeholder,
+        title: this.I18n.t('js.invite_user_modal.type.placeholder.title'),
+        description: this.I18n.t('js.invite_user_modal.type.placeholder.description'),
+        disabled: false,
+      });
+    } else {
       this.typeOptions.push({
         value: PrincipalType.Placeholder,
         title: this.I18n.t('js.invite_user_modal.type.placeholder.title_no_ee'),
@@ -130,13 +137,6 @@ export class ProjectSelectionComponent implements OnInit {
           }),
         }),
         disabled: true,
-      });
-    } else {
-      this.typeOptions.push({
-        value: PrincipalType.Placeholder,
-        title: this.I18n.t('js.invite_user_modal.type.placeholder.title'),
-        description: this.I18n.t('js.invite_user_modal.type.placeholder.description'),
-        disabled: false,
       });
     }
   }

--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.html
@@ -71,7 +71,7 @@
     <p>{{ text.dateAlerts.description }}</p>
   </div>
 
-  <div *ngIf="!eeShowBanners">
+  <div *ngIf="eeAvailable">
     <div
       class="op-reminder-settings-date-alerts--row"
       formGroupName="startDate"

--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.ts
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.ts
@@ -54,7 +54,7 @@ export class NotificationsSettingsPageComponent extends UntilDestroyedMixin impl
 
   public availableTimesOverdue = overDueReminderTimes();
 
-  public eeShowBanners = false;
+  public eeAvailable = false;
 
   public form = new UntypedFormGroup({
     assignee: new UntypedFormControl(false),
@@ -137,7 +137,7 @@ export class NotificationsSettingsPageComponent extends UntilDestroyedMixin impl
 
   ngOnInit():void {
     this.form.disable();
-    this.eeShowBanners = this.bannersService.showBannerFor('date_alerts');
+    this.eeAvailable = this.bannersService.allowsTo('date_alerts');
 
     this
       .currentUserService

--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
@@ -88,7 +88,7 @@
         </ng-container>
       </tr>
 
-      <tr *ngIf="!eeShowBanners">
+      <tr *ngIf="eeAvailable">
         <th class="op-table--cell op-table--cell_soft-heading">
           <h5>{{ text.dateAlerts.title }}</h5>
           <p>{{ text.dateAlerts.description }}</p>
@@ -98,7 +98,7 @@
         </ng-container>
       </tr>
 
-      <tr *ngIf="!eeShowBanners">
+      <tr *ngIf="eeAvailable">
         <th class="op-table--cell op-table--cell_soft-heading">
           {{ text.startDate }}
         </th>
@@ -122,7 +122,7 @@
         </ng-container>
       </tr>
 
-      <tr *ngIf="!eeShowBanners">
+      <tr *ngIf="eeAvailable">
         <th class="op-table--cell op-table--cell_soft-heading">
           {{ text.dueDate }}
         </th>
@@ -146,7 +146,7 @@
         </ng-container>
       </tr>
 
-      <tr *ngIf="!eeShowBanners">
+      <tr *ngIf="eeAvailable">
         <th class="op-table--cell op-table--cell_soft-heading">
           {{ text.overdue }}
         </th>

--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.ts
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.ts
@@ -21,7 +21,7 @@ export class NotificationSettingsTableComponent implements OnInit {
 
   @Input() settings:UntypedFormArray;
 
-  public eeShowBanners = false;
+  public eeAvailable = false;
 
   public availableTimes = [
     {
@@ -81,7 +81,7 @@ export class NotificationSettingsTableComponent implements OnInit {
   ) {}
 
   ngOnInit():void {
-    this.eeShowBanners = this.bannersService.showBannerFor('date_alerts');
+    this.eeAvailable = this.bannersService.allowsTo('date_alerts');
   }
 
   projectLink(href:string) {

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
@@ -98,7 +98,7 @@ export class OpBaselineComponent extends UntilDestroyedMixin implements OnInit {
 
   public tooltipPosition = SpotDropAlignmentOption.TopRight;
 
-  available = !this.Banner.showBannerFor('baseline_comparison');
+  available = this.Banner.allowsTo('baseline_comparison');
 
   public text = {
     toggle_title: this.I18n.t('js.baseline.toggle_title'),

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.component.ts
@@ -52,7 +52,7 @@ import { CollectionResource } from 'core-app/features/hal/resources/collection-r
 export class WorkPackageShareButtonComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public workPackage:WorkPackageResource;
 
-  showEnterpriseIcon = this.bannersService.showBannerFor('work_package_sharing');
+  showEnterpriseIcon = !this.bannersService.allowsTo('work_package_sharing');
 
   shareCount$:Observable<number>;
 

--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions.component.ts
@@ -48,7 +48,7 @@ export class WpCustomActionsComponent extends UntilDestroyedMixin implements OnI
 
   actions:CustomActionResource[] = [];
 
-  available = !this.bannersService.showBannerFor('custom_actions');
+  available = !this.bannersService.allowsTo('custom_actions');
 
   constructor(
     readonly apiV3Service:ApiV3Service,

--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions.component.ts
@@ -48,7 +48,7 @@ export class WpCustomActionsComponent extends UntilDestroyedMixin implements OnI
 
   actions:CustomActionResource[] = [];
 
-  available = !this.bannersService.allowsTo('custom_actions');
+  available = this.bannersService.allowsTo('custom_actions');
 
   constructor(
     readonly apiV3Service:ApiV3Service,

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
@@ -9,7 +9,7 @@
     <div class="form--field">
       <label class="form--label">
         <input type="radio"
-               [attr.disabled]="disabledValue(eeShowBanners)"
+               [attr.disabled]="disabledValue(eeAvailable)"
                [(ngModel)]="highlightingMode"
                (change)="updateMode($event.target.value)"
                value="inline"
@@ -41,7 +41,7 @@
     <div class="form--field">
       <label class="form--label">
         <input type="radio"
-               [attr.disabled]="disabledValue(eeShowBanners)"
+               [attr.disabled]="disabledValue(eeAvailable)"
                [(ngModel)]="entireRowMode"
                (change)="updateMode('entire-row')"
                [value]="true"
@@ -54,7 +54,7 @@
           <ng-select #rowHighlightNgSelect
                      [items]="availableRowHighlightedAttributes"
                      [(ngModel)]="lastEntireRowAttribute"
-                     [disabled]="disabledValue(eeShowBanners)"
+                     [disabled]="disabledValue(eeAvailable)"
                      [clearable]="false"
                      (open)="onOpen(rowHighlightNgSelect)"
                      (change)="updateMode($event.value)"
@@ -72,7 +72,7 @@
     <div class="form--field">
       <label class="form--label">
         <input type="radio"
-               [attr.disabled]="disabledValue(eeShowBanners)"
+               [attr.disabled]="disabledValue(eeAvailable)"
                [(ngModel)]="highlightingMode"
                (change)="updateMode($event.target.value)"
                value="none"

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -28,7 +28,7 @@ export class WpTableConfigurationHighlightingTabComponent implements TabComponen
 
   public lastEntireRowAttribute:HighlightingMode = 'status';
 
-  public eeShowBanners = false;
+  public eeAvailable = false;
 
   public availableInlineHighlightedAttributes:HalResource[] = [];
 
@@ -74,10 +74,10 @@ export class WpTableConfigurationHighlightingTabComponent implements TabComponen
 
     this.setSelectedValues();
 
-    this.eeShowBanners = this.Banners.showBannerFor('conditional_highlighting');
+    this.eeAvailable = this.Banners.allowsTo('conditional_highlighting');
     this.updateMode(this.wpTableHighlight.current.mode);
 
-    if (this.eeShowBanners) {
+    if (!this.eeAvailable) {
       this.updateMode('none');
     }
   }
@@ -106,8 +106,8 @@ export class WpTableConfigurationHighlightingTabComponent implements TabComponen
     this.selectedAttributes = model;
   }
 
-  public disabledValue(value:boolean):string | null {
-    return value ? 'disabled' : null;
+  public disabledValue(allowed:boolean):string | null {
+    return allowed ? null : 'disabled';
   }
 
   public get availableHighlightedAttributes():HalResource[] {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service.ts
@@ -32,7 +32,7 @@ export class WorkPackageViewHighlightingService extends WorkPackageQueryStateSer
    */
   public shouldHighlightInline(name:string):boolean {
     // 1. Are we in inline mode or unable to render?
-    if (!this.isInline || this.Banners.showBannerFor('conditional_highlighting')) {
+    if (!this.isInline || !this.Banners.allowsTo('conditional_highlighting')) {
       return false;
     }
 

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -56,10 +56,12 @@ export default class CustomFieldsController extends Controller {
   static values = {
     formatConfig: Array,
     enterpriseEdition: Boolean,
+    hierarchyEnabled: Boolean,
   };
 
   declare readonly formatConfigValue:[string, string, string[]][];
   declare readonly enterpriseEditionValue:boolean;
+  declare readonly hierarchyEnabledValue:boolean;
 
   declare readonly formatTarget:HTMLInputElement;
   declare readonly dragContainerTarget:HTMLElement;
@@ -252,13 +254,13 @@ export default class CustomFieldsController extends Controller {
 
   private toggleFormat(format:string) {
     if (this.hasSubmitButtonTarget) {
-      this.submitButtonTarget.disabled = format === 'hierarchy' && !this.enterpriseEditionValue;
+      this.submitButtonTarget.disabled = format === 'hierarchy' && !this.hierarchyEnabledValue;
     }
 
     this.formatConfigValue.forEach(([targetsName, operator, formats]) => {
       let active = operator === 'only' ? formats.includes(format) : !formats.includes(format);
-      if (targetsName === 'enterpriseBanner' && this.enterpriseEditionValue) {
-        active = false;
+      if (targetsName === 'enterpriseBanner') {
+        active = this.enterpriseEditionValue;
       }
 
       const targets = this[`${targetsName}Targets` as keyof typeof this] as HTMLElement[];

--- a/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/custom-fields.controller.ts
@@ -55,12 +55,10 @@ export default class CustomFieldsController extends Controller {
 
   static values = {
     formatConfig: Array,
-    enterpriseEdition: Boolean,
     hierarchyEnabled: Boolean,
   };
 
   declare readonly formatConfigValue:[string, string, string[]][];
-  declare readonly enterpriseEditionValue:boolean;
   declare readonly hierarchyEnabledValue:boolean;
 
   declare readonly formatTarget:HTMLInputElement;
@@ -258,10 +256,7 @@ export default class CustomFieldsController extends Controller {
     }
 
     this.formatConfigValue.forEach(([targetsName, operator, formats]) => {
-      let active = operator === 'only' ? formats.includes(format) : !formats.includes(format);
-      if (targetsName === 'enterpriseBanner') {
-        active = this.enterpriseEditionValue;
-      }
+      const active = operator === 'only' ? formats.includes(format) : !formats.includes(format);
 
       const targets = this[`${targetsName}Targets` as keyof typeof this] as HTMLElement[];
       if (targets) {

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -100,7 +100,12 @@ module API
 
         property :available_features,
                  getter: ->(*) {
-                   EnterpriseToken.current&.available_features || []
+                   EnterpriseToken.available_features
+                 }
+
+        property :trialling_features,
+                 getter: ->(*) {
+                   EnterpriseToken.trialling_features
                  }
 
         property :allowed_link_protocols,

--- a/spec/components/enterprise_edition/banner_component_spec.rb
+++ b/spec/components/enterprise_edition/banner_component_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
   context "when banner is dismissed" do
     let(:preference) { build_stubbed(:user_preference) }
     let(:user) { build_stubbed(:user, preference:) }
-    let(:dismiss_key) { :some_enterprise_feature }
+    let(:dismiss_key) { "some_enterprise_feature" }
     let(:component_args) { { dismissable: true } }
 
     before do
@@ -164,7 +164,7 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
     end
 
     context "when using a custom dismiss_key" do
-      let(:dismiss_key) { :foo }
+      let(:dismiss_key) { "foo" }
       let(:component_args) { { dismiss_key:, dismissable: true } }
 
       it_behaves_like "does not render the component"
@@ -292,6 +292,29 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
         expect do
           render_component_in_mo
         end.to raise_error(ArgumentError, "The 'video' parameter is required when the variant is :large.")
+      end
+    end
+  end
+
+  context "with a trial token" do
+    before do
+      allow(EnterpriseToken).to receive(:trialling?).and_return(true)
+    end
+
+    it_behaves_like "renders the component"
+
+    it "renders with trial overrides" do
+      render_component_in_mo
+
+      component = find_test_selector(component_test_selector)
+
+      expect(component[:class]).to include("op-enterprise-banner_trial")
+      expect(component[:class]).not_to include("op-enterprise-banner_medium")
+      expect(component[:class]).not_to include("op-enterprise-banner_large")
+
+      within(component) do
+        expect(page).to have_css(".op-enterprise-banner--close_icon")
+        expect(page).to have_content("Buy now")
       end
     end
   end

--- a/spec/features/custom_fields/hierarchy_custom_field_spec.rb
+++ b/spec/features/custom_fields/hierarchy_custom_field_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "custom fields of type hierarchy", :js do
   let(:hierarchy_page) { Pages::CustomFields::HierarchyPage.new }
 
   before do
-    allow(EnterpriseToken).to receive(:allows_to?).and_return(true)
+    allow(EnterpriseToken).to receive_messages(allows_to?: true, trialling?: false)
     login_as admin
   end
 

--- a/spec/support/shared/with_ee.rb
+++ b/spec/support/shared/with_ee.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
         .to receive_messages(token_object: token_object_double,
                              available_features: allowed.to_a,
                              expired?: false,
+                             trial?: false,
                              restrictions: {})
     end
   end

--- a/spec/support/shared/with_ee.rb
+++ b/spec/support/shared/with_ee.rb
@@ -47,7 +47,7 @@ end
 RSpec.configure do |config|
   config.before do |example|
     allowed = ee_actions(example)
-    if allowed.present?
+    if allowed.present? || example.metadata[:with_ee_trial]
       allowed = aggregate_parent_array(example, allowed.to_set)
 
       token_double = instance_double(EnterpriseToken)
@@ -65,7 +65,7 @@ RSpec.configure do |config|
         .to receive_messages(token_object: token_object_double,
                              available_features: allowed.to_a,
                              expired?: false,
-                             trial?: false,
+                             trial?: !!example.metadata[:with_ee_trial],
                              restrictions: {})
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/64263

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Notes

- Most enterprise banners worked out of the box, as they are always called in their respective views and the banner component itself decides if it is rendered or not based on the token
- Some cases needed additional changes, since their old implementations had additional checks to display either the banner or the feature, and both need to be possible simultaneously for this feature
- As this depends on the way the trial token is accessed/checked, some checks may be redundant. I don't know if something like `EnterpriseToken.allows_to?(:work_package_sharing) || EnterpriseToken.trialling?(:work_package_sharing)` will make sense after the work for multiple tokens is done

# Open points

- With regards to the thread Oliver started in Element about frontend logic, I'm not sure what we should do as that commit he mentioned is a part of this PR. Since we're unsure of the direction to take and he's away for a while still, I would propose to either keep this open until he's back or merge it in and then create a code maintenance WP to take a look at it again and decide if we want to remove the frontend checks entirely over there. Thoughts?

# Works for

- [x] baseline_comparison: Baseline Comparisons
- [x] board_view: Advanced Boards
- [x] conditional_highlighting: Conditional Highlighting
- [x] internal_comments: Internal Comments
- [x] custom_actions: Custom Actions **=> Fullscreen**
- [x] custom_field_hierarchies: Custom fields of type hierarchy
- [x] customize_life_cycle: Customize Life Cycle
- [x] date_alerts: Date Alerts
- [x] define_custom_style: Custom theme and logo **=> Fullscreen**
- [x] edit_attribute_groups: Edit Attribute Groups
- [x] gantt_pdf_export: Gantt PDF Export **=> No banner**
- [x] ldap_groups: LDAP users and group sync **=> Fullscreen**
- [x] nextcloud_sso: Single Sign-On for Nextcloud Storage 
- [x] one_drive_sharepoint_file_storage: OneDrive/SharePoint File Storage **=> Fullscreen**
- [x] placeholder_users: Placeholder Users **=> Fullscreen**
- [x] project_list_sharing: Project List Sharing
- [x] readonly_work_packages: Readonly Work Packages
- [x] sso_auth_providers: Single sign-on
- [x] team_planner_view: Team Planner View **=> Fullscreen**
- [x] virus_scanning: Antivirus Scanning
- [x] work_package_query_relation_columns: Work Package Query Relation Columns
- [x] work_package_sharing: Share work packages with external users
- [x] work_package_subject_generation: Work Package Subject Generation

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
