### PR TITLE
[65114] WP title is squeezed on mobile

### DIFF
--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
@@ -45,3 +45,5 @@
     display: block
     padding: 5px 0 5px 5px
 
+    @media screen and (max-width: $breakpoint-md)
+      padding-left: 0

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -131,6 +131,11 @@
     #toolbar-items
       margin-left: 0
 
+@media only screen and (max-width: $breakpoint-md)
+  .work-packages--subject-type-row
+    flex-wrap: wrap
+    overflow: hidden
+
 #work-packages-index
   .op-uc-link_permalink
     display: none
@@ -148,6 +153,8 @@
   line-height: 24px
 
 .work-packages--type-selector:not(.wp-new-top-row--element)
+  max-width: 100%
+  @include text-shortener()
   .inline-edit--display-field
     padding-right: 5px !important
     // Remove left padding from type


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65114

# What are you trying to accomplish?
Let type and WP title wrap on mobile

## Screenshots
**Before**
<img width="457" alt="Bildschirmfoto 2025-06-30 um 09 11 36" src="https://github.com/user-attachments/assets/ac16c790-ea58-440c-8583-17d7d7cfa7bd" />


**After**
<img width="448" alt="Bildschirmfoto 2025-06-30 um 09 12 05" src="https://github.com/user-attachments/assets/2248509d-9d67-4afc-8ac6-238f4f44c310" />
