### PR TITLE
[#65082] Editing multiple agenda items breaks the content

### DIFF
--- a/app/forms/settings/multi_lang_form.rb
+++ b/app/forms/settings/multi_lang_form.rb
@@ -59,7 +59,6 @@ module Settings
         disabled: setting_disabled?(name),
         visually_hide_label: true,
         rich_text_options: {
-          text_area_id: "settings-#{name}",
           turboMode: true,
           showAttachments: false
         }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2149,6 +2149,9 @@ en:
         one: "1 s"
         other: "%{count} s"
     units:
+      minute_abbreviated:
+        one: "min"
+        other: "mins"
       hour:
         one: "hour"
         other: "hours"

--- a/lib/primer/open_project/forms/rich_text_area.html.erb
+++ b/lib/primer/open_project/forms/rich_text_area.html.erb
@@ -1,8 +1,6 @@
 <%= render(FormControl.new(input: @input)) do %>
   <%= content_tag(:div, hidden: true) do %>
-    <%= builder.text_area(@input.name,
-                          id: @text_area_id,
-                          **@input.input_arguments) %>
+    <%= builder.text_area(@input.name, **@input.input_arguments) %>
   <% end %>
   <%= angular_component_tag "opce-ckeditor-augmented-textarea",
                             inputs: @rich_text_options.reverse_merge(

--- a/lib/primer/open_project/forms/rich_text_area.rb
+++ b/lib/primer/open_project/forms/rich_text_area.rb
@@ -15,7 +15,7 @@ module Primer
           @rich_text_data = rich_text_options.delete(:data) { {} }
           @rich_text_data[:"test-selector"] ||= "augmented-text-area-#{@input.name}"
           @rich_text_options = rich_text_options
-          @text_area_id = rich_text_options.delete(:text_area_id) || builder.field_id(@input.name)
+          @text_area_id = @input.id || builder.field_id(@input.name)
         end
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.html.erb
@@ -3,7 +3,8 @@
     primer_form_with(
       model: @meeting_agenda_item,
       method: @method,
-      url: @submit_path
+      url: @submit_path,
+      namespace: "form_#{wrapper_uniq_by}"
     ) do |f|
       grid_layout("op-meeting-agenda-item-form", tag: :div) do |grid|
         grid.with_area(:title) do

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -48,7 +49,7 @@ module MeetingAgendaItems
     end
 
     def wrapper_uniq_by
-      @meeting_agenda_item.id
+      @meeting_agenda_item.persisted? ? @meeting_agenda_item.id : "new"
     end
 
     def render?

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.html.erb
@@ -3,7 +3,8 @@
     primer_form_with(
       model: @meeting_outcome,
       method: @method,
-      url: @submit_path
+      url: @submit_path,
+      namespace: "form_#{wrapper_uniq_by}"
     ) do |f|
 
       flex_layout(tag: :div) do |flex|

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/form_component.rb
@@ -44,7 +44,7 @@ module MeetingAgendaItems::Outcomes
     end
 
     def wrapper_uniq_by
-      @meeting_outcome.id
+      @meeting_outcome.persisted? ? @meeting_outcome.id : "new"
     end
 
     private

--- a/modules/meeting/app/forms/meeting_agenda_item/duration.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/duration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -31,7 +32,7 @@ class MeetingAgendaItem::Duration < ApplicationForm
   form do |agenda_item_form|
     agenda_item_form.text_field(
       name: :duration_in_minutes,
-      placeholder: I18n.t("activerecord.attributes.meeting_agenda_item.duration_in_minutes"),
+      placeholder: I18n.t("datetime.units.minute_abbreviated", count: 2),
       label: MeetingAgendaItem.human_attribute_name(:duration_in_minutes),
       leading_visual: { icon: :stopwatch },
       visually_hide_label: true,

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
       meeting_agenda_item:
         title: "Title"
         author: "Author"
-        duration_in_minutes: "min"
+        duration_in_minutes: "Duration"
         description: "Notes"
         presenter: "Presenter"
       meeting_section:

--- a/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe MeetingAgendaItems::FormComponent, type: :component do
     )
   end
 
+  context "with a new agenda item" do
+    let(:meeting_agenda_item) { MeetingAgendaItem.new(meeting:, meeting_section:) }
+
+    it "renders component wrapper" do
+      expect(rendered_component).to have_element id: "meeting-agenda-items-form-component-new"
+    end
+  end
+
+  context "with an existing agenda item" do
+    it "renders component wrapper" do
+      expect(rendered_component).to have_element id: "meeting-agenda-items-form-component-#{meeting_agenda_item.id}"
+    end
+  end
+
   it "renders form" do
     expect(rendered_component).to have_element :form, method:, action: submit_path
   end

--- a/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "rails_helper"
+
+RSpec.describe MeetingAgendaItems::FormComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:meeting) { build_stubbed(:meeting) }
+  let(:meeting_section) { build_stubbed(:meeting_section, meeting:) }
+  let(:meeting_agenda_item) { build_stubbed(:meeting_agenda_item, meeting:, meeting_section:) }
+  let(:method) { :post }
+  let(:submit_path) { "/submit" }
+  let(:cancel_path) { "/cancel" }
+
+  current_user { build_stubbed(:admin) }
+
+  subject(:rendered_component) do
+    render_component(
+      meeting:, meeting_section:, meeting_agenda_item:, method:, submit_path:, cancel_path:
+    )
+  end
+
+  it "renders form" do
+    expect(rendered_component).to have_element :form, method:, action: submit_path
+  end
+
+  it "renders title field" do
+    expect(rendered_component).to have_field "Title", required: true
+  end
+
+  it "renders duration field" do
+    expect(rendered_component).to have_field "min", type: :number
+  end
+
+  it "renders presenter field" do
+    expect(rendered_component).to have_element :label, text: "Presenter" do |label|
+      expect(rendered_component).to have_element "opce-user-autocompleter",
+                                                 "data-input-name": "\"meeting_agenda_item[presenter_id]\"",
+                                                 "data-label-for-id": label["for"].to_json
+    end
+  end
+
+  it "renders notes field" do
+    expect(rendered_component).to have_field "Notes", type: :textarea, visible: :hidden do |textarea| # rubocop:disable OpenProject/NoDoEndBlockWithRSpecCapybaraMatcherInExpect
+      expect(rendered_component).to have_element "opce-ckeditor-augmented-textarea",
+                                                 "data-test-selector": "augmented-text-area-notes",
+                                                 "data-text-area-id": textarea["id"].to_json
+    end
+  end
+
+  it "renders Save button" do
+    expect(rendered_component).to have_button "Save"
+  end
+
+  it "renders Cancel button" do
+    expect(rendered_component).to have_link "Cancel", href: cancel_path
+  end
+end

--- a/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe MeetingAgendaItems::FormComponent, type: :component do
   end
 
   it "renders duration field" do
-    expect(rendered_component).to have_field "min", type: :number
+    expect(rendered_component).to have_field "Duration", type: :number, placeholder: "mins"
   end
 
   it "renders presenter field" do

--- a/modules/meeting/spec/components/meeting_agenda_items/outcomes/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/outcomes/form_component_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe MeetingAgendaItems::Outcomes::FormComponent, type: :component do
     )
   end
 
+  context "with a new outcome" do
+    let(:meeting_outcome) { MeetingOutcome.new(meeting_agenda_item:) }
+
+    it "renders component wrapper" do
+      expect(rendered_component).to have_element id: "meeting-agenda-items-outcomes-form-component-new"
+    end
+  end
+
+  context "with an existing outcome" do
+    it "renders component wrapper" do
+      expect(rendered_component).to have_element id: "meeting-agenda-items-outcomes-form-component-#{meeting_outcome.id}"
+    end
+  end
+
   it "renders form" do
     expect(rendered_component).to have_element :form, method:, action: submit_path
   end

--- a/modules/meeting/spec/components/meeting_agenda_items/outcomes/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/outcomes/form_component_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "rails_helper"
+
+RSpec.describe MeetingAgendaItems::Outcomes::FormComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:meeting) { build_stubbed(:meeting) }
+  let(:meeting_agenda_item) { build_stubbed(:meeting_agenda_item, meeting:) }
+  let(:meeting_outcome) { build_stubbed(:meeting_outcome, meeting_agenda_item:) }
+  let(:method) { :post }
+  let(:submit_path) { "/submit" }
+  let(:cancel_path) { "/cancel" }
+
+  current_user { build_stubbed(:admin) }
+
+  subject(:rendered_component) do
+    render_component(
+      meeting:, meeting_agenda_item:, meeting_outcome:, method:, submit_path:, cancel_path:
+    )
+  end
+
+  it "renders form" do
+    expect(rendered_component).to have_element :form, method:, action: submit_path
+  end
+
+  it "renders outcome field" do
+    expect(rendered_component).to have_field "Outcome", type: :textarea, visible: :hidden do |textarea| # rubocop:disable OpenProject/NoDoEndBlockWithRSpecCapybaraMatcherInExpect
+      expect(rendered_component).to have_element "opce-ckeditor-augmented-textarea",
+                                                 "data-test-selector": "augmented-text-area-notes",
+                                                 "data-text-area-id": textarea["id"].to_json
+    end
+  end
+
+  it "renders Save button" do
+    expect(rendered_component).to have_button "Save"
+  end
+
+  it "renders Cancel button" do
+    expect(rendered_component).to have_link "Cancel", href: cancel_path
+  end
+end

--- a/modules/meeting/spec/features/meetings_autofocus_spec.rb
+++ b/modules/meeting/spec/features/meetings_autofocus_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Meetings autofocus", :js do
     ## without sections
     # add item
     show_page.add_agenda_item do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_title")
 
       fill_in "Title", with: "My agenda item"
     end
@@ -92,7 +92,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # edit item
     show_page.edit_agenda_item(item) do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_#{item.id}_meeting_agenda_item_title")
 
       fill_in "Title", with: "Updated title"
       click_on "Save"
@@ -101,7 +101,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add second item
     show_page.add_agenda_item do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_title")
 
       fill_in "Title", with: "Second"
     end
@@ -134,7 +134,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add wp item
     show_page.add_agenda_item(type: WorkPackage) do
-      show_page.expect_focused_input("meeting_agenda_item_work_package_id")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_work_package_id")
 
       select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
                           query: "task",
@@ -147,7 +147,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # edit wp item
     show_page.edit_agenda_item(wp_item) do
-      show_page.expect_focused_input("meeting_agenda_item_work_package_id")
+      show_page.expect_focused_input("form_#{wp_item.id}_meeting_agenda_item_work_package_id")
       click_on "Cancel"
     end
 
@@ -185,7 +185,7 @@ RSpec.describe "Meetings autofocus", :js do
     ## inside a section
     # add item
     show_page.add_agenda_item do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_title")
 
       fill_in "Title", with: "My agenda item"
     end
@@ -205,7 +205,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # edit item
     show_page.edit_agenda_item(item) do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_#{item.id}_meeting_agenda_item_title")
 
       fill_in "Title", with: "Updated title"
       click_on "Save"
@@ -214,7 +214,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add second item
     show_page.add_agenda_item do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_title")
 
       fill_in "Title", with: "Second"
     end
@@ -247,7 +247,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add wp item
     show_page.add_agenda_item(type: WorkPackage) do
-      show_page.expect_focused_input("meeting_agenda_item_work_package_id")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_work_package_id")
 
       select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
                           query: "task",
@@ -260,7 +260,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # edit wp item
     show_page.edit_agenda_item(wp_item) do
-      show_page.expect_focused_input("meeting_agenda_item_work_package_id")
+      show_page.expect_focused_input("form_#{wp_item.id}_meeting_agenda_item_work_package_id")
       click_on "Cancel"
     end
 
@@ -279,7 +279,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add item
     show_page.add_agenda_item_to_backlog do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_title")
 
       fill_in "Title", with: "My agenda item"
     end
@@ -299,7 +299,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # edit item
     show_page.edit_agenda_item(item) do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_#{item.id}_meeting_agenda_item_title")
 
       fill_in "Title", with: "Updated title"
       click_on "Save"
@@ -308,7 +308,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add second item
     show_page.add_agenda_item_to_backlog do
-      show_page.expect_focused_input("meeting_agenda_item_title")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_title")
 
       fill_in "Title", with: "Second"
     end
@@ -317,7 +317,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # add wp item
     show_page.add_agenda_item_to_backlog(type: WorkPackage) do
-      show_page.expect_focused_input("meeting_agenda_item_work_package_id")
+      show_page.expect_focused_input("form_new_meeting_agenda_item_work_package_id")
 
       select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
                           query: "task",
@@ -330,7 +330,7 @@ RSpec.describe "Meetings autofocus", :js do
 
     # edit wp item
     show_page.edit_agenda_item(wp_item) do
-      show_page.expect_focused_input("meeting_agenda_item_work_package_id")
+      show_page.expect_focused_input("form_#{wp_item.id}_meeting_agenda_item_work_package_id")
       click_on "Cancel"
     end
 

--- a/modules/meeting/spec/features/meetings_edit_agenda_spec.rb
+++ b/modules/meeting/spec/features/meetings_edit_agenda_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+require_relative "../support/pages/meetings/show"
+
+RSpec.describe "Meetings edit agenda", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings work_package_tracking]) }
+  shared_let(:user) do
+    create :user,
+           lastname: "First",
+           preferences: { time_zone: "Etc/UTC" },
+           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings manage_agendas
+                                                    manage_outcomes view_work_packages] }
+  end
+  shared_let(:meeting) do
+    create :meeting,
+           project:,
+           author: user,
+           state: :in_progress
+  end
+
+  let(:current_user) { user }
+  let(:show_page) { Pages::Meetings::Show.new(meeting) }
+
+  before do
+    login_as current_user
+    show_page.visit!
+  end
+
+  it "allows simultaneous editing of multiple agenda items (OP#65082)" do
+    show_page.add_agenda_item do
+      fill_in "Title", with: "Agenda Item #1"
+      fill_in_rich_text "Notes", with: "Preliminary notes ✅"
+    end
+
+    show_page.expect_agenda_item title: "Agenda Item #1"
+    show_page.expect_notes "Preliminary notes ✅"
+
+    first_item = MeetingAgendaItem.find_by(title: "Agenda Item #1")
+
+    show_page.add_agenda_item do
+      fill_in "Title", with: "Agenda Item #2"
+      fill_in_rich_text "Notes", with: "More notes..."
+    end
+
+    show_page.expect_agenda_item title: "Agenda Item #2"
+    show_page.expect_notes "More notes..."
+
+    second_item = MeetingAgendaItem.find_by(title: "Agenda Item #2")
+
+    show_page.edit_agenda_item(first_item) do
+      expect(show_page).to have_selector :rich_text, "Notes", text: "Preliminary notes ✅"
+    end
+
+    show_page.edit_agenda_item(second_item) do
+      expect(show_page).to have_selector :rich_text, "Notes", text: "More notes..."
+    end
+  end
+end

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "history",
 
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "min", with: "25"
+      fill_in "Duration", with: "25"
     end
 
     show_page.expect_agenda_item(title: "My agenda item")
@@ -157,7 +157,7 @@ RSpec.describe "history",
     item = MeetingAgendaItem.find_by(title: "My agenda item")
     show_page.edit_agenda_item(item) do
       fill_in "Title", with: "Updated title"
-      fill_in "min", with: "5"
+      fill_in "Duration", with: "5"
       click_on "Save"
     end
 

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Meetings CRUD",
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "min", with: "25"
+      fill_in "Duration", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -181,7 +181,7 @@ RSpec.describe "Meetings CRUD",
 
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "min", with: "25"
+      fill_in "Duration", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -268,7 +268,7 @@ RSpec.describe "Meetings CRUD",
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "min", with: "25"
+      fill_in "Duration", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -290,7 +290,7 @@ RSpec.describe "Meetings CRUD",
 
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
-      fill_in "min", with: "25"
+      fill_in "Duration", with: "25"
     end
 
     show_page.expect_agenda_item title: "My agenda item"
@@ -468,7 +468,7 @@ RSpec.describe "Meetings CRUD",
         # add an item to the latest section
         show_page.add_agenda_item do
           fill_in "Title", with: "First item"
-          fill_in "min", with: "25"
+          fill_in "Duration", with: "25"
         end
 
         show_page.expect_agenda_item_in_section title: "First item", section: second_section
@@ -479,7 +479,7 @@ RSpec.describe "Meetings CRUD",
         item_in_second_section = MeetingAgendaItem.find_by!(title: "First item")
 
         show_page.edit_agenda_item(item_in_second_section) do
-          fill_in "min", with: "15"
+          fill_in "Duration", with: "15"
           click_on "Save"
         end
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -153,7 +153,7 @@ module Pages::Meetings
     end
 
     def in_agenda_form(&)
-      page.within("#meeting-agenda-items-form-component", &)
+      page.within("#meeting-agenda-items-form-component-new", &)
     end
 
     def assert_agenda_order!(*titles)

--- a/spec/lib/primer/open_project/forms/rich_text_area_spec.rb
+++ b/spec/lib/primer/open_project/forms/rich_text_area_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "spec_helper"
+
+RSpec.describe Primer::OpenProject::Forms::RichTextArea, type: :forms do
+  include ViewComponent::TestHelpers
+
+  let(:params) { { rich_text_options: {} } }
+  let(:model) { build_stubbed(:comment) }
+
+  def render_form
+    render_in_view_context(model, namespace, params) do |model, namespace, params|
+      primer_form_with(url: "/foo", model:, namespace:) do |f|
+        render_inline_form(f) do |test_form|
+          test_form.rich_text_area(name: :ultimate_answer, label: "Ultimate answer", **params)
+        end
+      end
+    end
+  end
+
+  subject(:rendered_form) do
+    render_form
+    page
+  end
+
+  shared_examples_for "successful render" do |text_area_id:|
+    it "renders the label" do
+      expect(rendered_form).to have_element :label, for: text_area_id
+    end
+
+    it "renders the hidden textarea" do
+      expect(rendered_form).to have_field text_area_id, type: "textarea", visible: :hidden
+    end
+
+    it "renders the rich text area" do
+      expect(rendered_form).to have_element "opce-ckeditor-augmented-textarea",
+                                            "data-text-area-id": text_area_id.to_json
+    end
+  end
+
+  context "without form namespace" do
+    let(:namespace) { nil }
+
+    context "with default field id" do
+      it_behaves_like "successful render", text_area_id: "comment_ultimate_answer"
+    end
+
+    context "with explicit field id" do
+      let(:params) { { id: "explicit_id", rich_text_options: {} } }
+
+      it_behaves_like "successful render", text_area_id: "explicit_id"
+    end
+  end
+
+  context "with form namespace" do
+    let(:namespace) { "super_form" }
+
+    context "with default field id" do
+      it_behaves_like "successful render", text_area_id: "super_form_comment_ultimate_answer"
+    end
+
+    context "with explicit field id" do
+      let(:params) { { id: "explicit_id", rich_text_options: {} } }
+
+      it "renders the label" do
+        expect(rendered_form).to have_element :label, for: "explicit_id"
+      end
+
+      it "renders the hidden textarea" do
+        pending "Primer Forms does not handle ids consistently when a form namespace is set."
+
+        expect(rendered_form).to have_field "explicit_id", type: "textarea", visible: :hidden
+      end
+
+      it "renders the rich text area" do
+        expect(rendered_form).to have_element "opce-ckeditor-augmented-textarea",
+                                              "data-text-area-id": "explicit_id".to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/65082

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

The explanation for this bug was detailed by @mrmir in #19425:

> When a `text_area_id` is not passed as a `rich_text_option` for a ckeditor rich text area, the text area id is auto generated based on the name of the rich text area, which for meetings is the same for all ckeditor fields of a particular type (either agenda item notes or agenda item outcomes). This is why the content of a different agenda item was being displayed when multiple editors were open at the same time.

While the diagnosis is correct, this PR takes a slightly different approach:

- rather than passing a `text_area_id` to each `rich_text_area` control, we pass the [`namespace:` option on `(primer_)form_with`](https://api.rubyonrails.org/v8.0.2/classes/ActionView/Helpers/FormHelper.html#method-i-form_with) to ensure generated ids are unique to the page.
- we fix `RichTextArea` to play well with namespacing (N.B. there is an issue where *both* a namespace is specified on the form and an explicit `id` argument is passed to the control - this appears to be a bug in upstream Primer).

I've added some component specs as well as a feature spec to test for regressions, as it appears spec coverage isn't great for this part of the codebase.

### What this PR doesn't do:

* Generated test selectors are often not unique - somehow our feature specs don't seem to be too adversely affected, but this is widespread. I was almost tempted to fix this for `RichTextArea`, but it is a rabbit hole I didn't want to go down today.
* It looks like its not possible to create multiple agenda items simultaneously in the meeting backlog. I don't know if this is by design or not (I may create a BUG to track). If we were to allow multiple new agenda items then would still face an issue with namespacing as `MeetingAgendaItem#wrapper_unique_by` (which is passed as `namespace:` option to `form_with`) will always return `new` for unpersisted records. I have a few ideas about how to solve this, but for now YAGNI.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
