### PR TITLE
[#64470] Missing help text for Subproject of field

### DIFF
--- a/app/components/open_project/common/attribute_label_component.rb
+++ b/app/components/open_project/common/attribute_label_component.rb
@@ -50,7 +50,7 @@ module OpenProject
 
         @help_text = ::AttributeHelpText.for(model)
           &.cached(current_user)
-          &.[](attribute.to_s)
+          &.[](AttributeHelpText.normalize_value_for(:attribute_name, attribute))
       end
     end
   end

--- a/app/models/attribute_help_text.rb
+++ b/app/models/attribute_help_text.rb
@@ -62,6 +62,8 @@ class AttributeHelpText < ApplicationRecord
     scope
   end
 
+  normalizes :attribute_name, with: -> { it.delete_suffix("_id") }
+
   validates :help_text, presence: true
   validates :attribute_name, uniqueness: { scope: :type }
 

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -206,7 +206,7 @@ Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_record.marshalling_format_version = 7.1
+Rails.application.config.active_record.marshalling_format_version = 7.1
 
 ###
 # Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.

--- a/spec/components/open_project/common/attribute_label_component_spec.rb
+++ b/spec/components/open_project/common/attribute_label_component_spec.rb
@@ -77,7 +77,18 @@ RSpec.describe OpenProject::Common::AttributeLabelComponent, type: :component do
     end
   end
 
-  context "with help text" do
+  context "with help text on an attribute" do
+    let!(:help_text) { create(:project_help_text, attribute_name: attribute) }
+
+    it_behaves_like "component renders"
+
+    it "renders help text" do
+      expect(subject).to have_element class: "op-attribute-help-text"
+    end
+  end
+
+  context "with help text on an association" do
+    let(:attribute) { "parent_id" }
     let!(:help_text) { create(:project_help_text, attribute_name: attribute) }
 
     it_behaves_like "component renders"

--- a/spec/models/attribute_help_text/project_spec.rb
+++ b/spec/models/attribute_help_text/project_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe AttributeHelpText::Project do
     end
   end
 
+  describe "normalization" do
+    it "normalizes attribute_name" do
+      expect(subject).to normalize(:attribute_name).from("parent_id").to("parent")
+    end
+  end
+
   describe "instance" do
     subject { build(:project_help_text) }
 

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -197,6 +197,14 @@ RSpec.describe AttributeHelpText::WorkPackage do
     end
   end
 
+  describe "normalization" do
+    it "normalizes attribute_name" do
+      expect(subject).to normalize(:attribute_name).from("category_id").to("category")
+      expect(subject).to normalize(:attribute_name).from("status_id").to("status")
+      expect(subject).to normalize(:attribute_name).from("author_id").to("author")
+    end
+  end
+
   describe "instance" do
     subject { build(:work_package_help_text) }
 


### PR DESCRIPTION
⚠️ **Understand the consequences of changing AR `marshalling_format_version` before merging!**

# Ticket

https://community.openproject.org/wp/64470

# What are you trying to accomplish?

Fix display of attribute help text for the "Subproject of" field and other fields backed by associations.

## Screenshots

<img width="702" alt="image" src="https://github.com/user-attachments/assets/80cc31d7-3117-4758-9d8c-889f9915fe4d" />

# What approach did you choose and why?

N.B. This PR sets [sets ActiveRecord marshalling_format_version to 8.0](https://github.com/opf/openproject/pull/19120/commits/b0b3de1060006f1b38661a81003e88da5aae89e5), which may have unintended consequences.

As the docs in `config/initializers/new_framework_defaults_7_1.rb` state:

```
# Enable a performance optimization that serializes Active Record models
# in a faster and more compact way.
#
# To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have
# not yet been upgraded must be able to read caches from upgraded servers,
# leave this optimization off on the first deploy, then enable it on a
# subsequent deploy.
```

FYI @machisuji - to evaluate whether this might cause issues for the deploy of 16.1.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
