### PR TITLE
[64417] Attribute help text page is missing a page title

### DIFF
--- a/app/views/attribute_help_texts/index.html.erb
+++ b/app/views/attribute_help_texts/index.html.erb
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+<% html_title t(:label_administration), t(:"attribute_help_texts.label_plural") %>
 
 <% tabs = [
      {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/64417/activity

# What are you trying to accomplish?
Add page title for Attribute help texts

