### PR TITLE
bug/64695 Upon setting a work package reminder, present the reminder time in relative humanized format

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4540,7 +4540,7 @@ en:
     reminders:
       label_remind_at: "Date"
       note_placeholder: "Why are you setting this reminder?"
-      success_creation_message: "Reminder set successfully. You will receive a notification for this work package at the chosen time."
+      create_success_message: "Reminder set successfully. You will receive a notification for this work package %{reminder_time}."
       success_update_message: "Reminder updated successfully."
       success_deletion_message: "Reminder deleted successfully."
   sharing:


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/64695

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Replace "chosen time" in the success message with more human relative time

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1746" alt="Screenshot 2025-06-18 at 11 08 19 AM" src="https://github.com/user-attachments/assets/c4a6da17-02dd-44f8-8a90-d388621c5431" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Display relative time via [OpPrimer::RelativeTimeComponent](https://github.com/opf/openproject/blob/dev/app/components/op_primer/relative_time_component.rb) which already accounts for locale (among other things).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
