### PR TITLE
[#64101] First section has "Move to top" and "Move up" actions  

### DIFF
--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -72,7 +72,7 @@ module MeetingSections
         if @first_and_last.first
           @first_and_last.first == @meeting_section
         else
-          @meeting_section.first?
+          @meeting_section.first_after_backlog?
         end
     end
 

--- a/modules/meeting/app/models/meeting_section.rb
+++ b/modules/meeting/app/models/meeting_section.rb
@@ -72,4 +72,8 @@ class MeetingSection < ApplicationRecord
       agenda_items.maximum(:position) + 1
     end
   end
+
+  def first_after_backlog?
+    position == meeting.backlog.position + 1
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/64101

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
The backlog section being created as part of the create service for meetings breaks previous assumptions about the section at the first position. This PR fixes that by checking for the first section after the backlog when referring to the first section of a meeting.