### PR TITLE
[#62610] Version from the shared work package not available in Version filter on global wp page

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -75,7 +75,8 @@ class Version < ApplicationRecord
 
   # Returns true if +user+ or current user is allowed to view the version
   def visible?(user = User.current)
-    user.allowed_in_project?(:view_work_packages, project) ||
+    systemwide? ||
+      user.allowed_in_project?(:view_work_packages, project) ||
       work_packages.visible(user).exists?
   end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -493,4 +493,77 @@ RSpec.describe Version do
     let(:model_instance) { version }
     let(:custom_field) { create(:version_custom_field) }
   end
+
+  describe ".visible scope" do
+    let(:user) { create(:user) }
+    let(:project1) { create(:project) }
+    let(:project2) { create(:project) }
+    let(:role) { create(:project_role, permissions: [:view_work_packages]) }
+    let!(:member) { create(:member, user: user, project: project1, roles: [role]) }
+
+    let!(:version_in_project1) { create(:version, project: project1) }
+    let!(:systemwide_version) { create(:version, project: project2, sharing: "system") }
+    let!(:version_in_project2) { create(:version, project: project2) }
+    let!(:work_package) { create(:work_package, project: project2, version: version_in_project2) }
+
+    before do
+      # Simulate that the user can see the work package in project2 (e.g., via sharing)
+      allow(WorkPackage).to receive(:visible).with(user).and_return(WorkPackage.where(id: work_package.id))
+    end
+
+    it "returns versions from visible projects, systemwide, and referenced by visible work packages" do
+      visible_versions = described_class.visible(user)
+      expect(visible_versions).to include(version_in_project1)
+      expect(visible_versions).to include(systemwide_version)
+      expect(visible_versions).to include(version_in_project2)
+    end
+
+    it "does not return unrelated versions" do
+      unrelated_version = create(:version)
+      expect(described_class.visible(user)).not_to include(unrelated_version)
+    end
+  end
+
+  describe "#visible?" do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+    let(:role) { create(:project_role, permissions: [:view_work_packages]) }
+    let!(:member) { create(:member, user: user, project: project, roles: [role]) }
+    let!(:version) { create(:version, project: project) }
+
+    context "when the user has project access" do
+      it "returns true" do
+        expect(version.visible?(user)).to be true
+      end
+    end
+
+    context "when the user has access to a shared work package but not the project" do
+      let(:other_user) { create(:user) }
+      let(:other_project) { create(:project) }
+      let!(:other_version) { create(:version, project: other_project) }
+      let!(:shared_wp) { create(:work_package, project: other_project, version: other_version) }
+
+      before do
+        # Simulate that the user can see the work package in other_project (e.g., via sharing)
+        allow(WorkPackage).to receive(:visible).with(other_user).and_return(WorkPackage.where(id: shared_wp.id))
+      end
+
+      it "returns true if the user can see a work package of the version" do
+        expect(other_version.visible?(other_user)).to be true
+      end
+    end
+
+    context "when the user has no access to the project or any work package" do
+      let(:stranger) { create(:user) }
+      let!(:unrelated_version) { create(:version) }
+
+      before do
+        allow(WorkPackage).to receive(:visible).with(stranger).and_return(WorkPackage.none)
+      end
+
+      it "returns false" do
+        expect(unrelated_version.visible?(stranger)).to be false
+      end
+    end
+  end
 end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -557,12 +557,17 @@ RSpec.describe Version do
       let(:stranger) { create(:user) }
       let!(:unrelated_version) { create(:version) }
 
-      before do
-        allow(WorkPackage).to receive(:visible).with(stranger).and_return(WorkPackage.none)
-      end
-
       it "returns false" do
         expect(unrelated_version.visible?(stranger)).to be false
+      end
+    end
+
+    context "when the version is systemwide" do
+      let(:stranger) { create(:user) }
+      let!(:systemwide_version) { create(:version, sharing: "system") }
+
+      it "returns true" do
+        expect(systemwide_version.visible?(stranger)).to be true
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62610

# What are you trying to accomplish?
- Display the work package shared Versions on the global work package page Version filter.

## Screenshots
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/a221b3ec-e40b-4989-81b3-a098fe8e5fa2" />

# What approach did you choose and why?
- Update the `Version.visible` scope to include versions that are shared via a work package with the user.
- Additionally update the `Version#visible?` instance method to return true if the Version is visible via a shared work package.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
