### PR TITLE
[#64471] Project Status missing attribute help text

### DIFF
--- a/app/components/projects/status_button_component.html.erb
+++ b/app/components/projects/status_button_component.html.erb
@@ -1,0 +1,29 @@
+<%=
+  component_wrapper do
+    flex_layout(align_items: :center) do |flex|
+      flex.with_column do
+        render(
+          OpPrimer::StatusButtonComponent.new(
+            current_status: build_item(@status),
+            items: build_items,
+            readonly: !edit_enabled?,
+            disabled: !edit_enabled?,
+            button_arguments: {
+              title: t("projects.status.button_edit"),
+              size: @size
+            }
+          )
+        )
+      end
+      flex.with_column(mr: 2) do
+        render(
+          OpenProject::Common::AttributeLabelComponent.new(
+            attribute: :status,
+            model: project,
+            current_user: user
+          )
+        )
+      end
+    end
+  end
+%>

--- a/app/components/projects/status_button_component.rb
+++ b/app/components/projects/status_button_component.rb
@@ -46,23 +46,6 @@ class Projects::StatusButtonComponent < ApplicationComponent
     @status = find_status(project.status_code)
   end
 
-  def call
-    component_wrapper do
-      render(
-        OpPrimer::StatusButtonComponent.new(
-          current_status: build_item(@status),
-          items: build_items,
-          readonly: !edit_enabled?,
-          disabled: !edit_enabled?,
-          button_arguments: {
-            title: t("projects.status.button_edit"),
-            size: @size
-          }
-        )
-      )
-    end
-  end
-
   private
 
   def edit_enabled?

--- a/spec/components/projects/status_button_component_spec.rb
+++ b/spec/components/projects/status_button_component_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
     it "does not render a Primer ActionMenu" do
       expect(subject).not_to have_element "action-menu"
     end
+
+    context "without attribute help text" do
+      it "does not render help text" do
+        expect(subject).to have_no_element class: "op-attribute-help-text"
+      end
+    end
+
+    context "with attribute help text" do
+      let!(:help_text) { create(:project_help_text, attribute_name: :status) }
+
+      it "renders help text" do
+        expect(subject).to have_element class: "op-attribute-help-text"
+      end
+    end
   end
 
   context "when the user has project edit permissions" do
@@ -129,6 +143,20 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
           expect(page).to have_selector :menuitem, text: "Discontinued"
           expect(page).to have_selector :menuitem, text: "Off track"
         end
+      end
+    end
+
+    context "without attribute help text" do
+      it "does not render help text" do
+        expect(subject).to have_no_element class: "op-attribute-help-text"
+      end
+    end
+
+    context "with attribute help text" do
+      let!(:help_text) { create(:project_help_text, attribute_name: :status) }
+
+      it "renders help text" do
+        expect(subject).to have_element class: "op-attribute-help-text"
       end
     end
   end

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -229,4 +229,66 @@ RSpec.describe "Projects", "editing settings", :js do
       end
     end
   end
+
+  describe "attribute help texts", :selenium do
+    let(:general_page) { Pages::Projects::Settings::General.new(project) }
+
+    context "without attribute help texts defined" do
+      before do
+        general_page.visit!
+      end
+
+      it "shows field labels without help text link" do
+        general_page.expect_field_label_without_help_text "Name"
+        general_page.expect_field_label_without_help_text "Description"
+        general_page.expect_field_label_without_help_text "Project status description"
+        general_page.expect_field_label_without_help_text "Subproject of"
+      end
+
+      it "does not show help text link next to status button" do
+        within_section "Project status" do
+          button = find_button("Edit project status")
+          expect(page).to have_no_link accessible_name: "Show help text", right_of: button
+        end
+      end
+    end
+
+    context "with attribute help texts defined" do
+      let!(:name_help_text) { create(:project_help_text, attribute_name: :name) }
+      let!(:description_help_text) { create(:project_help_text, attribute_name: :description) }
+      let!(:status_help_text) { create(:project_help_text, attribute_name: :status) }
+      let!(:status_description_help_text) { create(:project_help_text, attribute_name: :status_explanation) }
+      let!(:subproject_of_help_text) { create(:project_help_text, attribute_name: :parent) }
+
+      before do
+        general_page.visit!
+      end
+
+      it "shows field labels with help text link" do
+        general_page.expect_field_label_with_help_text "Name"
+        general_page.expect_field_label_with_help_text "Description"
+        general_page.expect_field_label_with_help_text "Project status description"
+        general_page.expect_field_label_with_help_text "Subproject of"
+      end
+
+      it "shows help text link next to status button" do
+        within_section "Project status" do
+          button = find_button("Edit project status")
+          expect(page).to have_link accessible_name: "Show help text", right_of: button
+        end
+      end
+
+      it "shows help text modal on clicking help text link" do
+        general_page.click_help_text_link_for_label "Description"
+
+        expect(page).to have_modal "Description"
+        within_modal "Description" do
+          expect(page).to have_text "Attribute help text"
+
+          click_on "Close"
+        end
+        expect(page).to have_no_modal "Description"
+      end
+    end
+  end
 end

--- a/spec/support/pages/projects/settings/general.rb
+++ b/spec/support/pages/projects/settings/general.rb
@@ -50,6 +50,29 @@ module Pages
           page.find_test_selector("project-settings-more-menu").click
           page.find_test_selector("project-settings--copy").click
         end
+
+        def expect_field_label_with_help_text(label_text)
+          expect_field_label(label_text)
+          expect(find_field_label(label_text)).to have_link accessible_name: "Show help text"
+        end
+
+        def expect_field_label_without_help_text(label_text)
+          expect_field_label(label_text)
+          expect(find_field_label(label_text)).to have_no_link accessible_name: "Show help text"
+        end
+
+        def click_help_text_link_for_label(label_text)
+          link = find_field_label(label_text).find(:link, accessible_name: "Show help text")
+          link.click
+        end
+
+        def expect_field_label(label_text)
+          expect(page).to have_element :label, text: label_text
+        end
+
+        def find_field_label(label_text)
+          page.find(:element, :label, text: label_text)
+        end
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64471

# What are you trying to accomplish?

Display missing attribute help text for Project Status Component introduced in #18649.

This PR also adds feature specs to verify that attribute help texts are displayed for all fields shown on the Project Settings > Information page.

## Screenshots

| With help text link | With help text link (focussed) | Help text dialog example |
|--------|--------|--------|
| <img width="704" alt="Screenshot 2025-06-16 at 10 58 37" src="https://github.com/user-attachments/assets/30b987f4-066b-4bff-ba9a-cee25822a572" /> | <img width="696" alt="Screenshot 2025-06-16 at 11 00 16" src="https://github.com/user-attachments/assets/c048a7a1-e5c0-45ac-8eec-5d65d0100fd7" /> | <img width="851" alt="Screenshot 2025-06-16 at 10 59 16" src="https://github.com/user-attachments/assets/d3582cfa-1fa0-4e02-94f8-5cbd4ebc0f45" /> | 

# What approach did you choose and why?

Since this isn't a form field per-sé, we display the help text to the right of the rendered component.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
