### PR TITLE
Fix cancelling oauth authorization

### DIFF
--- a/app/controllers/oauth/auth_base_controller.rb
+++ b/app/controllers/oauth/auth_base_controller.rb
@@ -41,7 +41,8 @@ module OAuth
     skip_before_action :check_if_login_required
     no_authorization_required! :new,
                                :create,
-                               :show
+                               :show,
+                               :destroy
 
     layout "only_logo"
 


### PR DESCRIPTION
When the user would deny the OAuth consent, they
would afterwards only receive an internal server error, because we check that all controllers ensure some kind of authorization and the cancel route was not yet covered.

# Ticket
https://community.openproject.org/wp/65836