### PR TITLE
Bug/65074 create a new custom field link on empty index page does not allow creating one

### DIFF
--- a/app/components/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/show_component.html.erb
@@ -46,18 +46,22 @@
               render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
             end
             empty_list_container.with_column do
-              render(
-                Primer::Beta::Button.new(
-                  tag: :a,
-                  href: new_admin_settings_project_custom_field_path(
-                    type: "ProjectCustomField", custom_field_section_id: @project_custom_field_section.id
-                  ),
+              render(Primer::Alpha::ActionMenu.new(data: { test_selector: "new-project-custom-field-button" })) do |menu|
+                menu.with_show_button(
                   scheme: :secondary,
-                  data: { turbo: "false", test_selector: "new-project-custom-field-button" }
-                )
-              ) do |button|
-                button.with_leading_visual_icon(icon: :plus)
-                t("settings.project_attributes.label_new_attribute")
+                  "aria-label": t("settings.project_attributes.label_new_attribute")
+                ) do |btn|
+                  btn.with_leading_visual_icon(icon: :plus)
+                  btn.with_trailing_visual_icon(icon: :"triangle-down")
+
+                  t("settings.project_attributes.label_new_attribute")
+                end
+
+                OpenProject::CustomFieldFormat.available_for_class_name("Project")
+                                              .sort_by(&:name)
+                                              .map do |format|
+                  action_menu_item_for_custom_field_format(menu, format)
+                end
               end
             end
           end

--- a/app/components/settings/project_custom_field_sections/show_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/show_component.html.erb
@@ -46,7 +46,7 @@
               render(Primer::Beta::Text.new(color: :subtle)) { t("settings.project_attributes.label_no_project_custom_fields") }
             end
             empty_list_container.with_column do
-              render(Primer::Alpha::ActionMenu.new(data: { test_selector: "new-project-custom-field-button" })) do |menu|
+              render(Primer::Alpha::ActionMenu.new(data: { test_selector: "new-project-custom-field-in-section-button" })) do |menu|
                 menu.with_show_button(
                   scheme: :secondary,
                   "aria-label": t("settings.project_attributes.label_new_attribute")

--- a/app/components/settings/project_custom_field_sections/show_component.rb
+++ b/app/components/settings/project_custom_field_sections/show_component.rb
@@ -147,7 +147,7 @@ module Settings
             custom_field_section_id: @project_custom_field_section.id
           ),
           content_arguments: { data: { turbo: "false",
-                                       test_selector: "new-project-custom-field-button" } }
+                                       test_selector: "new-project-custom-field-in-section-button-#{format.name}" } }
         )
       end
     end

--- a/app/components/settings/project_custom_field_sections/show_component.rb
+++ b/app/components/settings/project_custom_field_sections/show_component.rb
@@ -137,6 +137,19 @@ module Settings
             @project_custom_field_section.last?
           end
       end
+
+      def action_menu_item_for_custom_field_format(menu, format)
+        menu.with_item(
+          label: helpers.label_for_custom_field_format(format.name),
+          tag: :a,
+          href: new_admin_settings_project_custom_field_path(
+            field_format: format.name,
+            custom_field_section_id: @project_custom_field_section.id
+          ),
+          content_arguments: { data: { turbo: "false",
+                                       test_selector: "new-project-custom-field-button" } }
+        )
+      end
     end
   end
 end

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% if @custom_fields_by_type[tab[:name]].blank? %>
-  <%= no_results_box(action_url: new_custom_field_path(type: tab[:name]), display_action: true) %>
+  <%= no_results_box(display_action: false) %>
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
@@ -150,7 +150,7 @@ See COPYRIGHT and LICENSE files for more details.
                       <%= link_to t(:label_custom_field_add_no_type), types_path %>
                     </span>
                   <% end %>
-                  <%= safe_join type_links, ", ".html_safe %>
+                  <%= safe_join(type_links, ", ") %>
                 </td>
               <% end %>
               <% unless tab[:name] == 'WorkPackageCustomField' %>

--- a/spec/features/admin/custom_fields/projects/index_spec.rb
+++ b/spec/features/admin/custom_fields/projects/index_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe "List project custom fields", :js do
 
       it "redirects to the custom field new page via button in empty sections" do
         within_project_custom_field_section_container(section_for_multi_select_fields) do
-          expect(page).not_to have_test_selector("new-project-custom-field-button")
+          expect(page).not_to have_test_selector("new-project-custom-field-in-section-button")
         end
 
         multi_list_project_custom_field.destroy
@@ -253,11 +253,12 @@ RSpec.describe "List project custom fields", :js do
         cf_index_page.visit!
 
         within_project_custom_field_section_container(section_for_multi_select_fields) do
-          page.find_test_selector("new-project-custom-field-button").click
+          page.find_test_selector("new-project-custom-field-in-section-button").click
+          page.find_test_selector("new-project-custom-field-in-section-button-int").click
         end
 
         expect(page).to have_current_path(new_admin_settings_project_custom_field_path(
-                                            type: "ProjectCustomField",
+                                            field_format: "int",
                                             custom_field_section_id: section_for_multi_select_fields.id
                                           ))
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65074

- [x] This PR builds on top of #19328, review and merge that one first.

# What are you trying to accomplish?
This bug fix turned out to contain some hints of a feature, too.

Since the "Add" button for custom fields now requires you to preselect the field format in an action menu, a simple link to `:new` does not cut it anymore. We forgot two places where such a link/button shows up, though. This PR fixes these.

1. For project attribute, when there is an empty section, we now render a button with an action menu for the creation of a project attribute with a specific field format within that section. So much like the new `+ Project attribute` button, only in a different place.
2. For the general admin settings of custom fields, I removed the link that allows you to create a new custom field. The other button is right there next to it. Keeping the link or replacing it with an action menu button would require us to refactor the `no_results_box` helper for this use case. I do not deem it worth it.


## Screenshots

Before: Project attribute section button without an action menu, thus not allowing you to create a valid custom field
![pa_bug](https://github.com/user-attachments/assets/e372431b-49b5-4cef-9fd0-b35f770aec9b)

After: Project attribute section button with the new action menu:
![pa_fixed](https://github.com/user-attachments/assets/947f9baf-18fc-45f6-a8cd-10cee1eef062)

Before: Custom field link is present
![cf_bug](https://github.com/user-attachments/assets/c3372002-a7a1-447d-9df5-bc771e9cfd1d)

After: Custom field link has been removed
![cf_fixed](https://github.com/user-attachments/assets/23807a4d-235e-4699-91aa-a8ce3c525d5c)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
