### PR TITLE
[#64618] add controller for settings tab

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -60,9 +60,8 @@ class TypesController < ApplicationController
 
   def create
     additional_params = {}
-    if (value = params.dig(:type, :copy_workflow_from) && value.present?)
-      additional_params[:copy_workflow_from] = value
-    end
+    value = params.dig(:type, :copy_workflow_from)
+    additional_params[:copy_workflow_from] = value if value.present?
 
     service_call = WorkPackageTypes::CreateService
                      .new(user: current_user)

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -60,7 +60,7 @@ class TypesController < ApplicationController
 
   def create
     additional_params = {}
-    if (value = params.dig(:type, :copy_workflow_from))
+    if (value = params.dig(:type, :copy_workflow_from) && value.present?)
       additional_params[:copy_workflow_from] = value
     end
 
@@ -70,7 +70,7 @@ class TypesController < ApplicationController
 
     @type = service_call.result
     if service_call.success?
-      redirect_to_type_tab_path(@type, t(:notice_successful_create))
+      redirect_to edit_type_settings_path(@type), notice: t(:notice_successful_create), status: :see_other
     else
       render action: :new, status: :unprocessable_entity
     end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -34,7 +34,7 @@ module ::TypesHelper
     [
       {
         name: "settings",
-        path: edit_type_settings_path(type_id: @type.id),
+        path: edit_type_settings_path(@type),
         label: I18n.t("types.edit.settings.tab"),
       },
       {
@@ -52,7 +52,7 @@ module ::TypesHelper
       },
       {
         name: "projects",
-        path: edit_type_projects_path(type_id: @type.id),
+        path: edit_type_projects_path(@type),
         label: I18n.t("types.edit.projects.tab")
       },
       {

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -34,9 +34,8 @@ module ::TypesHelper
     [
       {
         name: "settings",
-        path: edit_tab_type_path(id: @type.id, tab: :settings),
+        path: edit_type_settings_path(type_id: @type.id),
         label: I18n.t("types.edit.settings.tab"),
-        view_component: WorkPackageTypes::SettingsComponent
       },
       {
         name: "form_configuration",
@@ -54,7 +53,6 @@ module ::TypesHelper
       {
         name: "projects",
         path: edit_type_projects_path(type_id: @type.id),
-        view_component: WorkPackageTypes::ProjectsComponent,
         label: I18n.t("types.edit.projects.tab")
       },
       {

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -124,7 +124,7 @@ See COPYRIGHT and LICENSE files for more details.
           <% for type in @types %>
             <tr>
               <td class="timelines-pet-name">
-                <%= link_to type.name, edit_tab_type_path(type, tab: "settings") %>
+                <%= link_to type.name, edit_type_settings_path(type_id: type.id) %>
               </td>
               <td>
                 <% if type.workflows.empty? %>

--- a/app/views/work_package_types/settings_tab/edit.html.erb
+++ b/app/views/work_package_types/settings_tab/edit.html.erb
@@ -1,0 +1,34 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_administration), "#{t(:label_edit)} #{t(:label_work_package_types)} #{h @type.name}" %>
+
+<%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
+
+<%= render WorkPackageTypes::SettingsComponent.new(@type) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
 
   resources :types do
     resource :projects, controller: "work_package_types/projects_tab", only: %i[update edit]
+    resource :settings, controller: "work_package_types/settings_tab", only: %i[update edit]
 
     member do
       get "edit/:tab" => "types#edit", as: "edit_tab"

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -67,14 +67,6 @@ RSpec.describe TypesController do
       end
     end
 
-    describe "GET edit" do
-      describe "the access should be restricted" do
-        before { get "edit", params: { id: "123" } }
-
-        it { expect(response).to have_http_status(:forbidden) }
-      end
-    end
-
     describe "POST create" do
       describe "the access should be restricted" do
         before { post "create" }
@@ -86,14 +78,6 @@ RSpec.describe TypesController do
     describe "DELETE destroy" do
       describe "the access should be restricted" do
         before { delete "destroy", params: { id: "123" } }
-
-        it { expect(response).to have_http_status(:forbidden) }
-      end
-    end
-
-    describe "POST update" do
-      describe "the access should be restricted" do
-        before { post "update", params: { id: "123" } }
 
         it { expect(response).to have_http_status(:forbidden) }
       end
@@ -146,7 +130,7 @@ RSpec.describe TypesController do
 
         it do
           type = Type.find_by(name: "New type")
-          expect(response).to redirect_to(action: "edit", tab: "settings", id: type.id)
+          expect(response).to redirect_to(edit_type_settings_path(type))
         end
       end
 
@@ -198,79 +182,13 @@ RSpec.describe TypesController do
 
         it do
           type = Type.find_by(name: "New type")
-          expect(response).to redirect_to(action: "edit", tab: "settings", id: type.id)
+          expect(response).to redirect_to(edit_type_settings_path(type))
         end
 
         it "has the copied workflows" do
           expect(Type.find_by(name: "New type")
                         .workflows.count).to eq(existing_type.workflows.count)
         end
-      end
-    end
-
-    describe "GET edit settings" do
-      render_views
-      let(:type) do
-        create(:type, name: "My type",
-                      is_milestone: true,
-                      projects: [project])
-      end
-
-      before do
-        get "edit", params: { id: type.id, tab: :settings }
-      end
-
-      it { expect(response).to have_http_status(:ok) }
-      it { expect(response).to render_template "edit" }
-      it { expect(response.body).to have_css "input[@name='type[name]'][@value='My type']" }
-      it { expect(response.body).to have_css "input[@name='type[is_milestone]'][@value='1'][@checked='checked']" }
-    end
-
-    describe "PATCH update" do
-      let(:project2) { create(:project) }
-      let(:type) do
-        create(:type, name: "My type",
-                      is_milestone: true,
-                      projects: [project, project2])
-      end
-
-      describe "WITH type rename" do
-        let(:params) do
-          { "id" => type.id,
-            "type" => { name: "My type renamed" },
-            "tab" => "settings" }
-        end
-
-        before do
-          patch :update, params:
-        end
-
-        it { expect(response).to be_redirect }
-
-        it do
-          expect(response).to(
-            redirect_to(edit_tab_type_path(id: type.id, tab: "settings"))
-          )
-        end
-
-        it "is renamed" do
-          expect(Type.find_by(name: "My type renamed").id).to eq(type.id)
-        end
-      end
-
-      describe "WITH the name being erroneously blank" do
-        let(:params) do
-          { "id" => type.id,
-            "type" => { name: "" },
-            "tab" => "settings" }
-        end
-
-        before do
-          patch :update, params:
-        end
-
-        it { expect(response).to have_http_status(:unprocessable_entity) }
-        it { expect(response).to render_template "edit" }
       end
     end
 

--- a/spec/controllers/work_package_types/settings_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/settings_tab_controller_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackageTypes::SettingsTabController do
+  let(:type) { create(:type_bug) }
+
+  before do
+    login_as user
+  end
+
+  context "without admin access" do
+    let(:user) { create :user }
+
+    describe "GET edit" do
+      before do
+        get :edit, params: { type_id: type.id }
+      end
+
+      it { expect(response).to have_http_status(:forbidden) }
+    end
+  end
+
+  context "with admin access" do
+    let(:user) { create :admin }
+
+    describe "GET edit" do
+      before do
+        get :edit, params: { type_id: type.id }
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template "edit" }
+    end
+
+    describe "PUT update" do
+      let(:lightsaber_red) { create(:color, name: "Lightsaber-Red") }
+      let(:params) do
+        {
+          "type_id" => type.id,
+          "type" => {
+            "name" => "Galactic Order",
+            "color_id" => lightsaber_red.id.to_s,
+            "description" => "This is how the emperor governs you ... yes you!",
+            "is_milestone" => "0",
+            "is_in_roadmap" => "1",
+            "is_default" => "0"
+          }
+        }
+      end
+
+      before do
+        put :update, params:
+      end
+
+      it { expect(response).to redirect_to(edit_type_settings_path(type_id: type.id)) }
+
+      context "if the the params are invalid" do
+        let(:another_type) { create(:type_feature) }
+        let(:params) do
+          {
+            "type_id" => type.id,
+            "type" => {
+              "name" => another_type.name
+            }
+          }
+        end
+
+        before do
+          another_type
+        end
+
+        it { expect(response).to have_http_status(:unprocessable_entity) }
+        it { expect(response).to render_template "edit" }
+      end
+    end
+  end
+end

--- a/spec/services/work_package_types/set_attributes_service_spec.rb
+++ b/spec/services/work_package_types/set_attributes_service_spec.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++


### PR DESCRIPTION
# Ticket
[#64618](https://community.openproject.org/work_packages/64618)

# What are you trying to accomplish?
- add specific controller for the settings tab of work package types
- fixed an issue, where the 'copy_workflow_from' was not allowed to be empty on creation

