### PR TITLE
Enforce enumerations to be active if they are default

### DIFF
--- a/app/components/admin/enumerations/item_form.rb
+++ b/app/components/admin/enumerations/item_form.rb
@@ -52,14 +52,18 @@ module Admin
 
         form.check_box(
           name: :active,
-          label: object.class.human_attribute_name(:active)
+          label: object.class.human_attribute_name(:active),
+          data: { action: "admin--enumerations#lockstepDefault",
+                  "admin--enumerations-target": "active" }
         )
 
         if object.class.can_have_default_value?
           form.check_box(
             name: :is_default,
             label: I18n.t(:label_default),
-            caption: I18n.t(:"priorities.admin.default.caption")
+            caption: I18n.t(:"priorities.admin.default.caption"),
+            data: { action: "admin--enumerations#lockstepActive",
+                    "admin--enumerations-target": "default" }
           )
         end
 

--- a/app/components/admin/enumerations/item_form.rb
+++ b/app/components/admin/enumerations/item_form.rb
@@ -53,8 +53,8 @@ module Admin
         form.check_box(
           name: :active,
           label: object.class.human_attribute_name(:active),
-          data: { action: "admin--enumerations#lockstepDefault",
-                  "admin--enumerations-target": "active" }
+          disabled: object.is_default,
+          data: { "admin--enumerations-target": "active" }
         )
 
         if object.class.can_have_default_value?

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -44,6 +44,7 @@ class Enumeration < ApplicationRecord
             uniqueness: { scope: %i(type project_id),
                           case_sensitive: false }
   validates :name, length: { maximum: 256 }
+  validate :default_is_active, if: -> { self.class.can_have_default_value? }
 
   scope :shared, -> { where(project_id: nil) }
   scope :active, -> { where(active: true) }
@@ -172,5 +173,11 @@ class Enumeration < ApplicationRecord
 
   def check_integrity
     raise "Can't delete enumeration" if in_use?
+  end
+
+  def default_is_active
+    if is_default? && !active?
+      errors.add(:is_default, :active_required)
+    end
   end
 end

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -37,6 +37,7 @@ class Enumeration < ApplicationRecord
   acts_as_tree order: "position ASC"
 
   before_save :unmark_old_default_value, if: :became_default_value?
+  before_save :ensure_activated, if: -> { self.class.can_have_default_value? && is_default? }
   before_destroy :check_integrity
 
   validates :name, presence: true
@@ -44,7 +45,6 @@ class Enumeration < ApplicationRecord
             uniqueness: { scope: %i(type project_id),
                           case_sensitive: false }
   validates :name, length: { maximum: 256 }
-  validate :default_is_active, if: -> { self.class.can_have_default_value? }
 
   scope :shared, -> { where(project_id: nil) }
   scope :active, -> { where(active: true) }
@@ -175,9 +175,7 @@ class Enumeration < ApplicationRecord
     raise "Can't delete enumeration" if in_use?
   end
 
-  def default_is_active
-    if is_default? && !active?
-      errors.add(:is_default, :active_required)
-    end
+  def ensure_activated
+    self.active = true
   end
 end

--- a/app/views/admin/settings/work_package_priorities/edit.html.erb
+++ b/app/views/admin/settings/work_package_priorities/edit.html.erb
@@ -43,6 +43,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% content_controller "admin--enumerations" %>
+
 <%= settings_primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :update, id: @enumeration)) do |f| %>
   <%= render(Admin::Enumerations::ItemForm.new(f)) %>
 <% end %>

--- a/app/views/admin/settings/work_package_priorities/new.html.erb
+++ b/app/views/admin/settings/work_package_priorities/new.html.erb
@@ -41,6 +41,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% content_controller "admin--enumerations" %>
+
 <%= settings_primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :create)) do |f| %>
   <%= render(Admin::Enumerations::ItemForm.new(f)) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1463,10 +1463,6 @@ en:
           only_one_trial: "Only one trial token can be active. Please delete the previous trial token before adding another."
           unreadable: "can't be read. Are you sure it is a support token?"
           already_added: "This token has already been added."
-        enumeration:
-          attributes:
-            active:
-              active_required: "needs the 'Active' property to be true."
         grids/grid:
           overlaps: "overlap."
           outside: "is outside of the grid."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1463,6 +1463,10 @@ en:
           only_one_trial: "Only one trial token can be active. Please delete the previous trial token before adding another."
           unreadable: "can't be read. Are you sure it is a support token?"
           already_added: "This token has already been added."
+        enumeration:
+          attributes:
+            active:
+              active_required: "needs the 'Active' property to be true."
         grids/grid:
           overlaps: "overlap."
           outside: "is outside of the grid."

--- a/frontend/src/stimulus/controllers/dynamic/admin/enumerations.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/enumerations.controller.ts
@@ -1,0 +1,55 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class EnumerationsController extends Controller {
+  static targets = [
+    'active',
+    'default',
+  ];
+
+  declare readonly activeTarget:HTMLInputElement;
+  declare readonly defaultTarget:HTMLInputElement;
+
+  declare readonly hasDefaultTarget:boolean;
+
+  public lockstepActive() {
+    if (this.defaultTarget.checked) {
+      this.activeTarget.checked = true;
+    }
+  }
+
+  public lockstepDefault() {
+    if (!this.activeTarget.checked && this.hasDefaultTarget) {
+      this.defaultTarget.checked = false;
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/dynamic/admin/enumerations.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/enumerations.controller.ts
@@ -44,12 +44,9 @@ export default class EnumerationsController extends Controller {
   public lockstepActive() {
     if (this.defaultTarget.checked) {
       this.activeTarget.checked = true;
-    }
-  }
-
-  public lockstepDefault() {
-    if (!this.activeTarget.checked && this.hasDefaultTarget) {
-      this.defaultTarget.checked = false;
+      this.activeTarget.disabled = true;
+    } else {
+      this.activeTarget.disabled = false;
     }
   }
 }

--- a/modules/costs/app/views/admin/settings/time_entry_activities/edit.html.erb
+++ b/modules/costs/app/views/admin/settings/time_entry_activities/edit.html.erb
@@ -43,6 +43,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% content_controller "admin--enumerations" %>
+
 <%= settings_primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :update, id: @enumeration)) do |f| %>
   <%= render(Admin::Enumerations::ItemForm.new(f)) %>
 <% end %>

--- a/modules/costs/app/views/admin/settings/time_entry_activities/new.html.erb
+++ b/modules/costs/app/views/admin/settings/time_entry_activities/new.html.erb
@@ -43,6 +43,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% content_controller "admin--enumerations" %>
+
 <%= primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :create)) do |f| %>
   <%= render(Admin::Enumerations::ItemForm.new(f)) %>
 <% end %>

--- a/modules/costs/spec/models/time_entry_activity_spec.rb
+++ b/modules/costs/spec/models/time_entry_activity_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe TimeEntryActivity do
     end
   end
 
-  it_behaves_like "enumeration validation", false do
-    let(:enumeration) { build_stubbed(:time_entry_activity) }
+  it_behaves_like "enumeration#active handling", false do
+    let(:enumeration) { described_class.new(attributes_for(:time_entry_activity)) }
   end
 end

--- a/modules/documents/app/views/admin/settings/document_categories/edit.html.erb
+++ b/modules/documents/app/views/admin/settings/document_categories/edit.html.erb
@@ -42,6 +42,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% content_controller "admin--enumerations" %>
+
 <%= settings_primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :update, id: @enumeration)) do |f| %>
   <%= render(Admin::Enumerations::ItemForm.new(f)) %>
 <% end %>

--- a/modules/documents/app/views/admin/settings/document_categories/new.html.erb
+++ b/modules/documents/app/views/admin/settings/document_categories/new.html.erb
@@ -41,6 +41,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
+<% content_controller "admin--enumerations" %>
+
 <%= primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :create)) do |f| %>
   <%= render(Admin::Enumerations::ItemForm.new(f)) %>
 <% end %>

--- a/modules/documents/spec/models/document_category_spec.rb
+++ b/modules/documents/spec/models/document_category_spec.rb
@@ -29,6 +29,8 @@
 #++
 require_relative "../spec_helper"
 
+require Rails.root.join("spec/models/enumerations/shared_enumeration_examples").to_s
+
 RSpec.describe DocumentCategory do
   let(:project) { create(:project) }
 
@@ -57,5 +59,9 @@ RSpec.describe DocumentCategory do
       create(:document_category, name: "new default", project:, is_default: true)
       old_default.reload
     end.to change { old_default.is_default? }.from(true).to(false)
+  end
+
+  it_behaves_like "enumeration validation", true do
+    let(:enumeration) { build_stubbed(:document_category) }
   end
 end

--- a/modules/documents/spec/models/document_category_spec.rb
+++ b/modules/documents/spec/models/document_category_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe DocumentCategory do
     end.to change { old_default.is_default? }.from(true).to(false)
   end
 
-  it_behaves_like "enumeration validation", true do
-    let(:enumeration) { build_stubbed(:document_category) }
+  it_behaves_like "enumeration#active handling", true do
+    let(:enumeration) { described_class.new(attributes_for(:document_category)) }
   end
 end

--- a/spec/models/enumerations/shared_enumeration_examples.rb
+++ b/spec/models/enumerations/shared_enumeration_examples.rb
@@ -30,22 +30,37 @@
 
 require "spec_helper"
 
-RSpec.shared_context "enumeration validation" do |default_supported| # rubocop:disable RSpec/ContextWording
+RSpec.shared_context "enumeration#active handling" do |default_supported| # rubocop:disable RSpec/ContextWording
   let(:enumeration) do
     super()
   rescue NoMethodError
     raise "'enumeration' let needs to be set"
   end
 
-  describe "#valid?" do
+  describe "#active" do
     if default_supported
-      context "with the enumeration being inactive and default" do
-        it "is invalid", :aggregate_failures do
+      context "with the enumeration being inactive and default before saving" do
+        it "sets the enumeration to be active", :aggregate_failures do
           enumeration.active = false
           enumeration.is_default = true
 
-          expect(enumeration.valid?).to be false
-          expect(enumeration.errors.symbols_for(:is_default)).to contain_exactly(:active_required)
+          enumeration.save
+
+          expect(enumeration).to be_persisted
+          expect(enumeration.active).to be true
+        end
+      end
+
+      context "with the enumeration being inactive and not default before saving" do
+        it "keeps the value of active", :aggregate_failures do
+          enumeration.active = false
+          enumeration.is_default = false
+
+          enumeration.save
+
+          expect(enumeration).to be_persisted
+          expect(enumeration.active).to be false
+          expect(enumeration.is_default).to be false
         end
       end
     end

--- a/spec/models/issue_priority_spec.rb
+++ b/spec/models/issue_priority_spec.rb
@@ -29,11 +29,17 @@
 #++
 require "spec_helper"
 
+require_relative "enumerations/shared_enumeration_examples"
+
 RSpec.describe IssuePriority do
   shared_let(:priority) { create(:priority) }
   shared_let(:default_priority) { create(:default_priority) }
 
   let(:stubbed_priority) { build_stubbed(:priority) }
+
+  it_behaves_like "enumeration validation", true do
+    let(:enumeration) { build_stubbed(:priority) }
+  end
 
   describe ".ancestors" do
     it "is an enumeration" do

--- a/spec/models/issue_priority_spec.rb
+++ b/spec/models/issue_priority_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe IssuePriority do
 
   let(:stubbed_priority) { build_stubbed(:priority) }
 
-  it_behaves_like "enumeration validation", true do
-    let(:enumeration) { build_stubbed(:priority) }
+  it_behaves_like "enumeration#active handling", true do
+    let(:enumeration) { described_class.new(attributes_for(:priority)) }
   end
 
   describe ".ancestors" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64842

# What are you trying to accomplish?

Prevent users from having an enumeration (e.g. Priority) that is both default and inactive.

This is checked in the backend as well to prevent the invalid state to be persisted. But since it is currently not possible to have a validation message on a check_box, a JS will toggle the fields while the user selects/deselects the values.

![Kapture 2025-07-09 at 11 37 03](https://github.com/user-attachments/assets/f0615a18-408c-4933-b07e-fb29ab5e3fa5)


# Merge checklist

- [x] Added/updated tests