### PR TITLE
[65360] Disabled project selector on project copy form is missing styling

### DIFF
--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -67,6 +67,20 @@ div.autocomplete
     .ng-select-container
       border-color: var(--content-form-error-color)
 
+  &.ng-select-disabled
+    .ng-select-container,
+    .ng-select-container .ng-value-container input
+      background-color: var(--control-bgColor-disabled) !important
+      border-color: var(--control-borderColor-disabled) !important
+      box-shadow: none !important
+      color: var(--control-fgColor-disabled) !important
+      cursor: not-allowed !important
+      opacity: 1
+      -webkit-text-fill-color: var(--control-fgColor-disabled)
+
+    &.ng-select-searchable .ng-select-container .ng-value-container .ng-input
+      opacity: 0
+
   .ng-value-container
     min-height: 2rem
     width: calc(100% - 30px)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65360

# What are you trying to accomplish?
Add disabled style for autocompleters

## Screenshots
<img width="717" alt="Bildschirmfoto 2025-07-10 um 09 33 58" src="https://github.com/user-attachments/assets/6fd05c3b-71b8-4d06-8fae-aa78d6608518" />
