### PR TITLE
update teaser text for 16.1

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -400,18 +400,17 @@ en:
           learn_about: "Learn more about all new features"
           # Include the version to invalidate outdated translations in other locales.
           # Otherwise, e.g. chinese might still have the translations for 10.0 in the 12.0 release.
-          "16_0":
+          "16_1":
             standard:
               new_features_html: >
                 The release contains various new features and improvements, such as <br>
                 <ul class="%{list_styling_class}">
-                  <li>Meeting backlogs and the end of classic meetings.</li>
-                  <li>Updated Enterprise plans.</li>
-                  <li>Internal comments in work packages (Enterprise add-on).</li>
-                  <li>Automatically generated work package subjects (Enterprise add-on).</li>
-                  <li>Separate time tracking module with calendar view.</li>
-                  <li>Parent relation displayed in work package relations tab.</li>
-                  <li>Release to Community: Graphs on project overview page.</li>
+                  <li>Structure the project life cycle with phases and phase gates.</li>
+                  <li>Export meetings in PDF format.</li>
+                  <li>Set smart default options for reminders.</li>
+                  <li>Use negative lag for work package dates.</li>
+                  <li>Display hierarchy trees for hierarchy custom fields.</li>
+                  <li>Benefit from improved accessibility for the date picker with ARIA live regions.</li>
                 </ul>
 
     ical_sharing_modal:

--- a/frontend/src/app/features/homescreen/blocks/new-features.component.ts
+++ b/frontend/src/app/features/homescreen/blocks/new-features.component.ts
@@ -33,7 +33,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 
 // The key used in the I18n files to distinguish between versions.
-const OpVersionI18n = '16_0';
+const OpVersionI18n = '16_1';
 // The key used to identify the svg representing the central feature in the version.
 // This might be different to OpVersionI18n for a while since the teaser text is often ready
 // before the image is.


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63181

# What are you trying to accomplish?

Update the teaser text (not the image):

<img width="479" alt="image" src="https://github.com/user-attachments/assets/f6dc5ecb-4b22-4111-9c8c-dacd09a4a340" />

