### PR TITLE
Fix broken `rake db:seed`

### DIFF
--- a/app/seeders/root_seeder.rb
+++ b/app/seeders/root_seeder.rb
@@ -40,6 +40,10 @@ class RootSeeder < Seeder
     load_available_seeders
   end
 
+  def applicable?
+    true
+  end
+
   # Returns the demo data in the default language.
   def seed_data
     @seed_data ||= begin

--- a/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
+++ b/modules/bim/spec/seeders/root_seeder_bim_edition_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe RootSeeder,
 
     before_all do
       with_edition("bim") do
-        root_seeder.seed_data!
+        root_seeder.seed!
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe RootSeeder,
       before_all do
         with_locale_env("de") do
           with_edition("bim") do
-            described_class.new.seed_data!
+            described_class.new.seed!
           end
         end
       end
@@ -161,7 +161,7 @@ RSpec.describe RootSeeder,
         Project.destroy_all
         # destroying all statuses will destroy all workflows by cascade
         Status.where.not(id: new_status.id).destroy_all
-        described_class.new.seed_data!
+        described_class.new.seed!
       end
 
       it "does not create additional data and does not raise any errors" do
@@ -183,7 +183,7 @@ RSpec.describe RootSeeder,
           "tr: #{original_translation}"
         end
 
-        root_seeder.seed_data!
+        root_seeder.seed!
       end
     end
 
@@ -223,7 +223,7 @@ RSpec.describe RootSeeder,
     before_all do
       with_locale_env("de", env_var_name: "OPENPROJECT_DEFAULT__LANGUAGE") do
         with_edition("bim") do
-          root_seeder.seed_data!
+          root_seeder.seed!
         end
       end
     end
@@ -247,7 +247,7 @@ RSpec.describe RootSeeder,
           allow(Settings::Definition["default_projects_modules"])
               .to receive(:writable?).and_return(false)
 
-          root_seeder.seed_data!
+          root_seeder.seed!
         end
       end
     end
@@ -285,7 +285,7 @@ RSpec.describe RootSeeder,
       with_env("OPENPROJECT_SEED_ADMIN_USER_LOCKED" => "true") do
         with_edition("bim") do
           reset(:seed_admin_user_locked)
-          root_seeder.seed_data!
+          root_seeder.seed!
         end
       end
     ensure

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RootSeeder,
 
     before_all do
       with_edition("standard") do
-        root_seeder.seed_data!
+        root_seeder.seed!
 
         # Run background jobs as those are also triggered by seeding.
         # But since those background jobs retrigger themselves, don't wrap the seeding inside a block.
@@ -176,7 +176,7 @@ RSpec.describe RootSeeder,
     context "when run a second time in a different language", :settings_reset do
       before_all do
         with_locale_env("de") do
-          described_class.new.seed_data!
+          described_class.new.seed!
         end
       end
 
@@ -206,7 +206,7 @@ RSpec.describe RootSeeder,
           # Simulate a user having deleted the seeded colors.
           # Could also be the user changing the hexcode of the colors, making lookup by hexcode fail.
           Color.where(name: ["Grey", "Blue", "Black"]).delete_all
-          described_class.new.seed_data!
+          described_class.new.seed!
         end
       end
 
@@ -226,7 +226,7 @@ RSpec.describe RootSeeder,
         Project.destroy_all
         # destroying all statuses will destroy all workflows by cascade
         Status.where.not(id: new_status.id).destroy_all
-        described_class.new.seed_data!
+        described_class.new.seed!
       end
 
       it "does not create additional data and does not raise any errors" do
@@ -249,7 +249,7 @@ RSpec.describe RootSeeder,
       AddWorkPackageRoles.new.up
 
       with_edition("standard") do
-        root_seeder.seed_data!
+        root_seeder.seed!
 
         # Run background jobs as those are also triggered by seeding.
         # But since those background jobs retrigger themselves, don't wrap the seeding inside a block.
@@ -270,7 +270,7 @@ RSpec.describe RootSeeder,
           original_translation = m.call(*args, **kw)
           "tr: #{original_translation}"
         end
-        root_seeder.seed_data!
+        root_seeder.seed!
 
         # Run background jobs as those are also triggered by seeding.
         # But since those background jobs retrigger themselves, don't wrap the seeding inside a block.
@@ -296,7 +296,7 @@ RSpec.describe RootSeeder,
       before_all do
         with_locale_env("de", env_var_name:) do
           with_edition("standard") do
-            root_seeder.seed_data!
+            root_seeder.seed!
 
             # Run background jobs as those are also triggered by seeding.
             # But since those background jobs retrigger themselves, don't wrap the seeding inside a block.
@@ -330,7 +330,7 @@ RSpec.describe RootSeeder,
         allow(Settings::Definition["default_projects_modules"])
           .to receive(:writable?).and_return(false)
 
-        root_seeder.seed_data!
+        root_seeder.seed!
       end
     end
 
@@ -363,7 +363,7 @@ RSpec.describe RootSeeder,
       with_env("OPENPROJECT_SEED_ADMIN_USER_LOCKED" => "true") do
         with_edition("standard") do
           reset(:seed_admin_user_locked)
-          root_seeder.seed_data!
+          root_seeder.seed!
         end
       end
     ensure


### PR DESCRIPTION
# Ticket

None.

# What are you trying to accomplish?

Fix `rake db:seed` broken by b0716517e47291de672.
It was failing with the error "cannot generate demo seed data without setting locale first".

## Screenshots

Error before the fix:
```
$ rails db:seed
/Users/cbliard/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/grape-2.3.0/lib/grape/util/registry.rb:10:in 'Grape::Util::Registry#register': json is already registered with class Bim::Bcf::API::ErrorFormatter::Json (StructuredWarnings::StandardWarning)
bin/rails aborted!
cannot generate demo seed data without setting locale first
/Users/cbliard/code/opf/openproject/review/app/seeders/root_seeder.rb:46:in 'RootSeeder#seed_data'
/Users/cbliard/code/opf/openproject/review/app/seeders/seeder.rb:73:in 'Seeder#applicable?'
/Users/cbliard/code/opf/openproject/review/app/seeders/seeder.rb:58:in 'Seeder#seed!'
/Users/cbliard/code/opf/openproject/review/db/seeds.rb:30:in '<top (required)>'
/Users/cbliard/code/opf/openproject/review/bin/rails:4:in '<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```

# What approach did you choose and why?

When seeding, there is a mechanism in place to ensure the seed data is not accessed before the language has been set. The new mechanism introduced in b0716517e47291de672 to check if all references are available in `applicable?` accesses the seed data before the language has been set for `RootSeeder`, making the `rake db:seed` task fail.

The fix is to bypass the `applicable?` check for `RootSeeder` and return `true`.

Also it was not detected by our test suite because `#seed_data!` was used instead of `#seed!`. This is now fixed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
