### PR TITLE
Code maintenance/64985 fix memoisation in lib/api/v3/work_packages/work_package_representer.rb

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -645,25 +645,33 @@ module API
 
         # Permissions
         def current_user_watcher?
-          @current_user_watcher ||= represented.watchers.any? { |w| w.user_id == current_user.id }
+          return @current_user_watcher if defined?(@current_user_watcher)
+
+          @current_user_watcher = represented.watchers.any? { |w| w.user_id == current_user.id }
         end
 
         def current_user_update_allowed?
-          @current_user_update_allowed ||=
+          return @current_user_update_allowed if defined?(@current_user_update_allowed)
+
+          @current_user_update_allowed =
             current_user.allowed_in_work_package?(:edit_work_packages, represented) ||
               current_user.allowed_in_project?(:change_work_package_status, represented.project) ||
               current_user.allowed_in_project?(:assign_versions, represented.project)
         end
 
         def view_time_entries_allowed?
-          @view_time_entries_allowed ||=
+          return @view_time_entries_allowed if defined?(@view_time_entries_allowed)
+
+          @view_time_entries_allowed =
             current_user.allowed_in_project?(:view_time_entries, represented.project) ||
             view_own_time_entries_allowed?
         end
 
         def view_own_time_entries_allowed?
-          @view_own_time_entries_allowed ||= if represented.new_record?
-                                               current_user.allowed_in_any_work_package?(:view_own_time_entries,
+          return @view_own_time_entries_allowed if defined?(@view_own_time_entries_allowed)
+
+          @view_own_time_entries_allowed = if represented.new_record?
+                                             current_user.allowed_in_any_work_package?(:view_own_time_entries,
                                                                                          in_project: represented.project)
                                              else
                                                current_user.allowed_in_work_package?(:view_own_time_entries, represented)
@@ -671,32 +679,42 @@ module API
         end
 
         def log_time_allowed?
-          @log_time_allowed ||=
+          return @log_time_allowed if defined?(@log_time_allowed)
+
+          @log_time_allowed =
             current_user.allowed_in_project?(:log_time, represented.project) ||
               current_user.allowed_in_work_package?(:log_own_time, represented)
         end
 
         def view_budgets_allowed?
-          @view_budgets_allowed ||= current_user.allowed_in_project?(:view_budgets, represented.project)
+          return @view_budgets_allowed if defined?(@view_budgets_allowed)
+
+          @view_budgets_allowed = current_user.allowed_in_project?(:view_budgets, represented.project)
         end
 
         def view_project_phase_allowed?
-          @view_project_phase_allowed ||= current_user.allowed_in_project?(:view_project_phases, represented.project) &&
+          return @view_project_phase_allowed if defined?(@view_project_phase_allowed)
+
+          @view_project_phase_allowed = current_user.allowed_in_project?(:view_project_phases, represented.project) &&
             OpenProject::FeatureDecisions.stages_and_gates_active?
         end
 
         def export_work_packages_allowed?
-          @export_work_packages_allowed ||=
-            current_user.allowed_in_work_package?(:export_work_packages, represented)
+          return @export_work_packages_allowed if defined?(@export_work_packages_allowed)
+
+          @export_work_packages_allowed = current_user.allowed_in_work_package?(:export_work_packages, represented)
         end
 
         def add_work_packages_allowed?
-          @add_work_packages_allowed ||=
-            current_user.allowed_in_project?(:add_work_packages, represented.project)
+          return @add_work_packages_allowed if defined?(@add_work_packages_allowed)
+
+          @add_work_packages_allowed = current_user.allowed_in_project?(:add_work_packages, represented.project)
         end
 
         def project_phase
-          @project_phase ||= represented.project_phase
+          return @project_phase if defined?(@project_phase)
+
+          @project_phase = represented.project_phase
         end
 
         def phase_set_and_active?


### PR DESCRIPTION
# Ticket

[OP#64985](https://community.openproject.org/wp/64985)

# What are you trying to accomplish?
Booleans or possibly `nil` values should not be memoized using `||=`, as they will get recalculated every time if value will be `false` or `nil`

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
