### PR TITLE
[#60355] Sharing project lists does not work

### DIFF
--- a/app/contracts/project_queries/permissions_guard.rb
+++ b/app/contracts/project_queries/permissions_guard.rb
@@ -27,6 +27,7 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+
 module ProjectQueries
   module PermissionsGuard
     extend ActiveSupport::Concern

--- a/app/contracts/project_queries/publish_contract.rb
+++ b/app/contracts/project_queries/publish_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/app/contracts/project_queries/publish_contract.rb
+++ b/app/contracts/project_queries/publish_contract.rb
@@ -29,5 +29,9 @@
 module ProjectQueries
   class PublishContract < BaseContract
     attribute :public
+
+    def validate_model?
+      false
+    end
   end
 end

--- a/app/contracts/project_queries/publish_contract.rb
+++ b/app/contracts/project_queries/publish_contract.rb
@@ -27,7 +27,9 @@
 #++
 
 module ProjectQueries
-  class PublishContract < BaseContract
+  class PublishContract < ::ModelContract
+    include PermissionsGuard
+
     attribute :public
 
     def validate_model?

--- a/app/models/project_queries/scopes/allowed_to.rb
+++ b/app/models/project_queries/scopes/allowed_to.rb
@@ -114,7 +114,8 @@ module ProjectQueries::Scopes
       def allowed_to_member_in_query_join(user) # rubocop:disable Metrics/AbcSize
         members_table = Member.arel_table
 
-        join_conditions = members_table[:user_id].eq(user.id)
+        principal_ids = [user.id] + user.group_ids
+        join_conditions = members_table[:user_id].in(principal_ids)
           .and(members_table[:entity_type].eq(model_name.name))
           .and(members_table[:entity_id].eq(arel_table[:id]))
 

--- a/app/services/project_queries/publish_service.rb
+++ b/app/services/project_queries/publish_service.rb
@@ -37,6 +37,9 @@ module ProjectQueries
     end
 
     def persist(service_call)
+      # Usually we want to have validations on ProjectQueries, however in this case
+      # it is not required. It would be unusual to show any validation error when the
+      # public switch toggled on the share dialog.
       model.save(validate: false)
 
       service_call

--- a/app/services/project_queries/publish_service.rb
+++ b/app/services/project_queries/publish_service.rb
@@ -37,7 +37,7 @@ module ProjectQueries
     end
 
     def persist(service_call)
-      model.save
+      model.save(validate: false)
 
       service_call
     end

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -367,6 +367,7 @@ RSpec.describe "Project list sharing",
           share_dialog.expect_toggle_public_off
 
           share_dialog.toggle_public
+          share_dialog.wait_for_toggle_public_to_load
 
           share_dialog.expect_toggle_public_on
           share_dialog.close

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe "Project list sharing",
           share_dialog.expect_toggle_public_off
 
           share_dialog.toggle_public
-          share_dialog.wait_for_toggle_public_to_load
+          wait_for_network_idle
 
           share_dialog.expect_toggle_public_on
           share_dialog.close

--- a/spec/models/project_queries/scopes/allowed_to_spec.rb
+++ b/spec/models/project_queries/scopes/allowed_to_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe ProjectQuery, "#allowed to" do # rubocop:disable RSpec/SpecFilePa
              create(:project_query_member, user:, roles: [edit_role])
            ])
   end
+  shared_let(:group) { create(:group, members: [user]) }
+
+  shared_let(:private_other_query_with_group_view) do
+    create(:project_query, user: other_user, members: [
+             create(:project_query_member, principal: group, roles: [view_role])
+           ])
+  end
+
+  shared_let(:private_other_query_with_group_edit) do
+    create(:project_query, user: other_user, members: [
+             create(:project_query_member, principal: group, roles: [edit_role])
+           ])
+  end
 
   context "when the user is locked" do
     let(:checked_user) { create(:locked_user) }
@@ -87,7 +100,10 @@ RSpec.describe ProjectQuery, "#allowed to" do # rubocop:disable RSpec/SpecFilePa
         owned_query,
         # view membership queries
         private_other_query_with_view,
-        private_other_query_with_edit
+        private_other_query_with_edit,
+        # group view membership query
+        private_other_query_with_group_view,
+        private_other_query_with_group_edit
       )
     end
   end
@@ -109,8 +125,10 @@ RSpec.describe ProjectQuery, "#allowed to" do # rubocop:disable RSpec/SpecFilePa
           owned_public_query,
           # user owned queries
           owned_query,
-          # view membership queries
-          private_other_query_with_edit
+          # edit membership queries
+          private_other_query_with_edit,
+          # group edit membership queries
+          private_other_query_with_group_edit
         )
       end
     end
@@ -121,7 +139,9 @@ RSpec.describe ProjectQuery, "#allowed to" do # rubocop:disable RSpec/SpecFilePa
           # user owned queries
           owned_query,
           # edit membership queries
-          private_other_query_with_edit
+          private_other_query_with_edit,
+          # group edit membership queries
+          private_other_query_with_group_edit
         )
       end
     end

--- a/spec/support/components/sharing/project_queries/share_modal.rb
+++ b/spec/support/components/sharing/project_queries/share_modal.rb
@@ -56,13 +56,6 @@ module Components
           find("toggle-switch").click
         end
 
-        def wait_for_toggle_public_to_load
-          within("toggle-switch") do
-            expect(page).to have_css('[data-target="toggle-switch.loadingSpinner"]')
-            expect(page).to have_no_css('[data-target="toggle-switch.loadingSpinner"]')
-          end
-        end
-
         def expect_toggle_public_disabled
           within("toggle-switch") do
             expect(find("button")).to be_disabled
@@ -70,15 +63,11 @@ module Components
         end
 
         def expect_toggle_public_on
-          within("toggle-switch") do
-            expect(find("button")[:"aria-pressed"]).to eq("true")
-          end
+          expect(page).to have_css("toggle-switch", text: "On")
         end
 
         def expect_toggle_public_off
-          within("toggle-switch") do
-            expect(find("button")[:"aria-pressed"]).to eq("false")
-          end
+          expect(page).to have_css("toggle-switch", text: "Off")
         end
       end
     end

--- a/spec/support/components/sharing/project_queries/share_modal.rb
+++ b/spec/support/components/sharing/project_queries/share_modal.rb
@@ -53,9 +53,11 @@ module Components
         end
 
         def toggle_public
+          find("toggle-switch").click
+        end
+
+        def wait_for_toggle_public_to_load
           within("toggle-switch") do
-            expect(page).to have_no_css('[data-target="toggle-switch.loadingSpinner"]')
-            click_button
             expect(page).to have_css('[data-target="toggle-switch.loadingSpinner"]')
             expect(page).to have_no_css('[data-target="toggle-switch.loadingSpinner"]')
           end

--- a/spec/support/components/sharing/project_queries/share_modal.rb
+++ b/spec/support/components/sharing/project_queries/share_modal.rb
@@ -53,12 +53,29 @@ module Components
         end
 
         def toggle_public
-          find("toggle-switch").click
+          within("toggle-switch") do
+            expect(page).to have_no_css('[data-target="toggle-switch.loadingSpinner"]')
+            click_button
+            expect(page).to have_css('[data-target="toggle-switch.loadingSpinner"]')
+            expect(page).to have_no_css('[data-target="toggle-switch.loadingSpinner"]')
+          end
         end
 
         def expect_toggle_public_disabled
           within("toggle-switch") do
             expect(find("button")).to be_disabled
+          end
+        end
+
+        def expect_toggle_public_on
+          within("toggle-switch") do
+            expect(find("button")[:"aria-pressed"]).to eq("true")
+          end
+        end
+
+        def expect_toggle_public_off
+          within("toggle-switch") do
+            expect(find("button")[:"aria-pressed"]).to eq("false")
           end
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/60355

# What are you trying to accomplish?
- Project Queries might fail to be shared if they are invalid, for example when they display a custom field that has been removed from the system.
- This should not prevent toggling the query to be public.
- Additionally the Project Queries shared via a group are not showing up for the group members.


## Screenshots

# What approach did you choose and why?
- Do not check for Project Query validity when sharing it public or private.
- Include the current user's groups in the `AllowedTo` queries.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
