### PR TITLE
[65546] Sidebar button floats on medium breakpoints

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -149,15 +149,18 @@ See COPYRIGHT and LICENSE files for more details.
       <%= content_tag :div,
                       id: "content",
                       class: "#{initial_classes} #{'content--split' if content_for?(:content_body_right)}" do %>
-        <%= render(OpenProject::Common::MainMenuToggleComponent.new(expanded: false)) %>
         <h1 class="hidden-for-sighted accessibility-helper"><%= t(:label_content) %></h1>
         <% if content_for?(:content_header) %>
           <div id="content-header">
+            <%= render(OpenProject::Common::MainMenuToggleComponent.new(expanded: false)) %>
+
             <%= content_for :content_header %>
           </div>
         <% end %>
 
         <div id="content-body">
+          <%= render(OpenProject::Common::MainMenuToggleComponent.new(expanded: false)) unless content_for?(:content_header) %>
+
           <%= content_for :content_body %>
           <% unless local_assigns[:no_layout_yield] %>
             <%= yield %>

--- a/frontend/src/global_styles/common/header/app-header.sass
+++ b/frontend/src/global_styles/common/header/app-header.sass
@@ -39,7 +39,7 @@
   &--start
     grid-area: start
     justify-content: flex-start
-    padding-left: var(--main-menu-x-spacing)
+    padding-left: 4px
 
   &--center
     grid-area: center

--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -120,6 +120,7 @@ $left-side-min-width: 300px
 
 #content-body
   grid-area: body
+  position: relative
   padding-bottom: $bottom-space
   padding-right: $right-space
   padding-left: $left-space

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -52,6 +52,9 @@
     padding-left: 15px
     padding-right: 15px
 
+  #content-body
+    position: static
+
   .hidden-for-mobile
     display: none !important
 


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/65546

# What are you trying to accomplish?
Avoid that the menu button floats in the middle of nowhere and align it with the top bar waffle icon

# What approach did you choose and why?
* In order to get the button scroll with the content, it needs to be part of the scrollable container. There is however the exception for those pages that already use the `content_header` slot, where the button of course needs to be in the div of the header.
