### PR TITLE
Remove application dynamic target

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% helpers.content_controller "admin--hierarchy-item", dynamic: true %>
+<% helpers.content_controller "admin--hierarchy-item" %>
 
 <%=
   component_wrapper(tag: "turbo-frame", refresh: :morph, data: { turbo_action: :advance }) do

--- a/app/components/admin/enumerations/index_component.rb
+++ b/app/components/admin/enumerations/index_component.rb
@@ -45,8 +45,7 @@ module Admin
 
       def wrapper_data_attributes
         {
-          controller: "generic-drag-and-drop",
-          "application-target": "dynamic"
+          controller: "generic-drag-and-drop"
         }
       end
 

--- a/app/components/enterprise_trials/welcome_dialog_component.html.erb
+++ b/app/components/enterprise_trials/welcome_dialog_component.html.erb
@@ -3,7 +3,6 @@
     Primer::Alpha::Dialog.new(
       id: "enterprise-trial-welcome-dialog",
       data: {
-        "application-target": "dynamic",
         controller: "auto-show-dialog iframe-media-dialog"
       },
       title: I18n.t("ee.trial.welcome_title"),

--- a/app/components/op_primer/expandable_list_component.rb
+++ b/app/components/op_primer/expandable_list_component.rb
@@ -47,8 +47,7 @@ module OpPrimer
 
     def wrapper_data_attributes
       {
-        controller: "expandable-list",
-        "application-target": "dynamic"
+        controller: "expandable-list"
       }
     end
   end

--- a/app/components/open_project/common/attribute_component.html.erb
+++ b/app/components/open_project/common/attribute_component.html.erb
@@ -1,6 +1,5 @@
 <div
   data-controller="attribute"
-  data-application-target="dynamic"
   data-attribute-background-reference-id-value="<%= background_reference_id %>"
   class="op-long-text-attribute">
 

--- a/app/components/open_project/common/submenu_component.html.erb
+++ b/app/components/open_project/common/submenu_component.html.erb
@@ -1,4 +1,4 @@
-<div class="op-submenu" data-controller="filter--filter-list" data-application-target="dynamic" data-test-selector="op-submenu">
+<div class="op-submenu" data-controller="filter--filter-list" data-test-selector="op-submenu">
   <% if @searchable %>
     <div class="op-submenu--search">
       <%= render Primer::Alpha::TextField.new(
@@ -56,9 +56,7 @@
     <% end %>
 
     <% nested_sidebar_menu_items.each do |menu_item| %>
-      <div data-controller="menus--submenu"
-           data-application-target="dynamic">
-
+      <div data-controller="menus--submenu">
         <button class="op-submenu--title"
                 type="button"
                 data-action="click->menus--submenu#toggleContainer">

--- a/app/components/projects/index_sub_header_component.rb
+++ b/app/components/projects/index_sub_header_component.rb
@@ -53,7 +53,6 @@ module Projects
     def sub_header_data_attributes
       {
         controller: "filter--filters-form",
-        "application-target": "dynamic",
         "filter--filters-form-perform-turbo-requests-value": true,
         "filter--filters-form-clear-button-id-value": clear_button_id
       }

--- a/app/components/projects/settings/life_cycle/index_component.rb
+++ b/app/components/projects/settings/life_cycle/index_component.rb
@@ -50,7 +50,6 @@ module Projects
         def wrapper_data_attributes
           {
             controller: "projects--settings--border-box-filter",
-            "application-target": "dynamic",
             "projects--settings--border-box-filter-clear-button-id-value": clear_button_id
           }
         end

--- a/app/components/projects/settings/project_custom_field_sections/index_component.rb
+++ b/app/components/projects/settings/project_custom_field_sections/index_component.rb
@@ -46,7 +46,6 @@ module Projects
         def wrapper_data_attributes
           {
             controller: "projects--settings--border-box-filter",
-            "application-target": "dynamic",
             "projects--settings--border-box-filter-clear-button-id-value": clear_button_id
           }
         end

--- a/app/components/projects/table_component.html.erb
+++ b/app/components/projects/table_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <%= component_wrapper(tag: "turbo-frame") do %>
-  <div class="project-list-page--table" data-controller="table-action-menu" data-application-target="dynamic">
+  <div class="project-list-page--table" data-controller="table-action-menu">
     <div class="generic-table--flex-container">
       <div class="generic-table--container <%= container_class %>">
         <div class="generic-table--results-container">

--- a/app/components/queries/sort_by_component.html.erb
+++ b/app/components/queries/sort_by_component.html.erb
@@ -1,6 +1,6 @@
 <%= render(Primer::Beta::Heading.new(tag: :h5)) { I18n.t("queries.configure_view.sort_by.automatic.heading") } %>
 <%= render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) { I18n.t("queries.configure_view.sort_by.automatic.description", plural: queried_plural_model_human_name) } %>
-<div data-controller="sort-by-config" data-application-target="dynamic">
+<div data-controller="sort-by-config">
   <%= hidden_field_tag :sortBy, current_orders, data: { "sort-by-config-target" => "sortByField" } %>
   <%= render(Primer::OpenProject::FlexLayout.new(data: { "sort-by-config-target" => "inputRowContainer" })) do |layout| %>
     <% order_limit.times do |i| %>

--- a/app/components/settings/project_custom_field_sections/index_component.rb
+++ b/app/components/settings/project_custom_field_sections/index_component.rb
@@ -47,8 +47,7 @@ module Settings
 
       def wrapper_data_attributes
         {
-          controller: "generic-drag-and-drop",
-          "application-target": "dynamic"
+          controller: "generic-drag-and-drop"
         }
       end
 

--- a/app/components/settings/project_life_cycle_step_definitions/index_component.rb
+++ b/app/components/settings/project_life_cycle_step_definitions/index_component.rb
@@ -41,8 +41,7 @@ module Settings
 
       def wrapper_data_attributes
         {
-          controller: "projects--settings--border-box-filter generic-drag-and-drop",
-          "application-target": "dynamic"
+          controller: "projects--settings--border-box-filter generic-drag-and-drop"
         }
       end
 

--- a/app/components/shares/invite_user_form_component.html.erb
+++ b/app/components/shares/invite_user_form_component.html.erb
@@ -4,7 +4,6 @@
         model: new_share,
         url: url_for([entity, Member]),
         data: { controller: 'user-limit shares--user-selected',
-                'application-target': 'dynamic',
                 'user-limit-open-seats-value': OpenProject::Enterprise.open_seats_count,
                 action: 'submit->shares--user-selected#ensureUsersSelected' }
       ) do |form|

--- a/app/components/shares/manage_shares_component.html.erb
+++ b/app/components/shares/manage_shares_component.html.erb
@@ -12,8 +12,7 @@
   end
 
   modal_content.with_row(data: { 'test-selector': 'op-share-dialog-active-list',
-                                  controller: 'shares--bulk-selection',
-                                  application_target: 'dynamic' }) do
+                                  controller: 'shares--bulk-selection' }) do
     render(border_box_container(list_id: insert_target_modifier_id)) do |border_box|
       border_box.with_header(color: :muted, data: { 'test-selector': 'op-share-dialog-header' }) do
         grid_layout('op-share-dialog-modal-body--header', tag: :div, align_items: :center) do |header_grid|

--- a/app/components/work_package_relations_tab/index_component.rb
+++ b/app/components/work_package_relations_tab/index_component.rb
@@ -204,7 +204,6 @@ class WorkPackageRelationsTab::IndexComponent < ApplicationComponent
     if scroll_to?(item)
       {
         controller: "work-packages--relations-tab--scroll",
-        application_target: "dynamic",
         "work-packages--relations-tab--scroll-target": "scrollToRow"
       }
     end

--- a/app/components/work_packages/activities_tab/index_component.rb
+++ b/app/components/work_packages/activities_tab/index_component.rb
@@ -59,7 +59,6 @@ module WorkPackages
         {
           test_selector: "op-wp-activity-tab",
           controller: index_stimulus_controller,
-          "application-target": "dynamic",
           index_stimulus_controller("-notification-center-path-name-value") => notifications_path,
           index_stimulus_controller("-update-streams-path-value") => update_streams_work_package_activities_path(work_package),
           index_stimulus_controller("-sorting-value") => journal_sorting,
@@ -77,7 +76,6 @@ module WorkPackages
         {
           test_selector: "op-work-package-journal--new-comment-component",
           controller: internal_comment_stimulus_controller,
-          "application-target": "dynamic",
           internal_comment_stimulus_controller("-target") => "formContainer",
           action: index_stimulus_controller(":onSubmit-end@window->#{internal_comment_stimulus_controller}#onSubmitEnd"),
           internal_comment_stimulus_controller("-highlight-class") => "work-packages-activities-tab-journals-new-component--journal-notes-body__internal-comment", # rubocop:disable Layout/LineLength

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -56,7 +56,6 @@ module WorkPackages
         def wrapper_data_attributes
           {
             controller: "work-packages--activities-tab--item",
-            "application-target": "dynamic",
             "work-packages--activities-tab--item-activity-url-value": activity_url(journal)
           }
         end
@@ -158,7 +157,6 @@ module WorkPackages
         def quote_action_data_attributes # rubocop:disable Metrics/AbcSize
           {
             controller: quote_comments_stimulus_controller,
-            "application-target": "dynamic",
             action: "click->#{quote_comments_stimulus_controller}#quote:prevent",
             quote_comments_stimulus_controller("-content-param") => journal.notes,
             quote_comments_stimulus_controller("-user-id-param") => journal.user_id,

--- a/app/components/work_packages/date_picker/dialog_content_component.html.erb
+++ b/app/components/work_packages/date_picker/dialog_content_component.html.erb
@@ -7,8 +7,7 @@
   <% end %>
   <%=
     component_wrapper(
-      data: { "application-target": "dynamic",
-              controller: "work-packages--date-picker--preview",
+      data: { controller: "work-packages--date-picker--preview",
               "work-packages--date-picker--preview-date-mode-value": date_mode,
               "work-packages--date-picker--preview-triggering-field-value": triggering_field,
               "work-packages--date-picker--preview-schedule-manually-value": schedule_manually,

--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -1,7 +1,6 @@
 <%=
   flex_layout(
     classes: "op-work-package-details-tab-component", data: {
-      "application-target": "dynamic",
       controller: "work-packages--details--tabs"
     }
   ) do |flex|

--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -9,7 +9,6 @@
         id: 'create-work-package-form',
         data: {
           controller: "work-packages--create-dialog",
-          application_target: "dynamic",
           "work-packages--create-dialog-refresh-url-value": refresh_form_project_work_packages_dialog_path(project)
         }
       }

--- a/app/components/work_packages/exports/generate/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/generate/modal_dialog_component.html.erb
@@ -11,7 +11,6 @@
           url: generate_pdf_work_package_path(work_package),
           data: {
             turbo: false,
-            "application-target": "dynamic",
             controller: "work-packages--export--generate-pdf-form"
           },
           id: GENERATE_PDF_FORM_ID

--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -4,7 +4,6 @@
         size: :xlarge,
         id: MODAL_ID,
         data: {
-          "application-target": "dynamic",
           controller: "work-packages--export--dialog"
         }
       )
@@ -36,7 +35,6 @@
                 url: export_format_url(format[:id]),
                 id: "#{EXPORT_FORM_ID}-#{format[:id]}",
                 data: {
-                  "application-target": "dynamic",
                   action: "submit->work-packages--export--form#submitForm",
                   controller: "work-packages--export--form",
                   "work-packages--export--form-job-status-dialog-id-value": MODAL_ID,

--- a/app/components/work_packages/exports/pdf/export_settings_component.html.erb
+++ b/app/components/work_packages/exports/pdf/export_settings_component.html.erb
@@ -1,7 +1,6 @@
 <%=
   flex_layout(
     data: {
-      "application-target": "dynamic",
       controller: "work-packages--export--pdf--settings"
     }
   ) do |container|

--- a/app/components/work_packages/progress/status_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/status_based/modal_body_component.html.erb
@@ -5,8 +5,7 @@
         class: "progress-form",
         id: "progress-form",
         html: { autocomplete: "off" },
-        data: { "application-target": "dynamic",
-                "work-packages--progress--preview-target": "form",
+        data: { "work-packages--progress--preview-target": "form",
                 controller: "work-packages--progress--preview" }
       ) do |f| %>
     <%= flex_layout do |modal_body| %>

--- a/app/components/work_packages/progress/work_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/work_based/modal_body_component.html.erb
@@ -5,8 +5,7 @@
         class: "progress-form",
         id: "progress-form",
         html: { autocomplete: "off" },
-        data: { "application-target": "dynamic",
-                "work-packages--progress--preview-target": "form",
+        data: { "work-packages--progress--preview-target": "form",
                 controller: "work-packages--progress--preview" }
       ) do |f| %>
     <%= flex_layout do |modal_body| %>

--- a/app/components/work_packages/reminder/modal_body_component.rb
+++ b/app/components/work_packages/reminder/modal_body_component.rb
@@ -78,7 +78,6 @@ module WorkPackages
           scheme: :secondary,
           data: {
             controller: "primer-to-angular-modal",
-            application_target: "dynamic",
             action: "click->primer-to-angular-modal#close",
             test_selector: "op-reminder-modal-close-button"
           }

--- a/app/components/work_packages/types/export_template_list_component.rb
+++ b/app/components/work_packages/types/export_template_list_component.rb
@@ -43,8 +43,7 @@ module WorkPackages
 
       def wrapper_data_attributes
         {
-          controller: "generic-drag-and-drop",
-          "application-target": "dynamic"
+          controller: "generic-drag-and-drop"
         }
       end
 

--- a/app/components/work_packages/types/subject_configuration_component.rb
+++ b/app/components/work_packages/types/subject_configuration_component.rb
@@ -48,7 +48,6 @@ module WorkPackages
           method: :put,
           model: form_model,
           data: {
-            application_target: "dynamic",
             controller: "admin--subject-configuration",
             admin__subject_configuration_hide_pattern_input_value: form_model.subject_configuration == :manual
           }

--- a/app/helpers/stimulus_helper.rb
+++ b/app/helpers/stimulus_helper.rb
@@ -28,12 +28,9 @@
 
 module StimulusHelper
   # rubocop:disable Rails/HelperInstanceVariable
-  def content_controller(name, dynamic: false, **data)
+  def content_controller(name, **data)
     @stimulus_content_data = data
-      .merge({
-               controller: name,
-               "application-target": dynamic ? "dynamic" : nil
-             })
+      .merge({ controller: name })
   end
 
   def stimulus_content_data

--- a/app/views/admin/settings/authentication_settings/_registration.html.erb
+++ b/app/views/admin/settings/authentication_settings/_registration.html.erb
@@ -33,7 +33,6 @@ See COPYRIGHT and LICENSE files for more details.
     url: admin_settings_authentication_path(tab: params[:tab]),
     data: {
       turbo_method: :patch,
-      application_target: "dynamic",
       controller: "admin--registration",
       admin__registration_target: "selfRegistrationRadioGroup",
       admin__registration_activation_by_email_value: Setting::SelfRegistration.value(key: :activation_by_email),

--- a/app/views/admin/settings/progress_tracking/show.html.erb
+++ b/app/views/admin/settings/progress_tracking/show.html.erb
@@ -41,7 +41,6 @@ See COPYRIGHT and LICENSE files for more details.
   settings_primer_form_with(
     scope: :settings, action: :update, method: :patch,
     data: {
-      application_target: "dynamic",
       controller: "admin--progress-tracking",
       admin__progress_tracking_target: "progressCalculationModeRadioGroup",
       admin__progress_tracking_initial_mode_value: Setting.work_package_done_ratio

--- a/app/views/admin/settings/project_custom_fields/edit.html.erb
+++ b/app/views/admin/settings/project_custom_fields/edit.html.erb
@@ -41,7 +41,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= error_messages_for "custom_field" %>
 
 <% content_controller "admin--custom-fields",
-                      dynamic: true,
                       "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/admin/settings/project_custom_fields/new.html.erb
+++ b/app/views/admin/settings/project_custom_fields/new.html.erb
@@ -34,7 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= error_messages_for "custom_field" %>
 
 <% content_controller "admin--custom-fields",
-                      dynamic: true,
                       "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config %>
 
 <%= labelled_tabular_form_for @custom_field, as: :custom_field,

--- a/app/views/custom_actions/edit.html.erb
+++ b/app/views/custom_actions/edit.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for @custom_action %>
 
-<% content_controller "hide-sections", dynamic: true %>
+<% content_controller "hide-sections" %>
 
 <%= labelled_tabular_form_for @custom_action,
                               data: { "hide-sections-target": "form" } do |f| %>

--- a/app/views/custom_actions/new.html.erb
+++ b/app/views/custom_actions/new.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= error_messages_for @custom_action %>
 
-<% content_controller "hide-sections", dynamic: true %>
+<% content_controller "hide-sections" %>
 
 <%= labelled_tabular_form_for @custom_action,
                               data: { "hide-sections-target": "form" } do |f| %>

--- a/app/views/custom_fields/edit.html.erb
+++ b/app/views/custom_fields/edit.html.erb
@@ -34,7 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= error_messages_for 'custom_field' %>
 
 <% content_controller "admin--custom-fields",
-                      dynamic: true,
                       'admin--custom-fields-format-config-value': OpenProject::CustomFieldFormatDependent.stimulus_config
 %>
 

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -44,7 +44,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= error_messages_for "custom_field" %>
 
 <% content_controller "admin--custom-fields",
-                      dynamic: true,
                       "admin--custom-fields-format-config-value": OpenProject::CustomFieldFormatDependent.stimulus_config,
                       "admin--custom-fields-hierarchy-enabled-value": EnterpriseToken.allows_to?(:custom_field_hierarchies) %>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -98,7 +98,6 @@ See COPYRIGHT and LICENSE files for more details.
         id="main-menu"
         class="main-menu"
         data-controller="menus--main"
-        data-application-target="dynamic"
       >
         <h1 class="hidden-for-sighted"><%= t(:label_main_menu) %></h1>
         <opce-main-menu-resizer></opce-main-menu-resizer>

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -36,8 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
                  "members-form-target": "addMemberForm",
                  controller: "user-limit",
                  "user-limit-open-seats-value": OpenProject::Enterprise.open_seats_count,
-                 "user-limit-member-autocompleter-value": true,
-                 "application-target": "dynamic"
+                 "user-limit-member-autocompleter-value": true
                }
     ) do |f| %>
     <a title="<%= t("js.close_form_title") %>"

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title t(:label_member_plural) -%>
 
-<% content_controller "members-form", dynamic: true %>
+<% content_controller "members-form" %>
 
 <% content_for :content_header do %>
   <%= render ::Members::IndexPageHeaderComponent.new(project: @project) %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -29,8 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render Messages::ShowPageHeaderComponent.new(topic: @topic, message: @message, forum: @forum, project:@project) %>
 
-<% content_controller 'forum-messages',
-                      dynamic: true %>
+<% content_controller 'forum-messages' %>
 
 <% title avatar(@topic.author) + h(@topic.subject) %>
 

--- a/app/views/projects/settings/repository/show.html.erb
+++ b/app/views/projects/settings/repository/show.html.erb
@@ -49,8 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
 
   <fieldset
     class="form--fieldset -with-control"
-    data-controller="repository-settings"
-    data-application-target="dynamic">
+    data-controller="repository-settings">
     <legend class="form--fieldset-legend">
       <%= t(:label_available_project_repositories) %>
     </legend>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% content_controller "repository-navigation", dynamic: true %>
+<% content_controller "repository-navigation" %>
 <%= render partial: "repository_header", locals: { empty: false } %>
 
 <% if !@entries.nil? && authorize_for('repositories', 'browse') %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -32,7 +32,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= error_messages_for(role) if @call %>
 
 <div data-controller="admin--roles"
-     data-application-target="dynamic"
      data-admin--roles-global-role-value="<%= role.is_a?(GlobalRole) %>">
   <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: "-slim" %>

--- a/app/views/statuses/edit.html.erb
+++ b/app/views/statuses/edit.html.erb
@@ -47,7 +47,6 @@ See COPYRIGHT and LICENSE files for more details.
   settings_primer_form_with(
     model: @status,
     data: {
-      application_target: "dynamic",
       controller: "admin--statuses"
     }
   ) do |f|

--- a/app/views/statuses/new.html.erb
+++ b/app/views/statuses/new.html.erb
@@ -47,7 +47,6 @@ See COPYRIGHT and LICENSE files for more details.
 primer_form_with(
   model: @status,
   data: {
-    application_target: "dynamic",
     controller: "admin--statuses"
   }
 ) do |f|

--- a/app/views/users/_general.html.erb
+++ b/app/views/users/_general.html.erb
@@ -48,7 +48,6 @@ See COPYRIGHT and LICENSE files for more details.
                               },
                               data: {
                                 controller: "admin--users",
-                                "application-target": "dynamic",
                                 "admin--users-password-auth-selected-value": @user.ldap_auth_source_id.blank?
                               },
                               as: :user do |f| %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -48,7 +48,6 @@ See COPYRIGHT and LICENSE files for more details.
                               html: { class: nil, autocomplete: "off" },
                               data: {
                                 controller: "admin--users",
-                                "application-target": "dynamic",
                                 "admin--users-password-auth-selected-value": @user.ldap_auth_source_id.blank?
                               },
                               as: :user do |f| %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -38,7 +38,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= form_tag({ action: "diff" }, method: :get) do %>
   <div class="generic-table--container"
-       data-application-target="dynamic"
        data-controller="journal-history">
     <div class="generic-table--results-container">
       <table class="generic-table wiki-page-versions">

--- a/app/views/wiki/menu.html.erb
+++ b/app/views/wiki/menu.html.erb
@@ -1,7 +1,6 @@
 <%= turbo_frame_tag "wiki_main_menu" do %>
   <div class="menu-wiki-pages-tree tree-menu--container"
        data-controller="menus--subtree"
-       data-application-target="dynamic"
        data-menus--subtree-selected-value="<%= @page&.slug %>">
     <% cache([@project, @project.wiki]) do %>
       <% pages = @project.wiki.pages.order(Arel.sql("title")).includes(:project)

--- a/docs/development/concepts/stimulus/README.md
+++ b/docs/development/concepts/stimulus/README.md
@@ -22,11 +22,10 @@ If you want to add a common pattern, manually register the controller under `fro
 ### Dynamically loaded controllers
 
 To dynamically load a controller, it needs to live under `frontend/src/stimulus/controllers/dynamic/<controller-name>.controller.ts`.
-
-In DOM, you'll tell the application the controller is dynamically loaded using the `data-application-target="dynamic"`attribute. It tells the application controller (`frontend/src/stimulus/controllers/op-application.controller.ts`) we load on every page on body to dynamically import and load the controller named `users`.
+The application controller (`frontend/src/stimulus/controllers/op-application.controller.ts`) will automatically load controllers dynamically if they are not registered in the `setup.ts` file.
 
 ```html
-<div data-controller="users" data-application-target="dynamic"></div>
+<div data-controller="users"></div>
 ```
 
 #### Namespacing dynamic controllers
@@ -37,7 +36,7 @@ If you want to organize your dynamic controllers in a subfolder, use the [double
 2. Specify the controller name with a double dash for each folder
 
 ```html
-<div data-controller="admin--settings" data-application-target="dynamic"></div>
+<div data-controller="admin--settings"></div>
 ```
 
 You need to take care to prefix all actions, values etc. with the exact same pattern, e.g., `data-admin--settings-target="foobar"`.
@@ -48,6 +47,5 @@ If you have a single controller used in a partial, we have added a helper to use
 
 ```erb
 <% content_controller 'project-storage-form',
-                      dynamic: true,
                       'project-storage-form-folder-mode-value': @project_storage.project_folder_mode %>
 ```

--- a/frontend/src/stimulus/controllers/op-application.controller.ts
+++ b/frontend/src/stimulus/controllers/op-application.controller.ts
@@ -1,18 +1,38 @@
 import { ControllerConstructor } from '@hotwired/stimulus/dist/types/core/controller';
 import { ApplicationController } from 'stimulus-use';
+import { AttributeObserver } from '@hotwired/stimulus';
+import { debugLog } from 'core-app/shared/helpers/debug_output';
 
 export class OpApplicationController extends ApplicationController {
-  static targets = ['dynamic'];
-
   private loaded = new Set<string>();
 
-  dynamicTargetConnected(target:HTMLElement) {
+  private controllerObserver:AttributeObserver;
+
+  connect() {
+    super.connect();
+    this.controllerObserver = new AttributeObserver(
+      this.element,
+      'data-controller',
+      {
+        elementMatchedAttribute: (element:HTMLElement, _) => this.controllerAttributeFound(element),
+      },
+    );
+
+    this.controllerObserver.start();
+  }
+
+  disconnect() {
+    this.controllerObserver.stop();
+  }
+
+  controllerAttributeFound(target:HTMLElement) {
     const controllers = (target.dataset.controller as string).split(' ');
-    const registered = this.application.controllers.map((controller) => controller.identifier);
+    const registered = this.application.router.modules.map((module) => module.definition.identifier);
 
     controllers.forEach((controller) => {
       const path = this.derivePath(controller);
       if (!registered.includes(controller) && !this.loaded.has(controller)) {
+        debugLog(`Loading controller ${controller}`);
         this.loaded.add(controller);
         void import(/* webpackChunkName: "[request]" */`./dynamic/${path}.controller`)
           .then((imported:{ default:ControllerConstructor }) => this.application.register(controller, imported.default))

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -39,7 +39,6 @@ instance.handleError = (error, message, detail) => {
   console.warn(error, message, detail);
 };
 
-instance.register('application', OpApplicationController);
 instance.register('async-dialog', AsyncDialogController);
 instance.register('disable-when-checked', OpDisableWhenCheckedController);
 instance.register('flash', FlashController);
@@ -61,5 +60,8 @@ instance.register('scroll-into-view', ScrollIntoViewController);
 instance.register('ckeditor-focus', CkeditorFocusController);
 instance.register('add-meeting-params', AddMeetingParamsController);
 instance.register('highlight-when-value-selected', HighlightWhenValueSelectedController);
-
 instance.register('auto-submit', AutoSubmit);
+
+// Application controller must be registered last, as it tries to automatically load other controllers
+// not yet registered.
+instance.register('application', OpApplicationController);

--- a/lookbook/previews/open_project/filter/filter_button_component_preview/filter_section_toggle.html.erb
+++ b/lookbook/previews/open_project/filter/filter_button_component_preview/filter_section_toggle.html.erb
@@ -1,5 +1,4 @@
 <div data-controller="filter--filters-form"
-     data-application-target="dynamic"
      data-filter--filters-form-display-filters-value="false"
      data-filter--filters-form-output-format-value="params">
   <%= render ::Filter::FilterButtonComponent.new(query: query) %>

--- a/modules/backlogs/app/views/layouts/backlogs.html.erb
+++ b/modules/backlogs/app/views/layouts/backlogs.html.erb
@@ -34,7 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
   <%= frontend_stylesheet_link_tag "backlogs.css" %>
 <% end %>
 
-<% content_controller "backlogs",
-                      dynamic: true %>
+<% content_controller "backlogs" %>
 
 <%= render template: "layouts/base", locals: local_assigns.merge(turbo_opt_out: true) %>

--- a/modules/budgets/app/views/budgets/subform/_labor_budget_subform.html.erb
+++ b/modules/budgets/app/views/budgets/subform/_labor_budget_subform.html.erb
@@ -35,7 +35,6 @@ See COPYRIGHT and LICENSE files for more details.
 <fieldset id="labor_budget_items_fieldset"
           class="form--fieldset -collapsible"
           data-controller="costs--budget-subform"
-          data-application-target="dynamic"
           data-costs--budget-subform-item-count-value="<%= @budget.labor_budget_items.length %>"
           data-costs--budget-subform-update-url-value="<%= url_for(action: :update_labor_budget_item, project_id: @project.id) %>">
   <legend class="form--fieldset-legend"><%= Budget.human_attribute_name(:labor_budget) %></legend>

--- a/modules/budgets/app/views/budgets/subform/_material_budget_subform.html.erb
+++ b/modules/budgets/app/views/budgets/subform/_material_budget_subform.html.erb
@@ -33,7 +33,6 @@ See COPYRIGHT and LICENSE files for more details.
   <fieldset id="material_budget_items_fieldset"
             class="form--fieldset -collapsible"
             data-controller="costs--budget-subform"
-            data-application-target="dynamic"
             data-costs--budget-subform-item-count-value="<%= @budget.material_budget_items.length %>"
             data-costs--budget-subform-update-url-value="<%= url_for(action: :update_material_budget_item, project_id: @project.id) %>">
     <legend class="form--fieldset-legend"><%= Budget.human_attribute_name(:material_budget) %></legend>

--- a/modules/costs/app/components/my/time_tracking/calendar_component.rb
+++ b/modules/costs/app/components/my/time_tracking/calendar_component.rb
@@ -43,7 +43,6 @@ module My
       def wrapper_data
         {
           "controller" => "my--time-tracking",
-          "application-target" => "dynamic",
           "my--time-tracking-mode-value" => mode,
           "my--time-tracking-view-mode-value" => "calendar",
           "my--time-tracking-time-entries-value" => time_entries_json,

--- a/modules/costs/app/components/my/time_tracking/list_component.rb
+++ b/modules/costs/app/components/my/time_tracking/list_component.rb
@@ -43,7 +43,6 @@ module My
       def wrapper_data
         {
           "controller" => "my--time-tracking",
-          "application-target" => "dynamic",
           "my--time-tracking-mode-value" => mode,
           "my--time-tracking-view-mode-value" => "list"
         }

--- a/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::Alpha::Dialog.new(title: t("caption_log_time_dialog"), size: :medium_portrait, id: MODAL_ID, data: { "keep-open-on-submit": true, "controller" => "time-entry", "application-target" => "dynamic", "time-entry-id" => time_entry.id, "ongoing" => time_entry.ongoing? })) do |d| %>
+<%= render(Primer::Alpha::Dialog.new(title: t("caption_log_time_dialog"), size: :medium_portrait, id: MODAL_ID, data: { "keep-open-on-submit": true, "controller" => "time-entry", "time-entry-id" => time_entry.id, "ongoing" => time_entry.ongoing? })) do |d| %>
   <% d.with_header(variant: :large) %>
   <% d.with_body do %>
     <%= render(

--- a/modules/costs/app/views/admin/cost_types/edit.html.erb
+++ b/modules/costs/app/views/admin/cost_types/edit.html.erb
@@ -51,7 +51,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= labelled_tabular_form_for @cost_type,
                               url: @cost_type.persisted? ? admin_cost_type_path(@cost_type) : admin_cost_types_path,
-                              data: { controller: "subform", "application-target": "dynamic" } do |f| %>
+                              data: { controller: "subform" } do |f| %>
   <%= error_messages_for "cost_type" %>
   <%= back_url_hidden_field_tag %>
 

--- a/modules/costs/app/views/hourly_rates/edit.html.erb
+++ b/modules/costs/app/views/hourly_rates/edit.html.erb
@@ -55,7 +55,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= labelled_tabular_form_for @user,
                               url: { action: "update", project_id: @project },
-                              data: { controller: "subform", "application-target": "dynamic" },
+                              data: { controller: "subform" },
                               method: :put do |f| %>
   <%= back_url_hidden_field_tag %>
   <%= error_messages_for "user" %>

--- a/modules/costs/app/views/my/timer/show.html.erb
+++ b/modules/costs/app/views/my/timer/show.html.erb
@@ -2,8 +2,7 @@
   <div
     class="op-menu--item-action"
     data-controller="my--timers"
-    data-my--timers-start-value="'<%= @timer.created_at %>'"
-    data-application-target="dynamic">
+    data-my--timers-start-value="'<%= @timer.created_at %>'">
 
     <span
       data-my--timers-target="elapsedTime"></span>

--- a/modules/job_status/app/components/job_status/dialog/dialog_component.html.erb
+++ b/modules/job_status/app/components/job_status/dialog/dialog_component.html.erb
@@ -5,7 +5,6 @@
         size: :large,
         id: MODAL_ID,
         data: {
-          "application-target": "dynamic",
           controller: "job-status-polling",
           "job-status-polling-back-on-close-value": back_on_close
         }

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.rb
@@ -60,7 +60,6 @@ module MeetingAgendaItems
     def wrapper_data_attributes
       {
         controller: "meeting-agenda-item-form ckeditor-focus scroll-into-view",
-        "application-target": "dynamic",
         "meeting-agenda-item-form-cancel-url-value": @cancel_path,
         "meeting-agenda-item-form-autofocus-value": @autofocus,
         "ckeditor-focus-target": "editor",

--- a/modules/meeting/app/components/meeting_sections/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/header_component.html.erb
@@ -47,7 +47,6 @@
         url: meeting_section_path(@meeting_section.meeting, @meeting_section),
         data: {
           controller: "meeting-section-form scroll-into-view",
-          "application-target": "dynamic",
           "meeting-section-form-cancel-url-value": cancel_edit_meeting_section_path(@meeting_section.meeting, @meeting_section)
         }
       ) do |f|

--- a/modules/meeting/app/components/meetings/exports/modal_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/exports/modal_dialog_component.html.erb
@@ -12,7 +12,6 @@
           url: project_meeting_path(@project, @meeting, format: :pdf),
           method: :get,
           data: {
-            "application-target": "dynamic",
             controller: "meetings--export--form",
             action: "submit->meetings--export--form#submitForm",
             "meetings--export--form-job-status-dialog-url-value": job_status_dialog_path("_job_uuid_")

--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -10,8 +10,7 @@
           "meetings--form",
           "show-when-value-selected",
           @meeting.is_a?(RecurringMeeting) ? "recurring-meetings--form" : nil
-        ].compact.join(" "),
-        "application-target": "dynamic"
+        ].compact.join(" ")
       },
       html: {
         id: "meeting-form"

--- a/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_sub_header_component.html.erb
@@ -2,7 +2,6 @@
       Primer::OpenProject::SubHeader.new(
         data: {
           controller: "filter--filters-form",
-          "application-target": "dynamic",
           "filter--filters-form-output-format-value": "json"
         }
       )

--- a/modules/meeting/app/components/meetings/show_component.rb
+++ b/modules/meeting/app/components/meetings/show_component.rb
@@ -43,8 +43,7 @@ module Meetings
 
     def wrapper_data_attributes
       {
-        controller: "meetings-drag-and-drop add-meeting-params",
-        "application-target": "dynamic"
+        controller: "meetings-drag-and-drop add-meeting-params"
       }
     end
   end

--- a/modules/meeting/app/components/meetings/side_panel/details_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_form_component.html.erb
@@ -5,8 +5,7 @@
       method: :put,
       data: { turbo: true,
               turbo_stream: true,
-              controller: "meetings--form",
-              "application-target": "dynamic" },
+              controller: "meetings--form" },
       url: update_details_project_meeting_path(@project, @meeting)
     ) do |f|
       component_collection do |collection|

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.rb
@@ -37,8 +37,7 @@ module Meetings
 
     def wrapper_data_attributes
       {
-        controller: "expandable-list",
-        "application-target": "dynamic"
+        controller: "expandable-list"
       }
     end
 

--- a/modules/meeting/app/forms/meeting/time_group.rb
+++ b/modules/meeting/app/forms/meeting/time_group.rb
@@ -70,8 +70,7 @@ class Meeting::TimeGroup < ApplicationForm
         required: true,
         caption: I18n.t("text_in_hours"),
         data: {
-          controller: "chronic-duration",
-          application_target: "dynamic"
+          controller: "chronic-duration"
         }
       )
     end

--- a/modules/overviews/app/components/overviews/project_phases/edit_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_phases/edit_component.html.erb
@@ -7,7 +7,6 @@
       data: {
         controller: "overview--project-life-cycles-form",
         "overview--project-life-cycles-form-url-value": preview_project_phase_path(model),
-        "application-target": "dynamic",
         turbo: true,
         turbo_stream: true,
         "test-selector": "async-dialog-content"

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.html.erb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.html.erb
@@ -14,7 +14,6 @@
         href: url_for({ controller: "cost_reports", action: :index, format: "xls", project_id: @project }),
         data: {
           controller: "costs--export",
-          "application-target": "dynamic",
           "costs--export-job-status-dialog-url-value": job_status_dialog_path("_job_uuid_"),
           action: "click->costs--export#download"
         }
@@ -32,7 +31,6 @@
         href: url_for({ controller: "cost_reports", action: :index, format: "pdf", project_id: @project }),
         data: {
           controller: "costs--export",
-          "application-target": "dynamic",
           "costs--export-job-status-dialog-url-value": job_status_dialog_path("_job_uuid_"),
           action: "click->costs--export#download"
         }

--- a/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/automatically_managed_project_folders_form_component.html.erb
@@ -7,7 +7,6 @@
         method: form_method,
         data: {
           controller: "storages--automatically-managed-project-folders-form",
-          "application-target": "dynamic",
           "storages--automatically-managed-project-folders-form-provider-type-value": storage.provider_type,
           "storages--automatically-managed-project-folders-form-is-automatically-managed-value": storage.automatic_management_enabled?,
           "storages--automatically-managed-project-folders-form-done-complete-label-value": I18n.t("storages.buttons.done_complete_setup"),

--- a/modules/storages/app/components/storages/admin/forms/general_info_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/general_info_form_component.html.erb
@@ -8,7 +8,6 @@
           data: {
             "turbo-frame": "page-content",
             controller: "storages--automatically-managed-project-folders-form",
-            "application-target": "dynamic",
             "storages--automatically-managed-project-folders-form-provider-type-value": storage.provider_type,
             "storages--automatically-managed-project-folders-form-is-automatically-managed-value": storage.automatic_management_enabled?
           }

--- a/modules/storages/app/components/storages/admin/forms/storage_audience_form_component.html.erb
+++ b/modules/storages/app/components/storages/admin/forms/storage_audience_form_component.html.erb
@@ -36,7 +36,6 @@ See COPYRIGHT and LICENSE files for more details.
         method: :patch,
         data: {
           turbo_frame: "page-content",
-          application_target: "dynamic",
           controller: "storages--storage-audience"
         }
       ) do |form|

--- a/modules/storages/app/components/storages/admin/storages/oauth_access_grant_nudge_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/oauth_access_grant_nudge_modal_component.html.erb
@@ -5,7 +5,6 @@
         id: dialog_id,
         title: heading_text,
         data: {
-          "application-target": "dynamic",
           controller: "storages--oauth-access-grant-nudge-modal",
           "storages--oauth-access-grant-nudge-modal-close-button-label-value": I18n.t("button_close"),
           "storages--oauth-access-grant-nudge-modal-loading-screen-reader-message-value": waiting_title

--- a/modules/storages/app/components/storages/admin/storages/oauth_access_granted_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/oauth_access_granted_modal_component.html.erb
@@ -5,7 +5,6 @@
         id: dialog_id,
         title:,
         data: {
-          "application-target": "dynamic",
           controller: "auto-show-dialog"
         },
         test_selector: "oauth-access-granted-modal"

--- a/modules/storages/app/components/storages/admin/storages/projects_storage_form_modal_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/projects_storage_form_modal_component.html.erb
@@ -69,7 +69,6 @@ See COPYRIGHT and LICENSE files for more details.
 
             flex.with_row(
               data: {
-                "application-target": "dynamic",
                 controller: "storages--project-folder-mode-form",
                 "storages--project-folder-mode-form-folder-mode-value": @project_storage.project_folder_mode,
                 "storages--project-folder-mode-form-placeholder-folder-name-value": t(:"storages.label_no_selected_folder"),

--- a/modules/storages/app/components/storages/open_project_storage_modal_component.rb
+++ b/modules/storages/app/components/storages/open_project_storage_modal_component.rb
@@ -50,7 +50,6 @@ class Storages::OpenProjectStorageModalComponent < ViewComponent::Base
   def data
     @data ||= {
       controller:,
-      "application-target": "dynamic",
       "#{controller}-project-storage-open-url-value": project_storage_open_url,
       "#{controller}-redirect-url-value": redirect_url,
       "#{controller}-subtitle-timeout-text-value": subtitle_timeout_text

--- a/modules/storages/app/views/storages/admin/storages/_new.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/_new.html.erb
@@ -28,7 +28,6 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% content_controller "storages--storage-form",
-                      dynamic: true,
                       "storages--storage-form-one-drive-placeholder-value": t(:"storages.provider_types.one_drive.name_placeholder"),
                       "storages--storage-form-nextcloud-placeholder-value": t(:"storages.provider_types.nextcloud.name_placeholder") %>
 

--- a/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
+++ b/modules/storages/app/views/storages/project_settings/_project_folder_form.html.erb
@@ -28,7 +28,6 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% content_controller "project-storage-form",
-                      dynamic: true,
                       "project-storage-form-folder-mode-value": @project_storage.project_folder_mode,
                       "project-storage-form-placeholder-folder-name-value": t(:"storages.label_no_selected_folder"),
                       "project-storage-form-not-logged-in-validation-value": t(:"storages.instructions.not_logged_into_storage"),

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
@@ -4,8 +4,7 @@
 <% html_title t(:field_otp) %>
 <div id="login-form"
      class="form -bordered"
-     data-controller="two-factor-authentication"
-     data-application-target="dynamic">
+     data-controller="two-factor-authentication">
   <%= styled_form_tag(
         { action: :confirm_otp },
         id: "submit_otp",

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/backup_codes/show.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/backup_codes/show.html.erb
@@ -30,9 +30,7 @@
 
 <hr class="hide-when-print">
 
-<div
-  data-controller="two-factor-authentication"
-  data-application-target="dynamic">
+<div data-controller="two-factor-authentication">
   <%= content_tag :a,
                   id: "download_2fa_backup_codes",
                   class: "button hide-when-print",

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/new.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/new.html.erb
@@ -17,7 +17,6 @@
                               url: { action: :register },
                               html: { class: nil, autocomplete: "off", data: {
                                 controller: "two-factor-authentication",
-                                application_target: "dynamic",
                                 challenge_url: optional_webauthn_challenge_url,
                                 device_type: @device_type,
                                 action: "submit->two-factor-authentication#onCreateDevice"

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/totp/_form.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/totp/_form.html.erb
@@ -14,8 +14,7 @@
 </fieldset>
 
 <div class="mobile-otp-qr-form"
-     data-controller="two-factor-authentication"
-     data-application-target="dynamic">
+     data-controller="two-factor-authentication">
   <div class="qr-code-element"
        data-value="<%= device.provisioning_url %>"
        data-two-factor-authentication-target="qrCodeElement">


### PR DESCRIPTION
# What are you trying to accomplish?
Avoid having developers to think about dynamic or registered controllers, by using our own MutationObserver instead of relying on a target on the ApplicationController

# What approach did you choose and why?
Use the AttributeObserver of Stimulus to identify `data-controller` attributes, and compare the list of registered controllers. If the given controller is not present, try to autoload it.

# Merge checklist

- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
