### PR TITLE
Bug/64253 flickering life cycle definition specs

### DIFF
--- a/spec/factories/project_phase_definition_factory.rb
+++ b/spec/factories/project_phase_definition_factory.rb
@@ -31,7 +31,6 @@
 FactoryBot.define do
   factory :project_phase_definition, class: "Project::PhaseDefinition" do
     sequence(:name) { |n| "Phase definition #{n}" }
-    sequence(:position)
 
     color
 

--- a/spec/features/admin/project_life_cycle_step_definitions_spec.rb
+++ b/spec/features/admin/project_life_cycle_step_definitions_spec.rb
@@ -31,9 +31,9 @@
 require "spec_helper"
 
 RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gates: true } do
-  shared_let(:initiating_stage) { create(:project_phase_definition, name: "Initiating") }
+  shared_let(:initiating_stage) { create(:project_phase_definition, name: "Initiating", position: 1) }
   shared_let(:executing_stage) do
-    create(:project_phase_definition, name: "Executing", start_gate: true, start_gate_name: "Ready to Execute")
+    create(:project_phase_definition, name: "Executing", start_gate: true, start_gate_name: "Ready to Execute", position: 2)
   end
 
   let(:definitions_page) { Pages::Admin::Settings::ProjectLifeCycleStepDefinitions.new }

--- a/spec/features/admin/project_life_cycle_step_definitions_spec.rb
+++ b/spec/features/admin/project_life_cycle_step_definitions_spec.rb
@@ -31,9 +31,9 @@
 require "spec_helper"
 
 RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gates: true } do
-  shared_let(:initiating_stage) { create(:project_phase_definition, name: "Initiating", position: 1) }
+  shared_let(:initiating_stage) { create(:project_phase_definition, name: "Initiating") }
   shared_let(:executing_stage) do
-    create(:project_phase_definition, name: "Executing", start_gate: true, start_gate_name: "Ready to Execute", position: 2)
+    create(:project_phase_definition, name: "Executing", start_gate: true, start_gate_name: "Ready to Execute")
   end
 
   let(:definitions_page) { Pages::Admin::Settings::ProjectLifeCycleStepDefinitions.new }

--- a/spec/features/admin/project_life_cycle_step_definitions_spec.rb
+++ b/spec/features/admin/project_life_cycle_step_definitions_spec.rb
@@ -144,21 +144,21 @@ RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gate
       definitions_page.expect_listed(["Initiating", "Starting", "Imagining", "Processing"])
 
       retry_block do
-        definitions_page.drag_and_drop_list(from: 0, to: 2,
+        definitions_page.drag_and_drop_list(from: 0, to: 3,
                                             elements: "[data-test-selector=project-life-cycle-step-definition]",
                                             handler: ".DragHandle")
         wait_for_network_idle
-        definitions_page.expect_listed(["Starting", "Imagining", "Initiating", "Processing"])
+        definitions_page.expect_listed(["Starting", "Imagining", "Processing", "Initiating"])
       end
 
       definitions_page.reload!
-      definitions_page.expect_listed(["Starting", "Imagining", "Initiating", "Processing"])
+      definitions_page.expect_listed(["Starting", "Imagining", "Processing", "Initiating"])
 
       # deleting
       accept_confirm I18n.t(:text_are_you_sure_with_project_life_cycle_step) do
         definitions_page.click_definition_action("Imagining", action: "Delete")
       end
-      definitions_page.expect_listed(["Starting", "Initiating", "Processing"])
+      definitions_page.expect_listed(["Starting", "Processing", "Initiating"])
     end
   end
 end

--- a/spec/features/admin/project_life_cycle_step_definitions_spec.rb
+++ b/spec/features/admin/project_life_cycle_step_definitions_spec.rb
@@ -115,14 +115,10 @@ RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gate
       definitions_page.select_color("Azure")
       click_on "Create"
 
-      definitions_page.expect_and_dismiss_flash(message: "Successful creation.")
-
       definitions_page.add
       fill_in "Name", with: "Initiating"
       definitions_page.select_color("Gold")
       click_on "Create"
-
-      definitions_page.expect_and_dismiss_flash(message: "Successful creation.")
 
       definitions_page.expect_listed(["Starting", "Processing", "Imagining", "Initiating"])
 
@@ -143,13 +139,11 @@ RSpec.describe "Projects life cycle settings", :js, with_flag: { stages_and_gate
       wait_for_network_idle
       definitions_page.expect_listed(["Initiating", "Starting", "Imagining", "Processing"])
 
-      retry_block do
-        definitions_page.drag_and_drop_list(from: 0, to: 3,
-                                            elements: "[data-test-selector=project-life-cycle-step-definition]",
-                                            handler: ".DragHandle")
-        wait_for_network_idle
-        definitions_page.expect_listed(["Starting", "Imagining", "Processing", "Initiating"])
-      end
+      definitions_page.drag_and_drop_list(from: 0, to: 3,
+                                          elements: "[data-test-selector=project-life-cycle-step-definition]",
+                                          handler: ".DragHandle")
+      wait_for_network_idle
+      definitions_page.expect_listed(["Starting", "Imagining", "Processing", "Initiating"])
 
       definitions_page.reload!
       definitions_page.expect_listed(["Starting", "Imagining", "Processing", "Initiating"])

--- a/spec/features/work_packages/table/project_phase_field_spec.rb
+++ b/spec/features/work_packages/table/project_phase_field_spec.rb
@@ -31,10 +31,10 @@
 require "spec_helper"
 
 RSpec.describe "Project phase field in the work package table", :js do
-  let(:phase_definition) { create(:project_phase_definition, position: 99) }
+  let(:phase_definition) { create(:project_phase_definition, position: 2) }
   let(:project_phase) { create(:project_phase, definition: phase_definition) }
   let(:project_phase_from_other_project) { create(:project_phase, definition: phase_definition) }
-  let(:other_project_phase) { create(:project_phase) }
+  let(:other_project_phase) { create(:project_phase, definition: create(:project_phase_definition, position: 1)) }
   let(:project) { create(:project_with_types, phases: [project_phase, other_project_phase]) }
   let(:another_project) { create(:project_with_types, phases: [project_phase_from_other_project]) }
   let(:all_permissions) do


### PR DESCRIPTION
https://community.openproject.org/wp/64253

factory bot sequence for position doesn't reset between tests, so if definitions are created for any tests before running this, position doesn't start with 1, so ordering gets broken, which is revealed by drag'n'drop test failing

kudos @cbliard
