### PR TITLE
[#65505] Show plaintext tokens in ScimClient UI.

### DIFF
--- a/app/components/admin/scim_clients/created_client_credentials_dialog_component.html.erb
+++ b/app/components/admin/scim_clients/created_client_credentials_dialog_component.html.erb
@@ -55,10 +55,10 @@ See COPYRIGHT and LICENSE files for more details.
             name: :client_secret,
             label: Doorkeeper::Application.human_attribute_name(:secret),
             visually_hide_label: false,
-            value: model.oauth_application.secret
+            value: @plaintext_secret
           )
           input_group.with_trailing_action_clipboard_copy_button(
-            value: model.oauth_application.secret,
+            value: @plaintext_secret,
             aria: { label: I18n.t("button_copy_to_clipboard") }
           )
         end

--- a/app/components/admin/scim_clients/created_client_credentials_dialog_component.rb
+++ b/app/components/admin/scim_clients/created_client_credentials_dialog_component.rb
@@ -35,9 +35,9 @@ module Admin
 
       TEST_SELECTOR = "op-scim-clients--created-client-credentials-dialog"
 
-      def initialize(model = nil, **options)
+      def initialize(model = nil, plaintext_secret:, **options)
         super
-        @plaintext_secret = options.fetch(:plaintext_secret)
+        @plaintext_secret = plaintext_secret
       end
 
       def system_arguments

--- a/app/components/admin/scim_clients/created_client_credentials_dialog_component.rb
+++ b/app/components/admin/scim_clients/created_client_credentials_dialog_component.rb
@@ -35,6 +35,11 @@ module Admin
 
       TEST_SELECTOR = "op-scim-clients--created-client-credentials-dialog"
 
+      def initialize(model = nil, **options)
+        super
+        @plaintext_secret = options.fetch(:plaintext_secret)
+      end
+
       def system_arguments
         options
       end

--- a/app/components/admin/scim_clients/created_token_dialog_component.html.erb
+++ b/app/components/admin/scim_clients/created_token_dialog_component.html.erb
@@ -39,10 +39,10 @@ See COPYRIGHT and LICENSE files for more details.
           name: :token,
           label: t(".label_token"),
           visually_hide_label: false,
-          value: model.token
+          value: model.plaintext_token
         )
         input_group.with_trailing_action_clipboard_copy_button(
-          value: model.token,
+          value: model.plaintext_token,
           aria: { label: I18n.t("button_copy_to_clipboard") }
         )
       end

--- a/app/views/admin/scim_clients/edit.html.erb
+++ b/app/views/admin/scim_clients/edit.html.erb
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= render(Admin::ScimClients::TokenListComponent.new(@scim_client)) if @scim_client.authentication_method_oauth2_token? %>
 
 <% if @setup_token %>
-  <%= render(Admin::ScimClients::CreatedTokenDialogComponent.new(@scim_client.access_tokens.first, data: { controller: "auto-show-dialog" })) %>
-<% elsif @setup_client_credentials %>
-  <%= render(Admin::ScimClients::CreatedClientCredentialsDialogComponent.new(@scim_client, data: { controller: "auto-show-dialog" })) %>
+  <%= render(Admin::ScimClients::CreatedTokenDialogComponent.new(@setup_token, data: { controller: "auto-show-dialog" })) %>
+<% elsif @setup_client_secret %>
+  <%= render(Admin::ScimClients::CreatedClientCredentialsDialogComponent.new(@scim_client, plaintext_secret: @setup_client_secret, data: { controller: "auto-show-dialog" })) %>
 <% end %>

--- a/spec/features/admin/scim_clients/create_spec.rb
+++ b/spec/features/admin/scim_clients/create_spec.rb
@@ -79,7 +79,9 @@ RSpec.describe "Creating a SCIM client", :js, :selenium, driver: :firefox_de do
 
     page.within_modal("Client credentials created") do
       expect(page).to have_field("Client ID", with: created_client.oauth_application.uid)
-      expect(page).to have_field("Client secret", with: created_client.oauth_application.secret)
+      plaintext_secret = page.find_field("Client secret").value
+      hashed_secret = created_client.oauth_application.secret
+      expect(Digest::SHA256.hexdigest(plaintext_secret)).to eq(hashed_secret)
     end
   end
 
@@ -97,7 +99,10 @@ RSpec.describe "Creating a SCIM client", :js, :selenium, driver: :firefox_de do
     expect(page).to have_current_path(edit_admin_scim_client_path(created_client, first_time_setup: true))
 
     page.within_modal("Token created") do
-      expect(page).to have_field("Token", with: created_client.oauth_application.access_tokens.last.token)
+      plaintext_token = page.find_field("Token").value
+      hashed_token = created_client.oauth_application.access_tokens.last.token
+      expect(plaintext_token).to be_present
+      expect(Digest::SHA256.hexdigest(plaintext_token)).to eq(hashed_token)
     end
   end
 end

--- a/spec/features/admin/scim_clients/update_spec.rb
+++ b/spec/features/admin/scim_clients/update_spec.rb
@@ -148,7 +148,10 @@ RSpec.describe "Updating a SCIM client", :js, :selenium, driver: :firefox_de do
 
     page.find_test_selector("op-scim-clients--add-token-button").click
     within_modal("Token created") do
-      expect(page).to have_field("Token", with: Doorkeeper::AccessToken.last.token)
+      plaintext_token = page.find_field("Token").value
+      hashed_token = Doorkeeper::AccessToken.last.token
+      expect(plaintext_token).to be_present
+      expect(Digest::SHA256.hexdigest(plaintext_token)).to eq(hashed_token)
       click_on("Close")
     end
     within_test_selector("Admin::ScimClients::TokenTableComponent") do


### PR DESCRIPTION
https://community.openproject.org/work_packages/65505

- Use `Doorkeeper::AccessToken#plaintext_token` in acces token dialog.
  It returns exactly what should be shown in the UI.
  This value stored in memory after token creation. Then it is gone forever.
- Use `Doorkeeper::Application#plaintext_secret` in client_id/client_secret dialog.
  Session is used to store `plaintext_secret`. I am not sure about that idea.
  Probably, it would be better to redesign OAuth application creation to avoid
  this.