### PR TITLE
[#65082] Editing multiple agenda items breaks the content 

### DIFF
--- a/modules/meeting/app/forms/meeting_agenda_item/notes.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/notes.rb
@@ -38,7 +38,8 @@ class MeetingAgendaItem::Notes < ApplicationForm
       classes: "ck-editor-primer-adjusted",
       rich_text_options: {
         resource:,
-        showAttachments: false
+        showAttachments: false,
+        text_area_id: "notes-#{object.id}"
       }
     )
   end

--- a/modules/meeting/app/forms/meeting_agenda_item/outcome/notes.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/outcome/notes.rb
@@ -39,7 +39,8 @@ class MeetingAgendaItem::Outcome::Notes < ApplicationForm
       rich_text_options: {
         resource:,
         editor_type: "constrained",
-        showAttachments: false
+        showAttachments: false,
+        text_area_id: "outcome-#{object.id}"
       }
     )
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/65082

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
When a `text_area_id` is not passed as a `rich_text_option` for  a ckeditor rich text area, the text area id is auto generated based on the name of the rich text area, which for meetings is the same for all ckeditor fields of a particular type (either agenda item notes or agenda item outcomes). This is why the content of a different agenda item was being displayed when multiple editors were open at the same time.

This is fixed here by explicitly providing a unique `text_area_id`, derived from the id of the agenda item or the outcome respectively
