### PR TITLE
Bug/65514 invite user does not work

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -206,6 +206,7 @@ import {
 import {
   OpWpDatePickerInstanceComponent,
 } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component';
+import { OpInviteUserModalAugmentService } from 'core-app/features/invite-user-modal/invite-user-modal-augment.service';
 
 export function initializeServices(injector:Injector) {
   return () => {
@@ -213,6 +214,7 @@ export function initializeServices(injector:Injector) {
     const keyboardShortcuts = injector.get(KeyboardShortcutService);
     const contextMenu = injector.get(OPContextMenuService);
     const currentProject = injector.get(CurrentProjectService);
+    const inviteUserAugmentService = injector.get(OpInviteUserModalAugmentService);
 
     // Conditionally add the Revit Add-In settings button
     injector.get(RevitAddInSettingsButtonService);
@@ -220,6 +222,7 @@ export function initializeServices(injector:Injector) {
     const runOnRenderAndLoad = () => {
       topMenuService.register();
       contextMenu.register();
+      inviteUserAugmentService.setupListener();
     };
     runOnRenderAndLoad();
 

--- a/frontend/src/app/features/invite-user-modal/invite-user-modal-augment.service.ts
+++ b/frontend/src/app/features/invite-user-modal/invite-user-modal-augment.service.ts
@@ -31,7 +31,6 @@ import { DOCUMENT } from '@angular/common';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { InviteUserModalComponent } from './invite-user.component';
-import ClickEvent = JQuery.ClickEvent;
 
 const attributeName = 'invite-user-modal-augment';
 
@@ -51,7 +50,7 @@ export class OpInviteUserModalAugmentService {
    * Create initial listeners for Rails-rendered modals
    */
   public setupListener() {
-    const matches = this.documentElement.querySelectorAll('[' + attributeName + ']');
+    const matches = this.documentElement.querySelectorAll(`[${attributeName}]`);
     for (let i = 0; i < matches.length; ++i) {
       const el = matches[i] as HTMLElement;
       el.addEventListener('click', this.spawnModal.bind(this));

--- a/frontend/src/app/features/invite-user-modal/invite-user-modal-augment.service.ts
+++ b/frontend/src/app/features/invite-user-modal/invite-user-modal-augment.service.ts
@@ -33,7 +33,7 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 import { InviteUserModalComponent } from './invite-user.component';
 import ClickEvent = JQuery.ClickEvent;
 
-const attributeSelector = '[invite-user-modal-augment]';
+const attributeName = 'invite-user-modal-augment';
 
 /**
  * This service triggers user-invite modals to clicks on elements
@@ -51,10 +51,11 @@ export class OpInviteUserModalAugmentService {
    * Create initial listeners for Rails-rendered modals
    */
   public setupListener() {
-    const matches = this.documentElement.querySelectorAll(attributeSelector);
+    const matches = this.documentElement.querySelectorAll('[' + attributeName + ']');
     for (let i = 0; i < matches.length; ++i) {
       const el = matches[i] as HTMLElement;
       el.addEventListener('click', this.spawnModal.bind(this));
+      el.removeAttribute(attributeName);
     }
   }
 

--- a/frontend/src/app/features/invite-user-modal/invite-user-modal.module.ts
+++ b/frontend/src/app/features/invite-user-modal/invite-user-modal.module.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, Injector, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -10,7 +10,6 @@ import { CurrentUserModule } from 'core-app/core/current-user/current-user.modul
 import { OpenprojectModalModule } from 'core-app/shared/components/modal/modal.module';
 import { InviteUserButtonModule } from 'core-app/features/invite-user-modal/button/invite-user-button.module';
 import { DynamicFormsModule } from 'core-app/shared/components/dynamic-forms/dynamic-forms.module';
-import { OpInviteUserModalAugmentService } from 'core-app/features/invite-user-modal/invite-user-modal-augment.service';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpInviteUserModalService } from 'core-app/features/invite-user-modal/invite-user-modal.service';
 import { InviteUserModalComponent } from './invite-user.component';
@@ -20,16 +19,6 @@ import { PrincipalSearchComponent } from './principal/principal-search.component
 import { RoleSearchComponent } from './role/role-search.component';
 import { SummaryComponent } from './summary/summary.component';
 import { SuccessComponent } from './success/success.component';
-
-export function initializeServices(injector:Injector) {
-  return function () {
-    const inviteUserAugmentService = injector.get(OpInviteUserModalAugmentService);
-    document.addEventListener('turbo:load', () => {
-      inviteUserAugmentService.setupListener();
-    });
-    inviteUserAugmentService.setupListener();
-  };
-}
 
 @NgModule({
   imports: [
@@ -58,9 +47,6 @@ export function initializeServices(injector:Injector) {
   ],
   providers: [
     OpInviteUserModalService,
-    {
-      provide: APP_INITIALIZER, useFactory: initializeServices, deps: [Injector], multi: true,
-    },
   ],
 })
 export class OpenprojectInviteUserModalModule {

--- a/frontend/src/app/features/invite-user-modal/invite-user-modal.module.ts
+++ b/frontend/src/app/features/invite-user-modal/invite-user-modal.module.ts
@@ -24,6 +24,9 @@ import { SuccessComponent } from './success/success.component';
 export function initializeServices(injector:Injector) {
   return function () {
     const inviteUserAugmentService = injector.get(OpInviteUserModalAugmentService);
+    document.addEventListener('turbo:load', () => {
+      inviteUserAugmentService.setupListener();
+    });
     inviteUserAugmentService.setupListener();
   };
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65514

# What are you trying to accomplish?
Bug is caused by links using the attribute to trigger the modal are not getting registered by turbo navigation

# What approach did you choose and why?
Trigger the setup also on `turbo:load`. Alternative would be to register click on document or maybe there is a general way of registering angular components to work with turbo?

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
