### PR TITLE
Fix links into OIDC docs

### DIFF
--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -160,11 +160,11 @@ sysadmin_docs:
   saml:
     href: https://www.openproject.org/docs/system-admin-guide/authentication/saml/
   oidc:
-    href: https://www.openproject.org/docs/installation-and-operations/misc/custom-openid-connect-providers/
+    href: https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/
   oidc_claims:
-    href: https://www.openproject.org/docs/installation-and-operations/misc/custom-openid-connect-providers/#claims
+    href: https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/#step-7-claims
   oidc_acr_values:
-    href: https://www.openproject.org/docs/installation-and-operations/misc/custom-openid-connect-providers/#non-essential-claims
+    href: https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/#step-7-claims
 storage_docs:
   nextcloud_setup:
     href: https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/


### PR DESCRIPTION
Those were pointing to a page that didn't contain the intended anchors, because those were moved to a different page. One of the anchors is not targetable at all anymore and was therefore replaced with the anchor to the higher-level headline.

# Ticket
none

# Screenshots

![image](https://github.com/user-attachments/assets/8e2d5fa7-c044-4f9a-b328-44f3f219ede1)
