### PR TITLE
Allow checking `starts_at` date for a token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,7 +201,7 @@ gem "aws-sdk-core", "~> 3.107"
 # File upload via fog + screenshots on travis
 gem "aws-sdk-s3", "~> 1.91"
 
-gem "openproject-token", "~> 7.1.0"
+gem "openproject-token", "~> 7.2.0"
 
 gem "plaintext", "~> 0.3.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (3.2.1)
+    bigdecimal (3.2.2)
     bindata (2.5.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
@@ -861,7 +861,7 @@ GEM
       activesupport (>= 7.1.0)
       openproject-octicons (>= 19.25.0)
       view_component (>= 3.1, < 4.0)
-    openproject-token (7.1.0)
+    openproject-token (7.2.1)
       activemodel
     openssl (3.3.0)
     openssl-signature_algorithm (1.3.0)
@@ -1450,7 +1450,7 @@ DEPENDENCIES
   openproject-reporting!
   openproject-storages!
   openproject-team_planner!
-  openproject-token (~> 7.1.0)
+  openproject-token (~> 7.2.0)
   openproject-two_factor_authentication!
   openproject-webhooks!
   openproject-xls_export!
@@ -1591,7 +1591,7 @@ CHECKSUMS
   bcrypt (3.1.20) sha256=8410f8c7b3ed54a3c00cd2456bf13917d695117f033218e2483b2e40b0784099
   benchmark (0.4.1) sha256=d4ef40037bba27f03b28013e219b950b82bace296549ec15a78016552f8d2cce
   better_html (2.1.1) sha256=046c3551d1488a3f2939a7cac6fabf2bde08c32e135c91fcd683380118e5af55
-  bigdecimal (3.2.1) sha256=1f68631e876c6aba8fe9b84b36983c55ad3293ff2d1ad4c6f115bde1e9d802e3
+  bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
   bootsnap (1.18.6) sha256=0ae2393c1e911e38be0f24e9173e7be570c3650128251bf06240046f84a07d00
   brakeman (7.0.2) sha256=b602d91bcec6c5ce4d4bc9e081e01f621c304b7a69f227d1e58784135f333786
@@ -1822,7 +1822,7 @@ CHECKSUMS
   openproject-reporting (1.0.0)
   openproject-storages (1.0.0)
   openproject-team_planner (1.0.0)
-  openproject-token (7.1.0) sha256=8208c9dbbf23eedd0a67e78f1b46402dffe375e26512bafa01da91e2d2354b16
+  openproject-token (7.2.1) sha256=fa1dcabfd85958d42b8f9c86dac7eb369c253403c4d208844d62be3e57b130ae
   openproject-two_factor_authentication (1.0.0)
   openproject-webhooks (1.0.0)
   openproject-xls_export (1.0.0)

--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -151,7 +151,9 @@ class EnterpriseToken < ApplicationRecord
            :plan,
            :features,
            :version,
+           :started?,
            :trial?,
+           :active?,
            to: :token_object
 
   def token_object

--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -96,13 +96,13 @@ class EnterpriseToken < ApplicationRecord
     end
 
     def set_active_tokens
-      # although we use the `active` scope here, we still need to filter out expired tokens
+      # although we use the `active` scope here, we still need to filter out non-active tokens
       # as not all token validity period is extracted into the DB
       EnterpriseToken
         .active
         .order(Arel.sql("created_at DESC"))
         .to_a
-        .reject(&:expired?)
+        .select { it.active? && !it.invalid_domain? }
     end
 
     def clear_current_tokens_cache

--- a/spec/models/enterprise_token_spec.rb
+++ b/spec/models/enterprise_token_spec.rb
@@ -309,6 +309,14 @@ RSpec.describe EnterpriseToken do
       end
     end
 
+    context "with a token that has not started yet" do
+      let!(:future_token) { create_enterprise_token("a_future_token", starts_at: 1.month.from_now) }
+
+      it "does not return the future token" do
+        expect(described_class.active_tokens).to be_empty
+      end
+    end
+
     context "with an active token" do
       let!(:active_token) { create_enterprise_token("an_active_token", expires_at: 1.year.from_now) }
 

--- a/spec/models/enterprise_token_spec.rb
+++ b/spec/models/enterprise_token_spec.rb
@@ -334,6 +334,18 @@ RSpec.describe EnterpriseToken do
         expect(described_class.active_tokens).to be_empty
       end
     end
+
+    context "when the user messed with the database to 'extend' their validity" do
+      let!(:expired_token) { create_enterprise_token("an_active_token", expires_at: 1.day.ago) }
+
+      before do
+        expired_token.update(valid_until: 1.year.from_now)
+      end
+
+      it "returns an empty array" do
+        expect(described_class.active_tokens).to be_empty
+      end
+    end
   end
 
   describe ".active" do

--- a/spec/support/enterprise_token_factory.rb
+++ b/spec/support/enterprise_token_factory.rb
@@ -88,6 +88,7 @@ module EnterpriseTokenFactory
 
   def mock_token_object(encoded_token_name, **attributes)
     token = OpenProject::Token.new(domain: Setting.host_name,
+                                   starts_at: Date.yesterday,
                                    expires_at: 1.year.from_now,
                                    **attributes)
     allow(OpenProject::Token)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/64650/activity

# What are you trying to accomplish?
- Use the current version of `openproject-token` so that we get a method to check the `starts_at` date
- Add a test for the case @cbliard mentioned, that we also test that the user did not mess with the data in the database

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
