### PR TITLE
Guard against possible race conditions in `CkEditorAugmentedTextareaComponent.saveForm`

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -184,6 +184,10 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public async saveForm(evt?:SubmitEvent):Promise<void> {
+    if (CkeditorAugmentedTextareaComponent.inFlight.get(this.formElement)) {
+      return;
+    }
+
     CkeditorAugmentedTextareaComponent.inFlight.set(this.formElement, true);
 
     this.syncToTextarea();

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -174,7 +174,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   private registerFormSubmitListener():void {
     fromEvent(this.formElement, 'submit')
       .pipe(
-        filter(() => !CkeditorAugmentedTextareaComponent.inFlight.get(this.formElement)),
+        filter(() => !CkeditorAugmentedTextareaComponent.inFlight.has(this.formElement)),
         this.untilDestroyed(),
       )
       .subscribe((evt:SubmitEvent) => {
@@ -184,7 +184,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public async saveForm(evt?:SubmitEvent):Promise<void> {
-    if (CkeditorAugmentedTextareaComponent.inFlight.get(this.formElement)) {
+    if (CkeditorAugmentedTextareaComponent.inFlight.has(this.formElement)) {
       return;
     }
 


### PR DESCRIPTION
https://community.openproject.org/wp/63556

This bug is not easily reproducable, but it seems to happen when a user leaves a tab open for a long time, comes back to it and continues to submit a comment- at this point, in one case there were reports of 2-3 parallel form submissions.

The idea here is to prevent any possible race conditions via a guard clause on the `inFlight` state, such that in case of _"any weirdness in form event streams"_, only one event for a given form instance is executed.

This is quite speculative, open to more/better ideas :)

_Expands on e8ec49a34cd6b1603f45d5f700d5bec61cc14e02, Follows #19185_