### PR TITLE
Bump @openproject/primer-view-components from 0.70.0 to 0.70.1 in /fr…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,7 @@
         "@ngneat/content-loader": "^7.0.0",
         "@ngx-formly/core": "^6.1.4",
         "@openproject/octicons-angular": "^19.25.0",
-        "@openproject/primer-view-components": "^0.70.0",
+        "@openproject/primer-view-components": "^0.70.1",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^21.5.0",
         "@primer/live-region-element": "^0.8.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,7 +102,7 @@
     "@ngneat/content-loader": "^7.0.0",
     "@ngx-formly/core": "^6.1.4",
     "@openproject/octicons-angular": "^19.25.0",
-    "@openproject/primer-view-components": "^0.70.0",
+    "@openproject/primer-view-components": "^0.70.1",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^21.5.0",
     "@primer/live-region-element": "^0.8.0",


### PR DESCRIPTION
…ontend

# Ticket

N/A

# What are you trying to accomplish?

Follow up from the following two PRs:

1. #19258
2. #19259

The above two PRs updated `Gemfile.lock`, `package-lock.json` but not `package.json`.

We should bump the version in `package.json`  as well.

It's good practice - `script/check_same_primer_view_components_version_everywhere` will also error if we the versions are not in sync.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
