### PR TITLE
[65254] Project attributes modal has no divider

### DIFF
--- a/modules/overviews/app/components/overviews/project_custom_fields/edit_dialog_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/edit_dialog_component.html.erb
@@ -10,7 +10,7 @@
     d.with_body(classes: "Overlay-body_autocomplete_height") do
       render(Overviews::ProjectCustomFields::EditComponent.new(project_custom_field_section: @project_custom_field_section, project: @project))
     end
-    d.with_footer do
+    d.with_footer(show_divider: true) do
       component_collection do |footer_collection|
         footer_collection.with_component(
           Primer::Beta::Button.new(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65254

# What are you trying to accomplish?
Add divider to footer of ProjectAttribute dialog

