### PR TITLE
Gracefully handle unknown input for filter and group by in Cost Query

### DIFF
--- a/modules/reporting/app/models/cost_query.rb
+++ b/modules/reporting/app/models/cost_query.rb
@@ -158,7 +158,12 @@ class CostQuery < ApplicationRecord
   end
 
   def add_chain(type, name, options)
-    chain type.const_get(name.to_s.camelcase), options
+    begin
+      chain type.const_get(name.to_s.camelcase), options
+    rescue NameError
+      # if something ends up in the column chain that does not exist, ignore it
+    end
+
     @transformer = nil
     @table = nil
     @depths = nil

--- a/modules/reporting/spec/models/cost_query/filter_spec.rb
+++ b/modules/reporting/spec/models/cost_query/filter_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe CostQuery, :reporting_query_helper do
       end
     end
 
+    it "does not fail when grouping by a non-existent column" do
+      expect { query.filter(:non_existent_column, value: "something").result }.not_to raise_error
+    end
+
     it "sets activity_id to -1 for cost entries" do
       query.result.each do |result|
         expect(result["activity_id"].to_i).to eq(-1) if result["type"] != "TimeEntry"

--- a/modules/reporting/spec/models/cost_query/group_by_spec.rb
+++ b/modules/reporting/spec/models/cost_query/group_by_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe CostQuery, :reporting_query_helper do
   minimal_query
 
   describe CostQuery::GroupBy do
+    it "does not fail when grouping by a non-existent column" do
+      expect { query.group_by(:non_existent_column).result }.not_to raise_error
+    end
+
     it "computes group_by on projects" do
       query.group_by :project_id
       expect(query.result.size).to eq(2)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/63823

# What are you trying to accomplish?
[Users somehow managed to get `undefined` as a value into the Query ...](https://appsignal.com/openproject-gmbh/sites/674718f1d2a5e4a7cb8b2298/exceptions/incidents/1038/samples/last)

```json
{
  "groups": {
    "columns": [
      "spent_on",
      "undefined", // <-- see 
      "assigned_to_id",
      "undefined" // <-- see 
    ],
    "rows": [
      "project_id",
      "project_id"
    ]
  },
}
```

# What approach did you choose and why?
Wrap the constantizing process in a rescue block. We will also investigate how the value ended up in there. But as the user can submit whatever they want, we should at least handle it gracefully and not die with an exception

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
