### PR TITLE
Bug/53722 hide the add project attribute button on the settings admin when sections are empty

### DIFF
--- a/app/components/settings/project_custom_fields/header_component.html.erb
+++ b/app/components/settings/project_custom_fields/header_component.html.erb
@@ -25,11 +25,14 @@
           id: "dialog-show-project-custom-field-section-dialog",
           tag: :a,
           href: new_link_admin_settings_project_custom_field_sections_path,
-          content_arguments: { data: { controller: "async-dialog" } }
+          content_arguments: { data: { controller: "async-dialog", test_selector: "add-project-custom-field-section" } }
         )
 
         if allow_custom_field_creation?
-          menu.with_sub_menu_item(label: t("settings.project_attributes.label_new_attribute")) do |sub_menu|
+          menu.with_sub_menu_item(
+            label: t("settings.project_attributes.label_new_attribute"),
+            content_arguments: { data: { test_selector: "add-project-custom-field-attribute" } }
+          ) do |sub_menu|
             OpenProject::CustomFieldFormat.available_for_class_name("Project")
                                           .sort_by(&:name)
                                           .map do |format|

--- a/app/components/settings/project_custom_fields/header_component.html.erb
+++ b/app/components/settings/project_custom_fields/header_component.html.erb
@@ -28,17 +28,19 @@
           content_arguments: { data: { controller: "async-dialog" } }
         )
 
-        menu.with_sub_menu_item(label: t("settings.project_attributes.label_new_attribute")) do |sub_menu|
-          OpenProject::CustomFieldFormat.available_for_class_name("Project")
-                                        .sort_by(&:name)
-                                        .map do |format|
-            sub_menu.with_item(
-              label: helpers.label_for_custom_field_format(format.name),
-              tag: :a,
-              href: new_admin_settings_project_custom_field_path(field_format: format.name),
-              content_arguments: { data: { turbo: "false",
-                                           test_selector: "new-project-custom-field-button" } }
-            )
+        if allow_custom_field_creation?
+          menu.with_sub_menu_item(label: t("settings.project_attributes.label_new_attribute")) do |sub_menu|
+            OpenProject::CustomFieldFormat.available_for_class_name("Project")
+                                          .sort_by(&:name)
+                                          .map do |format|
+              sub_menu.with_item(
+                label: helpers.label_for_custom_field_format(format.name),
+                tag: :a,
+                href: new_admin_settings_project_custom_field_path(field_format: format.name),
+                content_arguments: { data: { turbo: "false",
+                                             test_selector: "new-project-custom-field-button" } }
+              )
+            end
           end
         end
       end

--- a/app/components/settings/project_custom_fields/header_component.rb
+++ b/app/components/settings/project_custom_fields/header_component.rb
@@ -34,10 +34,20 @@ module Settings
       include OpTurbo::Streamable
       include CustomFieldsHelper
 
+      def initialize(allow_custom_field_creation:)
+        super
+
+        @allow_custom_field_creation = allow_custom_field_creation
+      end
+
       def breadcrumbs_items
         [{ href: admin_index_path, text: t("label_administration") },
          { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
          t("settings.project_attributes.heading")]
+      end
+
+      def allow_custom_field_creation?
+        @allow_custom_field_creation
       end
     end
   end

--- a/app/controllers/admin/settings/project_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/project_custom_field_sections_controller.rb
@@ -40,7 +40,7 @@ module Admin::Settings
       )
 
       if call.success?
-        update_header_via_turbo_stream # required to closed the dialog
+        update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
         update_section_dialog_body_form_via_turbo_stream(project_custom_field_section: call.result)
@@ -67,6 +67,7 @@ module Admin::Settings
       call = ::ProjectCustomFieldSections::DeleteService.new(user: current_user, model: @project_custom_field_section).call
 
       if call.success?
+        update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
         # TODO: show error message
@@ -95,6 +96,7 @@ module Admin::Settings
       )
 
       if call.success?
+        update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
         # TODO: show error message
@@ -110,6 +112,10 @@ module Admin::Settings
 
     def set_project_custom_field_section
       @project_custom_field_section = ProjectCustomFieldSection.find(params[:id])
+    end
+
+    def allow_custom_field_creation?
+      ProjectCustomFieldSection.any?
     end
 
     def project_custom_field_section_params

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -48,6 +48,8 @@ module Admin::Settings
     # rubocop:enable Rails/LexicallyScopedActionFilter
 
     def index
+      @allow_custom_field_creation = @project_custom_field_sections.any?
+
       respond_to :html
     end
 

--- a/app/controllers/concerns/admin/settings/project_custom_fields/component_streams.rb
+++ b/app/controllers/concerns/admin/settings/project_custom_fields/component_streams.rb
@@ -33,9 +33,11 @@ module Admin
         extend ActiveSupport::Concern
 
         included do
-          def update_header_via_turbo_stream
+          def update_header_via_turbo_stream(allow_custom_field_creation:)
             update_via_turbo_stream(
-              component: ::Settings::ProjectCustomFields::HeaderComponent.new
+              component: ::Settings::ProjectCustomFields::HeaderComponent.new(
+                allow_custom_field_creation:
+              )
             )
           end
 

--- a/app/views/admin/settings/project_custom_fields/index.html.erb
+++ b/app/views/admin/settings/project_custom_fields/index.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), t("settings.project_attributes.heading") %>
 
 <div data-turbo="true">
-  <%= render(Settings::ProjectCustomFields::HeaderComponent.new) %>
+  <%= render(Settings::ProjectCustomFields::HeaderComponent.new(allow_custom_field_creation: @allow_custom_field_creation)) %>
   <%= render(
         Settings::ProjectCustomFieldSections::IndexComponent.new(
           project_custom_field_sections: @project_custom_field_sections

--- a/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
+++ b/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
@@ -117,17 +117,10 @@ RSpec.describe "Create project custom fields in sections", :js do
       before do
         ProjectCustomFieldSection.destroy_all
         cf_index_page.visit!
-
-        cf_index_page.click_to_create_new_custom_field("Integer")
       end
 
-      it "prevents creating a new project custom field with an empty name" do
-        fill_in("custom_field_name", with: "New custom field")
-
-        click_on("Save")
-
-        expect(page).to have_field "custom_field_custom_field_section_id",
-                                   validation_message: "Please select an item in the list."
+      it "prevents creating a new project custom field" do
+        cf_index_page.expect_no_add_project_attribute_submenu
       end
     end
   end

--- a/spec/support/pages/admin/custom_fields/custom_fields_projects/index.rb
+++ b/spec/support/pages/admin/custom_fields/custom_fields_projects/index.rb
@@ -39,6 +39,32 @@ module Pages
             "/admin/settings/project_custom_fields"
           end
 
+          def expect_add_project_attribute_submenu(close_dialog: true)
+            wait_for_network_idle
+
+            click_button "Add"
+
+            expect(page).to have_test_selector("add-project-custom-field-attribute")
+
+            if close_dialog
+              element_in_dialog = find_test_selector("add-project-custom-field-section")
+              element_in_dialog.send_keys :escape
+            end
+          end
+
+          def expect_no_add_project_attribute_submenu(close_dialog: true)
+            wait_for_network_idle
+
+            click_button "Add"
+
+            expect(page).not_to have_test_selector("add-project-custom-field-attribute")
+
+            if close_dialog
+              element_in_dialog = find_test_selector("add-project-custom-field-section")
+              element_in_dialog.send_keys :escape
+            end
+          end
+
           def click_to_create_new_custom_field(type)
             wait_for_network_idle
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/53722

# What are you trying to accomplish?
Only allow project attributes to be created (by offering the button) when there is a place for it to go to i.e., at least one section exists.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
