### PR TITLE
[64711] Look up already seeded colors by hexcode in seeders

### DIFF
--- a/app/seeders/basic_data/color_seeder.rb
+++ b/app/seeders/basic_data/color_seeder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,7 +31,7 @@ module BasicData
   class ColorSeeder < ModelSeeder
     self.model_class = Color
     self.seed_data_model_key = "colors"
-    self.attribute_names_for_lookups = %i[name]
+    self.attribute_names_for_lookups = %i[hexcode]
 
     def model_attributes(color_data)
       {

--- a/app/seeders/basic_data/model_seeder.rb
+++ b/app/seeders/basic_data/model_seeder.rb
@@ -80,6 +80,8 @@ module BasicData
         if model = model_class.find_by(lookup_attributes)
           seed_data.store_reference(model_data["reference"], model)
         end
+      rescue ArgumentError
+        # ignore when lookups can not be done because of missing references
       end
     end
 

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -126,14 +128,16 @@ RSpec.describe RootSeeder,
 
     include_examples "no email deliveries"
 
-    context "when run a second time" do
+    context "when run a second time in a different language", :settings_reset do
       before_all do
-        with_edition("bim") do
-          described_class.new.seed_data!
+        with_locale_env("de") do
+          with_edition("bim") do
+            described_class.new.seed_data!
+          end
         end
       end
 
-      it "does not create additional data" do
+      it "does not create additional data and does not raise any errors" do
         expect(Project.count).to eq 4
         expect(WorkPackage.count).to eq 76
         expect(Wiki.count).to eq 3
@@ -198,13 +202,10 @@ RSpec.describe RootSeeder,
     shared_let(:root_seeder) { described_class.new }
 
     before_all do
-      with_env("OPENPROJECT_DEFAULT__LANGUAGE" => "de") do
-        reset(:default_language) # Settings are a pain to reset
+      with_locale_env("de", env_var_name: "OPENPROJECT_DEFAULT__LANGUAGE") do
         with_edition("bim") do
           root_seeder.seed_data!
         end
-      ensure
-        reset(:default_language)
       end
     end
 

--- a/spec/support/root_seeder_test_helpers.rb
+++ b/spec/support/root_seeder_test_helpers.rb
@@ -35,4 +35,15 @@ module RootSeederTestHelpers
       yield
     end
   end
+
+  # The example needs to have the :settings_reset metadata to have
+  # `reset(:default_language)` working.
+  def with_locale_env(locale, env_var_name: "OPENPROJECT_SEED_LOCALE", &)
+    with_env(env_var_name => locale) do
+      reset(:default_language) # Settings are a pain to reset
+      yield
+    ensure
+      reset(:default_language)
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64711

# What are you trying to accomplish?

Avoid error when seeding a second time with a language different from the one used at the original seeding.

## Screenshots


# What approach did you choose and why?

When seeding a second time in a different language, it was failing with the error "ArgumentError: Nothing registered with reference :default_color_blue (ArgumentError)".

Here is why: the type seeder, as some types are already in the database, will try to look up existing types by their name attribute to store their reference in the seeder registry. To get the name attribute, it computes all types attributes, so it also computes the `color_id` attribute.

To compute the `color_id` attribute, it will try to look up the color by its reference name in the seeder registry. As it's not there, it fails.

So now, why is it not there? It's because the colors are already seeded, so it tries to look up existing ones to store them in the registry. To find them, it looks them up by their name attribute. But that name is different if current language is not the one used when the initial seeding was done. As the lookup returns nothing, it does not store the color in the registry. That's why looking the color up later fails.

The fix is to look up the colors by their hexcode instead of their name.

And if the colors hexcode has been changed, or if the colors were deleted, it would fail too. The fix in this case is to catch the lookup error and ignore it. It's not seeding, it's only looking up existing records so it's safe to ignore the error.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
