### PR TITLE
Add static stimulus registry to allow registering from plugins

### DIFF
--- a/docs/development/concepts/stimulus/README.md
+++ b/docs/development/concepts/stimulus/README.md
@@ -19,6 +19,21 @@ All controllers live under `frontend/src/stimulus/controllers/`. The naming conv
 
 If you want to add a common pattern, manually register the controller under `frontend/src/stimulus/setup.ts`. Often you'll want to have a dynamically loaded controller instead though.
 
+### Adding a static controller from a plugin
+
+If you want to add a stimulus controller from plugin code, you can do so by manually adding it to the preregister:
+
+```typescript
+import { OpenProjectStimulusApplication } from 'core-app/stimulus/app';
+import { MyTestControllerClass } from './test/foo/my-test.controller';
+  
+
+OpenProjectStimulusApplication.preregister(
+  'test',
+  MyTestControllerClass
+);
+```
+
 ### Dynamically loaded controllers
 
 To dynamically load a controller, it needs to live under `frontend/src/stimulus/controllers/dynamic/<controller-name>.controller.ts`.
@@ -40,6 +55,21 @@ If you want to organize your dynamic controllers in a subfolder, use the [double
 ```
 
 You need to take care to prefix all actions, values etc. with the exact same pattern, e.g., `data-admin--settings-target="foobar"`.
+
+#### Dynamically loading controllers from plugins
+
+If you want to add a dynamic stimulus controller import from plugin code, you can do so by manually adding it to the preregister:
+
+```typescript
+import { OpenProjectStimulusApplication } from 'core-app/stimulus/app';
+
+OpenProjectStimulusApplication.preregisterDynamic(
+  'test',
+  () => import('./test.controller')
+);
+```
+
+This ensures that the controller is loaded only when it is needed, and not at application startup. The controller will then be engaded when the `data-controller` attribute is present in the DOM through the same mechanism as for the core dynamic controllers.
 
 ### Requiring a page controller
 

--- a/frontend/src/stimulus/controllers/op-application.controller.ts
+++ b/frontend/src/stimulus/controllers/op-application.controller.ts
@@ -2,6 +2,7 @@ import { ControllerConstructor } from '@hotwired/stimulus/dist/types/core/contro
 import { ApplicationController } from 'stimulus-use';
 import { AttributeObserver } from '@hotwired/stimulus';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
+import { OpenProjectStimulusApplication } from 'core-stimulus/openproject-stimulus-application';
 
 export class OpApplicationController extends ApplicationController {
   private loaded = new Set<string>();
@@ -30,17 +31,41 @@ export class OpApplicationController extends ApplicationController {
     const registered = this.application.router.modules.map((module) => module.definition.identifier);
 
     controllers.forEach((controller) => {
-      const path = this.derivePath(controller);
       if (!registered.includes(controller) && !this.loaded.has(controller)) {
         debugLog(`Loading controller ${controller}`);
         this.loaded.add(controller);
-        void import(/* webpackChunkName: "[request]" */`./dynamic/${path}.controller`)
-          .then((imported:{ default:ControllerConstructor }) => this.application.register(controller, imported.default))
-          .catch((err:unknown) => {
-            console.error('Failed to load dynamic controller chunk %O: %O', controller, err);
+
+        void this
+          .importController(controller)
+          .then((clazz) => {
+            if (clazz) {
+              this.application.register(controller, clazz);
+            }
           });
       }
     });
+  }
+
+  private async importController(controller:string):Promise<ControllerConstructor|null> {
+    try {
+      const imported = await this.fetchDynamicController(controller);
+      return imported.default;
+    } catch (err) {
+      console.error('Failed to load dynamic controller chunk %O: %O', controller, err);
+      return null;
+    }
+  }
+
+  private async fetchDynamicController(controller:string) {
+    if (OpenProjectStimulusApplication.dynamicImports.has(controller)) {
+      return OpenProjectStimulusApplication.dynamicImports.get(controller)!();
+    }
+
+    // Default: Try to load the controller from dynamic/ subfolder.
+    const path = this.derivePath(controller);
+    return await import(/* webpackChunkName: "[request]" */ `./dynamic/${path}.controller`) as Promise<{
+      default:ControllerConstructor
+    }>;
   }
 
   /**

--- a/frontend/src/stimulus/openproject-stimulus-application.ts
+++ b/frontend/src/stimulus/openproject-stimulus-application.ts
@@ -1,8 +1,14 @@
 import { ControllerConstructor } from '@hotwired/stimulus/dist/types/core/controller';
 import { Application } from '@hotwired/stimulus';
 
+export type DynamicControllerLoader = () => Promise<{ default:ControllerConstructor }>;
+
 export class OpenProjectStimulusApplication extends Application {
+  /** A map of controllers that have been preregistered. */
   static controllers = new Map<string, ControllerConstructor>();
+
+  /** A map of a dynamic controller loader to load when the controller name is found */
+  static dynamicImports = new Map<string, DynamicControllerLoader>();
 
   /**
    * Register a controller to be used in the application,
@@ -15,6 +21,27 @@ export class OpenProjectStimulusApplication extends Application {
    */
   static preregister(name:string, controller:ControllerConstructor) {
     this.controllers.set(name, controller);
+  }
+
+  /**
+   * Register a dynamic controller to be imported using the given path,
+   * allowing it to be defined somewhere else than within the dynamic/ subfolder.
+   *
+   * This is useful for plugins that want to define new dynamic controllers.
+   * How to use this: In your plugin's main.ts, call this
+   *
+   * ```typescript
+   * OpenProjectStimulusApplication.preregisterDynamic(
+   *   'test',
+   *   () => import('./test.controller')
+   * );
+   * ```
+   *
+   * @param name the name/identifier of the controller
+   * @param loader A callback to provide the controller asynchronously.
+   */
+  static preregisterDynamic(name:string, loader:DynamicControllerLoader) {
+    this.dynamicImports.set(name, loader);
   }
 
   async start():Promise<void> {

--- a/frontend/src/stimulus/openproject-stimulus-application.ts
+++ b/frontend/src/stimulus/openproject-stimulus-application.ts
@@ -1,0 +1,31 @@
+import { ControllerConstructor } from '@hotwired/stimulus/dist/types/core/controller';
+import { Application } from '@hotwired/stimulus';
+
+export class OpenProjectStimulusApplication extends Application {
+  static controllers = new Map<string, ControllerConstructor>();
+
+  /**
+   * Register a controller to be used in the application,
+   * allowing it to be registered before the Stimulus application is being initialized.
+   *
+   * This is useful for plugins that execute code before we call setup.ts
+   *
+   * @param name the name/identifier of the controller
+   * @param controller the controller class
+   */
+  static preregister(name:string, controller:ControllerConstructor) {
+    this.controllers.set(name, controller);
+  }
+
+  async start():Promise<void> {
+    this.preregisteredControllers.forEach((controller, name) => {
+      this.register(name, controller);
+    });
+
+    await super.start();
+  }
+
+  get preregisteredControllers() {
+    return OpenProjectStimulusApplication.controllers;
+  }
+}

--- a/frontend/src/stimulus/openproject-stimulus-application.ts
+++ b/frontend/src/stimulus/openproject-stimulus-application.ts
@@ -29,8 +29,7 @@ export class OpenProjectStimulusApplication extends Application {
    *
    * This is useful for plugins that want to define new dynamic controllers.
    * How to use this: In your plugin's main.ts, call this
-   *
-   * ```typescript
+   * @example
    * OpenProjectStimulusApplication.preregisterDynamic(
    *   'test',
    *   () => import('./test.controller')

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -1,4 +1,3 @@
-import { Application } from '@hotwired/stimulus';
 import { environment } from '../environments/environment';
 import { OpApplicationController } from './controllers/op-application.controller';
 import MainMenuController from './controllers/dynamic/menus/main.controller';
@@ -22,6 +21,8 @@ import ScrollIntoViewController from './controllers/scroll-into-view.controller'
 import CkeditorFocusController from './controllers/ckeditor-focus.controller';
 
 import AutoSubmit from '@stimulus-components/auto-submit';
+import { OpenProjectStimulusApplication } from 'core-stimulus/openproject-stimulus-application';
+import { Application } from '@hotwired/stimulus';
 
 declare global {
   interface Window {
@@ -29,35 +30,32 @@ declare global {
   }
 }
 
-const instance = Application.start();
+OpenProjectStimulusApplication.preregister('application', OpApplicationController);
+OpenProjectStimulusApplication.preregister('async-dialog', AsyncDialogController);
+OpenProjectStimulusApplication.preregister('disable-when-checked', OpDisableWhenCheckedController);
+OpenProjectStimulusApplication.preregister('flash', FlashController);
+OpenProjectStimulusApplication.preregister('menus--main', MainMenuController);
+OpenProjectStimulusApplication.preregister('password-confirmation-dialog', PasswordConfirmationDialogController);
+OpenProjectStimulusApplication.preregister('poll-for-changes', PollForChangesController);
+OpenProjectStimulusApplication.preregister('print', PrintController);
+OpenProjectStimulusApplication.preregister('refresh-on-form-changes', RefreshOnFormChangesController);
+OpenProjectStimulusApplication.preregister('form-preview', FormPreviewController);
+OpenProjectStimulusApplication.preregister('hover-card-trigger', HoverCardTriggerController);
+OpenProjectStimulusApplication.preregister('show-when-checked', OpShowWhenCheckedController);
+OpenProjectStimulusApplication.preregister('show-when-value-selected', OpShowWhenValueSelectedController);
+OpenProjectStimulusApplication.preregister('table-highlighting', TableHighlightingController);
+OpenProjectStimulusApplication.preregister('projects-zen-mode', OpProjectsZenModeController);
+OpenProjectStimulusApplication.preregister('work-packages--date-picker--preview', PreviewController);
+OpenProjectStimulusApplication.preregister('keep-scroll-position', KeepScrollPositionController);
+OpenProjectStimulusApplication.preregister('pattern-input', PatternInputController);
+OpenProjectStimulusApplication.preregister('scroll-into-view', ScrollIntoViewController);
+OpenProjectStimulusApplication.preregister('ckeditor-focus', CkeditorFocusController);
+OpenProjectStimulusApplication.preregister('auto-submit', AutoSubmit);
+
+const instance = OpenProjectStimulusApplication.start();
 window.Stimulus = instance;
 
 instance.debug = !environment.production;
 instance.handleError = (error, message, detail) => {
   console.warn(error, message, detail);
 };
-
-instance.register('async-dialog', AsyncDialogController);
-instance.register('disable-when-checked', OpDisableWhenCheckedController);
-instance.register('flash', FlashController);
-instance.register('menus--main', MainMenuController);
-instance.register('password-confirmation-dialog', PasswordConfirmationDialogController);
-instance.register('poll-for-changes', PollForChangesController);
-instance.register('print', PrintController);
-instance.register('refresh-on-form-changes', RefreshOnFormChangesController);
-instance.register('form-preview', FormPreviewController);
-instance.register('hover-card-trigger', HoverCardTriggerController);
-instance.register('show-when-checked', OpShowWhenCheckedController);
-instance.register('show-when-value-selected', OpShowWhenValueSelectedController);
-instance.register('table-highlighting', TableHighlightingController);
-instance.register('projects-zen-mode', OpProjectsZenModeController);
-instance.register('work-packages--date-picker--preview', PreviewController);
-instance.register('keep-scroll-position', KeepScrollPositionController);
-instance.register('pattern-input', PatternInputController);
-instance.register('scroll-into-view', ScrollIntoViewController);
-instance.register('ckeditor-focus', CkeditorFocusController);
-instance.register('auto-submit', AutoSubmit);
-
-// Application controller must be registered last, as it tries to automatically load other controllers
-// not yet registered.
-instance.register('application', OpApplicationController);


### PR DESCRIPTION
https://community.openproject.org/work_packages/65637

Right now, plugins can not register additional stimulus controllers. They either:

- Run before window.Stimulus is present
- After the page is initialized, causing the application controller to try and load dynamic controllers

To avoid this, we allow registering controllers in our own subclassed application. In a plugin's `main.ts`, you can now simply register new controllers.

**Dynamic controllers**

You can also load dynamic controllers like so:

```typescript
// In your plugin main.ts
OpenProjectStimulusApplication.preregisterDynamic(
  'test',
  () => import('./test.controller')
);
```