### PR TITLE
[65340] Some instances are missing a color for the sidebar border

### DIFF
--- a/app/models/colors/hex_color.rb
+++ b/app/models/colors/hex_color.rb
@@ -17,6 +17,13 @@ module Colors
     end
 
     ##
+    # Returns whether the color is dark according to
+    # YIQ lightness.
+    def dark?
+      brightness_yiq <= 100
+    end
+
+    ##
     # Returns whether the color is bright according to
     # YIQ lightness.
     def bright?

--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -43,9 +43,8 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
     <% if design_color.variable == "main-menu-bg-color" %>
       --main-menu-font-color: <%= design_color.contrasting_font_color %>;
-      <% if design_color.bright? %>
-        --main-menu-border-width: 1px;
-        --main-menu-border-color: #d0d7de;
+      <% if design_color.dark? %>
+        --main-menu-border-width: 0px;
       <% end %>
     <% end %>
     <% if design_color.variable == "primary-button-color" %>

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -81,7 +81,7 @@
   --main-menu-x-spacing: 12px;
   --main-menu-folded-width: 0px;
   --main-menu-border-color: #EAEAEA;
-  --main-menu-border-width: 0px;
+  --main-menu-border-width: 1px;
   --main-menu-item-height: 36px;
   --main-menu-bg-color: #FFFFFF;
   --main-menu-bg-selected-background: #175A8E;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65340

# What are you trying to accomplish?
Move the default for the sidebar menu border with around now that the default color is white and the border is needed

