### PR TITLE
[#64694] Add internal comments to capabilities API

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -320,25 +320,29 @@ Rails.application.reloader.to_prepare do
                      {},
                      permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: :view_work_packages
+                     dependencies: :view_work_packages,
+                     contract_actions: { internal_comments: %i[read] }
 
       wpt.permission :add_internal_comments,
                      {},
                      permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: %i[view_project view_internal_comments]
+                     dependencies: %i[view_project view_internal_comments],
+                     contract_actions: { internal_comments: %i[create] }
 
       wpt.permission :edit_own_internal_comments,
                      {},
                      permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: %i[view_project view_internal_comments]
+                     dependencies: %i[view_project view_internal_comments],
+                     contract_actions: { internal_comments: %i[update_own] }
 
       wpt.permission :edit_others_internal_comments,
                      {},
                      permissible_on: %i[project],
                      require: :loggedin,
-                     dependencies: %i[view_project view_internal_comments]
+                     dependencies: %i[view_project view_internal_comments],
+                     contract_actions: { internal_comments: %i[update_others] }
 
       # WP attachments can be added with :edit_work_packages, this permission allows it without Edit WP as well.
       wpt.permission :add_work_package_attachments,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/64694

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Allow mobile apps to utilise `internal_comments`, by making it possible to check permissions for them via the capabilities API.

You can test it by requesting for example `/api/v3/capabilities/internal_comments/create/p1-4`, where `p1` identifies the project with id 1 and `4` identifies the user with id 4. Be aware that if a user does not have the permission, the response will be a 404 error.
To avoid that, you can use the filters param instead, for example: `/api/v3/capabilities` with params 
```
filters = [
  {"principalId":{"operator":"=", "values":[4]}},
  {"context":{"operator":"=", "values":["p1"]}},
  {"action":{"operator":"=", "values":["work_packages/create"]}}
]
```

## Screenshots
### Example replies for `/api/v3/capabilities/internal_comments/create/p1-4`

#### User has the permission:
<img width="666" alt="internal_comments_capabilities_create" src="https://github.com/user-attachments/assets/6e14e6f0-ad57-4f1a-8a5b-cfa2be786139" />

#### User does not have the permission:
<img width="689" alt="internal_comments_capabilities_create_NO" src="https://github.com/user-attachments/assets/e4a28552-b472-4054-87a6-3506de59228a" />

### Example replies for `/api/v3/capabilities` with params

#### User has the permission:
<img width="561" alt="internal_comments_capabilities_create_alternative" src="https://github.com/user-attachments/assets/0b9533ae-ed83-40d4-b97f-fab54c735f9a" />

#### User does not have the permission:
<img width="572" alt="internal_comments_capabilities_create_alternative_NO" src="https://github.com/user-attachments/assets/3dcfacbd-e2a1-4168-aa92-f2704e6894ef" />

# What approach did you choose and why?
Follow the standard approach to add `contract_actions` to permission definitions for internal_comments.
There are four permissions defined and stuck with already used names for capabilities in API.
- `view_internal_comments` -> `internal_comments/read`
- `add_internal_comments` -> `internal_comments/create`
- `edit_own_internal_comments` -> `internal_comments/update_own`
- `edit_others_internal_comments` -> `internal_comments/update_others`


# Merge checklist

- [ ] ~~Added/updated tests~~ Already covered in existing tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
