### PR TITLE
[#65513] Form configuration page is broken on the work packages page

### DIFF
--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -144,7 +144,7 @@ See COPYRIGHT and LICENSE files for more details.
                     <%= t(:label_x_projects, count: custom_field.projects.count) %></td>
                   <% end %>
                 <td>
-                  <% type_links = custom_field.types.map { |t| link_to(t.name, edit_tab_type_path(id: t.id, tab: "form_configuration")) } %>
+                  <% type_links = custom_field.types.map { |t| link_to(t.name, edit_type_form_configuration_path(t)) } %>
                   <% if type_links.empty? %>
                     <span class="icon-context icon-warning">
                       <%= link_to t(:label_custom_field_add_no_type), types_path %>

--- a/lib/api/v3/work_packages/create_form_representer.rb
+++ b/lib/api/v3/work_packages/create_form_representer.rb
@@ -78,7 +78,7 @@ module API
              represented.type_id &&
              represented.type_id != 0
             {
-              href: edit_type_path(represented.type_id, tab: "form_configuration"),
+              href: edit_type_form_configuration_path(represented.type_id),
               type: "text/html",
               title: "Configure form"
             }

--- a/lib/api/v3/work_packages/create_project_form_representer.rb
+++ b/lib/api/v3/work_packages/create_project_form_representer.rb
@@ -76,8 +76,7 @@ module API
              represented.type_id &&
              represented.type_id != 0
             {
-              href: edit_type_path(represented.type_id,
-                                   tab: "form_configuration"),
+              href: edit_type_form_configuration_path(represented.type_id),
               type: "text/html",
               title: "Configure form"
             }

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -180,7 +180,7 @@ module API
           next unless represented.type_id
 
           {
-            href: edit_type_path(represented.type_id, tab: "form_configuration"),
+            href: edit_type_form_configuration_path(represented.type_id),
             type: "text/html",
             title: "Configure form"
           }

--- a/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe API::V3::WorkPackages::CreateFormRepresenter do
 
         it "has a link to configure the form" do
           expected = {
-            href: "/types/#{type.id}/edit?tab=form_configuration",
+            href: edit_type_form_configuration_path(type),
             type: "text/html",
             title: "Configure form"
           }

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe API::V3::WorkPackages::CreateProjectFormRepresenter do
 
         it "has a link to configure the form" do
           expected = {
-            href: "/types/#{type.id}/edit?tab=form_configuration",
+            href: edit_type_form_configuration_path(type),
             type: "text/html",
             title: "Configure form"
           }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1246,7 +1246,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
 
           it_behaves_like "has a titled link" do
             let(:link) { "configureForm" }
-            let(:href) { edit_type_path(work_package.type_id, tab: "form_configuration") }
+            let(:href) { edit_type_form_configuration_path(work_package.type_id) }
             let(:title) { "Configure form" }
           end
         end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65513

# What are you trying to accomplish?

Fix broken work package form configuration urls

## Screenshots

![image](https://github.com/user-attachments/assets/ee384422-fc4e-43f5-95e9-567da9a22a8b)
![image](https://github.com/user-attachments/assets/e11ecf4f-ea41-43b5-8476-83ad365c4364)

# What approach did you choose and why?

Replace the broken links `/types/1/edit?tab=form_configuration` with the new form configuration links `types/1/form_configuration/edit`.

Note: Not sure, but probably we should also fix the old urls?

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
