### PR TITLE
[#64106] Lose track of meeting item and switch to template editing when adding a meeting section  

### DIFF
--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -150,7 +150,7 @@ module Meetings
           render_agenda_item_form_in_section_via_turbo_stream(meeting:, meeting_section:, type:, collapsed:)
         end
 
-        update_new_button_via_turbo_stream(disabled: true)
+        update_new_button_via_turbo_stream(disabled: true) unless meeting_section == meeting.backlog
       end
 
       def render_agenda_item_form_for_empty_meeting_via_turbo_stream(type: :simple)

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -67,13 +67,11 @@ class MeetingAgendaItemsController < ApplicationController
           collapsed = false
         end
         update_section_via_turbo_stream(form_hidden: true, meeting_section:, collapsed:)
-      else
-        update_new_button_via_turbo_stream(disabled: false, meeting_section:)
       end
     end
 
     update_new_component_via_turbo_stream(hidden: true, meeting_section:)
-    update_new_button_via_turbo_stream(disabled: false)
+    update_new_button_via_turbo_stream(disabled: false) unless meeting_section&.backlog?
 
     respond_with_turbo_streams
   end
@@ -93,7 +91,6 @@ class MeetingAgendaItemsController < ApplicationController
     if call.success?
       if @meeting_agenda_item.meeting_section.backlog?
         update_section_via_turbo_stream(meeting_section: @meeting_agenda_item.meeting_section, collapsed: false)
-        update_new_button_via_turbo_stream(disabled: false)
       else
         reset_meeting_from_agenda_item
         # enable continue editing


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/64106

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
The bug is caused because the `update_new_button_via_turbo_stream` method, when triggered from a series backlog agenda item, has no context about the actual meeting occurrence. On triggering this method, the new button is updated, but for the backlog's meeting instead, ie, the template. This is why the page loads some template elements on further actions such as attempting to create a new section or agenda item.

While we deal with a similar problem when moving agenda items via the `add-params` stimulus controller, it is easier to simply prevent toggling of the new button when adding agenda items to the backlog, which is what this PR does.

This allows two new agenda item forms to be open simultaneously (one in the regular meeting + one in the backlog), but I don't see why this as a problem, especially since concurrent editing of agenda items is allowed already and results in the same situation with multiple ckeditors open at the same time.