### PR TITLE
[65275] Last sidebar menu item is overlapped by address bar (mobile)

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -64,10 +64,10 @@ $arrow-left-width: 36px
     display: flex
     flex-direction: column
     +allow-vertical-scrolling
-    height: calc(100vh - var(--header-height))
+    height: calc(100dvh - var(--header-height))
     position: relative
     @include styled-scroll-bar
-    padding: 0 var(--main-menu-x-spacing)
+    padding: 0 var(--main-menu-x-spacing) var(--main-menu-x-spacing) var(--main-menu-x-spacing)
 
   ul
     margin: 0


### PR DESCRIPTION

# Ticket
https://community.openproject.org/wp/65275

# What are you trying to accomplish?
Use dynamicViewHeight to aboid that the address bar overlaps the menu entries

## Screenshots

**Before**
<img width="447" alt="Bildschirmfoto 2025-07-01 um 08 33 33" src="https://github.com/user-attachments/assets/03d773fe-8905-41ea-b085-1fcecc7cba6b" />

**After**
<img width="454" alt="Bildschirmfoto 2025-07-01 um 08 38 45" src="https://github.com/user-attachments/assets/de07e367-478d-4b36-850b-e5750a92a51f" />
