### PR TITLE
Fix error when filtering by backlog type Task

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
+++ b/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -122,25 +124,18 @@ module OpenProject::Backlogs
     end
 
     def sql_for_task
-      <<-SQL
+      <<-SQL.squish
       (#{db_table}.type_id = #{Task.type} AND
-       #{db_table}.id IN (#{is_child_sql}))
+       #{db_table}.parent_id IS NOT NULL)
       SQL
     end
 
     def sql_for_impediment
-      <<-SQL
+      <<-SQL.squish
         (#{db_table}.type_id = #{Task.type} AND
          #{db_table}.id IN (#{blocks_backlogs_type_sql})
-         AND #{db_table}.id NOT IN (#{is_child_sql}))
+         AND #{db_table}.parent_id IS NULL)
       SQL
-    end
-
-    def is_child_sql
-      Relation
-        .hierarchy
-        .select(:to_id)
-        .to_sql
     end
 
     def blocks_backlogs_type_sql

--- a/modules/backlogs/spec/features/work_packages/filter_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/filter_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "Filter by backlog type", :js do
   let(:work_package_with_task_type) do
     create(:work_package,
            type: task_type,
+           parent: work_package_with_story_type,
            project:)
   end
 
@@ -104,5 +105,23 @@ RSpec.describe "Filter by backlog type", :js do
     filters.open
 
     filters.expect_filter_by("Backlog type", "is (OR)", "Story", "backlogsWorkPackageType")
+  end
+
+  it "can filter by task or any" do
+    filters.open
+
+    filters.add_filter_by("Backlog type", "is (OR)", "Story", "backlogsWorkPackageType")
+
+    wp_table.ensure_work_package_not_listed! work_package_with_task_type
+
+    filters.remove_filter "backlogsWorkPackageType"
+    filters.add_filter_by("Backlog type", "is (OR)", "Task", "backlogsWorkPackageType")
+
+    wp_table.expect_work_package_listed work_package_with_task_type
+
+    filters.remove_filter "backlogsWorkPackageType"
+    filters.add_filter_by("Backlog type", "is (OR)", "any", "backlogsWorkPackageType")
+
+    wp_table.expect_work_package_listed work_package_with_story_type, work_package_with_task_type
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65085

# What are you trying to accomplish?

Fix error when filtering work package list by "Backlog type" with "Task", "Impediment", or "any".
 
## Screenshots

An example of the error displayed when selecting backlog type = Task

![image](https://github.com/user-attachments/assets/5c3de1c7-4dd6-4c0d-bad6-e21e85153329)

# What approach did you choose and why?

It was using `Relation.hierarch` scope, which is not available since 491928a3fd3 (#10349) in March 2022.

Replaced by another SQL query to check if a work package is a child or not.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
