### PR TITLE
[#64836] Incorrect rescheduling after non working days are changed

### DIFF
--- a/app/workers/projects/phases/apply_working_days_change_job.rb
+++ b/app/workers/projects/phases/apply_working_days_change_job.rb
@@ -33,15 +33,14 @@ class Projects::Phases::ApplyWorkingDaysChangeJob < ApplyWorkingDaysChangeJobBas
 
   def apply_working_days_change
     Project.where(id: applicable_phases.select(:project_id)).find_each do |project|
-      phases = project.available_phases.to_a
-      from = phases.filter_map(&:start_date).first
+      available_phases = project.available_phases.to_a
+      phase = available_phases.find(&:start_date?)
+      from = phase&.start_date
       next unless from
 
-      ProjectPhases::RescheduleService.new(user: User.current, project:).call(phases:, from:)
+      phases = available_phases.filter { it.position >= phase.position }
 
-      project.journal_cause = journal_cause
-
-      project.touch_and_save_journals
+      reschedule_project_phases(project:, phases:, from:)
     end
   end
 
@@ -52,5 +51,13 @@ class Projects::Phases::ApplyWorkingDaysChangeJob < ApplyWorkingDaysChangeJobBas
     Project::Phase
       .active
       .covering_dates_or_days_of_week(days_of_week:, dates:)
+  end
+
+  def reschedule_project_phases(project:, phases:, from:)
+    ProjectPhases::RescheduleService.new(user: User.current, project:).call(phases:, from:)
+
+    project.journal_cause = journal_cause
+
+    project.touch_and_save_journals
   end
 end

--- a/spec/workers/projects/phases/apply_working_days_change_job_spec.rb
+++ b/spec/workers/projects/phases/apply_working_days_change_job_spec.rb
@@ -246,13 +246,13 @@ RSpec.describe Projects::Phases::ApplyWorkingDaysChangeJob do
           allow(project).to receive(:touch_and_save_journals)
         end
 
-        it "calls RescheduleService with first start_date" do
+        it "calls RescheduleService with first start_date and only with phases after the start date" do
           subject
 
           expect(ProjectPhases::RescheduleService)
             .to have_received(:new).with(user:, project:).once
           expect(reschedule_service)
-            .to have_received(:call).with(phases: phases, from: date + 1).once
+            .to have_received(:call).with(phases: phases[2..3], from: date + 1).once
         end
 
         it "journals project with correct cause" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/64836

# What are you trying to accomplish?
Fix the rescheduling mechanism when it is applied via changing non working days. The proposed solution is to reschedule phases starting from the first complete phase when changing non working days.

# What approach did you choose and why?

Change Project::Phase::ApplyWorkingDaysChangeJob to reschedule only from the first phase that has a start date.

 As a tradeoff, we will not reschedule any incomplete phases before the first complete phase, even if the added non working day falls on those incomplete phases before the complete one.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
