### PR TITLE
Specify non-abbreviated month format for Reminders success message `RelativeTimeComponent` to account for French locale

### DIFF
--- a/app/controllers/work_packages/reminders_controller.rb
+++ b/app/controllers/work_packages/reminders_controller.rb
@@ -109,7 +109,8 @@ class WorkPackages::RemindersController < ApplicationController
 
   def reminder_chosen_time(reminder)
     OpPrimer::RelativeTimeComponent.new(
-      datetime: in_user_zone(reminder.remind_at)
+      datetime: in_user_zone(reminder.remind_at),
+      month: :long
     ).render_in(view_context)
   end
 


### PR DESCRIPTION
https://community.openproject.org/wp/64695

In French, abbreviated month names (like "juil." for "juillet") officially require a period at the end, according to typographic and localization standards. For example, "juil." is the correct abbreviation for "juillet" in French, and the period is part of the abbreviation.

As our translation file ends with a period, the date component would add a seemingly redundant period at the end which looks like a double period ("..")

> ..notification for this work package le 26 juil..

[Lookbook Preview](https://primer.style/view-components/lookbook/inspect/primer/beta/relative_time/default/?month=long&datetime=2025-07-26T16%3A28%3A29&lang=fr)

_Before_

![image](https://github.com/user-attachments/assets/d9f46a5b-e329-458a-af52-ac6cd5cf04dc)

_After_

<img width="1162" alt="Screenshot 2025-06-25 at 6 14 06 PM" src="https://github.com/user-attachments/assets/ecc1b079-b333-4975-aab4-06202070ea70" />
<img width="1180" alt="Screenshot 2025-06-25 at 6 13 16 PM" src="https://github.com/user-attachments/assets/6054e7f1-7d71-4791-856a-83c8c34f7483" />


> [!NOTE]
> _Testing: Relative time is rendered as a dynamic component  that is a not assertable as text in capybara_

https://github.com/opf/openproject/blob/b05eeaeaa23f60d5728a327bcd8cb57f871b0762/spec/features/work_packages/reminders_spec.rb#L238-L242