### PR TITLE
[#64793] Differentiate between meeting agenda and meeting minutes in pdf export

### DIFF
--- a/modules/meeting/app/workers/meetings/pdf/agenda.rb
+++ b/modules/meeting/app/workers/meetings/pdf/agenda.rb
@@ -35,8 +35,12 @@ module Meetings::PDF
 
       write_hr
       write_optional_page_break
-      write_heading(I18n.t("meeting.export.label_meeting_agenda"))
+      write_meeting_heading
       write_agenda_sections
+    end
+
+    def write_meeting_heading
+      write_heading(meeting.state == "open" ? I18n.t("label_meeting_agenda") : I18n.t("label_meeting_minutes"))
     end
 
     def write_backlog

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -261,7 +261,6 @@ en:
     label_export_pdf: "Export PDF"
     export:
       your_meeting_export: "Meeting is being exported"
-      label_meeting_agenda: "Meeting agenda"
     export_pdf_dialog:
       title: Export PDF
       description: Generate a printable PDF file of this meeting at the current state.

--- a/modules/meeting/spec/workers/meetings/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/exporter_spec.rb
@@ -125,6 +125,9 @@ RSpec.describe Meetings::Exporter do
   end
 
   context "with a meeting with agenda items" do
+    let(:meeting) do
+      create(:meeting, author: user, project:, title: "Awesome closed meeting!", location: "Mars Base", state: :closed)
+    end
     let(:type_task) { create(:type_task) }
     let(:status) { create(:status, is_default: true, name: "Workin' on it") }
     let(:work_package) { create(:work_package, project:, status:, subject: "Important task", type: type_task) }
@@ -182,7 +185,7 @@ RSpec.describe Meetings::Exporter do
           "Export User", "  ", "Attended",
           "Other Account", "  ", "Invited",
 
-          "Meeting agenda",
+          "Minutes",
 
           "Untitled section", "  ", "15 mins",
 
@@ -226,7 +229,7 @@ RSpec.describe Meetings::Exporter do
         expected_document = [
           *expected_cover_page,
           *single_meeting_head,
-          "Meeting agenda",
+          "Minutes",
 
           "Untitled section", "  ", "15 mins",
           "Agenda Item TOP 1", "  ", "15 mins", "  ", "Export User",
@@ -268,7 +271,7 @@ RSpec.describe Meetings::Exporter do
         expected_document = [
           *expected_cover_page,
           *single_meeting_head,
-          "Meeting agenda",
+          "Agenda",
 
           "Work package ##{secret_work_package.id} not visible", "  ", "10 mins",
           "title of the work package should not be visible",
@@ -295,7 +298,7 @@ RSpec.describe Meetings::Exporter do
         expected_document = [
           *expected_cover_page,
           *single_meeting_head,
-          "Meeting agenda",
+          "Agenda",
 
           "Deleted work package reference", "  ", "10 mins",
           "title of the work package should not be visible",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64793

# What are you trying to achieve?

Show a different heading for open and in progess/closed meetings

# What approach did you choose and why?

Implementing it

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
