### PR TITLE
only trigger downstream tests if base is a known dev or release branch

### DIFF
--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -38,6 +38,11 @@ jobs:
         #   * the name of the core branch that has to be checked out downstream to run the tests
         #   * that is either dev, release/16.1 (for instance), or the pull request's branch name
         run: |
+          if [[ ! "${{ github.base_ref || github.ref_name }}" =~ dev|release/.+ ]]; then
+            echo "Base branch is not dev or release branch. Cannot check downstream tests."
+            exit 0
+          fi
+
           curl -i --fail-with-body -H"authorization: Bearer $TOKEN" \
             -XPOST -H"Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/$REPOSITORY/actions/workflows/$WORKFLOW_ID/dispatches \


### PR DESCRIPTION
Downstream tests cannot be triggered for PRs on feature or maintenance branches like [this](https://github.com/opf/openproject/pull/19431).

Skip trying to in that case to avoid the failed run.