### PR TITLE
[62199] The 'overdue' date colour does not adapt well to dark mode

### DIFF
--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -20,5 +20,5 @@
 .__hl_border_top { border-top: 4px solid hsl(var(--color-h), calc(var(--color-s) * 1%), calc((var(--color-l) - 15) * 1%)) !important; }
 
 <%# Overdue tasks %>
-.__hl_date_due_today { color: #F76707 !important; }
-.__hl_date_overdue { color: #C92A2A !important; font-weight: var(--base-text-weight-bold); }
+.__hl_date_due_today { color: var(--fgColor-severe) !important; }
+.__hl_date_overdue { color: var(--fgColor-danger) !important; font-weight: var(--base-text-weight-bold); }

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.sass
@@ -2,7 +2,7 @@
   color: var(--fgColor-muted)
 
   &_overdue
-    color: var(--warn)
+    color: var(--fgColor-danger)
 
   &--property
     font-weight: var(--base-text-weight-bold)

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -177,7 +177,7 @@
       opacity: 1
 
   &--inline-cancel-button
-    color: var(--warn)
+    color: var(--fgColor-danger)
 
   @media only screen and (max-width: $breakpoint-sm)
     &_shrink

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -151,13 +151,13 @@ th.hidden
 
 tr.context-menu-selection,
 tr.-checked
-  background-color: var(--codeMirror-selection-bgColor) !important
+  background-color: var(--bgColor-accent-muted) !important
   &[class*=__hl_background]
-    outline: var(--table-row-highlighting-outline-color) solid 2px
+    outline: var(--bgColor-accent-emphasis) solid 2px
 
   td
-    border-top: 1px solid var(--codeMirror-selection-bgColor) !important
-    border-bottom: 1px solid var(--codeMirror-selection-bgColor) !important
+    border-top: 1px solid var(--bgColor-accent-emphasis) !important
+    border-bottom: 1px solid var(--bgColor-accent-emphasis) !important
     color: var(--body-font-color) !important
     a
       color: var(--body-font-color) !important

--- a/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
@@ -100,7 +100,7 @@
   border-bottom: none
 
 .-duration-overflow
-  border-color: var(--warn)
+  border-color: var(--fgColor-danger)
 
 .children-duration-hover-container
   display: none
@@ -120,5 +120,3 @@
 
   .labelRight:not(.not-empty), .labelFarRight, .labelLeft
     display: none !important
-
-

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -107,7 +107,6 @@
   --drop-down-hover-bg-color: #EFEFEF;
   --wiki-default-font-size: var(--body-font-size);
   --user-avatar-border-radius: 50%;
-  --table-row-highlighting-outline-color: #00A6FF;
   --button--font-color: #222222;
   --button--background-color: var(--gray-light);
   --button--background-hover-color: #ededed;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62199

# What are you trying to accomplish?
Use Primer variables 

## Screenshots


<img width="1904" alt="Bildschirmfoto 2025-06-12 um 12 16 12" src="https://github.com/user-attachments/assets/3c44e76d-2ed8-42a8-8e74-e7b8b2905e11" />

⚠️ To be merged with https://github.com/opf/saas-openproject/pull/226 ⚠️ 