### PR TITLE
open notification settings on the same tab

### DIFF
--- a/app/components/notifications/index_page_header_component.html.erb
+++ b/app/components/notifications/index_page_header_component.html.erb
@@ -8,7 +8,6 @@
         mobile_label: I18n.t(:label_setting_plural),
         href: my_notifications_path,
         size: :medium,
-        target: "_blank",
         aria: { label: I18n.t("js.notifications.settings.title") }
       ) do |button|
         button.with_leading_visual_icon(icon: :gear)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/44867

# What are you trying to accomplish?

Open notification settings link on the same page, instead of a new one

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
