### PR TITLE
[#64496] The second phase's start date selection is not enabled

### DIFF
--- a/app/models/project/phase.rb
+++ b/app/models/project/phase.rb
@@ -86,24 +86,24 @@ class Project::Phase < ApplicationRecord
   end
 
   def follows_previous_phase?
-    previous_finish_dates.last.present?
+    !!previous_phase&.date_range_set?
   end
 
   def default_start_date
     return @default_start_date if defined?(@default_start_date)
 
-    previous_finish_date = previous_finish_dates.compact.last
+    previous_finish_date = previous_phase&.finish_date
     @default_start_date = previous_finish_date && Day.next_working(from: previous_finish_date).date
   end
 
   private
 
-  def previous_finish_dates
-    return @previous_finish_dates if defined?(@previous_finish_dates)
+  def previous_phase
+    return @previous_phase if defined?(@previous_phase)
 
-    @previous_finish_dates = project
+    @previous_phase = project
      .available_phases
      .select { it.position < position }
-     .map(&:finish_date)
+     .last
   end
 end

--- a/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe "Edit project phases on project overview page", :js, with_flag: {
         # The earliest enabled date should be after initiating date's finish date
         initiating_finish_date_succesor = initiating_finish_date + 1.day
 
-        datepicker.expect_disabled(initiating_finish_date)
+        datepicker.expect_not_disabled(initiating_finish_date)
         datepicker.expect_not_disabled(initiating_finish_date_succesor)
 
         dialog.close

--- a/spec/models/project/phase_spec.rb
+++ b/spec/models/project/phase_spec.rb
@@ -31,6 +31,11 @@
 require "rails_helper"
 
 RSpec.describe Project::Phase do
+  shared_let(:admin) { create(:admin) }
+  before do
+    login_as(admin)
+  end
+
   it "can be instantiated" do
     expect { described_class.new }.not_to raise_error(NotImplementedError)
   end
@@ -104,6 +109,104 @@ RSpec.describe Project::Phase do
       subject.start_date = nil
 
       expect(subject.calculate_duration).to be_nil
+    end
+  end
+
+  shared_context "with project phases" do
+    let(:project) { create(:project) }
+
+    let!(:definition1) { create(:project_phase_definition, position: 1) }
+    let!(:definition2) { create(:project_phase_definition, position: 2) }
+    let!(:phase1) do
+      create(:project_phase,
+             project:,
+             definition: definition1,
+             start_date: Time.zone.today,
+             finish_date: Time.zone.today + 5)
+    end
+    let!(:phase2) { create(:project_phase, project:, definition: definition2) }
+  end
+
+  describe "#follows_previous_phase?" do
+    include_context "with project phases"
+
+    context "when the previous phase has a date range set" do
+      it "returns truthy" do
+        expect(phase2).to be_follows_previous_phase
+      end
+    end
+
+    context "when the previous phase does not have a date range set" do
+      before do
+        phase1.update(start_date: nil, finish_date: nil)
+      end
+
+      it "returns falsy" do
+        expect(phase2).not_to be_follows_previous_phase
+      end
+    end
+
+    context "when there is no previous phase" do
+      it "returns falsy" do
+        expect(phase1).not_to be_follows_previous_phase
+      end
+    end
+
+    context "when only the start date is set on the previous phase" do
+      before do
+        phase1.update(start_date: Time.zone.today, finish_date: nil)
+      end
+
+      it "returns falsy" do
+        expect(phase2).not_to be_follows_previous_phase
+      end
+    end
+
+    context "when only the finish date is set on the previous phase" do
+      before do
+        phase1.update(start_date: nil, finish_date: Time.zone.today + 5)
+      end
+
+      it "returns falsy" do
+        expect(phase2).not_to be_follows_previous_phase
+      end
+    end
+
+    context "when the previous phase is inactive" do
+      before do
+        phase1.update(active: false)
+      end
+
+      it "does not consider the previous phase when it is inactive" do
+        expect(phase2).not_to be_follows_previous_phase
+      end
+    end
+  end
+
+  describe "#default_start_date" do
+    include_context "with project phases"
+
+    context "when the previous phase has a finish date" do
+      it "returns the next working day after the previous phase finish date" do
+        expected = Day.next_working(from: phase1.finish_date).date
+        expect(phase2.default_start_date).to eq(expected)
+      end
+    end
+
+    context "when the previous phase does not have a finish date" do
+      before do
+        phase1.update(finish_date: nil)
+      end
+
+      it "returns nil" do
+        expect(phase2.default_start_date).to be_nil
+      end
+    end
+
+    context "when there is no previous phase" do
+      it "returns nil" do
+        expect(phase1.default_start_date).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/64496

# What are you trying to accomplish?
Enable the selection of a start date on a following phase if the previous phase is incomplete.

# What approach did you choose and why?
Consider a default start date from a previous phase, only if the previous phase is complete, meaning it has both start and finish dates set.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
