### PR TITLE
Fix handling multi_value User Custom Action 

### DIFF
--- a/app/views/custom_actions/_form.html.erb
+++ b/app/views/custom_actions/_form.html.erb
@@ -85,6 +85,7 @@
                   <% selected = action.value_objects.map { |v| { id: v[:value], name: v[:label] } } %>
                   <%= angular_component_tag "opce-user-autocompleter",
                                             inputs: {
+                                              multiple: action.multi_value?,
                                               hideSelected: true,
                                               defaultData: false,
                                               placeholder: I18n.t(:label_user_search),

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
 
     cf
   end
+  let!(:multi_user_custom_field) do
+    create(:multi_user_wp_custom_field).tap do |cf|
+      project.work_package_custom_fields << cf
+      work_package.type.custom_fields << cf
+    end
+  end
   let(:index_ca_page) { Pages::Admin::CustomActions::Index.new }
   let(:activity_tab) { Components::WorkPackages::Activities.new(work_package) }
 
@@ -484,7 +490,7 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
     end
   end
 
-  it "disables the custom action button and editing other fields when submiting the custom action" do
+  it "disables the custom action button and editing other fields when submitting the custom action" do
     # create custom action 'Unassign'
     index_ca_page.visit!
 
@@ -541,6 +547,27 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
       wp_page.ensure_page_loaded
 
       wp_page.click_custom_action("Unassign", expect_success: true)
+    end
+  end
+
+  context "with a multi_user field (Bug#64981)" do
+    it "saves when a user is assigned to the custom field" do
+      # login_as(user)
+      index_ca_page.visit!
+
+      new_ca_page = index_ca_page.new
+      new_ca_page.set_name("MultiUser")
+      new_ca_page.set_description("Multiple User Custom Field Test")
+      new_ca_page.add_action(multi_user_custom_field.name, other_member_user.name)
+      new_ca_page.expect_action(multi_user_custom_field.name, [other_member_user.name])
+
+      new_ca_page.create
+
+      index_ca_page.expect_current_path
+      index_ca_page.expect_listed("MultiUser")
+
+      edit_ca_page = index_ca_page.edit("MultiUser")
+      edit_ca_page.expect_action(multi_user_custom_field.name, [other_member_user.name])
     end
   end
 end

--- a/spec/features/work_packages/custom_actions/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions/custom_actions_spec.rb
@@ -552,7 +552,6 @@ RSpec.describe "Custom actions", :js, with_ee: %i[custom_actions] do
 
   context "with a multi_user field (Bug#64981)" do
     it "saves when a user is assigned to the custom field" do
-      # login_as(user)
       index_ca_page.visit!
 
       new_ca_page = index_ca_page.new


### PR DESCRIPTION
Related Work Package: [OP#64981](https://community.openproject.org/projects/openproject/work_packages/64981)

When the special handling for `user` actions was added, the multiple flag was missed leading to the issue reported to us.