### PR TITLE
[65498] Mobile: double header when opening a WP from a notification

### DIFF
--- a/app/components/open_project/common/main_menu_toggle_component.sass
+++ b/app/components/open_project/common/main_menu_toggle_component.sass
@@ -53,6 +53,14 @@
       .wp-show--header-container--breadcrumb
         margin-left: 0
 
+    @media only screen and (max-width: $breakpoint-lg)
+      // Special logic for those pages that already use the new layout and have the content-bodyRight filled (so basically, the split screen opened full height on mobile)
+      #content:has(#content-bodyRight > *)
+        #menu-toggle--expand-button
+          top: 60px
+        .op-wp-breadcrumb
+          margin-left: 30px
+
   &:not(.hidden-navigation)
     #menu-toggle--expand-button
       display: none

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -78,6 +78,13 @@
     padding-top: var(--main-menu-toggler-top-spacing)
     margin-top: calc(var(--main-menu-toggler-top-spacing) * -1)
 
+  // Hide the header, when the content-bodyRight is shown, because it has it's own header.
+  // Otherwise, the sticky header would lay on top of the split screen
+  #content:has(#content-bodyRight > *)
+    page-header,
+    sub-header
+      display: none
+
   .work-packages--show-view .toolbar-container
     margin-bottom: 0
     .wp-show--header-container


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/65498

# What are you trying to accomplish?
Special logic for pages that use the page layout and have the split screen at the content-bodyRight. When that is shown on mobile, the original PageHeader can be hidden and the menuToggler needs to further down because of the tab bar

