### PR TITLE
Fix flaky hierarchy feature spec

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
@@ -115,7 +115,10 @@ export class WorkPackageRelationsComponent extends UntilDestroyedMixin implement
 
   private async updateFrontendData(event:CustomEvent) {
     if (event) {
-      const form = event.target as HTMLFormElement;
+      // A turbo:submit-end event *has* a `formSubmission` property, but I do not
+      // know how to avoid the eslint type warning. Please if you know, fix it.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const form = event.detail.formSubmission.formElement as HTMLFormElement;
       const updateWorkPackage = !!form.dataset?.updateWorkPackage;
 
       if (updateWorkPackage) {


### PR DESCRIPTION
failing spec: ./spec/features/work_packages/details/relations/hierarchy_spec.rb:151
failing job: https://github.com/opf/openproject/actions/runs/16163863659/job/45620997168?pr=19479

The data-update-work-package attribute is read to know if the relations tab and its counter should be reloaded. Sometimes the event target is the html document instead of the form element, probably due to some other reloading of the relations tab (it reloads a lot actually).

The fix is to read the form element from the formSubmission property given by the turbo:submit-end event. It's guaranteed to be the form element from which the event was triggered.