### PR TITLE
bug/63545 When editing a comment in the activity tab and polling occurs, the form can be force closed

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/edit.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/edit.html.erb
@@ -5,7 +5,13 @@
         id: "work-package-journal-form-element", # required for specs
         model: journal,
         method: :put,
-        data: { turbo: true, turbo_stream: true, test_selector: "op-work-package-journal-form-element" },
+        data: {
+          turbo: true,
+          turbo_stream: true,
+          test_selector: "op-work-package-journal-form-element",
+          "work-packages--activities-tab--index-target": "editForm",
+          journal_id: journal.id
+        },
         url: work_package_activity_path(work_package_id: work_package.id, id: journal.id, filter:)
       ) do |f|
         flex_layout do |form_container|

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -61,12 +61,13 @@ export default class IndexController extends Controller {
     unsavedChangesConfirmationMessage: String,
   };
 
-  static targets = ['journalsContainer', 'buttonRow', 'formRow', 'form', 'formSubmitButton', 'reactionButton'];
+  static targets = ['journalsContainer', 'buttonRow', 'formRow', 'form', 'editForm', 'formSubmitButton', 'reactionButton'];
 
   declare readonly journalsContainerTarget:HTMLElement;
   declare readonly buttonRowTarget:HTMLInputElement;
   declare readonly formRowTarget:HTMLElement;
   declare readonly formTarget:HTMLFormElement;
+  declare readonly editFormTargets:HTMLFormElement[];
   declare readonly formSubmitButtonTarget:HTMLButtonElement;
   declare readonly reactionButtonTargets:HTMLElement[];
 
@@ -226,13 +227,15 @@ export default class IndexController extends Controller {
 
     this.updateInProgress = true;
 
+    const editingJournals = this.captureEditingJournals();
+
     // Unfocus any reaction buttons that may have been focused
     // otherwise the browser will perform an auto scroll to the before focused button after the stream update was applied
     this.unfocusReactionButtons();
 
     const journalsContainerAtBottom = this.isJournalsContainerScrolledToBottom();
 
-    void this.performUpdateStreamsRequest(this.prepareUpdateStreamsUrl())
+    void this.performUpdateStreamsRequest(this.prepareUpdateStreamsUrl(editingJournals))
     .then(({ html, headers }) => {
       this.handleUpdateStreamsResponse(html, headers, journalsContainerAtBottom);
     }).catch((error) => {
@@ -242,16 +245,34 @@ export default class IndexController extends Controller {
     });
   }
 
+  private captureEditingJournals():Set<string> {
+    const editingJournals = new Set<string>();
+
+    const editForms = this.editFormTargets;
+    editForms.forEach((form) => {
+      const journalId = form.dataset.journalId;
+      if (journalId) { editingJournals.add(journalId); }
+    });
+
+    return editingJournals;
+  }
+
   private unfocusReactionButtons() {
     this.reactionButtonTargets.forEach((button) => button.blur());
   }
 
-  private prepareUpdateStreamsUrl():string {
+  private prepareUpdateStreamsUrl(editingJournals:Set<string>):string {
     const baseUrl = window.location.origin;
     const url = new URL(this.updateStreamsPathValue, baseUrl);
+
     url.searchParams.set('sortBy', this.sortingValue);
     url.searchParams.set('filter', this.filterValue);
     url.searchParams.set('last_update_timestamp', this.lastServerTimestampValue);
+
+    if (editingJournals.size > 0) {
+      url.searchParams.set('editing_journals', Array.from(editingJournals).join(','));
+    }
+
     return url.toString();
   }
 

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -397,6 +397,16 @@ module Components
 
         wait_for { page }.to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")
       end
+
+      def trigger_update_streams_poll
+        page.execute_script(<<~JS)
+          var target = document.querySelector('[data-controller*="work-packages--activities-tab--index"]')
+          var controller = window.Stimulus.getControllerForElementAndIdentifier(target, 'work-packages--activities-tab--index')
+          controller.updateActivitiesList();
+        JS
+
+        wait_for_network_idle
+      end
     end
   end
 end


### PR DESCRIPTION
* https://community.openproject.org/wp/63545
* https://community.openproject.org/wp/65680

The activities tab polling mechanism updates newly updated journals, based on the last update timestamp. In case an attachment is added, or the journal is updated in any other places- the UI item would be updated on the next poll, overriding the edit form.

This commit adds an exclusion for any forms that are in "edit" state- it does not yet take into account conflict resolution.