### PR TITLE
[65138] Do not seed if required references are missing

### DIFF
--- a/app/seeders/basic_data/model_seeder.rb
+++ b/app/seeders/basic_data/model_seeder.rb
@@ -69,7 +69,11 @@ module BasicData
     end
 
     def applicable?
-      model_class.none?
+      model_class.none? && seed_data.all_references_exist?(all_required_references)
+    end
+
+    def all_required_references
+      get_required_references(models_data)
     end
 
     def lookup_existing_references

--- a/app/seeders/basic_data/workflow_seeder.rb
+++ b/app/seeders/basic_data/workflow_seeder.rb
@@ -35,6 +35,7 @@ module BasicData
     ]
     self.model_class = Workflow
     self.seed_data_model_key = "workflows"
+    self.attribute_names_for_required_references = %w[statuses type]
 
     def seed_data!
       seed_workflows

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -60,9 +60,8 @@ module DemoData
       ]
     end
 
-    def applicable?
-      seed_data.reference_exists?(:default_role_project_admin) &&
-        types_seed_data.all? { |type_reference| seed_data.reference_exists?(type_reference) }
+    def all_required_references
+      [:default_role_project_admin] + types_seed_data
     end
 
     private

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -26,12 +26,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 module DemoData
   class WikiSeeder < Seeder
-    attr_reader :project, :project_data
+    attr_reader :project
+    alias_method :project_data, :seed_data
 
     def initialize(project, project_data)
-      super()
+      super(project_data)
       @project = project
-      @project_data = project_data
     end
 
     def seed_data!

--- a/app/seeders/source/seed_data.rb
+++ b/app/seeders/source/seed_data.rb
@@ -76,6 +76,10 @@ class Source::SeedData
     registry.key?(reference)
   end
 
+  def all_references_exist?(references)
+    references.all? { |reference| reference_exists?(reference) }
+  end
+
   # Get a `SeedData` instance with only the given top level keys.
   #
   # Used in tests to get the real statuses, types and other data.

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -144,6 +144,11 @@ projects:
         t_name: 'Kanban board'
         filters:
           - type: :default_type_task
+        statuses:
+          - :default_status_new
+          - :default_status_in_progress
+          - :default_status_closed
+          - :default_status_rejected
       basic:
         t_name: 'Basic board'
         lists:
@@ -500,6 +505,11 @@ projects:
     boards:
       kanban:
         t_name: 'Kanban board'
+        statuses:
+          - :default_status_new
+          - :default_status_in_progress
+          - :default_status_closed
+          - :default_status_rejected
       basic:
         t_name: 'Task board'
         lists:

--- a/modules/bim/app/seeders/bim/demo_data/bcf_xml_seeder.rb
+++ b/modules/bim/app/seeders/bim/demo_data/bcf_xml_seeder.rb
@@ -28,12 +28,12 @@
 module Bim
   module DemoData
     class BcfXmlSeeder < ::Seeder
-      attr_reader :project, :project_data
+      attr_reader :project
+      alias_method :project_data, :seed_data
 
       def initialize(project, project_data)
-        super()
+        super(project_data)
         @project = project
-        @project_data = project_data
       end
 
       def seed_data!

--- a/modules/bim/app/seeders/bim/demo_data/ifc_model_seeder.rb
+++ b/modules/bim/app/seeders/bim/demo_data/ifc_model_seeder.rb
@@ -28,12 +28,12 @@
 module Bim
   module DemoData
     class IfcModelSeeder < ::Seeder
-      attr_reader :project, :project_data
+      attr_reader :project
+      alias_method :project_data, :seed_data
 
       def initialize(project, project_data)
-        super()
+        super(project_data)
         @project = project
-        @project_data = project_data
       end
 
       def seed_data!

--- a/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
@@ -1,6 +1,7 @@
 module OpenProject::Bim::Patches::WorkPackageSeederPatch
   def self.included(base) # :nodoc:
     base.prepend InstanceMethods
+    base.attribute_names_for_required_references << "bcf_issue"
   end
 
   module InstanceMethods

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -151,6 +151,25 @@ RSpec.describe RootSeeder,
         expect(Boards::Grid.count).to eq 2
       end
     end
+
+    context "when run a second time after all demo projects and original statuses " \
+            "and workflows are deleted (Bug #65138)", :settings_reset do
+      before_all do
+        # Simulate a user having created new statuses, and deleted all default
+        # statuses and workflows (making looking up statuses by name impossible)
+        new_status = create(:status, :default, name: "My own default status")
+        Project.destroy_all
+        # destroying all statuses will destroy all workflows by cascade
+        Status.where.not(id: new_status.id).destroy_all
+        described_class.new.seed_data!
+      end
+
+      it "does not create additional data and does not raise any errors" do
+        # seeding does not recreate demo projects
+        expect(Project.count).to eq 0
+        expect(WorkPackage.count).to eq 0
+      end
+    end
   end
 
   describe "demo data mock-translated in another language" do

--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_agenda_items_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_agenda_items_seeder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,6 +33,7 @@ module Meetings
     class MeetingAgendaItemsSeeder < ::BasicData::ModelSeeder
       self.model_class = MeetingAgendaItem
       self.seed_data_model_key = "meeting_agenda_items"
+      self.attribute_names_for_required_references = %w[author presenter meeting work_package]
 
       ##
       #

--- a/modules/meeting/spec/seeders/demo_data/meeting_agenda_items_seeder_spec.rb
+++ b/modules/meeting/spec/seeders/demo_data/meeting_agenda_items_seeder_spec.rb
@@ -101,5 +101,10 @@ RSpec.describe Meetings::DemoData::MeetingAgendaItemsSeeder do
         title: nil
       )
     end
+
+    it "correctly sets the required references" do
+      expect(seeder.all_required_references)
+        .to contain_exactly(:user_alice, :user_bob, :weekly_meeting, :work_package_some_important_task)
+    end
   end
 end

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe "Team planner add existing work packages",
 
   let(:add_existing_pane) { Components::AddExistingPane.new }
   let(:filters) { Components::WorkPackages::Filters.new }
+  let(:this_tuesday) { start_of_week.next_occurring(:tuesday) }
+  let(:this_thursday) { start_of_week.next_occurring(:thursday) }
 
   context "with full permissions", with_ee: %i[team_planner_view] do
     before do
@@ -138,14 +140,14 @@ RSpec.describe "Team planner add existing work packages",
       add_existing_pane.expect_result second_wp
 
       # Drag it to the team planner...
-      add_existing_pane.drag_wp_by_pixel second_wp, 800, 0
+      add_existing_pane.drag_wp_to_date(second_wp, this_tuesday)
 
       team_planner.expect_and_dismiss_toaster(message: "Successful update.")
 
       # ... and thus update its attributes. Thereby the duration is maintained
       expect(second_wp.reload).to have_attributes(
-        start_date: start_of_week.next_occurring(:tuesday),
-        due_date: start_of_week.next_occurring(:thursday),
+        start_date: this_tuesday,
+        due_date: this_thursday,
         assigned_to_id: user.id
       )
 
@@ -154,14 +156,14 @@ RSpec.describe "Team planner add existing work packages",
       add_existing_pane.expect_result third_wp
 
       # Drag it to the team planner...
-      add_existing_pane.drag_wp_by_pixel third_wp, 800, 100
+      add_existing_pane.drag_wp_to_date(third_wp, this_tuesday)
 
       team_planner.expect_and_dismiss_toaster(message: "Successful update.")
 
       # ... and thus update its attributes. Since no dates were set before, start and end date are set to the same day
       expect(third_wp.reload).to have_attributes(
-        start_date: start_of_week.next_occurring(:tuesday),
-        due_date: start_of_week.next_occurring(:tuesday),
+        start_date: this_tuesday,
+        due_date: this_tuesday,
         assigned_to_id: user.id
       )
 
@@ -182,15 +184,15 @@ RSpec.describe "Team planner add existing work packages",
         add_existing_pane.expect_result third_wp
 
         # Drag it to the team planner...
-        add_existing_pane.drag_wp_by_pixel third_wp, 800, 0
+        add_existing_pane.drag_wp_to_date third_wp, this_tuesday
         team_planner.expect_and_dismiss_toaster(message: "Successful update.")
 
         # ... and thus update its attributes. Thereby the duration is maintained
         # and the due date is set to 15 days from the start date (11 days of
         # duration + 2x2 non-working days for the weekends)
         expect(third_wp.reload).to have_attributes(
-          start_date: start_of_week.next_occurring(:tuesday),
-          due_date: start_of_week.next_occurring(:tuesday) + 14.days,
+          start_date: this_tuesday,
+          due_date: this_tuesday + 14.days,
           assigned_to_id: user.id
         )
       end

--- a/modules/team_planner/spec/support/components/add_existing_pane.rb
+++ b/modules/team_planner/spec/support/components/add_existing_pane.rb
@@ -67,11 +67,10 @@ module Components
       end
     end
 
-    def drag_wp_by_pixel(work_package, by_x, by_y)
-      source = page
-                 .find("[data-test-selector='op-add-existing-pane--wp-#{work_package.id}']")
-
-      drag_by_pixel(element: source, by_x:, by_y:)
+    def drag_wp_to_date(work_package, date)
+      wp_card = card(work_package)
+      day_header = page.find(:columnheader, exact_text: date.strftime("%02d %A"))
+      drag_n_drop_element(from: wp_card, to: day_header, offset_y: day_header.native.size.height)
     end
 
     def card(work_package)

--- a/spec/seeders/demo_data/work_package_seeder_spec.rb
+++ b/spec/seeders/demo_data/work_package_seeder_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe DemoData::WorkPackageSeeder do
   let(:closed_status) { seed_data.find_reference(:default_status_closed) }
   let(:work_packages_data) { [] }
   let(:seed_data) { basic_seed_data.merge(Source::SeedData.new("work_packages" => work_packages_data)) }
+  let(:work_package_seeder) { described_class.new(project, seed_data) }
 
   def work_package_data(**attributes)
     {
@@ -51,7 +52,6 @@ RSpec.describe DemoData::WorkPackageSeeder do
   end
 
   before do
-    work_package_seeder = described_class.new(project, seed_data)
     work_package_seeder.seed!
   end
 
@@ -230,6 +230,11 @@ RSpec.describe DemoData::WorkPackageSeeder do
       ]
     end
 
+    it "correctly returns the required references" do
+      expect(work_package_seeder.all_required_references)
+        .to contain_exactly(:default_status_new, :default_type_task)
+    end
+
     it "creates a parent-child relation between work packages" do
       expect(WorkPackage.count).to eq(2)
       parent, child = WorkPackage.order(:id).to_a
@@ -246,6 +251,11 @@ RSpec.describe DemoData::WorkPackageSeeder do
                           ]),
         work_package_data(subject: "Child", parent: :this_one)
       ]
+    end
+
+    it "correctly returns the required references" do
+      expect(work_package_seeder.all_required_references)
+        .to contain_exactly(:default_status_new, :default_type_task)
     end
 
     it "creates parent-child relations between work packages" do

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -216,6 +216,26 @@ RSpec.describe RootSeeder,
         expect(Wiki.count).to eq 2
       end
     end
+
+    context "when run a second time after all demo projects and original statuses " \
+            "and workflows are deleted (Bug #65138)", :settings_reset do
+      before_all do
+        # Simulate a user having created new statuses, and deleted all default
+        # statuses and workflows (making looking up statuses by name impossible)
+        new_status = create(:status, :default, name: "My own default status")
+        Project.destroy_all
+        # destroying all statuses will destroy all workflows by cascade
+        Status.where.not(id: new_status.id).destroy_all
+        described_class.new.seed_data!
+      end
+
+      it "does not create additional data and does not raise any errors" do
+        # seeding recreates 2 demo projects
+        expect(Project.count).to eq 2
+        # but they're mostly empty because of the missing default statuses
+        expect(WorkPackage.count).to eq 0
+      end
+    end
   end
 
   describe "demo data with work package role migration having been run" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65138

# What are you trying to accomplish?

Avoid error when seeding on an instance having deleted all demo projects and all statuses (additional statuses were created) and having no workflows (because statuses were deleted, workflows were deleted too by cascade).

# What approach did you choose and why?

The seeders now have the ability to declare the attributes containing references to other objects. If those references are missing, the seeder will not run.

This is used on some seeders to avoid raising an error when seeding on an instance without any workflows (see bug 65138). The seeding is incomplete, but at least it does not raise during the seeding phase.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
