### PR TITLE
Reintroduce default value for all enumerations except TE activity

### DIFF
--- a/app/components/admin/enumerations/item_component.html.erb
+++ b/app/components/admin/enumerations/item_component.html.erb
@@ -20,13 +20,19 @@
 
         unless enumeration.active?
           enumeration_info.with_column(mr: 2) do
-            render(Primer::Beta::Text.new(color: :subtle)) { t(:label_inactive) }
+            render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) { t(:label_inactive) }
+          end
+        end
+
+        if enumeration.is_default?
+          enumeration_info.with_column(mr: 2) do
+            render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) { t(:label_default) }
           end
         end
       end
 
       enumeration_container.with_column do
-        render(Primer::Alpha::ActionMenu.new(test_selector: "op-time-entry-acrtivity--action-menu")) do |menu|
+        render(Primer::Alpha::ActionMenu.new(test_selector: "op-enumeration--action-menu")) do |menu|
           menu.with_show_button(
             icon: "kebab-horizontal",
             scheme: :invisible,

--- a/app/components/admin/enumerations/item_form.rb
+++ b/app/components/admin/enumerations/item_form.rb
@@ -55,6 +55,14 @@ module Admin
           label: object.class.human_attribute_name(:active)
         )
 
+        if object.class.can_have_default_value?
+          form.check_box(
+            name: :is_default,
+            label: I18n.t(:label_default),
+            caption: I18n.t(:"priorities.admin.default.caption")
+          )
+        end
+
         form.submit(
           name: :submit,
           label: I18n.t(:button_save),

--- a/app/models/issue_priority.rb
+++ b/app/models/issue_priority.rb
@@ -37,7 +37,7 @@ class IssuePriority < Enumeration
   end
 
   def color_label
-    I18n.t("prioritiies.edit.priority_color_text")
+    I18n.t("priorities.edit.priority_color_text")
   end
 
   def option_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -610,11 +610,14 @@ en:
         the data of another deleted account.
       irreversible: "This action is irreversible"
       confirmation: "Enter the placeholder user name %{name} to confirm the deletion."
-  prioritiies:
+  priorities:
     edit:
       priority_color_text: |
         Click to assign or change the color of this priority.
         It can be used for highlighting work packages in the table.
+    admin:
+      default:
+        caption: Making this priority default will override the previous default priority.
 
   reactions:
     action_title: "React"

--- a/spec/features/admin/settings/work_package_priorities_spec.rb
+++ b/spec/features/admin/settings/work_package_priorities_spec.rb
@@ -31,23 +31,47 @@
 require "spec_helper"
 
 RSpec.describe "Work package priorities", :js do
-  shared_let(:admin) { create(:admin) }
+  include Flash::Expectations
 
-  before do
-    login_as(admin)
+  current_user { create(:admin) }
+  let!(:default_priority) { create(:issue_priority, is_default: true, name: "Normal") }
+
+  def within_enumeration_item(priority, &)
+    page.within("#admin-enumerations-item-component-#{priority.id}", &)
   end
 
-  it "allows creating new priorities" do
+  it "can be managed (created, updated, deleted)" do
     visit admin_settings_work_package_priorities_path
+
+    within_enumeration_item(default_priority) do
+      expect(page).to have_content("Normal")
+      expect(page).to have_content("Default")
+    end
 
     page.find_test_selector("add-enumeration-button").click
 
     fill_in "Name", with: "Immediate"
+    check "Default"
     click_on("Save")
+
+    expect_and_dismiss_flash(message: "Successful update.")
 
     # we are redirected back to the index page
     expect(page).to have_current_path(admin_settings_work_package_priorities_path)
-    expect(page).to have_content("Immediate")
+
+    new_priority = IssuePriority.last
+
+    # The new priority is shown in the list as the default priority
+    within_enumeration_item(new_priority) do
+      expect(page).to have_content("Immediate")
+      expect(page).to have_content("Default")
+    end
+
+    # Since the new priority is now the default, the former default looses that flag
+    within_enumeration_item(default_priority) do
+      expect(page).to have_content("Normal")
+      expect(page).to have_no_content("Default")
+    end
 
     # It allows editing (Regression #62459)
     click_link "Immediate"
@@ -55,10 +79,30 @@ RSpec.describe "Work package priorities", :js do
     fill_in "Name", with: "Urgent"
     click_on("Save")
 
-    expect(page).to have_current_path(admin_settings_work_package_priorities_path)
-    expect(page).to have_content("Urgent")
+    expect_and_dismiss_flash(message: "Successful update.")
+
+    within_enumeration_item(new_priority) do
+      expect(page).to have_content("Urgent")
+      expect(page).to have_content("Default")
+    end
 
     expect(IssuePriority).to exist(name: "Urgent")
     expect(IssuePriority).not_to exist(name: "Immediate")
+
+    # It allows deleting priorities
+    within_enumeration_item(new_priority) do
+      find(test_selector("op-enumeration--action-menu")).click
+      click_button("Delete")
+    end
+
+    expect_and_dismiss_flash(message: "Successful deletion.")
+
+    expect(page).to have_no_content("Urgent")
+
+    # Since the old default is deleted another is now the default.
+    within_enumeration_item(default_priority) do
+      expect(page).to have_content("Normal")
+      expect(page).to have_no_content("Default")
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64369

# What are you trying to accomplish?

All enumerations except for the time entry activities should offer the possibility to single one out as a default value.

# Merge checklist

- [x] Added/updated tests
