### PR TITLE
[#64591] Link CF in PDF report only partially clickable when in multiple lines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ gem "structured_warnings", "~> 0.5.0"
 gem "airbrake", "~> 13.0.0", require: false
 
 gem "markly", "~> 0.13" # another markdown parser like commonmarker, but with AST support used in PDF export
-gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "be1ab00e2c49ce2e5e08a4edb4733438081c53ab"
+gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "9961752e4d1e990ec1d4bf48436de9277838763f"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/opf/md-to-pdf
-  revision: be1ab00e2c49ce2e5e08a4edb4733438081c53ab
-  ref: be1ab00e2c49ce2e5e08a4edb4733438081c53ab
+  revision: 9961752e4d1e990ec1d4bf48436de9277838763f
+  ref: 9961752e4d1e990ec1d4bf48436de9277838763f
   specs:
-    md_to_pdf (0.2.3)
+    md_to_pdf (0.2.4)
       base64 (~> 0.2)
       bigdecimal (~> 3.1)
       color_conversion (~> 0.1)
@@ -1760,7 +1760,7 @@ CHECKSUMS
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   markly (0.13.0) sha256=326a232c876cd95093d110b8d184be8effeadd776c3ffcefd59bdc8de7f59e0d
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
-  md_to_pdf (0.2.3)
+  md_to_pdf (0.2.4)
   messagebird-rest (1.4.2) sha256=1501e16ad76c87558f20f3b26cb39d05f587b349b44b8bf8056b040e9b495301
   meta-tags (2.22.1) sha256=e5ae1febbd320d396c7226d7edb868e5d63466c14b9c8b06622a1a74e6dce354
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5

--- a/app/models/exports/formatters/link_formatter.rb
+++ b/app/models/exports/formatters/link_formatter.rb
@@ -30,32 +30,21 @@
 
 module Exports
   module Formatters
-    class CustomFieldPdf < CustomField
-      def self.apply?(attribute, export_format)
-        export_format == :pdf && attribute.start_with?("cf_")
+    class LinkFormatter
+      def initialize(object, custom_field)
+        @href = object.custom_value_for(custom_field).to_s
       end
 
-      def format_value(value, options)
-        # avoid the value transformed in to a string by the super method
-        return value if value.is_a?(::Exports::Formatters::LinkFormatter)
-
-        super
+      def href
+        @href
       end
 
-      ##
-      # Print the value meant for PDF export.
-      #
-      # - For boolean values, use the Yes/No formatting for the PDF
-      #   treat nil as false
-      def format_for_export(object, custom_field)
-        if custom_field.field_format == "bool"
-          value = object.typed_custom_value_for(custom_field)
-          value ? I18n.t(:general_text_Yes) : I18n.t(:general_text_No)
-        elsif custom_field.field_format == "link"
-          LinkFormatter.new(object, custom_field)
-        else
-          super
-        end
+      def to_html
+        ApplicationController.helpers.link_to(@href, @href)
+      end
+
+      def to_s
+        @href
       end
     end
   end

--- a/app/models/exports/formatters/link_formatter.rb
+++ b/app/models/exports/formatters/link_formatter.rb
@@ -35,10 +35,6 @@ module Exports
         @href = object.custom_value_for(custom_field).to_s
       end
 
-      def href
-        @href
-      end
-
       def to_html
         ApplicationController.helpers.link_to(@href, @href)
       end

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -162,6 +162,9 @@ module WorkPackage::Exports
       def self.format_attribute_value(ar_name, model, obj)
         formatter = Exports::Register.formatter_for(model, ar_name, :pdf)
         value = formatter.format(obj)
+        # do NOT escape a tag for custom field link
+        return value.to_html if value.is_a?(::Exports::Formatters::LinkFormatter)
+
         # important NOT to return empty string as this could change meaning of markdown
         # e.g. **to_be_replaced** could be rendered as **** (horizontal line and a *)
         value.blank? ? " " : escape_tags(value)

--- a/app/models/work_package/exports/macros/links.rb
+++ b/app/models/work_package/exports/macros/links.rb
@@ -48,10 +48,6 @@ module WorkPackage::Exports
         [WorkPackagesLinkHandler]
       end
 
-      def self.html_replacement?
-        true
-      end
-
       # Faster inclusion check before the full regex is being applied
       def self.applicable?(content)
         /#\d/.match(content)

--- a/app/models/work_package/pdf_export/common/common.rb
+++ b/app/models/work_package/pdf_export/common/common.rb
@@ -361,4 +361,17 @@ module WorkPackage::PDFExport::Common::Common
       end
     end
   end
+
+  def get_cf_link_cell(custom_url)
+    make_link_href_cell(custom_url.to_s, custom_url.to_s)
+  end
+
+  def get_value_cell_by_column(work_package, column_name, format_subject)
+    value = get_column_value(work_package, column_name)
+    return get_cf_link_cell(value) if value.is_a?(::Exports::Formatters::LinkFormatter)
+    return get_id_column_cell(work_package, value) if column_name == :id
+    return get_subject_column_cell(work_package, value) if format_subject && column_name == :subject
+
+    escape_tags(value)
+  end
 end

--- a/app/models/work_package/pdf_export/common/macro.rb
+++ b/app/models/work_package/pdf_export/common/macro.rb
@@ -70,17 +70,13 @@ module WorkPackage::PDFExport::Common::Macro
   end
 
   def apply_macros_node_text(node, context)
-    formatted, applied_macros = apply_macro_text(node.string_content, context)
+    formatted = apply_macro_text(node.string_content, context)
     return if formatted == node.string_content
 
-    if has_html_macro?(applied_macros)
-      fragment = Markly::Node.new(:inline_html)
-      fragment.string_content = formatted
-      node.insert_before(fragment)
-      node.delete
-    else
-      node.string_content = formatted
-    end
+    fragment = Markly::Node.new(:inline_html)
+    fragment.string_content = formatted
+    node.insert_before(fragment)
+    node.delete
   end
 
   def apply_macros_node_html(node, context)
@@ -100,7 +96,7 @@ module WorkPackage::PDFExport::Common::Macro
         macro.process_match(Regexp.last_match, matched_string, context)
       end
     end
-    [text, applicable_macros]
+    text
   end
 
   def apply_macro_html(html, context)
@@ -111,20 +107,10 @@ module WorkPackage::PDFExport::Common::Macro
     doc.to_html
   end
 
-  def has_html_macro?(macros)
-    macros.any? { |macro| macro.respond_to?(:html_replacement?) && macro.html_replacement? }
-  end
-
   def apply_macro_html_node(node, context)
     if node.text?
-      formatted, applied_macros = apply_macro_text(node.content, context)
-      if formatted != node.content
-        if has_html_macro?(applied_macros)
-          node.replace(formatted)
-        else
-          node.content = formatted
-        end
-      end
+      formatted = apply_macro_text(node.content, context)
+      node.replace(formatted) if formatted != node.content
     elsif PREFORMATTED_BLOCKS.exclude?(node.name)
       node.children.each { |child| apply_macro_html_node(child, context) }
     end

--- a/app/models/work_package/pdf_export/export/markdown.rb
+++ b/app/models/work_package/pdf_export/export/markdown.rb
@@ -173,6 +173,8 @@ module WorkPackage::PDFExport::Export::Markdown
   end
 
   def write_markdown!(markdown, styling_yml)
+    return if markdown.blank?
+
     markdown_writer(styling_yml)
       .draw_markdown(markdown, pdf, ->(src) {
         with_images? ? attachment_image_filepath(src) : nil

--- a/app/models/work_package/pdf_export/export/report/attributes.rb
+++ b/app/models/work_package/pdf_export/export/report/attributes.rb
@@ -81,4 +81,8 @@ module WorkPackage::PDFExport::Export::Report::Attributes
       attribute_data[:value]
     ]
   end
+
+  def get_column_value_cell(work_package, column_name)
+    get_value_cell_by_column(work_package, column_name, wants_report?)
+  end
 end

--- a/app/models/work_package/pdf_export/export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/export/wp/attributes.rb
@@ -241,16 +241,7 @@ module WorkPackage::PDFExport::Export::Wp::Attributes
     ]
   end
 
-  def get_link_cell(custom_url)
-    make_link_href_cell(custom_url.to_s, custom_url.to_s)
-  end
-
   def get_column_value_cell(work_package, column_name)
-    value = get_column_value(work_package, column_name)
-    return get_link_cell(value) if value.is_a?(::Exports::Formatters::LinkFormatter)
-    return get_id_column_cell(work_package, value) if column_name == :id
-    return get_subject_column_cell(work_package, value) if column_name == :subject
-
-    escape_tags(value)
+    get_value_cell_by_column(work_package, column_name, true)
   end
 end

--- a/app/models/work_package/pdf_export/export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/export/wp/attributes.rb
@@ -242,7 +242,7 @@ module WorkPackage::PDFExport::Export::Wp::Attributes
   end
 
   def get_link_cell(custom_url)
-    make_link_href_cell(custom_url.href, custom_url.href)
+    make_link_href_cell(custom_url.to_s, custom_url.to_s)
   end
 
   def get_column_value_cell(work_package, column_name)

--- a/app/models/work_package/pdf_export/export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/export/wp/attributes.rb
@@ -241,8 +241,13 @@ module WorkPackage::PDFExport::Export::Wp::Attributes
     ]
   end
 
+  def get_link_cell(custom_url)
+    make_link_href_cell(custom_url.href, custom_url.href)
+  end
+
   def get_column_value_cell(work_package, column_name)
     value = get_column_value(work_package, column_name)
+    return get_link_cell(value) if value.is_a?(::Exports::Formatters::LinkFormatter)
     return get_id_column_cell(work_package, value) if column_name == :id
     return get_subject_column_cell(work_package, value) if column_name == :subject
 

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -301,12 +301,4 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
   def get_total_sums
     query.display_sums? ? (query.results.all_total_sums || {}) : {}
   end
-
-  def get_column_value_cell(work_package, column_name)
-    value = get_column_value(work_package, column_name)
-    return get_id_column_cell(work_package, value) if column_name == :id
-    return get_subject_column_cell(work_package, value) if wants_report? && column_name == :subject
-
-    escape_tags(value)
-  end
 end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
             I18n.t('export.macro.resource_not_found', resource: 'WorkPackage 1234567890'))}]  ",
           "Access denied:  ",
           "[#{I18n.t('export.macro.error', message:
-            I18n.t('export.macro.resource_not_found', resource: "WorkPackage #{forbidden_work_package.id}"))}]",
+            I18n.t('export.macro.resource_not_found', resource: "WorkPackage #{forbidden_work_package.id}"))}]"
         ]
       end
 

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   include Redmine::I18n
   include PDFExportSpecUtils
   let(:type) do
-    create(:type_bug, custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool])
+    create(:type_bug,
+           custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool, cf_link])
   end
   let(:parent_project) do
     create(:project, name: "Parent project")
@@ -65,10 +66,10 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
              project_custom_field_bool.id => true,
              project_custom_field_long_text.id => "foo"
            },
-           work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool],
+           work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool, cf_link],
 
            # cf_disabled_in_project.id not included == disabled
-           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id])
+           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id, cf_link.id])
   end
   let(:forbidden_project) do
     create(:project,
@@ -80,10 +81,10 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
            status_code: "on_track",
            active: true,
            parent: parent_project,
-           work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool],
+           work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool, cf_link],
 
            # cf_disabled_in_project.id not included == disabled
-           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id])
+           work_package_custom_field_ids: [cf_long_text.id, cf_empty_long_text.id, cf_global_bool.id, cf_link.id])
   end
   let(:user) do
     create(:user,
@@ -106,6 +107,9 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   let(:cf_empty_long_text_description) { "" }
   let(:cf_long_text) do
     create(:issue_custom_field, :text, name: "Work Package Custom Field Long Text")
+  end
+  let(:cf_link) do
+    create(:link_wp_custom_field, :link, name: "My Link")
   end
   let(:cf_empty_long_text) do
     create(:issue_custom_field, :text, name: "Empty Work Package Custom Field Long Text")
@@ -169,7 +173,8 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
              cf_long_text.id => cf_long_text_description,
              cf_empty_long_text.id => cf_empty_long_text_description,
              cf_disabled_in_project.id => "6.25",
-             cf_global_bool.id => true
+             cf_global_bool.id => true,
+             cf_link.id => "https://example.com"
            }).tap do |wp|
       allow(wp)
         .to receive(:attachments)
@@ -230,9 +235,10 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       "Project phase",
       "Date", "05/30/2024 - 03/13/2025",
       "Other",
-      "Work Package Custom Field Boolean", "Yes",
-      "Empty Work Package Custom Field Long Text",
       "Work Package Custom Field Long Text", "foo   faa",
+      "Empty Work Package Custom Field Long Text",
+      "Work Package Custom Field Boolean", "Yes",
+      "My Link", "https://example.com",
       "Costs",
       "Spent units", "Labor costs", "Unit costs", "Overall costs", "Budget"
     ]
@@ -339,6 +345,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
             <tr><td>Custom field rich text</td><td>
                 workPackageValue:1:"#{cf_long_text.name}"
             </td></tr>
+            <tr><td>My link in table</td><td>workPackageValue:"#{cf_link.name}"</td></tr>
             <tr><td>No replacement of:</td><td>
                 <code>workPackageValue:1:assignee</code>
                 <code>workPackageLabel:assignee</code>
@@ -352,11 +359,31 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
             workPackageLabel:assignee
             ```
 
+            workPackageValue:"My Link"
+
             Work package not found:
             workPackageValue:1234567890:assignee
             Access denied:
             workPackageValue:#{forbidden_work_package.id}:assignee
         DESCRIPTION
+      end
+
+      def expected_description
+        [
+          "Custom field boolean", I18n.t(:general_text_Yes),
+          "Custom field rich text", "[#{I18n.t('export.macro.rich_text_unsupported')}]",
+          "My link in table", "https://example.com",
+          "No replacement of:", "workPackageValue:1:assignee", " ", "workPackageLabel:assignee",
+          "workPackageValue:2:assignee workPackageLabel:assignee",
+          "workPackageValue:3:assignee", "workPackageLabel:assignee",
+          "https://example.com",
+          "Work package not found:  ",
+          "[#{I18n.t('export.macro.error', message:
+            I18n.t('export.macro.resource_not_found', resource: 'WorkPackage 1234567890'))}]  ",
+          "Access denied:  ",
+          "[#{I18n.t('export.macro.error', message:
+            I18n.t('export.macro.resource_not_found', resource: "WorkPackage #{forbidden_work_package.id}"))}]",
+        ]
       end
 
       it "contains resolved attributes and labels" do
@@ -372,17 +399,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
               API::Utilities::PropertyNameConverter.to_ar_name(embed[0].to_sym, context: work_package)
             ), embed[1]]
           end,
-          "Custom field boolean", I18n.t(:general_text_Yes),
-          "Custom field rich text", "[#{I18n.t('export.macro.rich_text_unsupported')}]",
-          "No replacement of:", "workPackageValue:1:assignee", " ", "workPackageLabel:assignee",
-          "workPackageValue:2:assignee workPackageLabel:assignee",
-          "workPackageValue:3:assignee", "workPackageLabel:assignee",
-          "Work package not found:  ",
-          "[#{I18n.t('export.macro.error', message:
-            I18n.t('export.macro.resource_not_found', resource: 'WorkPackage 1234567890'))}]  ",
-          "Access denied:  ",
-          "[#{I18n.t('export.macro.error', message:
-            I18n.t('export.macro.resource_not_found', resource: "WorkPackage #{forbidden_work_package.id}"))}]",
+          *expected_description,
           "2", export_date_formatted, project.name
         ].flatten.join(" ")
         expect(result).to eq(expected_result)

--- a/spec/support/work_packages/pdf_export.rb
+++ b/spec/support/work_packages/pdf_export.rb
@@ -9,6 +9,10 @@ module PDFExportSpecUtils
   end
 
   def label_title(column_name)
+    if column_name.start_with?("cf_")
+      id = column_name.delete_prefix("cf_").to_i
+      return ::CustomField.find_by(id:).name
+    end
     WorkPackage.human_attribute_name(column_name)
   end
 end

--- a/spec/support/work_packages/pdf_export.rb
+++ b/spec/support/work_packages/pdf_export.rb
@@ -11,7 +11,7 @@ module PDFExportSpecUtils
   def label_title(column_name)
     if column_name.start_with?("cf_")
       id = column_name.delete_prefix("cf_").to_i
-      return ::CustomField.find_by(id:).name
+      return ::CustomField.find(id).name
     end
     WorkPackage.human_attribute_name(column_name)
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64591

# What are you trying to achieve?

Links inserted by the Custom Field Type `Link` were inserted as plain text. Some PDF viewers trying to "auto-link" these failed if the link spanned multiple lines, resulting in clickable but invalid URLs.

# What approach did you choose and why?

- [x] Format these custom fields as proper links in PDF. 

These fields are exported 
* in the attribute table  in report and single wp export
* as a column in the work package table export
* as `workPackageValue:"Custom Field Name"` macros in description and long text custom field

- [x] [Fix a found bug](https://github.com/opf/md-to-pdf/commit/f1a5ee2d8cedf9ec6f5fd086e12626a4e1d8edd6), links in table cells could be exported without a title, hence be invisible => update md_to_pdf

# Merge checklist

- [x] Added/updated tests
- [x] Tested major PDF readers