### PR TITLE
[65711] Baseline feature is broken on trial instances

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
@@ -1,5 +1,5 @@
 <div class="op-baseline--header"
-     [class.op-baseline_banner_active]="!available"
+     [class.op-baseline--header_banner-active]="!available"
      [class.op-baseline_tab]="!showActionBar">
 
   <op-enterprise-banner-frame

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.sass
@@ -2,13 +2,12 @@
 
 .op-baseline
   &--header
-    display: flex
-    justify-content: space-between
-    align-items: flex-start
-    flex-direction: column
     width: 280px
     margin: $spot-spacing-1 $spot-spacing-1 0 $spot-spacing-1
     color: var(--fgColor-muted)
+
+    &_banner-active
+      width: 450px
 
     &:has(+ .op-baseline--body_ranged)
       width: auto
@@ -75,6 +74,3 @@
       margin-left: 0
     .op-baseline--range-container
       margin: 0
-
-  &_banner_active.op-baseline--header
-    width: 450px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65711

# What are you trying to accomplish?
Remove unnecessary flex box to make EE banner visible again. Cleanup class names a bit

## Screenshots
<img width="509" height="410" alt="Bildschirmfoto 2025-07-11 um 09 04 03" src="https://github.com/user-attachments/assets/1e13f1bc-67ad-475b-90f8-996587f6a540" />

<img width="347" height="284" alt="Bildschirmfoto 2025-07-11 um 09 04 57" src="https://github.com/user-attachments/assets/7f5ff31f-34bc-4bd3-b553-677586bc1dcd" />

