### PR TITLE
[65671] Hide warning banner initially on progress tracking admin page

### DIFF
--- a/app/views/admin/settings/progress_tracking/show.html.erb
+++ b/app/views/admin/settings/progress_tracking/show.html.erb
@@ -57,6 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
         render(
           Primer::Alpha::Banner.new(
             scheme: :warning,
+            hidden: true,
             data: { admin__progress_tracking_target: "warningToast" }
           )
         ) do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65671

# What are you trying to accomplish?

Avoid banner flickering on progress tracking admin page.

If not hidden initially, the banner is shown for a split second when the page is loaded.

## Screenshots

In the following screen captures, page is reloaded 3 or 4 times. You can see it reloads because the project selector and the resize handle are disappearing and then reappearing.

Before:

[admin-progress-flickering.webm](https://github.com/user-attachments/assets/4aec20b4-5db5-4e72-aed7-8dcc3e8b6edc)


After:

[admin-progress-no-flickering.webm](https://github.com/user-attachments/assets/dfb8abcb-3ef6-4752-8ee2-c039222c097c)


# What approach did you choose and why?

Simply add `hidden: true` to the banner, as it was before dda5d94f08e.

I did not add any tests because I have no idea how to write reliable tests for this.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
