### PR TITLE
[#64337] The time in the pdf export is different from the time in the file name

### DIFF
--- a/app/models/work_package/pdf_export/common/common.rb
+++ b/app/models/work_package/pdf_export/common/common.rb
@@ -268,8 +268,12 @@ module WorkPackage::PDFExport::Common::Common
     "#{truncate(sane_filename(base), length: 255 - suffix.length, escape: false)}#{suffix}".tr(" ", "-")
   end
 
+  def export_datetime
+    @export_datetime ||= Time.zone.now
+  end
+
   def title_datetime
-    @title_datetime ||= Time.now.strftime("%Y-%m-%d_%H-%M")
+    export_datetime.strftime("%Y-%m-%d_%H-%M")
   end
 
   def footer_date

--- a/app/models/work_package/pdf_export/common/common.rb
+++ b/app/models/work_package/pdf_export/common/common.rb
@@ -269,7 +269,7 @@ module WorkPackage::PDFExport::Common::Common
   end
 
   def title_datetime
-    DateTime.now.strftime("%Y-%m-%d_%H-%M")
+    @title_datetime ||= Time.now.strftime("%Y-%m-%d_%H-%M")
   end
 
   def footer_date


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64337

# What are you trying to achieve?

For long running exports the  export time in footer/ on cover page is different. Also, the user time zone is not respected.

# What approach did you choose and why?

* Use a timezone-aware time object
* Cache the date time, so it is the same in the PDF and in the filename

