### PR TITLE
Bug/64322 start finish date field not highlighted in phase date picker if both fields are set

### DIFF
--- a/app/forms/projects/life_cycles/form.rb
+++ b/app/forms/projects/life_cycles/form.rb
@@ -92,12 +92,17 @@ module Projects::LifeCycles
     end
 
     def autofocus?(field_name)
-      start_date_blank = model.start_date.blank? && model.default_start_date.blank?
-      case field_name
-      when :start_date
-        start_date_blank
-      when :finish_date
-        !start_date_blank && model.finish_date.blank?
+      # let javascipt handle focusing when rendering for preview
+      return false if model.changed?
+
+      field_name == autofocus_field_name
+    end
+
+    def autofocus_field_name
+      if start_date_disabled? || (model.start_date? && !model.finish_date?)
+        :finish_date
+      else
+        :start_date
       end
     end
 

--- a/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycles-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycles-form.controller.ts
@@ -111,7 +111,11 @@ export default class ProjectLifeCyclesFormController extends FormPreviewControll
     if (dates.length === 1) {
       if ((this.highlightedField === this.finishDateTarget) || this.startDateTarget.disabled) {
         this.finishDateTarget.value = this.dateToIso(dates[0]);
-        this.highlightField(this.startDateTarget, true);
+        if (this.startDateTarget.disabled) {
+          this.highlightField(this.finishDateTarget, true);
+        } else {
+          this.highlightField(this.startDateTarget, true);
+        }
       } else {
         this.startDateTarget.value = this.dateToIso(dates[0]);
         this.highlightField(this.finishDateTarget, true);
@@ -119,7 +123,11 @@ export default class ProjectLifeCyclesFormController extends FormPreviewControll
     } else {
       this.startDateTarget.value = this.dateToIso(dates[0]);
       this.finishDateTarget.value = this.dateToIso(dates[1]);
-      this.highlightField(this.startDateTarget);
+      if (this.startDateTarget.disabled) {
+        this.highlightField(this.finishDateTarget, true);
+      } else {
+        this.highlightField(this.startDateTarget, true);
+      }
     }
 
     this.updateFlatpickrCalendar();

--- a/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycles-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/overview/project-life-cycles-form.controller.ts
@@ -109,25 +109,19 @@ export default class ProjectLifeCyclesFormController extends FormPreviewControll
     const dates = event.detail.dates;
 
     if (dates.length === 1) {
-      if ((this.highlightedField === this.finishDateTarget) || this.startDateTarget.disabled) {
-        this.finishDateTarget.value = this.dateToIso(dates[0]);
-        if (this.startDateTarget.disabled) {
-          this.highlightField(this.finishDateTarget, true);
-        } else {
-          this.highlightField(this.startDateTarget, true);
-        }
-      } else {
-        this.startDateTarget.value = this.dateToIso(dates[0]);
-        this.highlightField(this.finishDateTarget, true);
-      }
+      const assignFinish = (this.highlightedField === this.finishDateTarget) || this.startDateTarget.disabled;
+
+      const assignTarget = assignFinish ? this.finishDateTarget : this.startDateTarget;
+      assignTarget.value = this.dateToIso(dates[0]);
+
+      const highlightTarget = assignFinish && !this.startDateTarget.disabled ? this.startDateTarget : this.finishDateTarget;
+      this.highlightField(highlightTarget, true);
     } else {
       this.startDateTarget.value = this.dateToIso(dates[0]);
       this.finishDateTarget.value = this.dateToIso(dates[1]);
-      if (this.startDateTarget.disabled) {
-        this.highlightField(this.finishDateTarget, true);
-      } else {
-        this.highlightField(this.startDateTarget, true);
-      }
+
+      const highlightTarget = this.startDateTarget.disabled ? this.finishDateTarget : this.startDateTarget;
+      this.highlightField(highlightTarget, true);
     }
 
     this.updateFlatpickrCalendar();


### PR DESCRIPTION
# Ticket
[OP#64322](https://community.openproject.org/wp/64322)

# What are you trying to accomplish?
Make highlighting of date fields consistent

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
