### PR TITLE
Modernize `WorkPackagesActivitiesTabIndexController` event listener management via `AbortController`

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -86,21 +86,13 @@ export default class IndexController extends Controller {
   declare showConflictFlashMessageUrlValue:string;
   declare unsavedChangesConfirmationMessageValue:string;
 
-  private handleWorkPackageUpdateBound:EventListener;
-  private handleVisibilityChangeBound:EventListener;
-  private rescueEditorContentBound:EventListener;
-  private handleTurboSubmitStartBound:EventListener;
-  private handleTurboSubmitEndBound:EventListener;
-
-  private onEscapeEditorBound:EventListener;
-  private adjustMarginBound:EventListener;
-  private onBlurEditorBound:EventListener;
-  private onFocusEditorBound:EventListener;
-
   private updateInProgress:boolean;
   private turboRequests:TurboRequestsService;
 
   private apiV3Service:ApiV3Service;
+
+  private abortController = new AbortController();
+  private ckEditorAbortController = new AbortController();
 
   async connect() {
     const context = await window.OpenProject.getPluginContext();
@@ -123,6 +115,7 @@ export default class IndexController extends Controller {
   disconnect() {
     this.rescueEditorContent();
     this.removeEventListeners();
+    this.removeCkEditorEventListeners();
     this.stopPolling();
     this.markAsDisconnected();
   }
@@ -145,30 +138,28 @@ export default class IndexController extends Controller {
   }
 
   private setupEventListeners() {
-    this.handleWorkPackageUpdateBound = () => { void this.handleWorkPackageUpdate(); };
-    this.handleVisibilityChangeBound = () => { void this.handleVisibilityChange(); };
-    this.rescueEditorContentBound = () => { void this.rescueEditorContent(); };
+    const { signal } = this.abortController;
 
-    this.handleTurboSubmitStartBound = (event:Event) => { void this.handleTurboSubmitStart(event); };
-    this.handleTurboSubmitEndBound = (event:Event) => { void this.handleTurboSubmitEnd(event); };
+    const handlers = {
+      workPackageUpdated: () => { void this.handleWorkPackageUpdate(); },
+      workPackageNotificationsUpdated: () => { void this.handleWorkPackageUpdate(); },
+      visibilityChange: () => { void this.handleVisibilityChange(); },
+      beforeUnload: () => { void this.rescueEditorContent(); },
+      turboSubmitStart: (event:Event) => { void this.handleTurboSubmitStart(event); },
+      turboSubmitEnd: (event:Event) => { void this.handleTurboSubmitEnd(event); },
+    };
 
-    document.addEventListener('work-package-updated', this.handleWorkPackageUpdateBound);
-    document.addEventListener('work-package-notifications-updated', this.handleWorkPackageUpdateBound);
-    document.addEventListener('visibilitychange', this.handleVisibilityChangeBound);
-    document.addEventListener('beforeunload', this.rescueEditorContentBound);
+    document.addEventListener('work-package-updated', handlers.workPackageUpdated, { signal });
+    document.addEventListener('work-package-notifications-updated', handlers.workPackageNotificationsUpdated, { signal });
+    document.addEventListener('visibilitychange', handlers.visibilityChange, { signal });
+    document.addEventListener('beforeunload', handlers.beforeUnload, { signal });
 
-    this.element.addEventListener('turbo:submit-start', this.handleTurboSubmitStartBound);
-    this.element.addEventListener('turbo:submit-end', this.handleTurboSubmitEndBound);
+    this.element.addEventListener('turbo:submit-start', handlers.turboSubmitStart, { signal });
+    this.element.addEventListener('turbo:submit-end', handlers.turboSubmitEnd, { signal });
   }
 
   private removeEventListeners() {
-    document.removeEventListener('work-package-updated', this.handleWorkPackageUpdateBound);
-    document.removeEventListener('work-package-notifications-updated', this.handleWorkPackageUpdateBound);
-    document.removeEventListener('visibilitychange', this.handleVisibilityChangeBound);
-    document.removeEventListener('beforeunload', this.rescueEditorContentBound);
-
-    this.element.removeEventListener('turbo:submit-start', this.handleTurboSubmitStartBound);
-    this.element.removeEventListener('turbo:submit-end', this.handleTurboSubmitEndBound);
+    this.abortController.abort();
   }
 
   private handleVisibilityChange() {
@@ -555,34 +546,32 @@ export default class IndexController extends Controller {
     }
   }
 
-  private addEventListenersToCkEditorInstance() {
-    this.onEscapeEditorBound = () => { void this.closeEditor(); };
-    this.adjustMarginBound = () => { void this.adjustJournalContainerMargin(); };
-    this.onBlurEditorBound = () => { void this.onBlurEditor(); };
-    this.onFocusEditorBound = () => {
-      void this.onFocusEditor();
-      if (this.isMobile()) {
-        void this.scrollInputContainerIntoView(200);
-      }
+  private addCkEditorEventListeners() {
+    const { signal } = this.ckEditorAbortController;
+
+    const handlers = {
+      onEscapeEditor: () => { void this.closeEditor(); },
+      adjustMargin: () => { void this.adjustJournalContainerMargin(); },
+      onBlurEditor: () => { void this.onBlurEditor(); },
+      onFocusEditor: () => {
+        void this.onFocusEditor();
+        if (this.isMobile()) { void this.scrollInputContainerIntoView(200); }
+      },
     };
 
     const editorElement = this.getCkEditorElement();
     if (editorElement) {
-      editorElement.addEventListener('editorEscape', this.onEscapeEditorBound);
-      editorElement.addEventListener('editorKeyup', this.adjustMarginBound);
-      editorElement.addEventListener('editorBlur', this.onBlurEditorBound);
-      editorElement.addEventListener('editorFocus', this.onFocusEditorBound);
+      editorElement.addEventListener('editorEscape', handlers.onEscapeEditor, { signal });
+      editorElement.addEventListener('editorKeyup', handlers.adjustMargin, { signal });
+      editorElement.addEventListener('editorBlur', handlers.onBlurEditor, { signal });
+      editorElement.addEventListener('editorFocus', handlers.onFocusEditor, { signal });
     }
   }
 
-  private removeEventListenersFromCkEditorInstance() {
-    const editorElement = this.getCkEditorElement();
-    if (editorElement) {
-      editorElement.removeEventListener('editorEscape', this.onEscapeEditorBound);
-      editorElement.removeEventListener('editorKeyup', this.adjustMarginBound);
-      editorElement.removeEventListener('editorBlur', this.onBlurEditorBound);
-      editorElement.removeEventListener('editorFocus', this.onFocusEditorBound);
-    }
+  private removeCkEditorEventListeners() {
+    this.ckEditorAbortController.abort();
+    // Create a new AbortController for future CKEditor events
+    this.ckEditorAbortController = new AbortController();
   }
 
   private adjustJournalContainerMargin() {
@@ -636,7 +625,7 @@ export default class IndexController extends Controller {
     this.formRowTarget.classList.remove('d-none');
     this.journalsContainerTarget?.classList.add('work-packages-activities-tab-index-component--journals-container_with-input-compensation');
 
-    this.addEventListenersToCkEditorInstance();
+    this.addCkEditorEventListeners();
 
     if (this.isMobile()) {
       this.focusEditor(0);
@@ -670,7 +659,7 @@ export default class IndexController extends Controller {
 
   hideEditor() {
     this.clearEditor(); // remove potentially empty lines
-    this.removeEventListenersFromCkEditorInstance();
+    this.removeCkEditorEventListeners();
     this.buttonRowTarget.classList.remove('d-none');
     this.formRowTarget.classList.add('d-none');
 


### PR DESCRIPTION
https://community.openproject.org/wp/65705

[AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) is a browser API that lets you manage the lifecycle of event listeners and other asynchronous operations. You create an AbortController, pass its signal to addEventListener, and later call abort() to remove all listeners attached with that signal.

Example:

```js
const controller = new AbortController();
window.addEventListener('beforeunload', handler, { signal: controller.signal });

// Later, to remove the listener:
controller.abort(); // All listeners attached with this signal are removed
```

Follows improvements seen in https://github.com/opf/openproject/pull/19442 😇

This change improves maintainability and ensures that event listeners are reliably cleaned up, reducing the risk of memory leaks in the WorkPackagesActivitiesTabIndexController.