### PR TITLE
Fix execution of features with user-data-dir

### DIFF
--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -22,6 +22,8 @@ cleanup() {
 	exit_code=$?
 	echo "CLEANUP"
 	rm -rf tmp/cache/parallel*
+	# Clean up Chrome user data directories created for parallel tests
+	rm -rf /tmp/chrome-user-data-*
 
 	if [ ! $exit_code -eq "0" ]; then
 		echo "ERROR: exit code $exit_code"

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -45,6 +45,12 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "new", over
     # Useful for parallel test runs.
     options.add_argument("disable-renderer-backgrounding")
 
+    # Use unique user data directory for each parallel test process
+    # This prevents "user data directory is already in use" errors in CI
+    test_env_number = ENV.fetch("TEST_ENV_NUMBER", "1")
+    user_data_dir = "/tmp/chrome-user-data-#{test_env_number}-#{Process.pid}"
+    options.add_argument("--user-data-dir=#{user_data_dir}")
+
     options.add_preference(:download,
                            directory_upgrade: true,
                            prompt_for_download: false,


### PR DESCRIPTION
1.1) Failure/Error: bridge = driver.browser.send :bridge

          Selenium::WebDriver::Error::SessionNotCreatedError:
            session not created: probably user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/response.rb:63:in `add_cause'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/response.rb:41:in `error'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/response.rb:52:in `assert_ok'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/response.rb:34:in `initialize'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/http/common.rb:101:in `new'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/http/common.rb:101:in `create_response'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/http/default.rb:103:in `request'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/http/common.rb:[67](https://github.com/opf/openproject-open_desk/actions/runs/16139711473/job/45544110278?pr=10#step:12:68):in `call'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/bridge.rb:685:in `execute'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/remote/bridge.rb:76:in `create_session'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/common/driver.rb:323:in `block in create_bridge'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/common/driver.rb:322:in `create_bridge'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/common/driver.rb:73:in `initialize'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/chrome/driver.rb:35:in `initialize'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/common/driver.rb:47:in `new'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver/common/driver.rb:47:in `for'
          # /usr/local/bundle/gems/selenium-webdriver-4.25.0/lib/selenium/webdriver.rb:89:in `for'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/selenium/driver.rb:75:in `browser'
          # ./spec/support/browsers/chrome.rb:[69](https://github.com/opf/openproject-open_desk/actions/runs/16139711473/job/45544110278?pr=10#step:12:70):in `block in register_chrome'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:106:in `driver'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:92:in `initialize'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `new'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `block in session_pool'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:317:in `current_session'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:46:in `page'
          # ./spec/support/authentication_helpers.rb:48:in `login_as'
          # ./spec/support/authentication_helpers.rb:105:in `block in current_user'
          # ./spec/support/capybara.rb:16:in `block (2 levels) in <top (required)>'
          # ./spec/support/webmock.rb:56:in `block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
          # ./spec/support/shared/with_env.rb:58:in `block (2 levels) in <top (required)>'
          # ./spec/support/shared/with_direct_uploads.rb:204:in `block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
          # ./spec/support/rspec_retry.rb:24:in `block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
          # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
          # ------------------
          # --- Caused by: ---
          # Selenium::WebDriver::Error::WebDriverError:
          #   #0 0x55c13bd4d1da <unknown>

For example, here: https://github.com/opf/openproject-open_desk/actions/runs/16139711473/job/45544110278?pr=10