### PR TITLE
[65118]  Sidebar toggle button scrolls out of view on mobile

### DIFF
--- a/app/components/open_project/common/main_menu_toggle_component.sass
+++ b/app/components/open_project/common/main_menu_toggle_component.sass
@@ -29,7 +29,8 @@
 #menu-toggle--expand-button
   position: absolute
   left: 11px
-  z-index: 1
+  top: var(--main-menu-toggler-top-spacing)
+  z-index: calc(var(--main-menu-toggler-z-index) + 1)
 
   @at-root .nosidebar &
     display: none

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -149,6 +149,7 @@ See COPYRIGHT and LICENSE files for more details.
       <%= content_tag :div,
                       id: "content",
                       class: "#{initial_classes} #{'content--split' if content_for?(:content_body_right)}" do %>
+        <%= render(OpenProject::Common::MainMenuToggleComponent.new(expanded: false)) %>
         <h1 class="hidden-for-sighted accessibility-helper"><%= t(:label_content) %></h1>
         <% if content_for?(:content_header) %>
           <div id="content-header">
@@ -157,7 +158,6 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
 
         <div id="content-body">
-          <%= render(OpenProject::Common::MainMenuToggleComponent.new(expanded: false)) %>
           <%= content_for :content_body %>
           <% unless local_assigns[:no_layout_yield] %>
             <%= yield %>

--- a/frontend/src/global_styles/common/header/app-header.sass
+++ b/frontend/src/global_styles/common/header/app-header.sass
@@ -22,6 +22,8 @@
 
     .op-app-header--start
       padding-left: 6px
+    .op-app-header--end
+      padding-right: 6px
 
   @at-root .zen-mode &
     display: none

--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -83,7 +83,7 @@
 // Because of those requirements, the #content element cannot take care of the paddings.
 // Instead the children elements have to do that themselves depending on which elements are present
 
-$top-space: 18px
+$top-space: var(--main-menu-toggler-top-spacing)
 $right-space: 16px
 $bottom-space: 10px
 $left-space: 16px
@@ -119,7 +119,6 @@ $left-side-min-width: 300px
   padding-left: $left-space
 
 #content-body
-  position: relative
   grid-area: body
   padding-bottom: $bottom-space
   padding-right: $right-space

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -39,12 +39,16 @@
     #main
       margin-top: 0
     #main,
-    #content-wrapper
+    #content-wrapper,
+    #main-menu #menu-sidebar
       height: 100dvh
+
+    #main .content-overlay
+      top: 0 !important
 
   #content-body,
   #content-header
-    padding-top: 15px !important
+    padding-top: var(--main-menu-toggler-top-spacing)
     padding-left: 15px
     padding-right: 15px
 
@@ -53,6 +57,30 @@
 
   h2
     font-size: 1.4rem
+
+  /*
+   * This is a very ugly hack to make the PageHeader sticky on mobile.
+   * The CSS sticky property relies on the direct parent element, see https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky
+   * Unfortunately, the html structure differs from page to page. So we don't know which element to make sticky.
+   * Therefore, we make all divs sticky between the content-header, (and for the older pages, the content-body) and the PageHeader itself.
+   */
+  #content-header div:has(page-header),
+  #content-body div:has(page-header),
+  page-header,
+  .work-packages--show-view .toolbar-container
+    position: sticky
+    top: calc(var(--main-menu-toggler-top-spacing) * -1)
+    z-index: var(--main-menu-toggler-z-index)
+    background-color: var(--body-background)
+    padding-top: var(--main-menu-toggler-top-spacing)
+    margin-top: calc(var(--main-menu-toggler-top-spacing) * -1)
+
+  .work-packages--show-view .toolbar-container
+    margin-bottom: 0
+    .wp-show--header-container
+      margin-bottom: 1rem
+      // Add a border bottom on mobile so that the sticky header has a clear cut to the content
+      border-bottom: var(--borderWidth-thin) solid var(--borderColor-muted)
 
 @media screen and (min-width: $breakpoint-sm)
   .hidden-for-desktop

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -28,7 +28,9 @@
 
 .router--work-packages-full-view:not(.router--work-packages-full-create)
   @include extended-content--bottom
-  @include extended-content--right
+
+  @media screen and (min-width: $breakpoint-sm)
+    @include extended-content--right
 
 .work-packages--show-view
   display: flex

--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -129,7 +129,7 @@
   .router--work-packages-partitioned-split-view
     // Ensure the WP cards can span the complete width on mobile
     #content-body
-      padding: 15px 0 !important
+      padding: var(--main-menu-toggler-top-spacing) 0 15px 0 !important
 
     .toolbar-container,
     .work-packages--filters-optional-container,

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -77,6 +77,8 @@
   --header-item-font-color: #FFFFFF;
   --header-item-font-hover-color: #FFFFFF;
   --header-item-bg-hover-color: #175A8E;
+  --main-menu-toggler-top-spacing: 18px;
+  --main-menu-toggler-z-index: 550;
   --main-menu-width: 280px;
   --main-menu-x-spacing: 12px;
   --main-menu-folded-width: 0px;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65118

# What are you trying to accomplish?
Make the PageHeader sticky on mobile

## Screenshots
![Jul-01-2025 13-56-36](https://github.com/user-attachments/assets/41669654-28bf-4395-a6df-63fc1a14c5e7)


# What approach did you choose and why?
I used the CSS sticky attribute. Unfortunately, it sets its stickyness based on the scroll position of the parent. However, we don't have on all pages the PageHeader directly inside the `content-body` or `content-header` elements. Sometimes there are additional `div` elements inside because of component wrapping for Turbo requests. That is why I have a very ugly CSS selector to match all elements between the content and the PageHeader as well. This is currently based on the assumption that the additional elements will all be `div`s, which might be wrong after all..


