### PR TITLE
Update documentation to point to 16.0 releases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ x-op-backend: &backend
     target: develop
   <<: [*image, *restart_policy]
   environment:
-    LOCAL_DEV_CHECK: "${LOCAL_DEV_CHECK:?The docker-compose file for OpenProject has moved to https://github.com/opf/openproject-deploy}"
+    LOCAL_DEV_CHECK: "${LOCAL_DEV_CHECK:?The docker-compose file for OpenProject has moved to https://github.com/opf/openproject-docker-compose}"
     RAILS_ENV: development
     OPENPROJECT_CACHE__MEMCACHE__SERVER: cache:11211
     OPENPROJECT_RAILS__CACHE__STORE: file_store

--- a/docs/contributions-guide/contribution-documentation/documentation-process-internal-contributor/README.md
+++ b/docs/contributions-guide/contribution-documentation/documentation-process-internal-contributor/README.md
@@ -31,19 +31,19 @@ In the modal window select the repository ""*opf/openproject*"". Also select a f
 
 > **Important**: Before you make changes always update your local repository.
 
-1. Select the branch you want to work on, e.g. `release/13.0` in the main toolbar.
+1. Select the branch you want to work on, e.g. `release/16.0` in the main toolbar.
 2. Click on the button **Fetch origin** in the main toolbar.
 
 ![fetch origin in github desktop](fetch-origin-in-github-desktop.png)
 
 ## Step 3: Create a new Git branch for your change
 
-1. Select the latest release branch e.g. `release/13.0` as the current branch.
+1. Select the latest release branch e.g. `release/16.0` as the current branch.
     ![create new branch - step 1](create-new-branch-step-1.png)
 
 2. In the same drop down click on **New branch**.
 
-3. In the next modal window insert a branch name that describes your changes. Also select the branch you want to work on, e.g. `release/13.0`. The click the button **Create branch**.
+3. In the next modal window insert a branch name that describes your changes. Also select the branch you want to work on, e.g. `release/16.0`. The click the button **Create branch**.
 
 ![create a new branch step 2](create-new-branch-step-2.png)
 
@@ -71,11 +71,11 @@ At the moment your change is only available in your local repository. To make it
 
 ## Step 8: Create a pull request
 
-A pull request is a workflow to ask for a review from the OpenProject team. With a pull request you basically ask a team member to check your changes and to merge it to the branch you want your change to merged to, e.g. `release/13.0` . After you pushed your local changes to your own repository click the button **Create Pull Request**.
+A pull request is a workflow to ask for a review from the OpenProject team. With a pull request you basically ask a team member to check your changes and to merge it to the branch you want your change to merged to, e.g. `release/16.0` . After you pushed your local changes to your own repository click the button **Create Pull Request**.
 
 ![Create a pull request](create-pull-request-github-desktop.png)
 
-In the first dropdown select the base branch you want your work to be merged in e.g. `release/13.0`. In the second dropdown select the branch you created in step 3 which contains your changes.
+In the first dropdown select the base branch you want your work to be merged in e.g. `release/16.0`. In the second dropdown select the branch you created in step 3 which contains your changes.
 
 ![comparing-changes.png](comparing-changes.png)
 
@@ -99,4 +99,4 @@ In the field "*Reviewers*" select "*opf/doc-writers".*
 
 * We always deploy the [main branch](https://github.com/opf/legal/tree/main) on our [website](https://www.openproject.org/legal/). This deployment needs to be manually triggered by the marketing team.
 * If you want to make minor changes you don't need a review do this directly in the main branch without creating a new branch and new pull request.
-* If you need a review you need to create a new branch from the main branch. The branch `release/13.0` only exists in the repository opf/openproject (OpenProject software).
+* If you need a review you need to create a new branch from the main branch. The branch `release/16.0` only exists in the repository opf/openproject (OpenProject software).

--- a/docs/contributions-guide/contribution-documentation/documentation-process/README.md
+++ b/docs/contributions-guide/contribution-documentation/documentation-process/README.md
@@ -65,7 +65,7 @@ Open `https://github.com/[your-user]/openproject`. On the forked repository go t
 
 ![switch-the-default-branch-step-1](switch-the-default-branch-step-1.png)
 
-Select `release/12.3` as default branch and confirm with **Update**
+Select `release/16.0` as default branch and confirm with **Update**
 
 *NOTE:* There will be an additional window. Press the button: **I understand, update the default branch.**
 
@@ -73,13 +73,13 @@ Select `release/12.3` as default branch and confirm with **Update**
 
 ## Step 8: Sync fork and Update branches (update local repository)
 
-Every time you start editing please make sure you have fetched the latest changes from GitHub.com. First you need to update your forked repository. There you select the branch you are working on, e.g. `release/12.3`. If there are updates in the main repository opf/openproject click on **Sync fork** and **Update branch**.
+Every time you start editing please make sure you have fetched the latest changes from GitHub.com. First you need to update your forked repository. There you select the branch you are working on, e.g. `release/16.0`. If there are updates in the main repository opf/openproject click on **Sync fork** and **Update branch**.
 
 ![sync fork update branch](sync-fork-update-branch.png)
 
 Now you have fetched the latest changes from the main repository and can go back to GitHub Desktop.
 
-Finally you have to press **"Pull origin"**. Afterwards your local repository is updated to the latest commits of eg. `opf/openproject/release/12.3`
+Finally you have to press **"Pull origin"**. Afterwards your local repository is updated to the latest commits of eg. `opf/openproject/release/16.0`
 
 ![pull-upstream-changes](pull-upstream-changes.png)
 
@@ -99,11 +99,11 @@ In the next screen select **To contribute to the parent project**.
 
 ## Step 10: Create a new Git branch for your change
 
-Select the latest release branch e.g. `release/12.3` as the current branch.
+Select the latest release branch e.g. `release/16.0` as the current branch.
 
 ![create new branch - step 1](create-new-branch-step-1.png)
 
-In the same drop down click on "New branch". In this window **insert a branch name that describes your changes** and **select the latest release branch** e.g. `release/12.3` the created branch is based on.
+In the same drop down click on "New branch". In this window **insert a branch name that describes your changes** and **select the latest release branch** e.g. `release/16.0` the created branch is based on.
 
 ![create new branch - step 2](create-new-branch-step-2.png)
 
@@ -179,7 +179,7 @@ In GitHub Desktop choose menu "Repository -> Repository settings". This will ope
 
 ### B) Fetch origin (in this case repository 'opf')
 
-In GitHub Desktop **at Current branch the old branch is visible [1]** . After you press **Fetch origin [2]** you will be able to **select the new branch at Current branch** (e.g. `origin/release/12.3`
+In GitHub Desktop **at Current branch the old branch is visible [1]** . After you press **Fetch origin [2]** you will be able to **select the new branch at Current branch** (e.g. `origin/release/16.0`
 
 ![rebase-your-fork-step-2](rebase-your-fork-step-2.png)
 

--- a/docs/development/packaging/README.md
+++ b/docs/development/packaging/README.md
@@ -15,8 +15,8 @@ This guide will provide some insights in how to develop and test integrations wi
 The packager.io website observes changes in the repository through webhooks and will automatically triggers builds for these branches:
 
 - `dev`: `https://packager.io/gh/opf/openproject`
-- `release/*` (e.g.,) `https://packager.io/gh/opf/openproject/refs/release/13.0`
-- `stable/*` (e.g.,) `https://packager.io/gh/opf/openproject/refs/stable/15`
+- `release/*` (e.g.,) `https://packager.io/gh/opf/openproject/refs/release/16.0`
+- `stable/*` (e.g.,) `https://packager.io/gh/opf/openproject/refs/stable/16`
 - `packaging/*`
 
 To see the status of a build, simply follow one of the links and choose a distribution whose logs you want to look at.

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -79,7 +79,7 @@ x-op-app: &app
     - "${OPDATA:-opdata}:/var/openproject/assets"
 
 # configuration cut off at this point.
-# Please use the file at https://github.com/opf/openproject-deploy/blob/stable/15/compose/docker-compose.yml
+# Please use the file at https://github.com/opf/openproject-docker-compose/blob/stable/16/docker-compose.yml
 ```
 
 Alternatively, you can also use an env file for docker-compose like so:
@@ -114,7 +114,7 @@ x-op-app: &app
     # ... more environment variables
 
 # configuration cut off at this point.
-# Please use the file at https://github.com/opf/openproject-deploy/blob/stable/15/compose/docker-compose.yml
+# Please use the file at https://github.com/opf/openproject-docker-compose/blob/stable/16/docker-compose.yml
 ```
 
 Let's say you have a `.env.prod`  file with some production-specific configuration. Then, start the services with that special env file specified.
@@ -711,7 +711,7 @@ OPENPROJECT_SECURITY__BADGE__DISPLAYED="false"
 
 `after_login_default_redirect_url`: Starting in OpenProject 15.4., users are redirected to the home page after logging in. To customize this behavior (e.g., redirecting them to the My page as before), you can override this with a path.
 
-Example: 
+Example:
 
 ```shell
 OPENPROJECT_AFTER__LOGIN__DEFAULT__REDIRECT__URL="/my/page"

--- a/docs/installation-and-operations/configuration/database/README.md
+++ b/docs/installation-and-operations/configuration/database/README.md
@@ -28,7 +28,7 @@ point to an external database.
 Example:
 
 ```shell
-docker run -d ... -e DATABASE_URL=postgres://user:pass@host:port/dbname openproject/openproject:15
+docker run -d ... -e DATABASE_URL=postgres://user:pass@host:port/dbname openproject/openproject:16
 ```
 
 Best practice is using the file `docker-compose.override.yml`. If you run the Compose based docker stack, you can simply override the `DATABASE_URL` environment variable, and remove the `db` service from the `docker-compose.yml` file, but because by pulling a new version `docker-compose.yml` might get replaced. Then you can restart the stack with:

--- a/docs/installation-and-operations/installation/docker/README.md
+++ b/docs/installation-and-operations/installation/docker/README.md
@@ -75,7 +75,7 @@ docker run -it -p 8080:80 \
   -e OPENPROJECT_HOST__NAME=localhost:8080 \
   -e OPENPROJECT_HTTPS=false \
   -e OPENPROJECT_DEFAULT__LANGUAGE=en \
-  openproject/openproject:15
+  openproject/openproject:16
 ```
 
 Explanation of the used configuration values:
@@ -105,7 +105,7 @@ docker run -d -p 8080:80 \
   -e OPENPROJECT_SECRET_KEY_BASE=secret \
   -e OPENPROJECT_HOST__NAME=localhost:8080 \
   -e OPENPROJECT_HTTPS=false \
-  openproject/openproject:15
+  openproject/openproject:16
 ```
 
 **Note**: We've had reports of people being unable to start OpenProject this way
@@ -137,7 +137,7 @@ docker run -d -p 8080:80 --name openproject \
   -e OPENPROJECT_SECRET_KEY_BASE=secret \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \
   -v /var/lib/openproject/assets:/var/openproject/assets \
-  openproject/openproject:15
+  openproject/openproject:16
 ```
 
 Please make sure you set the correct public facing hostname in `OPENPROJECT_HOST__NAME`. If you don't have a load-balancing or proxying web server in front of your docker container,
@@ -394,7 +394,7 @@ end
 **3. Create the `Dockerfile`** in the same folder. The contents have to look like this:
 
 ```dockerfile
-FROM openproject/openproject:15
+FROM openproject/openproject:16
 
 # If installing a local plugin (using `path:` in the `Gemfile.plugins` above),
 # you will have to copy the plugin code into the container here and use the
@@ -418,7 +418,7 @@ All the Dockerfile does is copy your custom plugins gemfile into the image, inst
 If you are using the `-slim` tag you will need to do the following to add your plugin.
 
 ```dockerfile
-FROM openproject/openproject:15 AS plugin
+FROM openproject/openproject:16 AS plugin
 
 # If installing a local plugin (using `path:` in the `Gemfile.plugins` above),
 # you will have to copy the plugin code into the container here and use the
@@ -433,7 +433,7 @@ COPY Gemfile.plugins /app/
 RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
 RUN ./docker/prod/setup/precompile-assets.sh
 
-FROM openproject/openproject:15-slim
+FROM openproject/openproject:16-slim
 
 COPY --from=plugin /usr/bin/git /usr/bin/git
 COPY --chown=$APP_USER:$APP_USER --from=plugin /app/vendor/bundle /app/vendor/bundle
@@ -457,7 +457,7 @@ The `-t` option is the tag for your image. You can choose what ever you want.
 **5. Run the image**
 
 You can run the image just like the normal OpenProject image (as shown [here](#quick-start)).
-You just have to use your chosen tag instead of `openproject/openproject:15`.
+You just have to use your chosen tag instead of `openproject/openproject:16`.
 To just give it a quick try you can run this:
 
 ```shell
@@ -480,10 +480,10 @@ sudo docker run -it -p 8080:80 \
   -e OPENPROJECT_DEFAULT__LANGUAGE=en \
   --mount type=bind,source=$(pwd)/my_root.crt,target=/tmp/my_root.crt \ #mount my_root.crt to /tmp
   -e SSL_CERT_FILE=/tmp/my_root.crt \ #set the SSL_CERT_FILE to the path of my_root.crt
-  openproject/openproject:15
+  openproject/openproject:16
 ```
 
-The second way would be to build a new image of the ```openproject/openproject:15``` or the ```-slim``` image.
+The second way would be to build a new image of the ```openproject/openproject:16``` or the ```-slim``` image.
 
 **1. Create a new folder** with any name, for instance `custom-openproject`. Change into that folder.
 
@@ -492,7 +492,7 @@ The second way would be to build a new image of the ```openproject/openproject:1
 **3. Create the `Dockerfile`** in the same folder. The contents have to look like this:
 
 ```dockerfile
-FROM openproject/openproject:15
+FROM openproject/openproject:16
 
 COPY ./my_root.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
@@ -501,7 +501,7 @@ RUN update-ca-certificates
 If you are using the -slim tag, you will need to do the following to import your root certificate:
 
 ```dockerfile
-FROM openproject/openproject:15-slim
+FROM openproject/openproject:16-slim
 
 USER root
 COPY ./smtp.local_rootCA.crt /usr/local/share/ca-certificates/
@@ -519,7 +519,7 @@ The `-t` option is the tag for your image. You can choose what ever you want.
 
 **5. Run the image**
 
-You can run the image just like the normal OpenProject image (as shown [here](#quick-start)). You just have to use your chosen tag instead of ```openproject/openproject:15```
+You can run the image just like the normal OpenProject image (as shown [here](#quick-start)). You just have to use your chosen tag instead of ```openproject/openproject:16```
 
 ## Offline/air-gapped installation
 
@@ -531,7 +531,7 @@ The installation works the same as described above. The only difference is that 
 On a system that has access to the internet run the following.
 
 ```shell
-docker pull openproject/openproject:15 && docker save openproject/openproject:15 | gzip > openproject-stable.tar.gz
+docker pull openproject/openproject:16 && docker save openproject/openproject:16 | gzip > openproject-stable.tar.gz
 ```
 
 This creates a compressed archive containing the latest OpenProject docker image.
@@ -606,7 +606,7 @@ We will show both possibilities later in the configuration.
 
 ### 3) Create stack
 
-To create a stack you need a stack file. The easiest way is to just copy OpenProject's [docker-compose.yml](https://github.com/opf/openproject/blob/stable/12/docker-compose.yml). Just download it and save it as, say, `openproject-stack.yml`.
+To create a stack you need a stack file. The easiest way is to just copy OpenProject's [docker-compose.yml](https://github.com/opf/openproject/blob/stable/16/docker-compose.yml). Just download it and save it as, say, `openproject-stack.yml`.
 
 #### Configuring storage
 
@@ -732,12 +732,12 @@ Once this has finished you should see something like this when running `docker s
 docker service ls
 ID                  NAME                 MODE                REPLICAS            IMAGE                      PORTS
 kpdoc86ggema        openproject_cache    replicated          1/1                 memcached:latest
-qrd8rx6ybg90        openproject_cron     replicated          1/1                 openproject/openproject:15
+qrd8rx6ybg90        openproject_cron     replicated          1/1                 openproject/openproject:16
 cvgd4c4at61i        openproject_db       replicated          1/1                 postgres:13
-uvtfnc9dnlbn        openproject_proxy    replicated          1/1                 openproject/openproject:15   *:8080->80/tcp
-g8e3lannlpb8        openproject_seeder   replicated          0/1                 openproject/openproject:15
-canb3m7ilkjn        openproject_web      replicated          1/1                 openproject/openproject:15
-7ovn0sbu8a7w        openproject_worker   replicated          1/1                 openproject/openproject:15
+uvtfnc9dnlbn        openproject_proxy    replicated          1/1                 openproject/openproject:16   *:8080->80/tcp
+g8e3lannlpb8        openproject_seeder   replicated          0/1                 openproject/openproject:16
+canb3m7ilkjn        openproject_web      replicated          1/1                 openproject/openproject:16
+7ovn0sbu8a7w        openproject_worker   replicated          1/1                 openproject/openproject:16
 ```
 
 You can now access OpenProject under `http://0.0.0.0:8080`.
@@ -775,12 +775,12 @@ This will take a moment to converge. Once done you should see something like the
 docker service ls
 ID                  NAME                 MODE                REPLICAS            IMAGE                      PORTS
 kpdoc86ggema        openproject_cache    replicated          1/1                 memcached:latest
-qrd8rx6ybg90        openproject_cron     replicated          1/1                 openproject/openproject:15
+qrd8rx6ybg90        openproject_cron     replicated          1/1                 openproject/openproject:16
 cvgd4c4at61i        openproject_db       replicated          1/1                 postgres:10
-uvtfnc9dnlbn        openproject_proxy    replicated          2/2                 openproject/openproject:15   *:8080->80/tcp
-g8e3lannlpb8        openproject_seeder   replicated          0/1                 openproject/openproject:15
-canb3m7ilkjn        openproject_web      replicated          6/6                 openproject/openproject:15
-7ovn0sbu8a7w        openproject_worker   replicated          1/1                 openproject/openproject:15
+uvtfnc9dnlbn        openproject_proxy    replicated          2/2                 openproject/openproject:16   *:8080->80/tcp
+g8e3lannlpb8        openproject_seeder   replicated          0/1                 openproject/openproject:16
+canb3m7ilkjn        openproject_web      replicated          6/6                 openproject/openproject:16
+7ovn0sbu8a7w        openproject_worker   replicated          1/1                 openproject/openproject:16
 ```
 
 Docker swarm handles the networking necessary to distribute the load among the nodes.

--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -159,7 +159,7 @@ with OpenProject. For more information, see [github.com/opf/openproject](https:/
 
 ```shell
 [openproject@host] cd ~
-[openproject@host] git clone https://github.com/opf/openproject.git --branch stable/9 --depth 1
+[openproject@host] git clone https://github.com/opf/openproject.git --branch stable/16 --depth 1
 [openproject@host] cd openproject
 # Ensure rubygems is up-to-date for bundler 2
 [openproject@host] gem update --system

--- a/docs/installation-and-operations/installation/packaged/README.md
+++ b/docs/installation-and-operations/installation/packaged/README.md
@@ -69,7 +69,7 @@ Add the OpenProject package source:
 
 ```shell
 sudo wget -O /etc/apt/sources.list.d/openproject.list \
-  https://dl.packager.io/srv/opf/openproject/stable/15/installer/ubuntu/22.04.repo
+  https://dl.packager.io/srv/opf/openproject/stable/16/installer/ubuntu/22.04.repo
 ```
 
 Download the OpenProject package:
@@ -102,7 +102,7 @@ Add the OpenProject package source:
 
 ```shell
 sudo wget -O /etc/apt/sources.list.d/openproject.list \
-  https://dl.packager.io/srv/opf/openproject/stable/15/installer/ubuntu/20.04.repo
+  https://dl.packager.io/srv/opf/openproject/stable/16/installer/ubuntu/20.04.repo
 ```
 
 Download the OpenProject package:
@@ -136,7 +136,7 @@ Add the OpenProject package source:
 
 ```shell
 wget -O /etc/apt/sources.list.d/openproject.list \
-  https://dl.packager.io/srv/opf/openproject/stable/15/installer/debian/12.repo
+  https://dl.packager.io/srv/opf/openproject/stable/16/installer/debian/12.repo
 ```
 
 Download the OpenProject package:
@@ -168,7 +168,7 @@ Add the OpenProject package source:
 
 ```shell
 wget -O /etc/apt/sources.list.d/openproject.list \
-  https://dl.packager.io/srv/opf/openproject/stable/15/installer/debian/11.repo
+  https://dl.packager.io/srv/opf/openproject/stable/16/installer/debian/11.repo
 ```
 
 Download the OpenProject package:
@@ -188,7 +188,7 @@ Add the OpenProject package source:
 
 ```shell
 sudo wget -O /etc/yum.repos.d/openproject.repo \
-  https://dl.packager.io/srv/opf/openproject/stable/15/installer/el/9.repo
+  https://dl.packager.io/srv/opf/openproject/stable/16/installer/el/9.repo
 ```
 
 If it is not already enabled, make sure to enable [Extra Packages for Enterprise Linux](https://fedoraproject.org/wiki/EPEL) (EPEL).
@@ -210,7 +210,7 @@ sudo yum install openproject
 
 Then finish the installation by reading the [*Initial configuration*](#initial-configuration) section.
 
-> [!NOTE] 
+> [!NOTE]
 > On this distribution full-text extraction for attachments [*is not supported*](#full-text-extraction-not-supported) by default.
 >
 
@@ -225,7 +225,7 @@ Add the OpenProject package source:
 
 ```shell
 wget -O /etc/zypp/repos.d/openproject.repo \
-  https://dl.packager.io/srv/opf/openproject/stable/15/installer/sles/15.repo
+  https://dl.packager.io/srv/opf/openproject/stable/16/installer/sles/15.repo
 ```
 
 If you already had an old package source that is being updated you must refresh
@@ -266,7 +266,7 @@ sudo openproject reconfigure #interactive - manual choices are stored in /etc/op
 sudo openproject configure #non-interactive - using values stored in /etc/openproject/installer.dat
 ```
 
-> [!NOTE] 
+> [!NOTE]
 > Every time you will run the OpenProject wizard, by using `sudo openproject reconfigure` your choices will be persisted in a configuration file at `/etc/openproject/installer.dat` and subsequent executions of `sudo openproject configure` will re-use these values, only showing you the wizard steps for options you have not yet been asked for.
 > In the interactive way you can skip dialogs you do not want to change simply by confirming them with `ENTER`.
 
@@ -303,7 +303,7 @@ The dialog allows you to choose from three options:
 
 Choose this option if you want OpenProject to set up and configure a local database server manually. This is the best choice if you are unfamiliar with administering databases, or do not have a separate PostgreSQL database server installed that you want to connect to.
 
-> [!NOTE] 
+> [!NOTE]
 > If you would like to use the database that was automatically installed by OpenProject at time of installation just choose `install` again
 
 ### Use an existing PostgreSQL database
@@ -336,7 +336,7 @@ The available options are:
 
 We recommend that you let OpenProject install and configure the outer web server, in which case we will install an Apache2 web server with a VirtualHost listening to the domain name you specify, optionally providing SSL/TLS termination.
 
-> [!NOTE] 
+> [!NOTE]
 > In case you re-run `sudo openproject reconfigure` later it is mandatory to select `install` at the webserver again
 
 In case you have selected to install Apache2, multiple dialogs will request the parameters for setting it up:
@@ -355,7 +355,7 @@ If you wish to install OpenProject under a server path prefix, such as `yourdoma
 
 #### SSL/TLS configuration
 
-> [!NOTE] 
+> [!NOTE]
 > With OpenProject version 12.2 **HTTPS configuration** was set to be **default** for every installation. **Now best practice is to proceed by selecting `yes` for using HTTPS (SSL/TLS)** and generating the needed certificates, otherwise you will have to manually deactivate HTTPS on the command line.
 
 OpenProject can configure Apache to support HTTPS (SSL/TLS). If you have SSL certificates and want to use SSL/TLS (recommended), select **Yes**.
@@ -372,7 +372,7 @@ Enabling this mode will result in OpenProject only responding to HTTPS requests,
 
 #### External SSL/TLS termination
 
-> [!NOTE] 
+> [!NOTE]
 > If you terminate SSL externally before the request hits the OpenProject server, you need to follow the following instructions to avoid errors in routing. If you want to use SSL on the server running OpenProject, skip this section.
 
 If you have a separate server that is terminating SSL and only forwarding/proxying to the OpenProject server, you must select "No" in this dialog. However, there are some parameters you need to put into your outer configuration.
@@ -388,29 +388,29 @@ If you have a separate server that is terminating SSL and only forwarding/proxyi
 
 Here an example for external SSL/TLS termination with apache (httpd):
 
-> [!NOTE] 
+> [!NOTE]
 > There is [another example](../docker/#1-virtual-host-root) for external SSL/TLS termination for **docker-compose** installations
 
 ```shell
 <VirtualHost *:443>
    ServerName openproject.example.com
-   
+
    # Logging
    LogLevel Warn
    ErrorLog /var/log/httpd/openproject.example.com-error.log
    CustomLog /var/log/httpd/openproject.example.com-access.log combined
-   
+
    # Reverse Proxy
    ProxyPreserveHost On
    ProxyRequests Off
    ProxyPass / http://[OPENPROJECT-HOST-IP]/
    ProxyPassReverse / http://[OPENPROJECT-HOST-IP]/
-   #ProxyPass / https://[OPENPROJECT-HOST-IP]/               # if openproject's internal apache2 server/ssl is YES 
+   #ProxyPass / https://[OPENPROJECT-HOST-IP]/               # if openproject's internal apache2 server/ssl is YES
    #ProxyPassReverse / https://[OPENPROJECT-HOST-IP]/        # if openproject's internal apache2 server/ssl is YES
-   
+
    # Request Header
    RequestHeader set "X-Forwarded-Proto" https
-   
+
    # SSL Certificate that was created by LetsEncrypt
    Include /etc/letsencrypt/options-ssl-apache.conf
    SSLEngine On
@@ -423,7 +423,7 @@ Here an example for external SSL/TLS termination with apache (httpd):
 
 ### Skip Apache2 web server install (not recommended)
 
-> [!NOTE] 
+> [!NOTE]
 > Skipping step 3 Apache2 web server install will ask later in step 7 for information about the hostname and HTTPS
 
 The installer will not set up an external web server for accessing. You will need to either install and set up a web server such as Apache2 or Nginx to function as the web server forwarding to our internal server listening at `localhost:6000` by proxying.
@@ -436,7 +436,7 @@ When installing with an existing Apache2, you can take a look at the source of o
 
 [For a minimal nginx config, please see this gist](https://gist.github.com/seLain/375d16ccd4542e3727e97a7478187d3a) as as starting point.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > If you reconfigure the OpenProject application and switch to `skip`, you might run into errors with the Apache configuration file, as that will not be automatically remove. Please double-check you removed references to the `openproject.conf` if you do reconfigure.
 
 ## Step 4: SVN/Git integration server
@@ -461,7 +461,7 @@ OpenProject heavily relies on caching, which is why the wizard suggests you to i
 
 ## Step 7: Host name and Protocol (if step 3 was skipped)
 
-> [!NOTE] 
+> [!NOTE]
 > This step is only shown if you decided to skip step 3, the Apache2 installation. OpenProject still needs to know what external host name you're running on, as well as if you're using HTTPS or not.
 
 First, enter the fully qualified domain where your OpenProject installation will be reached at. This will be used to generate full links from OpenProject, such as in emails.
@@ -474,7 +474,7 @@ Next, tell OpenProject whether you have SSL termination enabled somewhere in you
 
 ## Step 8: Default language
 
-> [!NOTE] 
+> [!NOTE]
 > This step is only shown on the very first installation of OpenProject, as it affects only the initial seeding of the basic and demo data. Changing this value after installation will have no effect.
 
 OpenProject can be used with a wide variety of languages. The initial data of the instance (basic data such as status names, types, etc.) as well as data for demonstrational purposes will be created in the language you select in this screen. Move through the list using the arrow keys and select the default language.

--- a/docs/installation-and-operations/installation/synology/README.md
+++ b/docs/installation-and-operations/installation/synology/README.md
@@ -12,7 +12,7 @@ This means OpenProject has to be used exactly as described in the [docker](../do
 Launching OpenProject works like launching any other container in [Synology](https://www.synology.com/en-global/knowledgebase/DSM/help/Docker/docker_container).
 
 First you have to go to the **Registry** section and download the OpenProject image.
-It's best to choose the specific tag of the latest stable version (`openproject/openproject:15` at the time of writing).
+It's best to choose the specific tag of the latest stable version (`openproject/openproject:16` at the time of writing).
 You can use `:latest` too but it might lead to surprises when a major version upgrade happens.
 
 Below are some settings you have to pay attention to when launching the container.

--- a/docs/installation-and-operations/misc/migration-to-postgresql13/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql13/README.md
@@ -36,7 +36,7 @@ sudo cat /var/lib/postgresql/10/main/PG_VERSION
 For RedHat/CentOS:
 
 ```shell
-sudo cat /var/lib/pgsql/10/data/PG_VERSION 
+sudo cat /var/lib/pgsql/10/data/PG_VERSION
 10
 ```
 
@@ -163,7 +163,7 @@ sudo yum remove pgsql10
 > Please follow this section only if you have installed OpenProject using [this procedure](../../installation/docker/).
 > Before attempting the upgrade, please ensure you have performed a backup of your installation by following the [backup guide](../../operation/backing-up/).
 
-You can find the upgrade instructions for your docker-compose setup in the [openproject-deploy](https://github.com/opf/openproject-deploy/blob/stable/15/compose/control/README.md#upgrade) repository.
+You can find the upgrade instructions for your docker-compose setup in the [openproject-docker-compose](https://github.com/opf/openproject-docker-compose/blob/stable/16/control/README.md#upgrade) repository.
 
 Remember that you need to have checked out that repository and work in the `compose` directory for the instructions to work.
 
@@ -188,20 +188,20 @@ Once the docker has stopped, you are ready to run the upgrade command. In this c
 docker run --rm -it \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \
   -v /var/lib/openproject/pgdata-next:/var/openproject/pgdata-next \
-  openproject/openproject:15 root ./docker/prod/postgres-db-upgrade
+  openproject/openproject:16 root ./docker/prod/postgres-db-upgrade
 ```
 
 If everything goes well, the process should end with a message as follows:
 
 ```text
-Upgrade Complete                                              
-----------------                                              
-Optimizer statistics are not transferred by pg_upgrade so,                  
+Upgrade Complete
+----------------
+Optimizer statistics are not transferred by pg_upgrade so,
 once you start the new server, consider running:
-    ./analyze_new_cluster.sh                                
-                                         
+    ./analyze_new_cluster.sh
+
 Running this script will delete the old cluster's data files:
-    ./delete_old_cluster.sh            
+    ./delete_old_cluster.sh
 ```
 
 You can then perform the following operation to switch the upgraded PostgreSQL with the older version:
@@ -217,7 +217,7 @@ docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \
   -v /var/lib/openproject/assets:/var/openproject/assets \
   [...]
-  openproject/openproject:15
+  openproject/openproject:16
 
 If your new installation looks fine, you can then choose to remove `/var/lib/openproject/pgdata-prev`:
 

--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -36,7 +36,7 @@ sudo cat /var/lib/postgresql/13/main/PG_VERSION
 For RedHat/CentOS:
 
 ```shell
-sudo cat /var/lib/pgsql/13/data/PG_VERSION 
+sudo cat /var/lib/pgsql/13/data/PG_VERSION
 13
 ```
 
@@ -165,7 +165,7 @@ sudo yum remove pgsql13
 > Please follow this section only if you have installed OpenProject using [this procedure](../../installation/docker/).
 > Before attempting the upgrade, please ensure you have performed a backup of your installation by following the [backup guide](../../operation/backing-up/).
 
-You can find the upgrade instructions for your docker-compose setup in the [openproject-deploy](https://github.com/opf/openproject-deploy/blob/stable/16/README.md#upgrade) repository.
+You can find the upgrade instructions for your docker-compose setup in the [openproject-docker-compose](https://github.com/opf/openproject-docker-compose/blob/stable/16/control/README.md#upgrade) repository.
 
 Remember that you need to have checked out that repository and work in the `compose` directory for the instructions to work.
 
@@ -190,20 +190,20 @@ Once the docker has stopped, you are ready to run the upgrade command. In this c
 docker run --rm -it \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \
   -v /var/lib/openproject/pgdata-next:/var/openproject/pgdata-next \
-  openproject/openproject:15 root ./docker/prod/postgres-db-upgrade
+  openproject/openproject:16 root ./docker/prod/postgres-db-upgrade
 ```
 
 If everything goes well, the process should end with a message as follows:
 
 ```text
-Upgrade Complete                                              
-----------------                                              
-Optimizer statistics are not transferred by pg_upgrade so,                  
+Upgrade Complete
+----------------
+Optimizer statistics are not transferred by pg_upgrade so,
 once you start the new server, consider running:
-    ./analyze_new_cluster.sh                                
-                                         
+    ./analyze_new_cluster.sh
+
 Running this script will delete the old cluster's data files:
-    ./delete_old_cluster.sh            
+    ./delete_old_cluster.sh
 ```
 
 You can then perform the following operation to switch the upgraded PostgreSQL with the older version:
@@ -219,7 +219,7 @@ docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \
   -v /var/lib/openproject/assets:/var/openproject/assets \
   [...]
-  openproject/openproject:15
+  openproject/openproject:16
 
 If your new installation looks fine, you can then choose to remove `/var/lib/openproject/pgdata-prev`:
 
@@ -282,7 +282,7 @@ psql -U postgres -h localhost -f /bitnami/postgresql/backup.sql
 7. Verify the Upgrade by ensuring everything is working as expected by checking that the PostgreSQL instance is running correctly and the frontend is accessible.
 
 8. Remove Backup Files:
-    
+
 Once verified, enter the shell of the PostgreSQL pod again and remove the backup files to clean up:
 
 ```shell

--- a/docs/installation-and-operations/operation/backing-up/README.md
+++ b/docs/installation-and-operations/operation/backing-up/README.md
@@ -62,7 +62,7 @@ sudo mkdir -p /var/lib/openproject/{pgdata,assets}
 docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \
   -v /var/lib/openproject/assets:/var/openproject/assets \
-  openproject/openproject:15
+  openproject/openproject:16
 ```
 
 Then you would need to backup the `/var/lib/openproject` folder (for instance to S3 or FTP server).

--- a/docs/installation-and-operations/operation/faq/README.md
+++ b/docs/installation-and-operations/operation/faq/README.md
@@ -44,12 +44,12 @@ Afterwards, you can navigate to your OpenProject instance and login with `admin`
 
 ## Do you provide different release channels?
 
-Yes! We release OpenProject in separate release channels that you can try out. For production environments, **always** use the `stable/MAJOR`  (e.g., stable/9) package source that will receive stable and release updates. Every major upgrade will result in a source switch (from `stable/9` to `stable/10` for example).
+Yes! We release OpenProject in separate release channels that you can try out. For production environments, **always** use the `stable/MAJOR`  (e.g., `stable/16`) package source that will receive stable and release updates. Every major upgrade will result in a source switch (from `stable/15` to `stable/16` for example).
 
 A closer look at the available branches:
 
-* [stable/11](https://packager.io/gh/opf/openproject/refs/stable/10): Latest stable releases, starting with 11.0.0 until the last minor and patch releases of 11.X.Y are released, this will receive updates.
-* [release/11.0](https://packager.io/gh/opf/openproject/refs/release/10.0): Regular (usually daily) release builds for the current next patch release (or for the first release in this version, such as 11.0.0). This will contain early bugfixes before they are being release into stable. **Do not use in production**. But, for upgrading to the next major version, this can be regarded as a _release candidate channel_ that you can use to test your upgrade on a copy of your production environment.
+* [stable/16](https://packager.io/gh/opf/openproject/refs/stable/16): Latest stable releases, starting with 11.0.0 until the last minor and patch releases of 11.X.Y are released, this will receive updates.
+* [release/16.0](https://packager.io/gh/opf/openproject/refs/release/16.0): Regular (usually daily) release builds for the current next patch release (or for the first release in this version, such as 11.0.0). This will contain early bugfixes before they are being release into stable. **Do not use in production**. But, for upgrading to the next major version, this can be regarded as a _release candidate channel_ that you can use to test your upgrade on a copy of your production environment.
 * [dev](https://packager.io/gh/opf/openproject/refs/dev): Daily builds of the current development build of OpenProject. While we try to keep this operable, this may result in broken code and/or migrations from time to time. Use when you're interested what the next release of OpenProject will look like. **Do not use in production!**
 
 ## How can I backup and restore my OpenProject installation?

--- a/docs/installation-and-operations/operation/restoring/README.md
+++ b/docs/installation-and-operations/operation/restoring/README.md
@@ -166,7 +166,7 @@ mkdir -p /var/lib/openproject/{pgdata,assets}
 Next we need to initialize the database.
 
 ```shell
-docker run --rm -v /var/lib/openproject/pgdata:/var/openproject/pgdata -it openproject/openproject:15
+docker run --rm -v /var/lib/openproject/pgdata:/var/openproject/pgdata -it openproject/openproject:16
 ```
 
 As soon as you see `Database setup finished.` in the container's output you can kill it by pressing Ctrl + C.

--- a/docs/installation-and-operations/operation/upgrading/README.md
+++ b/docs/installation-and-operations/operation/upgrading/README.md
@@ -39,14 +39,14 @@ sudo openproject configure
 
 On Ubuntu 22.04., you might see warnings like these:
 
-> W: `https://dl.packager.io/srv/deb/opf/openproject/stable/15/ubuntu/dists/22.04/InRelease`: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
+> W: `https://dl.packager.io/srv/deb/opf/openproject/stable/16/ubuntu/dists/22.04/InRelease`: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
 
 This message is due to Ubuntu 22.04 switching to a more secure way of adding repository sources, which is not yet supported by the repository provider. There is ongoing work on this item, the message is for information only.
 
 If you get an error like the following:
 
-> E: Repository '`https://dl.packager.io/srv/deb/opf/openproject/stable/15/ubuntu` 22.04 InRelease' changed its 'Origin' value from '' to '`https://packager.io/gh/opf/openproject`'
-> E: Repository '`https://dl.packager.io/srv/deb/opf/openproject/stable/15/ubuntu` 22.04 InRelease' changed its 'Label' value from '' to 'Ubuntu 22.04 packages for opf/openproject'
+> E: Repository '`https://dl.packager.io/srv/deb/opf/openproject/stable/16/ubuntu` 22.04 InRelease' changed its 'Origin' value from '' to '`https://packager.io/gh/opf/openproject`'
+> E: Repository '`https://dl.packager.io/srv/deb/opf/openproject/stable/16/ubuntu` 22.04 InRelease' changed its 'Label' value from '' to 'Ubuntu 22.04 packages for opf/openproject'
 
 These two messages messages are expected, due to a change in Origin and Label repository metadata, to better explain what the repository is about. You should allow the change, and/or run `sudo apt-get update --allow-releaseinfo-change` for the update to go through.
 
@@ -119,7 +119,7 @@ When using the all-in-one docker container, you need to perform the following st
 
 ```shell
 docker pull openproject/openproject:VERSION
-# e.g. docker pull openproject/openproject:15
+# e.g. docker pull openproject/openproject:16
 ```
 
 Then stop and remove your existing container (we assume that you are running with the recommended production setup here):
@@ -171,7 +171,7 @@ If you are using Docker, you should mount your OpenProject volume at `/var/openp
 
 ## Upgrade notes from 9.x to 10.4.x
 
-When upgrading from OpenProject <= 10.4.x to a newer version, you might need to remove the old cron jobs from ```/etc/cron.d/```.  
+When upgrading from OpenProject <= 10.4.x to a newer version, you might need to remove the old cron jobs from ```/etc/cron.d/```.
 You can list all OpenProject related cronjobs by using the ```sudo ls  /etc/cron.d/openproject-*``` command.
 
 ## Upgrade notes for 8.x to 9.x

--- a/docs/security-and-privacy/processing-of-personal-data/README.md
+++ b/docs/security-and-privacy/processing-of-personal-data/README.md
@@ -230,7 +230,7 @@ flowchart TD
   A1[Native client] -->|"HTTP(s) requests"| loadbalancer
   A2[SVN or Git client] -->|"HTTP(s) requests"| loadbalancer
   loadbalancer -->|Proxy| openproject
-  
+
   subgraph openproject[OpenProject Core Application]
     openprojectrailsapp[Rails application]
     C[Puma app server]
@@ -247,7 +247,7 @@ flowchart TD
     gil["GitLab (gil)"]
     cal["Calendar (cal)"]
    O["API integrations (api)"]
- 
+
 end
 
   subgraph services[Internal Services]
@@ -262,21 +262,17 @@ end
   openproject <--> services
   openproject --> integrations
   loadbalancer <--> integrations
-  
+
   subgraph localclients[Local Client / User device]
   direction TB
  browser
  A1
  A2
- 
- 
- 
- 
+
+
+
+
 end
-
-  
-  
-
 ```
 
 As a web application, the primary data flow is between the user's web browser (or attached API clients) through an external proxying web server (this might be a load balancer or proxying server). Depending on the individual setup the proxying server is responsible for terminating TLS connections for the course of this document - although encrypted connections between Load balancer and Puma server are possible. In case of packaged or Kubernetes installations, this proxying server might be part of the OpenProject stack (e.g., an Apache2 packaged installation server or nginx ingress).
@@ -313,34 +309,33 @@ flowchart LR
   Browser <-->|idp-01| IDP
   IDP <-->|idp-02| openproject[OpenProject]
   Browser <-->|idp-03| openproject
-  
+
   subgraph IDP[Identity Provider]
    direction LR
    ssoprovider[SSO provider]
    LDAP
-  
+
   end
-  
+
   subgraph openproject["Relying Party (OpenProject) "]
    direction LR
    ssoclient[SSO client]
    ldapauthentication[LDAP authentication]
    ldapgroupsync[LDAP group sync]
-   
+
  end
 
   subgraph localclients[Local clients]
    direction LR
    Browser
-   end
-  
+  end
 ```
 
 #### Purpose
 
 * Centralized identity and access management
 * Single sign on and single sign out ([OIDC](../../system-admin-guide/authentication/openid-providers/), [SAML](../../system-admin-guide/authentication/saml/))
-* [Syncing LDAP groups with OpenProject groups](../../system-admin-guide/authentication/ldap-connections/ldap-group-synchronization/)  
+* [Syncing LDAP groups with OpenProject groups](../../system-admin-guide/authentication/ldap-connections/ldap-group-synchronization/)
 
 #### Processed data
 
@@ -367,16 +362,16 @@ flowchart LR
   B <-->|eml-02| C[Email gateway]
   C <-->|eml-03| D[Email notification service]
 
- 
+
    subgraph localclients[Local clients]
   direction TB
    A
     end
- 
+
  subgraph internal[Internal services]
   direction TB
    C
-  
+
     end
 
   subgraph external[External services]
@@ -384,15 +379,11 @@ flowchart LR
    A
    B
     end
-    
+
   subgraph OpenProject
   direction TB
    D
     end
-    
-    
-
-
 ```
 
 #### Purpose
@@ -429,9 +420,9 @@ flowchart LR
 %%{init: {'theme':'neutral'}}%%
 flowchart LR
  opicalapi[OpenProject's iCal API] --> |cal-01|B
- B[Calendar web application] -->|cal-03| localcalendarapp[Local calendar application] 
+ B[Calendar web application] -->|cal-03| localcalendarapp[Local calendar application]
   opicalapi -->|cal-02| localcalendarapp
-  
+
   subgraph localclient[Local clients]
    direction TB
     localcalendarapp
@@ -442,10 +433,10 @@ flowchart LR
     direction TB
      B
     end
-    
+
     subgraph OpenProject
    direction TB
-     projectcalendar[Project calendar] --> opicalapi 
+     projectcalendar[Project calendar] --> opicalapi
     end
 ```
 
@@ -478,14 +469,14 @@ flowchart LR
   Browser <-->|nex-02| nextcloud
   nextclouddesktopclient[Nextcloud desktop client] <-->|nex-03| nextcloudapi
   appopenprojectintegration <-->|nex-04| openprojectapi
-  
+
   subgraph local[Local clients]
    Browser
    nextclouddesktopclient
    end
 
 subgraph openproject[OpenProject]
-   
+
    opnextcloudintegrattion[Nextcloud integration]
    openprojectapi[API]
     end
@@ -494,8 +485,7 @@ subgraph openproject[OpenProject]
    groupfolder[Group folder app]
    appopenprojectintegration[OpenProject integration app]
    nextcloudapi[API]
- end 
-  
+ end
 ```
 
 #### Purpose
@@ -527,14 +517,14 @@ flowchart LR
   Browser <-->|osh-02| onedrive
   onedrivedesktopclient[Nextcloud desktop client] <-->|osh-03| onedriveapi
   appopenprojectintegration <-->|osh-04| openprojectapi
-  
+
   subgraph local[Local clients]
    Browser
    onedrivedesktopclient[OneDrive desktop client]
    end
 
 subgraph openproject[OpenProject]
-   
+
    oponedrivetegration[OneDrive/SharePoint integration]
    openprojectapi[API]
     end
@@ -542,8 +532,7 @@ subgraph openproject[OpenProject]
   subgraph onedrive[OneDrive/SharePoint]
    appopenprojectintegration[OpenProject integration app]
    onedriveapi[API]
- end 
-  
+ end
 ```
 
 #### Purpose
@@ -580,7 +569,7 @@ flowchart LR
  githubwebhooks[Webhooks]
 
  end
- 
+
  subgraph localclients[Local clients]
    direction TB
    gitclient[Git client]
@@ -590,8 +579,6 @@ flowchart LR
    direction TB
    opgithubintegration[Github integration] --- workpackagesmodule[Work packages module]
  end
-  
-  
 ```
 
 #### Purpose
@@ -627,7 +614,7 @@ flowchart LR
  gitlabwebhooks[Webhooks]
 
  end
- 
+
  subgraph localclients[Local clients]
    direction TB
    gitclient[Git client]
@@ -637,8 +624,6 @@ flowchart LR
    direction TB
    opgitlabintegration[GitLab integration] --- workpackagesmodule[Work packages module]
  end
-  
-  
 ```
 
 #### Purpose
@@ -666,7 +651,7 @@ flowchart LR
 %%{init: {'theme':'neutral'}}%%
 flowchart LR
  api <-->|api-01| apiintegration[API integration]
- 
+
  subgraph externalintegreations[External integrations]
    direction TB
    apiintegration
@@ -698,9 +683,9 @@ OpenProject makes use of technical cookies to identity the browser client and/or
 
 | **Cookie name**                                | **Description**                                              | **Expiry**                                                   | **Security flags**                                    | **Implementation**                                           |
 | ---------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------ |
-| `_open_project_session` (name is configurable) | contains the information about the logged in user as well as information stored between requests on the user's choices (e.g. the filters for costs are in part stored there) | Session <br>+ configurable server-sideTTL                  | secure<br>httponly<br>Samesite=Lax<br>encrypted | [Code ref](https://github.com/opf/openproject/blob/release/13.0/config/initializers/session_store.rb#L34-L39) |
-| `autologin` (name is configurable)             | (Optional feature, requires opt-in under Administration > Authentication settings) <br>enables the user to automatically log in again after the session expired (e.g. because the browser was closed). It is set when the user checks the '*Stay logged in*' box in the login form.<br> | Cookie 1 year<br>+ server-side token N days (configurable) | secure<br>httponly<br>Samesite=Lax<br>encrypted | [Code ref](https://github.com/opf/openproject/blob/release/13.0/app/controllers/concerns/accounts/user_login.rb#L19C1-L29) |
-| `op2fa_remember_token`                         | the presence of that cookie suppresses the need for the user to provide a second factor upon login for N days (configurable by administration) if the user selects to do so when entering the 2fa information. | N days (configurable)                                        | secure<br>httponly<br>Samesite=Lax<br>encrypted | [Code ref](https://github.com/opf/openproject/blob/release/13.0/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/remember_token.rb#L28-L34) |
+| `_open_project_session` (name is configurable) | contains the information about the logged in user as well as information stored between requests on the user's choices (e.g. the filters for costs are in part stored there) | Session <br>+ configurable server-sideTTL                  | secure<br>httponly<br>Samesite=Lax<br>encrypted | [Code ref](https://github.com/opf/openproject/blob/release/16.0/config/initializers/session_store.rb#L34-L39) |
+| `autologin` (name is configurable)             | (Optional feature, requires opt-in under Administration > Authentication settings) <br>enables the user to automatically log in again after the session expired (e.g. because the browser was closed). It is set when the user checks the '*Stay logged in*' box in the login form.<br> | Cookie 1 year<br>+ server-side token N days (configurable) | secure<br>httponly<br>Samesite=Lax<br>encrypted | [Code ref](https://github.com/opf/openproject/blob/release/16.0/app/services/users/login_service.rb#L58-L74) |
+| `op2fa_remember_token`                         | the presence of that cookie suppresses the need for the user to provide a second factor upon login for N days (configurable by administration) if the user selects to do so when entering the 2fa information. | N days (configurable)                                        | secure<br>httponly<br>Samesite=Lax<br>encrypted | [Code ref](https://github.com/opf/openproject/blob/release/16.0/modules/two_factor_authentication/app/controllers/concerns/two_factor_authentication/remember_token.rb#L28-L33) |
 
 ## Deletion of personal data
 

--- a/modules/gitlab_integration/README.md
+++ b/modules/gitlab_integration/README.md
@@ -139,7 +139,7 @@ A typical workflow on GitLab side would be:
 You will have to configure both **OpenProject** and **Gitlab** for the integration to work.
 
 In case of **Docker** installation, follow the official OpenProject documentation [here](https://www.openproject.org/docs/installation-and-operations/installation/docker/#openproject-plugins). If for some reason the installation with Docker described in the official documentation does not work for you, you can try building your own docker image:
-* Clone from the OpenProject Repo: `git clone https://github.com/opf/openproject.git --branch=stable/15 --depth=1 .`
+* Clone from the OpenProject Repo: `git clone https://github.com/opf/openproject.git --branch=stable/16 --depth=1 .`
 * Clone the plugin inside the modules folder: `git clone https://github.com/btey/openproject-gitlab-integration.git --depth=1 modules/gitlab_integration`
 * Apply the changes below in Gemfile.lock and Gemfile.modules (the same ones you would do in a manual install).
 * Build the container: `docker build -t openproject-docker --file=docker/prod/Dockerfile .`


### PR DESCRIPTION
# Ticket

task https://community.openproject.org/wp/62392

bug https://community.openproject.org/wp/64362 (because task not done)

# What are you trying to accomplish?

Update installation documentation and other documentation links and information to point to stable/16 release instead of stable/15.

# What approach did you choose and why?

Do it manually.

We need to automate it. Ticket for doing it: https://community.openproject.org/wp/64521

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
