### PR TITLE
limit forced activation of feature flags to prod and dev

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -46,4 +46,4 @@ OpenProject::FeatureDecisions.add :built_in_oauth_applications,
 
 OpenProject::FeatureDecisions.add :stages_and_gates,
                                   description: "Enables the project phases feature.",
-                                  force_active: Rails.env.production? || Rails.env.development?
+                                  force_active: true

--- a/lib_static/open_project/feature_decisions.rb
+++ b/lib_static/open_project/feature_decisions.rb
@@ -60,10 +60,33 @@ module OpenProject
   module FeatureDecisions
     module_function
 
+    ##
+    # Adds a new feature flag to the system, setting up flag-specific methods and settings configurations.
+    # By default, the feature flag is inactive in production but active in development. A user can
+    # choose to activate it via ENV variable or in the administration.
+    # Once a feature is fully developed and tested, it can be set to always be active in production
+    # by setting `force_active: true`. Then, the ENV variable and the setting will be ignored.
+    # After the release, the feature flag can then be removed from the codebase.
+    #
+    # === Example:
+    # Adding a new feature flag:
+    #   OpenProject::FeatureDecisions.add :new_ui,
+    #                                     description: "Enables the new user interface",
+    #                                     force_active: true
+    #
+    # Querying the state of the feature flag:
+    #   OpenProject::FeatureDecisions.new_ui_active? # => true or false based on configuration
+    #
+    # @param [Symbol] flag_name The name of the feature flag to add.
+    # @param [String, nil] description A description of the feature flag for documentation purposes.
+    # @param [Boolean] force_active Whether to force the feature flag to be active in production or development environments.
+    # @return [void]
+    ##
     def add(flag_name, description: nil, force_active: false)
       all << flag_name
       define_flag_methods(flag_name)
-      define_setting_definition(flag_name, description:, force_active:)
+      define_setting_definition(flag_name, description:,
+                                           force_active: force_active && (Rails.env.production? || Rails.env.development?))
     end
 
     def active

--- a/spec/lib/open_project/feature_decisions_spec.rb
+++ b/spec/lib/open_project/feature_decisions_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
 
   shared_context "when adding the feature flag as always active" do
     before do
+      # Forcing the flag to be active only works in production and dev, not in test.
+      allow(Rails.env)
+        .to receive(:production?)
+              .and_return(true)
       described_class.add flag_name, force_active: true
     end
   end


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Limit the feature flag's forced active setting to only be forced in production and development so that tests can still toggle the setting.