### PR TITLE
[#65261] Performance: Add modal routes to robots.txt

### DIFF
--- a/app/views/homescreen/robots.text.erb
+++ b/app/views/homescreen/robots.text.erb
@@ -38,3 +38,5 @@ Disallow: <%= search_path(identifier) %>
 Disallow: <%= activities_path %>
 Disallow: /activity
 Disallow: <%= search_path %>
+Disallow: /project_queries/configure_view_modal
+Disallow: /projects/export_list_modal


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/65261

# What are you trying to achieve?

Disallow two modal routes for scraper bots

# What approach did you choose and why?

Add two GET paths to modals to the robots.txt
