### PR TITLE
[64603] Fix milestone handling when switching from manual to automatic

### DIFF
--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -309,7 +309,7 @@ class WorkPackages::DatePickerController < ApplicationController
   end
 
   def handle_milestone_dates
-    if work_package.is_milestone?
+    if work_package.is_milestone? && params.require(:work_package).has_key?(:start_date)
       # Set the dueDate as the SetAttributesService will otherwise throw an error because the fields do not match
       params.require(:work_package)[:due_date] = params.require(:work_package)[:start_date]
       params.require(:work_package)[:due_date_touched] = "true"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64603

# What are you trying to accomplish?

Avoid error when either:
* given a manually scheduled milestone successor with a date, when updating its scheduling mode from manual to automatic and trying to save it from the date picker modal
* given an automatically scheduled milestone successor with a date, when checking/unchecking its "Working days only" state and trying to save it from the date picker modal

## Screenshots

# What approach did you choose and why?

When it's a milestone being updated, the due date was copied from the start date. This works when the milestone is in manual scheduling mode, but when it's in automatic scheduling mode, or when it's switched to automatic scheduling mode, this copy gives a nil value to the due date, and due date cannot be set because it's readonly in automatic scheduling. This lead to the 422 error.

Now the copy of due date from start date is only done if the start date parameter is present too.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
