### PR TITLE
Fix: Meeting PDF export start date is a string

### DIFF
--- a/modules/meeting/app/workers/meetings/exporter.rb
+++ b/modules/meeting/app/workers/meetings/exporter.rb
@@ -112,7 +112,7 @@ module Meetings
     end
 
     def cover_page_dates
-      ["#{format_date(meeting.start_date)},",
+      ["#{format_date(meeting.start_time)},",
        format_time(meeting.start_time, include_date: false),
        "–",
        format_time(meeting.end_time, include_date: false)].join(" ")

--- a/modules/meeting/app/workers/meetings/pdf/page_head.rb
+++ b/modules/meeting/app/workers/meetings/pdf/page_head.rb
@@ -62,7 +62,7 @@ module Meetings::PDF
 
     def meeting_subtitle_dates
       [
-        "#{format_date(meeting.start_date)},",
+        "#{format_date(meeting.start_time)},",
         format_time(meeting.start_time, include_date: false),
         "–",
         format_time(meeting.end_time, include_date: false),
@@ -85,7 +85,7 @@ module Meetings::PDF
 
     def meeting_title
       if meeting.recurring?
-        "#{format_date(meeting.start_date)} - #{meeting.title}"
+        "#{format_date(meeting.start_time)} - #{meeting.title}"
       else
         meeting.title
       end

--- a/modules/meeting/spec/workers/meetings/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/exporter_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Meetings::Exporter do
   end
 
   def recurring_meeting_head
-    [format_date(meeting.start_date), "-", meeting.title,
+    [format_date(meeting.start_time), "-", meeting.title,
      "   #{exporter.badge_text}    ",
      exporter.meeting_subtitle_dates,
      "-", meeting.recurring_meeting.base_schedule]


### PR DESCRIPTION
https://community.openproject.org/projects/meetings-stream/work_packages/60730

# What are you trying to achieve?
meeting.start_date is a string on stage, causing all exports to fail

# What approach did you choose and why?
Don't use the meeting.start_date helper function which may be a string, use meeting.start_time
