### PR TITLE
impl/65232 Adapt the existing comments model to be agnostic of News commentable

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,7 +34,7 @@ class Comment < ApplicationRecord
 
   validates :commented, :author, :comments, presence: true
 
-  after_create :send_news_comment_added_mail
+  after_create :send_comment_added_event
 
   def text
     comments
@@ -43,6 +45,10 @@ class Comment < ApplicationRecord
   end
 
   private
+
+  def send_comment_added_event
+    send_news_comment_added_mail if commented_type == News.name
+  end
 
   def send_news_comment_added_mail
     OpenProject::Notifications.send(OpenProject::Events::NEWS_COMMENT_CREATED,


### PR DESCRIPTION
https://community.openproject.org/work_packages/65232

Only broadcast `NEWS_COMMENT_CREATED` event when commented model is `News`