### PR TITLE
[#64843] "Move to top" for sections is broken  

### DIFF
--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -72,7 +72,7 @@ module MeetingSections
         if @first_and_last.first
           @first_and_last.first == @meeting_section
         else
-          @meeting_section.first_after_backlog?
+          @meeting_section.first?
         end
     end
 

--- a/modules/meeting/app/models/meeting_section.rb
+++ b/modules/meeting/app/models/meeting_section.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -39,7 +40,7 @@ class MeetingSection < ApplicationRecord
     section.position_previously_changed?
   }
 
-  acts_as_list scope: :meeting
+  acts_as_list scope: [:meeting_id, { backlog: false }]
 
   default_scope { order(:position) }
 
@@ -71,9 +72,5 @@ class MeetingSection < ApplicationRecord
     else
       agenda_items.maximum(:position) + 1
     end
-  end
-
-  def first_after_backlog?
-    position == meeting.backlog.position + 1
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/64843
https://community.openproject.org/wp/64101

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Ensure "Move to top" is working correctly for sections
- Ensure the correct "Move" actions are visible for sections based on their position in the meeting agenda

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- I excluded the backlog from the `acts_as_list` scope as that was what was causing problems in the positioning
- This PR also reverts the changes in https://github.com/opf/openproject/pull/19194 as that fix is unnecessary with this PR's changes
