### PR TITLE
[#64531] Fix issues with attribute help text icon appearance/behaviour 

### DIFF
--- a/app/components/open_project/common/attribute_help_text_component.rb
+++ b/app/components/open_project/common/attribute_help_text_component.rb
@@ -38,7 +38,6 @@ module OpenProject
 
         @system_arguments = system_arguments
         @system_arguments[:id] ||= self.class.generate_id(help_text)
-        @system_arguments[:muted] = true
         @system_arguments[:classes] = class_names(
           @system_arguments[:classes],
           "op-attribute-help-text"

--- a/app/components/open_project/common/attribute_help_text_component.rb
+++ b/app/components/open_project/common/attribute_help_text_component.rb
@@ -50,7 +50,7 @@ module OpenProject
           for_id: @system_arguments[:id],
           type: :label,
           text: I18n.t("js.help_texts.show_modal"),
-          direction: :e
+          direction: :sw
         )
         @system_arguments[:aria] ||= {}
         @system_arguments[:aria][:labelledby] = @tooltip.id

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -620,7 +620,7 @@ en:
     label_view_has_changed: "This view has unsaved changes. Click to save them."
 
     help_texts:
-      show_modal: "Show attribute help text entry"
+      show_modal: "Show help text"
 
     onboarding:
       buttons:

--- a/spec/components/open_project/common/attribute_help_text_component_spec.rb
+++ b/spec/components/open_project/common/attribute_help_text_component_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component
   end
 
   shared_examples "component renders" do
-    it "renders a muted link" do
+    it "renders a link" do
       expect(subject).to have_link href: show_dialog_attribute_help_text_path(help_text),
-                                   class: "Link Link--muted"
+                                   class: "Link"
     end
 
     it "renders a tooltip" do

--- a/spec/components/open_project/common/attribute_help_text_component_spec.rb
+++ b/spec/components/open_project/common/attribute_help_text_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component
     end
 
     it "renders a tooltip" do
-      expect(subject).to have_element "tool-tip", text: "Show attribute help text entry",
+      expect(subject).to have_element "tool-tip", text: "Show help text",
                                                   for: /attribute-help-text-component-\d+/,
                                                   popover: "manual",
                                                   "data-direction": "sw",

--- a/spec/components/open_project/common/attribute_help_text_component_spec.rb
+++ b/spec/components/open_project/common/attribute_help_text_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component
       expect(subject).to have_element "tool-tip", text: "Show attribute help text entry",
                                                   for: /attribute-help-text-component-\d+/,
                                                   popover: "manual",
-                                                  "data-direction": "e",
+                                                  "data-direction": "sw",
                                                   "data-type": "label"
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64531

# What are you trying to accomplish?

Fixes various issues with attribute help text icon appearance/behaviour.

- Changes tooltip text to: "Show help text"
- Changes positioning of the tooltip to the bottom-right ("south-west" for some reason in Primer)
- Uses the Primer (non-muted) link colour (`fgColorLink` which resolves to `fgColorAccent`).

## Screenshots

| Before | After |
|--------|--------|
| <img width="712" alt="Screenshot 2025-06-09 at 11 18 29" src="https://github.com/user-attachments/assets/891ec946-1a68-4a37-a49c-a52cc8dc60be" /> | <img width="701" alt="Screenshot 2025-06-09 at 11 21 57" src="https://github.com/user-attachments/assets/5307c3b3-2100-40bb-9577-a6910ba00530" /> |
| <img width="706" alt="Screenshot 2025-06-09 at 11 18 38" src="https://github.com/user-attachments/assets/1315146b-2110-4abf-9e38-d14c4827bf38" /> | <img width="710" alt="Screenshot 2025-06-09 at 11 21 32" src="https://github.com/user-attachments/assets/c055ca81-bc63-4b98-b778-d2c8c7c7ccb5" /> | 

(N.B. ignore the field values in the screenshots!)

# What approach did you choose and why?



# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
