### PR TITLE
[64203] Fix unclear error message on parent self-assignment

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -289,6 +291,7 @@ module WorkPackages
 
     def validate_parent_not_self
       if model.parent == model
+        errors.delete(:parent_id) # remove the error added by closure_tree's cycle detection
         errors.add :parent, :cannot_be_self_assigned
       end
     end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -1185,8 +1185,6 @@ RSpec.describe WorkPackages::BaseContract do
     subject do
       contract.validate
 
-      # while we do validate the parent
-      # the errors are still put on :base so that the messages can be reused
       contract.errors.symbols_for(:parent)
     end
 
@@ -1196,6 +1194,7 @@ RSpec.describe WorkPackages::BaseContract do
       it "returns an error for the parent" do
         expect(subject)
           .to eq [:cannot_be_self_assigned]
+        expect(contract.errors.attribute_names).to contain_exactly(:parent)
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64203

# What are you trying to accomplish?

Make error message easier to understand (see screenshots)

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/a727f532-130d-478a-80ae-77482a51bfae)

After:
![image](https://github.com/user-attachments/assets/a4b0c47a-7338-407c-ac7b-f3e2f7f084e3)

# What approach did you choose and why?

When updating a work package to be parent of itself, `closure_tree` gem has hooks to update the work_package_hierarchies table and can detect cycles. When a cycle is detected, it adds a "You cannot add an ancestor as a descendant" error on `:parent_id`.

The fix is to remove this error before providing our own error message.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
