### PR TITLE
updated API link in system admin documenation

### DIFF
--- a/docs/system-admin-guide/api-and-webhooks/README.md
+++ b/docs/system-admin-guide/api-and-webhooks/README.md
@@ -19,7 +19,7 @@ Here, you can manage the **REST web service** to selectively control whether for
 
 ### Documentation
 
-If the **docs page** is enabled you can get an interactive view of the [APIv3 documentation](https://qa.openproject-edge.com/api/docs).
+If the **docs page** is enabled you can get an interactive view of the [APIv3 documentation](https://www.openproject.org/docs/api/introduction).
 
 ### Cross-Origin Resource Sharing (CORS)
 


### PR DESCRIPTION
# What are you trying to accomplish?

Exchanged a link which initially pointed to the edge environment. Now it leads users directly to the fitting part of the documentation.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
