### PR TITLE
[65279] Menu toggler overlaps back button and breadcrumb in WP full view

### DIFF
--- a/app/components/open_project/common/main_menu_toggle_component.sass
+++ b/app/components/open_project/common/main_menu_toggle_component.sass
@@ -42,8 +42,15 @@
   .hidden-navigation
     // Push the breadcrumb to the right when the sidebar is collapsed
     .PageHeader-contextBar,
-    .op-breadcrumbs
+    .op-breadcrumbs,
+    .wp-show--header-container--breadcrumb
       margin-left: 30px
+
+
+    @media only screen and (max-width: $breakpoint-sm)
+      // Reset the margin for mobile, because of the special position the WP breadcrumb has on mobile
+      .wp-show--header-container--breadcrumb
+        margin-left: 0
 
   &:not(.hidden-navigation)
     #menu-toggle--expand-button

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -11,7 +11,7 @@
 
       <op-back-button
         class="wp-show--header-container--back-button"
-        linkClass="work-packages-back-button op-back-button_mobile-limited-width"
+        linkClass="work-packages-back-button"
       >
       </op-back-button>
 

--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -114,6 +114,10 @@
       grid-template-areas: "backButton toolbar" "breadcrumb breadcrumb" "subject subject"
       grid-row-gap: 0.5rem
 
+      // On mobile, we will not show the back button any more. The space will be taken by the menu toggler.
+      .op-back-button
+        display: none
+
     .work-packages-full-view--split-container
       border-top: none
 

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -292,7 +292,9 @@ $scrollbar-size: 10px
   width: auto
 
   ul.op-breadcrumb
-    height: initial
+    // Match the height of the Primer breadcrumb which itself takes the height of the small action button it can have on mobile
+    height: var(--control-small-size)
+    line-height: var(--control-small-size)
     margin: 0
     padding: 0
     li
@@ -301,7 +303,6 @@ $scrollbar-size: 10px
       float: left
       margin: 0 5px 0 0
       padding: 0
-      line-height: 20px
       max-width: 100%
       @include text-shortener
 


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/65279

# What are you trying to accomplish?
Hide back button in WP full view on mobile so that it does not collide with the main menu toggler


