### PR TITLE
[64611] Make "subject or id" filter strip whitespaces

### DIFF
--- a/app/models/queries/work_packages/filter/subject_or_id_filter.rb
+++ b/app/models/queries/work_packages/filter/subject_or_id_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,8 +32,8 @@ class Queries::WorkPackages::Filter::SubjectOrIdFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
   include Queries::WorkPackages::Filter::OrFilterForWpMixin
 
-  CONTAINS_OPERATOR = "~".freeze
-  EQUALS_OPERATOR = "=".freeze
+  CONTAINS_OPERATOR = "~"
+  EQUALS_OPERATOR = "="
 
   FILTERS = [
     Queries::WorkPackages::Filter::FilterConfiguration.new(
@@ -56,6 +58,10 @@ class Queries::WorkPackages::Filter::SubjectOrIdFilter <
 
   def type
     :search
+  end
+
+  def values=(values)
+    super(Array(values).map { it.to_s.strip })
   end
 
   def human_name

--- a/spec/models/queries/work_packages/filter/subject_or_id_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/subject_or_id_filter_spec.rb
@@ -31,16 +31,14 @@
 require "spec_helper"
 
 RSpec.describe Queries::WorkPackages::Filter::SubjectOrIdFilter do
-  let(:value) { "bogus" }
   let(:operator) { "**" }
-  let(:subject) { "Some subject" }
-  let(:work_package) { create(:work_package, subject:) }
+  let(:work_package) { create(:work_package, subject: "Some subject") }
   let(:current_user) do
     create(:user, member_with_permissions: { work_package.project => %i[view_work_packages edit_work_packages] })
   end
   let(:query) { build_stubbed(:global_query, user: current_user) }
   let(:instance) do
-    described_class.create!(name: :search, context: query, operator:, values: [value])
+    described_class.create!(name: :search, context: query, operator:)
   end
 
   before do
@@ -55,6 +53,12 @@ RSpec.describe Queries::WorkPackages::Filter::SubjectOrIdFilter do
 
   it "finds in ID" do
     instance.values = [work_package.id.to_s]
+    expect(WorkPackage.eager_load(instance.includes).where(instance.where))
+      .to contain_exactly(work_package)
+  end
+
+  it "finds in ID, even with spaces before and/or after it" do
+    instance.values = [" #{work_package.id} "]
     expect(WorkPackage.eager_load(instance.includes).where(instance.where))
       .to contain_exactly(work_package)
   end


### PR DESCRIPTION


# Ticket

https://community.openproject.org/wp/64611

# What are you trying to accomplish?

Ignore trailing white spaces when pasting a work package ID in the time logging modal.

# What approach did you choose and why?

In `Queries::WorkPackages::Filter::SubjectOrIdFilter`, override `#values=` to strip whitespaces.
I wonder if that could be done at a higher level for all filters...

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
