### PR TITLE
[64846] Attribute help text links for widgets on Projects Overview page lack padding

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.sass
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.sass
@@ -1,6 +1,3 @@
 .op-widget-box--header
   &.-editable
     margin-top: 0
-
-  &-title
-    padding-right: 5px

--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -71,6 +71,7 @@ body.widget-grid-layout
 
   .op-widget-box--header
     display: flex
+    gap: var(--base-size-6)
 
   icon-triggered-context-menu
     visibility: hidden
@@ -108,7 +109,7 @@ body.widget-grid-layout
   margin-left: -19px
   padding-right: 1px
   padding-top: 4px
-  margin-top: 5px
+  margin-top: 4px
   opacity: 0
   cursor: grab
   float: left

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -116,6 +116,9 @@ $widget-box--enumeration-width: 20px
   border-bottom: none
   padding-bottom: 0
 
+  .help-text--entry
+    vertical-align: 2px
+
 .op-widget-box--header-title
   vertical-align: middle
   margin-bottom: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64846

# What are you trying to accomplish?
Give attribute help text more space and align it correctly

## Screenshots

<img width="345" alt="Bildschirmfoto 2025-06-17 um 11 53 53" src="https://github.com/user-attachments/assets/041696fa-c4c6-4be1-8977-7439b1c044a1" />
<img width="351" alt="Bildschirmfoto 2025-06-17 um 11 53 45" src="https://github.com/user-attachments/assets/4267b22e-6a91-4ebb-bfdc-2961c5f154be" />


