### PR TITLE
[#64260] Meeting text fields cleared without warning when status is changed

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/meetings/check-unsaved.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/check-unsaved.controller.ts
@@ -1,0 +1,93 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { ApplicationController } from 'stimulus-use';
+import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+
+export default class extends ApplicationController {
+  private turboRequests:TurboRequestsService;
+  private boundBeforeUnloadHandler = this.beforeUnloadHandler.bind(this);
+
+  static values = { unsavedChangesConfirmationMessage: String };
+
+  declare unsavedChangesConfirmationMessageValue:string;
+
+  async connect():Promise<void> {
+    window.addEventListener('beforeunload', this.boundBeforeUnloadHandler);
+
+    const context = await window.OpenProject.getPluginContext();
+    this.turboRequests = context.services.turboRequests;
+  }
+
+  disconnect():void {
+    window.removeEventListener('beforeunload', this.boundBeforeUnloadHandler);
+  }
+
+  handleClick(event:Event):void {
+    event.preventDefault();
+
+    const target = event.currentTarget as HTMLElement;
+    const url = target.dataset.href;
+
+    if (!url) return;
+
+    if (this.hasUnsavedChanges()) {
+      // eslint-disable-next-line no-alert
+      if (window.confirm(this.unsavedChangesConfirmationMessageValue)) {
+        this.sendRequest(url);
+      }
+    } else {
+      this.sendRequest(url);
+    }
+  }
+
+  private hasUnsavedChanges():boolean {
+    const textInputs = Array.from(document.querySelectorAll('input[type="text"], input[type="number"]'));
+    const allTextSaved = textInputs.every((input) => (input as HTMLInputElement).value.trim().length === 0);
+
+    return !allTextSaved || window.OpenProject.pageWasEdited;
+  }
+
+  private beforeUnloadHandler(event:BeforeUnloadEvent):void {
+    if (this.hasUnsavedChanges()) {
+      event.preventDefault();
+    }
+  }
+
+  private sendRequest(url:string):void {
+    void this.turboRequests.request(url, {
+      method: 'PUT',
+      headers: {
+        'X-CSRF-Token': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement).content,
+        Accept: 'text/vnd.turbo-stream.html',
+      },
+    });
+  }
+}

--- a/modules/meeting/app/components/meetings/show_component.html.erb
+++ b/modules/meeting/app/components/meetings/show_component.html.erb
@@ -1,12 +1,12 @@
 <%=
-  flex_layout(data: { turbo: true }) do |show_page|
+  flex_layout(data: show_page_data_attributes) do |show_page|
     show_page.with_row do
       render(Meetings::HeaderComponent.new(meeting: @meeting))
     end
 
     show_page.with_row do
       render(Primer::Alpha::Layout.new(stacking_breakpoint: :md)) do |content|
-        content.with_main(classes: "dragula-container", data: wrapper_data_attributes) do
+        content.with_main(classes: "dragula-container", data: main_content_data_attributes) do
           flex_layout do |agenda|
             agenda.with_row do
               render(MeetingAgendaItems::ListComponent.new(meeting: @meeting))

--- a/modules/meeting/app/components/meetings/show_component.rb
+++ b/modules/meeting/app/components/meetings/show_component.rb
@@ -41,10 +41,22 @@ module Meetings
 
     private
 
-    def wrapper_data_attributes
+    def show_page_data_attributes
+      {
+        turbo: true,
+        controller: "meetings--check-unsaved",
+        "meetings--check-unsaved-unsaved-changes-confirmation-message-value": unsaved_changes_confirmation_message
+      }
+    end
+
+    def main_content_data_attributes
       {
         controller: "meetings--drag-and-drop meetings--add-params"
       }
+    end
+
+    def unsaved_changes_confirmation_message
+      I18n.t("activities.work_packages.activity_tab.unsaved_changes_confirmation_message")
     end
   end
 end

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -17,10 +17,10 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_project_meeting_path(@project, @meeting, state: "in_progress"),
+              href: href("in_progress"),
               classes: "hide-when-print",
-              data: { "turbo-stream": true, "turbo-method": "put" },
-              test_selector: "close-meeting-button"
+              test_selector: "close-meeting-button",
+              data: button_data_attributes(href("in_progress"))
             ) do |button|
               button.with_leading_visual_icon(icon: :play)
               t("label_meeting_in_progress_action")
@@ -41,9 +41,9 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_project_meeting_path(@project, @meeting, state: "open"),
+              href: href("open"),
               classes: "hide-when-print",
-              data: { "turbo-stream": true, "turbo-method": "put" }
+              data: button_data_attributes(href("open"))
             ) do |button|
               button.with_leading_visual_icon(icon: :unlock)
               t("label_meeting_reopen_action")
@@ -64,10 +64,10 @@
           if edit_enabled?
             section.with_footer_button(
               tag: :a,
-              href: change_state_project_meeting_path(@project, @meeting, state: "closed"),
+              href: href("closed"),
               classes: "hide-when-print",
-              data: { "turbo-stream": true, "turbo-method": "put" },
-              test_selector: "close-meeting-button"
+              test_selector: "close-meeting-button",
+              data: button_data_attributes(href("closed"))
             ) do |button|
               button.with_leading_visual_icon(icon: :unlock)
               t("label_meeting_close_action")

--- a/modules/meeting/app/components/meetings/side_panel/state_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.rb
@@ -51,5 +51,16 @@ module Meetings
     def status_button
       render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting))
     end
+
+    def href(state)
+      change_state_project_meeting_path(@project, @meeting, state: state)
+    end
+
+    def button_data_attributes(href)
+      {
+        action: "click->meetings--check-unsaved#handleClick",
+        href: href
+      }
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
@@ -82,10 +82,10 @@ module Meetings
                                        color_namespace: :meeting_status,
                                        icon: :"issue-opened",
                                        tag: :a,
+                                       href: href("open"),
                                        description: t("text_meeting_open_dropdown_description"),
-                                       href: change_state_project_meeting_path(@project, @meeting, state: "open"),
                                        content_arguments: {
-                                         data: { "turbo-stream": true, "turbo-method": "put" }
+                                         data: data_attributes(href("open"))
                                        })
     end
 
@@ -95,10 +95,10 @@ module Meetings
                                        color_namespace: :meeting_status,
                                        icon: :play,
                                        tag: :a,
+                                       href: href("in_progress"),
                                        description: t("text_meeting_in_progress_dropdown_description"),
-                                       href: change_state_project_meeting_path(@project, @meeting, state: "in_progress"),
                                        content_arguments: {
-                                         data: { "turbo-stream": true, "turbo-method": "put" }
+                                         data: data_attributes(href("in_progress"))
                                        })
     end
 
@@ -108,11 +108,22 @@ module Meetings
                                        color_namespace: :meeting_status,
                                        icon: :"issue-closed",
                                        tag: :a,
+                                       href: href("closed"),
                                        description: t("text_meeting_closed_dropdown_description"),
-                                       href: change_state_project_meeting_path(@project, @meeting, state: "closed"),
                                        content_arguments: {
-                                         data: { "turbo-stream": true, "turbo-method": "put" }
+                                         data: data_attributes(href("closed"))
                                        })
+    end
+
+    def href(state)
+      change_state_project_meeting_path(@project, @meeting, state: state)
+    end
+
+    def data_attributes(href)
+      {
+        action: "click->meetings--check-unsaved#handleClick",
+        href: href
+      }
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/64260

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Ensure that text fields in a meeting are not removed unexpectedly on changing meeting status if they have some unsaved text. These include:
- Agenda item title
- Agenda item duration
- Agenda item notes
- Agenda item outcome
- Section title

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Heavily inspired by https://github.com/opf/openproject/blob/dev/frontend/src/stimulus/controllers/dynamic/meetings/add-params.controller.ts to intercept a status change action and then _do things_
- Here, whenever the buttons responsible for meeting status are pressed, the stimulus action checks all open ckeditor and text/number fields to detect unsaved text