### PR TITLE
Feature/64549 my time tracking collapse future days for week and work week views

### DIFF
--- a/modules/costs/app/components/my/time_tracking/list_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/list_component.html.erb
@@ -7,7 +7,7 @@
   <%= flex_layout(classes: ["my-time-tracking-list-view"]) do |flex| %>
     <% range.each do |date| %>
       <% flex.with_row do %>
-        <%= render(Primer::OpenProject::CollapsibleSection.new(collapsed: collapsed?(date))) do |section| %>
+        <%= render(Primer::OpenProject::CollapsibleSection.new(test_selector: "section-#{date.iso8601}", collapsed: collapsed?(date))) do |section| %>
           <% section.with_title { date_title(date) } %>
           <% section.with_caption { date_caption(date) } %>
           <% section.with_additional_information do %>

--- a/modules/costs/app/components/my/time_tracking/list_component.rb
+++ b/modules/costs/app/components/my/time_tracking/list_component.rb
@@ -101,7 +101,11 @@ module My
       def collapsed?(date)
         return false if mode == :day
 
-        date.past?
+        if range.include?(Date.current)
+          !date.today?
+        else
+          false
+        end
       end
 
       def date_caption(date)

--- a/modules/costs/spec/features/my_time_tracking_spec.rb
+++ b/modules/costs/spec/features/my_time_tracking_spec.rb
@@ -80,16 +80,36 @@ RSpec.describe "my time tracking", :js do
   end
 
   context "when requesting list view" do
-    before do
-      visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: "workweek")
+    context "for a defined work week", with_settings: { working_days: [1, 3, 4, 5] } do
+      before do
+        visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: "workweek")
+      end
+
+      it "shows all dates of the current work week" do
+        list_page.expect_displays_day_section("2025-04-07", collapsed: true)
+        list_page.expect_no_display_day_section("2025-04-08")
+        list_page.expect_displays_day_section("2025-04-09", collapsed: false)
+        list_page.expect_displays_day_section("2025-04-10", collapsed: false)
+        list_page.expect_displays_day_section("2025-04-11", collapsed: false)
+        list_page.expect_no_display_day_section("2025-04-12")
+        list_page.expect_no_display_day_section("2025-04-13")
+      end
     end
 
-    it "shows all dates of the current work week" do
-      list_page.expect_displays_day_section("2025-04-07", collapsed: true)
-      list_page.expect_displays_day_section("2025-04-08", collapsed: true)
-      list_page.expect_displays_day_section("2025-04-09", collapsed: false)
-      list_page.expect_displays_day_section("2025-04-10", collapsed: false)
-      list_page.expect_displays_day_section("2025-04-11", collapsed: false)
+    context "for a full week" do
+      before do
+        visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: "week")
+      end
+
+      it "shows all dates of the current week" do
+        list_page.expect_displays_day_section("2025-04-07", collapsed: true)
+        list_page.expect_displays_day_section("2025-04-08", collapsed: true)
+        list_page.expect_displays_day_section("2025-04-09", collapsed: false)
+        list_page.expect_displays_day_section("2025-04-10", collapsed: false)
+        list_page.expect_displays_day_section("2025-04-11", collapsed: false)
+        list_page.expect_displays_day_section("2025-04-12", collapsed: false)
+        list_page.expect_displays_day_section("2025-04-13", collapsed: false)
+      end
     end
   end
 

--- a/modules/costs/spec/features/my_time_tracking_spec.rb
+++ b/modules/costs/spec/features/my_time_tracking_spec.rb
@@ -80,42 +80,72 @@ RSpec.describe "my time tracking", :js do
   end
 
   context "when requesting list view" do
-    context "for a defined work week", with_settings: { working_days: [1, 3, 4, 5] } do
+    context "when today is part of the selected week" do
       before do
-        visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: "workweek")
+        visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: mode)
       end
 
-      it "shows all dates of the current work week" do
-        list_page.expect_displays_day_section("2025-04-07", collapsed: true)
-        list_page.expect_no_display_day_section("2025-04-08")
-        list_page.expect_displays_day_section("2025-04-09", collapsed: false)
-        list_page.expect_displays_day_section("2025-04-10", collapsed: false)
-        list_page.expect_displays_day_section("2025-04-11", collapsed: false)
-        list_page.expect_no_display_day_section("2025-04-12")
-        list_page.expect_no_display_day_section("2025-04-13")
+      context "for a defined work week", with_settings: { working_days: [1, 3, 4, 5] } do
+        let(:mode) { "workweek" }
+
+        it "shows all dates of the current work week with only today expanded" do
+          list_page.expect_displays_day_section("2025-04-07", collapsed: true)
+          list_page.expect_no_display_day_section("2025-04-08") # no work day
+          list_page.expect_displays_day_section("2025-04-09", collapsed: false) # today
+          list_page.expect_displays_day_section("2025-04-10", collapsed: true)
+          list_page.expect_displays_day_section("2025-04-11", collapsed: true)
+          list_page.expect_no_display_day_section("2025-04-12") # no work day
+          list_page.expect_no_display_day_section("2025-04-13") # no work day
+        end
+      end
+
+      context "for a full week" do
+        let(:mode) { "week" }
+
+        it "shows all dates of the current week with only today expanded" do
+          list_page.expect_displays_day_section("2025-04-07", collapsed: true)
+          list_page.expect_displays_day_section("2025-04-08", collapsed: true)
+          list_page.expect_displays_day_section("2025-04-09", collapsed: false) # today
+          list_page.expect_displays_day_section("2025-04-10", collapsed: true)
+          list_page.expect_displays_day_section("2025-04-11", collapsed: true)
+          list_page.expect_displays_day_section("2025-04-12", collapsed: true)
+          list_page.expect_displays_day_section("2025-04-13", collapsed: true)
+        end
       end
     end
 
-    context "for a full week" do
+    context "when today is not part of the selected week" do
       before do
-        visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: "week")
+        visit my_time_tracking_path(date: "2025-04-16", view_mode: "list", mode: mode)
       end
 
-      it "shows all dates of the current week" do
-        list_page.expect_displays_day_section("2025-04-07", collapsed: true)
-        list_page.expect_displays_day_section("2025-04-08", collapsed: true)
-        list_page.expect_displays_day_section("2025-04-09", collapsed: false)
-        list_page.expect_displays_day_section("2025-04-10", collapsed: false)
-        list_page.expect_displays_day_section("2025-04-11", collapsed: false)
-        list_page.expect_displays_day_section("2025-04-12", collapsed: false)
-        list_page.expect_displays_day_section("2025-04-13", collapsed: false)
-      end
-    end
-  end
+      context "for a defined work week", with_settings: { working_days: [1, 3, 4, 5] } do
+        let(:mode) { "workweek" }
 
-  context "when requesting calendar view" do # rubocop:disable RSpec/EmptyExampleGroup
-    before do
-      visit my_time_tracking_path(date: "2025-04-09", view_mode: "calendar", mode: "workweek")
+        it "shows all dates of the current work week" do
+          list_page.expect_displays_day_section("2025-04-14", collapsed: false)
+          list_page.expect_no_display_day_section("2025-04-15") # no work day
+          list_page.expect_displays_day_section("2025-04-16", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-17", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-18", collapsed: false)
+          list_page.expect_no_display_day_section("2025-04-19") # no work day
+          list_page.expect_no_display_day_section("2025-04-20") # no work day
+        end
+      end
+
+      context "for a full week" do
+        let(:mode) { "week" }
+
+        it "shows all dates of the current week" do
+          list_page.expect_displays_day_section("2025-04-14", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-15", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-16", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-17", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-18", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-19", collapsed: false)
+          list_page.expect_displays_day_section("2025-04-20", collapsed: false)
+        end
+      end
     end
   end
 end

--- a/modules/costs/spec/features/my_time_tracking_spec.rb
+++ b/modules/costs/spec/features/my_time_tracking_spec.rb
@@ -58,13 +58,44 @@ RSpec.describe "my time tracking", :js do
   end
   let!(:time_entry6) { create(:time_entry, user:, work_package: work_package2, spent_on: "2025-04-14", hours: 2.0) }
 
+  let(:allow_exact_time_tracking) { true }
+  let(:force_exact_time_tracking) { false }
+
+  let(:calendar_page) { Pages::MyTimeTracking::CalendarPage.new }
+  let(:list_page) { Pages::MyTimeTracking::ListPage.new }
+
   before do
+    allow(TimeEntry).to receive_messages(
+      can_track_start_and_end_time?: allow_exact_time_tracking,
+      must_track_start_and_end_time?: force_exact_time_tracking
+    )
+
     login_as user
   end
 
-  it "does something" do
-    allow(TimeEntry).to receive(:can_track_start_and_end_time?).and_return(true)
-    visit my_time_tracking_path(date: "2025-04-09", view_mode: "list")
-    # save_and_open_screenshot
+  around do |example|
+    travel_to "2025-04-09T12:00:00Z" do # rubocop:disable RSpecRails/TravelAround
+      example.run
+    end
+  end
+
+  context "when requesting list view" do
+    before do
+      visit my_time_tracking_path(date: "2025-04-09", view_mode: "list", mode: "workweek")
+    end
+
+    it "shows all dates of the current work week" do
+      list_page.expect_displays_day_section("2025-04-07", collapsed: true)
+      list_page.expect_displays_day_section("2025-04-08", collapsed: true)
+      list_page.expect_displays_day_section("2025-04-09", collapsed: false)
+      list_page.expect_displays_day_section("2025-04-10", collapsed: false)
+      list_page.expect_displays_day_section("2025-04-11", collapsed: false)
+    end
+  end
+
+  context "when requesting calendar view" do # rubocop:disable RSpec/EmptyExampleGroup
+    before do
+      visit my_time_tracking_path(date: "2025-04-09", view_mode: "calendar", mode: "workweek")
+    end
   end
 end

--- a/modules/costs/spec/support/pages/my_time_tracking/calendar_page.rb
+++ b/modules/costs/spec/support/pages/my_time_tracking/calendar_page.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module MyTimeTracking
+    class CalendarPage < Page
+    end
+  end
+end

--- a/modules/costs/spec/support/pages/my_time_tracking/list_page.rb
+++ b/modules/costs/spec/support/pages/my_time_tracking/list_page.rb
@@ -33,6 +33,10 @@ require "support/pages/page"
 module Pages
   module MyTimeTracking
     class ListPage < Page
+      def expect_no_display_day_section(date)
+        expect(page).to have_no_css("collapsible-section[data-test-selector='section-#{date.to_date.iso8601}']")
+      end
+
       def expect_displays_day_section(date, collapsed: false)
         selector = if collapsed
                      "collapsible-section[data-test-selector='section-#{date.to_date.iso8601}'][data-collapsed=true]"

--- a/modules/costs/spec/support/pages/my_time_tracking/list_page.rb
+++ b/modules/costs/spec/support/pages/my_time_tracking/list_page.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module MyTimeTracking
+    class ListPage < Page
+      def expect_displays_day_section(date, collapsed: false)
+        selector = if collapsed
+                     "collapsible-section[data-test-selector='section-#{date.to_date.iso8601}'][data-collapsed=true]"
+                   else
+                     "collapsible-section[data-test-selector='section-#{date.to_date.iso8601}']"
+                   end
+
+        expect(page).to have_css(selector)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/team-sirius/work_packages/64549

# What are you trying to accomplish?
After first usage of the my time tracking list view, we have gotten feedback that people want to mostly work on today. So we have changed the logic to show only today when we are in the current week. Otherwise we show all days expanded.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
