### PR TITLE
[65313] Wrong menu item is highlighted when copying a project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -56,6 +56,10 @@ class ProjectsController < ApplicationController
     :projects
   end
 
+  current_menu_item :copy_form do
+    :settings_general
+  end
+
   def index # rubocop:disable Metrics/AbcSize
     respond_to do |format|
       format.html do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65313

# What are you trying to accomplish?
Highlight correct menu item when copying a project
