### PR TITLE
[#64220] Refactor tab controllers

### DIFF
--- a/app/controllers/work_package_types/form_configuration_tab_controller.rb
+++ b/app/controllers/work_package_types/form_configuration_tab_controller.rb
@@ -29,14 +29,10 @@
 #++
 
 module WorkPackageTypes
-  class FormConfigurationTabController < ApplicationController
+  class FormConfigurationTabController < BaseTabController
     include PaginationHelper
 
     layout "admin"
-
-    before_action :require_admin
-    before_action :find_type
-    before_action :assign_tab, only: :update
 
     current_menu_item [:edit, :update] do
       :types
@@ -62,10 +58,6 @@ module WorkPackageTypes
     def find_type
       @type = ::Type.includes(:projects, :custom_fields).find(params[:type_id])
       show_error_not_found unless @type
-    end
-
-    def assign_tab
-      params[:tab] = "form_configuration" unless params[:tab]
     end
 
     def permitted_type_params

--- a/app/controllers/work_package_types/projects_tab_controller.rb
+++ b/app/controllers/work_package_types/projects_tab_controller.rb
@@ -45,7 +45,6 @@ module WorkPackageTypes
       if result.success?
         redirect_to edit_type_projects_path(type_id: @type.id), notice: I18n.t(:notice_successful_update)
       else
-        params[:tab] = "projects"
         flash_error(result)
         load_projects
         render :edit, status: :unprocessable_entity
@@ -60,10 +59,6 @@ module WorkPackageTypes
 
     def load_projects
       @projects = Project.all
-    end
-
-    def find_type
-      @type = ::Type.find(params[:type_id])
     end
 
     def permitted_project_params

--- a/app/controllers/work_package_types/settings_tab_controller.rb
+++ b/app/controllers/work_package_types/settings_tab_controller.rb
@@ -29,11 +29,8 @@
 #++
 
 module WorkPackageTypes
-  class SettingsTabController < ApplicationController
+  class SettingsTabController < BaseTabController
     layout "admin"
-
-    before_action :require_admin
-    before_action :find_type
 
     current_menu_item %i[edit update] do
       :types
@@ -48,16 +45,11 @@ module WorkPackageTypes
       if result.success?
         redirect_to edit_type_settings_path(type_id: @type.id), notice: I18n.t(:notice_successful_update)
       else
-        params[:tab] = "settings"
         render :edit, status: :unprocessable_entity
       end
     end
 
     private
-
-    def find_type
-      @type = ::Type.find(params[:type_id])
-    end
 
     def permitted_settings_params
       params.expect(type: %i[name color_id description is_milestone is_in_roadmap is_default])


### PR DESCRIPTION
# Ticket
[64220](https://community.openproject.org/wp/64220l)

# What are you trying to accomplish?
Updated FormConfigurationTabController and SettingsTabController to inherit from BaseTabController instead of ApplicationController. Removed redundant before_action filters and tab assignment logic now handled by the base class. Simplified error handling and parameter assignment in tab controllers for consistency.
