### PR TITLE
[64377] Use second level navigation for Relations create menu

### DIFF
--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -22,7 +22,13 @@
               t(:label_relation)
             end
 
-            render_add_relations_menu_items(menu, ADD_RELATION_MENU_TYPES)
+            render_add_relations_menu_items(menu, FIRST_LEVEL_RELATION_MENU_TYPES)
+            menu.with_sub_menu_item(
+              label: t("#{I18N_NAMESPACE}.relations.label_other_relations"),
+              menu_id: ADD_RELATION_SUB_MENU
+            ) do |sub_menu|
+              render_add_relations_menu_items(sub_menu, SECOND_LEVEL_RELATION_MENU_TYPES)
+            end
           end
         end
       end

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -9,6 +9,7 @@
 class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
   FRAME_ID = "work-package-relations-tab-content"
   ADD_RELATION_ACTION_MENU = "add-relation-action-menu"
+  ADD_RELATION_SUB_MENU = "add-relation-sub-menu"
   ADD_CHILD_ACTION_MENU = "add-child-action-menu"
   I18N_NAMESPACE = "work_package_relations_tab"
 
@@ -17,20 +18,23 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     Relation::TYPE_CHILD
   ].freeze
 
-  ADD_RELATION_MENU_TYPES = [
+  FIRST_LEVEL_RELATION_MENU_TYPES = [
     *ADD_CHILD_MENU_TYPES,
-    Relation::TYPE_RELATES,
     Relation::TYPE_FOLLOWS,
     Relation::TYPE_PRECEDES,
     Relation::TYPE_PARENT,
-    Relation::TYPE_DUPLICATES,
-    Relation::TYPE_DUPLICATED,
+    Relation::TYPE_RELATES
+  ].freeze
+
+  SECOND_LEVEL_RELATION_MENU_TYPES = [
     Relation::TYPE_BLOCKS,
     Relation::TYPE_BLOCKED,
     Relation::TYPE_INCLUDES,
     Relation::TYPE_PARTOF,
     Relation::TYPE_REQUIRES,
-    Relation::TYPE_REQUIRED
+    Relation::TYPE_REQUIRED,
+    Relation::TYPE_DUPLICATES,
+    Relation::TYPE_DUPLICATED
   ].freeze
 
   include ApplicationHelper

--- a/app/components/work_package_relations_tab/index_component.sass
+++ b/app/components/work_package_relations_tab/index_component.sass
@@ -1,6 +1,7 @@
 // We reference an ID as one is required to be specified for the action menu list.
 // It can't be nested inside the BEM model as it's placed as a #top-layer element.
 #add-relation-action-menu-list,
+#add-relation-sub-menu-list,
 #add-child-action-menu-list
   max-height: 510px
   max-width: 280px

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -895,6 +895,7 @@ en:
 
       label_parent_singular: "parent"
       label_parent_plural: "parent"
+      label_other_relations: "Other relations"
       ghost_relation_title: "Related work package"
       ghost_relation_description: "This is not visible to you due to permissions."
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -99,19 +99,19 @@ module Components
       end
 
       def select_relation_type(relation_type)
-        within_add_relation_action_menu do
+        within_add_relation_action_menu(relation_type:) do
           click_link_or_button relation_type
         end
       end
 
       def expect_new_relation_type(relation_type)
-        within_add_relation_action_menu do
+        within_add_relation_action_menu(relation_type:) do
           expect(page).to have_link(relation_type, wait: 1)
         end
       end
 
       def expect_no_new_relation_type(relation_type)
-        within_add_relation_action_menu do
+        within_add_relation_action_menu(relation_type:) do
           expect(page).to have_no_link(relation_type, wait: 1)
         end
       end
@@ -122,13 +122,28 @@ module Components
         new_relation_button.click
       end
 
+      def open_relation_sub_menu
+        return if add_relation_sub_menu.visible?
+
+        new_relation_sub_menu_button.click
+      end
+
       def add_relation_action_menu
         action_menu_id = new_relation_button["aria-controls"]
         page.find(id: action_menu_id, visible: :all)
       end
 
+      def add_relation_sub_menu
+        action_menu_id = new_relation_sub_menu_button["aria-controls"]
+        page.find(id: action_menu_id, visible: :all)
+      end
+
       def new_relation_button
-        page.find_test_selector("add-relation-action-menu").find_button
+        page.find(id: "add-relation-action-menu-button")
+      end
+
+      def new_relation_sub_menu_button
+        page.find(id: "add-relation-sub-menu-button")
       end
 
       def remove_relation(relatable)
@@ -389,8 +404,9 @@ module Components
 
       private
 
-      def within_add_relation_action_menu(&)
+      def within_add_relation_action_menu(relation_type:, &)
         open_add_relation_action_menu
+        open_relation_sub_menu unless first_level_relation?(relation_type)
         within(add_relation_action_menu, &)
       end
 
@@ -410,6 +426,10 @@ module Components
             yield
           end
         end
+      end
+
+      def first_level_relation?(relation_type)
+        ["Related To", "Create new child", "Child", "Parent", "Predecessor (before)", "Successor (after)"].include?(relation_type)
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/64377/activity



# What are you trying to accomplish?
Use second-level navigation for the Relations create menu


