### PR TITLE
Task/60343 set enterprise banner url when documentation page is ready

### DIFF
--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -156,6 +156,8 @@ enterprise_features:
     href: https://www.openproject.org/docs/user-guide/activity/#internal-comments-enterprise-add-on
   nextcloud_sso:
     href: https://www.openproject.org/docs/system-admin-guide/integrations/nextcloud/oidc-sso
+  customize_life_cycle:
+    href: https://www.openproject.org/docs/system-admin-guide/projects/project-life-cycle/
 sysadmin_docs:
   saml:
     href: https://www.openproject.org/docs/system-admin-guide/authentication/saml/


### PR DESCRIPTION
# Ticket
[OP#60343](https://community.openproject.org/wp/60343)

# What are you trying to accomplish?
Change link in enterprise banner over project phase definition admin to point to relevant documentation

# What approach did you choose and why?
Also reordered alphabetically all links

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
