### PR TITLE
Make sure to unblock requests before each test

### DIFF
--- a/spec/support/capybara/block_requests_made_outside_of_test.rb
+++ b/spec/support/capybara/block_requests_made_outside_of_test.rb
@@ -49,7 +49,7 @@ end
 RSpec.configure do |config|
   Capybara.app = RequestsBlocker.new(Capybara.app)
 
-  config.before(:each, type: :feature) do
+  config.before do
     Capybara.app.unblock_requests!
   end
 


### PR DESCRIPTION
This fixes some test flakiness observed in development when running feature specs along with unit tests.

A reproduction command is: `bin/rspec --seed 59590 './spec/features/admin/enterprise/enterprise_spec.rb[1:1:2:1]' './spec/views/layouts/base.html.erb_spec.rb[1:3:1:3]'`

The mechanism to block requests is working too well: it blocks requests after the feature test is finished. Other tests relying on Capybara but not using a browser then get a 500. To fix it, disabling of the blocking must not be only before feature tests, but before all tests.