### PR TITLE
[#65298] Fix broken top bar menus on form errors

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -217,13 +217,16 @@ export function initializeServices(injector:Injector) {
     // Conditionally add the Revit Add-In settings button
     injector.get(RevitAddInSettingsButtonService);
 
-    topMenuService.register();
-    contextMenu.register();
-
-    // Re-register on turbo:load
-    document.addEventListener('turbo:load', () => {
+    const runOnRenderAndLoad = () => {
       topMenuService.register();
       contextMenu.register();
+    };
+    runOnRenderAndLoad();
+
+    // Register on turbo:render, turbo:load
+    document.addEventListener('turbo:render', runOnRenderAndLoad);
+    document.addEventListener('turbo:load', () => {
+      runOnRenderAndLoad();
       currentProject.detect();
     });
 

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -15,7 +15,7 @@ import {
 } from 'core-app/core/setup/globals/global-listeners/setup-server-response';
 
 export function addTurboGlobalListeners() {
-  document.addEventListener('turbo:load', () => {
+  const runOnRenderAndLoad = () => {
     // Add to content if warnings displayed
     if (document.querySelector('.warning-bar--item')) {
       const content = document.querySelector('#content') as HTMLElement;
@@ -63,7 +63,9 @@ export function addTurboGlobalListeners() {
     focusFirstErroneousField();
     activateFlashNotice();
     activateFlashError();
-  });
+  };
+  document.addEventListener('turbo:render', runOnRenderAndLoad);
+  document.addEventListener('turbo:load', runOnRenderAndLoad);
 
   document.addEventListener('turbo:before-morph-element', (event) => {
     const element = event.target as HTMLElement;


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65298

# What are you trying to accomplish?

Menus in the top bar were not properly initialised after unsuccessful form submissions that result in an 422 Unprocessable Entity response via Turbo Drive.

This commit updates Angular-Turbo Drive integration code to listen to `turbo:render` in addition to `turbo:load`. `turbo:load` is only fired on Turbo Drive _visits_. However, a form submission response that is not a 303 Redirect is not considered a _visit_ by Turbo Drive.

# What approach did you choose and why?

This is a minimally-invasive approach that just updates the event listeners. The integration code could definitely be improved in the future - one approach we might take could use Stimulus controllers and `MutationObserver` rather than hooking into Turbo Drive events.

<details><summary>Context: load vs render</summary>

| Event Context | turbo:load | turbo:render |
| -- | -- | -- |
| Initial full page load | ✅ | ❌ |
| First Turbo visit | ✅ | ✅ |
| Subsequent Turbo visit | ❌ | ✅ |
| Browser reload (F5) | ✅ | ❌ |


<small>N.B. [generated by ChatGPT](https://chatgpt.com/s/t_686eb6a899cc819196e50f735f3e5f76)</small>
</details> 

See also: https://github.com/hotwired/turbo/issues/85
See also: https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
