### PR TITLE
[65259] Instance name is missing in Breadcrumb on global WP module

### DIFF
--- a/frontend/src/app/core/html/op-title.service.ts
+++ b/frontend/src/app/core/html/op-title.service.ts
@@ -21,6 +21,10 @@ export class OpTitleService {
     return this.current.split(titlePartsSeparator);
   }
 
+  public get appTitle():string {
+    return this.titleParts[this.titleParts.length - 1];
+  }
+
   public setFirstPart(value:string) {
     if (this.current.includes(this.base) && this.current.includes(titlePartsSeparator)) {
       const parts = this.titleParts;

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -391,4 +391,8 @@ export class PathHelperService {
   public myTimeTrackingRefresh(date:string, viewMode:string, mode:string) {
     return `${this.staticBase}/my/time-tracking/refresh?date=${date}&view_mode=${viewMode}&mode=${mode}`;
   }
+
+  public homePath() {
+    return `${this.staticBase}/`;
+  }
 }

--- a/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
@@ -116,6 +116,11 @@ export class WorkPackageViewPageComponent extends PartitionedQuerySpacePageCompo
         href: this.pathHelperService.projectPath(this.currentProject.identifier),
         text: this.currentProject.name,
       });
+    } else {
+      items.push({
+        href: this.pathHelperService.homePath(),
+        text: this.titleService.appTitle,
+      });
     }
     items.push(this.breadcrumbModuleEntry());
     if (this.selectedTitle) {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65259

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show instance name in breadcrumbs, when there is no project selected (in Work packages and Gantt charts)

## Screenshots

![Screenshot 2025-07-02 at 10 53 00](https://github.com/user-attachments/assets/d6a980dd-710d-4a2a-b2cb-fa6825ac8539)

There is no project selected:

![Screenshot 2025-07-02 at 10 52 35](https://github.com/user-attachments/assets/e43ec799-a7d6-4848-8582-d3e2835fab2c)
