### PR TITLE
Bug/63839 activerecord recordnotunique in post api v3 timeentries timeentriesapi time entries

### DIFF
--- a/frontend/src/app/shared/components/time_entries/create/create.service.ts
+++ b/frontend/src/app/shared/components/time_entries/create/create.service.ts
@@ -5,22 +5,16 @@ import {
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import {
-  map,
-  take,
-} from 'rxjs/operators';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { Moment } from 'moment';
-import { TimeEntryCreateModalComponent } from 'core-app/shared/components/time_entries/create/create.modal';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
-import { TimeEntryModalOptions } from 'core-app/shared/components/time_entries/edit/edit.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 @Injectable()
 export class TimeEntryCreateService {
@@ -35,59 +29,24 @@ export class TimeEntryCreateService {
   ) {
   }
 
-  public create(
-    date:Moment,
-    wp?:WorkPackageResource,
-    options:TimeEntryModalOptions = {},
-  ):Promise<{ entry:TimeEntryResource, action:'create' }> {
-    return new Promise<{ entry:TimeEntryResource, action:'create' }>((resolve, reject) => {
-      void this
-        .createNewTimeEntry(date, wp)
-        .subscribe((changeset) => {
-          this.opModalService.show(
-            TimeEntryCreateModalComponent,
-            this.injector,
-            { ...options, changeset },
-          ).subscribe((modal) => {
-            modal
-              .closingEvent
-              .pipe(take(1))
-              .subscribe(() => {
-                if (modal.createdEntry) {
-                  resolve({ entry: modal.createdEntry, action: 'create' });
-                } else {
-                  reject();
-                }
-              });
-          });
-        });
-    });
-  }
-
-  public createNewTimeEntry(date:Moment, wp?:WorkPackageResource, ongoing = false):Observable<ResourceChangeset> {
-    const payload:any = {
-      spentOn: date.format('YYYY-MM-DD'),
-      hours: null,
-      ongoing,
-    };
-
-    if (wp) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      payload._links = {
-        workPackage: {
-          href: wp.href,
+  public createNewTimeEntry(date:Moment, wp:WorkPackageResource, ongoing:boolean):Observable<ResourceChangeset> {
+    const resource:FormResource = this.halResource.createHalResourceOfType(
+      'Form',
+      {
+        payload: {
+          spentOn: date.format('YYYY-MM-DD'),
+          hours: null,
+          ongoing,
+          _links: {
+            workPackage: {
+              href: wp.href,
+            },
+          },
         },
-      };
-    }
+      },
+    );
 
-    return this
-      .apiV3Service
-      .time_entries
-      .form
-      .post(payload)
-      .pipe(
-        map((form) => this.fromCreateForm(form)),
-      );
+    return of(this.fromCreateForm(resource));
   }
 
   public fromCreateForm(form:FormResource):ResourceChangeset {
@@ -109,9 +68,6 @@ export class TimeEntryCreateService {
     entry.id = 'new';
     entry.hours = 'PT1H';
 
-    // Set update link to form
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,no-multi-assign
-    entry.update = entry.$links.update = form.$links.self;
     // Use POST /work_packages for saving link
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,no-multi-assign
     entry.updateImmediately = entry.$links.updateImmediately = (payload:Record<string, unknown>) => this
@@ -121,10 +77,6 @@ export class TimeEntryCreateService {
       .toPromise();
 
     entry.state.putValue(entry);
-    // We need to provide the schema to the cache so that it is available in the html form to e.g. determine
-    // the editability.
-    // It would be better if the edit field could simply rely on the changeset if it exists.
-    this.schemaCache.update(entry, form.schema);
 
     return entry;
   }

--- a/modules/costs/app/contracts/time_entries/base_contract.rb
+++ b/modules/costs/app/contracts/time_entries/base_contract.rb
@@ -60,6 +60,7 @@ module TimeEntries
     end
     attribute :ongoing do
       validate_self_timer
+      validate_no_other_ongoing
     end
     attribute :hours
     attribute :comments
@@ -133,6 +134,13 @@ module TimeEntries
 
     def validate_self_timer
       errors.add :ongoing, :not_current_user if model.ongoing? && model.user != user
+    end
+
+    def validate_no_other_ongoing
+      if model.ongoing? && model.ongoing_changed? && TimeEntry.ongoing_for_user_other_than(model.user, model).any?
+        errors.add :base,
+                   :duplicate_ongoing
+      end
     end
   end
 end

--- a/modules/costs/app/models/time_entries/scopes/ongoing_for_user_other_than.rb
+++ b/modules/costs/app/models/time_entries/scopes/ongoing_for_user_other_than.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module TimeEntries::Scopes
+  module OngoingForUserOtherThan
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def ongoing_for_user_other_than(user, time_entry)
+        ongoing.where(user:).where.not(id: time_entry.id)
+      end
+    end
+  end
+end

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -84,7 +84,8 @@ class TimeEntry < ApplicationRecord
   include Entry::SplashedDates
 
   scopes :of_user_and_day,
-         :ongoing
+         :ongoing,
+         :ongoing_for_user_other_than
 
   # TODO: move into service
   before_save :update_costs

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
         time_entry:
           invalid_time: "must be between 00:00 and 23:59."
           cannot_log_for_this_work_package: "Cannot log time for this work package."
+          duplicate_ongoing: "An ongoing time entry already exists for this user."
         work_package:
           is_not_a_valid_target_for_cost_entries: "Work package #%{id} is not a valid target for reassigning the cost entries."
           nullify_is_not_valid_for_cost_entries: "Cost entries can not be assigned to a project."

--- a/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe TimeEntries::CreateContract do
         t.changed_by_system(changed_by_system) if changed_by_system
       end
     end
-    let(:time_entry_ongoing) { false }
     let(:permissions) { %i(log_time) }
     let(:other_user) { build_stubbed(:user) }
     let(:changed_by_system) do

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -50,6 +50,7 @@ RSpec.shared_examples_for "time entry contract" do
   let(:time_entry_spent_on) { Time.zone.today }
   let(:time_entry_hours) { 5 }
   let(:time_entry_comments) { "A comment" }
+  let(:time_entry_ongoing) { false }
   let(:work_package_visible) { true }
   let(:user_visible) { true }
   let(:time_entry_day_sum) { 5 }
@@ -221,6 +222,21 @@ RSpec.shared_examples_for "time entry contract" do
 
     it "is valid" do
       expect_valid(true)
+    end
+  end
+
+  context "when ongoing and another ongoing time entry already exists for the current user" do
+    let(:time_entry_ongoing) { true }
+
+    before do
+      allow(TimeEntry)
+        .to receive(:ongoing_for_user_other_than)
+              .with(time_entry_user, time_entry)
+              .and_return([build_stubbed(:time_entry, user: time_entry_user, ongoing: true)])
+    end
+
+    it "is invalid" do
+      expect_valid(false, base: %i(duplicate_ongoing))
     end
   end
 

--- a/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe TimeEntries::UpdateContract do
                     activity: time_entry_activity,
                     spent_on: time_entry_spent_on,
                     hours: time_entry_hours,
-                    comments: time_entry_comments)
+                    comments: time_entry_comments) do |te|
+        te.ongoing = time_entry_ongoing
+      end
     end
     subject(:contract) { described_class.new(time_entry, current_user) }
 

--- a/modules/costs/spec/models/time_entries/scopes/ongoing_for_user_other_than_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/ongoing_for_user_other_than_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe TimeEntries::Scopes::OngoingForUserOtherThan do
+  shared_let(:user_with_ongoing) { create(:user) }
+  shared_let(:user_without_ongoing) { create(:user) }
+  shared_let(:ongoing_time_entry) { create(:time_entry, user: user_with_ongoing, ongoing: true) }
+  shared_let(:not_ongoing_time_entry) { create(:time_entry, user: user_without_ongoing, ongoing: false) }
+
+  describe ".ongoing_for_user_other_than" do
+    context "for a user with an ongoing time entry - for another time entry" do
+      let(:other_time_entry_of_user) { create(:time_entry, user: user_with_ongoing, ongoing: false) }
+
+      it "returns the ongoing time entry" do
+        expect(TimeEntry.ongoing_for_user_other_than(user_with_ongoing, other_time_entry_of_user))
+          .to contain_exactly(ongoing_time_entry)
+      end
+    end
+
+    context "for a user with an ongoing time entry - for that ongoing time entry" do
+      it "returns nothing" do
+        expect(TimeEntry.ongoing_for_user_other_than(user_with_ongoing, ongoing_time_entry))
+          .to be_empty
+      end
+    end
+
+    context "for a user with an ongoing time entry - for a new ongoing time entry" do
+      it "returns the ongoing time entry" do
+        expect(TimeEntry.ongoing_for_user_other_than(user_with_ongoing, TimeEntry.new(user: user_with_ongoing, ongoing: true)))
+          .to contain_exactly(ongoing_time_entry)
+      end
+    end
+
+    context "for a user without an ongoing time entry - for another time entry" do
+      let(:other_time_entry_of_user) { create(:time_entry, user: user_without_ongoing, ongoing: false) }
+
+      it "returns nothing" do
+        expect(TimeEntry.ongoing_for_user_other_than(user_without_ongoing, other_time_entry_of_user))
+          .to be_empty
+      end
+    end
+
+    context "for a user without an ongoing time entry - for a new ongoing time entry" do
+      it "returns nothing" do
+        expect(TimeEntry.ongoing_for_user_other_than(user_without_ongoing, TimeEntry.new(user: user_with_ongoing, ongoing: true)))
+          .to be_empty
+      end
+    end
+  end
+end

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -565,6 +565,27 @@ RSpec.describe "API v3 time_entry resource" do
           .at_path("message")
       end
     end
+
+    context "when starting an ongoing time entry with an ongoing timer already running" do
+      let(:additional_setup) { -> { existing_ongoing_time_entry } }
+
+      let(:existing_ongoing_time_entry) do
+        create(:time_entry, ongoing: true, project:, work_package:, user: current_user)
+      end
+
+      let(:params) do
+        super().merge({ ongoing: true })
+      end
+
+      it "returns 422 and remarks that another time entry is ongoing" do
+        expect(subject.status)
+          .to be(422)
+
+        expect(subject.body)
+          .to be_json_eql("An ongoing time entry already exists for this user.".to_json)
+                .at_path("message")
+      end
+    end
   end
 
   describe "PATCH api/v3/time_entries/:id" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63839

# What are you trying to accomplish?

1) Avoid PG unique index violation errors when creating another ongoing time entry for a user already having one by validating that in the contract.
2) Since race conditions might bypass the validation, catch the error if it happens in the service and provide an error response
3) Streamline clicking on the "Track time button" of a work package. The form is no longer needed so bypassing it leads to a snappier experience.

# Merge checklist

- [x] Added/updated tests
