### PR TITLE
fix failing spec on pressing WP back button in mobile mode

### DIFF
--- a/spec/features/work_packages/display_representations/switch_display_representations_on_mobile_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_on_mobile_spec.rb
@@ -65,8 +65,7 @@ RSpec.describe "Switching work package view on mobile", :js, :selenium do
       cards.select_work_package(wp_1)
       expect(page).to have_css(".work-packages--details--subject",
                                text: wp_1.subject)
-      page.find(".work-packages-back-button").click
-
+      page.go_back
       # The query is however unchanged
       expect(page).to have_no_css(".editable-toolbar-title--save")
       url = URI.parse(page.current_url).query


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65279

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
There is no WP back button in mobile mode, instead we should use browser back function
