### PR TITLE
Handle beforeunload for turbo in a separate controller

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -305,7 +305,7 @@ module ApplicationHelper
 
   def body_data_attributes(local_assigns)
     {
-      controller: "application hover-card-trigger",
+      controller: "application hover-card-trigger beforeunload",
       relative_url_root: root_path,
       overflowing_identifier: ".__overflowing_body",
       rendered_at: Time.zone.now.iso8601,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -756,6 +756,7 @@ en:
           last_day: "Last day"
 
     text_are_you_sure: "Are you sure?"
+    text_are_you_sure_to_cancel: "You have unsaved changes on this page. Are you sure you want to discard them?"
     breadcrumb: "Breadcrumb"
     text_data_lost: "All entered data will be lost."
     text_user_wrote: "%{value} wrote:"

--- a/frontend/src/app/core/setup/globals/global-listeners.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners.ts
@@ -96,24 +96,6 @@ export function initializeGlobalListeners():void {
       }
     }
   }
-
-  // Global submitting hook,
-  // necessary to avoid a data loss warning on beforeunload
-  jQuery(document).on('submit', 'form', () => {
-    window.OpenProject.pageIsSubmitted = true;
-  });
-
-  // Global beforeunload hook
-  jQuery(window).on('beforeunload', (e:JQuery.TriggeredEvent) => {
-    const event = e.originalEvent as BeforeUnloadEvent;
-    if (window.OpenProject.pageWasEdited && !window.OpenProject.pageIsSubmitted) {
-      // Cancel the event
-      event.preventDefault();
-      // Chrome requires returnValue to be set
-      event.returnValue = I18n.t('js.work_packages.confirm_edit_cancel');
-    }
-  });
-
   // Disable global drag & drop handling, which results in the browser loading the image and losing the page
   jQuery(document.documentElement)
     .on('dragover drop', (evt:Event) => {

--- a/frontend/src/app/core/setup/globals/openproject.ts
+++ b/frontend/src/app/core/setup/globals/openproject.ts
@@ -31,6 +31,8 @@ import { input, InputState } from '@openproject/reactivestates';
 import { getMetaElement, GlobalHelpers } from 'core-app/core/setup/globals/global-helpers';
 import { firstValueFrom } from 'rxjs';
 
+export type OpenProjectPageState = 'pristine'|'edited'|'submitted';
+
 /**
  * OpenProject instance methods
  */
@@ -38,6 +40,17 @@ export class OpenProject {
   public pluginContext:InputState<OpenProjectPluginContext> = input<OpenProjectPluginContext>();
 
   public helpers = new GlobalHelpers();
+
+  /** Globally setable variable whether the page was edited or submitted */
+  pageState:OpenProjectPageState = 'pristine';
+
+  public get pageWasEdited():boolean {
+    return this.pageState === 'edited';
+  }
+
+  public get pageWasSubmitted():boolean {
+    return this.pageState === 'submitted';
+  }
 
   /** Globally setable variable whether any of the EditFormComponent
    * contain changes.

--- a/frontend/src/app/core/setup/globals/openproject.ts
+++ b/frontend/src/app/core/setup/globals/openproject.ts
@@ -39,13 +39,6 @@ export class OpenProject {
 
   public helpers = new GlobalHelpers();
 
-  /** Globally setable variable whether the page was edited */
-  public pageWasEdited = false;
-
-  /** Globally setable variable whether the page form is submitted.
-   * Necessary to avoid a data loss warning on beforeunload */
-  public pageIsSubmitted = false;
-
   /** Globally setable variable whether any of the EditFormComponent
    * contain changes.
    * Necessary to show a data loss warning on beforeunload when clicking

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -59,6 +59,7 @@ import { AttachmentCollectionResource } from 'core-app/features/hal/resources/at
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { navigator } from '@hotwired/turbo';
 import { uniqueId } from 'lodash';
+import { setPageWasEdited, setPageWasSubmitted } from '../../../../../../stimulus/controllers/beforeunload.controller';
 
 @Component({
   templateUrl: './ckeditor-augmented-textarea.html',
@@ -191,7 +192,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     CkeditorAugmentedTextareaComponent.inFlight.set(this.formElement, true);
 
     this.syncToTextarea();
-    window.OpenProject.pageIsSubmitted = true;
+    setPageWasSubmitted();
 
     setTimeout(() => {
       if (evt?.submitter) {
@@ -232,7 +233,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public syncToTextarea() {
-    window.OpenProject.pageWasEdited = true;
+    setPageWasEdited();
 
     try {
       this.wrappedTextArea.value = this.ckEditorInstance.getTransformedContent(true);

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -59,7 +59,6 @@ import { AttachmentCollectionResource } from 'core-app/features/hal/resources/at
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { navigator } from '@hotwired/turbo';
 import { uniqueId } from 'lodash';
-import { setPageWasEdited, setPageWasSubmitted } from '../../../../../../stimulus/controllers/beforeunload.controller';
 
 @Component({
   templateUrl: './ckeditor-augmented-textarea.html',
@@ -192,7 +191,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     CkeditorAugmentedTextareaComponent.inFlight.set(this.formElement, true);
 
     this.syncToTextarea();
-    setPageWasSubmitted();
+    window.OpenProject.pageState = 'submitted';
 
     setTimeout(() => {
       if (evt?.submitter) {
@@ -233,7 +232,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public syncToTextarea() {
-    setPageWasEdited();
+    window.OpenProject.pageState = 'edited';
 
     try {
       this.wrappedTextArea.value = this.ckEditorInstance.getTransformedContent(true);

--- a/frontend/src/stimulus/controllers/beforeunload.controller.ts
+++ b/frontend/src/stimulus/controllers/beforeunload.controller.ts
@@ -12,6 +12,8 @@ export class BeforeunloadController extends ApplicationController {
     window.addEventListener('beforeunload', this, { signal });
     document.addEventListener('turbo:before-visit', this, { signal });
     document.addEventListener('turbo:submit-end', this, { signal });
+    document.addEventListener('turbo:load', this, { signal });
+    document.addEventListener('turbo:render', this, { signal });
     document.addEventListener('submit', this, { signal });
   }
 
@@ -26,6 +28,8 @@ export class BeforeunloadController extends ApplicationController {
         this.beforeunloadHandler(evt as BeforeUnloadEvent|TurboBeforeVisitEvent);
         break;
       case 'turbo:submit-end':
+      case 'turbo:load':
+      case 'turbo:render':
         window.OpenProject.pageState = 'pristine';
         break;
       case 'submit':

--- a/frontend/src/stimulus/controllers/beforeunload.controller.ts
+++ b/frontend/src/stimulus/controllers/beforeunload.controller.ts
@@ -1,61 +1,43 @@
 import { ApplicationController } from 'stimulus-use';
 import { TurboBeforeVisitEvent } from '@hotwired/turbo';
 
-export function setPageWasEdited() {
-  const application = window.Stimulus;
-  const controller = application.getControllerForElementAndIdentifier(document.body, 'beforeunload') as BeforeunloadController;
-  if (controller) {
-    controller.pageWasEdited = true;
-  }
-}
-
-export function setPageWasSubmitted() {
-  const application = window.Stimulus;
-  const controller = application.getControllerForElementAndIdentifier(document.body, 'beforeunload') as BeforeunloadController;
-  if (controller) {
-    controller.pageWasEdited = true;
-  }
-}
-
 export class BeforeunloadController extends ApplicationController {
-  /** Globally setable variable whether the page was edited */
-  public pageWasEdited = false;
-
-  /** Globally setable variable whether the page form is submitted.
-   * Necessary to avoid a data loss warning on beforeunload */
-  public pageIsSubmitted = false;
-
-  private boundBeforeUnloadHandler = this.beforeunloadHandler.bind(this);
-
-  private submitHandler = () => {
-    this.pageIsSubmitted = true;
-  };
-
-  private turboHandler = () => {
-    this.pageWasEdited = false;
-    this.pageIsSubmitted = false;
-  };
+  private abortController = new AbortController();
 
   connect() {
     super.connect();
 
-    window.addEventListener('beforeunload', this.boundBeforeUnloadHandler);
-    document.addEventListener('turbo:before-visit', this.boundBeforeUnloadHandler);
-    document.addEventListener('turbo:submit-end', this.turboHandler);
-    document.addEventListener('submit', this.submitHandler);
+    const { signal } = this.abortController;
+
+    window.addEventListener('beforeunload', this, { signal });
+    document.addEventListener('turbo:before-visit', this, { signal });
+    document.addEventListener('turbo:submit-end', this, { signal });
+    document.addEventListener('submit', this, { signal });
   }
 
   disconnect() {
-    window.removeEventListener('beforeunload', this.boundBeforeUnloadHandler);
-    document.removeEventListener('turbo:before-visit', this.boundBeforeUnloadHandler);
-    document.removeEventListener('turbo:submit-end', this.turboHandler);
-    document.removeEventListener('submit', this.submitHandler);
+    this.abortController.abort();
+  }
+
+  handleEvent(evt:BeforeUnloadEvent|TurboBeforeVisitEvent|CustomEvent) {
+    switch (evt.type) {
+      case 'beforeunload':
+      case 'turbo:before-visit':
+        this.beforeunloadHandler(evt as BeforeUnloadEvent|TurboBeforeVisitEvent);
+        break;
+      case 'turbo:submit-end':
+        window.OpenProject.pageState = 'pristine';
+        break;
+      case 'submit':
+        window.OpenProject.pageState = 'submitted';
+        break;
+      default:
+        break;
+    }
   }
 
   private beforeunloadHandler(evt:BeforeUnloadEvent|TurboBeforeVisitEvent) {
-    const { pageWasEdited, pageIsSubmitted } = this;
-
-    if (!pageWasEdited || pageIsSubmitted) {
+    if (window.OpenProject.pageState !== 'edited') {
       return;
     }
 

--- a/frontend/src/stimulus/controllers/beforeunload.controller.ts
+++ b/frontend/src/stimulus/controllers/beforeunload.controller.ts
@@ -46,7 +46,7 @@ export class BeforeunloadController extends ApplicationController {
     }
 
     // eslint-disable-next-line no-alert
-    if (window.confirm(I18n.t('js.work_packages.confirm_edit_cancel'))) {
+    if (window.confirm(I18n.t('js.text_are_you_sure_to_cancel'))) {
       return;
     }
 

--- a/frontend/src/stimulus/controllers/beforeunload.controller.ts
+++ b/frontend/src/stimulus/controllers/beforeunload.controller.ts
@@ -1,0 +1,75 @@
+import { ApplicationController } from 'stimulus-use';
+import { TurboBeforeVisitEvent } from '@hotwired/turbo';
+
+export function setPageWasEdited() {
+  const application = window.Stimulus;
+  const controller = application.getControllerForElementAndIdentifier(document.body, 'beforeunload') as BeforeunloadController;
+  if (controller) {
+    controller.pageWasEdited = true;
+  }
+}
+
+export function setPageWasSubmitted() {
+  const application = window.Stimulus;
+  const controller = application.getControllerForElementAndIdentifier(document.body, 'beforeunload') as BeforeunloadController;
+  if (controller) {
+    controller.pageWasEdited = true;
+  }
+}
+
+export class BeforeunloadController extends ApplicationController {
+  /** Globally setable variable whether the page was edited */
+  public pageWasEdited = false;
+
+  /** Globally setable variable whether the page form is submitted.
+   * Necessary to avoid a data loss warning on beforeunload */
+  public pageIsSubmitted = false;
+
+  private boundBeforeUnloadHandler = this.beforeunloadHandler.bind(this);
+
+  private submitHandler = () => {
+    this.pageIsSubmitted = true;
+  };
+
+  private turboHandler = () => {
+    this.pageWasEdited = false;
+    this.pageIsSubmitted = false;
+  };
+
+  connect() {
+    super.connect();
+
+    window.addEventListener('beforeunload', this.boundBeforeUnloadHandler);
+    document.addEventListener('turbo:before-visit', this.boundBeforeUnloadHandler);
+    document.addEventListener('turbo:submit-end', this.turboHandler);
+    document.addEventListener('submit', this.submitHandler);
+  }
+
+  disconnect() {
+    window.removeEventListener('beforeunload', this.boundBeforeUnloadHandler);
+    document.removeEventListener('turbo:before-visit', this.boundBeforeUnloadHandler);
+    document.removeEventListener('turbo:submit-end', this.turboHandler);
+    document.removeEventListener('submit', this.submitHandler);
+  }
+
+  private beforeunloadHandler(evt:BeforeUnloadEvent|TurboBeforeVisitEvent) {
+    const { pageWasEdited, pageIsSubmitted } = this;
+
+    if (!pageWasEdited || pageIsSubmitted) {
+      return;
+    }
+
+    // eslint-disable-next-line no-alert
+    if (window.confirm(I18n.t('js.work_packages.confirm_edit_cancel'))) {
+      return;
+    }
+
+    // Cancel the event
+    evt.preventDefault();
+
+    // Chrome requires returnValue to be set
+    if (evt.type === 'beforeunload') {
+      evt.returnValue = '';
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/meetings/check-unsaved.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/check-unsaved.controller.ts
@@ -81,7 +81,7 @@ export default class extends ApplicationController {
     const textInputs = Array.from(document.querySelectorAll('input[type="text"], input[type="number"]'));
     const allTextSaved = textInputs.every((input) => (input as HTMLInputElement).value.trim().length === 0);
 
-    return !allTextSaved || this.beforeUnloadController.pageWasEdited;
+    return !allTextSaved || window.OpenProject.pageWasEdited;
   }
 
   private beforeUnloadHandler(event:BeforeUnloadEvent):void {

--- a/frontend/src/stimulus/controllers/dynamic/meetings/check-unsaved.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/check-unsaved.controller.ts
@@ -30,9 +30,11 @@
 
 import { ApplicationController, useMeta } from 'stimulus-use';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
+import { BeforeunloadController } from '../../beforeunload.controller';
 
 export default class extends ApplicationController {
   private turboRequests:TurboRequestsService;
+  private beforeUnloadController:BeforeunloadController;
   private boundBeforeUnloadHandler = this.beforeUnloadHandler.bind(this);
 
   static values = { unsavedChangesConfirmationMessage: String };
@@ -50,6 +52,7 @@ export default class extends ApplicationController {
 
     const context = await window.OpenProject.getPluginContext();
     this.turboRequests = context.services.turboRequests;
+    this.beforeUnloadController = this.application.getControllerForElementAndIdentifier(document.body, 'beforeunload') as BeforeunloadController;
   }
 
   disconnect():void {
@@ -78,7 +81,7 @@ export default class extends ApplicationController {
     const textInputs = Array.from(document.querySelectorAll('input[type="text"], input[type="number"]'));
     const allTextSaved = textInputs.every((input) => (input as HTMLInputElement).value.trim().length === 0);
 
-    return !allTextSaved || window.OpenProject.pageWasEdited;
+    return !allTextSaved || this.beforeUnloadController.pageWasEdited;
   }
 
   private beforeUnloadHandler(event:BeforeUnloadEvent):void {

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -23,6 +23,7 @@ import CkeditorFocusController from './controllers/ckeditor-focus.controller';
 import AutoSubmit from '@stimulus-components/auto-submit';
 import { OpenProjectStimulusApplication } from 'core-stimulus/openproject-stimulus-application';
 import { Application } from '@hotwired/stimulus';
+import { BeforeunloadController } from './controllers/beforeunload.controller';
 
 declare global {
   interface Window {
@@ -51,6 +52,8 @@ OpenProjectStimulusApplication.preregister('pattern-input', PatternInputControll
 OpenProjectStimulusApplication.preregister('scroll-into-view', ScrollIntoViewController);
 OpenProjectStimulusApplication.preregister('ckeditor-focus', CkeditorFocusController);
 OpenProjectStimulusApplication.preregister('auto-submit', AutoSubmit);
+OpenProjectStimulusApplication.preregister('beforeunload', BeforeunloadController);
+
 
 const instance = OpenProjectStimulusApplication.start();
 window.Stimulus = instance;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/65563/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When navigating between pages using plain requests, a global listener exists in OpenProject that listens to beforeunload events. This event is never fired for turbo requests however.

This PR introduces a separate controller to handle those cases, all while encapsulating the previous global variables for that purpose. 

While doing that, I noticed that the pageIsSubmitted variable was never reset. In a turbo-stream enabled request, it needs to be unset after form-submit