### PR TITLE
Feature/59179 option to copy phase on copying a project

### DIFF
--- a/app/contracts/work_packages/copy_contract.rb
+++ b/app/contracts/work_packages/copy_contract.rb
@@ -37,10 +37,24 @@ module WorkPackages
     attribute :done_ratio,
               writable: true
 
+    # Overriding the definition in the CreateContract to allow copying based on the default
+    # permission of :add_work_packages.
+    attribute :project_phase_definition_id,
+              writable: ->(*) {
+                OpenProject::FeatureDecisions.stages_and_gates_active?
+              },
+              permission: :add_work_packages
+
     # Do not validate predecessors or children presence when copying: when
     # copying, it's possible to create a work package in automatic scheduling
     # mode even if it has no predecessors or children yet. They will be added
     # later in the process.
     def validate_has_predecessors_or_children; end
+
+    # No validation happening on whether the phase is active in the project.
+    # When copying a work package, e.g. from a project template, the phase
+    # might not be active in the project yet. But when it is activated later,
+    # the value should then be present.
+    def validate_phase_active_in_project; end
   end
 end

--- a/app/contracts/work_packages/copy_contract.rb
+++ b/app/contracts/work_packages/copy_contract.rb
@@ -37,13 +37,8 @@ module WorkPackages
     attribute :done_ratio,
               writable: true
 
-    # Overriding the definition in the CreateContract to allow copying based on the default
-    # permission of :add_work_packages.
-    attribute :project_phase_definition_id,
-              writable: ->(*) {
-                OpenProject::FeatureDecisions.stages_and_gates_active?
-              },
-              permission: :add_work_packages
+    # Use the default permission for the create contract, which is :add_work_packages.
+    attribute_permission :project_phase_definition_id, :add_work_packages
 
     # Do not validate predecessors or children presence when copying: when
     # copying, it's possible to create a work package in automatic scheduling

--- a/app/services/projects/copy/phases_dependent_service.rb
+++ b/app/services/projects/copy/phases_dependent_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects
+  module Copy
+    class PhasesDependentService < Dependency
+      def self.human_name
+        I18n.t("label_life_cycle_step_plural")
+      end
+
+      def source_count
+        source.phases.count
+      end
+
+      def copy_dependency(_params)
+        # TODO: check if upsert can be used here
+        source.phases.each do |source_phase|
+          target.phases.create! **source_phase.attributes.slice(
+            "definition_id",
+            "start_date",
+            "finish_date",
+            "active",
+            "duration"
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/projects/copy/phases_dependent_service.rb
+++ b/app/services/projects/copy/phases_dependent_service.rb
@@ -40,7 +40,6 @@ module Projects
       end
 
       def copy_dependency(_params)
-        # TODO: check if upsert can be used here
         source.phases.each do |source_phase|
           target.phases.create! **source_phase.attributes.slice(
             "definition_id",

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -33,7 +33,7 @@ module Projects
     include Projects::Concerns::NewProjectService
 
     def self.copy_dependencies
-      [
+      dependencies = [
         ::Projects::Copy::MembersDependentService,
         ::Projects::Copy::VersionsDependentService,
         ::Projects::Copy::CategoriesDependentService,
@@ -46,6 +46,12 @@ module Projects
         ::Projects::Copy::PhasesDependentService,
         ::Projects::Copy::StoragesDependentService
       ]
+
+      if OpenProject::FeatureDecisions.stages_and_gates_active?
+        dependencies
+      else
+        dependencies - [::Projects::Copy::PhasesDependentService]
+      end
     end
 
     # Project Folders and File Links aren't dependent services anymore,

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -43,6 +43,7 @@ module Projects
         ::Projects::Copy::QueriesDependentService,
         ::Projects::Copy::BoardsDependentService,
         ::Projects::Copy::OverviewDependentService,
+        ::Projects::Copy::PhasesDependentService,
         ::Projects::Copy::StoragesDependentService
       ]
     end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -95,27 +95,53 @@ RSpec.describe(
   end
 
   describe ".copyable_dependencies" do
-    it "includes the list of dependencies" do
-      expect(described_class.copyable_dependencies.pluck(:identifier)).to eq(
-        %w(
-          members
-          versions
-          categories
-          work_packages
-          work_package_attachments
-          work_package_shares
-          wiki
-          wiki_page_attachments
-          forums
-          queries
-          boards
-          overview
-          phases
-          storages
-          storage_project_folders
-          file_links
+    context "with project phases inactive", with_flag: { stages_and_gates: false } do
+      it "includes the list of dependencies" do
+        expect(described_class.copyable_dependencies.pluck(:identifier)).to eq(
+          %w(
+            members
+            versions
+            categories
+            work_packages
+            work_package_attachments
+            work_package_shares
+            wiki
+            wiki_page_attachments
+            forums
+            queries
+            boards
+            overview
+            storages
+            storage_project_folders
+            file_links
+          )
         )
-      )
+      end
+    end
+
+    context "with project phases active", with_flag: { stages_and_gates: true } do
+      it "includes the list of dependencies" do
+        expect(described_class.copyable_dependencies.pluck(:identifier)).to eq(
+          %w(
+            members
+            versions
+            categories
+            work_packages
+            work_package_attachments
+            work_package_shares
+            wiki
+            wiki_page_attachments
+            forums
+            queries
+            boards
+            overview
+            phases
+            storages
+            storage_project_folders
+            file_links
+          )
+        )
+      end
     end
   end
 
@@ -257,7 +283,7 @@ RSpec.describe(
 
       # rubocop:disable RSpec/ExampleLength
       # rubocop:disable RSpec/MultipleExpectations
-      it "copies all dependencies and set attributes" do
+      it "copies all dependencies and set attributes", with_flag: { stages_and_gates: true } do
         expect(subject).to be_success
 
         expect(project_copy.members.count).to eq 1
@@ -948,7 +974,7 @@ RSpec.describe(
         end
       end
 
-      context "with project phases" do
+      context "with project phases", with_flag: { stages_and_gates: true } do
         let(:only_args) { %i[phases] }
 
         let!(:inactive_source_project_phase) do

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -887,6 +887,25 @@ RSpec.describe(
             expect(duplicates_relation.to_id).to eq other_wp.id
           end
         end
+
+        context "with project phases associated", with_flag: { stages_and_gates: true } do
+          before do
+            source_wp.update_column(:project_phase_definition_id, source_project_phase.definition_id)
+          end
+
+          it "copies the project phase (regardless of the phase not being copied itself)" do
+            expect(subject).to be_success
+            expect(project_copy.work_packages.count).to eq(2)
+
+            copied_wp = project_copy.work_packages.find_by(subject: source_wp.subject)
+            expect(copied_wp.project_phase_definition_id).to eq(source_project_phase.definition_id)
+
+            [source_wp, source_wp_locked].each do |wp|
+              copied_wp = project_copy.work_packages.find_by(subject: wp.subject)
+              expect(copied_wp.project_phase_definition_id).to eq(wp.project_phase_definition_id)
+            end
+          end
+        end
       end
 
       context "with wiki" do

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
     set_factory_default(:user, user)
   end
 
+  shared_let(:project_phase_definition) { create(:project_phase_definition) }
   shared_let(:work_package) do
-    create(:work_package, author: user, project:, type:)
+    create(:work_package, author: user, project:, type:, project_phase_definition:)
   end
 
   let(:instance) { described_class.new(work_package:, user:) }
@@ -103,6 +104,13 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
         it "copies the watcher and does not add the copying user as a watcher" do
           expect(copy.watcher_users)
             .to contain_exactly(watcher_user)
+        end
+      end
+
+      describe "#project_phase_definition", with_flag: { stages_and_gates: true } do
+        it "is the one of the copied work package" do
+          expect(copy.project_phase_definition)
+            .to eql project_phase_definition
         end
       end
     end
@@ -193,6 +201,13 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
 
         it "copies the % complete value over" do
           expect(copy.done_ratio).to eq(40)
+        end
+      end
+
+      describe "#project_phase_definition", with_flag: { stages_and_gates: true } do
+        it "is the one of the copied work package" do
+          expect(copy.project_phase_definition)
+            .to eql project_phase_definition
         end
       end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59179

# What are you trying to accomplish?

Allow the project life cycle (project phases) to be copied when the project is copied. Additionally, ensure that the project phases linked with a work package are copied as well.

The later will always happen, even if the project phases are deselected from being copied. This is convenient to do as a work package is not linked to a project phase but rather the definition. That way, if a project phase definition is later enabled in a project, the work package will already be linked to it.

The permission normally necessary for linking a work package and a phase ("View project phases") is disabled on copy. 

The implementation for copying the project phases is rather simple. It does not depend on a full blown service. The reason for this is that no create/copy service existed and adding one would create a higher degree of complexity for a simple command to copy attributes. This can be changed later in case the requirements on copying justify this.

## Screenshots

<img width="963" alt="image" src="https://github.com/user-attachments/assets/58e4e6eb-1970-46ec-80e4-76b55f1202d3" />

# Merge checklist

- [x] Added/updated tests
