### PR TITLE
Bug/63109 this week filter is not working correctly

### DIFF
--- a/app/models/queries/projects/filters/filter_on_project_phase.rb
+++ b/app/models/queries/projects/filters/filter_on_project_phase.rb
@@ -148,7 +148,7 @@ module Queries::Projects::Filters::FilterOnProjectPhase
   end
 
   def end_of_week
-    beginning_of_week + 7.days
+    (beginning_of_week + 6.days).end_of_day
   end
 
   def project_phase_scope

--- a/spec/models/queries/projects/project_query_results_project_phase_any_spec.rb
+++ b/spec/models/queries/projects/project_query_results_project_phase_any_spec.rb
@@ -363,6 +363,32 @@ RSpec.describe ProjectQuery, "results of 'Project phase: Any' filter" do
         end
       end
     end
+
+    context "when being on Wednesday before the phase, the phase starts on Monday and the week is configured to start on Monday",
+            with_settings: { start_of_week: 1 } do
+      before do
+        phase.update_column(:start_date, Date.parse("2025-02-03"))
+      end
+
+      it "returns no project as the phase starts in the next week" do
+        Timecop.travel(Date.parse("2025-01-29").noon) do
+          expect(instance.results).to be_empty
+        end
+      end
+    end
+
+    context "when being on Sunday, same as the phase's start date and the week is configured to start on Monday",
+            with_settings: { start_of_week: 1 } do
+      before do
+        phase.update_column(:start_date, Date.parse("2025-02-09"))
+      end
+
+      it "returns the project whose gate is in the current week" do
+        Timecop.travel(Date.parse("2025-02-09").noon) do
+          expect(instance.results).to contain_exactly(project_with_phase)
+        end
+      end
+    end
   end
 
   context "with a <>d (between) operator" do

--- a/spec/models/queries/projects/project_query_results_project_phase_gate_spec.rb
+++ b/spec/models/queries/projects/project_query_results_project_phase_gate_spec.rb
@@ -309,14 +309,14 @@ RSpec.describe ProjectQuery, "results of a project phase gate filter" do
           gate.update_column(:"#{boundary}_date", Date.parse("2025-03-02"))
         end
 
-        it "returns no project as the stage ended in the week before" do
+        it "returns no project as the gate is in the week before" do
           Timecop.travel(Date.parse("2025-03-03").noon) do
             expect(instance.results).to be_empty
           end
         end
       end
 
-      context "when being on Sunday, the gate is on Monday and the week is configured to start on Monday",
+      context "when being on Sunday after the gate, the gate is on Monday and the week is configured to start on Monday",
               with_settings: { start_of_week: 1 } do
         before do
           # This might produce invalid phases where the start date is after the end date.
@@ -339,7 +339,7 @@ RSpec.describe ProjectQuery, "results of a project phase gate filter" do
           gate.update_column(:"#{boundary}_date", Date.parse("2025-03-03"))
         end
 
-        it "returns no project as the stage ended in the week before" do
+        it "returns no project as the gate is in the week before" do
           Timecop.travel(Date.parse("2025-03-09").noon) do
             expect(instance.results).to be_empty
           end

--- a/spec/models/queries/projects/project_query_results_project_phase_gate_spec.rb
+++ b/spec/models/queries/projects/project_query_results_project_phase_gate_spec.rb
@@ -345,6 +345,36 @@ RSpec.describe ProjectQuery, "results of a project phase gate filter" do
           end
         end
       end
+
+      context "when being on Wednesday before the gate, the gate is Monday and the week is configured to start on Monday",
+              with_settings: { start_of_week: 1 } do
+        before do
+          # This might produce invalid phases where the start date is after the end date.
+          # For the sake of the test, this is irrelevant.
+          gate.update_column(:"#{boundary}_date", Date.parse("2025-03-03"))
+        end
+
+        it "returns no project as the gate is in the week after" do
+          Timecop.travel(Date.parse("2025-02-26").noon) do
+            expect(instance.results).to be_empty
+          end
+        end
+      end
+
+      context "when being on Sunday, same as the gate and the week is configured to start on Monday",
+              with_settings: { start_of_week: 1 } do
+        before do
+          # This might produce invalid phases where the start date is after the end date.
+          # For the sake of the test, this is irrelevant.
+          gate.update_column(:"#{boundary}_date", Date.parse("2025-03-02"))
+        end
+
+        it "returns the project whose gate is in the current week" do
+          Timecop.travel(Date.parse("2025-03-02").noon) do
+            expect(instance.results).to contain_exactly(project_with_gate)
+          end
+        end
+      end
     end
 
     context "with a <>d (between) operator" do

--- a/spec/models/queries/projects/project_query_results_project_phase_spec.rb
+++ b/spec/models/queries/projects/project_query_results_project_phase_spec.rb
@@ -363,6 +363,32 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
         end
       end
     end
+
+    context "when being on Wednesday before the phase, the phase starts on Monday and the week is configured to start on Monday",
+            with_settings: { start_of_week: 1 } do
+      before do
+        stage.update_column(:start_date, Date.parse("2025-02-03"))
+      end
+
+      it "returns no project as the phase starts in the next week" do
+        Timecop.travel(Date.parse("2025-01-29").noon) do
+          expect(instance.results).to be_empty
+        end
+      end
+    end
+
+    context "when being on Sunday, same as the phase's start date and the week is configured to start on Monday",
+            with_settings: { start_of_week: 1 } do
+      before do
+        phase.update_column(:start_date, Date.parse("2025-02-09"))
+      end
+
+      it "returns the project whose gate is in the current week" do
+        Timecop.travel(Date.parse("2025-02-09").noon) do
+          expect(instance.results).to contain_exactly(project_with_phase)
+        end
+      end
+    end
   end
 
   context "with a <>d (between) operator" do

--- a/spec/models/queries/projects/project_query_results_project_phase_spec.rb
+++ b/spec/models/queries/projects/project_query_results_project_phase_spec.rb
@@ -32,20 +32,20 @@ require "spec_helper"
 
 RSpec.describe ProjectQuery, "results of a project phase filter" do
   let(:instance) { described_class.new }
-  let(:filter_key) { "project_phase_#{stage.definition_id}" }
+  let(:filter_key) { "project_phase_#{phase.definition_id}" }
 
   shared_let(:view_role) { create(:project_role, permissions: %i[view_project_phases]) }
 
   shared_let(:phase_start_date) { Date.parse("2025-02-07") }
   shared_let(:phase_finish_date) { Date.parse("2025-02-17") }
-  shared_let(:project_with_phase) { create(:project, name: "Project with stage") }
-  shared_let(:stage) do
+  shared_let(:project_with_phase) { create(:project, name: "Project with phase") }
+  shared_let(:phase) do
     create(:project_phase, project: project_with_phase, start_date: phase_start_date, finish_date: phase_finish_date)
   end
 
-  # This is added to ensure that the filter only works on the stage provided.
-  shared_let(:project_with_rival_phase) { create(:project, name: "Project with rival stage") }
-  shared_let(:rival_stage) do
+  # This is added to ensure that the filter only works on the phase provided.
+  shared_let(:project_with_rival_phase) { create(:project, name: "Project with rival phase") }
+  shared_let(:rival_phase) do
     create(:project_phase, project: project_with_rival_phase, start_date: phase_start_date, finish_date: phase_finish_date)
   end
 
@@ -70,7 +70,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
 
   def self.remove_phase_dates
     before do
-      stage.update_columns(finish_date: nil, start_date: nil)
+      phase.update_columns(finish_date: nil, start_date: nil)
     end
   end
 
@@ -92,31 +92,31 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       instance.where(filter_key, "=d", values)
     end
 
-    context "when filtering in the middle of the stage" do
+    context "when filtering in the middle of the phase" do
       let(:values) { [(phase_start_date + ((phase_finish_date - phase_start_date) / 2)).to_s] }
 
-      it "returns the project whose stage is covering an interval including the date" do
+      it "returns the project whose phase is covering an interval including the date" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when filtering on the first day of the stage" do
+    context "when filtering on the first day of the phase" do
       let(:values) { [phase_start_date.to_s] }
 
-      it "returns the project whose stage begins on that date" do
+      it "returns the project whose phase begins on that date" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when filtering on the last day of the stage" do
+    context "when filtering on the last day of the phase" do
       let(:values) { [phase_finish_date.to_s] }
 
-      it "returns the project whose stage ends on that date" do
+      it "returns the project whose phase ends on that date" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when filtering before the stage" do
+    context "when filtering before the phase" do
       let(:values) { [(phase_start_date - 1.day).to_s] }
 
       it "returns no project" do
@@ -124,7 +124,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when filtering after the stage" do
+    context "when filtering after the phase" do
       let(:values) { [(phase_finish_date + 1.day).to_s] }
 
       it "returns no project" do
@@ -132,7 +132,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when the stage has no dates" do
+    context "when the phase has no dates" do
       let(:values) { [phase_finish_date.to_s] }
 
       remove_phase_dates
@@ -142,7 +142,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when filtering in the middle of the stage but with the stage being inactive" do
+    context "when filtering in the middle of the phase but with the phase being inactive" do
       let(:values) { [(phase_start_date + ((phase_finish_date - phase_start_date) / 2)).to_s] }
 
       disable_phase
@@ -152,7 +152,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when filtering in the middle of the stage but without permissions" do
+    context "when filtering in the middle of the phase but without permissions" do
       let(:values) { [(phase_start_date + ((phase_finish_date - phase_start_date) / 2)).to_s] }
 
       remove_permissions
@@ -168,31 +168,31 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       instance.where(filter_key, "t", [])
     end
 
-    context "when being in the middle of the stage" do
-      it "returns the project whose stage is currently running" do
+    context "when being in the middle of the phase" do
+      it "returns the project whose phase is currently running" do
         Timecop.travel((phase_start_date + (phase_finish_date - phase_start_date)).noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when being on the first day of the stage" do
-      it "returns the project whose stage begins on that date" do
+    context "when being on the first day of the phase" do
+      it "returns the project whose phase begins on that date" do
         Timecop.travel(phase_start_date.noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when being on the last day of the stage" do
-      it "returns the project whose stage begins on that date" do
+    context "when being on the last day of the phase" do
+      it "returns the project whose phase begins on that date" do
         Timecop.travel(phase_finish_date.noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when being before the stage" do
+    context "when being before the phase" do
       it "returns no project" do
         Timecop.travel(phase_start_date.noon - 1.day) do
           expect(instance.results).to be_empty
@@ -200,7 +200,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being after the stage" do
+    context "when being after the phase" do
       it "returns no project" do
         Timecop.travel(phase_finish_date.noon + 1.day) do
           expect(instance.results).to be_empty
@@ -208,7 +208,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when the stage has no dates" do
+    context "when the phase has no dates" do
       remove_phase_dates
 
       it "returns no project" do
@@ -216,7 +216,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being in the middle of the stage but with the stage being disabled" do
+    context "when being in the middle of the phase but with the phase being disabled" do
       disable_phase
 
       it "returns no project" do
@@ -226,7 +226,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being in the middle of the stage but without permissions" do
+    context "when being in the middle of the phase but without permissions" do
       remove_permissions
 
       it "returns no project" do
@@ -242,31 +242,31 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       instance.where(filter_key, "w", [])
     end
 
-    context "when being in the middle of the stage" do
-      it "returns the project whose stage is currently running" do
+    context "when being in the middle of the phase" do
+      it "returns the project whose phase is currently running" do
         Timecop.travel((phase_start_date + 3.days).noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when the current week overlaps the beginning of the stage" do
-      it "returns the project whose stage begins within the week" do
+    context "when the current week overlaps the beginning of the phase" do
+      it "returns the project whose phase begins within the week" do
         Timecop.travel((phase_start_date - 1.day).noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when the current week overlaps the end of the stage" do
-      it "returns the project whose stage begins within the week" do
+    context "when the current week overlaps the end of the phase" do
+      it "returns the project whose phase begins within the week" do
         Timecop.travel(phase_finish_date.noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when being before the stage" do
+    context "when being before the phase" do
       it "returns no project" do
         Timecop.travel(phase_start_date.noon - 7.days) do
           expect(instance.results).to be_empty
@@ -274,7 +274,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being after the stage" do
+    context "when being after the phase" do
       it "returns no project" do
         Timecop.travel(phase_finish_date.noon + 7.days) do
           expect(instance.results).to be_empty
@@ -282,7 +282,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when the stage has no dates" do
+    context "when the phase has no dates" do
       remove_phase_dates
 
       it "returns no project" do
@@ -292,7 +292,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being in the middle of the stage but with the stage disabled" do
+    context "when being in the middle of the phase but with the phase disabled" do
       disable_phase
 
       it "returns no project" do
@@ -302,7 +302,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being in the middle of the stage but without permissions" do
+    context "when being in the middle of the phase but without permissions" do
       remove_permissions
 
       it "returns no project" do
@@ -312,52 +312,52 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when being on Monday, the stage ends on Sunday and the week is configured to start on Sunday",
+    context "when being on Monday, the phase ends on Sunday and the week is configured to start on Sunday",
             with_settings: { start_of_week: 7 } do
       before do
-        stage.update_column(:finish_date, Date.parse("2025-02-16"))
+        phase.update_column(:finish_date, Date.parse("2025-02-16"))
       end
 
-      it "returns the project whose stage has ended within the current week" do
+      it "returns the project whose phase has ended within the current week" do
         Timecop.travel(Date.parse("2025-02-17").noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when being on Monday, the stage ends on Sunday and the week is configured to start on Monday",
+    context "when being on Monday, the phase ends on Sunday and the week is configured to start on Monday",
             with_settings: { start_of_week: 1 } do
       before do
-        stage.update_column(:finish_date, Date.parse("2025-02-16"))
+        phase.update_column(:finish_date, Date.parse("2025-02-16"))
       end
 
-      it "returns no project as the stage ended in the week before" do
+      it "returns no project as the phase ended in the week before" do
         Timecop.travel(Date.parse("2025-02-17").noon) do
           expect(instance.results).to be_empty
         end
       end
     end
 
-    context "when being on Sunday, the stage ends on Monday and the week is configured to start on Monday",
+    context "when being on Sunday, the phase ends on Monday and the week is configured to start on Monday",
             with_settings: { start_of_week: 1 } do
       before do
-        stage.update_column(:finish_date, Date.parse("2025-02-17"))
+        phase.update_column(:finish_date, Date.parse("2025-02-17"))
       end
 
-      it "returns the project whose stage has ended within the current week" do
+      it "returns the project whose phase has ended within the current week" do
         Timecop.travel(Date.parse("2025-02-23").noon) do
           expect(instance.results).to contain_exactly(project_with_phase)
         end
       end
     end
 
-    context "when being on Sunday, the stage ends on Monday and the week is configured to start on Sunday",
+    context "when being on Sunday, the phase ends on Monday and the week is configured to start on Sunday",
             with_settings: { start_of_week: 7 } do
       before do
-        stage.update_column(:finish_date, Date.parse("2025-02-17"))
+        phase.update_column(:finish_date, Date.parse("2025-02-17"))
       end
 
-      it "returns no project as the stage ended in the week before" do
+      it "returns no project as the phase ended in the week before" do
         Timecop.travel(Date.parse("2025-02-23").noon) do
           expect(instance.results).to be_empty
         end
@@ -367,7 +367,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
     context "when being on Wednesday before the phase, the phase starts on Monday and the week is configured to start on Monday",
             with_settings: { start_of_week: 1 } do
       before do
-        stage.update_column(:start_date, Date.parse("2025-02-03"))
+        phase.update_column(:start_date, Date.parse("2025-02-03"))
       end
 
       it "returns no project as the phase starts in the next week" do
@@ -396,23 +396,23 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       instance.where(filter_key, "<>d", values)
     end
 
-    context "when encompassing the stage completely" do
+    context "when encompassing the phase completely" do
       let(:values) { [(phase_start_date - 1.day).to_s, (phase_finish_date + 1.day).to_s] }
 
-      it "returns the project with the stage" do
+      it "returns the project with the phase" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when encompassing the stage precisely" do
+    context "when encompassing the phase precisely" do
       let(:values) { [phase_start_date.to_s, phase_finish_date.to_s] }
 
-      it "returns the project with the stage" do
+      it "returns the project with the phase" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when the values overlap the stage's start date but not the end date" do
+    context "when the values overlap the phase's start date but not the end date" do
       let(:values) { [(phase_start_date - 1.day).to_s, (phase_finish_date - 1.day).to_s] }
 
       it "returns no project" do
@@ -420,7 +420,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when the values overlap the stage's end date but not the start date" do
+    context "when the values overlap the phase's end date but not the start date" do
       let(:values) { [(phase_start_date + 1.day).to_s, phase_finish_date.to_s] }
 
       it "returns no project" do
@@ -428,7 +428,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when the values are between the start and the end date of the stage" do
+    context "when the values are between the start and the end date of the phase" do
       let(:values) { [(phase_start_date + 1.day).to_s, (phase_finish_date - 1.day).to_s] }
 
       it "returns no project" do
@@ -436,23 +436,23 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when only the lower value is provided and that one is before the stage's start date" do
+    context "when only the lower value is provided and that one is before the phase's start date" do
       let(:values) { [(phase_start_date - 1.day).to_s, ""] }
 
-      it "returns the project with the stage" do
+      it "returns the project with the phase" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when only the lower value is provided and that one is on the stage's start date" do
+    context "when only the lower value is provided and that one is on the phase's start date" do
       let(:values) { [phase_start_date.to_s, ""] }
 
-      it "returns the project with the stage" do
+      it "returns the project with the phase" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when only the lower value is provided and that one after the stage's start date" do
+    context "when only the lower value is provided and that one after the phase's start date" do
       let(:values) { [(phase_start_date + 1.day).to_s, ""] }
 
       it "returns no project" do
@@ -460,15 +460,15 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when only the upper value is provided and that one is after the stage's end date" do
+    context "when only the upper value is provided and that one is after the phase's end date" do
       let(:values) { ["", (phase_finish_date + 1.day).to_s] }
 
-      it "returns the project with the stage" do
+      it "returns the project with the phase" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when the stage has no dates" do
+    context "when the phase has no dates" do
       let(:values) { [(phase_start_date - 1.day).to_s, (phase_finish_date + 1.day).to_s] }
 
       remove_phase_dates
@@ -486,7 +486,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when encompassing the stage completely but with the stage disabled" do
+    context "when encompassing the phase completely but with the phase disabled" do
       let(:values) { [(phase_start_date - 1.day).to_s, (phase_finish_date + 1.day).to_s] }
 
       disable_phase
@@ -496,7 +496,7 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
       end
     end
 
-    context "when encompassing the stage completely but without permissions" do
+    context "when encompassing the phase completely but without permissions" do
       let(:values) { [(phase_start_date - 1.day).to_s, (phase_finish_date + 1.day).to_s] }
 
       remove_permissions
@@ -515,18 +515,18 @@ RSpec.describe ProjectQuery, "results of a project phase filter" do
     context "when the phase is active but has no dates" do
       remove_phase_dates
 
-      it "returns the project with the stage" do
+      it "returns the project with the phase" do
         expect(instance.results).to contain_exactly(project_with_phase)
       end
     end
 
-    context "when the stage is active and has dates" do
+    context "when the phase is active and has dates" do
       it "returns no project" do
         expect(instance.results).to be_empty
       end
     end
 
-    context "when the stage is inactive and has no dates" do
+    context "when the phase is inactive and has no dates" do
       remove_phase_dates
       disable_phase
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63109

# What are you trying to accomplish?

Exclude the first day of the next week when filtering for the current week on any phase/gate filter. 

Additionally, renamed usages of stage to phase in specs.

# Merge checklist

- [x] Added/updated tests