### PR TITLE
Revert "Bump lookbook from 2.3.9 to 2.3.10"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -757,7 +757,7 @@ GEM
     loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lookbook (2.3.10)
+    lookbook (2.3.9)
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
@@ -1754,7 +1754,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   lograge (0.14.0) sha256=42371a75823775f166f727639f5ddce73dd149452a55fc94b90c303213dc9ae1
   loofah (2.24.1) sha256=655a30842b70ec476410b347ab1cd2a5b92da46a19044357bbd9f401b009a337
-  lookbook (2.3.10) sha256=82118fd1ee95b17f0706c0e0fa4d3432ca0a6e078944a6ee75618e582d1602d1
+  lookbook (2.3.9) sha256=b91fd92bd20281b87fbd23d7b22ffacb83ceb086c30986ab90275d220eaf0f39
   mail (2.8.1) sha256=ec3b9fadcf2b3755c78785cb17bc9a0ca9ee9857108a64b6f5cfc9c0b5bfc9ad
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   markly (0.13.0) sha256=326a232c876cd95093d110b8d184be8effeadd776c3ffcefd59bdc8de7f59e0d

--- a/lib/open_project/patches/lookbook_tree_node_inflector.rb
+++ b/lib/open_project/patches/lookbook_tree_node_inflector.rb
@@ -41,7 +41,7 @@ module OpenProject
 end
 
 if Rails.env.local?
-  OpenProject::Patches.patch_gem_version "lookbook", "2.3.10" do
+  OpenProject::Patches.patch_gem_version "lookbook", "2.3.9" do
     Lookbook::TreeNode.prepend OpenProject::Patches::LookbookTreeNodeInflector
   end
 end


### PR DESCRIPTION
Reverts opf/openproject#19180

Open issue: https://github.com/lookbook-hq/lookbook/issues/712