### PR TITLE
[61534] Autocompleter should not get autofocus by default

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.html
@@ -21,6 +21,7 @@
           (change)="addWatcher($event)"
           [url]="availableWatchersPath"
           [resetOnChange]="true"
+          [focusDirectly]="false"
           appendTo="body"
           class="wp-watcher--autocomplete"
         ></op-user-autocompleter>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/61534 

# What are you trying to accomplish?
Remove autofocus from watchers tab user autocompleter

