### PR TITLE
feature/60357 Reminders: Offer quick-set options like 'tomorrow' or 'next week' with smart defaults

### DIFF
--- a/app/components/work_packages/reminder/modal_body_component.rb
+++ b/app/components/work_packages/reminder/modal_body_component.rb
@@ -56,9 +56,9 @@ module WorkPackages
 
       def submit_path
         if @reminder.persisted?
-          work_package_reminder_path(@remindable, @reminder)
+          url_helpers.work_package_reminder_path(@remindable, @reminder)
         else
-          work_package_reminders_path(@remindable)
+          url_helpers.work_package_reminders_path(@remindable)
         end
       end
 

--- a/app/components/work_packages/reminder/modal_body_component.rb
+++ b/app/components/work_packages/reminder/modal_body_component.rb
@@ -37,14 +37,15 @@ module WorkPackages
 
       FORM_ID = "reminder-form"
 
-      attr_reader :remindable, :reminder, :errors
+      attr_reader :remindable, :reminder, :errors, :preset
 
-      def initialize(remindable:, reminder:, errors: nil)
+      def initialize(remindable:, reminder:, errors: nil, preset: nil)
         super
 
         @remindable = remindable
         @reminder = reminder
         @errors = errors
+        @preset = preset
       end
 
       class << self
@@ -82,11 +83,32 @@ module WorkPackages
       end
 
       def remind_at_date_initial_value
-        format_time_as_date(@reminder.remind_at, format: "%Y-%m-%d")
+        return time_as_date(@reminder.remind_at) if @reminder.remind_at
+        return calculate_preset_date if @preset
+
+        nil
       end
 
       def remind_at_time_initial_value
-        format_time(@reminder.remind_at, include_date: false, format: "%H:%M")
+        return format_time(@reminder.remind_at, include_date: false, format: "%H:%M") if @reminder.remind_at
+
+        "09:00"
+      end
+
+      private
+
+      def calculate_preset_date
+        case @preset
+        when "tomorrow" then time_as_date(1.day.from_now)
+        when "three_days" then time_as_date(3.days.from_now)
+        when "week" then time_as_date(7.days.from_now)
+        when "month" then time_as_date(1.month.from_now)
+        when "custom" then nil
+        end
+      end
+
+      def time_as_date(time)
+        format_time_as_date(time, format: "%Y-%m-%d")
       end
     end
   end

--- a/app/components/work_packages/reminder/modal_body_component.rb
+++ b/app/components/work_packages/reminder/modal_body_component.rb
@@ -36,6 +36,7 @@ module WorkPackages
       include OpPrimer::ComponentHelpers
 
       FORM_ID = "reminder-form"
+      DEFAULT_TIME = "09:00"
 
       attr_reader :remindable, :reminder, :errors, :preset
 
@@ -92,7 +93,7 @@ module WorkPackages
       def remind_at_time_initial_value
         return format_time(@reminder.remind_at, include_date: false, format: "%H:%M") if @reminder.remind_at
 
-        "09:00"
+        DEFAULT_TIME
       end
 
       private

--- a/app/controllers/work_packages/reminders_controller.rb
+++ b/app/controllers/work_packages/reminders_controller.rb
@@ -40,7 +40,8 @@ class WorkPackages::RemindersController < ApplicationController
   def modal_body
     render modal_component_class.new(
       remindable: @work_package,
-      reminder: @reminder
+      reminder: @reminder,
+      preset: params[:preset]
     )
   end
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1125,7 +1125,7 @@ en:
           three_days: "In 3 days"
           week: "In a week"
           month: "In a month"
-          custom: "Custom date/time"
+          custom: "At a particular date/time"
       scheduling:
         is_parent: "The dates of this work package are automatically deduced from its children. Activate 'Manual scheduling' to set the dates."
         is_switched_from_manual_to_automatic: "The dates of this work package may need to be recalculated after switching from manual to automatic scheduling due to relationships with other work packages."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1115,11 +1115,17 @@ en:
           duplicate_query_title: "Name of this view already exists. Change anyway?"
         text_no_results: "No matching views were found."
       reminders:
-        button_label: "Set reminder"
+        button_label: "Set a reminder"
         title:
-          new: "Set reminder"
+          new: "Set a reminder"
           edit: "Edit reminder"
         subtitle: "You will receive a notification for this work package at the chosen time."
+        presets:
+          tomorrow: "Tomorrow"
+          three_days: "In 3 days"
+          week: "In a week"
+          month: "In a month"
+          custom: "Custom date/time"
       scheduling:
         is_parent: "The dates of this work package are automatically deduced from its children. Activate 'Manual scheduling' to set the dates."
         is_switched_from_manual_to_automatic: "The dates of this work package may need to be recalculated after switching from manual to automatic scheduling due to relationships with other work packages."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1115,7 +1115,7 @@ en:
           duplicate_query_title: "Name of this view already exists. Change anyway?"
         text_no_results: "No matching views were found."
       reminders:
-        button_label: "Set a reminder"
+        button_label: "Set reminder"
         title:
           new: "Set a reminder"
           edit: "Edit reminder"

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-button.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-button.html
@@ -1,13 +1,21 @@
 <button
+  *ngIf="(hasReminder$ | async); else noReminder"
   class="button toolbar-icon"
   data-test-selector="op-wp-reminder-button"
   [attr.title]="buttonTitle"
   (click)="openModal()"
 >
-  <ng-container *ngIf="(hasReminder$ | async) as reminder; else noReminder">
-    <svg op-alarm-set-icon class="button--icon" size="small"></svg>
-  </ng-container>
-  <ng-template #noReminder>
-    <svg op-alarm-icon class="button--icon" size="small"></svg>
-  </ng-template>
+  <svg op-alarm-set-icon class="button--icon" size="small"></svg>
 </button>
+
+<ng-template #noReminder>
+  <button
+    class="button toolbar-icon"
+    data-test-selector="op-wp-reminder-button"
+    [attr.title]="buttonTitle"
+    wpReminderContextMenu
+    [wpReminderContextMenu-workPackage]="workPackage"
+  >
+    <svg op-alarm-icon class="button--icon" size="small"></svg>
+  </button>
+</ng-template>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
@@ -1,0 +1,65 @@
+import { Directive, ElementRef, Input, OnInit } from '@angular/core';
+import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
+import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
+import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { OpModalService } from 'core-app/shared/components/modal/modal.service';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { WorkPackageReminderModalComponent } from 'core-app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal';
+import { ReminderPreset, REMINDER_PRESET_OPTIONS } from 'core-app/features/work-packages/components/wp-reminder-modal/reminder.types';
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[wpReminderContextMenu]',
+})
+export class WorkPackageReminderContextMenuDirective extends OpContextMenuTrigger implements OnInit {
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  @Input('wpReminderContextMenu-workPackage') workPackage:WorkPackageResource;
+
+  protected items:OpContextMenuItem[] = [];
+
+  constructor(
+    readonly elementRef:ElementRef,
+    readonly opContextMenu:OPContextMenuService,
+    readonly I18n:I18nService,
+    readonly opModalService:OpModalService,
+  ) {
+    super(elementRef, opContextMenu);
+  }
+
+  ngOnInit() {
+    this.buildItems();
+  }
+
+  public get locals() {
+    return {
+      items: this.items,
+      contextMenuId: 'reminder-dropdown-menu',
+      label: this.I18n.t('js.work_packages.reminders.set_reminder'),
+    };
+  }
+
+  private buildItems() {
+    this.items = REMINDER_PRESET_OPTIONS.map((preset) => ({
+      disabled: false,
+      linkText: this.I18n.t(`js.work_packages.reminders.presets.${preset}`),
+      onClick: () => {
+        this.openModal(preset);
+        return true;
+      },
+    }));
+  }
+
+  private openModal(preset:ReminderPreset):void {
+    this.opModalService.show(
+      WorkPackageReminderModalComponent,
+      'global',
+      {
+        workPackage: this.workPackage,
+        preset,
+      },
+      false,
+      true,
+    );
+  }
+}

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
@@ -35,7 +35,7 @@ export class WorkPackageReminderContextMenuDirective extends OpContextMenuTrigge
     return {
       items: this.items,
       contextMenuId: 'reminder-dropdown-menu',
-      label: this.I18n.t('js.work_packages.reminders.set_reminder'),
+      label: this.I18n.t('js.work_packages.reminders.title.new'),
     };
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
@@ -36,12 +36,21 @@ export class WorkPackageReminderContextMenuDirective extends OpContextMenuTrigge
       items: this.items,
       contextMenuId: 'reminder-dropdown-menu',
       label: this.I18n.t('js.work_packages.reminders.title.new'),
-      visibleLabel: true,
     };
   }
 
   private buildItems() {
-    this.items = REMINDER_PRESET_OPTIONS.map((preset) => ({
+    this.items = [
+      {
+        isHeader: true,
+        linkText: this.I18n.t('js.work_packages.reminders.title.new'),
+      },
+      ...this.buildPresetItems(),
+    ];
+  }
+
+  private buildPresetItems() {
+    return REMINDER_PRESET_OPTIONS.map((preset) => ({
       disabled: false,
       linkText: this.I18n.t(`js.work_packages.reminders.presets.${preset}`),
       onClick: () => {

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
@@ -36,6 +36,7 @@ export class WorkPackageReminderContextMenuDirective extends OpContextMenuTrigge
       items: this.items,
       contextMenuId: 'reminder-dropdown-menu',
       label: this.I18n.t('js.work_packages.reminders.title.new'),
+      visibleLabel: true,
     };
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-reminder-modal/reminder.types.ts
+++ b/frontend/src/app/features/work-packages/components/wp-reminder-modal/reminder.types.ts
@@ -1,0 +1,11 @@
+export enum ReminderPreset {
+  TOMORROW = 'tomorrow',
+  THREE_DAYS = 'three_days',
+  WEEK = 'week',
+  MONTH = 'month',
+  CUSTOM = 'custom',
+}
+
+export type ReminderPresetValue = `${ReminderPreset}`;
+
+export const REMINDER_PRESET_OPTIONS = Object.values(ReminderPreset) as ReminderPreset[];

--- a/frontend/src/app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal.ts
+++ b/frontend/src/app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal.ts
@@ -15,6 +15,7 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { reminderModalUpdated } from 'core-app/features/work-packages/components/wp-reminder-modal/reminder.actions';
+import { ReminderPreset } from 'core-app/features/work-packages/components/wp-reminder-modal/reminder.types';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -33,6 +34,7 @@ export class WorkPackageReminderModalComponent extends OpModalComponent implemen
 
   private workPackage:WorkPackageResource;
   public frameSrc:string;
+  private preset:ReminderPreset | undefined;
 
   text = {
     new_title: this.I18n.t('js.work_packages.reminders.title.new'),
@@ -57,12 +59,13 @@ export class WorkPackageReminderModalComponent extends OpModalComponent implemen
     super(locals, cdRef, elementRef);
 
     this.workPackage = this.locals.workPackage as WorkPackageResource;
+    this.preset = this.locals.preset as ReminderPreset | undefined;
     this.title$ = this
       .isEditMode()
       .pipe(
         map((isEditMode) => (isEditMode ? this.text.edit_title : this.text.new_title)),
       );
-    this.frameSrc = this.pathHelper.workPackageReminderModalBodyPath(this.workPackage.id as string);
+    this.frameSrc = this.pathHelper.workPackageReminderModalBodyPath(this.workPackage.id as string) + (this.preset ? `?preset=${this.preset}` : '');
   }
 
   ngOnInit() {

--- a/frontend/src/app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal.ts
+++ b/frontend/src/app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal.ts
@@ -65,11 +65,11 @@ export class WorkPackageReminderModalComponent extends OpModalComponent implemen
       .pipe(
         map((isEditMode) => (isEditMode ? this.text.edit_title : this.text.new_title)),
       );
-    this.frameSrc = this.pathHelper.workPackageReminderModalBodyPath(this.workPackage.id as string) + (this.preset ? `?preset=${this.preset}` : '');
   }
 
   ngOnInit() {
     super.ngOnInit();
+    this.updateFrameSrc();
   }
 
   ngAfterViewInit() {
@@ -87,6 +87,17 @@ export class WorkPackageReminderModalComponent extends OpModalComponent implemen
     this.actions$.dispatch(reminderModalUpdated({ workPackageId: this.workPackage.id as string }));
 
     return super.onClose();
+  }
+
+  private updateFrameSrc():void {
+    const url = new URL(
+      this.pathHelper.workPackageReminderModalBodyPath(this.workPackage.id as string),
+      window.location.origin,
+    );
+    if (this.preset) {
+      url.searchParams.set('preset', this.preset);
+    }
+    this.frameSrc = url.toString();
   }
 
   private turboSubmitEndListener(event:CustomEvent) {

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -405,6 +405,9 @@ import {
 } from 'core-app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component';
 import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal';
 import { OpenprojectEnterpriseModule } from 'core-app/features/enterprise/openproject-enterprise.module';
+import {
+  WorkPackageReminderContextMenuDirective,
+} from 'core-app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive';
 
 @NgModule({
   imports: [
@@ -596,6 +599,7 @@ import { OpenprojectEnterpriseModule } from 'core-app/features/enterprise/openpr
     WorkPackageSplitViewToolbarComponent,
     WorkPackageWatcherButtonComponent,
     WorkPackageReminderButtonComponent,
+    WorkPackageReminderContextMenuDirective,
     WorkPackageShareButtonComponent,
     WorkPackageSubjectComponent,
 

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
@@ -5,6 +5,14 @@
       role="menu"
       [attr.aria-label]="locals.label"
       [ngClass]="{'-empty': items.length === 0 }">
+    <li *ngIf="locals.visibleLabel && locals.label" role="none">
+      <span
+        role="presentation"
+        [attr.aria-hidden]="true"
+        [textContent]="locals.label"
+        class="op-menu--headline">
+      </span>
+    </li>
     <ng-container *ngFor="let item of items">
       <li *ngIf="item.divider" class="dropdown-divider" role="separator"></li>
       <li *ngIf="!item.divider">

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
@@ -5,17 +5,17 @@
       role="menu"
       [attr.aria-label]="locals.label"
       [ngClass]="{'-empty': items.length === 0 }">
-    <li *ngIf="locals.visibleLabel && locals.label" role="none">
-      <span
-        role="presentation"
-        [attr.aria-hidden]="true"
-        [textContent]="locals.label"
-        class="op-menu--headline">
-      </span>
-    </li>
     <ng-container *ngFor="let item of items">
+      <li *ngIf="item.isHeader" role="none">
+        <span
+          role="presentation"
+          [attr.aria-hidden]="true"
+          [textContent]="item.linkText"
+          class="op-menu--headline">
+        </span>
+      </li>
       <li *ngIf="item.divider" class="dropdown-divider" role="separator"></li>
-      <li *ngIf="!item.divider">
+      <li *ngIf="!item.divider && !item.isHeader">
         <a
           *ngIf="item.href"
           class="menu-item"

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.types.ts
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.types.ts
@@ -20,6 +20,7 @@ export interface OpContextMenuLocalsMap {
   showAnchorRight?:boolean;
   contextMenuId?:string;
   label?:string;
+  visibleLabel?:boolean;
   /* eslint-disable @typescript-eslint/no-explicit-any */
   [key:string]:any;
 }

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.types.ts
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.types.ts
@@ -12,6 +12,7 @@ export interface OpContextMenuItem {
   linkText?:string;
   title?:string;
   divider?:boolean;
+  isHeader?:boolean;
   onClick?:($event:JQuery.TriggeredEvent|MouseEvent) => boolean;
 }
 
@@ -20,7 +21,6 @@ export interface OpContextMenuLocalsMap {
   showAnchorRight?:boolean;
   contextMenuId?:string;
   label?:string;
-  visibleLabel?:boolean;
   /* eslint-disable @typescript-eslint/no-explicit-any */
   [key:string]:any;
 }

--- a/spec/components/work_packages/reminder/modal_body_component_spec.rb
+++ b/spec/components/work_packages/reminder/modal_body_component_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::Reminder::ModalBodyComponent, type: :component do
+  let(:remindable) { build_stubbed(:work_package) }
+  let(:reminder) { build_stubbed(:reminder) }
+  let(:preset) { nil }
+
+  subject(:component) { described_class.new(remindable:, reminder:, preset:) }
+
+  before do
+    render_inline(component)
+  end
+
+  context "when the reminder is persisted" do
+    it "renders the component with the reminder data" do
+      expect(page).to have_field("Date", with: reminder.remind_at.in_time_zone(User.current.time_zone).to_date)
+      expect(page).to have_field("Time", with: reminder.remind_at.in_time_zone(User.current.time_zone).strftime("%H:%M"))
+      expect(page).to have_field("Note", with: reminder.note)
+
+      expect(page).to have_button("Save")
+    end
+  end
+
+  context "when the reminder is not persisted" do
+    let(:reminder) { Reminder.new }
+
+    it "renders the component with the default data" do
+      expect(page).to have_field("Date")
+      expect(page.find_field("Date").value).to be_nil
+
+      expect(page).to have_field("Time", with: "09:00")
+      expect(page).to have_field("Note")
+
+      expect(page).to have_button("Set reminder")
+    end
+  end
+
+  describe "Date presets" do
+    let(:reminder) { Reminder.new }
+
+    shared_examples "Date field with preset value" do |preset_key, preset_value|
+      context "when the preset is #{preset_key}" do
+        let(:preset) { preset_key }
+
+        it "renders the Date field with value #{preset_key}: #{preset_value.to_date}" do
+          expect(page).to have_field("Date", with: preset_value.to_date)
+        end
+      end
+    end
+
+    it_behaves_like "Date field with preset value", "tomorrow", 1.day.from_now
+    it_behaves_like "Date field with preset value", "three_days", 3.days.from_now
+    it_behaves_like "Date field with preset value", "week", 7.days.from_now
+    it_behaves_like "Date field with preset value", "month", 1.month.from_now
+
+    context "when the preset is custom" do
+      let(:preset) { "custom" }
+
+      it "renders the Date field without a value" do
+        date_field = page.find_field("Date")
+        expect(date_field.value).to be_nil
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -344,7 +344,13 @@ RSpec.describe "Work package reminder modal",
 
       specify "clicking on the reminder button opens the create reminder modal" do
         work_package_page.visit!
-        work_package_page.click_reminder_button_with_context_menu(menu_item: "Tomorrow")
+        work_package_page.click_reminder_button
+
+        within "#reminder-dropdown-menu" do
+          expect(page).to have_css(".dropdown-menu", aria: { label: "Set a reminder" })
+          click_link_or_button "Tomorrow"
+        end
+
         wait_for_network_idle
         within ".spot-modal" do
           expect(page)

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe "Work package reminder modal",
       date = time.to_date
 
       work_package_page.visit!
-      work_package_page.click_reminder_button
+      work_package_page.click_reminder_button_with_context_menu
       wait_for_network_idle
       within ".spot-modal" do
         expect(page)
-          .to have_css(".spot-modal--header-title", text: "Set reminder")
+          .to have_css(".spot-modal--header-title", text: "Set a reminder")
         expect(page)
           .to have_css(".spot-modal--subheader",
                        text: "You will receive a notification for this work package at the chosen time.")
@@ -176,12 +176,12 @@ RSpec.describe "Work package reminder modal",
 
       work_package_page.dismiss_flash!
       work_package_page.expect_reminder_button_alarm_not_set_icon
-      work_package_page.click_reminder_button
+      work_package_page.click_reminder_button_with_context_menu
       wait_for_network_idle
 
       within ".spot-modal" do
         # Now it should be the create reminder modal
-        expect(page).to have_css(".spot-modal--header-title", text: "Set reminder")
+        expect(page).to have_css(".spot-modal--header-title", text: "Set a reminder")
       end
     end
 
@@ -200,11 +200,11 @@ RSpec.describe "Work package reminder modal",
         today = Time.current.in_time_zone(current_user.time_zone).to_date
 
         work_package_page.visit!
-        work_package_page.click_reminder_button
+        work_package_page.click_reminder_button_with_context_menu
         wait_for_network_idle
         within ".spot-modal" do
           expect(page)
-            .to have_css(".spot-modal--header-title", text: "Set reminder")
+            .to have_css(".spot-modal--header-title", text: "Set a reminder")
           expect(page)
             .to have_css(".spot-modal--subheader",
                          text: "You will receive a notification for this work package at the chosen time.")
@@ -226,7 +226,6 @@ RSpec.describe "Work package reminder modal",
 
           wait_for_network_idle
           expect(page).to have_css(".FormControl-inlineValidation", text: "Time must be in the future.")
-          expect(page).to have_no_css(".FormControl-inlineValidation", text: "Date must be in the future.", wait: 0)
 
           # 30 minutes from now
           fill_in "Date", with: today
@@ -243,12 +242,12 @@ RSpec.describe "Work package reminder modal",
 
       it "renders a required error on the date or time field when either isn't set" do
         work_package_page.visit!
-        work_package_page.click_reminder_button
+        work_package_page.click_reminder_button_with_context_menu
         wait_for_network_idle
 
         within ".spot-modal" do
           expect(page)
-            .to have_css(".spot-modal--header-title", text: "Set reminder")
+            .to have_css(".spot-modal--header-title", text: "Set a reminder")
           expect(page)
             .to have_css(".spot-modal--subheader",
                          text: "You will receive a notification for this work package at the chosen time.")
@@ -258,10 +257,11 @@ RSpec.describe "Work package reminder modal",
 
           wait_for_network_idle
           expect(page).to have_css(".FormControl-inlineValidation", text: "Date can't be blank")
-          expect(page).to have_css(".FormControl-inlineValidation", text: "Time can't be blank")
+          expect(page).to have_field("Time", with: "09:00")
 
-          # Fill in the date but not the time
+          # Fill in the date and unset the time
           fill_in "Date", with: 1.week.from_now.to_date
+          fill_in "Time", with: ""
           click_link_or_button "Set reminder"
 
           wait_for_network_idle
@@ -317,6 +317,8 @@ RSpec.describe "Work package reminder modal",
 
       specify "clicking on the reminder button opens the edit reminder modal" do
         work_package_page.visit!
+        work_package_page.expect_reminder_button_alarm_set_icon
+
         work_package_page.click_reminder_button
         wait_for_network_idle
         within ".spot-modal" do
@@ -342,16 +344,16 @@ RSpec.describe "Work package reminder modal",
 
       specify "clicking on the reminder button opens the create reminder modal" do
         work_package_page.visit!
-        work_package_page.click_reminder_button
+        work_package_page.click_reminder_button_with_context_menu(menu_item: "Tomorrow")
         wait_for_network_idle
         within ".spot-modal" do
           expect(page)
-            .to have_css(".spot-modal--header-title", text: "Set reminder")
+            .to have_css(".spot-modal--header-title", text: "Set a reminder")
           expect(page)
             .to have_css(".spot-modal--subheader",
                          text: "You will receive a notification for this work package at the chosen time.")
-          expect(page).to have_field("Date")
-          expect(page).to have_field("Time")
+          expect(page).to have_field("Date", with: 1.day.from_now.to_date)
+          expect(page).to have_field("Time", with: "09:00")
           expect(page).to have_field("Note")
           expect(page).to have_button("Set reminder")
         end
@@ -360,11 +362,11 @@ RSpec.describe "Work package reminder modal",
 
     it "has a Primer close button that closes the Angular spot modal" do
       work_package_page.visit!
-      work_package_page.click_reminder_button
+      work_package_page.click_reminder_button_with_context_menu
       wait_for_network_idle
       within ".spot-modal" do
         expect(page)
-          .to have_css(".spot-modal--header-title", text: "Set reminder")
+          .to have_css(".spot-modal--header-title", text: "Set a reminder")
         find_test_selector("op-reminder-modal-close-button").click
       end
 

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -348,6 +348,8 @@ RSpec.describe "Work package reminder modal",
 
         within "#reminder-dropdown-menu" do
           expect(page).to have_css(".dropdown-menu", aria: { label: "Set a reminder" })
+          expect(page).to have_css(".op-menu--headline", text: "SET A REMINDER", aria: { hidden: true })
+
           click_link_or_button "Tomorrow"
         end
 

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -77,7 +77,7 @@ module Pages
       expect(page).not_to have_test_selector("op-wp-reminder-button")
     end
 
-    def click_reminder_button_with_context_menu(menu_item: "Custom date/time")
+    def click_reminder_button_with_context_menu(menu_item: "At a particular date/time")
       click_reminder_button
 
       within "#reminder-dropdown-menu" do

--- a/spec/support/pages/work_packages/full_work_package.rb
+++ b/spec/support/pages/work_packages/full_work_package.rb
@@ -33,7 +33,7 @@ require "support/pages/work_packages/abstract_work_package"
 module Pages
   class FullWorkPackage < Pages::AbstractWorkPackage
     def ensure_loaded
-      find(".work-packages--details--subject", match: :first)
+      first(".work-packages--details--subject")
     end
 
     def toolbar
@@ -75,6 +75,14 @@ module Pages
 
     def expect_no_reminder_button
       expect(page).not_to have_test_selector("op-wp-reminder-button")
+    end
+
+    def click_reminder_button_with_context_menu(menu_item: "Custom date/time")
+      click_reminder_button
+
+      within "#reminder-dropdown-menu" do
+        click_link_or_button menu_item
+      end
     end
 
     def click_reminder_button


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/60357

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Offer quick-set options like 'tomorrow' or 'next week' with smart defaults

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1415" alt="Screenshot 2025-05-29 at 5 10 39 PM" src="https://github.com/user-attachments/assets/3efb52a5-75a2-4535-a119-e37ab8a4b7ab" />

https://github.com/user-attachments/assets/be38b3f0-9750-4b0c-b5d6-fde98abfa4e8

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Extend the existing opContextMenu directive for the quick actions dropdown.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
