### PR TITLE
Implement UID on meetings and meeting series

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1878,6 +1878,7 @@ en:
     title: "Title"
     type: "Type"
     typeahead: "Autocomplete"
+    uid: "Unique identifier"
     updated_at: "Updated on"
     updated_on: "Updated on"
     uploader: "Uploader"

--- a/modules/meeting/app/contracts/meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/meetings/create_contract.rb
@@ -31,6 +31,7 @@
 module Meetings
   class CreateContract < BaseContract
     attribute :recurring_meeting_id
+    attribute :uid
 
     validate :user_allowed_to_add
     validate :recurring_meeting_visible

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -30,6 +30,7 @@
 
 class Meeting < ApplicationRecord
   include VirtualStartTime
+  include MeetingUid
   include ChronicDuration
   include OpenProject::Journal::AttachmentHelper
 

--- a/modules/meeting/app/models/meeting/meeting_uid.rb
+++ b/modules/meeting/app/models/meeting/meeting_uid.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,39 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module RecurringMeetings
-  class CreateContract < BaseContract
-    attribute :uid
+module Meeting::MeetingUid
+  extend ActiveSupport::Concern
 
-    validate :user_allowed_to_add
-    validate :project_is_present
-    validate :start_time_constraints
+  included do
+    after_initialize :generate_uid, if: :new_record?
+  end
 
-    private
-
-    def project_is_present
-      if model.project.nil?
-        errors.add :project_id, :blank
-      end
-    end
-
-    def user_allowed_to_add
-      return if model.project.nil?
-
-      unless user.allowed_in_project?(:create_meetings, model.project)
-        errors.add :base, :error_unauthorized
-      end
-    end
-
-    def start_time_constraints
-      return if model.start_time.nil?
-      return if model.start_time >= Time.zone.now
-
-      if model.start_time.today?
-        errors.add :start_time_hour, :after_today
-      else
-        errors.add :start_date, :after_today
-      end
-    end
+  def generate_uid
+    self.uid = "#{SecureRandom.uuid}@#{Setting.host_name}"
   end
 end

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -34,6 +34,7 @@ class RecurringMeeting < ApplicationRecord
   # Magical maximum of interval, derived from other calendars
   MAX_INTERVAL = 100
   include ::Meeting::VirtualStartTime
+  include ::Meeting::MeetingUid
   include Redmine::I18n
 
   belongs_to :project

--- a/modules/meeting/app/services/meetings/copy_service.rb
+++ b/modules/meeting/app/services/meetings/copy_service.rb
@@ -94,7 +94,7 @@ module Meetings
     end
 
     def writable_meeting_attributes(meeting)
-      instantiate_contract(meeting, user).writable_attributes - %w[start_date start_time_hour]
+      instantiate_contract(meeting, user).writable_attributes - %w[start_date start_time_hour uid]
     end
 
     def copy_meeting_attachment(copy)

--- a/modules/meeting/app/services/meetings/ical_helpers.rb
+++ b/modules/meeting/app/services/meetings/ical_helpers.rb
@@ -81,10 +81,6 @@ module Meetings
       end
     end
 
-    def ical_uid(suffix)
-      "#{Setting.app_title}-#{Setting.host_name}-#{suffix}".dasherize
-    end
-
     def ical_datetime(time, timezone_id)
       Icalendar::Values::DateTime.new time.in_time_zone(timezone_id), "tzid" => timezone_id
     end

--- a/modules/meeting/app/services/meetings/ical_service.rb
+++ b/modules/meeting/app/services/meetings/ical_service.rb
@@ -63,7 +63,7 @@ module Meetings
         e.url = url_helpers.meeting_url(meeting)
         e.summary = "[#{meeting.project.name}] #{meeting.title}"
         e.description = ical_subject
-        e.uid = "#{meeting.id}@#{meeting.project.identifier}"
+        e.uid = meeting.uid
         e.organizer = ical_organizer
         e.location = meeting.location.presence
 

--- a/modules/meeting/app/services/recurring_meetings/ical_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/ical_service.rb
@@ -148,7 +148,7 @@ module RecurringMeetings
     end
 
     def base_series_attributes(event) # rubocop:disable Metrics/AbcSize
-      event.uid = ical_uid("meeting-series-#{series.id}")
+      event.uid = series.uid
       event.summary = "[#{series.project.name}] #{series.title}"
       event.description = "[#{series.project.name}] #{I18n.t(:label_meeting_series)}: #{series.title}"
       event.organizer = ical_organizer

--- a/modules/meeting/db/migrate/20250703143214_add_uid_to_meetings.rb
+++ b/modules/meeting/db/migrate/20250703143214_add_uid_to_meetings.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddUidToMeetings < ActiveRecord::Migration[8.0]
+  class MigrationSeries < ApplicationRecord
+    self.table_name = "recurring_meetings"
+  end
+
+  def change
+    add_column :meetings, :uid, :string
+    add_column :recurring_meetings, :uid, :string
+
+    add_index :meetings, :uid, unique: true
+    add_index :recurring_meetings, :uid, unique: true
+
+    reversible do |dir|
+      dir.up do
+        # Backfill Meeting UIDs using current ICal logic
+        execute <<~SQL.squish
+          UPDATE meetings
+          SET uid = meetings.id || '@' || projects.identifier
+          FROM projects
+          WHERE meetings.project_id = projects.id;
+        SQL
+
+        MigrationSeries.select(:id).find_each do |series|
+          uid = "#{Setting.app_title}-#{Setting.host_name}-meeting-series-#{series.id}".dasherize
+          series.update_columns(uid:)
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -209,6 +209,14 @@ RSpec.describe Meeting do
     end
   end
 
+  describe "uid" do
+    it "assigns a uid on create" do
+      meeting = described_class.new(project:, author: user1)
+      expect(meeting.uid).to be_present
+      expect(meeting.uid).to include "@#{Setting.host_name}"
+    end
+  end
+
   describe "#destroy" do
     context "with an attachment" do
       let!(:meeting) { create(:meeting, project: project) }

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -235,4 +235,12 @@ RSpec.describe RecurringMeeting,
       expect(recurring_meeting.upcoming_instantiated_meetings).to eq [ongoing_meeting]
     end
   end
+
+  describe "uid" do
+    it "assigns a uid on create" do
+      series = build(:recurring_meeting)
+      expect(series.uid).to be_present
+      expect(series.uid).to include "@#{Setting.host_name}"
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/65499

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Right now, the way we create UIDs for meetings and series is not really globally unique. We should use a truly unique identifier and refer to the emitting host name as per the RFC (https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.4.7)

- [x]  Backfill current UIDs for series and one-time meetings
- [x] Use a UUID and the host name to create a globally stable UID
- [x]  Store this UUID in case of future changes with an index for lookup on incoming mails

