### PR TITLE
Enable CI metrics

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -25,17 +25,15 @@ jobs:
     name: Units + Features
     if: github.repository == 'opf/openproject'
     runs-on:
-      labels:
-        - runs-on
-        - runner=32cpu-linux-x64
-        - family=m7+c7+r7+i7
-        - ram=128
-        - run-id=${{ github.run_id }}
+      labels: "runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/family=m7+c7+r7+i7/ram=128"
     timeout-minutes: 40
     env:
       DOCKER_BUILDKIT: 1
       CI_RETRY_COUNT: 3
     steps:
+    - uses: runs-on/action@v2
+      with:
+        metrics: cpu,memory,disk,io,network
     - uses: actions/checkout@v4
     - name: Cache DOCKER
       id: cache_docker


### PR DESCRIPTION
We now get runtime metrics and costs directly within the post-step of `runs-on/action`: https://github.com/opf/openproject/actions/runs/15852822320/job/44690492572?pr=19303#step:31:11

![2025-06-24-000050-Enable CI metrics · opfopenproject@1a88e78](https://github.com/user-attachments/assets/dec539af-85df-4a3b-9235-66ef72f2f5f2)
