### PR TITLE
[Backport #64475] Replace ng `opce-attribute-help-text` component usages with Primer `AttributeHelpTextComponent`

### DIFF
--- a/app/components/open_project/common/attribute_help_text_component.html.erb
+++ b/app/components/open_project/common/attribute_help_text_component.html.erb
@@ -1,6 +1,9 @@
-<%=
-  render Primer::Beta::Link.new(**@system_arguments) do
-    render Primer::Beta::Octicon.new(:question, size: :xsmall)
-  end
-%>
+<%= render Primer::Beta::Link.new(**@system_arguments) do |link| %>
+  <% if additional_label? %>
+    <% link.with_trailing_visual_icon(icon: :question, size: :xsmall) %>
+    <%= additional_label %>
+  <% else %>
+    <%= render Primer::Beta::Octicon.new(:question, size: :xsmall) %>
+  <% end %>
+<% end %>
 <%= render @tooltip %>

--- a/app/components/open_project/common/attribute_help_text_component.rb
+++ b/app/components/open_project/common/attribute_help_text_component.rb
@@ -65,6 +65,7 @@ module OpenProject
         return unless @help_text
 
         @system_arguments[:href] = show_dialog_attribute_help_text_path(@help_text)
+        @system_arguments[:data][:qa_help_text_for] = @help_text.attribute_name.camelize(:lower)
       end
     end
   end

--- a/app/components/open_project/common/attribute_help_text_component.rb
+++ b/app/components/open_project/common/attribute_help_text_component.rb
@@ -31,6 +31,10 @@
 module OpenProject
   module Common
     class AttributeHelpTextComponent < ApplicationComponent
+      renders_one :additional_label, lambda { |**system_arguments|
+        Primer::Beta::Text.new(**system_arguments)
+      }
+
       def initialize(help_text:, **system_arguments) # rubocop:disable Metrics/AbcSize
         super()
 

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -42,13 +42,11 @@
                           edit_attribute_help_text_path(attribute_help_text) %>
             </td>
             <td>
-              <%= angular_component_tag "opce-attribute-help-text",
-                                        inputs: {
-                                          helpTextId: attribute_help_text.id,
-                                          attribute: attribute_help_text.attribute_name,
-                                          attributeScope: attribute_help_text.attribute_scope,
-                                          additionalLabel: t(:"attribute_help_texts.show_preview")
-                                        } %>
+              <%=
+                render OpenProject::Common::AttributeHelpTextComponent.new(help_text: attribute_help_text) do |help_text|
+                  help_text.with_additional_label_content(t(:"attribute_help_texts.show_preview"))
+                end
+              %>
             </td>
             <td class="buttons">
               <%= link_to(

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -70,14 +70,15 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
       <div class="grid-content medium-8 small-12 -flex -with-button">
         <div class="form--field">
-          <%= styled_label_tag :member_role_ids do %>
-            <%= content_tag :span, t(:label_role_search) %>
-            <%= angular_component_tag "opce-attribute-help-text",
-                                      inputs: {
-                                        attribute: "members",
-                                        attributeScope: "Project"
-                                      } %>
-          <% end %>
+          <%= styled_label_tag :member_role_ids, title: t(:label_role_search) do
+                render OpenProject::Common::AttributeLabelComponent.new(
+                  attribute: "members",
+                  model: Project,
+                  tag: nil
+                ) do
+                  render(Primer::Beta::Text.new) { t(:label_role_search) }
+                end
+              end %>
           <div class="form--field-container">
             <div class="form--select-container -auto">
               <% options = roles.collect { |obj| [obj.name, obj.id] } %>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -138,9 +138,6 @@ import {
 import {
   DraggableAutocompleteComponent,
 } from 'core-app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component';
-import {
-  AttributeHelpTextComponent,
-} from 'core-app/shared/components/attribute-help-texts/attribute-help-text.component';
 import { OpExclusionInfoComponent } from 'core-app/shared/components/fields/display/info/op-exclusion-info.component';
 import { NewProjectComponent } from 'core-app/features/projects/components/new-project/new-project.component';
 import { CopyProjectComponent } from 'core-app/features/projects/components/copy-project/copy-project.component';
@@ -421,7 +418,6 @@ export class OpenProjectModule implements DoBootstrap {
     registerCustomElement('opce-macro-wp-quickinfo', WorkPackageQuickinfoMacroComponent, { injector });
     registerCustomElement('opce-ckeditor-augmented-textarea', CkeditorAugmentedTextareaComponent, { injector });
     registerCustomElement('opce-draggable-autocompleter', DraggableAutocompleteComponent, { injector });
-    registerCustomElement('opce-attribute-help-text', AttributeHelpTextComponent, { injector });
     registerCustomElement('opce-static-attribute-help-text', StaticAttributeHelpTextComponent, { injector });
     registerCustomElement('opce-exclusion-info', OpExclusionInfoComponent, { injector });
     registerCustomElement('opce-attachments', OpAttachmentsComponent, { injector });

--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -423,6 +423,9 @@ fieldset.form--fieldset
   .form--label.-error &
     color: var(--content-form-error-color)
 
+  &:has(.op-attribute-help-text)
+    @extend .op-attribute-label
+
 .form--field-container
   @include grid-content(10)
   // override max-width set by including grid-content

--- a/modules/overviews/app/components/overviews/project_custom_fields/item_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/item_component.html.erb
@@ -8,18 +8,12 @@
     }
   ) do |custom_field_value_container|
     # temporarily using inline styles in order to align the content as desired
-    custom_field_value_container.with_row(mb: 1) do
-      render(Primer::Beta::Text.new(font_weight: :bold)) do
-        concat(@project_custom_field.name + " ")
-        concat(
-          helpers.angular_component_tag(
-            "opce-attribute-help-text",
-            inputs: {
-              attribute: @project_custom_field.attribute_name(:camel_case),
-              attributeScope: "Project"
-            }
-          )
-        )
+    custom_field_value_container.with_row(mb: 1) do |attribute_name|
+      render OpenProject::Common::AttributeLabelComponent.new(
+        attribute: @project_custom_field.attribute_name,
+        model: @project
+      ) do
+        render(Primer::Beta::Text.new(font_weight: :bold)) { @project_custom_field.name }
       end
     end
 

--- a/modules/overviews/app/components/overviews/project_custom_fields/item_component.rb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/item_component.rb
@@ -35,11 +35,12 @@ module Overviews
       include CustomFieldsHelper
       include OpPrimer::ComponentHelpers
 
-      def initialize(project_custom_field:, project_custom_field_values:)
+      def initialize(project_custom_field:, project_custom_field_values:, project:)
         super
 
         @project_custom_field = project_custom_field
         @project_custom_field_values = project_custom_field_values
+        @project = project
       end
 
       private

--- a/modules/overviews/app/components/overviews/project_custom_fields/show_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/show_component.html.erb
@@ -28,7 +28,8 @@
             render(
               Overviews::ProjectCustomFields::ItemComponent.new(
                 project_custom_field:,
-                project_custom_field_values: get_eager_loaded_project_custom_field_values_for(project_custom_field.id)
+                project_custom_field_values: get_eager_loaded_project_custom_field_values_for(project_custom_field.id),
+                project: @project
               )
             )
           end

--- a/spec/components/open_project/common/attribute_help_text_component_spec.rb
+++ b/spec/components/open_project/common/attribute_help_text_component_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component
     it "applies an ID" do
       expect(subject).to have_element :a, id: /attribute-help-text-component-\d+/
     end
+
+    it "defines a data-qa-help-text-for attribute" do
+      expect(subject).to have_element :a, "data-qa-help-text-for": attribute_name.to_s.camelize(:lower)
+    end
+
+    context "without an additional label" do
+      it "does not render additional label content" do
+        expect(subject).to have_no_css ".Link-content"
+      end
+    end
   end
 
   shared_examples "component does not render" do
@@ -80,15 +90,35 @@ RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component
   end
 
   context "with a project help text" do
-    let(:help_text) { build_stubbed(:project_help_text) }
+    let(:help_text) { build_stubbed(:project_help_text, attribute_name:) }
 
-    it_behaves_like "component renders"
+    context "for a default attribute" do
+      let(:attribute_name) { :name }
+
+      it_behaves_like "component renders"
+    end
+
+    context "for a project attribute" do
+      let(:attribute_name) { :custom_field_2105 }
+
+      it_behaves_like "component renders"
+    end
   end
 
   context "with a work package help text" do
-    let(:help_text) { build_stubbed(:work_package_help_text) }
+    let(:help_text) { build_stubbed(:work_package_help_text, attribute_name:) }
 
-    it_behaves_like "component renders"
+    context "for a default attribute" do
+      let(:attribute_name) { :subject }
+
+      it_behaves_like "component renders"
+    end
+
+    context "for a custom field attribute" do
+      let(:attribute_name) { :custom_field_99 }
+
+      it_behaves_like "component renders"
+    end
   end
 
   context "with nil help text" do

--- a/spec/components/open_project/common/attribute_help_text_component_spec.rb
+++ b/spec/components/open_project/common/attribute_help_text_component_spec.rb
@@ -33,8 +33,10 @@ require "rails_helper"
 RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component do
   include Rails.application.routes.url_helpers
 
+  let(:block) { nil }
+
   subject do
-    render_inline(described_class.new(help_text:))
+    render_inline(described_class.new(help_text:), &block)
     page
   end
 
@@ -75,6 +77,31 @@ RSpec.describe OpenProject::Common::AttributeHelpTextComponent, type: :component
     context "without an additional label" do
       it "does not render additional label content" do
         expect(subject).to have_no_css ".Link-content"
+      end
+    end
+
+    context "with an additional label" do
+      let(:block) do
+        proc do |help_text|
+          help_text.with_additional_label_content "Normal Help Text Link"
+        end
+      end
+
+      it "renders additional label content" do
+        expect(subject).to have_css ".Link-content", text: "Normal Help Text Link"
+      end
+    end
+
+    context "with an additional styled label" do
+      let(:block) do
+        proc do |help_text|
+          help_text.with_additional_label(font_weight: :bold) { "Bold Help Text Link" }
+        end
+      end
+
+      it "renders additional label content" do
+        expect(subject).to have_css ".Link-content", text: "Bold Help Text Link"
+        expect(subject).to have_css ".text-bold", text: "Bold Help Text Link"
       end
     end
   end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe "Attribute help texts", :js do
   shared_let(:user_with_permission) { create(:user, global_permissions: [:edit_attribute_help_texts]) }
 
   let(:instance) { AttributeHelpText.last }
-  let(:modal) { Components::AttributeHelpTextModal.new(instance) }
   let(:editor) { Components::WysiwygEditor.new }
   let(:image_fixture) { UploadedFile.load_from("spec/fixtures/files/image.png") }
   let(:enterprise_token) { true }
@@ -97,16 +96,21 @@ RSpec.describe "Attribute help texts", :js do
         expect(instance.help_text).to match /\/api\/v3\/attachments\/\d+\/content/
 
         # Open help text modal
-        modal.open!
-        expect(modal.modal_container).to have_text "My attribute help text"
-        expect(modal.modal_container).to have_css("img")
-        modal.expect_edit(editable: true)
+        click_on "Preview text"
 
-        # Expect files section to be present
-        expect(modal.modal_container).to have_css(".form--fieldset-legend", text: "ATTACHMENTS")
-        expect(modal.modal_container).to have_test_selector("op-files-tab--file-list-item-title")
+        expect(page).to have_modal "Status"
+        within_modal "Status" do
+          expect(page).to have_text "My attribute help text"
+          expect(page).to have_css "img"
 
-        modal.close!
+          expect(page).to have_link "Edit"
+
+          # Expect files section to be present
+          expect(page).to have_heading "Attachments"
+          expect(page).to have_test_selector("op-files-tab--file-list-item-title")
+
+          click_on "Close"
+        end
 
         # -> edit
         SeleniumHubWaiter.wait
@@ -128,16 +132,25 @@ RSpec.describe "Attribute help texts", :js do
         expect(instance.help_text).to eq "New**help**text"
 
         # Open help text modal
-        modal.open!
-        expect(modal.modal_container).to have_css("strong", text: "help")
-        modal.expect_edit(editable: true)
+        click_on "Preview text"
 
-        modal.close!
+        within_modal "Status" do
+          expect(page).to have_css "strong", text: "help"
+
+          expect(page).to have_link "Edit"
+
+          click_on "Close"
+        end
+
         expect(page).to have_css(".attribute-help-text--entry td", text: "Status")
 
         # Open again and edit this time
-        modal.open!
-        modal.edit_button.click
+        click_on "Preview text"
+
+        within_modal "Status" do
+          click_on "Edit"
+        end
+
         expect(page).to have_css("#attribute_help_text_attribute_name[disabled]")
         visit attribute_help_texts_path
 

--- a/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
@@ -850,14 +850,23 @@ RSpec.describe "Show project custom fields on project overview page", :js do
       create :project_help_text,
              attribute_name: boolean_project_custom_field.attribute_name
     end
-    let(:modal) { Components::AttributeHelpTextModal.new(instance) }
 
     it "displays when active" do
       overview_page.visit_page
+
       # Open help text modal
-      modal.open!
-      expect(modal.modal_container).to have_text "Attribute help text"
-      modal.expect_edit(editable: true)
+      page.find("[data-qa-help-text-for='#{instance.attribute_name.camelize(:lower)}']").click
+
+      within_modal "Boolean field" do
+        expect(page).to have_text "Attribute help text"
+
+        expect(page).to have_button "Close"
+        expect(page).to have_link "Edit"
+
+        click_on "Close"
+      end
+
+      expect(page).to have_no_modal "Boolean field"
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64475

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
