### PR TITLE
[65078] On mobile web, text blocks in widgets on the home page can be too narrow when there's an image

### DIFF
--- a/frontend/src/app/features/homescreen/blocks/new-features.component.sass
+++ b/frontend/src/app/features/homescreen/blocks/new-features.component.sass
@@ -1,3 +1,5 @@
+@import "helpers"
+
 .op-new-features
   &--teaser-image
       background-image: var(--new-feature-teaser-image)
@@ -5,3 +7,11 @@
       background-size: contain
       background-repeat: no-repeat
       background-position-x: right
+
+  @media (max-width: $breakpoint-md)
+    .widget-box--description
+      grid-template-columns: 1fr !important
+
+    .op-new-features--teaser-image
+      order: -1
+      justify-self: center


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65078

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
In the new features' widget, make the image span the whole width and move text below the image.

## Screenshots
Before:
![Screenshot 2025-07-04 at 15 24 19](https://github.com/user-attachments/assets/06f6bd59-ac93-4209-9840-8199df11d7dd)

After:
![Screenshot 2025-07-04 at 15 23 42](https://github.com/user-attachments/assets/d6633548-c158-4d68-9715-70e37adefea1)

