### PR TITLE
[64653] Global search loading spinner is misplaced, as it overlaps with the X icon

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -139,4 +139,4 @@ $search-input-height: 30px
     // Fix position of the spinner
     .ng-spinner-loader
       position: relative
-      right: 14px
+      right: 24px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64653

# What are you trying to accomplish?
Give the loading spinner more space to the right

## Screenshots
<img width="540" alt="Bildschirmfoto 2025-06-23 um 14 36 35" src="https://github.com/user-attachments/assets/f9db6630-fc8f-4827-969f-d2fdffdcf4f9" />


<img width="517" alt="Bildschirmfoto 2025-06-23 um 14 36 57" src="https://github.com/user-attachments/assets/1e05645c-2375-439c-aa63-dda6fb34e252" />

