### PR TITLE
[#64840] Visual artifacts (opaque background) shown behind Primerized banners

### DIFF
--- a/frontend/src/global_styles/primer/_flash.sass
+++ b/frontend/src/global_styles/primer/_flash.sass
@@ -44,3 +44,6 @@ $op-primer-flash-toaster-width: 80%
 
   &--item
     word-wrap: break-word
+
+  .flash
+    background-color: var(--body-background)

--- a/frontend/src/global_styles/primer/_flash.sass
+++ b/frontend/src/global_styles/primer/_flash.sass
@@ -36,7 +36,6 @@ $op-primer-flash-toaster-width: 80%
   left: 10%
   right: 10%
   top: 1rem
-  background-color: var(--body-background)
 
   // Align multiple toasts
   display: flex


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64840

# What are you trying to accomplish?

Fix opaque background artefact behind banners on pages using Turbo Streams to update flash messages (e.g. Project Status section on Project Settings > Information page).

## Screenshots

![Screenshot 2025-06-16 at 15 32 36](https://github.com/user-attachments/assets/adf2e4d9-515a-44e9-929f-b8ecc9ee0740)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
