### PR TITLE
[#64794] Wrong wording for project phases in system administration

### DIFF
--- a/app/components/settings/project_life_cycle_step_definitions/form_header_component.html.erb
+++ b/app/components/settings/project_life_cycle_step_definitions/form_header_component.html.erb
@@ -27,8 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<% helpers.html_title t(:label_administration),
+                      t("settings.project_phase_definitions.heading"),
+                      definition_heading %>
+
 <%= render Primer::OpenProject::PageHeader.new do |header|
-      header.with_title { t("settings.project_phase_definitions.#{heading_scope}.heading") }
+      header.with_title { definition_heading }
       header.with_description { t("settings.project_phase_definitions.new.description") }
       header.with_breadcrumbs(breadcrumbs_items)
     end %>

--- a/app/components/settings/project_life_cycle_step_definitions/form_header_component.rb
+++ b/app/components/settings/project_life_cycle_step_definitions/form_header_component.rb
@@ -31,7 +31,13 @@
 module Settings
   module ProjectLifeCycleStepDefinitions
     class FormHeaderComponent < ApplicationComponent
-      options :heading_scope
+      def definition_heading
+        if model.persisted?
+          model.name
+        else
+          t("settings.project_phase_definitions.new.heading")
+        end
+      end
 
       def breadcrumbs_items
         [
@@ -47,7 +53,7 @@ module Settings
             href: admin_settings_project_phase_definitions_path,
             text: t("settings.project_phase_definitions.heading")
           },
-          t("settings.project_phase_definitions.#{heading_scope}.heading")
+          definition_heading
         ]
       end
     end

--- a/app/views/admin/settings/project_life_cycle_definitions/form.html.erb
+++ b/app/views/admin/settings/project_life_cycle_definitions/form.html.erb
@@ -27,12 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% heading_scope = @definition.persisted? ? :edit : :new %>
-
-<% html_title t(:label_administration),
-              t("settings.project_phase_definitions.heading"),
-              t("settings.project_phase_definitions.#{heading_scope}.heading") %>
-
-<%= render Settings::ProjectLifeCycleStepDefinitions::FormHeaderComponent.new(@definition, heading_scope:) %>
+<%= render Settings::ProjectLifeCycleStepDefinitions::FormHeaderComponent.new(@definition) %>
 
 <%= render Projects::LifeCycleStepDefinitions::FormComponent.new(@definition) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4117,8 +4117,6 @@ en:
       new:
         description: "Changes to this project phase will be reflected in all projects where it is enabled."
         heading: "New phase"
-      edit:
-        heading: "Edit phase"
       both_gate: "Start and finish gate"
       no_gate: "No gate"
       start_gate: "Start gate"

--- a/spec/features/admin/project_life_cycle_step_definitions_spec.rb
+++ b/spec/features/admin/project_life_cycle_step_definitions_spec.rb
@@ -100,6 +100,9 @@ RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gate
 
       # editing steps
       definitions_page.click_definition("Initiating")
+
+      definitions_page.expect_header_to_display("Initiating")
+
       fill_in "Name", with: "Starting"
       click_on "Update"
 
@@ -111,6 +114,9 @@ RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gate
 
       # creating steps
       definitions_page.add
+
+      definitions_page.expect_header_to_display("New phase")
+
       fill_in "Name", with: "Imagining"
       definitions_page.select_color("Azure")
       click_on "Create"

--- a/spec/support/pages/admin/settings/project_life_cycle_step_definitions.rb
+++ b/spec/support/pages/admin/settings/project_life_cycle_step_definitions.rb
@@ -36,6 +36,12 @@ module Pages
       class ProjectLifeCycleStepDefinitions < ::Pages::Page
         def path = "/admin/settings/project_life_cycle"
 
+        def expect_header_to_display(text)
+          expect(page).to have_css("h2", text:)
+          expect(page).to have_css(".breadcrumb-item-selected a", text:)
+          expect(page).to have_title("#{text} | Project life cycle | Administration | OpenProject")
+        end
+
         def expect_listed(names)
           page.document.synchronize do
             found = page.all("[data-test-selector=project-life-cycle-step-definition-name]").collect(&:text)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/64794

# What are you trying to accomplish?
Update the breadcrumbs from `Edit Phase` to the phase name ie: `Initiating`.

## Screenshots

<details><summary>Before</summary>
<p>

<img width="789" alt="image" src="https://github.com/user-attachments/assets/4d24a780-f5ce-43de-b7af-fa6d65a716ad" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="796" alt="image" src="https://github.com/user-attachments/assets/298cf9a1-fa21-44ba-bd13-0a7ff98f7d75" />

</p>
</details> 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
