### PR TITLE
Do not require prometheus by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -225,7 +225,7 @@ gem "appsignal", "~> 3.10.0", require: false
 
 # Yabeda integration
 gem "yabeda-activerecord"
-gem "yabeda-prometheus-mmap"
+gem "yabeda-prometheus-mmap", require: false
 gem "yabeda-puma-plugin"
 gem "yabeda-rails"
 


### PR DESCRIPTION
The code enabling it in config.ru is already requiring this file, indicating that it was intended to only be enabled when needed. However, due to automatically requiring gems through bundler, this gem was still loaded.

We could validate in heap dumps that before this change, the gem was active and consuming a non-neglectible amount of memory (probably to do its job) even if it was not enabled. After the change it's not.

# What are you trying to achieve

We found that - at least on a development machine - a relevant of retained memory allocations came from the `prometheus-mmap` gem. This change is intended to avoid the memory penalty when prometheus is disabled.

# Ticket
https://community.openproject.org/wp/64214