### PR TITLE
Fixed Postgres Upgrade Instructions for Rocky Linux

### DIFF
--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -109,7 +109,7 @@ For Debian/Ubuntu:
 
 ```shell
 sudo su - postgres -c "cp /etc/postgresql/{13,17}/main/conf.d/custom.conf"
-sudo su - postgres -c "sed -i 's|45432|45433|' /etc/postgresql/17/main/conf.d/custom.conf"
+sudo su - postgres -c "sed -i 's|45432|45433|' /etc/postgresql/13/main/conf.d/custom.conf"
 sudo su - postgres -c "cp /etc/postgresql/13/main/pg_hba.conf /etc/postgresql/17/main/pg_hba.conf"
 sudo su - postgres -c "/usr/lib/postgresql/17/bin/pg_ctl start --wait --pgdata=/var/lib/postgresql/17/main -o '-c config_file=/etc/postgresql/17/main/postgresql.conf'"
 ```

--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -157,7 +157,7 @@ For RedHat/CentOS:
 
 ```shell
 sudo rm -rf /var/lib/pgsql/13/data
-sudo yum remove pgsql13
+sudo yum remove postgresql13
 ```
 
 ## Compose-based docker installation

--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -124,6 +124,7 @@ sudo su - postgres -c "vi /var/lib/pgsql/17/data/postgresql.conf"
 include_dir = 'conf.d'
 
 sudo su - postgres -c "cp -p /var/lib/pgsql/13/data/conf.d/custom.conf /var/lib/pgsql/17/data/conf.d/custom.conf"
+sudo su - postgres -c "sed -i 's|45432|45433|' /var/lib/pgsql/13/data/conf.d/custom.conf"
 sudo su - postgres -c "/usr/pgsql-17/bin/pg_ctl start --wait --pgdata=/var/lib/pgsql/17/data -o '-c config_file=/var/lib/pgsql/17/data/postgresql.conf'"
 
 # Getting the password for the PostgreSQL database from the configuration

--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -53,7 +53,7 @@ sudo pg_createcluster 17 main --start
 For RedHat/CentOS:
 
 ```shell
-sudo yum install pgsql17
+sudo yum install postgresql17 postgresql17-contrib
 sudo /usr/bin/postgresql-17-setup initdb
 ```
 
@@ -109,7 +109,7 @@ For Debian/Ubuntu:
 
 ```shell
 sudo su - postgres -c "cp /etc/postgresql/{13,17}/main/conf.d/custom.conf"
-sudo su - postgres -c "sed -i 's|45432|45433|' /etc/postgresql/13/main/conf.d/custom.conf"
+sudo su - postgres -c "sed -i 's|45432|45433|' /etc/postgresql/73/main/conf.d/custom.conf"
 sudo su - postgres -c "cp /etc/postgresql/13/main/pg_hba.conf /etc/postgresql/17/main/pg_hba.conf"
 sudo su - postgres -c "/usr/lib/postgresql/17/bin/pg_ctl start --wait --pgdata=/var/lib/postgresql/17/main -o '-c config_file=/etc/postgresql/17/main/postgresql.conf'"
 ```
@@ -124,8 +124,7 @@ sudo su - postgres -c "vi /var/lib/pgsql/17/data/postgresql.conf"
 include_dir = 'conf.d'
 
 sudo su - postgres -c "cp -p /var/lib/pgsql/13/data/conf.d/custom.conf /var/lib/pgsql/17/data/conf.d/custom.conf"
-sudo su - postgres -c "sed -i 's|45432|45433|' /var/lib/pgsql/13/data/conf.d/custom.conf"
-sudo su - postgres -c "/usr/pgsql-17/bin/pg_ctl start --wait --pgdata=/var/lib/pgsql/17/data -o '-c config_file=/etc/postgresql/17/main/postgresql.conf'"
+sudo su - postgres -c "/usr/pgsql-17/bin/pg_ctl start --wait --pgdata=/var/lib/pgsql/17/data -o '-c config_file=/var/lib/pgsql/17/data/postgresql.conf'"
 
 # Getting the password for the PostgreSQL database from the configuration
 sudo openproject config:get DATABASE_URL

--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -109,7 +109,7 @@ For Debian/Ubuntu:
 
 ```shell
 sudo su - postgres -c "cp /etc/postgresql/{13,17}/main/conf.d/custom.conf"
-sudo su - postgres -c "sed -i 's|45432|45433|' /etc/postgresql/73/main/conf.d/custom.conf"
+sudo su - postgres -c "sed -i 's|45432|45433|' /etc/postgresql/17/main/conf.d/custom.conf"
 sudo su - postgres -c "cp /etc/postgresql/13/main/pg_hba.conf /etc/postgresql/17/main/pg_hba.conf"
 sudo su - postgres -c "/usr/lib/postgresql/17/bin/pg_ctl start --wait --pgdata=/var/lib/postgresql/17/main -o '-c config_file=/etc/postgresql/17/main/postgresql.conf'"
 ```


### PR DESCRIPTION
# What are you trying to accomplish?
I tried upgrading my postgres version on a rocky 9 Linux, it did not work, so i looked into it and fixed the install instructions. See changelog


# Merge checklist
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)

