### PR TITLE
[64204] Upsell buttons have the wrong border color

### DIFF
--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -138,5 +138,5 @@
   --full-view-split-right-width: 550px;
   --gantt-split-width: 50%;
   --enterprise-upsell-color: #FB8F44;
-  --enterprise-upsell-border-color: var(--borderColor-severe-muted);
+  --enterprise-upsell-border-color: #fb8f4466;
 }


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/64204

# What are you trying to accomplish?
Do not use Primer variables in `variable_defaults.scss` as  that file is loaded before the sass files. So the variables are not available here. 
The fixed value could be overwritten for Dark or HighContrast mode, but the HighContrast mode uses an own borderColor anyway and Dark mode is fine.
