### PR TITLE
ease the validation on project phases

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -559,7 +559,7 @@ module WorkPackages
     def validate_phase_active_in_project
       if model.project.present? &&
         model.project_phase_definition_id.present? &&
-        !(model.project_changed? && !model.project_phase_definition_changed?) &&
+        model.project_phase_definition_changed? &&
         !project_definition_assignable?
         errors.add :project_phase_id, :inclusion
       end

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -343,6 +343,18 @@ RSpec.describe WorkPackages::UpdateContract do
         it_behaves_like "contract is valid"
       end
 
+      context "when not changing the value but changing a different attribute while the project phase is inactive" do
+        before do
+          work_package.project_phase_definition = persisted_inactive_project_phase.definition
+          work_package.save
+          work_package.reload
+
+          work_package.subject = "A new subject"
+        end
+
+        it_behaves_like "contract is valid"
+      end
+
       context "when changing the value and assigning a project in which the phase is not active" do
         before do
           work_package.project_phase_definition = persisted_project_phase_definition


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65303

# What are you trying to accomplish?

Validation will only take place when the project_phase_definition_id value is changed. Before, it was always validated (unless the project was changed). But with the larger amount of possibilities to disable project phases and with subsequent changes to the work package potentically being done by somebody who does not have the permission to change the value, the validation needs to be more precise.

# Merge checklist

- [x] Added/updated tests
