### PR TITLE
[65524] PageHeader has the wrong background on project overview

### DIFF
--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -9,7 +9,7 @@ $grid--widget-padding: 20px 20px 20px 20px
   display: grid
 
 body.widget-grid-layout
-  #content
+  #content, page-header
     background-color: var(--grid-background-color)
 
 .grid--container

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -71,7 +71,6 @@
     position: sticky
     top: calc(var(--main-menu-toggler-top-spacing) * -1)
     z-index: var(--main-menu-toggler-z-index)
-    background-color: var(--body-background)
     padding-top: var(--main-menu-toggler-top-spacing)
     margin-top: calc(var(--main-menu-toggler-top-spacing) * -1)
 

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -71,6 +71,7 @@
     position: sticky
     top: calc(var(--main-menu-toggler-top-spacing) * -1)
     z-index: var(--main-menu-toggler-z-index)
+    background-color: var(--body-background)
     padding-top: var(--main-menu-toggler-top-spacing)
     margin-top: calc(var(--main-menu-toggler-top-spacing) * -1)
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65524

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Remove background-color of page header in mobile mode, so it has the same color as its body.

## Screenshots
Before:
![Screenshot 2025-07-04 at 12 20 27](https://github.com/user-attachments/assets/536cefe2-6022-49d3-919c-bf06cefca603)

After:
![Screenshot 2025-07-04 at 12 19 54](https://github.com/user-attachments/assets/24551c97-15b8-412d-9cde-55439f14e4f1)
