### PR TITLE
[65612] Adjust spacings in sidebar

### DIFF
--- a/app/components/enterprise_edition/trial_teaser_component.rb
+++ b/app/components/enterprise_edition/trial_teaser_component.rb
@@ -43,9 +43,7 @@ module EnterpriseEdition
     def set_system_arguments(system_arguments)
       @system_arguments = system_arguments
       @system_arguments[:tag] = :div
-      @system_arguments[:mx] = 2
-      @system_arguments[:mt] = 2
-      @system_arguments[:mb] = 3
+      @system_arguments[:my] = 2
       @system_arguments[:id] = "op-enterprise-banner-teaser"
       @system_arguments[:test_selector] = "op-enterprise-banner"
       @system_arguments[:classes] = class_names(

--- a/app/components/open_project/common/submenu_component.sass
+++ b/app/components/open_project/common/submenu_component.sass
@@ -8,7 +8,7 @@
     top: 0
     z-index: 1
     background: var(--main-menu-bg-color)
-    padding: 12px var(--main-menu-x-spacing)
+    padding: 4px 0
     color: var(--main-menu-font-color)
     display: flex
     flex-direction: column

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -190,7 +190,7 @@ $arrow-left-width: 36px
   top: 0
   z-index: 1
   background: var(--main-menu-bg-color)
-  padding: 0px 10px 0 0px
+  padding: 0
   height: calc(var(--main-menu-item-height) + 10px)
 
   .main-menu--arrow-left-to-project:not(.Button)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65612

# What are you trying to accomplish?
* Adjust spacings arond
  * trial teaser
  * search field
  * submenu header

## Screenshots
| Before    | After |
| -------- | ------- |
| <img width="240" alt="Bildschirmfoto 2025-07-09 um 15 48 33" src="https://github.com/user-attachments/assets/9f73c138-df51-48e1-9b35-bd93e7ad8239" />  | <img width="236" alt="Bildschirmfoto 2025-07-09 um 15 47 48" src="https://github.com/user-attachments/assets/830f5310-2375-4d37-9b7b-4319903ae9e4" />    |



