### PR TITLE
[64367] Checkbox label not clickable in 2FA settings

### DIFF
--- a/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
@@ -64,7 +64,7 @@
       <fieldset class="form--fieldset">
         <legend class="form--fieldset-legend"><%= t(:label_setting_plural) %></legend>
         <div class="form--field">
-          <label class="form--label" for='settings[enforced]'><%= t("two_factor_authentication.settings.label_enforced") %></label>
+          <label class="form--label" for='settings_enforced'><%= t("two_factor_authentication.settings.label_enforced") %></label>
           <div class="form--field-container ">
             <%= styled_check_box_tag "settings[enforced]",
                                      "1",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/64367/activity

# What are you trying to accomplish?
Correct label "for" attribute to make checkbox connected to label

