### PR TITLE
Properly check whether user is locked

### DIFF
--- a/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
+++ b/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
@@ -43,7 +43,7 @@ module OpenProject
 
           def authenticate_user(id)
             user = id && User.find_by(id:)
-            if user
+            if user&.active?
               success!(user)
             else
               fail_with_header!(error: "invalid_token")

--- a/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
+++ b/lib_static/open_project/authentication/strategies/warden/doorkeeper_oauth.rb
@@ -42,8 +42,8 @@ module OpenProject
           end
 
           def authenticate_user(id)
-            user = id && User.find_by(id:)
-            if user&.active?
+            user = id && User.active.find_by(id:)
+            if user
               success!(user)
             else
               fail_with_header!(error: "invalid_token")


### PR DESCRIPTION
The current implementation opens a small window of opportunity to authenticate through a previously issued access token even after a user account was locked.

If access tokens had a longer lifetime, this could become a large window of opportunity.

# Ticket
* https://community.openproject.org/wp/64883
* Noticed while working on https://github.com/opf/openproject/pull/19206, where we introduce access tokens with a longer lifespan