### PR TITLE
[#64831] Remove attachment deletion from attribute help text dialog

### DIFF
--- a/app/components/attribute_help_texts/show_dialog_component.html.erb
+++ b/app/components/attribute_help_texts/show_dialog_component.html.erb
@@ -11,7 +11,10 @@
 
       if has_attachments?
         concat render(Primer::Beta::Heading.new(tag: :h4)) { I18n.t(:label_attachment_plural) }
-        concat helpers.list_attachments(resource_representer, inputs: { allowUploading: false })
+        concat helpers.list_attachments(
+          resource_representer,
+          inputs: { allowUploading: false, allowRemoval: false }
+        )
       end
     end
 

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
@@ -45,7 +45,7 @@
       <span class="spot-icon spot-icon_download-arrow"></span>
     </a>
     <button
-      *ngIf="!!attachment._links.delete"
+      *ngIf="showDelete && !!attachment._links.delete"
       type="button"
       class="spot-link"
       [title]="deleteIconTitle"

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
@@ -65,6 +65,8 @@ export class OpAttachmentListItemComponent extends UntilDestroyedMixin implement
 
   @Input() public showTimestamp = true;
 
+  @Input() public showDelete = true;
+
   @Output() public removeAttachment = new EventEmitter<void>();
 
   @ViewChild('avatar') avatar:ElementRef;

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
@@ -69,7 +69,7 @@ export class OpAttachmentListItemComponent extends UntilDestroyedMixin implement
 
   @Output() public removeAttachment = new EventEmitter<void>();
 
-  @ViewChild('avatar') avatar:ElementRef;
+  @ViewChild('avatar') avatar:ElementRef<HTMLDivElement>;
 
   static imageFileExtensions:string[] = ['jpeg', 'jpg', 'gif', 'bmp', 'png'];
 

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.html
@@ -9,6 +9,7 @@
     data-test-selector="op-attachment-list-item"
     [attachment]="attachment"
     [showTimestamp]="showTimestamp"
+    [showDelete]="showDelete"
     [index]="i"
     (removeAttachment)="removeAttachment(attachment)"
   ></li>

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
@@ -49,6 +49,8 @@ export class OpAttachmentListComponent extends UntilDestroyedMixin {
 
   @Input() public showTimestamp = true;
 
+  @Input() public showDelete = true;
+
   @Output() public attachmentRemoved = new EventEmitter<void>();
 
   constructor(

--- a/frontend/src/app/shared/components/attachments/attachments.component.html
+++ b/frontend/src/app/shared/components/attachments/attachments.component.html
@@ -7,6 +7,7 @@
   [attachments]="attachments$ | async"
   [collectionKey]="collectionKey"
   [showTimestamp]="showTimestamp"
+  [showDelete]="allowRemoval"
   (attachmentRemoved)="attachmentRemoved.emit()"
 ></op-attachment-list>
 

--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -76,6 +76,8 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
 
   @Input() public allowUploading = true;
 
+  @Input() public allowRemoval = true;
+
   @Input() public destroyImmediately = true;
 
   @Input() public externalUploadButton:string|null = null;

--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -105,7 +105,7 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
   };
 
   private get attachmentsSelfLink():string {
-    const attachments = this.resource.attachments as unknown&{ href:string };
+    const attachments = this.resource.attachments as { href:string };
     return attachments.href;
   }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64831

# What are you trying to accomplish?

Removes attachment deletion functionality from the attribute help text dialog.

This works around an issue where the attachments delete confirmation dialog (ng implementation) opens behind the attribute help texts dialog (Primerized implementation).

## Screenshots

| Before | After |
|--------|--------|
| <img width="658" alt="Screenshot 2025-06-16 at 12 23 39" src="https://github.com/user-attachments/assets/b095ff32-07b8-4168-83a4-6ae370157314" /> | <img width="655" alt="Screenshot 2025-06-16 at 12 23 11" src="https://github.com/user-attachments/assets/9e6562f4-b784-458c-8cd8-dc1bd8b9a0e1" /> | 

# What approach did you choose and why?

Please [see work package](https://community.openproject.org/wp/64831) for more details on why we decided to remove this functionality.

N.B. This PR doesn't add any spec coverage - this should probably wait for #19134 to be merged (#19134 adds comprehensive feature specs for the attribute help text dialog, including examples that test the listing of attachments).

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
