### PR TITLE
Handle non-turbo responses in async-dialog controller

### DIFF
--- a/frontend/src/stimulus/controllers/async-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.ts
@@ -49,13 +49,20 @@ export default class AsyncDialogController extends ApplicationController {
         Accept: 'text/vnd.turbo-stream.html',
         'X-Authentication-Scheme': 'Session',
       },
-    }).then((r) => r.text())
-      .then((html) => {
-        renderStreamMessage(html);
-      })
-      .finally(() => {
-        TurboHelpers.hideProgressBar();
-      });
+    }).then((response) => {
+      const contentType = response.headers.get('Content-Type') || '';
+      const isTurboStream = contentType.includes('text/vnd.turbo-stream.html');
+
+      if (!isTurboStream) {
+        return Promise.reject();
+      }
+
+      return response.text();
+    }).then((html) => {
+      renderStreamMessage(html);
+    }).finally(() => {
+      TurboHelpers.hideProgressBar();
+    });
   }
 
   get href() {


### PR DESCRIPTION
We make a web request, expecting a proper turbo response, but so far we didn't check that we receive a turbo response. As a result any non-turbo error page (NGINX error, rails error page, etc.) would blindly be appended to the page.

By checking the content type, we can at least make sure that the web server intended for us to handle the response in the way we do.

# Ticket
* https://community.openproject.org/wp/64974
* Similar problem/fix: https://github.com/opf/openproject/pull/18957