### PR TITLE
[#62480] do not attempt to render user hover card for groups

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -35,6 +35,7 @@ import { ValueOption } from 'core-app/shared/components/fields/edit/field-types/
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { UserResource } from 'core-app/features/hal/resources/user-resource';
 
 @Component({
   templateUrl: './multi-select-edit-field.component.html',
@@ -247,10 +248,10 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
 
   /**
    * For multi-select fields that are of type User, we want to show a hover card when hovering over users in the
-   * dropdown. For this to happen we must define a URL for the hover card.
+   * dropdown. For this to happen, we must define a URL for the hover card.
    */
-  protected getHoverCardUrl(item:{ id?:string }) {
-    if (item && item.id) {
+  protected getHoverCardUrl(item:HalResource) {
+    if (item instanceof UserResource && item.id) {
       return this.pathHelperService.userHoverCardPath(item.id);
     }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62480

# What are you trying to accomplish?
Multi select user custom fields (quick, say this 10 times in rapid succession!) did not properly check for the data type of the rendered resource. It attempted to render a user hover card for groups and placeholder users, which leads to an error. Fixed.

eslint went haywire since this file breaks more rules than a 4 year old board gamer that hates losing. I left it like that 😇
