### PR TITLE
[#63790] add flex-wrap to health report rows

### DIFF
--- a/modules/storages/app/components/storages/admin/health/check_result_component.html.erb
+++ b/modules/storages/app/components/storages/admin/health/check_result_component.html.erb
@@ -30,16 +30,16 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   flex_layout do |cell|
     cell.with_row do
-      flex_layout(justify_content: :space_between) do |row|
-        row.with_column(flex_layout: true) do |text|
-          text.with_column do
+      flex_layout(justify_content: :space_between, classes: "flex-wrap") do |row|
+        row.with_column(flex_layout: true, classes: "flex-wrap") do |text|
+          text.with_column(mr: 2) do
             render(Primer::Beta::Text.new(font_weight: :bold)) { data[:text] }
           end
-          text.with_column(ml: 2) do
+          text.with_column(mr: 2) do
             render(Primer::Beta::Text.new(font_size: :small, color: data[:status_color])) { data[:status_text] }
           end
           if data[:error_code].present?
-            text.with_column(ml: 2) do
+            text.with_column do
               render(Primer::Beta::Label.new(scheme: data[:status_color])) { data[:error_code] }
             end
           end

--- a/modules/storages/app/components/storages/admin/health/health_report_component.html.erb
+++ b/modules/storages/app/components/storages/admin/health/health_report_component.html.erb
@@ -68,7 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
               report_container.with_row(mt: 3) do
                 render(Primer::Beta::BorderBox.new(test_selector: "op-storages--health-report-group")) do |box|
                   box.with_header do
-                    flex_layout(justify_content: :space_between) do |header|
+                    flex_layout(justify_content: :space_between, classes: "flex-wrap") do |header|
                       header.with_column do
                         render(Primer::Beta::Text.new(font_weight: :bold)) { group_result.humanize_title }
                       end


### PR DESCRIPTION
# Ticket
[#63790](https://community.openproject.org/work_packages/63790)

# What are you trying to accomplish?
- allow agreeable mobile behaviour for the health report

## Screenshots

![Screenshot from 2025-06-18 14-05-16](https://github.com/user-attachments/assets/8e2758d1-8bfd-4eef-8668-43ece65ffbf4)

# What approach did you choose and why?
- use flex-wrap in all rows that concatenate multiple content elements
