### PR TITLE
Freeze string literals in two more modules

### DIFF
--- a/modules/auth_saml/app/components/saml/providers/info_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/info_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Saml
   module Providers
     class InfoComponent < ApplicationComponent

--- a/modules/auth_saml/app/components/saml/providers/row_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/row_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Saml
   module Providers
     class RowComponent < ::OpPrimer::BorderBoxRowComponent

--- a/modules/auth_saml/app/components/saml/providers/side_panel/information_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel/information_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/components/saml/providers/side_panel/metadata_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel/metadata_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/components/saml/providers/side_panel_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/components/saml/providers/table_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/table_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Saml
   module Providers
     class TableComponent < ::OpPrimer::BorderBoxTableComponent

--- a/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/contracts/saml/providers/create_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/contracts/saml/providers/delete_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/delete_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/contracts/saml/providers/update_contract.rb
+++ b/modules/auth_saml/app/contracts/saml/providers/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Saml
   class ProvidersController < ::ApplicationController
     include OpTurbo::ComponentStream

--- a/modules/auth_saml/app/forms/saml/providers/base_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/base_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/configuration_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/encryption_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/encryption_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/mapping_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/mapping_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/metadata_options_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/metadata_options_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/metadata_url_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/metadata_url_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/metadata_xml_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/metadata_xml_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/name_input_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/name_input_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/request_attributes_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/request_attributes_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/forms/saml/providers/submit_or_cancel_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/submit_or_cancel_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/models/saml/provider.rb
+++ b/modules/auth_saml/app/models/saml/provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Saml
   class Provider < AuthProvider
     include HashBuilder

--- a/modules/auth_saml/app/models/saml/provider/hash_builder.rb
+++ b/modules/auth_saml/app/models/saml/provider/hash_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Saml
   module Provider::HashBuilder
     def formatted_attribute_statements

--- a/modules/auth_saml/app/seeders/env_data/saml/provider_seeder.rb
+++ b/modules/auth_saml/app/seeders/env_data/saml/provider_seeder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 
 # OpenProject is an open source project management software.

--- a/modules/auth_saml/app/services/saml/configuration_mapper.rb
+++ b/modules/auth_saml/app/services/saml/configuration_mapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/services/saml/providers/create_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/services/saml/providers/delete_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/delete_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/services/saml/providers/set_attributes_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/services/saml/providers/update_metadata.rb
+++ b/modules/auth_saml/app/services/saml/providers/update_metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/services/saml/providers/update_service.rb
+++ b/modules/auth_saml/app/services/saml/providers/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/app/services/saml/sync_service.rb
+++ b/modules/auth_saml/app/services/saml/sync_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/config/routes.rb
+++ b/modules/auth_saml/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   scope :admin do
     namespace :saml do

--- a/modules/auth_saml/db/migrate/20240821121856_migrate_saml_settings_to_providers.rb
+++ b/modules/auth_saml/db/migrate/20240821121856_migrate_saml_settings_to_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MigrateSamlSettingsToProviders < ActiveRecord::Migration[7.1]
   def up
     settings = Setting.plugin_openproject_auth_saml

--- a/modules/auth_saml/lib/open_project/auth_saml.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject
   module AuthSaml
     require "open_project/auth_saml/engine"

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "omniauth-saml"
 module OpenProject
   module AuthSaml

--- a/modules/auth_saml/lib/open_project/auth_saml/inspector.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenProject
   module AuthSaml
     module Inspector

--- a/modules/auth_saml/lib/openproject-auth_saml.rb
+++ b/modules/auth_saml/lib/openproject-auth_saml.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "open_project/auth_saml"

--- a/modules/auth_saml/openproject-auth_saml.gemspec
+++ b/modules/auth_saml/openproject-auth_saml.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = "openproject-auth_saml"
   s.version     = "1.0.0"

--- a/modules/auth_saml/spec/contracts/saml/providers/create_contract_spec.rb
+++ b/modules/auth_saml/spec/contracts/saml/providers/create_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/contracts/saml/providers/update_contract_spec.rb
+++ b/modules/auth_saml/spec/contracts/saml/providers/update_contract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/factories/saml_provider_factory.rb
+++ b/modules/auth_saml/spec/factories/saml_provider_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/features/administration/saml_crud_spec.rb
+++ b/modules/auth_saml/spec/features/administration/saml_crud_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/models/saml/provider_spec.rb
+++ b/modules/auth_saml/spec/models/saml/provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/requests/saml_metadata_endpoint_spec.rb
+++ b/modules/auth_saml/spec/requests/saml_metadata_endpoint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/requests/saml_provider_callback_spec.rb
+++ b/modules/auth_saml/spec/requests/saml_provider_callback_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/services/saml/providers/create_service_spec.rb
+++ b/modules/auth_saml/spec/services/saml/providers/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/services/saml/providers/update_service_spec.rb
+++ b/modules/auth_saml/spec/services/saml/providers/update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/auth_saml/spec/spec_helper.rb
+++ b/modules/auth_saml/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -- load spec_helper from OpenProject core
 require "spec_helper"
 require_relative "support/certificate_helper"

--- a/modules/auth_saml/spec/support/certificate_helper.rb
+++ b/modules/auth_saml/spec/support/certificate_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CertificateHelper
   module_function
 

--- a/modules/documents/app/contracts/documents/base_contract.rb
+++ b/modules/documents/app/contracts/documents/base_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/contracts/documents/create_contract.rb
+++ b/modules/documents/app/contracts/documents/create_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/contracts/documents/update_contract.rb
+++ b/modules/documents/app/contracts/documents/update_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/helpers/documents_helper.rb
+++ b/modules/documents/app/helpers/documents_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/mailers/documents_mailer.rb
+++ b/modules/documents/app/mailers/documents_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/activities/document_activity_provider.rb
+++ b/modules/documents/app/models/activities/document_activity_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/document.rb
+++ b/modules/documents/app/models/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/document_category.rb
+++ b/modules/documents/app/models/document_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/journal/document_journal.rb
+++ b/modules/documents/app/models/journal/document_journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents.rb
+++ b/modules/documents/app/models/queries/documents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/document_query.rb
+++ b/modules/documents/app/models/queries/documents/document_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/filters/document_filter.rb
+++ b/modules/documents/app/models/queries/documents/filters/document_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/filters/project_filter.rb
+++ b/modules/documents/app/models/queries/documents/filters/project_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/orders/default_order.rb
+++ b/modules/documents/app/models/queries/documents/orders/default_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/seeders/basic_data/documents/enumeration_seeder.rb
+++ b/modules/documents/app/seeders/basic_data/documents/enumeration_seeder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/services/documents/create_service.rb
+++ b/modules/documents/app/services/documents/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/services/documents/set_attributes_service.rb
+++ b/modules/documents/app/services/documents/set_attributes_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/services/documents/update_service.rb
+++ b/modules/documents/app/services/documents/update_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/services/notifications/create_from_model_service/document_strategy.rb
+++ b/modules/documents/app/services/notifications/create_from_model_service/document_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/app/services/notifications/mail_service/document_strategy.rb
+++ b/modules/documents/app/services/notifications/mail_service/document_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/db/migrate/20180323140208_to_v710_aggregated_documents_migrations.rb
+++ b/modules/documents/db/migrate/20180323140208_to_v710_aggregated_documents_migrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/db/migrate/20200217090016_document_timestamps.rb
+++ b/modules/documents/db/migrate/20200217090016_document_timestamps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/api/v3/attachments/attachments_by_document_api.rb
+++ b/modules/documents/lib/api/v3/attachments/attachments_by_document_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/api/v3/documents/document_collection_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_collection_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/api/v3/documents/document_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/api/v3/documents/documents_api.rb
+++ b/modules/documents/lib/api/v3/documents/documents_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/open_project/documents.rb
+++ b/modules/documents/lib/open_project/documents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/open_project/documents/patches.rb
+++ b/modules/documents/lib/open_project/documents/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/open_project/documents/patches/project_patch.rb
+++ b/modules/documents/lib/open_project/documents/patches/project_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/lib/openproject-documents.rb
+++ b/modules/documents/lib/openproject-documents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/openproject-documents.gemspec
+++ b/modules/documents/openproject-documents.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = "openproject-documents"
   s.version     = "1.0.0"

--- a/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
+++ b/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/application_helper_spec.rb
+++ b/modules/documents/spec/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/factories/document_category_factory.rb
+++ b/modules/documents/spec/factories/document_category_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/factories/document_factory.rb
+++ b/modules/documents/spec/factories/document_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/factories/journal/document_journal_factory.rb
+++ b/modules/documents/spec/factories/journal/document_journal_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/features/document_categories_spec.rb
+++ b/modules/documents/spec/features/document_categories_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/lib/open_project/markdown_formatting_spec.rb
+++ b/modules/documents/spec/lib/open_project/markdown_formatting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/lib/redmine/access_control_spec.rb
+++ b/modules/documents/spec/lib/redmine/access_control_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/mailers/documents_mailer_spec.rb
+++ b/modules/documents/spec/mailers/documents_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/models/document_category_spec.rb
+++ b/modules/documents/spec/models/document_category_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/models/document_spec.rb
+++ b/modules/documents/spec/models/document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/models/queries/documents/document_query_spec.rb
+++ b/modules/documents/spec/models/queries/documents/document_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/models/queries/documents/filters/project_filter_spec.rb
+++ b/modules/documents/spec/models/queries/documents/filters/project_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/requests/api/v3/attachments/attachments_by_documents_resource_spec.rb
+++ b/modules/documents/spec/requests/api/v3/attachments/attachments_by_documents_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
+++ b/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/routing/documents_routing_spec.rb
+++ b/modules/documents/spec/routing/documents_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/services/notifications/create_from_model_service_document_spec.rb
+++ b/modules/documents/spec/services/notifications/create_from_model_service_document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/services/notifications/mail_service_spec.rb
+++ b/modules/documents/spec/services/notifications/mail_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/documents/spec/spec_helper.rb
+++ b/modules/documents/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH


### PR DESCRIPTION
Diff was achieved by running

    rubocop -A --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment,Style/RedundantFreeze

for the module folders of the affected modules.
This change is part of the effort to slowly roll out frozen string literals across the entire application.