### PR TITLE
Bug/64802 administration project life cycle page using wrong primer components

### DIFF
--- a/app/components/projects/phase_definitions/form_component.html.erb
+++ b/app/components/projects/phase_definitions/form_component.html.erb
@@ -33,49 +33,37 @@ See COPYRIGHT and LICENSE files for more details.
     ) do |f|
       flex_layout do |body|
         body.with_row do
-          render Primer::Alpha::TabPanels.new(label: "label") do |tab_panel|
-            tab_panel.with_tab(selected: selected?(:details), id: "tab-phases--details") do |tab|
-              tab.with_text { I18n.t("label_details") }
-              tab.with_panel do
-                render Projects::PhaseDefinitions::DetailsForm.new(f)
-              end
-            end
-            tab_panel.with_tab(selected: selected?(:phase_gates), id: "tab-phases--phase-gates") do |tab|
-              tab.with_text { I18n.t("settings.project_phase_definitions.phase_gates") }
-              tab.with_panel do
-                flex_layout do |gates_tab|
-                  gates_tab.with_row(mt: 2) do
-                    render Projects::PhaseDefinitions::StartGateCheckboxForm.new(f)
-                  end
-                  gates_tab.with_row(
-                    mt: 2,
-                    classes: model.start_gate.blank? ? "d-none" : "",
-                    data: {
-                      target_name: "start_gate",
-                      "show-when-checked-target": "effect",
-                      visibility_class: "d-none"
-                    }
-                  ) do
-                    render Projects::PhaseDefinitions::StartGateNameForm.new(f)
-                  end
-                  gates_tab.with_row(mt: 2) do
-                    render Projects::PhaseDefinitions::FinishGateCheckboxForm.new(f)
-                  end
-                  gates_tab.with_row(
-                    mt: 2,
-                    classes: model.finish_gate.blank? ? "d-none" : "",
-                    data: {
-                      target_name: "finish_gate",
-                      "show-when-checked-target": "effect",
-                      visibility_class: "d-none"
-                    }
-                  ) do
-                    render Projects::PhaseDefinitions::FinishGateNameForm.new(f)
-                  end
-                end
-              end
-            end
-          end
+          render Projects::PhaseDefinitions::DetailsForm.new(f)
+        end
+
+        body.with_row(mt: 2) do
+          render Projects::PhaseDefinitions::StartGateCheckboxForm.new(f)
+        end
+        body.with_row(
+          mt: 2,
+          classes: model.start_gate.blank? ? "d-none" : "",
+          data: {
+            target_name: "start_gate",
+            "show-when-checked-target": "effect",
+            visibility_class: "d-none"
+          }
+        ) do
+          render Projects::PhaseDefinitions::StartGateNameForm.new(f)
+        end
+
+        body.with_row(mt: 2) do
+          render Projects::PhaseDefinitions::FinishGateCheckboxForm.new(f)
+        end
+        body.with_row(
+          mt: 2,
+          classes: model.finish_gate.blank? ? "d-none" : "",
+          data: {
+            target_name: "finish_gate",
+            "show-when-checked-target": "effect",
+            visibility_class: "d-none"
+          }
+        ) do
+          render Projects::PhaseDefinitions::FinishGateNameForm.new(f)
         end
 
         body.with_row(mt: 4) do

--- a/app/components/projects/phase_definitions/form_component.html.erb
+++ b/app/components/projects/phase_definitions/form_component.html.erb
@@ -36,11 +36,11 @@ See COPYRIGHT and LICENSE files for more details.
           render Projects::PhaseDefinitions::DetailsForm.new(f)
         end
 
-        body.with_row(mt: 2) do
+        body.with_row(mt: 3) do
           render Projects::PhaseDefinitions::StartGateCheckboxForm.new(f)
         end
         body.with_row(
-          mt: 2,
+          mt: 3,
           classes: model.start_gate.blank? ? "d-none" : "",
           data: {
             target_name: "start_gate",
@@ -51,11 +51,11 @@ See COPYRIGHT and LICENSE files for more details.
           render Projects::PhaseDefinitions::StartGateNameForm.new(f)
         end
 
-        body.with_row(mt: 2) do
+        body.with_row(mt: 3) do
           render Projects::PhaseDefinitions::FinishGateCheckboxForm.new(f)
         end
         body.with_row(
-          mt: 2,
+          mt: 3,
           classes: model.finish_gate.blank? ? "d-none" : "",
           data: {
             target_name: "finish_gate",

--- a/app/components/projects/phase_definitions/form_component.rb
+++ b/app/components/projects/phase_definitions/form_component.rb
@@ -31,23 +31,5 @@ module Projects::PhaseDefinitions
   class FormComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
     include OpPrimer::FormHelpers
-
-    def selected?(tabname)
-      tabname == if no_errors || details_tab_errors.any?
-                   :details
-                 else
-                   :phase_gates
-                 end
-    end
-
-    private
-
-    def no_errors
-      model.errors.empty?
-    end
-
-    def details_tab_errors
-      model.errors.attribute_names & %i[name color]
-    end
   end
 end

--- a/spec/features/admin/project_phase_definitions_spec.rb
+++ b/spec/features/admin/project_phase_definitions_spec.rb
@@ -114,8 +114,6 @@ RSpec.describe "Projects phase definition settings", :js do
       fill_in "Name", with: "Initiating"
       definitions_page.select_color("Gold")
 
-      click_on "Phase gates"
-
       check "Start phase gate"
       fill_in "Start phase gate name", with: "Ready to Initiate"
       check "Finish phase gate"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64802

# What are you trying to accomplish?
Backport to 16.2
Join tab panels of phase definition form and fix spacing between inputs

## Screenshots
| | |
|---|---|
| was | <img width="420" alt="image" src="https://github.com/user-attachments/assets/5323a281-7d69-4802-9d85-458208d26105" /> + <img width="420" alt="image" src="https://github.com/user-attachments/assets/11474870-62cd-4210-ae37-6a5939316929" /> |
| now | <img width="420" alt="image" src="https://github.com/user-attachments/assets/8fe70559-83ed-4038-a7b3-81feeedae27f" /> |

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
