### PR TITLE
[64799] Enterprise banner buttons on homescreen are not bottom-aligned

### DIFF
--- a/app/components/enterprise_edition/banner_component.html.erb
+++ b/app/components/enterprise_edition/banner_component.html.erb
@@ -12,7 +12,7 @@
         end
 
         grid.with_area(:content) do
-          flex_layout do |flex|
+          flex_layout(h: :full) do |flex|
             flex.with_row do
               if medium? || large?
                 flex_layout(

--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -73,6 +73,7 @@ $op-enterprise-banner-fixed-height-large: 320px
     grid-template-columns: 1fr 1fr
 
     &--content
+      height: $op-enterprise-banner-fixed-height-medium
       z-index: 1
       align-self: center
       padding: var(--base-size-16)
@@ -127,6 +128,8 @@ $op-enterprise-banner-fixed-height-large: 320px
       top: var(--base-size-24)
       right: var(--base-size-24)
 
+  &--description
+    flex-grow: 1
 
   &--content
     padding: var(--base-size-6) var(--base-size-8)

--- a/app/components/enterprise_trials/banner_component.html.erb
+++ b/app/components/enterprise_trials/banner_component.html.erb
@@ -25,22 +25,26 @@
         end
       %>
 
-      <p class="widget-box--blocks--upsell-description">
-        <% if @trial_key %>
-          <%= I18n.t("ee.trial.confirmation_info",
-                     date: helpers.format_date(@trial_key.created_at),
-                     email: @trial_key.data[:email]) %>
-        <% else %>
-          <%= t("ee.upsell.homescreen_description") %>
-        <% end %>
-      </p>
-      <p class="widget-box--blocks--upsell-description">
-        <% if @trial_key %>
-          <%= t("ee.trial.confirmation_subline") %>
-        <% else %>
-          <%= t("ee.upsell.homescreen_subline") %>
-        <% end %>
-      </p>
+      <div class="widget-box--blocks--upsell-description">
+        <p>
+          <% if @trial_key %>
+            <%= I18n.t(
+                  "ee.trial.confirmation_info",
+                  date: helpers.format_date(@trial_key.created_at),
+                  email: @trial_key.data[:email]
+                ) %>
+          <% else %>
+            <%= t("ee.upsell.homescreen_description") %>
+          <% end %>
+        </p>
+        <p>
+          <% if @trial_key %>
+            <%= t("ee.trial.confirmation_subline") %>
+          <% else %>
+            <%= t("ee.upsell.homescreen_subline") %>
+          <% end %>
+        </p>
+      </div>
 
       <%= render EnterpriseEdition::UpsellButtonsComponent.new(nil, show_buy_now: true) %>
     </div>

--- a/app/views/homescreen/blocks/_upsell.html.erb
+++ b/app/views/homescreen/blocks/_upsell.html.erb
@@ -18,12 +18,14 @@
       end
     %>
 
-    <p class="widget-box--blocks--upsell-description">
-      <%= t("ee.upsell.homescreen_description") %>
-    </p>
-    <p class="widget-box--blocks--upsell-description">
-      <%= t("ee.upsell.homescreen_subline") %>
-    </p>
+    <div class="widget-box--blocks--upsell-description">
+      <p>
+        <%= t("ee.upsell.homescreen_description") %>
+      </p>
+      <p>
+        <%= t("ee.upsell.homescreen_subline") %>
+      </p>
+    </div>
 
     <%= render EnterpriseEdition::UpsellButtonsComponent.new(nil) %>
   </div>

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -52,6 +52,9 @@
   display: flex
 
 .widget-box--blocks--upsell-text
+  display: flex
+  flex-direction: column
+  height: 100%
   width: 60%
   position: relative
   z-index: 1
@@ -73,5 +76,4 @@
     background-size: cover
 
 .widget-box--blocks--upsell-description
-  margin: 10px 0 10px 0
-  display: flex
+  flex-grow: 1


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64799

# What are you trying to accomplish?
Make buttons in EE banners bottom aligned

## Screenshots

<img width="1307" alt="Bildschirmfoto 2025-06-30 um 12 00 03" src="https://github.com/user-attachments/assets/fd720277-dc95-4175-834e-7fdac31450f1" />

<img width="1645" alt="Bildschirmfoto 2025-06-30 um 12 00 11" src="https://github.com/user-attachments/assets/b5a144d2-906c-4e21-82ca-8bbcd39b2d36" />

<img width="1654" alt="Bildschirmfoto 2025-06-30 um 12 00 19" src="https://github.com/user-attachments/assets/51f8663a-78b5-4226-8444-684747caa139" />
