### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]
-      - dependency_name: "@openproject/primer-view-components"
+      - dependency-name: "@openproject/primer-view-components"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -30,7 +30,7 @@ updates:
         patterns:
           - "aws-*"
     ignore:
-      - dependency_name: "openproject-primer_view_components"
+      - dependency-name: "openproject-primer_view_components"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Why?
To avoid the following failures: https://github.com/opf/openproject/pull/18447/checks?check_run_id=44669318147
How?
Use `dependabot-name` everywhere in the config file
