### PR TITLE
Bug/65009 activerecord recordnotunique app services journals create service rb 99 in block in journals createservice create journal

### DIFF
--- a/app/contracts/attachments/create_contract.rb
+++ b/app/contracts/attachments/create_contract.rb
@@ -68,29 +68,29 @@ module Attachments
     end
 
     ##
-    # Validates the content type, if a whitelist is set
+    # Validates the content type, if a allowlist is set
     def validate_content_type
-      # If the whitelist is empty, assume all files are allowed
+      # If the allowlist is empty, assume all files are allowed
       # as before
-      unless matches_whitelist?(attachment_whitelist)
-        Rails.logger.info { "Uploaded file #{model.filename} with type #{model.content_type} does not match whitelist" }
-        errors.add :content_type, :not_whitelisted, value: model.content_type
+      unless matches_allowlist?(attachment_allowlist)
+        Rails.logger.info { "Uploaded file #{model.filename} with type #{model.content_type} does not match allowlist" }
+        errors.add :content_type, :not_allowlisted, value: model.content_type
       end
     end
 
     ##
-    # Get the user-defined whitelist or a custom whitelist
+    # Get the user-defined allowlist or a custom allowlist
     # defined for this invocation
-    def attachment_whitelist
-      Array(options.fetch(:whitelist, Setting.attachment_whitelist))
+    def attachment_allowlist
+      Array(options.fetch(:allowlist, Setting.attachment_whitelist))
     end
 
     ##
-    # Returns whether the attachment matches the whitelist
-    def matches_whitelist?(whitelist)
-      return true if whitelist.empty?
+    # Returns whether the attachment matches the allowlist
+    def matches_allowlist?(allowlist)
+      return true if allowlist.empty?
 
-      whitelist.include?(model.content_type) || whitelist.include?("*#{model.extension}")
+      allowlist.include?(model.content_type) || allowlist.include?("*#{model.extension}")
     end
   end
 end

--- a/app/services/attachments/base_service.rb
+++ b/app/services/attachments/base_service.rb
@@ -36,8 +36,8 @@ module Attachments
     # @param whitelist A custom whitelist to validate with, or empty to disable validation
     #
     # Warning: When passing an empty whitelist, this results in no validations on the content type taking place.
-    def self.bypass_whitelist(user:, whitelist: [])
-      new(user:, contract_options: { whitelist: whitelist.map(&:to_s) })
+    def self.bypass_allowlist(user:, allowlist: [])
+      new(user:, contract_options: { allowlist: allowlist.map(&:to_s) })
     end
   end
 end

--- a/app/services/attachments/finish_direct_upload_service.rb
+++ b/app/services/attachments/finish_direct_upload_service.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Attachments
+  class FinishDirectUploadService < BaseServices::BaseContracted
+    def initialize(user:, model:, contract_class: nil, contract_options: {})
+      self.model = model
+      super(user:, contract_class:, contract_options:)
+    end
+
+    protected
+
+    alias_method :attachment, :model
+
+    def service_context(send_notifications:, &)
+      # Overwriting the call to in_context to place the semaphore on the container and not on the attachment.
+      # Since the service will write a journal on the container, there should not be another
+      # process that modifies the container while this service is running.
+      in_context(attachment.container, send_notifications:, &)
+    end
+
+    def validate_params(_params)
+      super.tap do |call|
+        validate_local_file_exists(call)
+      end
+    end
+
+    def before_perform(*)
+      super.tap do
+        set_attachment_parameters
+      end
+    end
+
+    def persist(call)
+      super.tap do
+        attachment.save!
+      end
+    end
+
+    def after_perform(service_call)
+      super.tap do
+        journalize_container
+        attachment_created_event
+        schedule_jobs
+      end
+    end
+
+    def validate_local_file_exists(call)
+      unless local_file
+        call.errors.add(:base, "File for attachment #{attachment.filename} was not uploaded.")
+        call.success = false
+      end
+    end
+
+    def set_attachment_parameters
+      attachment.extend(OpenProject::ChangedBySystem)
+      attachment.change_by_system do
+        attachment.status = :uploaded
+        attachment.set_file_size local_file
+        attachment.set_content_type local_file
+        attachment.set_digest local_file
+      end
+    end
+
+    def schedule_jobs
+      attachment.extract_fulltext
+    end
+
+    def journalize_container
+      journable = attachment.container
+
+      return unless journable&.class&.journaled?
+
+      # Touching the journable will lead to the journal created next having its own timestamp.
+      # That timestamp will not adequately reflect the time the attachment was uploaded. This job
+      # right here might be executed way later than the time the attachment was uploaded. Ideally,
+      # the journals would be created bearing the time stamps of the attachment's created_at.
+      # This remains a TODO.
+      # But with the timestamp update in place as it is, at least the collapsing of aggregated journals
+      # from days before with the newly uploaded attachment is prevented.
+      touch_journable(journable)
+
+      Journals::CreateService
+        .new(journable, attachment.author)
+        .call
+    end
+
+    def touch_journable(journable)
+      # Not using touch here on purpose,
+      # as to avoid changing lock versions on the journables for this change
+      attributes = journable.send(:timestamp_attributes_for_update_in_model)
+
+      timestamps = attributes.index_with { Time.current }
+      journable.update_columns(timestamps) if timestamps.any?
+    end
+
+    def attachment_created_event
+      OpenProject::Notifications.send(
+        OpenProject::Events::ATTACHMENT_CREATED,
+        attachment:
+      )
+    end
+
+    def default_contract_class
+      ::Attachments::CreateContract
+    end
+
+    def local_file
+      # An attachment is guaranteed to have a file.
+      # But if the attachment is nil the expression attachment&.file will be nil and attachment&.file.local_file
+      # will throw a NoMethodError: undefined method local_file' for nil:NilClass`.
+      attachment&.file&.local_file
+    end
+  end
+end

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -29,115 +29,44 @@
 class Attachments::FinishDirectUploadJob < ApplicationJob
   queue_with_priority :high
 
-  def perform(attachment_id, whitelist: true)
+  def perform(attachment_id, allowlist: true)
     attachment = Attachment.pending_direct_upload.find_by(id: attachment_id)
-    # An attachment is guaranteed to have a file.
-    # But if the attachment is nil the expression attachment&.file will be nil and attachment&.file.local_file
-    # will throw a NoMethodError: undefined method local_file' for nil:NilClass`.
-    local_file = attachment && attachment.file.local_file
 
-    if local_file.nil?
-      return Rails.logger.error("File for attachment #{attachment_id} was not uploaded.")
-    end
-
-    User.execute_as(attachment.author) do
-      attach_uploaded_file(attachment, local_file, whitelist)
+    Attachments::FinishDirectUploadService
+      .new(user: attachment.author, model: attachment, contract_options: derive_contract_options(allowlist))
+      .call
+      .on_failure do |call|
+      destroy_attachment_and_log_errors(attachment, call.errors)
     end
   end
 
   private
 
-  def attach_uploaded_file(attachment, local_file, whitelist)
-    set_attributes_from_file(attachment, local_file)
-    validate_attachment(attachment, whitelist)
-    save_attachment(attachment)
-    journalize_container(attachment)
-    attachment_created_event(attachment)
-    schedule_jobs(attachment)
-  rescue StandardError => e
-    ::OpenProject.logger.error e
+  def destroy_attachment_and_log_errors(attachment, errors)
     attachment.destroy
-  ensure
-    FileUtils.rm_rf(local_file.path)
+    errors = errors.full_messages
+
+    OpenProject.logger.error(
+      <<~MSG
+        Failed to finish attachment upload for:
+          * user: #{attachment.author}
+          * container: #{attachment.container}
+          * attachment file name: #{attachment.filename}
+
+        Errors:
+          #{errors.join("\n")}
+      MSG
+    )
   end
 
-  def set_attributes_from_file(attachment, local_file)
-    attachment.extend(OpenProject::ChangedBySystem)
-    attachment.change_by_system do
-      attachment.status = :uploaded
-      attachment.set_file_size local_file
-      attachment.set_content_type local_file
-      attachment.set_digest local_file
-    end
-  end
-
-  def save_attachment(attachment)
-    attachment.save! if attachment.changed?
-  end
-
-  def validate_attachment(attachment, whitelist)
-    contract = create_contract attachment, whitelist
-
-    unless contract.valid?
-      errors = contract.errors.full_messages.join(", ")
-      raise "Failed to validate attachment #{attachment.id}: #{errors}"
-    end
-  end
-
-  def create_contract(attachment, whitelist)
-    options = derive_contract_options(whitelist)
-    ::Attachments::CreateContract.new attachment,
-                                      attachment.author,
-                                      options:
-  end
-
-  def schedule_jobs(attachment)
-    attachment.extract_fulltext
-  end
-
-  def derive_contract_options(whitelist)
-    case whitelist
+  def derive_contract_options(allowlist)
+    case allowlist
     when false
-      { whitelist: [] }
+      { allowlist: [] }
     when Array
-      { whitelist: whitelist.map(&:to_s) }
+      { allowlist: allowlist.map(&:to_s) }
     else
       {}
     end
-  end
-
-  def journalize_container(attachment)
-    journable = attachment.container
-
-    return unless journable&.class&.journaled?
-
-    # Touching the journable will lead to the journal created next having its own timestamp.
-    # That timestamp will not adequately reflect the time the attachment was uploaded. This job
-    # right here might be executed way later than the time the attachment was uploaded. Ideally,
-    # the journals would be created bearing the time stamps of the attachment's created_at.
-    # This remains a TODO.
-    # But with the timestamp update in place as it is, at least the collapsing of aggregated journals
-    # from days before with the newly uploaded attachment is prevented.
-    touch_journable(journable)
-
-    Journals::CreateService
-      .new(journable, attachment.author)
-      .call
-  end
-
-  def touch_journable(journable)
-    # Not using touch here on purpose,
-    # as to avoid changing lock versions on the journables for this change
-    attributes = journable.send(:timestamp_attributes_for_update_in_model)
-
-    timestamps = attributes.index_with { Time.now }
-    journable.update_columns(timestamps) if timestamps.any?
-  end
-
-  def attachment_created_event(attachment)
-    OpenProject::Notifications.send(
-      OpenProject::Events::ATTACHMENT_CREATED,
-      attachment:
-    )
   end
 end

--- a/app/workers/backup_job.rb
+++ b/app/workers/backup_job.rb
@@ -134,7 +134,7 @@ class BackupJob < ApplicationJob
   def store_backup(file_name, backup:, user:)
     File.open(file_name) do |file|
       call = Attachments::CreateService
-        .bypass_whitelist(user:)
+        .bypass_allowlist(user:)
         .call(container: backup, filename: file_name, file:, description: "OpenProject backup")
 
       call.on_success do

--- a/app/workers/exports/export_job.rb
+++ b/app/workers/exports/export_job.rb
@@ -117,7 +117,7 @@ module Exports
       filename = clean_filename(export_result)
 
       call = Attachments::CreateService
-               .bypass_whitelist(user: User.current)
+               .bypass_allowlist(user: User.current)
                .call(container:, file:, filename:, description: "")
 
       call.on_success do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1286,7 +1286,7 @@ en:
           attributes:
             content_type:
               blank: "The content type of the file cannot be blank."
-              not_whitelisted: "The file was rejected by an automatic filter. '%{value}' is not whitelisted for upload."
+              not_allowlisted: "The file was rejected by an automatic filter. '%{value}' is not allowed for upload."
               format: "%{message}"
         capability:
           context:

--- a/modules/bim/app/controllers/bim/bcf/issues_controller.rb
+++ b/modules/bim/app/controllers/bim/bcf/issues_controller.rb
@@ -215,7 +215,7 @@ module Bim
       def create_attachment
         filename = params[:bcf_file].original_filename
         call = Attachments::CreateService
-          .bypass_whitelist(user: current_user, whitelist: %w[application/zip])
+          .bypass_allowlist(user: current_user, allowlist: %w[application/zip])
           .call(file: params[:bcf_file],
                 filename:,
                 description: filename)

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -49,6 +49,10 @@ module Bim
                           .includes(:project, :uploader)
       end
 
+      def show
+        frontend_redirect params[:id].to_i
+      end
+
       def new
         @ifc_model = @project.ifc_models.build
         prepare_form(@ifc_model)
@@ -56,10 +60,6 @@ module Bim
 
       def edit
         prepare_form(@ifc_model)
-      end
-
-      def show
-        frontend_redirect params[:id].to_i
       end
 
       def defaults
@@ -116,7 +116,7 @@ module Bim
 
         if service_result.success?
           ::Attachments::FinishDirectUploadJob.perform_later attachment.id,
-                                                             whitelist: false
+                                                             allowlist: false
 
           flash[:notice] = if new_model
                              t("ifc_models.flash_messages.upload_successful")
@@ -183,7 +183,7 @@ module Bim
         return unless OpenProject::Configuration.direct_uploads?
 
         call = ::Attachments::PrepareUploadService
-                 .bypass_whitelist(user: current_user)
+                 .bypass_allowlist(user: current_user)
                  .call(filename: "model.ifc", filesize: 0)
 
         call.on_failure { flash[:error] = call.message }

--- a/modules/bim/app/models/bim/bcf/viewpoint.rb
+++ b/modules/bim/app/models/bim/bcf/viewpoint.rb
@@ -73,7 +73,7 @@ module Bim::Bcf
 
     def build_snapshot(file, user: User.current)
       ::Attachments::BuildService
-        .bypass_whitelist(user:)
+        .bypass_allowlist(user:)
         .call(file:, container: self, filename: file.original_filename, description: "snapshot")
         .result
     end

--- a/modules/bim/app/models/bim/ifc_models/ifc_model.rb
+++ b/modules/bim/app/models/bim/ifc_models/ifc_model.rb
@@ -41,7 +41,7 @@ module Bim
           delete_attachment name
           filename = file.respond_to?(:original_filename) ? file.original_filename : File.basename(file.path)
           call = ::Attachments::CreateService
-            .bypass_whitelist(user: User.current)
+            .bypass_allowlist(user: User.current)
             .call(file:, container: self, filename:, description: name)
 
           call.on_failure { Rails.logger.error "Failed to add #{name} attachment: #{call.message}" }

--- a/modules/bim/app/services/bim/ifc_models/set_attributes_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/set_attributes_service.rb
@@ -78,7 +78,7 @@ module Bim
 
       def build_ifc_attachment(ifc_attachment)
         ::Attachments::BuildService
-          .bypass_whitelist(user:)
+          .bypass_allowlist(user:)
           .call(file: ifc_attachment, container: model, filename: ifc_attachment.original_filename, description: "ifc")
           .on_failure do |build_attachment_result|
             build_attachment_result.errors.each do |error|

--- a/modules/bim/spec/contracts/ifc_models/shared_contract_examples.rb
+++ b/modules/bim/spec/contracts/ifc_models/shared_contract_examples.rb
@@ -102,7 +102,7 @@ RSpec.shared_examples_for "ifc model contract" do
     let(:ifc_file) { FileHelpers.mock_uploaded_file name: "model.ifc", content_type: "application/binary", binary: true }
     let(:ifc_attachment) do
       Attachments::BuildService
-        .bypass_whitelist(user: current_user)
+        .bypass_allowlist(user: current_user)
         .call(file: ifc_file, filename: "model.ifc")
         .result
     end
@@ -118,7 +118,7 @@ RSpec.shared_examples_for "ifc model contract" do
     end
     let(:ifc_attachment) do
       Attachments::BuildService
-        .bypass_whitelist(user: current_user)
+        .bypass_allowlist(user: current_user)
         .call(file: ifc_file, filename: "model.ifc")
         .result
     end

--- a/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
@@ -66,15 +66,14 @@ RSpec.describe WorkPackages::ExportJob do
 
         service = double("attachments create service")
 
-        expect(Attachments::CreateService)
-          .to receive(:bypass_whitelist)
-                .with(user:)
+        allow(Attachments::CreateService)
+          .to receive(:bypass_allowlist)
                 .and_return(service)
 
-        expect(Exports::CleanupOutdatedJob)
+        allow(Exports::CleanupOutdatedJob)
           .to receive(:perform_after_grace)
 
-        expect(service)
+        allow(service)
           .to(receive(:call))
           .and_return(ServiceResult.success(result: attachment))
 
@@ -85,6 +84,16 @@ RSpec.describe WorkPackages::ExportJob do
         expect(subject.job_status).to be_present
         expect(subject.job_status[:status]).to eq "success"
         expect(subject.job_status[:payload]["download"]).to eq "/api/v3/attachments/1234/content"
+
+        expect(Attachments::CreateService)
+          .to have_received(:bypass_allowlist)
+                .with(user:)
+
+        expect(Exports::CleanupOutdatedJob)
+          .to have_received(:perform_after_grace)
+
+        expect(service)
+          .to have_received(:call)
       end
     end
   end

--- a/spec/contracts/attachments/create_contract_spec.rb
+++ b/spec/contracts/attachments/create_contract_spec.rb
@@ -104,28 +104,28 @@ RSpec.describe Attachments::CreateContract do
     end
   end
 
-  context "with an empty whitelist",
+  context "with an empty allowlist",
           with_settings: { attachment_whitelist: %w[] } do
     it_behaves_like "contract is valid"
   end
 
-  context "with a matching mime whitelist",
+  context "with a matching mime allowlist",
           with_settings: { attachment_whitelist: %w[image/png] } do
     it_behaves_like "contract is valid"
   end
 
-  context "with a matching extension whitelist",
+  context "with a matching extension allowlist",
           with_settings: { attachment_whitelist: %w[*.png] } do
     it_behaves_like "contract is valid"
   end
 
-  context "with a non-matching whitelist",
+  context "with a non-matching allowlist",
           with_settings: { attachment_whitelist: %w[*.jpg image/jpeg] } do
-    it_behaves_like "contract is invalid", content_type: :not_whitelisted
+    it_behaves_like "contract is invalid", content_type: :not_allowlisted
 
     context "when disabling the whitelist check" do
       let(:contract_options) do
-        { whitelist: [] }
+        { allowlist: [] }
       end
 
       it_behaves_like "contract is valid"
@@ -133,7 +133,7 @@ RSpec.describe Attachments::CreateContract do
 
     context "when overriding the whitelist" do
       let(:contract_options) do
-        { whitelist: %w[*.png] }
+        { allowlist: %w[*.png] }
       end
 
       it_behaves_like "contract is valid"

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -157,7 +157,7 @@ RSpec.shared_examples "it supports direct uploads" do
         end
       end
 
-      context "with an attachment whitelist", with_settings: { attachment_whitelist: ["text/csv"] } do
+      context "with an attachment allowlist", with_settings: { attachment_whitelist: ["text/csv"] } do
         context "with an allowed content type" do
           let(:metadata) { { fileName: "cats.csv", fileSize: file.size, contentType: "text/csv" } }
 
@@ -171,14 +171,14 @@ RSpec.shared_examples "it supports direct uploads" do
 
           it "fails" do
             expect(subject.status).to eq 422
-            expect(subject.body).to include "not whitelisted"
+            expect(subject.body).to include "'text/plain' is not allowed for upload."
           end
         end
 
-        context "with a non-specific content type not on the whitelist" do
+        context "with a non-specific content type not on the allowlist" do
           let(:metadata) { { fileName: "cats.bin", fileSize: file.size, contentType: "application/binary" } }
 
-          # the actual whitelist check will be performed in the FinishDirectUpload job in this case
+          # the actual allowlist check will be performed in the FinishDirectUpload job in this case
           it "still succeeds" do
             expect(subject.status).to eq 201
           end

--- a/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
+++ b/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Attachments::FinishDirectUploadJob, "integration", type: :job do
     it_behaves_like "adding a journal to the attachment in the name of the attachment's author"
   end
 
-  context "with an incompatible attachment whitelist",
+  context "with an incompatible attachment allowlist",
           with_settings: { attachment_whitelist: %w[image/png] } do
     let!(:container) { create(:work_package) }
     let!(:container_timestamp) { container.updated_at }
@@ -156,9 +156,9 @@ RSpec.describe Attachments::FinishDirectUploadJob, "integration", type: :job do
       expect { pending_attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    context "when the job is getting a whitelist override" do
+    context "when the job is getting a allowlist override" do
       it "Does save the attachment" do
-        job.perform(pending_attachment.id, whitelist: false)
+        job.perform(pending_attachment.id, allowlist: false)
 
         container.reload
 

--- a/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
+++ b/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
@@ -136,6 +136,18 @@ RSpec.describe Attachments::FinishDirectUploadJob, "integration", type: :job do
     it_behaves_like "adding a journal to the attachment in the name of the attachment's author"
   end
 
+  context "for an attachment that has been removed in the meantime" do
+    let!(:container) { create(:work_package) }
+
+    it "logs the error and resolves the job as done" do
+      allow(OpenProject.logger).to receive(:error)
+
+      job.perform(pending_attachment.id + 1)
+
+      expect(OpenProject.logger).to have_received(:error)
+    end
+  end
+
   context "with an incompatible attachment allowlist",
           with_settings: { attachment_whitelist: %w[image/png] } do
     let!(:container) { create(:work_package) }

--- a/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_spec.rb
@@ -68,15 +68,14 @@ RSpec.describe WorkPackages::ExportJob do
     let(:exporter_instance) { instance_double(exporter) }
 
     it "exports" do
-      expect(Attachments::CreateService)
-        .to receive(:bypass_whitelist)
-              .with(user:)
+      allow(Attachments::CreateService)
+        .to receive(:bypass_allowlist)
               .and_return(service)
 
-      expect(Exports::CleanupOutdatedJob)
+      allow(Exports::CleanupOutdatedJob)
         .to receive(:perform_after_grace)
 
-      expect(service)
+      allow(service)
         .to receive(:call) do |file:, **_args|
         expect(File.basename(file))
           .to start_with "some_title"
@@ -96,6 +95,13 @@ RSpec.describe WorkPackages::ExportJob do
       expect(subject.job_status.reference).to eq export
       expect(subject.job_status[:status]).to eq "success"
       expect(subject.job_status[:payload]["download"]).to eq "/api/v3/attachments/1234/content"
+
+      expect(Attachments::CreateService)
+        .to have_received(:bypass_allowlist)
+              .with(user:)
+
+      expect(Exports::CleanupOutdatedJob)
+        .to have_received(:perform_after_grace)
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65009
https://community.openproject.org/wp/63380

# What are you trying to accomplish?

Prevent errors like these
```
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_journals_on_journable_type_and_journable_id_and_version"
DETAIL:  Key (journable_type, journable_id, version)=(?) already exists.
```

This happens when two `Attachments::FinishDirectUploadJob` run the code to generate a journal at the same time. When that error is thrown, the uploaded attachment is destroyed so that it vanishes from the container, probably without the user noticing it. 

This problem can be prevented by using the already existing semaphore functionality of placing advisory locks on the container of the attachment. This is deeply ingrained into the existing `Service` classes. That is why now a service takes up most of the functionality that was previously in the job. 

I couldn't come up with a way to write an automatic test for this.

The PR also changes variables previously called 'whitelist' to 'allowlist'.

For reproducing it was necessary to:

* Have direct upload configured for the local dev installations
* Have good_job run with multiple threads: `good_job start --max-threads=20` . Make sure that the database pool size allows this many threads.
* Modify the jobs in code by adding a sleep statement around the [place where the journals are created](https://github.com/opf/openproject/pull/19267/files#diff-941bdfe7cacef85917bd833e39d97b6edc75edfcd1e9d8fbcfaf669c033ecd3aL123). I had the sleep statement wait until a fixed time.
* Upload 20 attachments to the same work package
* Wait until the time is passed on the sleep statement.
* Watch out for the error message written down above
* Reload the work package attachment list and see if any attachment just disappears. 