### PR TITLE
[65091] Change default color of sidebar in light mode

### DIFF
--- a/app/components/open_project/common/main_menu_toggle_component.sass
+++ b/app/components/open_project/common/main_menu_toggle_component.sass
@@ -35,8 +35,6 @@
     display: none
 
 #menu-toggle--collapse-button
-  margin-right: 5px
-
   .Button-visual
     color: var(--main-menu-font-color)
 

--- a/app/components/open_project/common/submenu_component.sass
+++ b/app/components/open_project/common/submenu_component.sass
@@ -44,9 +44,11 @@
     background: transparent
     color: var(--main-menu-fieldset-header-color)
     border: 1px solid transparent
+    border-radius: var(--borderRadius-medium)
     text-transform: uppercase
     padding: 8px var(--main-menu-x-spacing) 8px var(--main-menu-x-spacing)
     margin-top: 12px
+    margin-bottom: 2px
     font-size: 12px
     cursor: pointer
     width: 100%
@@ -61,6 +63,9 @@
 
     &_collapsed
       display: none
+
+  &--item
+    margin-bottom: 2px !important
 
   &--item-action
     display: flex

--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -48,9 +48,6 @@ See COPYRIGHT and LICENSE files for more details.
         --main-menu-border-color: #d0d7de;
       <% end %>
     <% end %>
-    <% if design_color.variable == "main-menu-bg-selected-background" %>
-      --main-menu-selected-font-color: <%= design_color.contrasting_font_color %>;
-    <% end %>
     <% if design_color.variable == "primary-button-color" %>
         --primary-button-color--major1: <%= design_color.darken 0.18 %>;
         --primary-button-color--minor1: <%= design_color.lighten 0.8 %>;

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -103,7 +103,7 @@ See COPYRIGHT and LICENSE files for more details.
         <div id="menu-sidebar">
           <div class="main-menu--top-container">
             <%= render(Primer::OpenProject::FlexLayout.new(align_items: :center, pt: 3)) do |flex|
-              flex.with_column(overflow: :hidden, ml: 2) do
+              flex.with_column(overflow: :hidden) do
                 render_projects_top_menu_node
               end
               flex.with_column(text_align: :right, flex: :auto) do

--- a/db/migrate/20250627121119_change_default_main_menu_color.rb
+++ b/db/migrate/20250627121119_change_default_main_menu_color.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ChangeDefaultMainMenuColor < ActiveRecord::Migration[8.0]
+  def up
+    update_color(OpenProject::CustomStyles::ColorThemes::DEPRECATED_MAIN_MENU_COLOR, "#FFFFFF")
+  end
+
+  def down
+    update_color("#FFFFFF", OpenProject::CustomStyles::ColorThemes::DEPRECATED_MAIN_MENU_COLOR)
+  end
+
+  def update_color(old, new)
+    execute <<-SQL.squish
+      UPDATE design_colors
+      SET hexcode = '#{new}'
+      WHERE variable = 'main-menu-bg-color' AND hexcode = '#{old}'
+    SQL
+  end
+end

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.sass
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.sass
@@ -22,7 +22,7 @@
     height: var(--control-medium-size)
     color: var(--main-menu-font-color)
     font-weight: var(--base-text-weight-semibold)
-    padding: 0 8px
+    padding: 0 var(--main-menu-x-spacing)
     border: 1px solid transparent
     border-radius: var(--borderRadius-medium)
     background-color: transparent

--- a/frontend/src/global_styles/common/header/app-header.sass
+++ b/frontend/src/global_styles/common/header/app-header.sass
@@ -21,7 +21,7 @@
     right: 0
 
     .op-app-header--start
-      padding-left: 5px
+      padding-left: 6px
 
   @at-root .zen-mode &
     display: none
@@ -35,6 +35,7 @@
   &--start
     grid-area: start
     justify-content: flex-start
+    padding-left: var(--main-menu-x-spacing)
 
   &--center
     grid-area: center

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -28,17 +28,17 @@
 
 @import "app/spot/styles/sass/common/icon"
 
-$menu-item-line-height: 30px
-$arrow-left-width: 40px
+$arrow-left-width: 36px
 
 @mixin main-menu-hover($main-item: true)
   background: var(--control-transparent-bgColor-hover)
   color: var(--main-menu-font-color)
   border-style: solid
   border-color: var(--main-menu-hover-border-color)
+  border-radius: var(--borderRadius-medium)
   @if $main-item
     border-width: 1px 1px 1px 5px
-    padding-left: 12px
+    padding-left: 8px
   @else
     border-width: 1px
 
@@ -46,8 +46,9 @@ $arrow-left-width: 40px
   background: var(--control-transparent-bgColor-selected)
   color: var(--main-menu-selected-font-color)
   border: 1px solid var(--main-menu-bg-selected-border)
+  border-radius: var(--borderRadius-medium)
   border-left: 5px solid var(--main-menu-bg-selected-background) !important
-  padding-left: 12px
+  padding-left: 8px
 
 .main-menu
   width: var(--main-menu-width)
@@ -66,6 +67,7 @@ $arrow-left-width: 40px
     height: calc(100vh - var(--header-height))
     position: relative
     @include styled-scroll-bar
+    padding: 0 var(--main-menu-x-spacing)
 
   ul
     margin: 0
@@ -118,7 +120,7 @@ $arrow-left-width: 40px
       text-decoration: none
 
   .toggler
-    width: 40px
+    width: $arrow-left-width
     height: var(--main-menu-item-height)
     overflow: hidden
     display: flex
@@ -147,13 +149,19 @@ $arrow-left-width: 40px
 
       & ~ .toggler
         @include main-menu-hover(false)
+        border-top-left-radius: 0
+        border-bottom-left-radius: 0
+
+      &:has(+.toggler)
+        border-top-right-radius: 0
+        border-bottom-right-radius: 0
 
   a:not(.Button):not(.toggler)
     @extend .small-12
 
   a:not(.Button):not(:only-child):first-of-type
-    flex: 0 0 calc(100% - 40px)
-    max-width: calc(100% - 40px)
+    flex: 0 0 calc(100% - $arrow-left-width)
+    max-width: calc(100% - $arrow-left-width)
 
 // -------------------- CHILD menu items ---------------------------
 .main-menu--children
@@ -182,16 +190,14 @@ $arrow-left-width: 40px
   top: 0
   z-index: 1
   background: var(--main-menu-bg-color)
-  padding: 0px 10px 0 4px
+  padding: 0px 10px 0 0px
   height: calc(var(--main-menu-item-height) + 10px)
 
   .main-menu--arrow-left-to-project:not(.Button)
     display: inline-block
     width: $arrow-left-width
     float: left
-    border-radius: 3px
-    padding-left: var(--main-menu-x-spacing-small)
-    padding-right: var(--main-menu-x-spacing-small)
+    border-radius: var(--borderRadius-medium)
     border: 1px solid transparent
 
     &:hover, &:focus, &:active
@@ -204,13 +210,13 @@ $arrow-left-width: 40px
   background: var(--main-menu-bg-color)
 
   .main-menu--projects-divider
-    background: var(--borderColor-neutral-emphasis)
+    background: var(--borderColor-neutral-muted)
     margin: 1rem 0
 
 a.main-menu--parent-node:not(.Button)
   border: 1px solid transparent
   display: inline-block
-  padding: 0 var(--main-menu-x-spacing-small)
+  padding: 0 var(--main-menu-x-spacing)
   font-size: var(--main-menu-font-size)
   font-weight: var(--base-text-weight-bold)
   width: calc(100% - #{$arrow-left-width})
@@ -259,6 +265,7 @@ a.main-menu--parent-node:not(.Button)
     &.open
       > li
         display: list-item
+        margin-bottom: 2px
 
         .main-menu--children-menu-header
           display: none
@@ -335,17 +342,19 @@ a.main-menu--parent-node:not(.Button)
 
   .tree-menu--item
     &.-selected
-      background: var(--main-menu-bg-selected-background)
+      border-left: 5px solid var(--main-menu-bg-selected-background)
 
       .tree-menu--title
         color: var(--main-menu-selected-font-color)
 
     &:hover
-      background: var(--control-transparent-bgColor-hover)
-
       .tree-menu--title
         color: var(--main-menu-font-color)
         text-decoration: none
+
+    .tree-menu--title
+      &:hover
+        background: transparent !important
 
 // Resizer & toggle styles
 .main-menu--resizer

--- a/frontend/src/global_styles/layout/_tree_menu.sass
+++ b/frontend/src/global_styles/layout/_tree_menu.sass
@@ -1,4 +1,4 @@
-$tree-menu-item-height: 40px
+$tree-menu-item-height: 36px
 
 #main-menu ul ul.main-menu--children ul.pages-hierarchy,
 div.wiki ul.pages-hierarchy,
@@ -31,6 +31,7 @@ div.wiki ul.pages-hierarchy,
   // collapsed: right arrow
   .tree-menu--hierarchy-indicator
     color: var(--accent-color)
+    display: block
     height: $tree-menu-item-height
     line-height: $tree-menu-item-height
     text-decoration: none !important
@@ -53,6 +54,9 @@ div.wiki ul.pages-hierarchy,
   .tree-menu--hierarchy-indicator-icon
     @include icon-common
     @extend .icon-arrow-down1
+    display: flex
+    align-items: center
+    line-height: $tree-menu-item-height
     font-size: 0.6rem
     padding-right: 10px
 
@@ -64,6 +68,9 @@ div.wiki ul.pages-hierarchy,
     > .tree-menu--item > .tree-menu--hierarchy-span > .tree-menu--hierarchy-indicator > .tree-menu--hierarchy-indicator-icon
       @include icon-common
       @extend .icon-arrow-right2
+      display: flex
+      align-items: center
+      line-height: $tree-menu-item-height
       font-size: 0.6rem
     > ul.-with-hierarchy
       display: none
@@ -74,15 +81,19 @@ div.wiki ul.pages-hierarchy,
     list-style-type: none
 
   .tree-menu--item
-    display: inline-block
+    display: flex
+    align-items: center
     width: 100%
-    border-radius: 3px
+    border-radius: var(--borderRadius-medium)
     line-height: $tree-menu-item-height
-    padding: 0 10px 0 0
+    padding: 0
     white-space: nowrap
+    margin-bottom: 2px
     &.-selected
       background: var(--control-transparent-bgColor-hover)
       .tree-menu--title
+        padding-left: 7px
+        border-left: 0px
         color: var(--main-menu-font-color)
     &:hover
       background: var(--control-transparent-bgColor-hover)

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -77,9 +77,8 @@
   --header-item-font-color: #FFFFFF;
   --header-item-font-hover-color: #FFFFFF;
   --header-item-bg-hover-color: #175A8E;
-  --main-menu-width: 230px;
-  --main-menu-x-spacing: 16px;
-  --main-menu-x-spacing-small: 12px;
+  --main-menu-width: 280px;
+  --main-menu-x-spacing: 12px;
   --main-menu-folded-width: 0px;
   --main-menu-border-color: #EAEAEA;
   --main-menu-border-width: 0px;
@@ -90,7 +89,7 @@
   --main-menu-resizer-color: var(--main-menu-border-color);
   --main-menu-selected-font-color: var(--main-menu-font-color);
   --main-menu-font-size: 14px;
-  --main-menu-fieldset-header-color: #B0B2B3;
+  --main-menu-fieldset-header-color: #59636e;
   --main-menu-hover-border-color: transparent;
   --main-menu-bg-selected-border: transparent;
   --breadcrumb-height: 40px;

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -83,12 +83,12 @@
   --main-menu-folded-width: 0px;
   --main-menu-border-color: #EAEAEA;
   --main-menu-border-width: 0px;
-  --main-menu-item-height: 40px;
-  --main-menu-bg-color: #333739;
+  --main-menu-item-height: 36px;
+  --main-menu-bg-color: #FFFFFF;
   --main-menu-bg-selected-background: #175A8E;
-  --main-menu-font-color: #FFFFFF;
+  --main-menu-font-color: var(--body-font-color);
   --main-menu-resizer-color: var(--main-menu-border-color);
-  --main-menu-selected-font-color: #FFFFFF;
+  --main-menu-selected-font-color: var(--main-menu-font-color);
   --main-menu-font-size: 14px;
   --main-menu-fieldset-header-color: #B0B2B3;
   --main-menu-hover-border-color: transparent;

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -37,6 +37,7 @@ module OpenProject::CustomStyles
     DEPRECATED_BIM_ALTERNATIVE_COLOR = "#349939".freeze
     DEPRECATED_PRIMARY_DARK_COLOR = "#175A8E".freeze
     DEPRECATED_LINK_COLOR = "#155282".freeze
+    DEPRECATED_MAIN_MENU_COLOR = "#333739".freeze
     PRIMER_PRIMARY_BUTTON_COLOR = "#1F883D".freeze
     ACCENT_COLOR = "#1A67A3".freeze
 
@@ -48,7 +49,7 @@ module OpenProject::CustomStyles
           "accent-color" => ACCENT_COLOR,
           "header-bg-color" => "#1A67A3",
           "header-item-bg-hover-color" => "#175A8E",
-          "main-menu-bg-color" => "#333739",
+          "main-menu-bg-color" => "#FFFFFF",
           "main-menu-bg-selected-background" => "#175A8E",
         }
       },

--- a/spec/migrations/change_default_main_menu_color_spec.rb
+++ b/spec/migrations/change_default_main_menu_color_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20250627121119_change_default_main_menu_color.rb")
+
+RSpec.describe ChangeDefaultMainMenuColor, type: :model do
+  context "when migrating up" do
+    context "with the standard color defined" do
+      before do
+        create(:design_color, variable: "main-menu-bg-color", hexcode: OpenProject::CustomStyles::ColorThemes::DEPRECATED_MAIN_MENU_COLOR)
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+      it "replaces the value'" do
+        expect { subject }.not_to change(DesignColor, :count)
+        expect(DesignColor.find_by(variable: "main-menu-bg-color").hexcode).to eq "#FFFFFF"
+      end
+    end
+
+    context "with a custom color defined" do
+      before do
+        create(:design_color, variable: "main-menu-bg-color", hexcode: "#ABC123")
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+      it "keeps the custom the value'" do
+        expect { subject }.not_to change(DesignColor, :count)
+        expect(DesignColor.find_by(variable: "main-menu-bg-color").hexcode).to eq "#ABC123"
+      end
+    end
+  end
+
+  context "when migrating down" do
+    context "with the standard color defined" do
+      before do
+        create(:design_color, variable: "main-menu-bg-color", hexcode: "#FFFFFF")
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.down } }
+
+      it "replaces the value'" do
+        expect { subject }.not_to change(DesignColor, :count)
+        expect(DesignColor.find_by(variable: "main-menu-bg-color").hexcode).to eq OpenProject::CustomStyles::ColorThemes::DEPRECATED_MAIN_MENU_COLOR
+      end
+    end
+
+    context "with a custom color defined" do
+      before do
+        create(:design_color, variable: "main-menu-bg-color", hexcode: "#ABC123")
+      end
+
+      # Silencing migration logs, since we are not interested in that during testing
+      subject { ActiveRecord::Migration.suppress_messages { described_class.new.down } }
+
+      it "keeps the custom the value'" do
+        expect { subject }.not_to change(DesignColor, :count)
+        expect(DesignColor.find_by(variable: "main-menu-bg-color").hexcode).to eq "#ABC123"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65091

# What are you trying to accomplish?
* Change the default color of the main menu to white
* Make the menu wider (280px) per default
* Change the styling of the menu items to look closer to the Primer ActionList

## Screenshots

<img width="1889" alt="Bildschirmfoto 2025-06-27 um 14 33 55" src="https://github.com/user-attachments/assets/1e764cc4-64bb-451e-a1f5-61561d66524c" />

