### PR TITLE
[#65742] Some formatted texts in wp description field don't show on pdf report

### DIFF
--- a/app/models/work_package/pdf_export/export/markdown.rb
+++ b/app/models/work_package/pdf_export/export/markdown.rb
@@ -173,7 +173,7 @@ module WorkPackage::PDFExport::Export::Markdown
   end
 
   def markdown_writer(styling_yml)
-    @markdown_writer ||= MD2PDFExport.new(styling_yml, pdf, hyphenation_language)
+    MD2PDFExport.new(styling_yml, pdf, hyphenation_language)
   end
 
   def write_markdown!(markdown, styling_yml)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/65742

# What are you trying to achieve?

An internal state in md_to_pdf is kept, so caching our instance for bulk export is not possible as the caching interferes with them, leading to swallowing of whole descriptions and custom text fields.

# What approach did you choose and why?

Remove the caching of the md_to_pdf instance, so it starts fresh for each Markdown text, avoiding the faulty export.

This is a quick fix, as md_to_pdf needs to offer a proper API, so we no longer access internal functions via a module.
