### PR TITLE
[65226] Editable toolbar is cut off on mobile

### DIFF
--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -63,10 +63,11 @@
       .op-back-button
         grid-column: 1 / 3
         grid-row: 1 / 2
-      .title-container
-        grid-column: 1 / 2
+      .toolbar-title--container
+        grid-column: 1 / 3
         grid-row: 2 / 3
         overflow: hidden
       .toolbar-items
-        grid-column: 2 / 3
-        grid-row: 2 / 3
+        grid-column: 1 / 3
+        grid-row: 3 / 4
+        justify-self: end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65226

# What are you trying to accomplish?
Give the toolbar title more space so that users are actually able to read it

## Screenshots

**Before**
<img width="436" alt="Bildschirmfoto 2025-06-30 um 09 22 30" src="https://github.com/user-attachments/assets/6d5a36f1-2d0a-4063-a53b-183c63da2897" />


**After**
<img width="452" alt="Bildschirmfoto 2025-06-30 um 09 22 07" src="https://github.com/user-attachments/assets/3a3db578-e732-4263-bc5e-92288b4b3115" />
