### PR TITLE
Bump rubocop-openproject to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1102,7 +1102,7 @@ GEM
     rspec-support (3.13.4)
     rspec-wait (1.0.2)
       rspec (>= 3.4)
-    rubocop (1.77.0)
+    rubocop (1.78.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -1122,7 +1122,7 @@ GEM
     rubocop-factory_bot (2.27.1)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-openproject (0.2.0)
+    rubocop-openproject (0.3.0)
       rubocop
     rubocop-performance (1.25.0)
       lint_roller (~> 1.1)
@@ -1924,11 +1924,11 @@ CHECKSUMS
   rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858
   rspec-support (3.13.4) sha256=184b1814f6a968102b57df631892c7f1990a91c9a3b9e80ef892a0fc2a71a3f7
   rspec-wait (1.0.2) sha256=865f921239325d3d26fc10ded4bdd485d8b58bcaaad1a28dd85ed15266b5a912
-  rubocop (1.77.0) sha256=1f360b4575ef7a124be27b0dfffa227a2b2d9420d22d4fd8bf179d702bcc88c0
+  rubocop (1.78.0) sha256=8b74a6f912eb4fd3e6878851f7f7f45dcad8c7185c34250d4f952b0ee80d6bc0
   rubocop-ast (1.45.1) sha256=94042e49adc17f187ba037b33f941ba7398fede77cdf4bffafba95190a473a3e
   rubocop-capybara (2.22.1) sha256=ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c
   rubocop-factory_bot (2.27.1) sha256=9d744b5916778c1848e5fe6777cc69855bd96548853554ec239ba9961b8573fe
-  rubocop-openproject (0.2.0) sha256=2300ed6b638a34a9368b458dc5fb618ae396da6a27670b50519ad1e3cea65ccb
+  rubocop-openproject (0.3.0) sha256=9554496e7ef0a2cf65dc2b32bee1bfa223b4f9ae058a5c603489d34e9001a828
   rubocop-performance (1.25.0) sha256=6f7d03568a770054117a78d0a8e191cefeffb703b382871ca7743831b1a52ec1
   rubocop-rails (2.32.0) sha256=9fcc623c8722fe71e835e99c4a18b740b5b0d3fb69915d7f0777f00794b30490
   rubocop-rspec (3.6.0) sha256=c0e4205871776727e54dee9cc91af5fd74578001551ba40e1fe1a1ab4b404479

--- a/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe MeetingAgendaItems::FormComponent, type: :component do
   end
 
   it "renders notes field" do
-    expect(rendered_component).to have_field "Notes", type: :textarea, visible: :hidden do |textarea| # rubocop:disable OpenProject/NoDoEndBlockWithRSpecCapybaraMatcherInExpect
+    expect(rendered_component).to have_field "Notes", type: :textarea, visible: :hidden do |textarea|
       expect(rendered_component).to have_element "opce-ckeditor-augmented-textarea",
                                                  "data-test-selector": "augmented-text-area-notes",
                                                  "data-text-area-id": textarea["id"].to_json

--- a/modules/meeting/spec/components/meeting_agenda_items/outcomes/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/outcomes/form_component_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe MeetingAgendaItems::Outcomes::FormComponent, type: :component do
   end
 
   it "renders outcome field" do
-    expect(rendered_component).to have_field "Outcome", type: :textarea, visible: :hidden do |textarea| # rubocop:disable OpenProject/NoDoEndBlockWithRSpecCapybaraMatcherInExpect
+    expect(rendered_component).to have_field "Outcome", type: :textarea, visible: :hidden do |textarea|
       expect(rendered_component).to have_element "opce-ckeditor-augmented-textarea",
                                                  "data-test-selector": "augmented-text-area-notes",
                                                  "data-text-area-id": textarea["id"].to_json


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Update rubocop-openproject to 0.3.0, which removes a no longer necessary cop, `NoDoEndBlockWithRSpecCapybaraMatcherInExpect`.

# What approach did you choose and why?

⚠️ While dependency updates normally target `dev`, but this change is needed to quieten Rubocop offenses in a bug fix targeting 16.2, #19468.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
