### PR TITLE
Reset default Rack::Timeout wait_timeout to 30, matching default

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1160,7 +1160,7 @@ module Settings
         default: {
           "workers" => 2,
           "timeout" => Rails.env.production? ? 120 : 0,
-          "wait_timeout" => 10,
+          "wait_timeout" => 30,
           "min_threads" => 4,
           "max_threads" => 16
         },


### PR DESCRIPTION
This is the default of rack-timeout: https://github.com/zombocom/rack-timeout/blob/main/doc/settings.md