### PR TITLE
Improve readability of webhook responses

### DIFF
--- a/frontend/src/global_styles/content/modules/_webhooks.sass
+++ b/frontend/src/global_styles/content/modules/_webhooks.sass
@@ -27,7 +27,6 @@
   min-width: 25vw
 
   pre
-    background: #f1f1f1
     padding: 5px
 
 

--- a/modules/webhooks/app/components/webhooks/outgoing/deliveries/response_component.html.erb
+++ b/modules/webhooks/app/components/webhooks/outgoing/deliveries/response_component.html.erb
@@ -13,10 +13,10 @@
     <div class="spot-divider"></div>
     <div class="spot-modal--body spot-container">
       <h2 class="spot-subheader-extra-small">Headers</h2>
-      <pre class="webhooks--response-headers"><%- response_headers.each do |k, v| -%><strong><%= h k -%></strong>:  <span><%= h v -%></span><br><%- end -%></pre>
-        <div class="spot-divider"></div>
+      <pre class="op-uc-code-block webhooks--response-headers"><%- response_headers.each do |k, v| -%><strong><%= h k -%></strong>:  <span><%= h v -%></span><br><%- end -%></pre>
+      <div class="spot-divider"></div>
       <h2 class="spot-subheader-extra-small">Response body</h2>
-      <pre class="webhooks--response-body"><%= response_body %></pre>
+      <pre class="op-uc-code-block webhooks--response-body"><%= response_body %></pre>
     </div>
     <div class="spot-action-bar hidden-for-mobile">
       <div class="spot-action-bar--right">


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65651

## Screenshots

### Before

#### dark

![image](https://github.com/user-attachments/assets/fbf9fd0f-6a7d-47b8-bf45-1bb48ee28640)

#### light

![image](https://github.com/user-attachments/assets/21ba5019-78ab-421e-8be5-4c7baf2c69af)

### After

#### dark

![image](https://github.com/user-attachments/assets/f1f0fb5b-ffc9-41e5-8269-da9d4f346b65)

#### light

![image](https://github.com/user-attachments/assets/a611370b-d436-467b-8cde-312e72d0dd06)

# What approach did you choose and why?

Removing custom styling that didn't account for dark theme at all. I briefly thought about primerizing the modal alone, but once I found the relevant piece of CSS, I figured that I'd leave it at a pure bugfix.

Since I found the result not nice to look at when just removing the color, I decided to also add the regular stying that pre-formatted code blocks would receive in OpenProject by adding the `op-uc-code-block` class.