### PR TITLE
Do not suppress rack timeout errors completely, but let it log to Rails.logger

### DIFF
--- a/lib/rack/timeout/suppress_internal_error_report_on_timeout.rb
+++ b/lib/rack/timeout/suppress_internal_error_report_on_timeout.rb
@@ -2,7 +2,10 @@ module Rack
   class Timeout
     module SuppressInternalErrorReportOnTimeout
       def op_handle_error(message_or_exception, context = {})
-        return if respond_to?(:request) && request.env[Rack::Timeout::ENV_INFO_KEY].try(:state) == :timed_out
+        if respond_to?(:request) && request.env[Rack::Timeout::ENV_INFO_KEY].try(:state) == :timed_out
+          Rails.logger.error "Rack::Timeout: Receiving timeout exception: #{message_or_exception}"
+          return
+        end
 
         super
       end


### PR DESCRIPTION
This got added in https://github.com/opf/openproject/pull/11115 without a clear indication why it would be double, and by now we're not receiving any of these error logs