### PR TITLE
[#64828] Meeting PDF export: Refinement

### DIFF
--- a/app/models/work_package/pdf_export/export/meetings/schema.json
+++ b/app/models/work_package/pdf_export/export/meetings/schema.json
@@ -1400,6 +1400,15 @@
             }
           ]
         },
+        "symbol": {
+          "type": "object",
+          "title": "Agenda item outcome symbol",
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            }
+          ]
+        },
         "indent": {
           "title": "Indent width",
           "description": "Indent for agenda item notes",

--- a/app/models/work_package/pdf_export/export/meetings/standard.yml
+++ b/app/models/work_package/pdf_export/export/meetings/standard.yml
@@ -228,7 +228,10 @@ notes:
         no_border_top: true
 
 outcome:
-  indent: 15
+  indent: 0
+  symbol:
+    size: 10
+    color: "1F883D"
   title:
     size: 10
     styles: [ "bold" ]
@@ -393,7 +396,7 @@ outcome:
         no_border_top: true
 
 heading:
-  size: 16
+  size: 11
   styles: [ "bold" ]
   margin_bottom: 8
   hr:
@@ -431,8 +434,8 @@ agenda_section:
   title_cell:
     padding_top: 2
     padding_bottom: 5
-    padding_left: 5
-    padding_right: 5
+    padding_left: 0
+    padding_right: 0
     border_color: "D0D7DE"
     border_width: 1
     no_border_top: true
@@ -443,14 +446,14 @@ agenda_section:
     margin_bottom: 10
 
 agenda_item:
-  indent: 5
+  indent: 0
   title_margin:
     margin_bottom: 10
   title_cell:
     padding_top: 0
     padding_bottom: 0
-    padding_left: 5
-    padding_right: 5
+    padding_left: 0
+    padding_right: 0
     no_border: true
   title:
     styles: [ "bold" ]

--- a/app/models/work_package/pdf_export/export/meetings/standard.yml
+++ b/app/models/work_package/pdf_export/export/meetings/standard.yml
@@ -4,7 +4,7 @@ page:
   margin_bottom: 60
   margin_left: 36
   margin_right: 36
-  page_break_threshold: 100
+  page_break_threshold: 150
   link_color: "175A8E"
 
 page_header:
@@ -21,7 +21,7 @@ page_logo:
   align: "right"
 
 page_heading:
-  size: 14
+  size: 18
   styles: [ "bold" ]
   margin_bottom: 2
 
@@ -235,7 +235,7 @@ outcome:
     margin_top: 5
     margin_bottom: 5
   markdown_margin:
-    margin: 16
+    margin_bottom: 8
   markdown:
     font:
       size: 10
@@ -393,12 +393,12 @@ outcome:
         no_border_top: true
 
 heading:
-  size: 12
+  size: 16
   styles: [ "bold" ]
   margin_bottom: 8
   hr:
     color: "6E7781"
-    height: 1.5
+    height: 1
     margin_bottom: 10
 
 participants:
@@ -422,7 +422,7 @@ attachments:
 
 agenda_section:
   title:
-    size: 12
+    size: 14
     color: "000000"
     styles: [ "bold" ]
   subtitle:
@@ -430,14 +430,17 @@ agenda_section:
     color: "636C76"
   title_cell:
     padding_top: 2
-    padding_bottom: 10
+    padding_bottom: 5
     padding_left: 5
     padding_right: 5
-    no_border: true
-    background_color: "EAEAEA"
+    border_color: "D0D7DE"
+    border_width: 1
+    no_border_top: true
+    no_border_left: true
+    no_border_right: true
   title_margins:
     margin_top: 15
-    margin_bottom: 5
+    margin_bottom: 10
 
 agenda_item:
   indent: 5
@@ -456,7 +459,7 @@ agenda_item:
     color: "636C76"
     size: 10
   hr:
-    color: "D0D7DE"
-    height: 1
+    color: "FFFFFF"
+    height: 0
     margin_top: 6
     margin_bottom: 6

--- a/app/models/work_package/pdf_export/export/meetings/styles.rb
+++ b/app/models/work_package/pdf_export/export/meetings/styles.rb
@@ -83,6 +83,10 @@ module WorkPackage::PDFExport::Export::Meetings::Styles
       resolve_font(@styles.dig(:outcome, :title))
     end
 
+    def outcome_symbol
+      resolve_font(@styles.dig(:outcome, :symbol))
+    end
+
     def outcome_title_margins
       resolve_margin(@styles.dig(:outcome, :title))
     end

--- a/app/models/work_package/pdf_export/export/meetings/styles.rb
+++ b/app/models/work_package/pdf_export/export/meetings/styles.rb
@@ -87,6 +87,10 @@ module WorkPackage::PDFExport::Export::Meetings::Styles
       resolve_margin(@styles.dig(:outcome, :title))
     end
 
+    def outcome_markdown_margins
+      resolve_margin(@styles.dig(:outcome, :markdown_margin))
+    end
+
     def outcome_indent
       @styles.dig(:outcome, :indent).presence || 15
     end

--- a/modules/meeting/app/workers/meetings/exporter.rb
+++ b/modules/meeting/app/workers/meetings/exporter.rb
@@ -112,10 +112,17 @@ module Meetings
     end
 
     def cover_page_dates
-      ["#{format_date(meeting.start_time)},",
-       format_time(meeting.start_time, include_date: false),
-       "–",
-       format_time(meeting.end_time, include_date: false)].join(" ")
+      [
+        "#{meeting_mode},",
+        "#{format_date(meeting.start_time)},",
+        format_time(meeting.start_time, include_date: false),
+        "–",
+        format_time(meeting.end_time, include_date: false)
+      ].join(" ")
+    end
+
+    def meeting_mode
+      meeting.state == "open" ? I18n.t("label_meeting_agenda") : I18n.t("label_meeting_minutes")
     end
 
     def cover_page_subheading

--- a/modules/meeting/app/workers/meetings/pdf/agenda.rb
+++ b/modules/meeting/app/workers/meetings/pdf/agenda.rb
@@ -218,10 +218,12 @@ module Meetings::PDF
     end
 
     def write_outcome_notes(notes)
-      write_markdown!(
-        apply_markdown_field_macros(notes, { project: meeting.project, user: User.current }),
-        styles.outcome_markdown_styling_yml
-      )
+      with_vertical_margin(styles.outcome_markdown_margins) do
+        write_markdown!(
+          apply_markdown_field_macros(notes, { project: meeting.project, user: User.current }),
+          styles.outcome_markdown_styling_yml
+        )
+      end
     end
   end
 end

--- a/modules/meeting/app/workers/meetings/pdf/agenda.rb
+++ b/modules/meeting/app/workers/meetings/pdf/agenda.rb
@@ -33,14 +33,8 @@ module Meetings::PDF
     def write_agenda
       return if meeting.sections.empty?
 
-      write_hr
       write_optional_page_break
-      write_meeting_heading
       write_agenda_sections
-    end
-
-    def write_meeting_heading
-      write_heading(meeting.state == "open" ? I18n.t("label_meeting_agenda") : I18n.t("label_meeting_minutes"))
     end
 
     def write_backlog
@@ -206,6 +200,7 @@ module Meetings::PDF
       return if outcome.notes.blank?
 
       pdf.indent(styles.outcome_indent) do
+        write_optional_page_break
         write_outcome_title
         write_outcome_notes(outcome.notes)
       end
@@ -213,7 +208,10 @@ module Meetings::PDF
 
     def write_outcome_title
       with_vertical_margin(styles.outcome_title_margins) do
-        pdf.formatted_text([{ text: I18n.t("label_agenda_outcome") }.merge(styles.outcome_title)])
+        pdf.formatted_text([
+                             { text: "✓ " }.merge(styles.outcome_symbol),
+                             { text: I18n.t("label_agenda_outcome") }.merge(styles.outcome_title)
+                           ])
       end
     end
 

--- a/modules/meeting/app/workers/meetings/pdf/page_head.rb
+++ b/modules/meeting/app/workers/meetings/pdf/page_head.rb
@@ -41,7 +41,7 @@ module Meetings::PDF
 
     def write_page_title
       pdf.formatted_text([styles.page_heading.merge(
-        { text: meeting_title, link: url_helpers.meeting_url(meeting) }
+        { text: meeting.title, link: url_helpers.meeting_url(meeting) }
       )])
     end
 
@@ -55,18 +55,12 @@ module Meetings::PDF
     end
 
     def meeting_subtitle
-      list = ["", meeting_subtitle_dates]
-      list.push("-", meeting.recurring_meeting.base_schedule) if meeting.recurring?
-      list.join(" ")
-    end
-
-    def meeting_subtitle_dates
       [
+        "",
         "#{format_date(meeting.start_time)},",
         format_time(meeting.start_time, include_date: false),
         "–",
-        format_time(meeting.end_time, include_date: false),
-        "(#{OpenProject::Common::DurationComponent.new(meeting.duration, :hours, abbreviated: true).text})"
+        format_time(meeting.end_time, include_date: false)
       ].join(" ")
     end
 
@@ -81,14 +75,6 @@ module Meetings::PDF
     def meetings_state_color
       status = Meetings::Statuses.find_by_id(meeting.state) # rubocop:disable Rails/DynamicFindBy
       (status || Meetings::Statuses::OPEN).color
-    end
-
-    def meeting_title
-      if meeting.recurring?
-        "#{format_date(meeting.start_time)} - #{meeting.title}"
-      else
-        meeting.title
-      end
     end
   end
 end

--- a/modules/meeting/app/workers/meetings/pdf/page_head.rb
+++ b/modules/meeting/app/workers/meetings/pdf/page_head.rb
@@ -37,6 +37,7 @@ module Meetings::PDF
       with_vertical_margin(styles.page_subtitle_margins) do
         write_meeting_subtitle
       end
+      write_hr
     end
 
     def write_page_title
@@ -46,35 +47,17 @@ module Meetings::PDF
     end
 
     def write_meeting_subtitle
-      pdf.formatted_text(
-        [
-          prawn_badge(badge_text, badge_color, offset: 0, radius: 2),
-          styles.page_subtitle.merge({ text: meeting_subtitle })
-        ]
-      )
+      pdf.formatted_text([styles.page_subtitle.merge({ text: meeting_subtitle })])
     end
 
     def meeting_subtitle
       [
-        "",
+        "#{meeting_mode} (#{I18n.t("label_meeting_state_#{meeting.state}")}),",
         "#{format_date(meeting.start_time)},",
         format_time(meeting.start_time, include_date: false),
         "–",
         format_time(meeting.end_time, include_date: false)
       ].join(" ")
-    end
-
-    def badge_text
-      I18n.t("label_meeting_state_#{meeting.state}")
-    end
-
-    def badge_color
-      meetings_state_color.hexcode&.sub("#", "") || "F0F0F0"
-    end
-
-    def meetings_state_color
-      status = Meetings::Statuses.find_by_id(meeting.state) # rubocop:disable Rails/DynamicFindBy
-      (status || Meetings::Statuses::OPEN).color
     end
   end
 end

--- a/modules/meeting/app/workers/meetings/pdf/participants.rb
+++ b/modules/meeting/app/workers/meetings/pdf/participants.rb
@@ -57,11 +57,24 @@ module Meetings::PDF
     end
 
     def participants
-      meeting.invited_or_attended_participants
+      meeting.invited_or_attended_participants.sort_by(&:name)
+    end
+
+    def participants_groups(columns_count)
+      # note participants.in_groups does not work with the alphabetically sorted requirement
+      # should be left to right and then the next row
+      array = Array.new(columns_count) { [] }
+      chunks = participants.in_groups_of(columns_count)
+      chunks.each do |chunk|
+        chunk.each_with_index do |participant, participant_index|
+          array[participant_index] << participant
+        end
+      end
+      array
     end
 
     def participants_table_rows(columns_count)
-      groups = participants.in_groups(columns_count)
+      groups = participants_groups(columns_count)
       return [] if groups.empty?
 
       Array.new(groups[0].size) do |row_index|

--- a/modules/meeting/app/workers/meetings/pdf/participants.rb
+++ b/modules/meeting/app/workers/meetings/pdf/participants.rb
@@ -33,7 +33,6 @@ module Meetings::PDF
     def write_participants
       return if participants.empty?
 
-      write_hr
       write_heading(participants_title)
       write_participants_table
     end

--- a/modules/meeting/spec/workers/meetings/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/exporter_spec.rb
@@ -80,9 +80,7 @@ RSpec.describe Meetings::Exporter do
   end
 
   def meeting_head
-    [meeting.title,
-     "   #{exporter.badge_text}   ",
-     exporter.meeting_subtitle]
+    [meeting.title, exporter.meeting_subtitle]
   end
 
   context "with an empty single meeting" do
@@ -178,12 +176,10 @@ RSpec.describe Meetings::Exporter do
           "Export User", "  ", "Attended",
           "Other Account", "  ", "Invited",
 
-          "Minutes",
-
           "Untitled section", "  ", "15 mins",
           "Agenda Item TOP 1", "  ", "15 mins", "  ", "Export User",
           "foo",
-          "Outcome",
+          "✓   Outcome",
           "An outcome",
 
           "Second section", "  ", "10 mins",
@@ -221,7 +217,6 @@ RSpec.describe Meetings::Exporter do
         expected_document = [
           *expected_cover_page,
           *meeting_head,
-          "Minutes",
 
           "Untitled section", "  ", "15 mins",
           "Agenda Item TOP 1", "  ", "15 mins", "  ", "Export User",
@@ -263,7 +258,6 @@ RSpec.describe Meetings::Exporter do
         expected_document = [
           *expected_cover_page,
           *meeting_head,
-          "Agenda",
 
           "Work package ##{secret_work_package.id} not visible", "  ", "10 mins",
           "title of the work package should not be visible",
@@ -290,7 +284,6 @@ RSpec.describe Meetings::Exporter do
         expected_document = [
           *expected_cover_page,
           *meeting_head,
-          "Agenda",
 
           "Deleted work package reference", "  ", "10 mins",
           "title of the work package should not be visible",

--- a/modules/meeting/spec/workers/meetings/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/exporter_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Meetings::Exporter do
     let(:meeting_section_second) { create(:meeting_section, meeting:, title: "Second section") }
     let(:meeting_agenda_item) do
       create(:meeting_agenda_item, meeting_section:, duration_in_minutes: 15, title: "Agenda Item TOP 1", presenter: user,
-             notes: "**foo**")
+                                   notes: "**foo**")
     end
     let(:wp_agenda_item) do
       create(:wp_meeting_agenda_item,
@@ -142,8 +142,8 @@ RSpec.describe Meetings::Exporter do
     let(:attachment) { create(:attachment, container: meeting) }
     let(:meeting_backlog_item) do
       create(:meeting_agenda_item, meeting_section: meeting.backlog,
-             duration_in_minutes: 1,
-             title: "Agenda Item in Backlog", presenter: user, notes: "# yeah")
+                                   duration_in_minutes: 1,
+                                   title: "Agenda Item in Backlog", presenter: user, notes: "# yeah")
     end
     let(:invited) { create(:meeting_participant, user: other_user, meeting:, invited: true) }
     let(:attended) { create(:meeting_participant, :attendee, user: user, meeting:) }
@@ -246,7 +246,7 @@ RSpec.describe Meetings::Exporter do
     let(:secret_work_package) { create(:work_package, project: secret_project) }
     let(:wp_agenda_item) do
       create(:wp_meeting_agenda_item, meeting:, work_package: secret_work_package, duration_in_minutes: 10,
-             notes: "title of the work package should not be visible")
+                                      notes: "title of the work package should not be visible")
     end
 
     before do

--- a/modules/meeting/spec/workers/meetings/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/exporter_spec.rb
@@ -79,24 +79,17 @@ RSpec.describe Meetings::Exporter do
      export_time_formatted]
   end
 
-  def single_meeting_head
+  def meeting_head
     [meeting.title,
-     "   #{exporter.badge_text}    ",
-     exporter.meeting_subtitle_dates]
-  end
-
-  def recurring_meeting_head
-    [format_date(meeting.start_time), "-", meeting.title,
-     "   #{exporter.badge_text}    ",
-     exporter.meeting_subtitle_dates,
-     "-", meeting.recurring_meeting.base_schedule]
+     "   #{exporter.badge_text}   ",
+     exporter.meeting_subtitle]
   end
 
   context "with an empty single meeting" do
     it "renders the expected document" do
       expected_document = [
         *expected_cover_page,
-        *single_meeting_head,
+        *meeting_head,
         "1", # Page number
         export_time_formatted,
         project.name
@@ -114,7 +107,7 @@ RSpec.describe Meetings::Exporter do
     it "renders the expected document" do
       expected_document = [
         *expected_cover_page,
-        *recurring_meeting_head,
+        *meeting_head,
         "1", # Page number
         export_time_formatted,
         project.name
@@ -135,7 +128,7 @@ RSpec.describe Meetings::Exporter do
     let(:meeting_section_second) { create(:meeting_section, meeting:, title: "Second section") }
     let(:meeting_agenda_item) do
       create(:meeting_agenda_item, meeting_section:, duration_in_minutes: 15, title: "Agenda Item TOP 1", presenter: user,
-                                   notes: "**foo**")
+             notes: "**foo**")
     end
     let(:wp_agenda_item) do
       create(:wp_meeting_agenda_item,
@@ -149,8 +142,8 @@ RSpec.describe Meetings::Exporter do
     let(:attachment) { create(:attachment, container: meeting) }
     let(:meeting_backlog_item) do
       create(:meeting_agenda_item, meeting_section: meeting.backlog,
-                                   duration_in_minutes: 1,
-                                   title: "Agenda Item in Backlog", presenter: user, notes: "# yeah")
+             duration_in_minutes: 1,
+             title: "Agenda Item in Backlog", presenter: user, notes: "# yeah")
     end
     let(:invited) { create(:meeting_participant, user: other_user, meeting:, invited: true) }
     let(:attended) { create(:meeting_participant, :attendee, user: user, meeting:) }
@@ -180,7 +173,7 @@ RSpec.describe Meetings::Exporter do
       it "renders the expected document" do
         expected_document = [
           *expected_cover_page,
-          *single_meeting_head,
+          *meeting_head,
           "Participants (2)",
           "Export User", "  ", "Attended",
           "Other Account", "  ", "Invited",
@@ -188,7 +181,6 @@ RSpec.describe Meetings::Exporter do
           "Minutes",
 
           "Untitled section", "  ", "15 mins",
-
           "Agenda Item TOP 1", "  ", "15 mins", "  ", "Export User",
           "foo",
           "Outcome",
@@ -228,7 +220,7 @@ RSpec.describe Meetings::Exporter do
       it "renders the expected document" do
         expected_document = [
           *expected_cover_page,
-          *single_meeting_head,
+          *meeting_head,
           "Minutes",
 
           "Untitled section", "  ", "15 mins",
@@ -254,7 +246,7 @@ RSpec.describe Meetings::Exporter do
     let(:secret_work_package) { create(:work_package, project: secret_project) }
     let(:wp_agenda_item) do
       create(:wp_meeting_agenda_item, meeting:, work_package: secret_work_package, duration_in_minutes: 10,
-                                      notes: "title of the work package should not be visible")
+             notes: "title of the work package should not be visible")
     end
 
     before do
@@ -270,7 +262,7 @@ RSpec.describe Meetings::Exporter do
       it "renders the expected document" do
         expected_document = [
           *expected_cover_page,
-          *single_meeting_head,
+          *meeting_head,
           "Agenda",
 
           "Work package ##{secret_work_package.id} not visible", "  ", "10 mins",
@@ -297,7 +289,7 @@ RSpec.describe Meetings::Exporter do
       it "renders the expected document" do
         expected_document = [
           *expected_cover_page,
-          *single_meeting_head,
+          *meeting_head,
           "Agenda",
 
           "Deleted work package reference", "  ", "10 mins",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64828

# What are you trying to achieve?

- [x] Remove the date of reoccurring meetings in the meeting title
- [x] Remove the duration e.g. "(1 hr)" in the meeting subtitle
- [x] Remove the base schedule of reoccurring meetings in the subtitle
- [x] Replace the section background with a border line below
- [x] Remove horizontal lines between Agenda items
- [x] Remove ""Minutes" or "Agenda" title
- [x] Add "Minutes" or "Agenda" and a comma to the cover page (before the date)
- [x] Remove the status badge, replace it with "Minutes (In progress)", "Minutes (closed)" or "Agenda (open)"
- [x] Remove all left indents (for sections/agenda items/outcome)
- [x] Remove the horizontal line between participants and agenda
- [x] Add a green check symbol before the "Outcome" title
- [x] Adjust font sizes
        Meeting title: 18ppt
        Area title (Participants, Attachments, Backlogs...): 11ppt
        Section title: 14ppt
        Agenda title: 11ppt
- [x] Sort participants by name (horizontal)

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
