### PR TITLE
bug/65077 Inline comment attachments are not linked to the comment when submit is via API

### DIFF
--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -111,7 +111,6 @@ class WorkPackages::ActivitiesTabController < ApplicationController
       call = create_journal_service_call
 
       if call.success? && call.result
-        claim_journal_attachments_for(call.result)
         set_last_server_timestamp_to_headers
         handle_successful_create_call(call)
       else
@@ -129,7 +128,6 @@ class WorkPackages::ActivitiesTabController < ApplicationController
       call = update_journal_service_call
 
       if call.success? && call.result
-        claim_journal_attachments_for(call.result)
         update_item_show_component(journal: call.result, grouped_emoji_reactions: grouped_emoji_reactions_for_journal)
       else
         handle_failed_create_or_update_call(call)
@@ -319,12 +317,6 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   def update_journal_service_call
     notes = @journal.internal? ? sanitized_journal_notes : journal_params[:notes]
     Journals::UpdateService.new(model: @journal, user: User.current).call(notes:)
-  end
-
-  def claim_journal_attachments_for(journal)
-    WorkPackages::ActivitiesTab::CommentAttachmentsClaims::ClaimsService
-      .new(user: User.current, model: journal)
-      .call
   end
 
   def generate_time_based_update_streams(last_update_timestamp)

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -190,6 +190,25 @@ RSpec.describe API::V3::Activities::ActivitiesAPI, content_type: :json do
         end
       end
     end
+
+    context "with attachments" do
+      let(:attachment1) { create(:attachment, container: nil, author: current_user) }
+      let(:attachment2) { create(:attachment, container: nil, author: current_user) }
+
+      let(:comment) do
+        <<~HTML
+          <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{attachment1.id}/content">
+          Lorem ipsum dolor sit amet
+          <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{attachment2.id}/content">
+          consectetur adipiscing elit
+        HTML
+      end
+
+      it "creates attachment claims" do
+        expect(last_response.body).to be_json_eql(comment.to_json).at_path("comment/raw")
+        expect(activity.reload.attachments).to contain_exactly(attachment1, attachment2)
+      end
+    end
   end
 
   describe "#get api" do

--- a/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
+++ b/spec/requests/api/v3/activities_by_work_package_resource_spec.rb
@@ -209,6 +209,28 @@ RSpec.describe API::V3::Activities::ActivitiesByWorkPackageAPI, with_ee: [:inter
           end
         end
       end
+
+      context "with attachments" do
+        include_context "create activity"
+
+        let(:attachment1) { create(:attachment, container: nil, author: current_user) }
+        let(:attachment2) { create(:attachment, container: nil, author: current_user) }
+
+        let(:comment) do
+          <<~HTML
+            <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{attachment1.id}/content">
+            Lorem ipsum dolor sit amet
+            <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{attachment2.id}/content">
+            consectetur adipiscing elit
+          HTML
+        end
+
+        it "creates attachment claims" do
+          expect(last_response.body).to be_json_eql(comment.to_json).at_path("comment/raw")
+          journal = work_package.journals.last
+          expect(journal.attachments).to contain_exactly(attachment1, attachment2)
+        end
+      end
     end
   end
 end

--- a/spec/services/journals/update_service_spec.rb
+++ b/spec/services/journals/update_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "services/base_services/behaves_like_update_service"
+
+RSpec.describe Journals::UpdateService do
+  it_behaves_like "BaseServices update service" do
+    let(:factory) { :journal }
+
+    describe "Inline attachments" do
+      let(:model_instance) { build_stubbed(:work_package_journal, notes: "Foobar") }
+      let(:claims_service) { WorkPackages::ActivitiesTab::CommentAttachmentsClaims::ClaimsService }
+      let(:attachment1) { build_stubbed(:attachment) }
+      let(:attachment2) { build_stubbed(:attachment) }
+
+      let(:notes) do
+        <<~HTML
+          <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{attachment1.id}/content">
+          Lorem ipsum dolor sit amet
+          <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{attachment2.id}/content">
+          consectetur adipiscing elit
+        HTML
+      end
+
+      let(:call_attributes) { { notes: } }
+
+      let(:mock_claim_service_instance) do
+        instance_double(claims_service, call: ServiceResult.success(result: [attachment1, attachment2]))
+      end
+
+      before do
+        allow(claims_service).to receive(:new).and_return(mock_claim_service_instance)
+      end
+
+      context "when the journal notes have attachments" do
+        context "and note creation is successful" do
+          it "creates an attachment claim" do
+            expect(subject).to be_success
+            expect(WorkPackages::ActivitiesTab::CommentAttachmentsClaims::ClaimsService)
+              .to have_received(:new).with(user: user, model: model_instance)
+
+            dependent_results = subject.dependent_results
+            expect(dependent_results.size).to eq(1)
+            expect(dependent_results.first).to be_a_success
+            expect(dependent_results.first.result).to contain_exactly(attachment1, attachment2)
+          end
+        end
+
+        context "and note creation is unsuccessful" do
+          let(:model_save_result) { false }
+
+          it "does not create an attachment claim" do
+            expect(subject).to be_a_failure
+            expect(WorkPackages::ActivitiesTab::CommentAttachmentsClaims::ClaimsService)
+              .not_to have_received(:new)
+
+            expect(subject.dependent_results).to be_empty
+          end
+        end
+      end
+
+      context "with empty notes" do
+        let(:model_instance) { build_stubbed(:work_package_journal, notes: "") }
+
+        it "does not create an attachment claim" do
+          expect(subject).to be_a_success
+
+          expect(WorkPackages::ActivitiesTab::CommentAttachmentsClaims::ClaimsService)
+              .not_to have_received(:new)
+
+          expect(subject.dependent_results).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/65077

Relocate attachment claims in corresponding (journal) comment create and update services as dependent services so that they are always invoked in both API & HTML contexts.

Follows:
 * https://github.com/opf/openproject/pull/18537
 * https://github.com/opf/openproject/pull/18648