### PR TITLE
[65785] Redundant scrollbar in wp side menu

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -191,7 +191,7 @@ $arrow-left-width: 36px
   z-index: 1
   background: var(--main-menu-bg-color)
   padding: 0
-  height: calc(var(--main-menu-item-height) + 10px)
+  height: var(--main-menu-item-height)
 
   .main-menu--arrow-left-to-project:not(.Button)
     display: inline-block
@@ -233,8 +233,8 @@ a.main-menu--parent-node:not(.Button)
   ul.menu_root
     flex-grow: 1
 
-    > li,
-    .main-menu-item
+    > li:not(.partial),
+    .main-menu-item:not(.partial)
       margin-bottom: 2px
 
     &.closed
@@ -257,8 +257,7 @@ a.main-menu--parent-node:not(.Button)
 
         .main-menu--children
           display: block
-          // Children header == 50px
-          height: calc(100% - 50px)
+          height: calc(100% - #{var(--main-menu-item-height)})
           overflow: auto
 
           li


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65785

# What are you trying to accomplish?
Remove redundant scrollbar caused by the unnecessary margin-bottom on the partial
