### PR TITLE
[59945] Project search is under the Search icon in New Recurring Meeting modal

### DIFF
--- a/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
+++ b/frontend/src/global_styles/content/_projects_autocomplete_with_search_icon.sass
@@ -1,7 +1,7 @@
 @import 'helpers'
 
 .projects-autocomplete-with-search-icon
-  ng-select[ng-reflect-multiple='false']
+  ng-select:not(.ng-select-multiple)
     input
       margin-left: 18px
   ng-select


### PR DESCRIPTION


# Ticket
https://community.openproject.org/projects/design-system/work_packages/59945/activity

# What are you trying to accomplish?
In Firefox on production, the data attribute `ng-reflect-multiple` was not added to ng-select (for whatever reason). Because of that, the indentation styling was not applied there. We now use a class instead of the data attribute 

**Before**
<img width="346" alt="Bildschirmfoto 2025-06-02 um 12 06 55" src="https://github.com/user-attachments/assets/1812c9a9-dc43-481d-89d4-bf0a91c8b95a" />
