### PR TITLE
Fix incorrectly applied Angular class decorators

### DIFF
--- a/frontend/src/app/core/global_search/global-search-work-packages.component.ts
+++ b/frontend/src/app/core/global_search/global-search-work-packages.component.ts
@@ -67,7 +67,6 @@ import {
     </wp-embedded-table>
   `,
 })
-
 export class GlobalSearchWorkPackagesComponent extends UntilDestroyedMixin implements OnInit, OnDestroy, AfterViewInit {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   public queryProps:{ [key:string]:any };

--- a/frontend/src/app/core/global_search/tabs/global-search-tabs.component.ts
+++ b/frontend/src/app/core/global_search/tabs/global-search-tabs.component.ts
@@ -38,7 +38,6 @@ import { TabDefinition } from 'core-app/shared/components/tabs/tab.interface';
   templateUrl: '../../../shared/components/tabs/scrollable-tabs/scrollable-tabs.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 export class GlobalSearchTabsComponent extends ScrollableTabsComponent implements OnInit, OnDestroy {
   private currentTabSub:Subscription;
 

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -41,7 +41,6 @@ import { StateService } from '@uirouter/core';
   selector: 'op-refresh-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 export class RefreshButtonComponent {
   public text = {
     refresh: this.I18n.t('js.bcf.refresh'),

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -60,7 +60,6 @@ import { HalResourceService } from 'core-app/features/hal/services/hal-resource.
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./board-inline-add-autocompleter.sass'],
 })
-
 export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
   readonly text = {
     placeholder: this.I18n.t('js.relations_autocomplete.placeholder'),

--- a/frontend/src/app/features/work-packages/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -42,7 +42,6 @@ import { QueryFilterResource } from 'core-app/features/hal/resources/query-filte
   selector: 'wp-filter-by-text-input',
   templateUrl: './quick-filter-by-text-input.html',
 })
-
 export class WorkPackageFilterByTextInputComponent extends UntilDestroyedMixin {
   @Output() public deactivateFilter = new EventEmitter<QueryFilterResource>();
 

--- a/frontend/src/app/shared/components/copy-to-clipboard/copy-to-clipboard.service.ts
+++ b/frontend/src/app/shared/components/copy-to-clipboard/copy-to-clipboard.service.ts
@@ -33,7 +33,6 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 @Injectable({
   providedIn: 'root',
 })
-
 export class CopyToClipboardService {
   constructor(
     readonly toastService:ToastService,

--- a/frontend/src/app/shared/components/fields/display/field-types/excluded-icon-helper.service.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/excluded-icon-helper.service.ts
@@ -32,7 +32,6 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 import { StatusResource } from 'core-app/features/hal/resources/status-resource';
 
 @Injectable({ providedIn: 'root' })
-
 export class ExcludedIconHelperService {
   constructor(
     private apiV3Service:ApiV3Service,

--- a/frontend/src/app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service.ts
@@ -32,7 +32,6 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 @Injectable({ providedIn: 'root' })
-
 export class HierarchyQueryLinkHelperService {
   constructor(
     private pathHelper:PathHelperService,

--- a/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
+++ b/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
@@ -56,7 +56,6 @@ interface TokenNameFormValue {
   templateUrl: './query-get-ical-url.modal.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 export class QueryGetIcalUrlModalComponent extends OpModalComponent implements OnInit {
   public tokenName = '';
 

--- a/frontend/src/app/shared/components/no-results/no-results.component.ts
+++ b/frontend/src/app/shared/components/no-results/no-results.component.ts
@@ -35,7 +35,6 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   selector: 'op-no-results',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 export class NoResultsComponent {
   @Input() title:string;
 

--- a/frontend/src/app/shared/components/resizer/resizer/main-menu-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/main-menu-resizer.component.ts
@@ -58,7 +58,6 @@ import {
     </op-resizer>
   `,
 })
-
 export class MainMenuResizerComponent extends UntilDestroyedMixin implements OnInit {
   public toggleTitle:string;
 

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -46,7 +46,6 @@ import { fromEvent } from 'rxjs';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, AfterViewInit {
   @Input() elementClass:string;
 

--- a/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
+++ b/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
@@ -30,7 +30,6 @@ import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decora
   styleUrls: ['./scrollable-tabs.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 export class ScrollableTabsComponent extends UntilDestroyedMixin implements AfterViewInit, OnChanges {
   @ViewChild('scrollContainer', { static: true }) scrollContainer:ElementRef;
 

--- a/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.component.ts
@@ -31,7 +31,6 @@ import {
     WpGraphConfigurationService,
   ],
 })
-
 export class WorkPackageOverviewGraphComponent implements OnInit {
   @Input() initialFilters:any;
 

--- a/frontend/src/app/shared/components/work-packages/alternative-search.service.ts
+++ b/frontend/src/app/shared/components/work-packages/alternative-search.service.ts
@@ -3,7 +3,6 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { QueryFilterResource } from 'core-app/features/hal/resources/query-filter-resource';
 
 @Injectable({ providedIn: 'root' })
-
 export class AlternativeSearchService {
   constructor(
     readonly I18n:I18nService,


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

`@Component`, `@Injectable` and other decorators *must* be placed directly above the classes they decorate - with no blank lines.

# What approach did you choose and why?

⚠️ This fix might unintentionally break other behaviour — I can't be completely sure!

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
