### PR TITLE
[#64049] PDF export shows empty table of associated work packages

### DIFF
--- a/app/models/work_package/pdf_export/export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/export/wp/attributes.rb
@@ -92,7 +92,7 @@ module WorkPackage::PDFExport::Export::Wp::Attributes
     # QueryGroup are relative to our work package, so we need to adjust the filter
     group.query.filters.each do |filter|
       if filter.respond_to?(:has_templated_value?) && filter.has_templated_value?
-        group.query.filters[0].values = [work_package.id]
+        filter.values = [work_package.id]
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64049

# What are you trying to achieve?
Queries with templated filter were not "untemplated" right, resulting in empty tables in the PDF

# What approach did you choose and why?
Fix the bug in the query filter preparation step not using the right filter element
