### PR TITLE
[#62669] Show more action in agenda items and outcomes also when meeting is closed  

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -56,44 +56,42 @@
       end
 
       grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
-        if edit_enabled?
-          render(Primer::Alpha::ActionMenu.new) do |menu|
-            menu.with_show_button(
-              icon: "kebab-horizontal",
-              "aria-label": I18n.t(:label_agenda_item_actions),
-              scheme: :invisible,
-              ml: 2,
-              test_selector: "op-meeting-agenda-actions"
-            )
+        render(Primer::Alpha::ActionMenu.new) do |menu|
+          menu.with_show_button(
+            icon: "kebab-horizontal",
+            "aria-label": I18n.t(:label_agenda_item_actions),
+            scheme: :invisible,
+            ml: 2,
+            test_selector: "op-meeting-agenda-actions"
+          )
 
-            edit_action_item(menu) if @meeting_agenda_item.editable?
-            if !in_backlog?
-              copy_action_item(menu)
-            end
-
-            menu.with_divider if note_or_outcome_action_added?
-
-            add_note_action_item(menu) if add_note_action?
-            add_outcome_action_item(menu) if add_outcome_action?
-
-            unless first? && last?
-              menu.with_divider
-              move_actions(menu)
-            end
-
-            menu.with_divider if move_to_different_section_or_meeting_action_added?
-
-            if !in_template? || in_backlog?
-              move_to_current_meeting_action_item(menu) if in_backlog?
-              move_to_backlog_action_item(menu) if !in_backlog?
-            end
-            if move_to_next_meeting_enabled?
-              move_to_next_meeting_action_item(menu)
-            end
-
-            menu.with_divider
-            delete_action_item(menu)
+          edit_action_item(menu)
+          if !in_backlog?
+            copy_action_item(menu)
           end
+
+          menu.with_divider if note_or_outcome_action_added? && editable?
+
+          add_note_action_item(menu) if add_note_action?
+          add_outcome_action_item(menu) if add_outcome_action?
+
+          unless first? && last?
+            menu.with_divider if editable?
+            move_actions(menu)
+          end
+
+          menu.with_divider if move_to_different_section_or_meeting_action_added?
+
+          if !in_template? || in_backlog?
+            move_to_current_meeting_action_item(menu) if in_backlog?
+            move_to_backlog_action_item(menu) if !in_backlog?
+          end
+          if move_to_next_meeting_enabled?
+            move_to_next_meeting_action_item(menu)
+          end
+
+          menu.with_divider if editable?
+          delete_action_item(menu)
         end
       end
 

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.html.erb
@@ -13,20 +13,18 @@
         end
 
         grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
-          if edit_enabled?
-            render(Primer::Alpha::ActionMenu.new) do |menu|
-              menu.with_show_button(
-                icon: "kebab-horizontal",
-                "aria-label": t(:label_agenda_outcome_actions),
-                scheme: :invisible,
-                ml: 2,
-                test_selector: "op-meeting-outcome-actions"
-              )
-              edit_action_item(menu)
-              copy_action_item(menu)
-              menu.with_divider
-              delete_action_item(menu)
-            end
+          render(Primer::Alpha::ActionMenu.new) do |menu|
+            menu.with_show_button(
+              icon: "kebab-horizontal",
+              "aria-label": t(:label_agenda_outcome_actions),
+              scheme: :invisible,
+              ml: 2,
+              test_selector: "op-meeting-outcome-actions"
+            )
+            edit_action_item(menu)
+            copy_action_item(menu)
+            menu.with_divider if edit_enabled?
+            delete_action_item(menu)
           end
         end
       end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.rb
@@ -50,7 +50,13 @@ module MeetingAgendaItems
         !@agenda_item.in_backlog?
     end
 
+    def in_backlog?
+      @agenda_item.meeting_section.backlog?
+    end
+
     def edit_action_item(menu)
+      return unless edit_enabled?
+
       menu.with_item(label: t("label_agenda_outcome_edit"),
                      href: edit_meeting_outcome_path(@meeting, @meeting_outcome),
                      content_arguments: {
@@ -61,6 +67,8 @@ module MeetingAgendaItems
     end
 
     def copy_action_item(menu)
+      return if in_backlog?
+
       url = meeting_url(@meeting, anchor: "outcome-#{@meeting_outcome.id}")
       menu.with_item(label: t("button_copy_link_to_clipboard"),
                      tag: :"clipboard-copy",
@@ -70,6 +78,8 @@ module MeetingAgendaItems
     end
 
     def delete_action_item(menu)
+      return unless edit_enabled?
+
       menu.with_item(label: t("label_agenda_outcome_delete"),
                      scheme: :danger,
                      href: meeting_outcome_path(@meeting, @meeting_outcome),

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_move_to_next_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_move_to_next_spec.rb
@@ -128,7 +128,11 @@ RSpec.describe "Recurring meetings move to next meeting", :js do
 
       it "does not show the move to next meeting option" do
         meeting_page.expect_agenda_item(title: "Test notes")
-        meeting_page.expect_no_agenda_action_menu(agenda_item)
+
+        meeting_page.open_menu(agenda_item) do
+          expect(page).to have_no_css(".ActionListItem-label", text: "Move to next meeting")
+          expect(page).to have_css(".ActionListItem-label", count: 1)
+        end
       end
     end
   end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -202,12 +202,17 @@ RSpec.describe "Meetings CRUD",
     expect(page).to have_css("#meeting-agenda-items-new-button-component")
     expect(page).to have_test_selector("op-meeting-agenda-actions", count: 3)
 
-    # other_use can view, but not edit
+    # other_use can view and copy links, but not edit
     login_as other_user
     show_page.visit!
 
     expect(page).to have_no_css("#meeting-agenda-items-new-button-component")
-    expect(page).not_to have_test_selector("op-meeting-agenda-actions")
+    expect(page).to have_test_selector("op-meeting-agenda-actions", count: 3)
+
+    show_page.open_menu(second) do
+      expect(page).to have_css(".ActionListItem-label", text: "Copy to clipboard")
+      expect(page).to have_css(".ActionListItem-label", count: 1)
+    end
   end
 
   it "can delete a meeting and get back to the index page" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/62669

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Always show the action menu with a single "Copy link to clipboard" action

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
