### PR TITLE
[65614] WP details diffs are not in colours anymore

### DIFF
--- a/frontend/src/global_styles/content/_diff.sass
+++ b/frontend/src/global_styles/content/_diff.sass
@@ -34,13 +34,13 @@ img.diff, div.diff, table.diff, blockquote.diff, address.diff, h1.diff, h2.diff,
 
 del
   &.diffmod, &.diffdel
-    background: var(--diffBlob-deletion-bgColor-word)
-    color: var(--diffBlob-deletion-fgColor-text)
+    background: var(--diffBlob-deletionWord-bgColor)
+    color: var(--diffBlob-deletionLine-fgColor)
 
 ins
   &.diffmod, &.diffins
-    background: var(--diffBlob-addition-bgColor-word)
-    color: var(--diffBlob-addition-fgColor-text)
+    background: var(--diffBlob-additionWord-bgColor)
+    color: var(--diffBlob-additionLine-fgColor)
 
 .text-diff
   padding: 1em


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65614

# What are you trying to accomplish?
Update to new primer variables that were introduced in: https://github.com/primer/primitives/pull/1068

## Screenshots
<img width="1581" alt="Bildschirmfoto 2025-07-08 um 14 23 29" src="https://github.com/user-attachments/assets/24d72855-0291-4b02-9a9e-e966f22cdd4a" />
