### PR TITLE
[#64851] only show the hover card with mouse over the trigger

### DIFF
--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -44,6 +44,7 @@ export default class HoverCardTriggerController extends ApplicationController {
   private readonly triggerTargets:HTMLElement[];
 
   private mouseInModal = false;
+  private mouseIsHoveringOverTrigger = false;
   private hoverTimeout:number|null = null;
   private closeTimeout:number|null = null;
   private previousTarget:HTMLElement|null = null;
@@ -103,6 +104,7 @@ export default class HoverCardTriggerController extends ApplicationController {
   private onMouseLeave() {
     this.clearHoverTimer();
     this.mouseInModal = false;
+    this.mouseIsHoveringOverTrigger = false;
     this.closeAfterTimeout();
   }
 
@@ -126,6 +128,8 @@ export default class HoverCardTriggerController extends ApplicationController {
 
       el = trigger;
     }
+
+    this.mouseIsHoveringOverTrigger = true;
 
     if (this.previousTarget && this.previousTarget === el) {
       // Re-entering the trigger counts as hovering over the card:
@@ -156,6 +160,8 @@ export default class HoverCardTriggerController extends ApplicationController {
     if (!this.element.contains(el)) { return; }
     // Do not try to show two hover cards at the same time.
     if (this.isShowingHoverCard) { return; }
+    // The mouse might have left the trigger while we were waiting for the hover delay.
+    if (!this.mouseIsHoveringOverTrigger) { return; }
 
     this.loadAndShowHoverCard(el, turboFrameUrl);
   }
@@ -205,8 +211,6 @@ export default class HoverCardTriggerController extends ApplicationController {
       this.mouseInModal = false;
     }
 
-    // It is important to check if we are currently showing a hover card. If we closed the modal service without
-    // doing so, we might accidentally close another modal (e.g. share dialog).
     if (this.isShowingHoverCard && !this.mouseInModal) {
       this.getAndResetOverlay();
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64851

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Between starting the delay timer and displaying the hover card, the mouse pointer might have left the trigger. Do not display the hover card in this case. Fixes the issue of the opening date model for phase gates not dismissing the hover card.

## Screenshots

https://github.com/user-attachments/assets/b823d7e3-d579-4579-9aed-396594bb8125

