### PR TITLE
[#65416] Show custom field format on #new

### DIFF
--- a/app/components/settings/project_custom_fields/new_form_header_component.html.erb
+++ b/app/components/settings/project_custom_fields/new_form_header_component.html.erb
@@ -31,6 +31,6 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t("settings.project_attributes.new.heading") }
     header.with_description { t("settings.project_attributes.new.description") }
-    header.with_breadcrumbs(breadcrumb_items)
+    header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: :normal)
   end
 %>

--- a/app/components/settings/project_custom_fields/new_form_header_component.rb
+++ b/app/components/settings/project_custom_fields/new_form_header_component.rb
@@ -30,10 +30,13 @@ module Settings
   module ProjectCustomFields
     class NewFormHeaderComponent < ApplicationComponent
       def breadcrumb_items
-        [{ href: admin_index_path, text: t("label_administration") },
-         { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
-         { href: admin_settings_project_custom_fields_path, text: t("settings.project_attributes.heading") },
-         t("settings.project_attributes.new.heading")]
+        [
+          { href: admin_index_path, text: t("label_administration") },
+          { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
+          { href: admin_settings_project_custom_fields_path, text: t("settings.project_attributes.heading") },
+          helpers.nested_breadcrumb_element(helpers.label_for_custom_field_format(model.field_format),
+                                            t("settings.project_attributes.new.heading"))
+        ]
       end
     end
   end

--- a/app/views/admin/settings/project_custom_fields/new.html.erb
+++ b/app/views/admin/settings/project_custom_fields/new.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_administration), t("settings.project_attributes.heading"), t("settings.project_attributes.new.heading") %>
 
-<%= render(Settings::ProjectCustomFields::NewFormHeaderComponent.new) %>
+<%= render(Settings::ProjectCustomFields::NewFormHeaderComponent.new(@custom_field)) %>
 
 <% if @custom_field.field_format_calculated_value? %>
   <%= render Admin::CustomFields::CalculatedValues::DetailsComponent.new(@custom_field) %>

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -36,7 +36,8 @@ See COPYRIGHT and LICENSE files for more details.
       [{ href: admin_index_path, text: t(:label_administration) },
        { href: custom_fields_path, text: t(:label_custom_field_plural) },
        { href: custom_fields_path(tab: @custom_field.type), text: I18n.t(@custom_field.type_name) },
-       t(:label_custom_field_new)]
+       nested_breadcrumb_element(label_for_custom_field_format(@custom_field.field_format), t(:label_custom_field_new))],
+      selected_item_font_weight: :normal
     )
   end
 %>

--- a/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
+++ b/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Create project custom fields in sections", :js do
         expect(page).to have_link("Administration")
         expect(page).to have_link("Projects")
         expect(page).to have_link("Project attributes")
-        expect(page).to have_text("New attribute")
+        expect(page).to have_text("Integer: New attribute")
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65416

Display the custom field format within the breadcrumb navigation for both custom fields and project attributes.

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots

### Custom field
![image](https://github.com/user-attachments/assets/f93a8552-c598-4a85-9ec1-38446ce931e9)

### Project attribute
![image](https://github.com/user-attachments/assets/7e2b69fb-bae9-4e6b-8d94-d28a5f338ad2)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
