### PR TITLE
[#64628] Clearing the start date of a following phase is not possible

### DIFF
--- a/app/forms/projects/life_cycles/form.rb
+++ b/app/forms/projects/life_cycles/form.rb
@@ -118,14 +118,14 @@ module Projects::LifeCycles
     def value(field_name)
       case field_name
       when :start_date
-        model.start_date || model.default_start_date || model.start_date_before_type_cast
+        model.start_date || model.start_date_before_type_cast
       when :finish_date
         model.finish_date_before_type_cast
       end
     end
 
     def start_date_disabled?
-      model.follows_previous_phase? && model.default_start_date.present?
+      model.follows_previous_phase? && model.start_date.present?
     end
 
     def start_date_caption

--- a/app/models/project/phase.rb
+++ b/app/models/project/phase.rb
@@ -92,7 +92,7 @@ class Project::Phase < ApplicationRecord
   def default_start_date
     return @default_start_date if defined?(@default_start_date)
 
-    previous_finish_date = previous_phase&.finish_date
+    previous_finish_date = previous_phase.finish_date if follows_previous_phase?
     @default_start_date = previous_finish_date && Day.next_working(from: previous_finish_date).date
   end
 

--- a/app/services/project_phases/set_attributes_service.rb
+++ b/app/services/project_phases/set_attributes_service.rb
@@ -36,8 +36,11 @@ module ProjectPhases
 
     private
 
-    def ensure_default_attributes(_params)
-      model.start_date ||= model.default_start_date if model.default_start_date.present?
+    def ensure_default_attributes(params)
+      # Set default start date only when there is no user provided value.
+      if params[:start_date].nil? && model.default_start_date.present?
+        model.start_date ||= model.default_start_date
+      end
     end
 
     def set_calculated_duration

--- a/app/services/project_phases/set_attributes_service.rb
+++ b/app/services/project_phases/set_attributes_service.rb
@@ -35,14 +35,6 @@ module ProjectPhases
     end
 
     private
-
-    def ensure_default_attributes(params)
-      # Set default start date only when there is no user provided value.
-      if params[:start_date].nil? && model.default_start_date.present?
-        model.start_date ||= model.default_start_date
-      end
-    end
-
     def set_calculated_duration
       model.duration = model.calculate_duration
     end

--- a/spec/models/project/phase_spec.rb
+++ b/spec/models/project/phase_spec.rb
@@ -186,16 +186,16 @@ RSpec.describe Project::Phase do
   describe "#default_start_date" do
     include_context "with project phases"
 
-    context "when the previous phase has a finish date" do
+    context "when the previous phase has a complete date range" do
       it "returns the next working day after the previous phase finish date" do
         expected = Day.next_working(from: phase1.finish_date).date
         expect(phase2.default_start_date).to eq(expected)
       end
     end
 
-    context "when the previous phase does not have a finish date" do
+    context "when the previous phase has an incomplete date range" do
       before do
-        phase1.update(finish_date: nil)
+        phase1.update(start_date: nil)
       end
 
       it "returns nil" do

--- a/spec/services/project_phases/set_attributes_service_spec.rb
+++ b/spec/services/project_phases/set_attributes_service_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe ProjectPhases::SetAttributesService, type: :model do
           allow(phase).to receive(:default_start_date).and_return(date)
         end
 
-        context "and the previous_date is not set" do
+        context "and the previous start date is not set" do
           let(:previous_date) { nil }
 
           it "sets the model's start_date to the default_start_date" do
@@ -116,11 +116,19 @@ RSpec.describe ProjectPhases::SetAttributesService, type: :model do
           end
         end
 
-        context "and the previous_date is set" do
+        context "and the previous start date is set" do
           let(:previous_date) { Time.zone.yesterday }
 
           it "does not sets the model's start_date to the default_start_date" do
             expect { subject }.not_to change(phase, :start_date)
+          end
+
+          context "and the current start date is cleared" do
+            let(:call_attributes) { { start_date: "", finish_date: date + 27 } }
+
+            it "sets the model's start_date to nil" do
+              expect { subject }.to change(phase, :start_date).from(previous_date).to(nil)
+            end
           end
         end
       end

--- a/spec/services/project_phases/set_attributes_service_spec.rb
+++ b/spec/services/project_phases/set_attributes_service_spec.rb
@@ -97,53 +97,5 @@ RSpec.describe ProjectPhases::SetAttributesService, type: :model do
         end
       end
     end
-
-    describe "setting default start date" do
-      let(:phase) do
-        build_stubbed(:project_phase, project:, start_date: previous_date)
-      end
-
-      context "when there is a default_start_date on the phase" do
-        before do
-          allow(phase).to receive(:default_start_date).and_return(date)
-        end
-
-        context "and the previous start date is not set" do
-          let(:previous_date) { nil }
-
-          it "sets the model's start_date to the default_start_date" do
-            expect { subject }.to change(phase, :start_date).from(nil).to(date)
-          end
-        end
-
-        context "and the previous start date is set" do
-          let(:previous_date) { Time.zone.yesterday }
-
-          it "does not sets the model's start_date to the default_start_date" do
-            expect { subject }.not_to change(phase, :start_date)
-          end
-
-          context "and the current start date is cleared" do
-            let(:call_attributes) { { start_date: "", finish_date: date + 27 } }
-
-            it "sets the model's start_date to nil" do
-              expect { subject }.to change(phase, :start_date).from(previous_date).to(nil)
-            end
-          end
-        end
-      end
-
-      context "when there is no default_start_date on the phase" do
-        let(:previous_date) { date }
-
-        before do
-          allow(phase).to receive(:default_start_date).and_return(nil)
-        end
-
-        it "does not set the model's start_date" do
-          expect { subject }.not_to change(phase, :start_date).from(date)
-        end
-      end
-    end
   end
 end

--- a/spec/support/components/projects/project_life_cycles/edit_dialog.rb
+++ b/spec/support/components/projects/project_life_cycles/edit_dialog.rb
@@ -51,13 +51,15 @@ module Components
           close if close_after_yield
         end
 
-        def clear_dates
-          if has_button?("start_date_clear_button")
+        def clear_dates(fields: %i(start_date finish_date))
+          fields = Array(fields)
+
+          if fields.include?(:start_date) && has_button?("start_date_clear_button")
             click_button("start_date_clear_button")
             wait_for_form_preview_to_reload
           end
 
-          if has_button?("finish_date_clear_button")
+          if fields.include?(:finish_date) && has_button?("finish_date_clear_button")
             click_button("finish_date_clear_button")
             wait_for_form_preview_to_reload
           end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/64628

# What are you trying to accomplish?
Allow clearing the start date on a following phase that has an incomplete predecessor.

# What approach did you choose and why?
Do not automatically fill the default start date on the UI, but rather assign it via the rescheduling.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
