### PR TITLE
[65348] Breadcrumb can overlap title

### DIFF
--- a/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.sass
+++ b/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.sass
@@ -2,7 +2,6 @@
 
 .op-breadcrumbs
   // Match the height of the Primer breadcrumb which itself takes the height of the small action button it can have on mobile
-  height: var(--control-small-size)
   line-height: var(--control-small-size)
 
   .op-breadcrumbs--items


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65348

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Remove height of breadcrumbs, so it won't overlap with title

## Screenshots
Before:
![Screenshot 2025-07-02 at 16 41 03](https://github.com/user-attachments/assets/5e8d3ef9-6ee4-489c-aaf8-24eac5bf1da3)

After:
![Screenshot 2025-07-02 at 16 40 32](https://github.com/user-attachments/assets/df8789ce-d3cc-4dc2-a71d-4284eaa40193)

