### PR TITLE
[65260] 'Auto hide success message' menu item is missing caption

### DIFF
--- a/app/forms/my/alerts_form.rb
+++ b/app/forms/my/alerts_form.rb
@@ -34,7 +34,8 @@ class My::AlertsForm < ApplicationForm
                 label: I18n.t("activerecord.attributes.user_preference.warn_on_leaving_unsaved")
 
     f.check_box name: :auto_hide_popups,
-                label: I18n.t("activerecord.attributes.user_preference.auto_hide_popups")
+                label: I18n.t("activerecord.attributes.user_preference.auto_hide_popups"),
+                caption: I18n.t("activerecord.attributes.user_preference.auto_hide_popups_caption")
 
     f.submit(name: :submit, label: I18n.t("activerecord.attributes.user_preference.button_update_alerts"), scheme: :default)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1246,7 +1246,8 @@ en:
           You can choose to disable default <a href="%{href}">keyboard shortcuts</a> if you use a screen  reader or want to avoid accidentally triggering an action with a  shortcut.
         dismissed_enterprise_banners: "Hidden enterprise banners"
         impaired: "Accessibility mode"
-        auto_hide_popups: "Auto-hide success notifications"
+        auto_hide_popups: "Automatically hide success banners"
+        auto_hide_popups_caption: "When enabled, the green success banners will automatically disappear after 5 seconds."
         warn_on_leaving_unsaved: "Warn me when leaving a work package with unsaved changes"
         theme: "Colour mode"
         time_zone: "Time zone"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65260

# What are you trying to accomplish?
Add caption for auto hiding success messages setting

