### PR TITLE
Feature/65850 add program and portfolio options to top menu creation options

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -185,6 +185,7 @@ class ProjectsController < ApplicationController
 
   def new_blank
     @new_project = @parent&.children&.build || Project.new
+    @new_project.type = params[:type] if params[:type].present?
 
     render layout: "no_menu"
   end
@@ -195,6 +196,8 @@ class ProjectsController < ApplicationController
       .new(user: current_user, source: @template, contract_options: { validate_model: false })
       .call(target_project_params: params.permit(:parent_id).to_h, attributes_only: true)
       .result
+
+    @new_project.type = params[:type] if params[:type].present?
 
     render layout: "no_menu"
   end

--- a/app/forms/projects/settings/type_form.rb
+++ b/app/forms/projects/settings/type_form.rb
@@ -31,12 +31,19 @@ module Projects
   module Settings
     class TypeForm < ApplicationForm
       form do |f|
-        f.select_list(
-          name: :type,
-          label: attribute_name(:type)
-        ) do |list|
-          Project.types.each_key do |label|
-            list.option(label: I18n.t("activerecord.attributes.project.type_enum.#{label}"), value: label)
+        if model.new_record?
+          # Hide the type field when creating a new project, as the type is determined via GET parameter.
+          f.hidden(name: :type)
+        else
+          # Offer changing the type of existing projects when editing them. Otherwise, there would be no way
+          # for users to change the type of project.
+          f.select_list(
+            name: :type,
+            label: attribute_name(:type)
+          ) do |list|
+            Project.types.each_key do |label|
+              list.option(label: I18n.t("activerecord.attributes.project.type_enum.#{label}"), value: label)
+            end
           end
         end
       end

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -29,8 +29,17 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t("label_project_new") %>
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t(:label_project_new) }
-    header.with_breadcrumbs([t(:label_project_new)])
+    new_label = case @new_project.type
+                when "portfolio"
+                  t(:label_project_portfolio_new)
+                when "program"
+                  t(:label_project_program_new)
+                else
+                  t(:label_project_new)
+                end
+
+    header.with_title { new_label }
+    header.with_breadcrumbs([new_label])
   end
 %>
 

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -75,15 +75,15 @@ Redmine::MenuManager.map :top_menu do |menu|
 end
 
 Redmine::MenuManager.map :quick_add_menu do |menu|
-  menu.push :new_project,
+  menu.push :new_portfolio,
             ->(project) {
-              { controller: "/projects", action: :new, project_id: nil, parent_id: project&.id }
+              { controller: "/projects", action: :new, project_id: nil, type: "portfolio", parent_id: project&.id }
             },
-            caption: ->(_) { Project.model_name.human },
-            icon: "plus",
+            caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.portfolio") },
+            icon: "briefcase",
             html: {
-              aria: { label: I18n.t(:label_project_new) },
-              title: I18n.t(:label_project_new)
+              aria: { label: I18n.t(:label_project_portfolio_new) },
+              title: I18n.t(:label_project_portfolio_new)
             },
             if: ->(project) {
               User.current.allowed_globally?(:add_project) ||
@@ -95,7 +95,7 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
               { controller: "/projects", action: :new, project_id: nil, type: "program", parent_id: project&.id }
             },
             caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.program") },
-            icon: "plus",
+            icon: "versions",
             html: {
               aria: { label: I18n.t(:label_project_program_new) },
               title: I18n.t(:label_project_program_new)
@@ -105,15 +105,15 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
                 User.current.allowed_in_project?(:add_subprojects, project)
             }
 
-  menu.push :new_portfolio,
+  menu.push :new_project,
             ->(project) {
-              { controller: "/projects", action: :new, project_id: nil, type: "portfolio", parent_id: project&.id }
+              { controller: "/projects", action: :new, project_id: nil, parent_id: project&.id }
             },
-            caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.portfolio") },
-            icon: "plus",
+            caption: ->(_) { Project.model_name.human },
+            icon: "project",
             html: {
-              aria: { label: I18n.t(:label_project_portfolio_new) },
-              title: I18n.t(:label_project_portfolio_new)
+              aria: { label: I18n.t(:label_project_new) },
+              title: I18n.t(:label_project_new)
             },
             if: ->(project) {
               User.current.allowed_globally?(:add_project) ||

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -90,6 +90,36 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
                 User.current.allowed_in_project?(:add_subprojects, project)
             }
 
+  menu.push :new_program,
+            ->(project) {
+              { controller: "/projects", action: :new, project_id: nil, type: "program", parent_id: project&.id }
+            },
+            caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.program") },
+            icon: "plus",
+            html: {
+              aria: { label: I18n.t(:label_project_program_new) },
+              title: I18n.t(:label_project_program_new)
+            },
+            if: ->(project) {
+              User.current.allowed_globally?(:add_project) ||
+                User.current.allowed_in_project?(:add_subprojects, project)
+            }
+
+  menu.push :new_portfolio,
+            ->(project) {
+              { controller: "/projects", action: :new, project_id: nil, type: "portfolio", parent_id: project&.id }
+            },
+            caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.portfolio") },
+            icon: "plus",
+            html: {
+              aria: { label: I18n.t(:label_project_portfolio_new) },
+              title: I18n.t(:label_project_portfolio_new)
+            },
+            if: ->(project) {
+              User.current.allowed_globally?(:add_project) ||
+                User.current.allowed_in_project?(:add_subprojects, project)
+            }
+
   menu.push :invite_user,
             nil,
             caption: :label_invite_user,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3160,6 +3160,8 @@ en:
   label_project_hierarchy: "Project hierarchy"
   label_project_mappings: "Projects"
   label_project_new: "New project"
+  label_project_portfolio_new: "New portfolio"
+  label_project_program_new: "New program"
   label_project_plural: "Projects"
   label_project_list_plural: "Project lists"
   label_project_life_cycle: "Project life cycle"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65850

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
* Offer dedicated menu items in quick menu for creation of projects, programs and portfolios
* Adjust the form for `projects#new`
* The form for `projects#edit` stays as it is.

## Screenshots
<img width="923" height="559" alt="image" src="https://github.com/user-attachments/assets/7cf62b12-ea92-4663-92be-99aba9ffe950" />

<img width="923" height="559" alt="image" src="https://github.com/user-attachments/assets/1adffc5b-9777-4dae-b908-8c95434b2668" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
