### PR TITLE
[65566] SCIM boxtable title and content are misaligned

### DIFF
--- a/app/components/op_primer/border_box_table_component.rb
+++ b/app/components/op_primer/border_box_table_component.rb
@@ -89,6 +89,7 @@ module OpPrimer
     def header_classes(column)
       classes = [heading_class]
       classes << "op-border-box-grid--main-column" if main_column?(column)
+      classes << "op-border-box-grid--heading-action" if column == :actions
 
       classes.join(" ")
     end

--- a/app/components/op_primer/border_box_table_component.sass
+++ b/app/components/op_primer/border_box_table_component.sass
@@ -6,7 +6,9 @@
   &--row-item
     word-break: break-word
 
-  &--row-action
+  &--row-action,
+  &--heading-action
+    display: flex
     align-items: center
     justify-content: flex-end
 
@@ -25,11 +27,6 @@
 
       &:not(:last-child)
         padding-right: 6px
-
-      &:last-child
-        justify-content: flex-end !important
-        display: flex !important
-        flex-direction: row !important
 
     &--mobile-heading,
     &--row-label


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65566

# What are you trying to accomplish?
Only align to the right side, when the column is an action column instead of  per default the last column

<img width="1922" alt="Bildschirmfoto 2025-07-08 um 09 04 33" src="https://github.com/user-attachments/assets/93260c6e-d46d-4208-89a9-a04e063bfd7f" />

<img width="1930" alt="Bildschirmfoto 2025-07-08 um 09 04 40" src="https://github.com/user-attachments/assets/fd5682be-7ea7-4182-a342-04a1cc14ddf1" />

<img width="924" alt="Bildschirmfoto 2025-07-08 um 09 04 51" src="https://github.com/user-attachments/assets/2f257793-f6b9-448f-a2a0-2f7abdfa59e9" />
