### PR TITLE
[64625] Move js-en.yml translations for enterprise tokens to en.yml

### DIFF
--- a/app/views/enterprise_tokens/_info.html.erb
+++ b/app/views/enterprise_tokens/_info.html.erb
@@ -33,7 +33,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render EnterpriseTrials::BannerComponent.new %>
 
-
 <%=
   render(Primer::Beta::Subhead.new) do |subhead|
     subhead.with_heading(size: :medium) { EnterpriseToken.human_attribute_name(:encoded_token) }
@@ -69,17 +68,17 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <div class="info-boxes upsell-benefits">
-  <h3 class="info-boxes--title -no-border"><%= t("js.admin.enterprise.upsell.benefits.description") %></h3>
+  <h3 class="info-boxes--title -no-border"><%= t("ee.upsell.benefits.description") %></h3>
 
   <div class="info-boxes--container">
     <div class="info-boxes--item">
       <%= image_tag "installation_alerts.svg",
                     class: "info-boxes--teaser-image",
-                    title: t("js.admin.enterprise.upsell.benefits.installation"),
-                    alt: t("js.admin.enterprise.upsell.benefits.installation") %>
-      <h4 class="info-boxes--item-title"><%= t("js.admin.enterprise.upsell.benefits.installation") %></h4>
+                    title: t("ee.upsell.benefits.installation"),
+                    alt: t("ee.upsell.benefits.installation") %>
+      <h4 class="info-boxes--item-title"><%= t("ee.upsell.benefits.installation") %></h4>
       <div class="info-boxes--item-content">
-        <p><%= t("js.admin.enterprise.upsell.benefits.installation_text") %></p>
+        <p><%= t("ee.upsell.benefits.installation_text") %></p>
         <ul class="widget-box--arrow-links">
           <li>
             <%= static_link_to :upsell_benefits_installation %>
@@ -90,11 +89,11 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="info-boxes--item">
       <%= image_tag "professional_support.svg",
                     class: "info-boxes--teaser-image",
-                    title: t("js.admin.enterprise.upsell.benefits.professional_support"),
-                    alt: t("js.admin.enterprise.upsell.benefits.professional_support") %>
-      <h4 class="info-boxes--item-title"><%= t("js.admin.enterprise.upsell.benefits.professional_support") %></h4>
+                    title: t("ee.upsell.benefits.professional_support"),
+                    alt: t("ee.upsell.benefits.professional_support") %>
+      <h4 class="info-boxes--item-title"><%= t("ee.upsell.benefits.professional_support") %></h4>
       <div class="info-boxes--item-content">
-        <p><%= t("js.admin.enterprise.upsell.benefits.professional_support_text") %></p>
+        <p><%= t("ee.upsell.benefits.professional_support_text") %></p>
         <ul class="widget-box--arrow-links">
           <li>
             <%= static_link_to :upsell_benefits_support %>
@@ -105,11 +104,11 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="info-boxes--item">
       <%= image_tag "enterprise-add-on.svg",
                     class: "info-boxes--teaser-image",
-                    title: t("js.admin.enterprise.upsell.benefits.premium_features"),
-                    alt: t("js.admin.enterprise.upsell.benefits.premium_features") %>
-      <h4 class="info-boxes--item-title"><%= t("js.admin.enterprise.upsell.benefits.premium_features") %></h4>
+                    title: t("ee.upsell.benefits.premium_features"),
+                    alt: t("ee.upsell.benefits.premium_features") %>
+      <h4 class="info-boxes--item-title"><%= t("ee.upsell.benefits.premium_features") %></h4>
       <div class="info-boxes--item-content">
-        <p><%= t("js.admin.enterprise.upsell.benefits.premium_features_text") %></p>
+        <p><%= t("ee.upsell.benefits.premium_features_text") %></p>
         <ul class="widget-box--arrow-links">
           <li>
             <%= static_link_to :upsell_benefits_features %>
@@ -120,11 +119,11 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="info-boxes--item">
       <%= image_tag "security_alerts.svg",
                     class: "info-boxes--teaser-image",
-                    title: t("js.admin.enterprise.upsell.benefits.high_security"),
-                    alt: t("js.admin.enterprise.upsell.benefits.high_security") %>
-      <h4 class="info-boxes--item-title"><%= t("js.admin.enterprise.upsell.benefits.high_security") %></h4>
+                    title: t("ee.upsell.benefits.high_security"),
+                    alt: t("ee.upsell.benefits.high_security") %>
+      <h4 class="info-boxes--item-title"><%= t("ee.upsell.benefits.high_security") %></h4>
       <div class="info-boxes--item-content">
-        <p><%= t("js.admin.enterprise.upsell.benefits.high_security_text") %></p>
+        <p><%= t("ee.upsell.benefits.high_security_text") %></p>
         <ul class="widget-box--arrow-links">
           <li>
             <%= static_link_to :upsell_benefits_security %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2150,6 +2150,17 @@ en:
       homescreen_subline: By upgrading, you will also be supporting an open source project.
       baseline_comparison:
         description: Highlight changes made to this list since any point in the past.
+      benefits:
+        description: "What are the benefits of the Enterprise on-premises edition?"
+        high_security: "Security features"
+        high_security_text: "Single sign on (SAML, OpenID Connect, CAS), LDAP groups."
+        installation: "Installation support"
+        installation_text: "Experienced software engineers guide you through the complete installation and setup process in your own infrastructure."
+        premium_features: "Enterprise add-ons"
+        premium_features_text: "Agile boards, custom theme and logo, graphs, intelligent workflows with custom actions, full text search for work package attachments and multi-select custom fields."
+        professional_support: "Professional support"
+        professional_support_text: "Get reliable, high-touch support from senior support engineers with expert knowledge about running OpenProject in business-critical environments."
+
       work_package_subject_generation:
         description: "Create automatically generated subjects using referenced attributes and text."
       customize_life_cycle:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -224,18 +224,6 @@ en:
         edit_query: "Edit query"
         new_group: "New group"
         reset_to_defaults: "Reset to defaults"
-      enterprise:
-        upsell:
-          benefits:
-            description: "What are the benefits of the Enterprise on-premises edition?"
-            high_security: "Security features"
-            high_security_text: "Single sign on (SAML, OpenID Connect, CAS), LDAP groups."
-            installation: "Installation support"
-            installation_text: "Experienced software engineers guide you through the complete installation and setup process in your own infrastructure."
-            premium_features: "Enterprise add-ons"
-            premium_features_text: "Agile boards, custom theme and logo, graphs, intelligent workflows with custom actions, full text search for work package attachments and multi-select custom fields."
-            professional_support: "Professional support"
-            professional_support_text: "Get reliable, high-touch support from senior support engineers with expert knowledge about running OpenProject in business-critical environments."
 
       working_days:
         calendar:


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64625

# What are you trying to accomplish?

Move enterprise upsell translations from frontend to backend as all the components are rendered by the backend now.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
