### PR TITLE
[63191] Show % complete also in status-based progress calculation mode

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -116,11 +118,13 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
       sortable: false,
       summable: false
     },
-    done_ratio: {
+    done_ratio_for_weighted_average: {
+      if: -> { WorkPackage.work_weighted_average_mode? },
+      name: :done_ratio,
       sortable: "#{WorkPackage.table_name}.done_ratio",
       groupable: true,
       summable: true,
-      summable_select: <<~SQL.squish
+      summable_select: <<~SQL.squish,
         CASE
           WHEN estimated_hours IS NULL OR remaining_hours IS NULL OR estimated_hours <= 0 THEN NULL
           WHEN remaining_hours <= 0 THEN 100
@@ -130,6 +134,25 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
           ELSE ROUND( ((1 - (remaining_hours / estimated_hours)) * 100)::numeric )::integer
         END as done_ratio
       SQL
+      summable_work_packages_select: false
+    },
+    done_ratio_for_simple_average: {
+      if: -> { WorkPackage.simple_average_mode? },
+      name: :done_ratio,
+      sortable: "#{WorkPackage.table_name}.done_ratio",
+      groupable: true,
+      summable: true,
+      summable_select: <<~SQL.squish,
+        CASE
+          WHEN done_ratio_count = 0 THEN NULL
+          WHEN done_ratio >= done_ratio_count * 100 THEN 100
+          WHEN done_ratio >= done_ratio_count * 99 THEN 99
+          WHEN done_ratio <= 0 THEN 0
+          WHEN done_ratio <= done_ratio_count THEN 1
+          ELSE ROUND(done_ratio::numeric / done_ratio_count)::integer
+        END as done_ratio
+      SQL
+      summable_work_packages_count_select: true
     },
     created_at: {
       sortable: "#{WorkPackage.table_name}.created_at",
@@ -145,8 +168,13 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
   }
 
   def self.instances(_context = nil)
-    property_selects.filter_map do |name, options|
-      new(name, options)
+    active_selects = property_selects.reject do |_, options|
+      condition = options[:if]
+      condition && !condition.call
+    end
+    active_selects.filter_map do |default_name, options|
+      name = options[:name] || default_name
+      new(name, options.without(:if, :name))
     end
   end
 end

--- a/app/models/queries/work_packages/selects/work_package_select.rb
+++ b/app/models/queries/work_packages/selects/work_package_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -38,6 +40,7 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
               :association,
               :null_handling,
               :summable_select,
+              :summable_work_packages_count_select,
               :summable_work_packages_select
 
   def self.instances(_context = nil)
@@ -74,7 +77,7 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
   end
 
   def displayable
-    @displayable.nil? ? true : @displayable
+    @displayable.nil? || @displayable
   end
 
   def sortable
@@ -128,6 +131,7 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
       groupable_join
       summable
       summable_select
+      summable_work_packages_count_select
       summable_work_packages_select
       association
       group_by_column_name

--- a/app/models/query/results/sums.rb
+++ b/app/models/query/results/sums.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -117,11 +119,17 @@ module ::Query::Results::Sums
         []
       end
 
-    group_statement + summed_columns
+    group_statement + summed_columns + counted_summed_columns
   end
 
   def summed_columns
     query.summed_up_columns.filter_map(&:summable_work_packages_select).map { |c| "SUM(#{c}) #{c}" }
+  end
+
+  def counted_summed_columns
+    query.summed_up_columns
+         .select(&:summable_work_packages_count_select)
+         .map { |col| "COUNT(#{col.name}) #{col.name}_count" }
   end
 
   def callable_summed_up_columns

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -215,6 +215,14 @@ class WorkPackage < ApplicationRecord
     Setting.work_package_done_ratio == "field"
   end
 
+  def self.work_weighted_average_mode?
+    Setting.total_percent_complete_mode == "work_weighted_average"
+  end
+
+  def self.simple_average_mode?
+    Setting.total_percent_complete_mode == "simple_average"
+  end
+
   def self.complete_on_status_closed?
     Setting.percent_complete_on_status_closed == "set_100p"
   end

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -124,10 +124,9 @@ class WorkPackages::UpdateAncestorsService < BaseServices::BaseCallable
   def compute_derived_done_ratio(work_package, loader)
     return if no_children?(work_package, loader)
 
-    case Setting.total_percent_complete_mode
-    when "work_weighted_average"
+    if WorkPackage.work_weighted_average_mode?
       calculate_work_weighted_average_percent_complete(work_package)
-    when "simple_average"
+    elsif WorkPackage.simple_average_mode?
       calculate_simple_average_percent_complete(work_package, loader)
     end
   end

--- a/app/workers/work_packages/progress/sql_commands.rb
+++ b/app/workers/work_packages/progress/sql_commands.rb
@@ -185,9 +185,9 @@ module WorkPackages::Progress::SqlCommands
   # packages having children.
   def update_totals
     update_work_and_remaining_work_totals
-    if Setting.total_percent_complete_mode == "work_weighted_average"
+    if WorkPackage.work_weighted_average_mode?
       update_total_percent_complete_in_work_weighted_average_mode
-    elsif Setting.total_percent_complete_mode == "simple_average"
+    elsif WorkPackage.simple_average_mode?
       update_total_percent_complete_in_simple_average_mode
     end
   end

--- a/spec/models/query/results_sums_integration_spec.rb
+++ b/spec/models/query/results_sums_integration_spec.rb
@@ -131,15 +131,6 @@ RSpec.describe Query::Results, "sums" do
            float_cf.attribute_name => 3.414,
            story_points: 7)
   end
-  let(:estimated_hours_column) { query.displayable_columns.detect { |c| c.name.to_s == "estimated_hours" } }
-  let(:int_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == int_cf.column_name } }
-  let(:float_cf_column) { query.displayable_columns.detect { |c| c.name.to_s == float_cf.column_name } }
-  let(:material_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "material_costs" } }
-  let(:labor_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "labor_costs" } }
-  let(:overall_costs_column) { query.displayable_columns.detect { |c| c.name.to_s == "overall_costs" } }
-  let(:remaining_hours_column) { query.displayable_columns.detect { |c| c.name.to_s == "remaining_hours" } }
-  let(:done_ratio_column) { query.displayable_columns.detect { |c| c.name.to_s == "done_ratio" } }
-  let(:story_points_column) { query.displayable_columns.detect { |c| c.name.to_s == "story_points" } }
   let(:group_by) { nil }
   let(:query) do
     build(:query,
@@ -154,18 +145,22 @@ RSpec.describe Query::Results, "sums" do
     login_as(current_user)
   end
 
+  def stringify_column_keys(sums_hash)
+    sums_hash.transform_keys { |column| column.name.to_s }
+  end
+
   describe "#all_total_sums" do
     it "is a hash of all summable columns" do
-      expect(query_results.all_total_sums)
-        .to eq(estimated_hours_column => 20.0,
-               int_cf_column => 30,
-               float_cf_column => 10.24,
-               material_costs_column => 400.0,
-               labor_costs_column => 600.0,
-               overall_costs_column => 1000.0,
-               remaining_hours_column => 14.0,
-               done_ratio_column => 30,
-               story_points_column => 21)
+      expect(stringify_column_keys(query_results.all_total_sums))
+        .to eq("estimated_hours" => 20.0,
+               int_cf.column_name => 30,
+               float_cf.column_name => 10.24,
+               "material_costs" => 400.0,
+               "labor_costs" => 600.0,
+               "overall_costs" => 1000.0,
+               "remaining_hours" => 14.0,
+               "done_ratio" => 30,
+               "story_points" => 21)
     end
 
     context "when filtering" do
@@ -174,16 +169,16 @@ RSpec.describe Query::Results, "sums" do
       end
 
       it "is a hash of all summable columns and includes only the work packages matching the filter" do
-        expect(query_results.all_total_sums)
-          .to eq(estimated_hours_column => 10.0,
-                 int_cf_column => 20,
-                 float_cf_column => 6.83,
-                 material_costs_column => 200.0,
-                 labor_costs_column => 300.0,
-                 overall_costs_column => 500.0,
-                 remaining_hours_column => 5.0,
-                 done_ratio_column => 50,
-                 story_points_column => 14)
+        expect(stringify_column_keys(query_results.all_total_sums))
+          .to eq("estimated_hours" => 10.0,
+                 int_cf.column_name => 20,
+                 float_cf.column_name => 6.83,
+                 "material_costs" => 200.0,
+                 "labor_costs" => 300.0,
+                 "overall_costs" => 500.0,
+                 "remaining_hours" => 5.0,
+                 "done_ratio" => 50,
+                 "story_points" => 14)
       end
     end
   end
@@ -194,26 +189,26 @@ RSpec.describe Query::Results, "sums" do
 
       it "is a hash of sums grouped by user values (and nil) and grouped columns" do
         expect(query_results.all_group_sums.keys).to contain_exactly(current_user, nil)
-        expect(query_results.all_group_sums[current_user])
-          .to eq(estimated_hours_column => 10.0,
-                 int_cf_column => 20,
-                 float_cf_column => 6.83,
-                 material_costs_column => 200.0,
-                 labor_costs_column => 300.0,
-                 overall_costs_column => 500.0,
-                 remaining_hours_column => 5.0,
-                 done_ratio_column => 50,
-                 story_points_column => 14)
-        expect(query_results.all_group_sums[nil])
-          .to eq(estimated_hours_column => 10.0,
-                 int_cf_column => 10,
-                 float_cf_column => 3.41,
-                 material_costs_column => 200.0,
-                 labor_costs_column => 300.0,
-                 overall_costs_column => 500.0,
-                 remaining_hours_column => 9.0,
-                 done_ratio_column => 10,
-                 story_points_column => 7)
+        expect(stringify_column_keys(query_results.all_group_sums[current_user]))
+          .to eq("estimated_hours" => 10.0,
+                 int_cf.column_name => 20,
+                 float_cf.column_name => 6.83,
+                 "material_costs" => 200.0,
+                 "labor_costs" => 300.0,
+                 "overall_costs" => 500.0,
+                 "remaining_hours" => 5.0,
+                 "done_ratio" => 50,
+                 "story_points" => 14)
+        expect(stringify_column_keys(query_results.all_group_sums[nil]))
+          .to eq("estimated_hours" => 10.0,
+                 int_cf.column_name => 10,
+                 float_cf.column_name => 3.41,
+                 "material_costs" => 200.0,
+                 "labor_costs" => 300.0,
+                 "overall_costs" => 500.0,
+                 "remaining_hours" => 9.0,
+                 "done_ratio" => 10,
+                 "story_points" => 7)
       end
 
       context "when filtering" do
@@ -223,16 +218,16 @@ RSpec.describe Query::Results, "sums" do
 
         it "is a hash of sums grouped by user values and grouped columns" do
           expect(query_results.all_group_sums.keys).to contain_exactly(current_user)
-          expect(query_results.all_group_sums[current_user])
-            .to eq(estimated_hours_column => 5.0,
-                   int_cf_column => 10,
-                   float_cf_column => 3.41,
-                   material_costs_column => 0.0,
-                   labor_costs_column => 0.0,
-                   overall_costs_column => 0.0,
-                   remaining_hours_column => 2.5,
-                   done_ratio_column => 50,
-                   story_points_column => 7)
+          expect(stringify_column_keys(query_results.all_group_sums[current_user]))
+            .to eq("estimated_hours" => 5.0,
+                   int_cf.column_name => 10,
+                   float_cf.column_name => 3.41,
+                   "material_costs" => 0.0,
+                   "labor_costs" => 0.0,
+                   "overall_costs" => 0.0,
+                   "remaining_hours" => 2.5,
+                   "done_ratio" => 50,
+                   "story_points" => 7)
         end
       end
     end
@@ -242,26 +237,26 @@ RSpec.describe Query::Results, "sums" do
 
       it "is a hash of sums grouped by done_ratio values and grouped columns" do
         expect(query_results.all_group_sums.keys).to contain_exactly(50, 10)
-        expect(query_results.all_group_sums[50])
-          .to eq(estimated_hours_column => 10.0,
-                 int_cf_column => 20,
-                 float_cf_column => 6.83,
-                 material_costs_column => 200.0,
-                 labor_costs_column => 300.0,
-                 overall_costs_column => 500.0,
-                 remaining_hours_column => 5.0,
-                 done_ratio_column => 50,
-                 story_points_column => 14)
-        expect(query_results.all_group_sums[10])
-           .to eq(estimated_hours_column => 10.0,
-                  int_cf_column => 10,
-                  float_cf_column => 3.41,
-                  material_costs_column => 200.0,
-                  labor_costs_column => 300.0,
-                  overall_costs_column => 500.0,
-                  remaining_hours_column => 9.0,
-                  done_ratio_column => 10,
-                  story_points_column => 7)
+        expect(stringify_column_keys(query_results.all_group_sums[50]))
+          .to eq("estimated_hours" => 10.0,
+                 int_cf.column_name => 20,
+                 float_cf.column_name => 6.83,
+                 "material_costs" => 200.0,
+                 "labor_costs" => 300.0,
+                 "overall_costs" => 500.0,
+                 "remaining_hours" => 5.0,
+                 "done_ratio" => 50,
+                 "story_points" => 14)
+        expect(stringify_column_keys(query_results.all_group_sums[10]))
+           .to eq("estimated_hours" => 10.0,
+                  int_cf.column_name => 10,
+                  float_cf.column_name => 3.41,
+                  "material_costs" => 200.0,
+                  "labor_costs" => 300.0,
+                  "overall_costs" => 500.0,
+                  "remaining_hours" => 9.0,
+                  "done_ratio" => 10,
+                  "story_points" => 7)
       end
 
       context "when filtering" do
@@ -271,16 +266,16 @@ RSpec.describe Query::Results, "sums" do
 
         it "is a hash of sums grouped by done_ratio values and grouped columns" do
           expect(query_results.all_group_sums.keys).to contain_exactly(50)
-          expect(query_results.all_group_sums[50])
-            .to eq(estimated_hours_column => 5.0,
-                   int_cf_column => 10,
-                   float_cf_column => 3.41,
-                   material_costs_column => 0.0,
-                   labor_costs_column => 0.0,
-                   overall_costs_column => 0.0,
-                   remaining_hours_column => 2.5,
-                   done_ratio_column => 50,
-                   story_points_column => 7)
+          expect(stringify_column_keys(query_results.all_group_sums[50]))
+            .to eq("estimated_hours" => 5.0,
+                   int_cf.column_name => 10,
+                   float_cf.column_name => 3.41,
+                   "material_costs" => 0.0,
+                   "labor_costs" => 0.0,
+                   "overall_costs" => 0.0,
+                   "remaining_hours" => 2.5,
+                   "done_ratio" => 50,
+                   "story_points" => 7)
         end
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63191

# What are you trying to accomplish?

For now, % complete sum is based on work and remaining work sums only.
This does not work for users using status-based progress calculation mode.

So calculation of sums will now depend on "Calculation of % Complete hierarchy totals" mode:
- when "Weighted by work" is selected, % complete sum is calculated from work and remaining work sums only. Work packages having only % complete are ignored
- when "Simple average" is selected, % complete sum is an average of % complete values. Work packages not having any values are ignored.

## Screenshots

In "Weighted by work" mode:

![image](https://github.com/user-attachments/assets/7c58fce9-6799-4109-afd9-4cb9b8a38f73)

In "Simple average" mode:

![image](https://github.com/user-attachments/assets/104a5362-df29-4883-ae6d-6212919afbdd)


# What approach did you choose and why?

Refactor the test `spec/models/query/results_sums_integration_spec.rb` to make it faster to run, as I wanted to add a lot of tests for edge cases.

In `Queries::WorkPackages::Selects::PropertySelect` where all columns are declared, add 2 summable column definitions for `done_ratio` and add a `:if` in the definition so that only one activates depending on the "calculation of % complete hierarchy totals" mode. Then add a `count` in the sql aggregations as it is needed to compute an average. Thanksfuly `count(done_ratio)` only counts rows for which `done_ratio` is not `NULL`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
