### PR TITLE
[#64532] The following phase's finish date is inconsistent with the s…

### DIFF
--- a/app/models/project/phase.rb
+++ b/app/models/project/phase.rb
@@ -61,7 +61,7 @@ class Project::Phase < ApplicationRecord
     end
   end
 
-  def any_dates_set?
+  def any_date_set?
     start_date? || finish_date?
   end
 

--- a/app/models/project/phase.rb
+++ b/app/models/project/phase.rb
@@ -61,6 +61,10 @@ class Project::Phase < ApplicationRecord
     end
   end
 
+  def any_dates_set?
+    start_date? || finish_date?
+  end
+
   def date_range_set?
     start_date? && finish_date?
   end

--- a/app/services/project_phases/activation_service.rb
+++ b/app/services/project_phases/activation_service.rb
@@ -85,17 +85,23 @@ module ProjectPhases
 
       if preceding_phase
         preceding_phase
-      elsif phase.date_range_set?
+      elsif phase.any_dates_set?
         phase
       end
     end
 
     def preceding_active_phase(phase)
-      project.available_phases.reverse.find { it.date_range_set? && it.position < phase.position }
+      project.available_phases.reverse.find { it.any_dates_set? && it.position < phase.position }
     end
 
     def initial_reschedule_date(phase)
-      phase.active? ? phase.finish_date + 1 : phase.start_date
+      if phase.date_range_set?
+        phase.active? ? phase.finish_date + 1 : phase.start_date
+      else
+        from = phase.start_date || phase.finish_date
+        from += 1 if phase.active?
+        from
+      end
     end
 
     def default_contract_class

--- a/app/services/project_phases/activation_service.rb
+++ b/app/services/project_phases/activation_service.rb
@@ -98,9 +98,7 @@ module ProjectPhases
       if phase.date_range_set?
         phase.active? ? phase.finish_date + 1 : phase.start_date
       else
-        from = phase.start_date || phase.finish_date
-        from += 1 if phase.active?
-        from
+        phase.start_date || phase.finish_date
       end
     end
 

--- a/app/services/project_phases/activation_service.rb
+++ b/app/services/project_phases/activation_service.rb
@@ -85,13 +85,13 @@ module ProjectPhases
 
       if preceding_phase
         preceding_phase
-      elsif phase.any_dates_set?
+      elsif phase.any_date_set?
         phase
       end
     end
 
     def preceding_active_phase(phase)
-      project.available_phases.reverse.find { it.any_dates_set? && it.position < phase.position }
+      project.available_phases.reverse.find { it.any_date_set? && it.position < phase.position }
     end
 
     def initial_reschedule_date(phase)

--- a/app/services/project_phases/reschedule_service.rb
+++ b/app/services/project_phases/reschedule_service.rb
@@ -52,8 +52,13 @@ module ProjectPhases
         if phase.date_range_set?
           next_start_date = reschedule_phase_and_retrieve_next_start(phase, from)
           from = next_start_date unless next_start_date.nil?
-        elsif phase.start_date.present?
-          reschedule_phase_start_only(phase, from)
+        else
+          reschedule_phase_start(phase, from)
+
+          if phase.finish_date.present?
+            next_start_date = reschedule_phase_finish_and_retrieve_next_start(phase, from)
+            from = next_start_date unless next_start_date.nil?
+          end
         end
       end
     end
@@ -74,9 +79,16 @@ module ProjectPhases
       [days.first.date, days.last.date] if days.length == duration
     end
 
-    def reschedule_phase_start_only(phase, from)
+    def reschedule_phase_start(phase, from)
       start_date = working_days_from(from, count: 1).first.date
-      phase.update(start_date: start_date)
+      phase.update(start_date:)
+    end
+
+    def reschedule_phase_finish_and_retrieve_next_start(phase, from)
+      finish_date = [from, phase.finish_date].max
+      working_finish_date = working_days_from(finish_date, count: 1).first.date
+      phase.update(finish_date: working_finish_date)
+      working_finish_date + 1
     end
 
     def working_days_from(from, count:)

--- a/app/services/project_phases/reschedule_service.rb
+++ b/app/services/project_phases/reschedule_service.rb
@@ -77,15 +77,18 @@ module ProjectPhases
 
     def reschedule_partial_phase_and_retrieve_next_start(phase, from)
       phase.start_date = calculate_start_date(from)
+      next_start_date = phase.start_date
 
       if phase.finish_date?
         phase.finish_date = calculate_finish_date(phase, from)
         phase.duration = phase.calculate_duration
+        # The phase's date range is complete now, and 1 day gap should follow it.
+        next_start_date = phase.finish_date + 1
       end
 
       phase.save
 
-      phase.finish_date + 1 if phase.finish_date?
+      next_start_date
     end
 
     def calculate_start_date(from)

--- a/app/services/project_phases/reschedule_service.rb
+++ b/app/services/project_phases/reschedule_service.rb
@@ -85,7 +85,7 @@ module ProjectPhases
 
       phase.save
 
-      (phase.finish_date || phase.start_date) + 1
+      phase.finish_date + 1 if phase.finish_date?
     end
 
     def calculate_start_date(from)

--- a/app/services/project_phases/reschedule_service.rb
+++ b/app/services/project_phases/reschedule_service.rb
@@ -85,7 +85,7 @@ module ProjectPhases
 
       phase.save
 
-      phase.finish_date + 1 if phase.finish_date?
+      (phase.finish_date || phase.start_date) + 1
     end
 
     def calculate_start_date(from)

--- a/app/services/project_phases/reschedule_service.rb
+++ b/app/services/project_phases/reschedule_service.rb
@@ -77,7 +77,12 @@ module ProjectPhases
 
     def reschedule_partial_phase_and_retrieve_next_start(phase, from)
       phase.start_date = calculate_start_date(from)
-      phase.finish_date = calculate_finish_date(phase, from) if phase.finish_date?
+
+      if phase.finish_date?
+        phase.finish_date = calculate_finish_date(phase, from)
+        phase.duration = phase.calculate_duration
+      end
+
       phase.save
 
       phase.finish_date + 1 if phase.finish_date?

--- a/app/services/project_phases/reschedule_service.rb
+++ b/app/services/project_phases/reschedule_service.rb
@@ -77,7 +77,7 @@ module ProjectPhases
 
     def reschedule_partial_phase_and_retrieve_next_start(phase, from)
       reschedule_phase_start(phase, from)
-      return if phase.finish_date.blank?
+      return unless phase.finish_date?
 
       reschedule_phase_finish_and_retrieve_next_start(phase, from)
     end

--- a/app/services/project_phases/update_service.rb
+++ b/app/services/project_phases/update_service.rb
@@ -33,7 +33,7 @@ module ProjectPhases
     delegate :project, to: :model
 
     def after_perform(*)
-      reschedule_following_phases if model.date_range_set?
+      reschedule_following_phases if model.any_dates_set?
 
       project.touch_and_save_journals
 
@@ -48,7 +48,13 @@ module ProjectPhases
     end
 
     def initial_reschedule_date
-      model.active? ? model.finish_date + 1 : model.start_date
+      if model.date_range_set?
+        model.active? ? model.finish_date + 1 : model.start_date
+      else
+        from = model.start_date || model.finish_date
+        from += 1 if model.active?
+        from
+      end
     end
   end
 end

--- a/app/services/project_phases/update_service.rb
+++ b/app/services/project_phases/update_service.rb
@@ -33,7 +33,7 @@ module ProjectPhases
     delegate :project, to: :model
 
     def after_perform(*)
-      reschedule_following_phases if model.any_dates_set?
+      reschedule_following_phases if model.any_date_set?
 
       project.touch_and_save_journals
 

--- a/app/services/project_phases/update_service.rb
+++ b/app/services/project_phases/update_service.rb
@@ -51,9 +51,7 @@ module ProjectPhases
       if model.date_range_set?
         model.active? ? model.finish_date + 1 : model.start_date
       else
-        from = model.start_date || model.finish_date
-        from += 1 if model.active?
-        from
+        model.start_date || model.finish_date
       end
     end
   end

--- a/spec/services/project_phases/activation_service_spec.rb
+++ b/spec/services/project_phases/activation_service_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
 
@@ -194,7 +194,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
         end
@@ -245,7 +245,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
           end
         end
       end
@@ -382,7 +382,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
 
@@ -394,7 +394,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
         end
@@ -433,7 +433,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
           end
         end
       end
@@ -465,7 +465,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
 
@@ -477,7 +477,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
         end
@@ -516,7 +516,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
           end
         end
       end

--- a/spec/services/project_phases/activation_service_spec.rb
+++ b/spec/services/project_phases/activation_service_spec.rb
@@ -173,6 +173,58 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
           end
         end
 
+        context "with a start date only" do
+          context "and earlier than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date - 3, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            end
+          end
+
+          context "and later than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            end
+          end
+        end
+
+        context "with a finish date only" do
+          context "and earlier than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date - 3) }
+
+            it "reschedules that and following phases filling the start date and creating 1 day phase" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+            end
+          end
+
+          context "and later than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 3) }
+
+            it "reschedules that and following phases filling the start date and maintining the finish date" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
+            end
+          end
+        end
+
         context "when already activated" do
           let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date + 2, finish_date: date + 3) }
 
@@ -192,7 +244,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
-            expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
             expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
           end
         end
@@ -303,6 +355,172 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
         end
       end
 
+      context "having preceding phases with a start_date only" do
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: date - 1, finish_date: nil) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
+
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules that and following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
+          end
+        end
+
+        context "with a start date only" do
+          context "and earlier than the preceding phase start date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date - 3, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            end
+          end
+
+          context "and later than the preceding phase start date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            end
+          end
+        end
+
+        context "with a finish date only" do
+          context "and earlier than the preceding phase start date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date - 3) }
+
+            it "reschedules that and following phases filling the start date and creating 1 day phase" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+            end
+          end
+
+          context "and later than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 3) }
+
+            it "reschedules that and following phases filling the start date and maintining the finish date" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
+            end
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with start date" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+      end
+
+      context "having preceding phases with a finish_date only" do
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: nil, finish_date: date - 1) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
+
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules that and following phases" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
+          end
+        end
+
+        context "with a start date only" do
+          context "and earlier than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date - 3, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            end
+          end
+
+          context "and later than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            end
+          end
+        end
+
+        context "with a finish date only" do
+          context "and earlier than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date - 3) }
+
+            it "reschedules that and following phases filling the start date and creating 1 day phase" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+            end
+          end
+
+          context "and later than the preceding phase finish date" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 3) }
+
+            it "reschedules that and following phases filling the start date and maintining the finish date" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
+            end
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with start date" do
+            service.call(active: true)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+      end
+
       context "having preceding phases without date range" do
         let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: nil, finish_date: nil) }
         let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
@@ -318,6 +536,58 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 3)
             expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
+          end
+        end
+
+        context "with a start date only" do
+          context "and earlier than the following phase" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date - 3, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 3, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 2, finish_date: date)
+            end
+          end
+
+          context "and later than the following phase" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 10, finish_date: nil) }
+
+            it "reschedules that and following phases" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date + 10, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 11, finish_date: date + 13)
+            end
+          end
+        end
+
+        context "with a finish date only" do
+          context "and earlier than the following phase" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date - 3) }
+
+            it "reschedules that and following phases filling the start date and creating 1 day phase" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 3)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 2, finish_date: date)
+            end
+          end
+
+          context "and later than the following phase" do
+            let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 10) }
+
+            it "reschedules that and following phases filling the start date and maintining the finish date" do
+              service.call(active: true)
+
+              expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
+              expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: date + 10)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 11, finish_date: date + 13)
+            end
           end
         end
 
@@ -391,44 +661,204 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
     end
 
     context "when deactivating one phase" do
-      let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: date - 1, finish_date: date - 1) }
-      let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
+      context "having preceding phases with date range" do
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: date - 1, finish_date: date - 1) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
 
-      let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
-      context "with date range" do
-        let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date + 2, finish_date: date + 3) }
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date + 2, finish_date: date + 3) }
 
-        it "reschedules following phases using dates of the closest preceding phase with date range" do
-          service.call(active: false)
+          it "reschedules following phases using dates of the closest preceding phase with date range" do
+            service.call(active: false)
 
-          expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
-          expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
-          expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "when already deactivated" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules following phases using dates of the closest preceding phase with date range" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with date range" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "with a start date only" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date - 3, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with date range" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date - 3, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "with a finish date only" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: date - 3) }
+
+          it "reschedules that and following phases filling the start date and creating 1 day phase" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: date - 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
         end
       end
 
-      context "when already deactivated" do
-        let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: date + 3) }
+      context "having preceding phases with a start_date only" do
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: date - 1, finish_date: nil) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
 
-        it "reschedules following phases using dates of the closest preceding phase with date range" do
-          service.call(active: false)
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
-          expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
-          expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
-          expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "when already deactivated" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "with a start date only" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date - 3, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date - 3, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "with a finish date only" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: date - 3) }
+
+          it "reschedules following phases using the dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: date - 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
         end
       end
 
-      context "without date range" do
-        let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: nil) }
+      context "having preceding phases with a finish_date only" do
+        let!(:phase0) { create_phase(definition: definitions[0], active: true, start_date: nil, finish_date: date - 1) }
+        let!(:phase2) { create_phase(definition: definitions[2], active: true, start_date: date + 7, finish_date: date + 9) }
 
-        it "reschedules following phases using dates of the closest preceding phase with date range" do
-          service.call(active: false)
+        let(:service) { described_class.new(user:, project:, definitions: [definitions[1]]) }
 
-          expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
-          expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
-          expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+        context "with date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "when already deactivated" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: date + 2, finish_date: date + 3) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "without date range" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "with a start date only" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: date - 3, finish_date: nil) }
+
+          it "reschedules following phases using dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: date - 3, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
+        end
+
+        context "with a finish date only" do
+          let!(:phase1) { create_phase(definition: definitions[1], active: true, start_date: nil, finish_date: date - 3) }
+
+          it "reschedules following phases using the dates of the closest preceding phase with a start date" do
+            service.call(active: false)
+
+            expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
+            expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: date - 3)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+          end
         end
       end
     end

--- a/spec/services/project_phases/activation_service_spec.rb
+++ b/spec/services/project_phases/activation_service_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
             end
           end
 
@@ -194,7 +194,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
             end
           end
         end
@@ -245,7 +245,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
           end
         end
       end
@@ -382,7 +382,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
             end
           end
 
@@ -394,7 +394,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
             end
           end
         end
@@ -433,7 +433,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
           end
         end
       end
@@ -465,7 +465,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
             end
           end
 
@@ -477,7 +477,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
               expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
             end
           end
         end
@@ -516,7 +516,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
           end
         end
       end

--- a/spec/services/project_phases/activation_service_spec.rb
+++ b/spec/services/project_phases/activation_service_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
           context "and later than the preceding phase finish date" do
             let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 3) }
 
-            it "reschedules that and following phases filling the start date and maintining the finish date" do
+            it "reschedules that and following phases filling the start date and maintaining the finish date" do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
@@ -415,7 +415,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
           context "and later than the preceding phase finish date" do
             let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 3) }
 
-            it "reschedules that and following phases filling the start date and maintining the finish date" do
+            it "reschedules that and following phases filling the start date and maintaining the finish date" do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
@@ -498,7 +498,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
           context "and later than the preceding phase finish date" do
             let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 3) }
 
-            it "reschedules that and following phases filling the start date and maintining the finish date" do
+            it "reschedules that and following phases filling the start date and maintaining the finish date" do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
@@ -581,7 +581,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
           context "and later than the following phase" do
             let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 10) }
 
-            it "reschedules that and following phases filling the start date and maintining the finish date" do
+            it "reschedules that and following phases filling the start date and maintaining the finish date" do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)

--- a/spec/services/project_phases/activation_service_spec.rb
+++ b/spec/services/project_phases/activation_service_spec.rb
@@ -368,8 +368,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
-            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
           end
         end
 
@@ -381,8 +381,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
             end
           end
 
@@ -393,8 +393,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
             end
           end
         end
@@ -407,8 +407,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
 
@@ -419,7 +419,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 3)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 3)
               expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
             end
           end
@@ -432,8 +432,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
-            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
       end
@@ -451,8 +451,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
-            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 1)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date + 2, finish_date: date + 4)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
           end
         end
 
@@ -464,8 +464,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
             end
           end
 
@@ -476,8 +476,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
             end
           end
         end
@@ -490,8 +490,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 1, finish_date: date + 3)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date - 1)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
             end
           end
 
@@ -502,7 +502,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
-              expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: date + 3)
+              expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 3)
               expect(phase2.reload).to have_attributes(active: true, start_date: date + 4, finish_date: date + 6)
             end
           end
@@ -515,8 +515,8 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
             service.call(active: true)
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
-            expect(phase1.reload).to have_attributes(active: true, start_date: date, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase1.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
       end
@@ -548,7 +548,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: date - 3, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date - 2, finish_date: date)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 3, finish_date: date - 1)
             end
           end
 
@@ -560,7 +560,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: date + 10, finish_date: nil)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 11, finish_date: date + 13)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 10, finish_date: date + 12)
             end
           end
         end
@@ -569,24 +569,24 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
           context "and earlier than the following phase" do
             let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date - 3) }
 
-            it "reschedules that and following phases filling the start date and creating 1 day phase" do
+            it "reschedules that and following phases" do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 3)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date - 2, finish_date: date)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date - 3, finish_date: date - 1)
             end
           end
 
           context "and later than the following phase" do
             let!(:phase1) { create_phase(definition: definitions[1], active: false, start_date: nil, finish_date: date + 10) }
 
-            it "reschedules that and following phases filling the start date and maintaining the finish date" do
+            it "reschedules that and following phases" do
               service.call(active: true)
 
               expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: nil)
               expect(phase1.reload).to have_attributes(active: true, start_date: nil, finish_date: date + 10)
-              expect(phase2.reload).to have_attributes(active: true, start_date: date + 11, finish_date: date + 13)
+              expect(phase2.reload).to have_attributes(active: true, start_date: date + 10, finish_date: date + 12)
             end
           end
         end
@@ -742,7 +742,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -754,7 +754,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -766,7 +766,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -778,7 +778,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: false, start_date: date - 3, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -790,7 +790,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: date - 1, finish_date: nil)
             expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: date - 3)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
       end
@@ -809,7 +809,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -821,7 +821,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: false, start_date: date + 2, finish_date: date + 3)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -833,7 +833,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -845,7 +845,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: false, start_date: date - 3, finish_date: nil)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
 
@@ -857,7 +857,7 @@ RSpec.describe ProjectPhases::ActivationService, type: :model do
 
             expect(phase0.reload).to have_attributes(active: true, start_date: nil, finish_date: date - 1)
             expect(phase1.reload).to have_attributes(active: false, start_date: nil, finish_date: date - 3)
-            expect(phase2.reload).to have_attributes(active: true, start_date: date, finish_date: date + 2)
+            expect(phase2.reload).to have_attributes(active: true, start_date: date - 1, finish_date: date + 1)
           end
         end
       end

--- a/spec/services/project_phases/reschedule_service_spec.rb
+++ b/spec/services/project_phases/reschedule_service_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
           create(:project_phase, project:, start_date: nil, finish_date: nil, duration: 5),
           create(:project_phase, project:, start_date: date, finish_date: date, duration: 13),
           # Always ending later than the schedule (rescheduling extends the duration)
-          create(:project_phase, project:, start_date: nil, finish_date: [from, date].max + 27, duration: 1),
+          create(:project_phase, project:, start_date: nil, finish_date: [from, date].max + 21, duration: 1),
           # Always ending earlier than the schedule (rescheduling shrinks the duration)
           create(:project_phase, project:, start_date: nil, finish_date: [from, date].min - 1, duration: 2)
         ]
@@ -162,11 +162,11 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
         expect(subject).to be_success
         expect(phases[0]).to have_attributes(start_date: from, finish_date: from, duration: 1)
         expect(phases[1]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
-        expect(phases[2]).to have_attributes(start_date: from + 2, finish_date: nil, duration: 5)
-        expect(phases[3]).to have_attributes(start_date: from + 5, finish_date: nil, duration: 5)
-        expect(phases[4]).to have_attributes(start_date: from + 6, finish_date: from + 22, duration: 13)
-        expect(phases[5]).to have_attributes(start_date: from + 23, finish_date: from + 27, duration: 3)
-        expect(phases[6]).to have_attributes(start_date: from + 28, finish_date: from + 28, duration: 1)
+        expect(phases[2]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
+        expect(phases[3]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
+        expect(phases[4]).to have_attributes(start_date: from + 1, finish_date: from + 19, duration: 13)
+        expect(phases[5]).to have_attributes(start_date: from + 20, finish_date: from + 21, duration: 2)
+        expect(phases[6]).to have_attributes(start_date: from + 22, finish_date: from + 22, duration: 1)
       end
 
       context "when the from date is earlier than the phases dates" do
@@ -176,11 +176,11 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
           expect(subject).to be_success
           expect(phases[0]).to have_attributes(start_date: from, finish_date: date, duration: 2)
           expect(phases[1]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
-          expect(phases[2]).to have_attributes(start_date: date + 2, finish_date: nil, duration: 5)
-          expect(phases[3]).to have_attributes(start_date: date + 3, finish_date: nil, duration: 5)
-          expect(phases[4]).to have_attributes(start_date: date + 6, finish_date: date + 22, duration: 13)
-          expect(phases[5]).to have_attributes(start_date: date + 23, finish_date: date + 27, duration: 3)
-          expect(phases[6]).to have_attributes(start_date: date + 28, finish_date: date + 28, duration: 1)
+          expect(phases[2]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
+          expect(phases[3]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
+          expect(phases[4]).to have_attributes(start_date: date + 1, finish_date: date + 17, duration: 13)
+          expect(phases[5]).to have_attributes(start_date: date + 20, finish_date: date + 21, duration: 2)
+          expect(phases[6]).to have_attributes(start_date: date + 22, finish_date: date + 22, duration: 1)
         end
       end
     end

--- a/spec/services/project_phases/reschedule_service_spec.rb
+++ b/spec/services/project_phases/reschedule_service_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
           create(:project_phase, project:, start_date: nil, finish_date: nil, duration: 5),
           create(:project_phase, project:, start_date: date, finish_date: date, duration: 13),
           # Always ending later than the schedule (rescheduling extends the duration)
-          create(:project_phase, project:, start_date: nil, finish_date: [from, date].max + 21, duration: 1),
+          create(:project_phase, project:, start_date: nil, finish_date: [from, date].max + 27, duration: 1),
           # Always ending earlier than the schedule (rescheduling shrinks the duration)
           create(:project_phase, project:, start_date: nil, finish_date: [from, date].min - 1, duration: 2)
         ]
@@ -162,11 +162,11 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
         expect(subject).to be_success
         expect(phases[0]).to have_attributes(start_date: from, finish_date: from, duration: 1)
         expect(phases[1]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
-        expect(phases[2]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
-        expect(phases[3]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
-        expect(phases[4]).to have_attributes(start_date: from + 1, finish_date: from + 19, duration: 13)
-        expect(phases[5]).to have_attributes(start_date: from + 20, finish_date: from + 21, duration: 2)
-        expect(phases[6]).to have_attributes(start_date: from + 22, finish_date: from + 22, duration: 1)
+        expect(phases[2]).to have_attributes(start_date: from + 2, finish_date: nil, duration: 5)
+        expect(phases[3]).to have_attributes(start_date: from + 5, finish_date: nil, duration: 5)
+        expect(phases[4]).to have_attributes(start_date: from + 6, finish_date: from + 22, duration: 13)
+        expect(phases[5]).to have_attributes(start_date: from + 23, finish_date: from + 27, duration: 3)
+        expect(phases[6]).to have_attributes(start_date: from + 28, finish_date: from + 28, duration: 1)
       end
 
       context "when the from date is earlier than the phases dates" do
@@ -176,11 +176,11 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
           expect(subject).to be_success
           expect(phases[0]).to have_attributes(start_date: from, finish_date: date, duration: 2)
           expect(phases[1]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
-          expect(phases[2]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
-          expect(phases[3]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
-          expect(phases[4]).to have_attributes(start_date: date + 1, finish_date: date + 17, duration: 13)
-          expect(phases[5]).to have_attributes(start_date: date + 20, finish_date: date + 21, duration: 2)
-          expect(phases[6]).to have_attributes(start_date: date + 22, finish_date: date + 22, duration: 1)
+          expect(phases[2]).to have_attributes(start_date: date + 2, finish_date: nil, duration: 5)
+          expect(phases[3]).to have_attributes(start_date: date + 3, finish_date: nil, duration: 5)
+          expect(phases[4]).to have_attributes(start_date: date + 6, finish_date: date + 22, duration: 13)
+          expect(phases[5]).to have_attributes(start_date: date + 23, finish_date: date + 27, duration: 3)
+          expect(phases[6]).to have_attributes(start_date: date + 28, finish_date: date + 28, duration: 1)
         end
       end
     end

--- a/spec/services/project_phases/reschedule_service_spec.rb
+++ b/spec/services/project_phases/reschedule_service_spec.rb
@@ -149,7 +149,10 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
           create(:project_phase, project:, start_date: date + 1, finish_date: nil, duration: 5),
           create(:project_phase, project:, start_date: nil, finish_date: nil, duration: 5),
           create(:project_phase, project:, start_date: date, finish_date: date, duration: 13),
-          create(:project_phase, project:, start_date: date, finish_date: nil, duration: 2)
+          # Always ending later than the schedule (rescheduling extends the duration)
+          create(:project_phase, project:, start_date: nil, finish_date: [from, date].max + 21, duration: 1),
+          # Always ending earlier than the schedule (rescheduling shrinks the duration)
+          create(:project_phase, project:, start_date: nil, finish_date: [from, date].min - 1, duration: 2)
         ]
       end
 
@@ -157,12 +160,13 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
 
       it "reschedules only the ones with a start_date or finish_date present" do
         expect(subject).to be_success
-        expect(phases[0]).to have_attributes(start_date: from, finish_date: from, calculate_duration: 1)
-        expect(phases[1]).to have_attributes(start_date: from + 1, finish_date: nil, calculate_duration: nil)
-        expect(phases[2]).to have_attributes(start_date: from + 1, finish_date: nil, calculate_duration: nil)
-        expect(phases[3]).to have_attributes(start_date: from + 1, finish_date: nil, calculate_duration: nil)
-        expect(phases[4]).to have_attributes(start_date: from + 1, finish_date: from + 19, calculate_duration: 13)
-        expect(phases[5]).to have_attributes(start_date: from + 20, finish_date: nil, calculate_duration: nil)
+        expect(phases[0]).to have_attributes(start_date: from, finish_date: from, duration: 1)
+        expect(phases[1]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
+        expect(phases[2]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
+        expect(phases[3]).to have_attributes(start_date: from + 1, finish_date: nil, duration: 5)
+        expect(phases[4]).to have_attributes(start_date: from + 1, finish_date: from + 19, duration: 13)
+        expect(phases[5]).to have_attributes(start_date: from + 20, finish_date: from + 21, duration: 2)
+        expect(phases[6]).to have_attributes(start_date: from + 22, finish_date: from + 22, duration: 1)
       end
 
       context "when the from date is earlier than the phases dates" do
@@ -170,12 +174,13 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
 
         it "reschedules only the ones with a start_date or finish_date present" do
           expect(subject).to be_success
-          expect(phases[0]).to have_attributes(start_date: from, finish_date: date, calculate_duration: 2)
-          expect(phases[1]).to have_attributes(start_date: date + 1, finish_date: nil, calculate_duration: nil)
-          expect(phases[2]).to have_attributes(start_date: date + 1, finish_date: nil, calculate_duration: nil)
-          expect(phases[3]).to have_attributes(start_date: date + 1, finish_date: nil, calculate_duration: nil)
-          expect(phases[4]).to have_attributes(start_date: date + 1, finish_date: date + 17, calculate_duration: 13)
-          expect(phases[5]).to have_attributes(start_date: date + 20, finish_date: nil, calculate_duration: nil)
+          expect(phases[0]).to have_attributes(start_date: from, finish_date: date, duration: 2)
+          expect(phases[1]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
+          expect(phases[2]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
+          expect(phases[3]).to have_attributes(start_date: date + 1, finish_date: nil, duration: 5)
+          expect(phases[4]).to have_attributes(start_date: date + 1, finish_date: date + 17, duration: 13)
+          expect(phases[5]).to have_attributes(start_date: date + 20, finish_date: date + 21, duration: 2)
+          expect(phases[6]).to have_attributes(start_date: date + 22, finish_date: date + 22, duration: 1)
         end
       end
     end

--- a/spec/services/project_phases/reschedule_service_spec.rb
+++ b/spec/services/project_phases/reschedule_service_spec.rb
@@ -153,20 +153,16 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
         ]
       end
 
-      subject do
-        service_response = service.call(phases:, from:)
-        phases.each { |p| p.duration = p.calculate_duration }
-        service_response
-      end
+      subject { service.call(phases:, from:) }
 
       it "reschedules only the ones with a start_date or finish_date present" do
         expect(subject).to be_success
-        expect(phases[0]).to have_attributes(start_date: from, finish_date: from, duration: 1)
-        expect(phases[1]).to have_attributes(start_date: from + 1, finish_date: nil, duration: nil)
-        expect(phases[2]).to have_attributes(start_date: from + 1, finish_date: nil, duration: nil)
-        expect(phases[3]).to have_attributes(start_date: from + 1, finish_date: nil, duration: nil)
-        expect(phases[4]).to have_attributes(start_date: from + 1, finish_date: from + 19, duration: 13)
-        expect(phases[5]).to have_attributes(start_date: from + 20, finish_date: nil, duration: nil)
+        expect(phases[0]).to have_attributes(start_date: from, finish_date: from, calculate_duration: 1)
+        expect(phases[1]).to have_attributes(start_date: from + 1, finish_date: nil, calculate_duration: nil)
+        expect(phases[2]).to have_attributes(start_date: from + 1, finish_date: nil, calculate_duration: nil)
+        expect(phases[3]).to have_attributes(start_date: from + 1, finish_date: nil, calculate_duration: nil)
+        expect(phases[4]).to have_attributes(start_date: from + 1, finish_date: from + 19, calculate_duration: 13)
+        expect(phases[5]).to have_attributes(start_date: from + 20, finish_date: nil, calculate_duration: nil)
       end
 
       context "when the from date is earlier than the phases dates" do
@@ -174,12 +170,12 @@ RSpec.describe ProjectPhases::RescheduleService, type: :model do
 
         it "reschedules only the ones with a start_date or finish_date present" do
           expect(subject).to be_success
-          expect(phases[0]).to have_attributes(start_date: from, finish_date: date, duration: 2)
-          expect(phases[1]).to have_attributes(start_date: date + 1, finish_date: nil, duration: nil)
-          expect(phases[2]).to have_attributes(start_date: date + 1, finish_date: nil, duration: nil)
-          expect(phases[3]).to have_attributes(start_date: date + 1, finish_date: nil, duration: nil)
-          expect(phases[4]).to have_attributes(start_date: date + 1, finish_date: date + 17, duration: 13)
-          expect(phases[5]).to have_attributes(start_date: date + 20, finish_date: nil, duration: nil)
+          expect(phases[0]).to have_attributes(start_date: from, finish_date: date, calculate_duration: 2)
+          expect(phases[1]).to have_attributes(start_date: date + 1, finish_date: nil, calculate_duration: nil)
+          expect(phases[2]).to have_attributes(start_date: date + 1, finish_date: nil, calculate_duration: nil)
+          expect(phases[3]).to have_attributes(start_date: date + 1, finish_date: nil, calculate_duration: nil)
+          expect(phases[4]).to have_attributes(start_date: date + 1, finish_date: date + 17, calculate_duration: 13)
+          expect(phases[5]).to have_attributes(start_date: date + 20, finish_date: nil, calculate_duration: nil)
         end
       end
     end

--- a/spec/services/project_phases/update_service_spec.rb
+++ b/spec/services/project_phases/update_service_spec.rb
@@ -157,9 +157,9 @@ RSpec.describe ProjectPhases::UpdateService, type: :model do
         it "reschedules all of them relying on duration" do
           expect(service.call(start_date: date, finish_date: nil)).to be_success
 
-          expect(following1).to have_attributes(start_date: date + 1, finish_date: date + 5, duration: 3)
-          expect(following2).to have_attributes(start_date: date + 6, finish_date: date + 7, duration: 2)
-          expect(following3).to have_attributes(start_date: date + 8, finish_date: date + 8, duration: 1)
+          expect(following1).to have_attributes(start_date: date, finish_date: date + 2, duration: 3)
+          expect(following2).to have_attributes(start_date: date + 5, finish_date: date + 6, duration: 2)
+          expect(following3).to have_attributes(start_date: date + 7, finish_date: date + 7, duration: 1)
         end
       end
 
@@ -167,9 +167,9 @@ RSpec.describe ProjectPhases::UpdateService, type: :model do
         it "reschedules all of them relying on duration" do
           expect(service.call(start_date: nil, finish_date: date + 1)).to be_success
 
-          expect(following1).to have_attributes(start_date: date + 2, finish_date: date + 6, duration: 3)
-          expect(following2).to have_attributes(start_date: date + 7, finish_date: date + 8, duration: 2)
-          expect(following3).to have_attributes(start_date: date + 9, finish_date: date + 9, duration: 1)
+          expect(following1).to have_attributes(start_date: date + 1, finish_date: date + 5, duration: 3)
+          expect(following2).to have_attributes(start_date: date + 6, finish_date: date + 7, duration: 2)
+          expect(following3).to have_attributes(start_date: date + 8, finish_date: date + 8, duration: 1)
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64532

# What are you trying to accomplish?

Solve the edge case of not assigning following phase start date (resulting in a validation error) when the previous phase has a finish date only.

# What approach did you choose and why?

Reschedule project phases when only a single start or finish date is available.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
