### PR TITLE
[#64999] Float values with thousand delimiter

### DIFF
--- a/config/locales/crowdin/de.yml
+++ b/config/locales/crowdin/de.yml
@@ -3418,7 +3418,7 @@ de:
   #Default format for numbers
   number:
     format:
-      delimiter: ""
+      delimiter: "."
       precision: 2
       separator: ","
     human:

--- a/config/locales/crowdin/de.yml
+++ b/config/locales/crowdin/de.yml
@@ -3418,7 +3418,7 @@ de:
   #Default format for numbers
   number:
     format:
-      delimiter: "."
+      delimiter: ""
       precision: 2
       separator: ","
     human:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3549,7 +3549,7 @@ en:
   # Default format for numbers
   number:
     format:
-      delimiter: ""
+      delimiter: ","
       precision: 3
       separator: "."
     human:

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -207,22 +207,6 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
       end
     end
 
-    context "with german locale" do
-      let(:current_user) { create(:admin, language: :de) }
-
-      it "exports successfully the work packages with a cost column localized" do
-        I18n.with_locale :de do
-          sheet
-        end
-
-        expect(sheet.rows.size).to eq(4 + 1)
-        cost_column = sheet.columns.last.to_a
-        %w[1 99,99 1.000].each do |value|
-          expect(cost_column).to include(value)
-        end
-      end
-    end
-
     it "includes work" do
       expect(sheet.rows.size).to eq(4 + 1)
 

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
       expect(sheet.rows.size).to eq(4 + 1)
 
       cost_column = sheet.columns.last.to_a
-      %w[1 99.99 1000].each do |value|
+      %w[1 99.99 1,000].each do |value|
         expect(cost_column).to include(value)
       end
     end
@@ -217,7 +217,7 @@ RSpec.describe XlsExport::WorkPackage::Exporter::XLS do
 
         expect(sheet.rows.size).to eq(4 + 1)
         cost_column = sheet.columns.last.to_a
-        %w[1 99,99 1000].each do |value|
+        %w[1 99,99 1.000].each do |value|
           expect(cost_column).to include(value)
         end
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64999

# What are you trying to achieve?

The frontend format floats with thousand delimiter (actually the browsers are forrmating this), the backend does not. Rails has this as default but it was overridden with an empty string in [redmine 2009](https://github.com/opf/openproject/commit/7b0cb6aba8715aff00519f200060fbf46ae9bb97#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7)

This PR changes this for the English source locale. Other locales must be changed as well but on Crowdin.

## Screenshots

# What approach did you choose and why?

Set the thousand delimiter in en.yml to `","`
e.g. 1000.00 is then formatted as 1,000.00

Please note: A German locale test case, which did not assess the export functionality of floating-point numbers to XLS files but rather tested reading XLS and Rails formatting, has been removed.  This test case was deemed irrelevant as the application does not process cost reports from XLS files.  Floating-point numbers are exported directly to XLS files without locale-specific formatting.

# Merge checklist

- [x] Added/updated tests
