### PR TITLE
Bug/63556 duplicate work package comments when submitting via ctlr cmd enter

### DIFF
--- a/app/components/work_packages/activities_tab/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/index_component.html.erb
@@ -42,7 +42,7 @@
                   data: add_comment_wrapper_data_attributes
                 ) do
                   render(
-                    WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:)
+                    WorkPackages::ActivitiesTab::Journals::NewComponent.new(work_package:, filter:, last_server_timestamp:)
                   )
                 end
               end

--- a/app/components/work_packages/activities_tab/journals/new_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/new_component.html.erb
@@ -42,14 +42,13 @@
         data: { "work-packages--activities-tab--index-target": "formRow" }
       ) do
         primer_form_with(
-          id: "work-package-journal-form-element", # required for specs
+          id: "work-package-journal-form-element",
           model: journal,
           method: :post,
           data: {
             turbo: true,
             turbo_stream: true,
             "work-packages--activities-tab--index-target": "form",
-            action: "submit->work-packages--activities-tab--index#onSubmit",
             test_selector: "op-work-package-journal-form-element"
           },
           url: work_package_activities_path(work_package_id: work_package.id)
@@ -59,7 +58,12 @@
               classes: "work-packages-activities-tab-journals-new-component--ck-editor-column",
               mb: 3
             ) do
-              render(WorkPackages::ActivitiesTab::Journals::NotesForm.new(f))
+              render(
+                Primer::Forms::FormList.new(
+                  WorkPackages::ActivitiesTab::Journals::HiddenForm.new(f, filter:, last_server_timestamp:),
+                  WorkPackages::ActivitiesTab::Journals::NotesForm.new(f)
+                )
+              )
             end
 
             form_container.with_row(flex_layout: true, justify_content: adding_internal_comment_allowed? ? :space_between : :flex_end) do |form_container_row|

--- a/app/components/work_packages/activities_tab/journals/new_component.rb
+++ b/app/components/work_packages/activities_tab/journals/new_component.rb
@@ -35,17 +35,19 @@ module WorkPackages
         include OpTurbo::Streamable
         include WorkPackages::ActivitiesTab::StimulusControllers
 
-        def initialize(work_package:, journal: nil, form_hidden_initially: true)
+        def initialize(work_package:, filter:, last_server_timestamp:, journal: nil, form_hidden_initially: true)
           super
 
           @work_package = work_package
+          @filter = filter
+          @last_server_timestamp = last_server_timestamp
           @journal = journal
           @form_hidden_initially = form_hidden_initially
         end
 
         private
 
-        attr_reader :work_package, :form_hidden_initially
+        attr_reader :work_package, :filter, :last_server_timestamp, :form_hidden_initially
 
         def journal
           @journal || Journal.new(journable: work_package)

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -216,7 +216,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def set_filter
-    @filter = params[:filter]&.to_sym || :all
+    @filter = (params[:filter] || params.dig(:journal, :filter))&.to_sym || :all
   end
 
   def journal_sorting
@@ -255,7 +255,10 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def perform_update_streams_from_last_update_timestamp
-    if params[:last_update_timestamp].present? && (last_updated_at = Time.zone.parse(params[:last_update_timestamp]))
+    last_update_timestamp = params[:last_update_timestamp] || params.dig(:journal, :last_update_timestamp)
+
+    if last_update_timestamp.present?
+      last_updated_at = Time.zone.parse(last_update_timestamp)
       generate_time_based_update_streams(last_updated_at)
       generate_work_package_journals_emoji_reactions_update_streams
     else

--- a/app/forms/work_packages/activities_tab/journals/hidden_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/hidden_form.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages::ActivitiesTab::Journals
+  class HiddenForm < ApplicationForm
+    form do |journals_form|
+      journals_form.hidden(name: :last_update_timestamp, value: @last_server_timestamp)
+      journals_form.hidden(name: :filter, value: @filter)
+    end
+
+    def initialize(last_server_timestamp:, filter: :all)
+      super()
+      @last_server_timestamp = last_server_timestamp
+      @filter = filter
+    end
+  end
+end

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -184,7 +184,6 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public async saveForm(evt?:SubmitEvent):Promise<void> {
-    this.saveRequested.emit(); // Provide a hook for the parent component to do something before the form is submitted
     CkeditorAugmentedTextareaComponent.inFlight.set(this.formElement, true);
 
     this.syncToTextarea();

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -1,3 +1,33 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
 import { Controller } from '@hotwired/stimulus';
 import {
   ICKEditorInstance,

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -717,7 +717,7 @@ export default class IndexController extends Controller {
           );
         }
         this.handleStemVisibility();
-      }, 10);
+      }, 100);
     }
   }
 

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe "activity comments", :js, :selenium do
           page.find_test_selector("op-submit-work-package-journal-form").click
           activity_tab.expect_journal_notes(text: "this is a comment!1")
         end
+
+        it "submits with ctrl/cmd+enter" do
+          activity_tab.type_comment("this is a comment!2")
+          activity_tab.get_editor_form_field_element.input_element.send_keys :control, :enter
+          activity_tab.expect_journal_notes(text: "this is a comment!2")
+        end
       end
 
       describe "autocomplete" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/63556

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

> _I was not able to reproduce the double submit bug_

This PR attempts to reduce the likelihood of double form submit by removing custom behavior and replacing with default turbo functionality that includes enhanced protections for double form submits. (https://github.com/opf/openproject/pull/18885/commits/e8ec49a34cd6b1603f45d5f700d5bec61cc14e02)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Replace the custom event based Stimulus action with [`Turbo.navigator.submitForm(formElement, submitter)`](https://github.com/hotwired/turbo/blob/71a769167eb64fafed48fe45ed175a54738216af/src/core/drive/navigator.js#L27) contained in the CKEditor component.

This is also has a nice advantage of reducing perceived complexity.

Some enhancements to prevent double submit actions are already done in:

* https://github.com/opf/openproject/pull/18885/commits/e8ec49a34cd6b1603f45d5f700d5bec61cc14e02
* https://github.com/opf/openproject/pull/13725/commits/fbee3b0889bba7b9e0afd3973c162943e02cab65
* https://github.com/opf/openproject/pull/17858/commits/1d5c43b95bd52a9aeb7fef07972e1eb24f6396c8

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
