### PR TITLE
Add foreign key for service_account_associations

### DIFF
--- a/db/migrate/20250612133700_service_account_association_foreign_keys.rb
+++ b/db/migrate/20250612133700_service_account_association_foreign_keys.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ServiceAccountAssociationForeignKeys < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :service_account_associations, :users, column: :service_account_id, on_delete: :cascade
+  end
+end


### PR DESCRIPTION
Ensuring database consistency between associations and users.

We can't do the same in the services direction, because services are a polymorphic association and thus can point to different tables.

# Ticket
https://community.openproject.org/wp/63012