### PR TITLE
[64472] Focus should return to trigger element on closing attribute help text dialog

### DIFF
--- a/frontend/src/stimulus/controllers/async-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.ts
@@ -34,23 +34,20 @@ import { TurboHelpers } from '../../turbo/helpers';
 
 export default class AsyncDialogController extends ApplicationController {
   connect() {
-    this.element.addEventListener('click', (event:MouseEvent) => this.handleClick(event));
-    this.element.addEventListener('keydown', (event:KeyboardEvent) => this.handleKeydown(event));
-  }
-
-  handleClick(event:MouseEvent) {
-    event.preventDefault();
-    this.triggerTurboStream();
-  }
-
-  handleKeydown(event:KeyboardEvent) {
-    if (event.key === 'Enter' || event.key === ' ') {
+    this.element.addEventListener('click', (event:MouseEvent) => {
       event.preventDefault();
       this.triggerTurboStream();
-    }
+    });
+
+    this.element.addEventListener('keydown', (event:KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        this.triggerTurboStream();
+      }
+    });
   }
 
-  triggerTurboStream():void {
+  private triggerTurboStream():void {
     TurboHelpers.showProgressBar();
 
     void fetch(this.href, {

--- a/frontend/src/stimulus/controllers/async-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.ts
@@ -34,10 +34,20 @@ import { TurboHelpers } from '../../turbo/helpers';
 
 export default class AsyncDialogController extends ApplicationController {
   connect() {
-    this.element.addEventListener('click', (e) => {
-      e.preventDefault();
+    this.element.addEventListener('click', (event:MouseEvent) => this.handleClick(event));
+    this.element.addEventListener('keydown', (event:KeyboardEvent) => this.handleKeydown(event));
+  }
+
+  handleClick(event:MouseEvent) {
+    event.preventDefault();
+    this.triggerTurboStream();
+  }
+
+  handleKeydown(event:KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
       this.triggerTurboStream();
-    });
+    }
   }
 
   triggerTurboStream():void {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64472

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Added explicit keyboard event handling (keydown for Enter and Space) in the AsyncDialogController to prevent default anchor navigation and ensure consistent behavior across mouse and keyboard interactions.