### PR TITLE
[65772] Empty "Other relations" entry when missing permissions

### DIFF
--- a/app/components/work_package_relations_tab/index_component.html.erb
+++ b/app/components/work_package_relations_tab/index_component.html.erb
@@ -23,11 +23,14 @@
             end
 
             render_add_relations_menu_items(menu, FIRST_LEVEL_RELATION_MENU_TYPES)
-            menu.with_sub_menu_item(
-              label: t("#{I18N_NAMESPACE}.relations.label_other_relations"),
-              menu_id: ADD_RELATION_SUB_MENU
-            ) do |sub_menu|
-              render_add_relations_menu_items(sub_menu, SECOND_LEVEL_RELATION_MENU_TYPES)
+
+            if should_render_add_relations?
+              menu.with_sub_menu_item(
+                label: t("#{I18N_NAMESPACE}.relations.label_other_relations"),
+                menu_id: ADD_RELATION_SUB_MENU
+              ) do |sub_menu|
+                render_add_relations_menu_items(sub_menu, SECOND_LEVEL_RELATION_MENU_TYPES)
+              end
             end
           end
         end

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -597,6 +597,26 @@ RSpec.describe "Primerized work package relations tab",
         relations_tab.relatable_action_menu(child_wp).click
         relations_tab.expect_relatable_delete_button(child_wp)
       end
+
+      it "does not show the option add new relations except for child" do
+        scroll_to_element relations_panel
+
+        wait_for_network_idle
+
+        tabs.expect_counter("relations", 8)
+
+        # The menu is shown as the user can add a child
+        relations_tab.expect_add_relation_button
+        relations_tab.open_add_relation_action_menu
+
+        # Expect options to add children
+        relations_tab.expect_new_relation_type("Parent")
+        relations_tab.expect_new_relation_type("Child")
+        relations_tab.expect_no_new_relation_type("Related To")
+
+        # .. but no sub menu for further relations
+        relations_tab.expect_no_add_menu_sub_menu
+      end
     end
   end
 end

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
       it "shows only the action to add a parent" do
         wp_page.visit_tab!("relations")
         relations_tab.expect_add_relation_button
-        relations_tab.expect_no_new_relation_type("Related to")
+        relations_tab.expect_no_new_relation_type("Related To")
         relations_tab.expect_no_new_relation_type("Child")
         relations_tab.expect_no_new_relation_type("Create new child")
         relations_tab.expect_new_relation_type("Parent")

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -116,6 +116,12 @@ module Components
         end
       end
 
+      def expect_no_add_menu_sub_menu
+        within(add_relation_action_menu) do
+          expect(page).to have_no_link("add_relation_sub_menu", wait: 1)
+        end
+      end
+
       def open_add_relation_action_menu
         return if add_relation_action_menu.visible?
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65772

# What are you trying to accomplish?
Hide submenu when the user has no permission to manage relations

