### PR TITLE
[64229] Search is missing a screen reader label

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -1,14 +1,26 @@
-<div class="top-menu-search">
+<div class="top-menu-search" [attr.aria-label]="placeholder">
+
   <button
     *ngIf="expanded"
     (click)="toggleMobileSearch()"
     class="top-menu-search--back-button"
     href="#"
-    title="{{text.close_search}}"
+    [attr.title]="text.close_search"
+    [attr.aria-label]="text.close_search"
   >
     <i class="icon-arrow-left1" aria-hidden="true"></i>
   </button>
-
+  <button
+    role="button"
+    #btn
+    id="top-menu-search-button"
+    class="top-menu-search--button search-form-normal"
+    [attr.aria-label]="text.search || 'Search'"
+    [class.-input-focused]="expanded"
+    (click)="handleClick($event)"
+  >
+    <op-icon icon-classes="icon5 icon-search ellipsis"></op-icon>
+  </button>
   <op-autocompleter
     #select
     [defaultData]="false"
@@ -75,9 +87,7 @@
                 {{ item.project.name }}
               </span>
             </div>
-            <span
-              class="global-search--wp-subject"
-            >
+            <span class="global-search--wp-subject">
               {{ item.subject }}
             </span>
           </div>
@@ -85,17 +95,4 @@
       </ng-template>
     </ng-template>
   </op-autocompleter>
-
-  <button
-    role="button"
-    #btn
-    id="top-menu-search-button"
-    class="top-menu-search--button search-form-normal"
-    [attr.aria-label]="text.search"
-    [class.-input-focused]="expanded"
-    (click)="handleClick($event)"
-
-  >
-    <op-icon icon-classes="icon5 icon-search ellipsis"></op-icon>
-  </button>
 </div>

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -16,6 +16,7 @@
     #btn
     id="top-menu-search-button"
     class="top-menu-search--button search-form-normal"
+    [attr.title]="text.search"
     [attr.aria-label]="text.search"
     [class.-input-focused]="expanded"
     (click)="handleClick($event)"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -1,4 +1,4 @@
-<div class="top-menu-search" [attr.aria-label]="placeholder">
+<div role="search" class="top-menu-search" [attr.aria-label]="placeholder">
 
   <button
     *ngIf="expanded"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -15,7 +15,7 @@
     #btn
     id="top-menu-search-button"
     class="top-menu-search--button search-form-normal"
-    [attr.aria-label]="text.search || 'Search'"
+    [attr.aria-label]="text.search"
     [class.-input-focused]="expanded"
     (click)="handleClick($event)"
   >

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -2,6 +2,7 @@
 
   <button
     *ngIf="expanded"
+    type="button"
     (click)="toggleMobileSearch()"
     class="top-menu-search--back-button"
     href="#"
@@ -11,7 +12,7 @@
     <i class="icon-arrow-left1" aria-hidden="true"></i>
   </button>
   <button
-    role="button"
+    type="button"
     #btn
     id="top-menu-search-button"
     class="top-menu-search--button search-form-normal"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -25,6 +25,7 @@ $search-input-height: 30px
     right: 2px
     font-size: var(--header-item-font-size)
     color: var(--header-item-font-color)
+    z-index: 1
 
     &.-input-focused
       color: var(--body-font-color) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64229

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Move search button to be the first element of global search box, so it will be read out by the screen reader first.
