### PR TITLE
Use `querySelector` if we only need first `Element`

### DIFF
--- a/frontend/src/app/core/current-user/current-user.module.ts
+++ b/frontend/src/app/core/current-user/current-user.module.ts
@@ -6,7 +6,7 @@ import { CurrentUserQuery } from './current-user.query';
 import { firstValueFrom } from 'rxjs';
 
 function loadUserMetadata(currentUserService:CurrentUserService) {
-  const userMeta = document.querySelectorAll('meta[name=current_user]')[0] as HTMLElement|undefined;
+  const userMeta = document.querySelector<HTMLMetaElement>('meta[name=current_user]');
   currentUserService.setUser({
     id: userMeta?.dataset.id || null,
     name: userMeta?.dataset.name || null,

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -292,7 +292,7 @@ import { UserLinkComponent } from 'core-app/shared/components/user-link/user-lin
 import {
   WorkPackageWatcherButtonComponent,
 } from 'core-app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component';
-import { WpResizerDirective } from 'core-app/shared/components/resizer/resizer/wp-resizer.component';
+import { WpResizerComponent } from 'core-app/shared/components/resizer/resizer/wp-resizer.component';
 import {
   GroupDescriptor,
   WorkPackageSingleViewComponent,
@@ -511,7 +511,7 @@ import {
     WorkPackagesTableConfigMenuComponent,
     WorkPackageTablePaginationComponent,
 
-    WpResizerDirective,
+    WpResizerComponent,
 
     WorkPackageTableSumsRowController,
 
@@ -655,7 +655,7 @@ import {
     WorkPackageFilterContainerComponent,
     QueryFiltersComponent,
 
-    WpResizerDirective,
+    WpResizerComponent,
     WorkPackageBreadcrumbComponent,
     WorkPackageBreadcrumbParentComponent,
     WorkPackageSplitViewToolbarComponent,

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, OnDestroy } from '@angular/core';
 import { debounceTime } from 'rxjs/operators';
 import { TransitionService } from '@uirouter/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -47,7 +47,7 @@ import { fromEvent } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
-export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, AfterViewInit {
+export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
   @Input() elementClass:string;
 
   @Input() resizeEvent:string;
@@ -56,7 +56,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   @Input() variableName:string = '--split-screen-width';
 
-  private resizingElement:HTMLElement;
+  private resizingElement:HTMLElement|null;
 
   private elementWidth:number;
 
@@ -72,7 +72,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
   public resizerClass = 'work-packages--resizer icon-resizer-vertical-lines';
 
   constructor(
-    private elementRef:ElementRef,
+    private elementRef:ElementRef<HTMLElement>,
     readonly $transitions:TransitionService,
   ) {
     super();
@@ -83,7 +83,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     // We use this more complicated approach of taking the last element of the class as it allows
     // to still work in case an element is duplicated by Angular.
     const elements = document.getElementsByClassName(this.elementClass);
-    this.resizingElement = <HTMLElement>elements[elements.length - 1];
+    this.resizingElement = elements[elements.length - 1] as HTMLElement|null;
 
     if (!this.resizingElement) {
       return;
@@ -118,7 +118,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
   ngAfterViewInit():void {
     // Get the reziser
-    this.resizer = <HTMLElement> this.elementRef.nativeElement.getElementsByClassName(this.resizerClass)[0];
+    this.resizer = this.elementRef.nativeElement.getElementsByClassName(this.resizerClass)[0] as HTMLElement;
 
     this.applyColumnLayout();
   }
@@ -131,7 +131,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     // In case we dragged the resizer farther than the element can actually grow,
     // we reset it to the actual width at the start of the new resizing
     const localStorageValue = this.parseLocalStorageValue();
-    const actualElementWidth = this.resizingElement.offsetWidth;
+    const actualElementWidth = this.resizingElement?.offsetWidth || 0;
     if (localStorageValue && localStorageValue > actualElementWidth) {
       this.elementWidth = actualElementWidth;
     }
@@ -187,6 +187,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
     return undefined;
   }
+
   private applyColumnLayout(checkWidth = 750) {
     const singleView = document.querySelector<HTMLElement>("[data-selector='wp-single-view']");
     if (singleView) {

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -46,8 +46,7 @@ import { fromEvent } from 'rxjs';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
-export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
+export class WpResizerComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
   @Input() elementClass:string;
 
   @Input() resizeEvent:string;

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -188,7 +188,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     return undefined;
   }
   private applyColumnLayout(checkWidth = 750) {
-    const singleView = document.querySelectorAll("[data-selector='wp-single-view']")[0] as HTMLElement;
+    const singleView = document.querySelector<HTMLElement>("[data-selector='wp-single-view']");
     if (singleView) {
       jQuery(singleView).toggleClass('work-package--single-view_with-columns', singleView.offsetWidth > checkWidth);
     }

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -158,9 +158,9 @@ export class SpotDropModalComponent implements OnDestroy {
           window.addEventListener('resize', this.onResize);
           window.addEventListener('orientationchange', this.onResize);
 
-          const focusCatcherContainer = document.querySelectorAll("[data-modal-focus-catcher-container='true']")[0];
+          const focusCatcherContainer = document.querySelector<HTMLElement>("[data-modal-focus-catcher-container='true']");
           if (focusCatcherContainer) {
-            (findAllFocusableElementsWithin(focusCatcherContainer as HTMLElement)[0])?.focus();
+            (findAllFocusableElementsWithin(focusCatcherContainer)[0])?.focus();
           } else {
             // Index 1 because the element at index 0 is the trigger button to open the modal
             (findAllFocusableElementsWithin(document.querySelector('.spot-drop-modal-portal')!)[1])?.focus();

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -95,7 +95,7 @@ export class SpotDropModalComponent implements OnDestroy {
 
   @ViewChild('anchor') anchor:ElementRef;
 
-  @ViewChild('body') body:TemplateRef<any>;
+  @ViewChild('body') body:TemplateRef<unknown>;
 
   @ViewChild('focusGrabber') focusGrabber:ElementRef;
 


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Small code cleanup to use `document.querySelector` rather than `document.querySelectorAll` when we're only interested in the first `Element`.


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
