### PR TITLE
robustness on calling account/consent outside of login process

### DIFF
--- a/app/controllers/concerns/accounts/user_consent.rb
+++ b/app/controllers/concerns/accounts/user_consent.rb
@@ -30,10 +30,17 @@
 # Intended to be used by the AccountController to implement the user consent
 # check.
 module Accounts::UserConsent
+  extend ActiveSupport::Concern
+
   include ::UserConsentHelper
 
+  included do
+    before_action :require_consenting_user,
+                  only: %i[consent confirm_consent]
+  end
+
   def consent
-    if user_consent_required? && consenting_user&.consent_expired?
+    if user_consent_required? && consenting_user.consent_expired?
       render "account/consent"
     else
       consent_finished
@@ -41,10 +48,8 @@ module Accounts::UserConsent
   end
 
   def confirm_consent
-    user = consenting_user
-
-    if user.present? && consent_param?
-      approve_consent!(user)
+    if consent_param?
+      approve_consent!(consenting_user)
     else
       reject_consent!
     end
@@ -63,8 +68,14 @@ module Accounts::UserConsent
     redirect_to authentication_stage_failure_path :consent
   end
 
+  private
+
+  def require_consenting_user
+    reject_consent! unless consenting_user
+  end
+
   def consenting_user
-    User.find_by id: session[:authenticated_user_id]
+    @consenting_user ||= User.find_by id: session[:authenticated_user_id]
   end
 
   def approve_consent!(user)

--- a/spec/features/auth/consent_auth_stage_spec.rb
+++ b/spec/features/auth/consent_auth_stage_spec.rb
@@ -270,4 +270,13 @@ RSpec.describe "Authentication Stages" do
       end
     end
   end
+
+  context "when calling the consent page outside of the login process" do
+    it "redirects to the login page" do
+      visit "account/consent"
+
+      expect_flash message: "Consent failed, cannot proceed.", type: :error
+      expect(page).to have_current_path "/login"
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65535

# What are you trying to accomplish?

Fix the 500 on path creation that results when calling /account/consent outside of the login process. 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
