### PR TITLE
[64636] Prevent importing the same enterprise token twice

### DIFF
--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -122,10 +122,12 @@ class EnterpriseToken < ApplicationRecord
   FAR_FUTURE_DATE = Date.new(9999, 1, 1)
   private_constant :FAR_FUTURE_DATE
 
-  validates :encoded_token, presence: true
+  validates :encoded_token, presence: true,
+                            uniqueness: { message: I18n.t("activerecord.errors.models.enterprise_token.already_added") }
   validate :valid_token_object
   validate :valid_domain
 
+  before_validation :strip_encoded_token
   before_save :extract_validity_from_token
   before_save :clear_current_tokens_cache
   before_destroy :clear_current_tokens_cache
@@ -225,6 +227,10 @@ class EnterpriseToken < ApplicationRecord
   end
 
   private
+
+  def strip_encoded_token
+    self.encoded_token = encoded_token.strip if encoded_token.present?
+  end
 
   def load_token!
     @token_object = OpenProject::Token.import(encoded_token)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1350,6 +1350,7 @@ en:
           general_consent: "Please accept the terms and conditions."
         enterprise_token:
           unreadable: "can't be read. Are you sure it is a support token?"
+          already_added: "This token has already been added."
         grids/grid:
           overlaps: "overlap."
           outside: "is outside of the grid."

--- a/spec/features/admin/enterprise/enterprise_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_spec.rb
@@ -34,18 +34,6 @@ RSpec.describe "Enterprise token", :js do
   include Redmine::I18n
 
   shared_let(:admin) { create(:admin) }
-  let(:token_object) do
-    OpenProject::Token.new.tap do |token|
-      token.subscriber = "Foobar"
-      token.mail = "foo@example.org"
-      token.starts_at = Date.current
-      token.expires_at = nil
-      token.domain = Setting.host_name
-    end
-  end
-
-  let(:textarea) { find_by_id "enterprise_token_encoded_token" }
-  let(:submit_button) { find_by_id "token-submit-button" }
 
   describe "EnterpriseToken management" do
     before do
@@ -53,24 +41,40 @@ RSpec.describe "Enterprise token", :js do
       visit enterprise_tokens_path
     end
 
-    it "shows a teaser page and has a button to add a token" do
+    it "shows a teaser page and has a button to add a token with a dialog" do
       expect(page).to have_link("Start free trial")
 
-      # Try adding invalid enterprise token data
       expect(page).to have_button("Add Enterprise token")
       click_button "Add Enterprise token"
 
       expect(page).to have_dialog("Add Enterprise token")
-      fill_in "Type support token text", with: "foobar"
-      click_button "Add"
+      expect(page).to have_field("Type support token text", type: "textarea")
+    end
 
-      # The dialog is still open with an error message on token field
-      expect(page).to have_dialog("Add Enterprise token")
-      expect(page).to have_field("Type support token text",
-                                 validation_error: "Enterprise support token can't be read. Are you sure it is a support token?")
+    context "with invalid input" do
+      it "shows an error message" do
+        click_button "Add Enterprise token"
+        fill_in "Type support token text", with: "foobar"
+        click_button "Add"
+
+        # The dialog is still open with an error message on token field
+        expect(page).to have_dialog("Add Enterprise token")
+        validation_error = "Enterprise support token can't be read. Are you sure it is a support token?"
+        expect(page).to have_field("Type support token text", validation_error:)
+      end
     end
 
     context "with valid input" do
+      let(:token_object) do
+        OpenProject::Token.new.tap do |token|
+          token.subscriber = "Foobar"
+          token.mail = "foo@example.org"
+          token.starts_at = Date.current
+          token.expires_at = nil
+          token.domain = Setting.host_name
+        end
+      end
+
       before do
         allow(OpenProject::Token).to receive(:import).and_return(token_object)
       end
@@ -119,6 +123,32 @@ RSpec.describe "Enterprise token", :js do
         # Token deleted
         expect_and_dismiss_flash(message: I18n.t(:notice_successful_delete))
         expect(EnterpriseToken.all).to be_empty
+      end
+
+      it "cannot import same token twice" do
+        click_button "Add Enterprise token"
+        fill_in "Type support token text", with: "foobar"
+        click_button "Add"
+
+        expect_and_dismiss_flash(message: I18n.t(:notice_successful_update))
+
+        click_button "Add Enterprise token"
+        fill_in "Type support token text", with: "foobar"
+        click_button "Add"
+
+        # The dialog is still open with an error message on token field
+        expect(page).to have_dialog("Add Enterprise token")
+        validation_error = "This token has already been added."
+        expect(page).to have_field("Type support token text", validation_error:)
+
+        # Try importing with blank spaces and newlines before and after
+        fill_in "Type support token text", with: " \nfoobar \n"
+        click_button "Add"
+
+        # The dialog is still open with an error message on token field
+        expect(page).to have_dialog("Add Enterprise token")
+        validation_error = "This token has already been added."
+        expect(page).to have_field("Type support token text", validation_error:)
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64636

# What are you trying to accomplish?

Prevent importing the same enterprise token twice.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

It's not very strict right now: it relies on rails uniqueness validation. There is no database unique constraint so two parallel requests could add the same token, but that's unlikely to happen.

You can also import the same token twice if you add some garbage before and/or after, but it strips whitespaces and for most customer scenarios, it should be enough as users are unlikely to add random characters before their token.

Also even if the same token is added twice, it's not a big deal. It will still work as expected.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
