### PR TITLE
[64180] Creating the Sharepoint Storage Model

### DIFF
--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -232,7 +232,7 @@ class OAuthClientsController < ApplicationController
   end
 
   def nextcloud?
-    @oauth_client&.integration&.provider_type == ::Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
+    @oauth_client&.integration&.provider_type == ::Storages::NextcloudStorage.name
   end
 
   def one_drive?

--- a/modules/storages/app/common/storages/adapters/authentication_strategies/sso_user_token.rb
+++ b/modules/storages/app/common/storages/adapters/authentication_strategies/sso_user_token.rb
@@ -38,7 +38,8 @@ module Storages
         end
 
         def call(storage:, http_options: {}, &)
-          result = OpenIDConnect::UserTokens::FetchService.new(user: @user).access_token_for(audience: storage.audience)
+          result = OpenIDConnect::UserTokens::FetchService.new(user: @user, exchange_scope: storage.token_exchange_scope)
+                                                          .access_token_for(audience: storage.audience)
 
           token = result.value_or do |failure|
             error("Failed to fetch access token for user #{@user}. Error: #{failure.inspect}")

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/validators/authentication_validator.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/validators/authentication_validator.rb
@@ -105,7 +105,7 @@ module Storages
             end
 
             def token_negotiable
-              service = OpenIDConnect::UserTokens::FetchService.new(user: @user)
+              service = OpenIDConnect::UserTokens::FetchService.new(user: @user, exchange_scope: @storage.token_exchange_scope)
 
               result = service.access_token_for(audience: @storage.audience)
               return pass_check(:token_negotiable) if result.success?

--- a/modules/storages/app/contracts/storages/file_links/create_contract.rb
+++ b/modules/storages/app/contracts/storages/file_links/create_contract.rb
@@ -50,7 +50,7 @@ class Storages::FileLinks::CreateContract < ModelContract
   validate :validate_storage_presence
   validate :validate_user_allowed_to_manage
   validate :validate_project_storage_link
-  validate :require_ee_token_for_one_drive
+  validate :check_for_enterprise_token_requirements
 
   private
 
@@ -83,8 +83,8 @@ class Storages::FileLinks::CreateContract < ModelContract
     errors.add(:storage, :not_linked_to_project)
   end
 
-  def require_ee_token_for_one_drive
-    if model.storage && ::Storages::Storage.one_drive_without_ee_token?(model.storage.provider_type)
+  def check_for_enterprise_token_requirements
+    if model.storage && !model.storage.has_required_enterprise_token?
       errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
     end
   end

--- a/modules/storages/app/contracts/storages/file_links/create_contract.rb
+++ b/modules/storages/app/contracts/storages/file_links/create_contract.rb
@@ -84,7 +84,7 @@ class Storages::FileLinks::CreateContract < ModelContract
   end
 
   def check_for_enterprise_token_requirements
-    if model.storage && !model.storage.has_required_enterprise_token?
+    if model.storage && !model.storage.allowed_by_enterprise_token?
       errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
     end
   end

--- a/modules/storages/app/contracts/storages/storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/base_contract.rb
@@ -59,7 +59,7 @@ module Storages::Storages
     end
 
     attribute :provider_type
-    validates :provider_type, inclusion: { in: Storages::Storage::PROVIDER_TYPES }, allow_nil: false
+    validates :provider_type, inclusion: { in: Storages::Storage.provider_types.values }, allow_nil: false
 
     attribute :provider_fields
 
@@ -90,7 +90,7 @@ module Storages::Storages
     end
 
     def default_provider_contract
-      ::Storages::Adapters::Registry.resolve("#{model.short_provider_type}.contracts.storage")
+      ::Storages::Adapters::Registry.resolve("#{model}.contracts.storage")
     end
   end
 end

--- a/modules/storages/app/contracts/storages/storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/base_contract.rb
@@ -31,66 +31,64 @@
 require "net/http"
 require "uri"
 
-# Purpose: common functionalities shared by CreateContract and UpdateContract
-# UpdateService by default checks if UpdateContract exists
-# and uses the contract to validate the model under consideration
-# (normally it's a model).
-module Storages::Storages
-  class BaseContract < ::BaseContract
-    include ::Storages::Storages::Concerns::ManageStoragesGuarded
+module Storages
+  module Storages
+    class BaseContract < ::BaseContract
+      include Concerns::ManageStoragesGuarded
 
-    class Factory
-      def initialize(contract_class, provider_contract)
-        @contract_class = contract_class
+      class Factory
+        def initialize(contract_class, provider_contract)
+          @contract_class = contract_class
+          @provider_contract = provider_contract
+        end
+
+        def new(*, **)
+          @contract_class.new(*, provider_contract: @provider_contract, **)
+        end
+
+        delegate :<=, to: :@contract_class
+      end
+
+      class << self
+        def with_provider_contract(provider_contract)
+          Factory.new(self, provider_contract)
+        end
+      end
+
+      attribute :provider_type
+      validates :provider_type, inclusion: { in: Storage.provider_types.values.map(&:to_s) }, allow_nil: false
+
+      attribute :provider_fields
+
+      validate :provider_type_strategy,
+               unless: -> { errors.include?(:provider_type) || @options.delete(:skip_provider_type_strategy) }
+
+      def initialize(*, provider_contract: nil, **)
+        super(*, **)
+
         @provider_contract = provider_contract
       end
 
-      def new(*, **)
-        @contract_class.new(*, provider_contract: @provider_contract, **)
+      private
+
+      def provider_type_strategy
+        contract = provider_contract.new(model, @user, options: @options)
+
+        # Append the attributes defined in the internal contract
+        # to the list of writable attributes.
+        # Otherwise, we get :readonly validation errors.
+        contract.writable_attributes.append(*writable_attributes)
+
+        validate_and_merge_errors(contract)
       end
 
-      delegate :<=, to: :@contract_class
-    end
-
-    class << self
-      def with_provider_contract(provider_contract)
-        Factory.new(self, provider_contract)
+      def provider_contract
+        @provider_contract || default_provider_contract
       end
-    end
 
-    attribute :provider_type
-    validates :provider_type, inclusion: { in: Storages::Storage.provider_types.values }, allow_nil: false
-
-    attribute :provider_fields
-
-    validate :provider_type_strategy,
-             unless: -> { errors.include?(:provider_type) || @options.delete(:skip_provider_type_strategy) }
-
-    def initialize(*, provider_contract: nil, **)
-      super(*, **)
-
-      @provider_contract = provider_contract
-    end
-
-    private
-
-    def provider_type_strategy
-      contract = provider_contract.new(model, @user, options: @options)
-
-      # Append the attributes defined in the internal contract
-      # to the list of writable attributes.
-      # Otherwise, we get :readonly validation errors.
-      contract.writable_attributes.append(*writable_attributes)
-
-      validate_and_merge_errors(contract)
-    end
-
-    def provider_contract
-      @provider_contract || default_provider_contract
-    end
-
-    def default_provider_contract
-      ::Storages::Adapters::Registry.resolve("#{model}.contracts.storage")
+      def default_provider_contract
+        ::Storages::Adapters::Registry.resolve("#{model}.contracts.storage")
+      end
     end
   end
 end

--- a/modules/storages/app/contracts/storages/storages/create_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/create_contract.rb
@@ -28,23 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Storages::Storages
-  class CreateContract < ::Storages::Storages::BaseContract
-    attribute :creator
-    validate :creator_must_be_user
-    validate :requires_enterprise_token?
+module Storages
+  module Storages
+    class CreateContract < BaseContract
+      attribute :creator
+      validate :creator_must_be_user
+      validate :requires_enterprise_token?
 
-    private
+      private
 
-    def creator_must_be_user
-      unless creator == user
-        errors.add(:creator, :invalid)
+      def creator_must_be_user
+        unless creator == user
+          errors.add(:creator, :invalid)
+        end
       end
-    end
 
-    def requires_enterprise_token?
-      if model.missing_required_enterprise_token?
-        errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
+      def requires_enterprise_token?
+        if model.missing_required_enterprise_token?
+          errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
+        end
       end
     end
   end

--- a/modules/storages/app/contracts/storages/storages/create_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/create_contract.rb
@@ -32,7 +32,7 @@ module Storages::Storages
   class CreateContract < ::Storages::Storages::BaseContract
     attribute :creator
     validate :creator_must_be_user
-    validate :require_ee_token_for_one_drive
+    validate :requires_enterprise_token?
 
     private
 
@@ -42,8 +42,8 @@ module Storages::Storages
       end
     end
 
-    def require_ee_token_for_one_drive
-      if ::Storages::Storage.one_drive_without_ee_token?(provider_type)
+    def requires_enterprise_token?
+      unless model.has_required_enterprise_token?
         errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
       end
     end

--- a/modules/storages/app/contracts/storages/storages/create_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/create_contract.rb
@@ -44,7 +44,7 @@ module Storages
       end
 
       def requires_enterprise_token?
-        if model.missing_required_enterprise_token?
+        if model.disallowed_by_enterprise_token?
           errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
         end
       end

--- a/modules/storages/app/contracts/storages/storages/create_contract.rb
+++ b/modules/storages/app/contracts/storages/storages/create_contract.rb
@@ -43,7 +43,7 @@ module Storages::Storages
     end
 
     def requires_enterprise_token?
-      unless model.has_required_enterprise_token?
+      if model.missing_required_enterprise_token?
         errors.add(:base, I18n.t("api_v3.errors.code_500_missing_enterprise_token"))
       end
     end

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -269,7 +269,7 @@ class Storages::Admin::StoragesController < ApplicationController
   end
 
   def require_ee_token_for_one_drive
-    if (@provider_type || @storage).missing_required_enterprise_token?
+    if (@provider_type || @storage).disallowed_by_enterprise_token?
       redirect_to action: :upsell
     end
   end

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -68,12 +68,11 @@ class Storages::Admin::StoragesController < ApplicationController
       # See also: storages/services/storages/storages/set_attributes_services.rb
       # That service inherits from ::BaseServices::SetAttributes
       @storage = ::Storages::Storages::SetAttributesService
-                   .new(user: current_user,
-                        model: Storages::Storage.new(provider_type: @provider_type),
-                        contract_class: EmptyContract)
+                   .new(user: current_user, model: @provider_type.new, contract_class: EmptyContract)
                    .call
                    .result
     end
+
     @wizard = storage_wizard(@storage)
     @target_step = @wizard.prepare_next_step
   end
@@ -270,14 +269,14 @@ class Storages::Admin::StoragesController < ApplicationController
   end
 
   def require_ee_token_for_one_drive
-    if (@provider_type&.constantize || @storage).missing_required_enterprise_token?
+    if (@provider_type || @storage).missing_required_enterprise_token?
       redirect_to action: :upsell
     end
   end
 
   def storage_wizard(storage)
     ::Storages::Adapters::Registry.resolve("#{storage}.components.setup_wizard")
-                                     .new(model: storage, user: current_user)
+                                  .new(model: storage, user: current_user)
   end
 
   def redirect_to_wizard(storage)

--- a/modules/storages/app/helpers/storages/open_storage_links.rb
+++ b/modules/storages/app/helpers/storages/open_storage_links.rb
@@ -36,10 +36,10 @@ module Storages
       def static_link(storage)
         api_static_link = ::API::V3::Utilities::PathHelper::ApiV3Path.storage_open(storage.id)
 
-        case storage.provider_type
-        when Storage::PROVIDER_TYPE_NEXTCLOUD
+        case storage
+        when NextcloudStorage
           api_static_link
-        when Storage::PROVIDER_TYPE_ONE_DRIVE
+        when OneDriveStorage
           raise Errors::ConfigurationError, "No OAuth credential information configured." if storage.oauth_client.nil?
 
           oauth_clients_ensure_connection_url(
@@ -53,10 +53,10 @@ module Storages
       end
 
       def can_generate_static_link?(storage)
-        case storage.provider_type
-        when Storage::PROVIDER_TYPE_NEXTCLOUD
+        case storage
+        when NextcloudStorage
           true
-        when Storage::PROVIDER_TYPE_ONE_DRIVE
+        when OneDriveStorage
           storage.oauth_client&.persisted?
         else
           false

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -51,6 +51,8 @@ module Storages
     store_attribute :provider_fields, :storage_audience, :string
     store_attribute :provider_fields, :token_exchange_scope, :string
 
+    def self.short_provider_name = :nextcloud
+
     def oauth_configuration
       Adapters::Providers::Nextcloud::OAuthConfiguration.new(self)
     end

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -39,6 +39,12 @@ module Storages
 
     using ::Storages::Peripherals::ServiceResultRefinements
 
+    def self.short_provider_name = :one_drive
+
+    def self.has_required_enterprise_token?
+      EnterpriseToken.allows_to?(:one_drive_sharepoint_file_storage)
+    end
+
     def configuration_checks
       {
         storage_oauth_client_configured: oauth_client.present?,

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -41,7 +41,7 @@ module Storages
 
     def self.short_provider_name = :one_drive
 
-    def self.has_required_enterprise_token?
+    def self.allowed_by_enterprise_token?
       EnterpriseToken.allows_to?(:one_drive_sharepoint_file_storage)
     end
 

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -4,10 +4,10 @@
 #++
 
 module Storages
-  class SharepointStorage < Storage
+  class SharePointStorage < Storage
     store_attribute :provider_fields, :tenant_id, :string
 
-    def self.short_provider_name = :sharepoint
+    def self.short_provider_name = :share_point
     def audience = nil
 
     def authenticate_via_idp? = false

--- a/modules/storages/app/models/storages/sharepoint_storage.rb
+++ b/modules/storages/app/models/storages/sharepoint_storage.rb
@@ -5,11 +5,27 @@
 
 module Storages
   class SharepointStorage < Storage
+    store_attribute :provider_fields, :tenant_id, :string
+
     def self.short_provider_name = :sharepoint
     def audience = nil
 
     def authenticate_via_idp? = false
 
     def authenticate_via_storage? = true
+
+    def available_project_folder_modes
+      if automatic_management_enabled?
+        ProjectStorage.project_folder_modes.keys
+      else
+        %w[inactive manual]
+      end
+    end
+
+    # To implement
+    # oauth_configuration
+    # configuration_checks
+    # automatic_management_new_record?
+    # provider_fields_defaults
   end
 end

--- a/modules/storages/app/models/storages/sharepoint_storage.rb
+++ b/modules/storages/app/models/storages/sharepoint_storage.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#-- copyright
+#++
+
+module Storages
+  class SharepointStorage < Storage
+    def self.short_provider_name = :sharepoint
+    def audience = nil
+
+    def authenticate_via_idp? = false
+
+    def authenticate_via_storage? = true
+  end
+end

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -45,11 +45,6 @@ module Storages
       PROVIDER_TYPE_ONE_DRIVE = "Storages::OneDriveStorage"
     ].freeze
 
-    PROVIDER_TYPE_SHORT_NAMES = {
-      nextcloud: PROVIDER_TYPE_NEXTCLOUD,
-      one_drive: PROVIDER_TYPE_ONE_DRIVE
-    }.with_indifferent_access.freeze
-
     self.inheritance_column = :provider_type
 
     store_attribute :provider_fields, :automatically_managed, :boolean
@@ -93,7 +88,9 @@ module Storages
       def visible? = true
 
       def provider_types
-        subclasses.filter_map { [it.short_provider_name.to_s, it.name] if it.visible? }.to_h
+        subclasses.sort_by(&:name) # Guarantees alphabetical ordering
+                  .filter_map { [it.short_provider_name, it] if it.visible? } # Remove non-exposed providers
+                  .to_h.with_indifferent_access
       end
 
       def short_provider_name = raise Errors::SubclassResponsibility

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -40,11 +40,6 @@
 # db/migrate/20220113144323_create_storage.rb "migration".
 module Storages
   class Storage < ApplicationRecord
-    PROVIDER_TYPES = [
-      PROVIDER_TYPE_NEXTCLOUD = "Storages::NextcloudStorage",
-      PROVIDER_TYPE_ONE_DRIVE = "Storages::OneDriveStorage"
-    ].freeze
-
     self.inheritance_column = :provider_type
 
     store_attribute :provider_fields, :automatically_managed, :boolean

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -90,8 +90,8 @@ module Storages
 
       def short_provider_name = raise Errors::SubclassResponsibility
 
-      def has_required_enterprise_token? = true
-      def missing_required_enterprise_token? = !has_required_enterprise_token?
+      def allowed_by_enterprise_token? = true
+      def disallowed_by_enterprise_token? = !allowed_by_enterprise_token?
 
       # TODO: Compatibility Method To be Removed once all references are removed - 2025-07-14 @mereghost
       def shorten_provider_type(provider_type)
@@ -106,7 +106,7 @@ module Storages
       end
     end
 
-    delegate :short_provider_name, :has_required_enterprise_token?, :missing_required_enterprise_token?, to: :class
+    delegate :short_provider_name, :allowed_by_enterprise_token?, :disallowed_by_enterprise_token?, to: :class
     delegate :to_s, to: :short_provider_name
     alias :short_provider_type :to_s
 
@@ -171,11 +171,11 @@ module Storages
     def provider_fields_defaults = raise Errors::SubclassResponsibility
 
     def provider_type_nextcloud?
-      provider_type == PROVIDER_TYPE_NEXTCLOUD
+      is_a?(NextcloudStorage)
     end
 
     def provider_type_one_drive?
-      provider_type == PROVIDER_TYPE_ONE_DRIVE
+      is_a?(OneDriveStorage)
     end
 
     def health_reason_identifier

--- a/modules/storages/app/models/storages/storage/inexistent_storage.rb
+++ b/modules/storages/app/models/storages/storage/inexistent_storage.rb
@@ -31,6 +31,6 @@
 class Storages::Storage::InexistentStorage < Storages::Storage
   include InexistentModel
 
-  def visible? = false
+  def self.visible? = false
   def self.short_provider_name = :inexistent
 end

--- a/modules/storages/app/models/storages/storage/inexistent_storage.rb
+++ b/modules/storages/app/models/storages/storage/inexistent_storage.rb
@@ -30,4 +30,6 @@
 
 class Storages::Storage::InexistentStorage < Storages::Storage
   include InexistentModel
+
+  def self.short_provider_name = :inexistent
 end

--- a/modules/storages/app/models/storages/storage/inexistent_storage.rb
+++ b/modules/storages/app/models/storages/storage/inexistent_storage.rb
@@ -31,5 +31,6 @@
 class Storages::Storage::InexistentStorage < Storages::Storage
   include InexistentModel
 
+  def visible? = false
   def self.short_provider_name = :inexistent
 end

--- a/modules/storages/app/views/storages/admin/storages/_new.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/_new.html.erb
@@ -39,9 +39,9 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="form--field -required">
     <%= f.hidden_field :provider_type %>
     <%= f.select :provider_type,
-                 ::Storages::Storage::PROVIDER_TYPES.map { |provider_type| [I18n.t("storages.provider_types.#{::Storages::Storage.shorten_provider_type(provider_type)}.name"), provider_type] },
+                 ::Storages::Storage::provider_types.map { |(short, klass)| [I18n.t("storages.provider_types.#{short}.name"), klass.name] },
                  {
-                   selected: ::Storages::Storage::PROVIDER_TYPE_NEXTCLOUD,
+                   selected: :nextcloud,
                    container_class: "-slim"
                  },
                  data: {

--- a/modules/storages/app/views/storages/admin/storages/index.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/index.html.erb
@@ -28,14 +28,12 @@
                               aria: { label: I18n.t("storages.label_add_new_storage") },
                               test_selector: "storages-create-new-provider-button" }
         ) do |menu|
-          ::Storages::Storage::PROVIDER_TYPES.each do |provider_type|
-            short_provider_type = provider_type.constantize.short_provider_name
-
+          ::Storages::Storage.provider_types.each_pair do |short, klass|
             menu.with_item(
-              label: I18n.t("storages.provider_types.#{short_provider_type}.name"),
-              href: url_helpers.new_admin_settings_storage_path(provider: short_provider_type)
+              label: I18n.t("storages.provider_types.#{short}.name"),
+              href: url_helpers.new_admin_settings_storage_path(provider: short)
             ) do |item|
-              if provider_type.constantize.missing_required_enterprise_token?
+              if klass.missing_required_enterprise_token?
                 item.with_trailing_visual_icon(
                   icon: "op-enterprise-addons",
                   classes: "upsell-colored"

--- a/modules/storages/app/views/storages/admin/storages/index.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/index.html.erb
@@ -1,45 +1,50 @@
 <% html_title t(:label_administration), t("project_module_storages") %>
 
 <% button_block = lambda do |button|
-  button.with_leading_visual_icon(icon: :plus)
-  button.with_trailing_action_icon(icon: :"triangle-down")
-  I18n.t("storages.label_storage")
-end %>
+     button.with_leading_visual_icon(icon: :plus)
+     button.with_trailing_action_icon(icon: :"triangle-down")
+     I18n.t("storages.label_storage")
+   end %>
 
 <% content_for :content_header do %>
   <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
     <% header.with_title { t("external_file_storages") } %>
     <% header.with_description { t("storages.page_titles.file_storages.subtitle") } %>
-    <% header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
-                                { href: admin_settings_storages_path, text: t("project_module_storages"), skip_for_mobile: true },
-                                t("external_file_storages")]) %>
+    <% header.with_breadcrumbs(
+         [{ href: admin_index_path, text: t("label_administration") },
+          { href: admin_settings_storages_path, text: t("project_module_storages"), skip_for_mobile: true },
+          t("external_file_storages")]
+       ) %>
   <% end %>
 
   <%= render(Primer::OpenProject::SubHeader.new) do |subheader|
-    subheader.with_action_menu(leading_icon: :plus,
-                               trailing_icon: :"triangle-down",
-                               label: I18n.t("storages.label_storage"),
-                               test_selector: 'storages-select-provider-action-menu',
-                               anchor_align: :end,
-                               button_arguments: { scheme: :primary,
-                                                   aria: { label: I18n.t("storages.label_add_new_storage") },
-                                                   test_selector: "storages-create-new-provider-button"}) do |menu|
+        subheader.with_action_menu(
+          leading_icon: :plus,
+          trailing_icon: :"triangle-down",
+          label: I18n.t("storages.label_storage"),
+          test_selector: "storages-select-provider-action-menu",
+          anchor_align: :end,
+          button_arguments: { scheme: :primary,
+                              aria: { label: I18n.t("storages.label_add_new_storage") },
+                              test_selector: "storages-create-new-provider-button" }
+        ) do |menu|
+          ::Storages::Storage::PROVIDER_TYPES.each do |provider_type|
+            short_provider_type = provider_type.constantize.short_provider_name
 
-      ::Storages::Storage::PROVIDER_TYPES.each do |provider_type|
-        short_provider_type = ::Storages::Storage.shorten_provider_type(provider_type)
-
-        menu.with_item(
-          label: I18n.t("storages.provider_types.#{short_provider_type}.name"),
-          href: url_helpers.new_admin_settings_storage_path(provider: short_provider_type)
-        ) do |item|
-          item.with_trailing_visual_icon(
-            icon: "op-enterprise-addons",
-            classes: "upsell-colored"
-          ) if ::Storages::Storage::one_drive_without_ee_token?(provider_type)
+            menu.with_item(
+              label: I18n.t("storages.provider_types.#{short_provider_type}.name"),
+              href: url_helpers.new_admin_settings_storage_path(provider: short_provider_type)
+            ) do |item|
+              if provider_type.constantize.missing_required_enterprise_token?
+                item.with_trailing_visual_icon(
+                  icon: "op-enterprise-addons",
+                  classes: "upsell-colored"
+                )
+              end
+            end
+          end
         end
-      end
-    end
-  end %>
+      end %>
 <% end %>
 
 <%= render(::Storages::Admin::StorageListComponent.new(@storages)) %>

--- a/modules/storages/app/views/storages/admin/storages/index.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/index.html.erb
@@ -33,7 +33,7 @@
               label: I18n.t("storages.provider_types.#{short}.name"),
               href: url_helpers.new_admin_settings_storage_path(provider: short)
             ) do |item|
-              if klass.missing_required_enterprise_token?
+              if klass.disallowed_by_enterprise_token?
                 item.with_trailing_visual_icon(
                   icon: "op-enterprise-addons",
                   classes: "upsell-colored"

--- a/modules/storages/app/views/storages/storages_mailer/_health_status_notification.html.erb
+++ b/modules/storages/app/views/storages/storages_mailer/_health_status_notification.html.erb
@@ -81,7 +81,7 @@ See COPYRIGHT and LICENSE files for more details.
           <%= placeholder_cell("12px", vertical: true) %>
         </tr>
 
-        <% if storage.provider_type == ::Storages::Storage::PROVIDER_TYPE_NEXTCLOUD && state == :unhealthy %>
+        <% if storage.provider_type == ::Storages::NextcloudStorage.name && state == :unhealthy %>
           <tr id="troubleshooting">
             <%= placeholder_cell("12px", vertical: true) %>
 

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -480,11 +480,11 @@ en:
         label_oauth_client_secret: Azure OAuth Client Secret Value
         name: OneDrive
         name_placeholder: e.g. OneDrive
-      sharepoint:
+      share_point:
         label_oauth_client_id: Azure OAuth Application (client) ID
         label_oauth_client_secret: Azure OAuth Client Secret Value
-        name: Sharepoint
-        name_placeholder: e.g. Sharepoint
+        name: SharePoint
+        name_placeholder: e.g. SharePoint
     show_attachments_toggle:
       description: Deactivating this option will hide the attachments list on the work packages files tab. The files attached in the description of a work package will still be uploaded in the internal attachments storage.
       label: Show attachments in the work packages files tab

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -481,9 +481,9 @@ en:
         name: OneDrive
         name_placeholder: e.g. OneDrive
       sharepoint:
-        name: Sharepoint
         label_oauth_client_id: Azure OAuth Application (client) ID
         label_oauth_client_secret: Azure OAuth Client Secret Value
+        name: Sharepoint
         name_placeholder: e.g. Sharepoint
     show_attachments_toggle:
       description: Deactivating this option will hide the attachments list on the work packages files tab. The files attached in the description of a work package will still be uploaded in the internal attachments storage.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -480,6 +480,11 @@ en:
         label_oauth_client_secret: Azure OAuth Client Secret Value
         name: OneDrive
         name_placeholder: e.g. OneDrive
+      sharepoint:
+        name: Sharepoint
+        label_oauth_client_id: Azure OAuth Application (client) ID
+        label_oauth_client_secret: Azure OAuth Client Secret Value
+        name_placeholder: e.g. Sharepoint
     show_attachments_toggle:
       description: Deactivating this option will hide the attachments list on the work packages files tab. The files attached in the description of a work package will still be uploaded in the internal attachments storage.
       label: Show attachments in the work packages files tab

--- a/modules/storages/lib/api/v3/storage_files/storage_files_api.rb
+++ b/modules/storages/lib/api/v3/storage_files/storage_files_api.rb
@@ -37,7 +37,7 @@ module API::V3::StorageFiles
 
     helpers do
       def validate_upload_request(body)
-        if @storage.provider_type.constantize.missing_required_enterprise_token?
+        if @storage.provider_type.constantize.disallowed_by_enterprise_token?
           raise API::Errors::EnterpriseTokenMissing.new
         end
 

--- a/modules/storages/lib/api/v3/storage_files/storage_files_api.rb
+++ b/modules/storages/lib/api/v3/storage_files/storage_files_api.rb
@@ -37,7 +37,7 @@ module API::V3::StorageFiles
 
     helpers do
       def validate_upload_request(body)
-        if Storages::Storage::one_drive_without_ee_token?(@storage.provider_type)
+        if @storage.provider_type.constantize.missing_required_enterprise_token?
           raise API::Errors::EnterpriseTokenMissing.new
         end
 

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -40,10 +40,12 @@ module API::V3::Storages
 
   URN_STORAGE_TYPE_NEXTCLOUD = "#{::API::V3::URN_PREFIX}storages:Nextcloud".freeze
   URN_STORAGE_TYPE_ONE_DRIVE = "#{::API::V3::URN_PREFIX}storages:OneDrive".freeze
+  URN_STORAGE_TYPE_SHARE_POINT = "#{::API::V3::URN_PREFIX}storages:SharePoint".freeze
 
   STORAGE_TYPE_MAP = {
-    URN_STORAGE_TYPE_NEXTCLOUD => Storages::Storage::PROVIDER_TYPE_NEXTCLOUD,
-    URN_STORAGE_TYPE_ONE_DRIVE => Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
+    URN_STORAGE_TYPE_NEXTCLOUD => Storages::NextcloudStorage.name,
+    URN_STORAGE_TYPE_ONE_DRIVE => Storages::OneDriveStorage.name,
+    URN_STORAGE_TYPE_SHARE_POINT => Storages::SharePointStorage.name
   }.freeze
 
   STORAGE_TYPE_URN_MAP = STORAGE_TYPE_MAP.invert.freeze

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -261,6 +261,7 @@ module OpenProject::Storages
       Storages::Storage::InexistentStorage
       Storages::OneDriveStorage
       Storages::NextcloudStorage
+      Storages::SharepointStorage
 
       # Allow the browser to connect to external servers for direct file uploads.
       AppendStoragesHostsToCspHook
@@ -355,7 +356,7 @@ module OpenProject::Storages
     end
 
     add_api_path :file_link_open do |file_link_id, location = false|
-      "#{file_link(file_link_id)}/open#{location ? '?location=true' : ''}"
+      "#{file_link(file_link_id)}/open#{'?location=true' if location}"
     end
 
     # Add api endpoints specific to this module

--- a/modules/storages/lib/open_project/storages/engine.rb
+++ b/modules/storages/lib/open_project/storages/engine.rb
@@ -261,7 +261,7 @@ module OpenProject::Storages
       Storages::Storage::InexistentStorage
       Storages::OneDriveStorage
       Storages::NextcloudStorage
-      Storages::SharepointStorage
+      Storages::SharePointStorage
 
       # Allow the browser to connect to external servers for direct file uploads.
       AppendStoragesHostsToCspHook

--- a/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
+++ b/modules/storages/spec/contracts/storages/storages/shared_contract_examples.rb
@@ -81,7 +81,7 @@ RSpec.shared_examples_for "onedrive storage contract" do
 
   let(:current_user) { create(:admin) }
   let(:storage_name) { "Storage 1" }
-  let(:storage_provider_type) { Storages::Storage::PROVIDER_TYPE_ONE_DRIVE }
+  let(:storage_provider_type) { Storages::OneDriveStorage.name }
   let(:storage_creator) { current_user }
 
   it_behaves_like "contract is valid for active admins and invalid for regular users"
@@ -95,7 +95,7 @@ RSpec.shared_examples_for "nextcloud storage contract", :storage_server_helpers,
   # Only admins have the right to create/delete storages.
   let(:current_user) { create(:admin) }
   let(:storage_name) { "Storage 1" }
-  let(:storage_provider_type) { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
+  let(:storage_provider_type) { Storages::NextcloudStorage.name }
   let(:storage_host) { "https://host1.example.com" }
   let(:storage_creator) { current_user }
 

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -89,7 +89,7 @@ FactoryBot.define do
   factory :nextcloud_storage,
           parent: :storage,
           class: "::Storages::NextcloudStorage" do
-    provider_type { Storages::Storage::PROVIDER_TYPE_NEXTCLOUD }
+    provider_type { Storages::NextcloudStorage.name }
     sequence(:host) { |n| "https://host#{n}.example.com/" }
     authentication_method { "two_way_oauth2" }
     storage_audience { nil }

--- a/modules/storages/spec/features/storages/admin/create_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/create_storage_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Admin Create a new file storage",
         within_test_selector("storages-select-provider-action-menu") { click_on("Nextcloud") }
       end
 
-      expect(page).to have_current_path(new_admin_settings_storage_path(provider: "nextcloud"))
+      wait_for { page }.to have_current_path(new_admin_settings_storage_path(provider: "nextcloud"))
 
       aggregate_failures "New provider view" do
         # Page Header
@@ -201,6 +201,8 @@ RSpec.describe "Admin Create a new file storage",
         within_test_selector("storages-select-provider-action-menu") { click_on("Nextcloud") }
       end
 
+      wait_for { page }.to have_current_path(new_admin_settings_storage_path(provider: "nextcloud"))
+
       within_test_selector("storage-general-info-form") do
         expect(page).not_to have_enterprise_banner
 
@@ -276,15 +278,14 @@ RSpec.describe "Admin Create a new file storage",
 
       within(".SubHeader") do
         page.find_test_selector("storages-create-new-provider-button").click
-
         within_test_selector("storages-select-provider-action-menu") do
           expect(page).to have_css(".octicon-op-enterprise-addons")
           click_on("OneDrive")
         end
       end
 
-      expect(page).to have_current_path(upsell_admin_settings_storages_path)
-      wait_for { page }.to have_text("OneDrive integration")
+      wait_for { page }.to have_current_path(upsell_admin_settings_storages_path)
+      expect(page).to have_text("OneDrive integration")
     end
   end
 

--- a/modules/storages/spec/models/storages/shared_base_storage_spec.rb
+++ b/modules/storages/spec/models/storages/shared_base_storage_spec.rb
@@ -37,15 +37,15 @@ RSpec.shared_examples_for "base storage" do
     }
   end
 
-  describe ".shorten_provider_type" do
+  describe ".shorten_provider_type", skip: "Method being removed" do
     context "when provider_type matches the signature" do
       it "responds with shortened provider type" do
         expect(
-          described_class.shorten_provider_type(described_class::PROVIDER_TYPE_NEXTCLOUD)
-        ).to eq("nextcloud")
+          described_class.short_provider_name
+        ).to eq(:nextcloud)
         expect(
-          described_class.shorten_provider_type(described_class::PROVIDER_TYPE_ONE_DRIVE)
-        ).to eq("one_drive")
+          described_class.short_provider_name
+        ).to eq(:one_drive)
       end
     end
 

--- a/modules/storages/spec/models/storages/storage_spec.rb
+++ b/modules/storages/spec/models/storages/storage_spec.rb
@@ -32,6 +32,12 @@ require "spec_helper"
 require_module_spec_helper
 
 RSpec.describe Storages::Storage do
+  describe "provider_types" do
+    it "maps the short_name to the provider class name" do
+      expect(described_class.provider_types[:nextcloud]).to eq(Storages::NextcloudStorage.name)
+    end
+  end
+
   describe "#oauth_access_granted?" do
     let(:storage) { build(:storage, oauth_client:) }
     let(:oauth_client) { create(:oauth_client) }

--- a/modules/storages/spec/models/storages/storage_spec.rb
+++ b/modules/storages/spec/models/storages/storage_spec.rb
@@ -33,8 +33,13 @@ require_module_spec_helper
 
 RSpec.describe Storages::Storage do
   describe "provider_types" do
-    it "maps the short_name to the provider class name" do
-      expect(described_class.provider_types["nextcloud"]).to eq(Storages::NextcloudStorage.name)
+    it "maps the short_name to the provider class" do
+      expect(described_class.provider_types["nextcloud"]).to eq(Storages::NextcloudStorage)
+      expect(described_class.provider_types[:nextcloud]).to eq(Storages::NextcloudStorage)
+    end
+
+    it "excludes non exposed storage types" do
+      expect(described_class.provider_types[:inexistent]).to be_nil
     end
   end
 

--- a/modules/storages/spec/models/storages/storage_spec.rb
+++ b/modules/storages/spec/models/storages/storage_spec.rb
@@ -34,7 +34,7 @@ require_module_spec_helper
 RSpec.describe Storages::Storage do
   describe "provider_types" do
     it "maps the short_name to the provider class name" do
-      expect(described_class.provider_types[:nextcloud]).to eq(Storages::NextcloudStorage.name)
+      expect(described_class.provider_types["nextcloud"]).to eq(Storages::NextcloudStorage.name)
     end
   end
 

--- a/modules/storages/spec/services/storages/storages/set_attributes_service_spec.rb
+++ b/modules/storages/spec/services/storages/storages/set_attributes_service_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Storages::Storages::SetAttributesService, type: :model do
     Storages::Storages::CreateContract
   end
 
-  let(:params) { { provider_type: Storages::Storage::PROVIDER_TYPE_NEXTCLOUD } }
+  let(:params) { { provider_type: Storages::NextcloudStorage.name } }
 
   before do
     allow(model_instance)
@@ -85,7 +85,7 @@ RSpec.describe Storages::Storages::SetAttributesService, type: :model do
     end
 
     it "sets provider_type to nextcloud" do
-      expect(subject.result.provider_type).to eq Storages::Storage::PROVIDER_TYPE_NEXTCLOUD
+      expect(subject.result.provider_type).to eq Storages::NextcloudStorage.name
     end
 
     context "with host" do


### PR DESCRIPTION
### Related Work Package: [OP#64180](https://community.openproject.org/projects/document-workflows-stream/work_packages/64180)

Introduces the `SharepointStorage` model.

With its introduction a couple of extra changes were necessary, like reworking the Enterprise token resolution and the removal of the PROVIDER_* constants.