### PR TITLE
Allow to synchronize groups via OpenID Connect

### DIFF
--- a/modules/openid_connect/app/models/openid_connect/group_link.rb
+++ b/modules/openid_connect/app/models/openid_connect/group_link.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenIDConnect
+  class GroupLink < ::ApplicationRecord
+    self.table_name = "oidc_group_links"
+
+    belongs_to :group
+    belongs_to :auth_provider
+  end
+end

--- a/modules/openid_connect/app/models/openid_connect/group_membership.rb
+++ b/modules/openid_connect/app/models/openid_connect/group_membership.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenIDConnect
+  class GroupMembership < ::ApplicationRecord
+    self.table_name = "oidc_group_memberships"
+
+    belongs_to :auth_provider
+    belongs_to :group_user
+
+    delegate :group, :user, to: :group_user
+  end
+end

--- a/modules/openid_connect/app/services/openid_connect/groups/sync_service.rb
+++ b/modules/openid_connect/app/services/openid_connect/groups/sync_service.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenIDConnect
+  module Groups
+    class SyncService
+      def initialize(user:)
+        @user = user
+        @result = ServiceResult.success
+      end
+
+      def call(groups_claim:)
+        raise ArgumentError, "groups_claim must not be nil" if groups_claim.nil?
+
+        user_groups = []
+
+        groups_claim.each do |oidc_group_name|
+          group = process_oidc_group(oidc_group_name)
+          user_groups << group if group
+        end
+
+        remove_groups_except(user_groups)
+
+        @result
+      end
+
+      private
+
+      def process_oidc_group(oidc_group_name)
+        oidc_group_name = filter_and_name_group(oidc_group_name)
+        return nil if oidc_group_name.nil?
+
+        group = find_group(oidc_group_name)
+        update_group_users(group) { |user_ids| (user_ids + [@user.id]).uniq }
+
+        membership = group.group_users.find_by(user: @user)
+        membership.oidc_group_memberships.find_or_create_by!(auth_provider: authentication_provider)
+
+        group
+      end
+
+      def remove_groups_except(keep_groups)
+        (@user.groups - keep_groups).each do |group|
+          update_group_users(group) { |user_ids| user_ids - [@user.id] }
+        end
+      end
+
+      def filter_and_name_group(group_name)
+        matcher = authentication_provider.group_matchers.find { |m| m.match?(group_name) }
+        return nil if matcher.nil?
+
+        match = matcher.match(group_name)
+        if match.size > 1
+          match[1..].join.presence
+        else
+          group_name
+        end
+      end
+
+      def find_group(oidc_group_name)
+        group_link = GroupLink.find_or_initialize_by(auth_provider: authentication_provider, oidc_group_name:)
+        if group_link.group.nil?
+          group_link.group = ::Group.find_or_create_by!(name: oidc_group_name)
+          group_link.save!
+        end
+
+        group_link.group
+      end
+
+      def update_group_users(group)
+        # TODO: is that service well suited for many small group changes?
+        current_user_ids = group.group_users.pluck(:user_id)
+        new_user_ids = yield current_user_ids
+        @result.merge!(
+          ::Groups::UpdateService.new(user: User.system, model: group).call(user_ids: new_user_ids)
+        )
+      end
+
+      def authentication_provider
+        @user.authentication_provider # TODO: should we find that differently? (risk of multiple auth providers)
+      end
+    end
+  end
+end

--- a/modules/openid_connect/db/migrate/20250710133700_add_oidc_group_links.rb
+++ b/modules/openid_connect/db/migrate/20250710133700_add_oidc_group_links.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddOidcGroupLinks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :oidc_group_links do |t|
+      t.belongs_to :group, null: false, index: true, foreign_key: { to_table: :users, on_delete: :cascade }
+
+      t.belongs_to :auth_provider, null: false, index: false, foreign_key: { on_delete: :cascade }
+      t.string :oidc_group_name, null: false
+      t.index %i[auth_provider_id oidc_group_name], unique: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/modules/openid_connect/db/migrate/20250711133700_add_oidc_group_memberships.rb
+++ b/modules/openid_connect/db/migrate/20250711133700_add_oidc_group_memberships.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddOidcGroupMemberships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :oidc_group_memberships do |t|
+      t.belongs_to :auth_provider, null: false,
+                                   index: false,
+                                   foreign_key: { on_delete: :cascade }
+      t.belongs_to :group_user, null: false,
+                                index: true,
+                                foreign_key: { on_delete: :cascade }
+      t.index %i[auth_provider_id group_user_id], unique: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -56,7 +56,7 @@ module OpenProject::OpenIDConnect
       openid_connect/auth_provider-custom.png
     )
 
-    patches %i[Sessions::UserSession User]
+    patches %i[Sessions::UserSession Group User GroupUser]
 
     class_inflection_override("openid_connect" => "OpenIDConnect")
 
@@ -87,6 +87,7 @@ module OpenProject::OpenIDConnect
             omniauth.oidc_access_token
             omniauth.oidc_refresh_token
             omniauth.oidc_expires_in
+            omniauth.oidc_groups
           ]
 
           h[:backchannel_logout_callback] = ->(logout_token) do

--- a/modules/openid_connect/lib/open_project/openid_connect/patches/group_patch.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/patches/group_patch.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::OpenIDConnect::Patches::GroupPatch
+  def self.included(base) # :nodoc:
+    base.extend(ClassMethods)
+    base.include(InstanceMethods)
+
+    base.class_eval do
+      has_many :oidc_group_links, class_name: "OpenIDConnect::GroupLink"
+    end
+  end
+
+  module ClassMethods
+  end
+
+  module InstanceMethods
+  end
+end

--- a/modules/openid_connect/lib/open_project/openid_connect/patches/group_user_patch.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/patches/group_user_patch.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::OpenIDConnect::Patches::GroupUserPatch
+  def self.included(base) # :nodoc:
+    base.extend(ClassMethods)
+    base.include(InstanceMethods)
+
+    base.class_eval do
+      has_many :oidc_group_memberships, class_name: "OpenIDConnect::GroupMembership"
+    end
+  end
+
+  module ClassMethods
+  end
+
+  module InstanceMethods
+  end
+end

--- a/modules/openid_connect/spec/factories/oidc_group_link_factory.rb
+++ b/modules/openid_connect/spec/factories/oidc_group_link_factory.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :oidc_group_link, class: "OpenIDConnect::GroupLink" do
+    group
+    auth_provider factory: :oidc_provider
+    sequence(:oidc_group_name) { |i| "oidc_group_#{i}" }
+  end
+end

--- a/modules/openid_connect/spec/models/provider_spec.rb
+++ b/modules/openid_connect/spec/models/provider_spec.rb
@@ -54,4 +54,53 @@ RSpec.describe OpenIDConnect::Provider do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe "#group_matchers" do
+    subject { provider.group_matchers }
+
+    let(:provider) { create(:oidc_provider, group_prefixes:, group_regexes:) }
+
+    context "when prefixes and regular expressions were never defined" do
+      let(:group_prefixes) { nil }
+      let(:group_regexes) { nil }
+
+      it { is_expected.to eq([/(.+)/]) }
+    end
+
+    context "when prefixes and regular expressions are empty" do
+      let(:group_prefixes) { [] }
+      let(:group_regexes) { [] }
+
+      it { is_expected.to eq([/(.+)/]) }
+    end
+
+    context "when prefixes were defined" do
+      let(:group_prefixes) { ["a_", "b_"] }
+      let(:group_regexes) { [] }
+
+      it { is_expected.to eq([/^a_(.+)$/, /^b_(.+)$/]) }
+
+      context "and when prefix contains regular expression special characters" do
+        let(:group_prefixes) { ["pre.fix", "(prefix)"] }
+
+        it { is_expected.to eq([/^pre\.fix(.+)$/, /^\(prefix\)(.+)$/]) }
+      end
+    end
+
+    context "when regular expressions were defined" do
+      let(:group_prefixes) { [] }
+      let(:group_regexes) { ["[a-z_]+", "^specific_group_name$"] }
+
+      it { is_expected.to eq([/[a-z_]+/, /^specific_group_name$/]) }
+    end
+
+    context "when prefixes and regular expressions were defined" do
+      let(:group_prefixes) { ["a"] }
+      let(:group_regexes) { [/[b]/] }
+
+      it "prefers prefixes over regular expressions" do
+        expect(subject).to eq([/^a(.+)$/])
+      end
+    end
+  end
 end

--- a/modules/openid_connect/spec/services/openid_connect/groups/sync_service_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/groups/sync_service_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenIDConnect::Groups::SyncService do
+  subject(:call_service) { described_class.new(user:).call(groups_claim:) }
+
+  let(:user) { create(:user, authentication_provider: provider) }
+  let(:provider) { create(:oidc_provider) }
+  let(:groups_claim) { ["oidc_group_a"] }
+
+  it { is_expected.to be_success }
+
+  it "creates a group" do
+    call_service
+
+    expect(Group.first&.name).to eq("oidc_group_a")
+  end
+
+  it "links the OIDC group to the local group" do
+    call_service
+    expect(Group.first.oidc_group_links.where(oidc_group_name: "oidc_group_a", auth_provider: provider)).to be_exist
+  end
+
+  it "adds the user to the group" do
+    call_service
+
+    expect(user.reload.groups).to include(Group.first)
+  end
+
+  it "marks the connection between user and group to be OIDC-related" do
+    call_service
+
+    oidc_membership = provider.oidc_group_memberships.first
+    expect(oidc_membership).not_to be_nil
+    expect(oidc_membership.user).to eq(user)
+    expect(oidc_membership.group.name).to eq("oidc_group_a")
+  end
+
+  context "when a group already exists" do
+    context "and it has the same name" do
+      let!(:existing_group) { create(:group, name: "oidc_group_a") }
+
+      it { is_expected.to be_success }
+
+      it "links the OIDC group to the local group" do
+        call_service
+        expect(existing_group.oidc_group_links.where(oidc_group_name: "oidc_group_a", auth_provider: provider)).to be_exist
+      end
+
+      it "adds the user to the existing group" do
+        call_service
+
+        expect(user.reload.groups).to include(existing_group)
+      end
+    end
+
+    context "and it is linked to the OIDC group" do
+      let!(:existing_group) { create(:group, name: "local_group_a") }
+      let!(:group_link) do
+        create(:oidc_group_link, group: existing_group, auth_provider: provider, oidc_group_name: "oidc_group_a")
+      end
+
+      it "adds the user to the existing group" do
+        call_service
+
+        expect(user.reload.groups).to include(existing_group)
+      end
+    end
+  end
+
+  context "when the user was member of the group before" do
+    let!(:existing_group) { create(:group, name: "oidc_group_a", members: [user]) }
+
+    it { is_expected.to be_success }
+
+    it "keeps the user in the group" do
+      call_service
+
+      expect(user.reload.groups).to include(existing_group)
+    end
+
+    it "marks the connection between user and group to be OIDC-related" do
+      call_service
+
+      oidc_membership = provider.oidc_group_memberships.first
+      expect(oidc_membership).not_to be_nil
+      expect(oidc_membership.user).to eq(user)
+      expect(oidc_membership.group.name).to eq("oidc_group_a")
+    end
+
+    context "and when the membership was already marked as being OIDC-related" do
+      before do
+        existing_group.group_users.find_by!(user:).oidc_group_memberships.create!(auth_provider: provider)
+      end
+
+      it { is_expected.to be_success }
+
+      it "doesn't mark the connection between user and group to be OIDC-related twice" do
+        call_service
+
+        oidc_memberships = existing_group.group_users.find_by!(user:).oidc_group_memberships
+        expect(oidc_memberships.count).to eq(1)
+      end
+    end
+  end
+
+  context "when the user was member of a different group before" do
+    let!(:existing_group) { create(:group, name: "oidc_group_b", members: [user]) }
+
+    it { is_expected.to be_success }
+
+    it "removes the user from the other group" do
+      call_service
+
+      expect(user.reload.groups).not_to include(existing_group)
+    end
+
+    context "and that was marked through an OIDC group membership" do
+      let!(:membership) do
+        existing_group.group_users.find_by(user:).oidc_group_memberships.create!(auth_provider: provider)
+      end
+
+      it { is_expected.to be_success }
+
+      it "removes the user from the other group" do
+        call_service
+
+        expect(user.reload.groups).not_to include(existing_group)
+      end
+
+      it "removes the OIDC group membership as well" do
+        expect { call_service }.to change { OpenIDConnect::GroupMembership.where(id: membership.id).count }.from(1).to(0)
+      end
+    end
+
+    context "and the groups claim adds the user to zero groups" do
+      let(:groups_claim) { [] }
+
+      it { is_expected.to be_success }
+
+      it "removes the user from all groups" do
+        call_service
+
+        expect(user.reload.groups).to be_empty
+      end
+    end
+  end
+
+  describe "group prefix matching" do
+    let(:provider) { create(:oidc_provider, group_prefixes: ["/abc/", "/xyz/"]) }
+    let(:groups_claim) { ["/abc/def/ghi", "/abc/ghi/def", "/def/abc/ghi", "/xyz/stu"] }
+
+    it "creates matching groups" do
+      expect { call_service }.to change(Group, :count).by(3)
+    end
+
+    it "cuts the prefix from the created group names" do
+      call_service
+
+      expect(Group.order(:name).pluck(:name)).to eq(["def/ghi", "ghi/def", "stu"])
+    end
+
+    it "links the OIDC group to the local group" do
+      call_service
+
+      expect(OpenIDConnect::GroupLink.find_by(oidc_group_name: "def/ghi")&.group&.name).to eq("def/ghi")
+    end
+
+    context "when prefix captures the full group name" do
+      let(:provider) { create(:oidc_provider, group_prefixes: ["/abc/"]) }
+      let(:groups_claim) { ["/abc/"] }
+
+      it "creates no group (empty group name)" do
+        expect { call_service }.not_to change(Group, :count)
+      end
+    end
+  end
+
+  describe "group regexp matching" do
+    let(:provider) { create(:oidc_provider, group_regexes: ["/abc/(.{2})", "/xyz/(.{3})"]) }
+    let(:groups_claim) { ["/abc/def/ghi", "abc/123", "/def/abc/ghi", "/xyz/stu"] }
+
+    it "creates matching groups" do
+      expect { call_service }.to change(Group, :count).by(3)
+    end
+
+    it "uses regular expression groups to determine name" do
+      call_service
+
+      expect(Group.order(:name).pluck(:name)).to eq(["de", "gh", "stu"])
+    end
+
+    it "links the OIDC group to the local group with correct names on both ends" do
+      call_service
+
+      expect(OpenIDConnect::GroupLink.find_by(oidc_group_name: "de")&.group&.name).to eq("de")
+    end
+
+    context "when there is no regular expression group" do
+      let(:provider) { create(:oidc_provider, group_regexes: ["/abc/"]) }
+      let(:groups_claim) { ["/abc/def/ghi", "/xyz/stu"] }
+
+      it "uses the full group name" do
+        call_service
+
+        expect(Group.order(:name).pluck(:name)).to eq(["/abc/def/ghi"])
+      end
+    end
+
+    context "when there are multiple regular expression groups" do
+      let(:provider) { create(:oidc_provider, group_regexes: ["/abc/([a-z]+)/([a-z]+)"]) }
+      let(:groups_claim) { ["/abc/def/ghi", "/def/abc/ghi/jkl", "/abc/stu"] }
+
+      it "concatenates the match groups" do
+        call_service
+
+        expect(Group.order(:name).pluck(:name)).to eq(["defghi", "ghijkl"])
+      end
+    end
+
+    context "when regex captures an empty group name" do
+      let(:provider) { create(:oidc_provider, group_regexes: ["/abc/([a-z]*)"]) }
+      let(:groups_claim) { ["/abc/"] }
+
+      it "creates no group" do
+        expect { call_service }.not_to change(Group, :count)
+      end
+    end
+  end
+end

--- a/modules/openid_connect/spec/services/principals/delete_job_integration_spec.rb
+++ b/modules/openid_connect/spec/services/principals/delete_job_integration_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Principals::DeleteJob, "OpenIDConnect", type: :model do
+  subject(:job) { described_class.perform_now(principal) }
+
+  let(:principal) do
+    create(:group)
+  end
+
+  context "with an OIDC group link" do
+    let!(:link) { create(:oidc_group_link, group: principal) }
+
+    it "deletes both the group and the group link" do
+      job
+
+      expect(Group.find_by(id: principal.id)).to be_nil
+      expect(OpenIDConnect::GroupLink.find_by(id: link.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
When the corresponding claim is present and synchronization of groups is enabled, then we'll import groups from the groups claim.

There is no UI yet to configure group synchronization and it's disabled by default

# Ticket
https://community.openproject.org/wp/58408

# Merge checklist

- [x] Added/updated tests
- [x] Tested manually
