### PR TITLE
Disable turbo on logout action to fix OIDC post logout redirect

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -122,7 +122,14 @@ Redmine::MenuManager.map :account_menu do |menu|
             }
   menu.push :logout,
             :signout_path,
-            if: ->(_) { User.current.logged? }
+            if: ->(_) { User.current.logged? },
+            html: {
+              data: {
+                # Turbo-drive needs to be disabled, as we might redirect to other origins
+                # as a result here (e.g., post logout SSO redirects).
+                turbo: false
+              }
+            }
 end
 
 Redmine::MenuManager.map :global_menu do |menu|

--- a/modules/openid_connect/spec/features/oidc_end_session_redirect_spec.rb
+++ b/modules/openid_connect/spec/features/oidc_end_session_redirect_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "OpenID Connect end_session_redirect",
+               :js,
+               with_ee: %i[sso_auth_providers] do
+  let!(:provider) do
+    create(:oidc_provider,
+           slug: "keycloak",
+           end_session_endpoint: "https://example.com")
+  end
+
+  let(:password) { "password!123" }
+  let(:user) { create(:user, authentication_provider: provider, password:, password_confirmation: password) }
+
+  it "redirects to the OIDC logout endpoint without turbo (Regression #65076)" do
+    login_with(user.login, password)
+
+    visit home_path
+
+    page.find(".op-top-menu-user").click
+    click_link_or_button "Sign out"
+
+    expect(page).to have_current_path("https://example.com")
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/65076

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Restore the redirect to the iDP's end_session_endpoint after an internal logout is triggered by the user

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Set `data-turbo=false` for the logout action. We cannot redirect to other origins in a turbo-enabled request, so this is the only option I see. (Related issue: https://github.com/hotwired/turbo-rails/issues/483#issuecomment-1977465696)

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
