### PR TITLE
[65131 ]Allow multi-value User Custom Field Actions to handle multiple users

### DIFF
--- a/app/services/custom_actions/update_work_package_service.rb
+++ b/app/services/custom_actions/update_work_package_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -68,7 +70,6 @@ class CustomActions::UpdateWorkPackageService
 
     if new_actions.any? && actions.length != new_actions.length
       work_package.restore_attributes(work_package.changes.keys - changes_before.keys)
-
       apply_actions(work_package, new_actions)
     end
   end

--- a/spec/models/custom_actions/actions/strategies/user_custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/strategies/user_custom_field_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+#-- copyright
+#++
+
+require "spec_helper"
+
+module CustomActions
+  module Actions
+    module Strategies
+      RSpec.describe UserCustomField do
+        shared_let(:role) do
+          create(:project_role, permissions: %i[view_work_packages view_projects edit_work_packages])
+        end
+        shared_let(:user_cf) { create(:user_wp_custom_field) }
+        shared_let(:multi_user_cf) { create(:multi_user_wp_custom_field) }
+        shared_let(:users) { create_list(:user, 5) }
+        shared_let(:single_user_project) do
+          create(:project, members: [[users[0], role]]).tap do |project|
+            [user_cf, multi_user_cf].each do |cf|
+              project.types.each { it.custom_fields << cf }
+              project.work_package_custom_fields << cf
+            end
+          end
+        end
+        shared_let(:multi_user_project) do
+          create(:project, members: users[0..3].map { [it, role] }).tap do |project|
+            [user_cf, multi_user_cf].each do |cf|
+              project.work_package_custom_fields << cf
+            end
+          end
+        end
+
+        let(:user_cf_action) { CustomActions::Actions::CustomField.for("custom_field_#{user_cf.id}").new }
+        let(:multi_user_cf_action) { CustomActions::Actions::CustomField.for("custom_field_#{multi_user_cf.id}").new }
+        let(:single_user_work_package) { create(:work_package, project: single_user_project) }
+        let(:multi_user_work_package) { create(:work_package, project: multi_user_project) }
+
+        let(:custom_action) do
+          create(:custom_action,
+                 type_conditions: [single_user_work_package.type],
+                 project_conditions: [single_user_project],
+                 actions: [user_cf_action, multi_user_cf_action])
+        end
+
+        let(:user) { users[0] }
+
+        context "when no users can be assigned to the single value custom field" do
+          before do
+            user_cf_action.values = users[4].id
+            multi_user_cf_action.values = users[1..3].map(&:id)
+            custom_action.save
+          end
+
+          it "fails with an error" do
+            login_as user
+            result = UpdateWorkPackageService.new(user:, action: custom_action)
+                                             .call(work_package: single_user_work_package)
+
+            expect(result).to be_failure
+            expect(result.errors.size).to eq(1)
+
+            updated = result.result.reload
+            expect(updated.send("custom_field_#{multi_user_cf.id}")).to eq([nil])
+            expect(updated.send("custom_field_#{user_cf.id}")).to be_nil
+          end
+        end
+
+        context "when at least one user can be assigned to custom field" do
+          before do
+            user_cf_action.values = user.id
+            multi_user_cf_action.values = users[0..3].map(&:id)
+            custom_action.save
+            login_as user
+          end
+
+          it "succeeds" do
+            result = UpdateWorkPackageService.new(user:, action: custom_action).call(work_package: single_user_work_package)
+            expect(result).to be_success
+
+            multi_user_result = UpdateWorkPackageService.new(user:, action: custom_action)
+                                                        .call(work_package: multi_user_work_package)
+
+            expect(multi_user_result).to be_success
+          end
+
+          it "saves the custom field values on the work package" do
+            result = UpdateWorkPackageService.new(user:, action: custom_action)
+                                             .call(work_package: single_user_work_package)
+
+            updated = result.result.reload
+            expect(updated.send("custom_field_#{user_cf.id}")).to eq(user)
+            expect(updated.send("custom_field_#{multi_user_cf.id}")).to eq([user])
+
+            muti_user_result = UpdateWorkPackageService.new(user:, action: custom_action)
+                                             .call(work_package: multi_user_work_package)
+
+            updated = muti_user_result.result.reload
+            expect(updated.send("custom_field_#{user_cf.id}")).to eq(user)
+            expect(updated.send("custom_field_#{multi_user_cf.id}")).to eq(users[0..3])
+          end
+        end
+
+        describe "handling of the 'me' values" do
+          before do
+            user_cf_action.values = "current_user"
+            multi_user_cf_action.values = ["current_user"] + users[1..3].map(&:id)
+            custom_action.save
+            login_as user
+          end
+
+          it "assigns the current user to the custom field" do
+            result = UpdateWorkPackageService.new(user:, action: custom_action)
+                                             .call(work_package: single_user_work_package)
+
+            updated = result.result.reload
+            expect(updated.send("custom_field_#{user_cf.id}")).to eq(user)
+            expect(updated.send("custom_field_#{multi_user_cf.id}")).to eq([user])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related Work Package: [OP#65131](https://community.openproject.org/projects/openproject/work_packages/65131)

First, single value fields behaviour is unchanged.

For multi-value fields, we cut down what is defined in the action to actual users that are possible to be applied to the WP. This ends up of never generating an error, which, while isn't ideal kind of mimics us retrying and discarding the action.