### PR TITLE
Bug/63461 reminders saving without entering a date or time throws an error but also unnecessarily clears the other field

### DIFF
--- a/app/components/work_packages/reminder/modal_body_component.rb
+++ b/app/components/work_packages/reminder/modal_body_component.rb
@@ -40,13 +40,15 @@ module WorkPackages
 
       attr_reader :remindable, :reminder, :errors, :preset
 
-      def initialize(remindable:, reminder:, errors: nil, preset: nil)
+      def initialize(remindable:, reminder:, errors: nil, preset: nil, remind_at_date: nil, remind_at_time: nil)
         super
 
         @remindable = remindable
         @reminder = reminder
         @errors = errors
         @preset = preset
+        @remind_at_date = remind_at_date
+        @remind_at_time = remind_at_time
       end
 
       class << self
@@ -84,6 +86,11 @@ module WorkPackages
       end
 
       def remind_at_date_initial_value
+        if attribute_blank?(:remind_at_time) && @remind_at_date.present?
+          # If the time is not set, we return the date that was passed in
+          return @remind_at_date
+        end
+
         return time_as_date(@reminder.remind_at) if @reminder.remind_at
         return calculate_preset_date if @preset
 
@@ -91,6 +98,11 @@ module WorkPackages
       end
 
       def remind_at_time_initial_value
+        if attribute_blank?(:remind_at_date) && @remind_at_time.present?
+          # If the date is not set, we return the time that was passed in
+          return @remind_at_time
+        end
+
         return format_time(@reminder.remind_at, include_date: false, format: "%H:%M") if @reminder.remind_at
 
         DEFAULT_TIME
@@ -110,6 +122,11 @@ module WorkPackages
 
       def time_as_date(time)
         format_time_as_date(time, format: "%Y-%m-%d")
+      end
+
+      def attribute_blank?(attribute)
+        @errors.present? &&
+          @errors.any? { |error| error.attribute == attribute && error.type == :blank }
       end
     end
   end

--- a/app/controllers/work_packages/reminders_controller.rb
+++ b/app/controllers/work_packages/reminders_controller.rb
@@ -59,7 +59,9 @@ class WorkPackages::RemindersController < ApplicationController
         component: modal_component_class.new(
           remindable: @work_package,
           reminder: @reminder,
-          errors: @errors
+          errors: @errors,
+          remind_at_date:,
+          remind_at_time:
         )
       )
 
@@ -82,7 +84,9 @@ class WorkPackages::RemindersController < ApplicationController
         component: modal_component_class.new(
           remindable: @work_package,
           reminder: @reminder,
-          errors: @errors
+          errors: @errors,
+          remind_at_date:,
+          remind_at_time:
         )
       )
 

--- a/app/controllers/work_packages/reminders_controller.rb
+++ b/app/controllers/work_packages/reminders_controller.rb
@@ -175,22 +175,8 @@ class WorkPackages::RemindersController < ApplicationController
   end
 
   def reminder_params
-    params.require(:reminder)
-          .permit(%i[remind_at_date remind_at_time note])
-          .tap do |initial_params|
-      date = initial_params.delete(:remind_at_date)
-      time = initial_params.delete(:remind_at_time)
-
-      initial_params[:remind_at] = build_remind_at_from_params(date, time)
-      initial_params[:remindable] = @work_package
-      initial_params[:creator] = User.current
-    end
-  end
-
-  def build_remind_at_from_params(remind_at_date, remind_at_time)
-    if remind_at_date.present? && remind_at_time.present?
-      User.current.time_zone.parse("#{remind_at_date} #{remind_at_time}")
-    end
+    params.expect(reminder: %i[remind_at_date remind_at_time note])
+          .merge(remindable: @work_package, creator: User.current)
   end
 
   def remind_at_date

--- a/app/services/reminders/set_attributes_service.rb
+++ b/app/services/reminders/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,5 +30,23 @@
 
 module Reminders
   class SetAttributesService < ::BaseServices::SetAttributes
+    private
+
+    def set_attributes(params)
+      remind_at_date = params.delete(:remind_at_date)
+      remind_at_time = params.delete(:remind_at_time)
+
+      if (remind_at_date && remind_at_time).present?
+        params[:remind_at] = build_remind_at_from_params(remind_at_date, remind_at_time)
+      end
+
+      super
+    end
+
+    def build_remind_at_from_params(remind_at_date, remind_at_time)
+      if remind_at_date.present? && remind_at_time.present?
+        User.current.time_zone.parse("#{remind_at_date} #{remind_at_time}")
+      end
+    end
   end
 end

--- a/app/services/reminders/set_attributes_service.rb
+++ b/app/services/reminders/set_attributes_service.rb
@@ -30,23 +30,65 @@
 
 module Reminders
   class SetAttributesService < ::BaseServices::SetAttributes
-    private
-
-    def set_attributes(params)
+    def perform(params = {})
       remind_at_date = params.delete(:remind_at_date)
       remind_at_time = params.delete(:remind_at_time)
 
-      if (remind_at_date && remind_at_time).present?
-        params[:remind_at] = build_remind_at_from_params(remind_at_date, remind_at_time)
+      if remind_at_date.present? && remind_at_time.present?
+        params[:remind_at] = User.current.time_zone.parse("#{remind_at_date} #{remind_at_time}")
       end
 
-      super
+      contract_call = super
+
+      if contract_call.failure?
+        prepare_errors_from_result({ remind_at_date:, remind_at_time: }, contract_call)
+      end
+
+      contract_call
     end
 
-    def build_remind_at_from_params(remind_at_date, remind_at_time)
-      if remind_at_date.present? && remind_at_time.present?
-        User.current.time_zone.parse("#{remind_at_date} #{remind_at_time}")
+    private
+
+    # At the form level, we split the date and time into two form fields.
+    # In order to be a bit more informative of which field is causing
+    # the remind_at attribute to be in the past/invalid, we need to
+    # remap the error attribute to the appropriate field.
+    def prepare_errors_from_result(remind_at_params, contract_call)
+      return contract_call unless contract_call.errors.include?(:remind_at)
+
+      case contract_call.errors.find { |error| error.attribute == :remind_at }.type
+      when :blank
+        handle_blank_error(remind_at_params, contract_call)
+      when :datetime_must_be_in_future
+        handle_future_error(contract_call)
       end
+
+      contract_call.errors.delete(:remind_at)
+    end
+
+    def handle_blank_error(remind_at_params, contract_call)
+      %i[remind_at_date remind_at_time].each do |attribute|
+        contract_call.errors.add(attribute, :blank) if remind_at_params[attribute].blank?
+      end
+    end
+
+    def handle_future_error(contract_call)
+      reminder = contract_call.result
+
+      {
+        remind_at_date: (reminder.remind_at.to_date < today_in_user_time_zone),
+        remind_at_time: (reminder.remind_at < now_in_user_time_zone)
+      }.each do |attribute, in_the_past|
+        contract_call.errors.add(attribute, :datetime_must_be_in_future) if in_the_past
+      end
+    end
+
+    def today_in_user_time_zone
+      @today_in_user_time_zone ||= now_in_user_time_zone.to_date
+    end
+
+    def now_in_user_time_zone
+      @now_in_user_time_zone ||= Time.current.in_time_zone(User.current.time_zone)
     end
   end
 end

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Work package reminder modal",
       expect(Reminder.upcoming_and_visible_to(user_with_permissions).count).to eq(0)
     end
 
-    it "renders an error flash when the reminder modal is opened in edit mode" \
+    it "renders an error flash when the reminder modal is opened in edit mode " \
        "and the notification for it is fired and subsequently clicking save",
        with_settings: { notifications_polling_interval: 1_000 } do
       Reminders::CreateService.new(user: current_user).call(
@@ -336,6 +336,19 @@ RSpec.describe "Work package reminder modal",
           expect(page).to have_field("Time", with: reminder.remind_at.in_time_zone(current_user.time_zone).strftime("%H:%M"))
           expect(page).to have_field("Note", with: reminder.note)
           expect(page).to have_button("Save")
+
+          # Edit form renders validation errors
+          fill_in "Date", with: ""
+          fill_in "Time", with: ""
+
+          click_link_or_button "Save"
+
+          wait_for_network_idle
+          expect(page).to have_css(".FormControl-inlineValidation", text: "Date can't be blank.")
+          expect(page).to have_css(".FormControl-inlineValidation", text: "Time can't be blank.")
+          expect(page).to have_field("Date", with: "")
+          expect(page).to have_field("Time", with: "09:00") # Default time
+          expect(page).to have_field("Note", with: reminder.note)
         end
       end
     end

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -259,8 +259,9 @@ RSpec.describe "Work package reminder modal",
           expect(page).to have_css(".FormControl-inlineValidation", text: "Date can't be blank")
           expect(page).to have_field("Time", with: "09:00")
 
+          one_week_from_now = 1.week.from_now
           # Fill in the date and unset the time
-          fill_in "Date", with: 1.week.from_now.to_date
+          fill_in "Date", with: one_week_from_now.to_date
           fill_in "Time", with: ""
           click_link_or_button "Set reminder"
 
@@ -268,15 +269,19 @@ RSpec.describe "Work package reminder modal",
           # The error message is only on the time field
           expect(page).to have_css(".FormControl-inlineValidation", text: "Time can't be blank")
           expect(page).to have_no_css(".FormControl-inlineValidation", text: "Date can't be blank", wait: 0)
+          expect(page).to have_field("Date", with: one_week_from_now.to_date)
 
           # Fill in the time but not the date
           fill_in "Date", with: ""
-          fill_in "Time", with: Time.zone.parse("05:00")
+          fill_in "Time", with: Time.use_zone(current_user.time_zone) { Time.zone.parse("05:00") }
           click_link_or_button "Set reminder"
 
           wait_for_network_idle
           expect(page).to have_css(".FormControl-inlineValidation", text: "Date can't be blank.")
           expect(page).to have_no_css(".FormControl-inlineValidation", text: "Time can't be blank.", wait: 0)
+          expect(page).to have_field("Time", with: Time.use_zone(current_user.time_zone) {
+            Time.zone.parse("05:00").localtime.strftime("%H:%M:%S")
+          })
         end
       end
 

--- a/spec/services/reminders/set_attributes_service_spec.rb
+++ b/spec/services/reminders/set_attributes_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Reminders::SetAttributesService do
+  let(:user) { build_stubbed(:user) }
+  let(:model_instance) { Reminder.new }
+  let(:remindable) { build_stubbed(:work_package) }
+  let(:contract_class) { EmptyContract }
+
+  current_user { user }
+
+  subject(:service) do
+    described_class.new(user: user,
+                        model: model_instance,
+                        contract_class:)
+  end
+
+  it "sets the remind_at attribute from date and time params" do
+    params = {
+      remind_at_date: "2023-10-01",
+      remind_at_time: "12:00",
+      note: "Some notes",
+      remindable:,
+      creator: user
+    }
+
+    service.perform(params)
+
+    expect(model_instance).to have_attributes(
+      remind_at: current_user.time_zone.parse("2023-10-01 12:00"),
+      note: "Some notes",
+      remindable:,
+      creator: user
+    )
+  end
+
+  context "when remind_at_date or remind_at_time is not provided" do
+    it "does not set the remind_at attribute" do
+      aggregate_failures "one is nil" do
+        service.perform(remind_at_date: nil, remind_at_time: "12:00")
+        expect(model_instance.remind_at).to be_nil
+      end
+
+      aggregate_failures "both are nil" do
+        service.perform(remind_at_date: nil, remind_at_time: nil)
+        expect(model_instance.remind_at).to be_nil
+      end
+
+      aggregate_failures "none provided" do
+        service.perform({})
+        expect(model_instance.remind_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/63461

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Adjust reminders form to retain valid user inputted fields when there are validation errors with other form attributes

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

![reminders-validation-errors](https://github.com/user-attachments/assets/e5538bdb-fb32-41c8-b499-763c25824af2)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The `remind_at` timestamp is split up in the actual UI form as `remind_at_{date,time}`. Make the building logic consistent by refactoring the structure to be more conventional to OP; by moving the attributes setting to the `Reminders::SetAttributesService` allowing for isolated unit testing and general fluency.

> [!NOTE]
> AC: _"When the in-error is displayed and the user corrects it by entering the missing information, dismiss the errorExplore auto_check_src ([ref](https://primer.style/view-components/lookbook/pages/forms/inputs/text_field)) for this as a test"_
> **_Will be addressed in a separate PR._**

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
