### PR TITLE
[#64337] The time in the pdf export is different from the time in the filename

### DIFF
--- a/app/models/work_package/pdf_export/common/common.rb
+++ b/app/models/work_package/pdf_export/common/common.rb
@@ -268,12 +268,16 @@ module WorkPackage::PDFExport::Common::Common
     "#{truncate(sane_filename(base), length: 255 - suffix.length, escape: false)}#{suffix}".tr(" ", "-")
   end
 
+  def export_datetime
+    @export_datetime ||= Time.zone.now
+  end
+
   def title_datetime
-    DateTime.now.strftime("%Y-%m-%d_%H-%M")
+    export_datetime.strftime("%Y-%m-%d_%H-%M")
   end
 
   def footer_date
-    format_time(Time.zone.now)
+    format_time(export_datetime)
   end
 
   def current_page_nr


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64337

# What are you trying to achieve?

For long running exports the  export time in footer/ on cover page is different. Also, the user time zone is not respected.

# What approach did you choose and why?

* Use a timezone-aware time object
* Cache the date time, so it is the same in the PDF and in the filename

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)