### PR TITLE
Fix broken relations children spec

### DIFF
--- a/spec/support/capybara/patched_accessible_selectors.rb
+++ b/spec/support/capybara/patched_accessible_selectors.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+#  Modifies combo_box_list_box provided by Capybara Accessible Selectors
+#  to work with our autocompleter (ng-select) implementation: we allow
+# `aria-owns`/`aria-controls` to be specified on ancestor of the
+# `listbox`.
+Capybara.modify_selector(:combo_box_list_box) do
+  xpath do |input|
+    ids = (input[:"aria-owns"] || input[:"aria-controls"])&.split(/\s+/)&.compact
+    raise Capybara::ElementNotFound, "listbox cannot be found without attributes aria-owns or aria-controls" if ids.blank?
+
+    XPath.anywhere[[
+      XPath.descendant[XPath.attr(:role) == "listbox"],
+      ids.map { |id| XPath.attr(:id) == id }.reduce(:|)
+    ].reduce(:&)]
+  end
+end

--- a/spec/support/components/work_packages/create_dialog.rb
+++ b/spec/support/components/work_packages/create_dialog.rb
@@ -44,11 +44,8 @@ module Components
       end
 
       def select_type(value)
-        retry_block do
-          select_autocomplete page.find_test_selector("work_package_create_dialog_type"),
-                              query: value,
-                              select_text: value.upcase,
-                              results_selector: "#create-work-package-dialog"
+        in_dialog do
+          select_combo_box_option value, from: "Type"
         end
       end
 


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Fix a broken spec (`work_packages/tabs/relations_children_spec.rb`) consistently failing on `releases/16.2`.

# What approach did you choose and why?

This eschews our own `NgSelectAutocompleteHelpers` in favour of the selectors provided by Capybara Accessible Selectors. These selectors rely on semantic elements and accessibility metadata (roles, ARIA attributes) rather than test selectors and CSS classes.

Possible alternative to:
- ##19536
- ##19511

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
