### PR TITLE
Tell Dependabot to ignore Primer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]
+      - dependency_name: "@openproject/primer-view-components"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -28,6 +29,8 @@ updates:
       aws-gems:
         patterns:
           - "aws-*"
+    ignore:
+      - dependency_name: "openproject-primer_view_components"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Ticket

N/A


# What are you trying to accomplish?

Configure Dependabot to ignore dependency Primer dependency updates. Ignores both npm and gem updates.

The D-Team would prefer to manage updates to Primer manually for the time-being, particularly while we are working on potentially breaking changes (e.g. https://github.com/opf/openproject/pull/19253).

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
