### PR TITLE
[63777] Breadcrumb index creates unnecessary navigation buttons on mobile web

### DIFF
--- a/app/components/members/index_page_header_component.rb
+++ b/app/components/members/index_page_header_component.rb
@@ -93,6 +93,10 @@ class Members::IndexPageHeaderComponent < ApplicationComponent
   end
 
   def first_menu_item?
-    current_query[:query_href] == project_members_path(@project)
+    if current_query.present?
+      return current_query[:query_href] == project_members_path(@project)
+    end
+
+    false
   end
 end

--- a/app/components/members/index_page_header_component.rb
+++ b/app/components/members/index_page_header_component.rb
@@ -39,7 +39,7 @@ class Members::IndexPageHeaderComponent < ApplicationComponent
 
   def breadcrumb_items
     [{ href: project_overview_path(@project.id), text: @project.name },
-     { href: project_members_path(@project), text: t(:label_member_plural) },
+     *([{ href: project_members_path(@project), text: I18n.t(:label_member_plural) }] unless first_menu_item?),
      current_breadcrumb_element]
   end
 
@@ -64,6 +64,8 @@ class Members::IndexPageHeaderComponent < ApplicationComponent
     if @query && query_name
       if menu_header.present?
         helpers.nested_breadcrumb_element(menu_header, query_name)
+      elsif first_menu_item?
+        helpers.nested_breadcrumb_element(I18n.t(:label_member_plural), query_name)
       else
         query_name
       end
@@ -74,17 +76,23 @@ class Members::IndexPageHeaderComponent < ApplicationComponent
 
   def current_query
     query_name = nil
+    query_href = nil
     menu_header = nil
 
     Members::Menu.new(project: @project, params:).menu_items.find do |section|
       section.children.find do |menu_query|
         if !!menu_query.selected
           query_name = menu_query.title
+          query_href = menu_query.href
           menu_header = section.header
         end
       end
     end
 
-    { query_name:, menu_header: }
+    { query_name:, query_href:, menu_header: }
+  end
+
+  def first_menu_item?
+    current_query[:query_href] == project_members_path(@project)
   end
 end

--- a/app/components/notifications/index_page_header_component.rb
+++ b/app/components/notifications/index_page_header_component.rb
@@ -77,7 +77,7 @@ module Notifications
     end
 
     def first_menu_item?
-      current_item.href == notifications_path
+      current_item&.href == notifications_path
     end
   end
 end

--- a/app/components/notifications/index_page_header_component.rb
+++ b/app/components/notifications/index_page_header_component.rb
@@ -46,8 +46,7 @@ module Notifications
     end
 
     def breadcrumb_items
-      [{ href: home_path, text: helpers.organization_name },
-       { href: notifications_path, text: I18n.t("js.notifications.title") },
+      [{ href: notifications_path, text: I18n.t("js.notifications.title") },
        current_breadcrumb_element]
     end
 

--- a/app/components/notifications/index_page_header_component.rb
+++ b/app/components/notifications/index_page_header_component.rb
@@ -46,13 +46,15 @@ module Notifications
     end
 
     def breadcrumb_items
-      [{ href: notifications_path, text: I18n.t("js.notifications.title") },
+      [*([{ href: notifications_path, text: I18n.t("js.notifications.title") }] unless first_menu_item?),
        current_breadcrumb_element]
     end
 
     def current_breadcrumb_element
       if current_section && current_section.header.present?
         helpers.nested_breadcrumb_element(current_section.header, page_title)
+      elsif first_menu_item?
+        helpers.nested_breadcrumb_element(I18n.t("js.notifications.title"), current_item.title)
       else
         page_title
       end
@@ -72,6 +74,10 @@ module Notifications
       @current_item = Notifications::Menu
                         .new(params:, current_user: User.current)
                         .selected_menu_item
+    end
+
+    def first_menu_item?
+      current_item.href == notifications_path
     end
   end
 end

--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -15,7 +15,7 @@
         )
         page_title
       end
-      header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: current_breadcrumb_element == page_title ? :bold : :normal)
+      header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: current_breadcrumb_element == page_title && !first_menu_item? ? :bold : :normal)
 
       if can_save?
         header_save_action(

--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -112,7 +112,6 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
 
   def breadcrumb_items
     [
-      { href: home_path, text: helpers.organization_name },
       { href: projects_path, text: t(:label_project_plural) },
       current_breadcrumb_element
     ]

--- a/app/components/projects/settings/index_page_header_component.html.erb
+++ b/app/components/projects/settings/index_page_header_component.html.erb
@@ -4,9 +4,9 @@
     header.with_breadcrumbs(
       [
         { href: project_overview_path(@project.id), text: @project.name },
-        { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
-        t(:label_information_plural)
-      ]
+        helpers.nested_breadcrumb_element(t(:label_project_settings), t(:label_information_plural))
+      ],
+      selected_item_font_weight: :normal
     )
 
     if User.current.allowed_in_project?(:add_subprojects, @project)

--- a/app/components/settings/project_phase_definitions/index_header_component.html.erb
+++ b/app/components/settings/project_phase_definitions/index_header_component.html.erb
@@ -31,6 +31,6 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t("settings.project_phase_definitions.heading") }
     header.with_description { t("settings.project_phase_definitions.heading_description") }
-    header.with_breadcrumbs(breadcrumbs_items)
+    header.with_breadcrumbs(breadcrumbs_items, selected_item_font_weight: :normal)
   end
 %>

--- a/app/components/settings/project_phase_definitions/index_header_component.rb
+++ b/app/components/settings/project_phase_definitions/index_header_component.rb
@@ -34,8 +34,7 @@ module Settings
       def breadcrumbs_items
         [
           { href: admin_index_path, text: t("label_administration") },
-          { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
-          t("settings.project_phase_definitions.heading")
+          helpers.nested_breadcrumb_element(t(:label_project_plural), t("settings.project_phase_definitions.heading"))
         ]
       end
     end

--- a/app/helpers/homescreen_helper.rb
+++ b/app/helpers/homescreen_helper.rb
@@ -34,9 +34,9 @@ module HomescreenHelper
   end
 
   ##
-  # Homescreen organization icon
-  def organization_icon
-    op_icon("icon-context icon-enterprise")
+  # Homescreen breadcrumb element
+  def homescreen_breadcrumb_element
+    nested_breadcrumb_element(organization_name, I18n.t(:label_home))
   end
 
   ##

--- a/app/views/account/lost_password.html.erb
+++ b/app/views/account/lost_password.html.erb
@@ -32,8 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_password_lost) }
     header.with_breadcrumbs(
-      [{ href: home_path, text: organization_name },
-       t(:label_password_lost)]
+      [t(:label_password_lost)]
     )
   end
 %>

--- a/app/views/account/password_recovery.html.erb
+++ b/app/views/account/password_recovery.html.erb
@@ -32,8 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_password_lost) }
     header.with_breadcrumbs(
-      [{ href: home_path, text: organization_name },
-       t(:label_password_lost)]
+      [t(:label_password_lost)]
     )
   end
 %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -34,8 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { (@author.nil? ? t(:label_activity) : t(:label_user_activity, value: link_to_user(@author))).html_safe }
     header.with_description { t(:label_date_from_to, start: format_date(@date_to - @days), end: format_date(@date_to - 1)) }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        t(:label_activity)]
     )
   end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -33,8 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_overview) }
     header.with_breadcrumbs(
-      [{ href: admin_index_path, text: t(:label_administration) },
-       t(:label_overview)]
+      [nested_breadcrumb_element(t(:label_administration), t(:label_overview))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/admin/settings/aggregation_settings/show.html.erb
+++ b/app/views/admin/settings/aggregation_settings/show.html.erb
@@ -34,8 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t(:"menus.admin.aggregation") }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },
-       { href: admin_settings_aggregation_path, text: t(:"menus.admin.mails_and_notifications") },
-       t(:"menus.admin.aggregation")]
+       nested_breadcrumb_element(t(:"menus.admin.mails_and_notifications"), t(:"menus.admin.aggregation"))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/admin/settings/api_settings/show.html.erb
+++ b/app/views/admin/settings/api_settings/show.html.erb
@@ -33,8 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t(:label_api_access_key_type) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
-       t(:label_api_access_key_type)]
+       nested_breadcrumb_element(t("menus.admin.api_and_webhooks"), t(:label_api_access_key_type))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/admin/settings/authentication_settings/show.html.erb
+++ b/app/views/admin/settings/authentication_settings/show.html.erb
@@ -55,8 +55,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t("authentication.login_and_registration") }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },
-       { href: admin_settings_authentication_path, text: t(:label_authentication) },
-       t("authentication.login_and_registration")]
+       nested_breadcrumb_element(t(:label_authentication), t("authentication.login_and_registration"))],
+      selected_item_font_weight: :normal
     )
     render_tab_header_nav(header, tabs)
   end

--- a/app/views/admin/settings/general_settings/show.html.erb
+++ b/app/views/admin/settings/general_settings/show.html.erb
@@ -34,8 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t(:label_general) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: admin_settings_general_path, text: t(:label_system_settings) },
-       t(:label_general)]
+       nested_breadcrumb_element(t(:label_system_settings), t(:label_general))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/admin/settings/users_settings/show.html.erb
+++ b/app/views/admin/settings/users_settings/show.html.erb
@@ -33,8 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t(:label_user_settings) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: admin_settings_users_path, text: t(:label_user_and_permission) },
-       t(:label_user_settings)]
+       nested_breadcrumb_element(t(:label_user_and_permission), t(:label_user_settings))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/admin/settings/work_packages_general/show.html.erb
+++ b/app/views/admin/settings/work_packages_general/show.html.erb
@@ -34,8 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { t(:label_general) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: admin_settings_work_packages_general_path, text: t(:label_work_package_plural) },
-       t(:label_general)]
+       nested_breadcrumb_element(t(:label_work_package_plural), t(:label_general))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/admin/settings/working_days_and_hours_settings/show.html.erb
+++ b/app/views/admin/settings/working_days_and_hours_settings/show.html.erb
@@ -34,8 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title(test_selector: "op-working-days-admin-settings--title") { t(:label_working_days_and_hours) }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
-       { href: admin_settings_working_days_and_hours_path, text: t(:label_calendars_and_dates) },
-       t(:label_working_days_and_hours)]
+       nested_breadcrumb_element(t(:label_calendars_and_dates), t(:label_working_days_and_hours))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { I18n.t("label_home") }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name }, I18n.t(:label_home)])
+    header.with_breadcrumbs([I18n.t(:label_home)])
   end
 %>
 

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { I18n.t("label_home") }
-    header.with_breadcrumbs([nested_breadcrumb_element(organization_name, t(:label_home))],
+    header.with_breadcrumbs([homescreen_breadcrumb_element],
                             selected_item_font_weight: :normal)
   end
 %>

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -29,7 +29,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { I18n.t("label_home") }
-    header.with_breadcrumbs([I18n.t(:label_home)])
+    header.with_breadcrumbs([nested_breadcrumb_element(organization_name, t(:label_home))],
+                            selected_item_font_weight: :normal)
   end
 %>
 

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -33,8 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_profile) }
     header.with_breadcrumbs(
-      [{ href: my_account_path, text: t(:label_my_account) },
-       t(:label_profile)]
+      [nested_breadcrumb_element(t(:label_my_account), t(:label_profile))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/app/views/news/edit.html.erb
+++ b/app/views/news/edit.html.erb
@@ -32,8 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { @news.title }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        *([href: project_news_index_path(@project.id), text: t(:label_news_plural)] if @project),
        @news.title]
     )

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -37,8 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_news_plural) }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        t(:label_news_plural)]
     )
   end

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -31,8 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { "#{avatar(@news.author)}  #{h @news.title}".html_safe }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        *([href: project_news_index_path(@project.id), text: t(:label_news_plural)] if @project),
        @news.title]
     )

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_project_new) }
-    header.with_breadcrumbs([{ href: home_path, text: organization_name }, t(:label_project_new)])
+    header.with_breadcrumbs([t(:label_project_new)])
   end
 %>
 

--- a/app/views/wiki/index.html.erb
+++ b/app/views/wiki/index.html.erb
@@ -34,9 +34,9 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [
         { href: project_overview_path(@project.id), text: @project.name },
-        { href: url_for({ controller: "/wiki", action: "index", project_id: @project.identifier, id: @related_page }), text: t("activerecord.models.wiki") },
-        t(:label_wiki_toc)
-      ]
+        nested_breadcrumb_element(t("activerecord.models.wiki"), t(:label_wiki_toc))
+      ],
+      selected_item_font_weight: :normal
     )
     watcher_action_button(header, @wiki)
   end

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -179,6 +179,7 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent i
 
   breadcrumbItems() {
     return [
+      { href: this.pathHelperService.homePath(), text: this.titleService.appTitle },
       { href: this.pathHelperService.projectPath(this.currentProject.identifier as string), text: (this.currentProject.name) },
       { href: this.pathHelperService.projectBCFPath(this.currentProject.identifier as string), text: this.I18n.t('js.bcf.label_bcf') },
       this.selectedTitle?? '',

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
@@ -200,6 +200,7 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
 
   breadcrumbItems() {
     return [
+      { href: this.pathHelperService.homePath(), text: this.titleService.appTitle },
       { href: this.pathHelperService.projectPath(this.currentProject.identifier as string), text: (this.currentProject.name) },
       { href: this.pathHelperService.boardsPath(this.currentProject.identifier as string), text: this.I18n.t('js.label_board_plural') },
       this.selectedTitle?? '',

--- a/frontend/src/app/features/calendar/wp-calendar-page/wp-calendar-page.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar-page/wp-calendar-page.component.ts
@@ -74,6 +74,7 @@ export class WorkPackagesCalendarPageComponent extends PartitionedQuerySpacePage
 
   breadcrumbItems() {
     return [
+      { href: this.pathHelperService.homePath(), text: this.titleService.appTitle },
       { href: this.pathHelperService.projectPath(this.currentProject.identifier as string), text: (this.currentProject.name) },
       { href: this.pathHelperService.projectCalendarPath(this.currentProject.identifier as string), text: this.I18n.t('js.calendar.label_calendar_plural') },
       this.selectedTitle?? '',

--- a/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
@@ -125,6 +125,7 @@ export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent
 
   breadcrumbItems() {
     return [
+      { href: this.pathHelperService.homePath(), text: this.titleService.appTitle },
       { href: this.pathHelperService.projectPath(this.currentProject.identifier as string), text: (this.currentProject.name) },
       { href: this.pathHelperService.projectTeamplannerPath(this.currentProject.identifier as string), text: this.I18n.t('js.team_planner.label_team_planner_plural') },
       this.selectedTitle?? '',

--- a/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-page/wp-view-page.component.ts
@@ -45,6 +45,7 @@ import { of } from 'rxjs';
 import { WorkPackageFoldToggleButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-fold-toggle-button/wp-fold-toggle-button.component';
 import { OpProjectIncludeComponent } from 'core-app/shared/components/project-include/project-include.component';
 import { OpBaselineModalComponent } from 'core-app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component';
+import { BreadcrumbItem } from 'core-app/shared/components/breadcrumbs/op-breadcrumbs.component';
 
 @Component({
   selector: 'wp-view-page',
@@ -109,20 +110,20 @@ export class WorkPackageViewPageComponent extends PartitionedQuerySpacePageCompo
   }
 
   breadcrumbItems() {
-    const items = [];
+    const items:BreadcrumbItem[] = [{
+      href: this.pathHelperService.homePath(),
+      text: this.titleService.appTitle,
+    }];
 
     if (this.currentProject?.identifier) {
       items.push({
         href: this.pathHelperService.projectPath(this.currentProject.identifier),
-        text: this.currentProject.name,
-      });
-    } else {
-      items.push({
-        href: this.pathHelperService.homePath(),
-        text: this.titleService.appTitle,
+        text: this.currentProject.name as string,
       });
     }
+
     items.push(this.breadcrumbModuleEntry());
+
     if (this.selectedTitle) {
       items.push(this.selectedTitle);
     }

--- a/lib/open_project/patches/primer_page_header_breadcrumb.rb
+++ b/lib/open_project/patches/primer_page_header_breadcrumb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/lib/open_project/patches/primer_page_header_breadcrumb.rb
+++ b/lib/open_project/patches/primer_page_header_breadcrumb.rb
@@ -30,7 +30,12 @@ module OpenProject
   module Patches
     module PrimerPageHeaderBreadcrumb
       def with_breadcrumbs(breadcrumbs, **)
-        super([{ href: home_path, text: helpers.organization_name}] + breadcrumbs, **)
+        unless breadcrumbs.length == 1 && breadcrumbs[0] == helpers.homescreen_breadcrumb_element
+          super([{ href: home_path, text: helpers.organization_name }] + breadcrumbs, **)
+          return
+        end
+
+        super
       end
     end
   end

--- a/lib/open_project/patches/primer_page_header_breadcrumb.rb
+++ b/lib/open_project/patches/primer_page_header_breadcrumb.rb
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Patches
+    module PrimerPageHeaderBreadcrumb
+      def with_breadcrumbs(breadcrumbs, **)
+        super([{ href: home_path, text: helpers.organization_name}] + breadcrumbs, **)
+      end
+    end
+  end
+end
+
+OpenProject::Patches.patch_gem_version "openproject-primer_view_components", "0.70.2" do
+  Primer::OpenProject::PageHeader.prepend OpenProject::Patches::PrimerPageHeaderBreadcrumb
+end

--- a/modules/boards/app/views/boards/boards/index.html.erb
+++ b/modules/boards/app/views/boards/boards/index.html.erb
@@ -33,8 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t("boards.label_boards") }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        t("boards.label_boards")]
     )
   end

--- a/modules/boards/app/views/boards/boards/new.html.erb
+++ b/modules/boards/app/views/boards/boards/new.html.erb
@@ -33,8 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t("boards.label_create_new_board") }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        *([href: project_work_package_boards_path(@project.id), text: t("boards.label_boards")] if @project),
        t("boards.label_create_new_board")]
     )

--- a/modules/calendar/app/views/calendar/calendars/index.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/index.html.erb
@@ -32,8 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_calendar_plural) }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        t(:label_calendar_plural)]
     )
   end

--- a/modules/calendar/app/views/calendar/calendars/new.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/new.html.erb
@@ -33,8 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t(:label_new_calendar) }
     header.with_breadcrumbs(
-      [{ href: home_path, text: organization_name },
-       { href: calendars_path, text: t(:label_calendar_plural) },
+      [{ href: calendars_path, text: t(:label_calendar_plural) },
        t(:label_new_calendar)]
     )
   end

--- a/modules/costs/app/components/my/time_tracking/header_component.html.erb
+++ b/modules/costs/app/components/my/time_tracking/header_component.html.erb
@@ -2,7 +2,6 @@
       header.with_title { I18n.t(:label_my_time_tracking) }
       header.with_breadcrumbs(
         [
-          { href: home_path, text: helpers.organization_name },
           { text: I18n.t(:label_my_time_tracking), href: my_time_tracking_path }
         ]
       )

--- a/modules/costs/app/views/admin/costs_settings/show.html.erb
+++ b/modules/costs/app/views/admin/costs_settings/show.html.erb
@@ -35,9 +35,9 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [
         { href: admin_index_path, text: t("label_administration") },
-        { href: admin_costs_settings_path, text: t(:project_module_costs) },
-        t(:label_defaults)
-      ]
+        nested_breadcrumb_element(t(:project_module_costs), t(:label_defaults))
+      ],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/modules/costs/app/views/hourly_rates/edit.html.erb
+++ b/modules/costs/app/views/hourly_rates/edit.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
                        [{ href: project_overview_path(@project.identifier), text: @project.name },
                         { href: projects_budgets_path(@project.identifier), text: I18n.t(:label_budget_plural) }]
                      else
-                       [{ href: home_path, text: organization_name }]
+                       []
                      end
 %>
 

--- a/modules/costs/app/views/hourly_rates/show.html.erb
+++ b/modules/costs/app/views/hourly_rates/show.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
                        [{ href: project_overview_path(@project.identifier), text: @project.name },
                         { href: projects_budgets_path(@project.identifier), text: I18n.t(:label_budget_plural) }]
                      else
-                       [{ href: home_path, text: organization_name }]
+                       []
                      end
 %>
 

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -75,7 +75,7 @@ module Meetings
 
     def breadcrumb_items
       [
-        parent_element,
+        *([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
         { href: @project.present? ? project_meetings_path(@project.id) : meetings_path,
           text: I18n.t(:label_meeting_plural) },
         meeting_series_element,
@@ -96,14 +96,6 @@ module Meetings
     def meeting_series_element
       if @series.present?
         { href: project_recurring_meeting_path(@series.project, @series), text: @series.title }
-      end
-    end
-
-    def parent_element
-      if @project.present?
-        { href: project_overview_path(@project.id), text: @project.name }
-      else
-        { href: home_path, text: helpers.organization_name }
       end
     end
 

--- a/modules/meeting/app/components/meetings/index_page_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.html.erb
@@ -3,5 +3,5 @@
 
 <%= render(Primer::OpenProject::PageHeader.new) do |header|
   header.with_title { page_title }
-  header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: section_present? ? :normal : :bold)
+  header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: section_present? || first_menu_item? ? :normal : :bold)
 end %>

--- a/modules/meeting/app/components/meetings/index_page_header_component.rb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.rb
@@ -47,14 +47,16 @@ module Meetings
 
     def breadcrumb_items
       [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
-       { href: url_for({ controller: "meetings", action: :index, project_id: @project }),
-         text: I18n.t(:label_meeting_plural) },
+       *([{ href: url_for({ controller: "meetings", action: :index, project_id: @project }),
+            text: I18n.t(:label_meeting_plural) }] unless first_menu_item?),
        current_breadcrumb_element]
     end
 
     def current_breadcrumb_element
       if section_present?
         helpers.nested_breadcrumb_element(current_section.header, page_title)
+      elsif first_menu_item?
+        helpers.nested_breadcrumb_element(I18n.t(:label_meeting_plural), current_item.title)
       else
         page_title
       end
@@ -78,6 +80,10 @@ module Meetings
       @current_item = Meetings::Menu
                         .new(project: @project, params: params.merge(current_href: request.path))
                         .selected_menu_item
+    end
+
+    def first_menu_item?
+      current_item.href == (@project.present? ? project_meetings_path(@project.identifier) : meetings_path)
     end
   end
 end

--- a/modules/meeting/app/components/meetings/index_page_header_component.rb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.rb
@@ -46,18 +46,10 @@ module Meetings
     end
 
     def breadcrumb_items
-      [parent_element,
+      [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
        { href: url_for({ controller: "meetings", action: :index, project_id: @project }),
          text: I18n.t(:label_meeting_plural) },
        current_breadcrumb_element]
-    end
-
-    def parent_element
-      if @project.present?
-        { href: project_overview_path(@project.id), text: @project.name }
-      else
-        { href: home_path, text: helpers.organization_name }
-      end
     end
 
     def current_breadcrumb_element

--- a/modules/meeting/app/components/meetings/index_page_header_component.rb
+++ b/modules/meeting/app/components/meetings/index_page_header_component.rb
@@ -47,8 +47,10 @@ module Meetings
 
     def breadcrumb_items
       [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
-       *([{ href: url_for({ controller: "meetings", action: :index, project_id: @project }),
-            text: I18n.t(:label_meeting_plural) }] unless first_menu_item?),
+       *(unless first_menu_item?
+           [{ href: url_for({ controller: "meetings", action: :index, project_id: @project }),
+              text: I18n.t(:label_meeting_plural) }]
+         end),
        current_breadcrumb_element]
     end
 
@@ -83,7 +85,7 @@ module Meetings
     end
 
     def first_menu_item?
-      current_item.href == (@project.present? ? project_meetings_path(@project.identifier) : meetings_path)
+      current_item&.href == (@project.present? ? project_meetings_path(@project.identifier) : meetings_path)
     end
   end
 end

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
@@ -83,18 +83,10 @@ module RecurringMeetings
     end
 
     def breadcrumb_items
-      [parent_element,
+      [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
        { href: @project.present? ? project_meetings_path(@project.id) : meetings_path,
          text: I18n.t(:label_meeting_plural) },
        page_title(true)]
-    end
-
-    def parent_element
-      if @project.present?
-        { href: project_overview_path(@project.id), text: @project.name }
-      else
-        { href: home_path, text: I18n.t(:label_home) }
-      end
     end
   end
 end

--- a/modules/meeting/app/views/recurring_meetings/new.html.erb
+++ b/modules/meeting/app/views/recurring_meetings/new.html.erb
@@ -31,11 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_recurring_meeting_new) }
     header.with_breadcrumbs(
-      [if @project.present?
-         { href: project_overview_path(@project.id), text: @project.name }
-       else
-         { href: home_path, text: I18n.t(:label_home) }
-       end,
+      [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
        { href: @project.present? ? project_recurring_meetings_path(@project.id) : recurring_meetings_path,
          text: I18n.t(:label_meeting_plural) },
        t(:label_recurring_meeting_new)]

--- a/modules/my_page/app/views/my/page/show.html.erb
+++ b/modules/my_page/app/views/my/page/show.html.erb
@@ -5,7 +5,6 @@
     header.with_title { t("my_page.label") }
     header.with_breadcrumbs(
       [
-        { href: home_path, text: organization_name },
         t("my_page.label")
       ]
     )

--- a/modules/overviews/app/views/overviews/overviews/show.html.erb
+++ b/modules/overviews/app/views/overviews/overviews/show.html.erb
@@ -8,9 +8,9 @@
     header.with_title(variant: :medium) { t("overviews.label") }
     header.with_breadcrumbs(
       [
-        { href: project_path(@project), text: @project.name },
-        t("overviews.label")
-      ]
+        nested_breadcrumb_element(@project.name, t("overviews.label"))
+      ],
+      selected_item_font_weight: :normal
     )
     favored = @project.favored_by?(User.current)
     header.with_action_icon_button(

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.rb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.rb
@@ -41,7 +41,10 @@ module CostReports
 
     def breadcrumb_items
       [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
-       *([{ href: cost_reports_path(@project), text: I18n.t(:cost_reports_title) }] if current_section && current_section.header.present?),
+       *(if current_section && current_section.header.present?
+           [{ href: cost_reports_path(@project),
+              text: I18n.t(:cost_reports_title) }]
+         end),
        current_breadcrumb_element]
     end
 

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.rb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.rb
@@ -39,24 +39,17 @@ module CostReports
       @user =  User.current
     end
 
-    def page_title
-      I18n.t(:label_meeting_plural)
-    end
-
     def breadcrumb_items
       [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
-       { href: url_for({ controller: "cost_reports", action: :index, project_id: @project }),
-         text: I18n.t(:cost_reports_title) },
+       *([{ href: cost_reports_path(@project), text: I18n.t(:cost_reports_title) }] if current_section && current_section.header.present?),
        current_breadcrumb_element]
     end
 
     def current_breadcrumb_element
-      return I18n.t(:label_new_report) unless @query.persisted?
-
       if current_section && current_section.header.present?
         helpers.nested_breadcrumb_element(current_section.header, @query.name)
       else
-        I18n.t(:label_new_report)
+        helpers.nested_breadcrumb_element(I18n.t(:cost_reports_title), I18n.t(:label_new_report))
       end
     end
 

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.rb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.rb
@@ -44,18 +44,10 @@ module CostReports
     end
 
     def breadcrumb_items
-      [parent_element,
+      [*([{ href: project_overview_path(@project.id), text: @project.name }] if @project.present?),
        { href: url_for({ controller: "cost_reports", action: :index, project_id: @project }),
          text: I18n.t(:cost_reports_title) },
        current_breadcrumb_element]
-    end
-
-    def parent_element
-      if @project.present?
-        { href: project_overview_path(@project.id), text: @project.name }
-      else
-        { href: home_path, text: helpers.organization_name }
-      end
     end
 
     def current_breadcrumb_element

--- a/modules/storages/app/views/storages/admin/storages/index.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/index.html.erb
@@ -10,9 +10,11 @@ end %>
   <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
     <% header.with_title { t("external_file_storages") } %>
     <% header.with_description { t("storages.page_titles.file_storages.subtitle") } %>
-    <% header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
-                                { href: admin_settings_storages_path, text: t("project_module_storages") },
-                                t("external_file_storages")]) %>
+    <% header.with_breadcrumbs(
+         [{ href: admin_index_path, text: t("label_administration") },
+          nested_breadcrumb_element(t(:project_module_storages), t(:external_file_storages))],
+         selected_item_font_weight: :normal
+       ) %>
   <% end %>
 
   <%= render(Primer::OpenProject::SubHeader.new) do |subheader|

--- a/modules/team_planner/app/views/team_planner/team_planner/new.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/new.html.erb
@@ -32,8 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t("team_planner.label_new_team_planner") }
     header.with_breadcrumbs(
-      [*([href: home_path, text: organization_name] unless @project),
-       *([href: project_overview_path(@project.id), text: @project.name] if @project),
+      [*([href: project_overview_path(@project.id), text: @project.name] if @project),
        t("team_planner.label_new_team_planner")]
     )
   end

--- a/modules/team_planner/app/views/team_planner/team_planner/overview.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/overview.html.erb
@@ -3,8 +3,7 @@
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { t("team_planner.label_team_planner_plural") }
     header.with_breadcrumbs(
-      [{ href: home_path, text: organization_name },
-       t("team_planner.label_team_planner_plural")]
+      [t("team_planner.label_team_planner_plural")]
     )
   end
 %>

--- a/spec/features/a11y/breadcrumb_spec.rb
+++ b/spec/features/a11y/breadcrumb_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Breadcrumbs", :js do
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
+
+  before do
+    login_as user
+  end
+
+  context "when being on a page which is not the home screen" do
+    it "displays the instance name as an individual nav item" do
+      visit project_path(project)
+
+      within ".PageHeader-breadcrumbs" do
+        expect(page).to have_link href: "#", text: "#{project.name}: Overview", aria: { current: "page" }
+        expect(page).to have_link href: "/", text: "OpenProject"
+      end
+    end
+  end
+
+  context "when being on the home screen" do
+    it "does not display the instance name as a link in the breadcrumb" do
+      visit "/"
+
+      within ".PageHeader-breadcrumbs" do
+        expect(page).to have_link href: "#", text: "OpenProject: Home", aria: { current: "page" }
+        expect(page).to have_no_link href: "/", text: "OpenProject"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/63777

# What are you trying to accomplish?
- [x] Create a OP specific patch for the PageHeader to always prepend the organization name as the first element in the breadcrumb
- [x] On affected pages, merge the current 'useless' link into the 'current' bit of the breadcrumb, which is not a link.
- [x] Hide the breadcrumb on mobile on the homescreen


