### PR TITLE
[64973] Fix error 500 when making a predecessor with children a child of its successor

### DIFF
--- a/app/services/work_packages/schedule_dependency/dependency_graph.rb
+++ b/app/services/work_packages/schedule_dependency/dependency_graph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -62,9 +64,28 @@ class WorkPackages::ScheduleDependency::DependencyGraph
   def full_dependencies_of(work_package_id)
     @full_dependent_ids ||= {}
     @full_dependent_ids[work_package_id] ||= begin
-      ids = dependent_ids_for_work_package_id(work_package_id)
-      ids += ids.flat_map { full_dependencies_of(_1) }
-      ids.uniq
+      visited = Set.new
+      stack = [work_package_id]
+      result = Set.new
+
+      while stack.any?
+        current_id = stack.pop
+
+        visited.add(current_id)
+
+        # Get direct dependencies for current work package
+        dependent_ids = dependent_ids_for_work_package_id(current_id)
+
+        dependent_ids.each do |dependent_id|
+          # Add to result set
+          result.add(dependent_id) unless dependent_id == work_package_id
+
+          # Add to stack for further processing (if not already visited)
+          stack.push(dependent_id) unless visited.include?(dependent_id)
+        end
+      end
+
+      result.to_a
     end
   end
 

--- a/spec/services/work_packages/schedule_dependency/dependency_graph_spec.rb
+++ b/spec/services/work_packages/schedule_dependency/dependency_graph_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::ScheduleDependency::DependencyGraph do
+  create_shared_association_defaults_for_work_package_factory
+
+  describe "#depends_on?" do
+    context "with simple linear predecessor/successor dependencies" do
+      # create a linear dependency: wp1 -> wp2 -> wp3
+      let_work_packages(<<~TABLE)
+        hierarchy | scheduling mode | successors
+        wp1       | manual          | wp2
+        wp2       | automatic       | wp3
+        wp3       | automatic       |
+      TABLE
+
+      let(:schedule_dependency) { WorkPackages::ScheduleDependency.new([wp1]) }
+      let(:wp1_dependency) { WorkPackages::ScheduleDependency::Dependency.new(wp1, schedule_dependency) }
+      let(:wp2_dependency) { WorkPackages::ScheduleDependency::Dependency.new(wp2, schedule_dependency) }
+      let(:wp3_dependency) { WorkPackages::ScheduleDependency::Dependency.new(wp3, schedule_dependency) }
+      let(:dependencies) { [wp1_dependency, wp2_dependency, wp3_dependency] }
+
+      it "returns true when a given work package depends on the work package from the given dependency" do
+        dependency_graph = described_class.new(dependencies)
+
+        expect(dependency_graph.depends_on?(wp1, wp1_dependency)).to be(false)
+        expect(dependency_graph.depends_on?(wp1, wp2_dependency)).to be(false)
+        expect(dependency_graph.depends_on?(wp1, wp3_dependency)).to be(false)
+
+        expect(dependency_graph.depends_on?(wp2, wp1_dependency)).to be(true)
+        expect(dependency_graph.depends_on?(wp2, wp2_dependency)).to be(false)
+        expect(dependency_graph.depends_on?(wp2, wp3_dependency)).to be(false)
+
+        expect(dependency_graph.depends_on?(wp3, wp1_dependency)).to be(true)
+        expect(dependency_graph.depends_on?(wp3, wp2_dependency)).to be(true)
+        expect(dependency_graph.depends_on?(wp3, wp3_dependency)).to be(false)
+      end
+    end
+
+    context "with circular dependencies between two work packages" do
+      # Create circular dependency: wp1 -> wp2 -> wp1
+      let_work_packages(<<~TABLE)
+        subject | scheduling mode | successors
+        wp1     | automatic       | wp2
+        wp2     | automatic       | wp1
+      TABLE
+
+      let(:schedule_dependency) { WorkPackages::ScheduleDependency.new([wp1]) }
+      let(:wp1_dependency) { WorkPackages::ScheduleDependency::Dependency.new(wp1, schedule_dependency) }
+      let(:wp2_dependency) { WorkPackages::ScheduleDependency::Dependency.new(wp2, schedule_dependency) }
+      let(:dependencies) { [wp1_dependency, wp2_dependency] }
+
+      it "avoids infinite recursion and returns true when given a dependent dependency" do
+        dependency_graph = described_class.new(dependencies)
+
+        expect(dependency_graph.depends_on?(wp1, wp1_dependency)).to be(false)
+        expect(dependency_graph.depends_on?(wp1, wp2_dependency)).to be(true)
+
+        expect(dependency_graph.depends_on?(wp2, wp1_dependency)).to be(true)
+        expect(dependency_graph.depends_on?(wp2, wp2_dependency)).to be(false)
+      end
+    end
+
+    context "with circular dependency between one work package" do
+      # Create circular dependency: wp1 -> wp2 -> wp1
+      let_work_packages(<<~TABLE)
+        subject | scheduling mode | successors
+        wp1     | automatic       | wp1
+      TABLE
+
+      let(:schedule_dependency) { WorkPackages::ScheduleDependency.new([wp1]) }
+      let(:wp1_dependency) { WorkPackages::ScheduleDependency::Dependency.new(wp1, schedule_dependency) }
+      let(:dependencies) { [wp1_dependency] }
+
+      it "avoids infinite recursion and returns false when given itsef as a dependency" do
+        dependency_graph = described_class.new(dependencies)
+
+        expect(dependency_graph.depends_on?(wp1, wp1_dependency)).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64973

# What are you trying to accomplish?

Avoid infinite recursion when making an automatically scheduled predecessor with children a child of an automatically scheduled successor.

## Screenshots

See reproduction video in linked ticket.

# What approach did you choose and why?

The error was caused by a transient circular dependency when computing futures dates of parent. The circular dependency is transient because it tries to set the parent, and then an error is displayed saying it's impossible. Meanwhile the SetAttributesService still tries to compute the correct dates of the parent, using data with a circular dependency in it.

This is fixed by marking visited work packages and skipping them when they have already been visited.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
