### PR TITLE
Bug/65303 error on updating work package progress tracking 16 2

### DIFF
--- a/app/components/work_packages/progress/base_modal_component.rb
+++ b/app/components/work_packages/progress/base_modal_component.rb
@@ -33,6 +33,7 @@ module WorkPackages
     # rubocop:disable OpenProject/AddPreviewForViewComponent
     class BaseModalComponent < ApplicationComponent
       # rubocop:enable OpenProject/AddPreviewForViewComponent
+      include OpTurbo::Streamable
 
       FIELD_MAP = {
         "estimatedTime" => :estimated_hours,

--- a/app/components/work_packages/progress/status_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/status_based/modal_body_component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "work_package_progress_modal" do %>
+<%= component_wrapper do %>
   <%= primer_form_with(
         model: work_package,
         url: submit_path,

--- a/app/components/work_packages/progress/work_based/modal_body_component.html.erb
+++ b/app/components/work_packages/progress/work_based/modal_body_component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "work_package_progress_modal" do %>
+<%= component_wrapper do %>
   <%= primer_form_with(
         model: work_package,
         url: submit_path,

--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -96,6 +96,8 @@ module OpTurbo
     end
 
     def render_flash_message_via_turbo_stream(message:, component: OpPrimer::FlashComponent, **)
+      return if message.blank?
+
       instance = component.new(**).with_content(message)
       turbo_streams << instance.render_as_turbo_stream(view_context:, action: :flash)
     end

--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -29,6 +29,8 @@
 # ++
 
 class WorkPackages::ProgressController < ApplicationController
+  include OpTurbo::ComponentStream
+
   ERROR_PRONE_ATTRIBUTES = %i[status_id
                               estimated_hours
                               remaining_hours
@@ -41,17 +43,27 @@ class WorkPackages::ProgressController < ApplicationController
     make_fake_initial_work_package
     set_progress_attributes_to_work_package
 
-    render progress_modal_component
+    render_modal
   end
 
   def edit
     find_work_package
     set_progress_attributes_to_work_package
 
-    render progress_modal_component
+    render_modal
   end
 
-  # rubocop:disable Metrics/AbcSize
+  def preview
+    if params[:work_package_id]
+      find_work_package
+    else
+      make_fake_initial_work_package
+    end
+
+    set_progress_attributes_to_work_package
+    render_modal
+  end
+
   def create
     make_fake_initial_work_package
     service_call = set_progress_attributes_to_work_package
@@ -61,13 +73,16 @@ class WorkPackages::ProgressController < ApplicationController
                    .intersect?(ERROR_PRONE_ATTRIBUTES)
       respond_to do |format|
         format.turbo_stream do
+          update_via_turbo_stream(
+            component: progress_modal_component,
+            method: "morph"
+          )
+
           # Bundle 422 status code into stream response so
           # Angular has context as to the success or failure of
           # the request in order to fetch the new set of Work Package
           # attributes in the ancestry solely on success.
-          render turbo_stream: [
-            turbo_stream.morph("work_package_progress_modal", progress_modal_component)
-          ], status: :unprocessable_entity
+          respond_with_turbo_streams(status: :unprocessable_entity)
         end
       end
     else
@@ -76,7 +91,6 @@ class WorkPackages::ProgressController < ApplicationController
                      percentageDone: @work_package.done_ratio }
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def update
     find_work_package
@@ -86,27 +100,33 @@ class WorkPackages::ProgressController < ApplicationController
                      .call(work_package_progress_params)
 
     if service_call.success?
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: []
-        end
-      end
+      head :ok
     else
       respond_to do |format|
         format.turbo_stream do
+          update_via_turbo_stream(
+            component: progress_modal_component,
+            method: "morph"
+          )
+
           # Bundle 422 status code into stream response so
           # Angular has context as to the success or failure of
           # the request in order to fetch the new set of Work Package
           # attributes in the ancestry solely on success.
-          render turbo_stream: [
-            turbo_stream.morph("work_package_progress_modal", progress_modal_component)
-          ], status: :unprocessable_entity
+          respond_with_turbo_streams(status: :unprocessable_entity)
         end
       end
     end
   end
 
   private
+
+  def render_modal
+    render :modal,
+           locals: {
+             progress_modal_component:
+           }
+  end
 
   def progress_modal_component
     modal_class.new(@work_package, focused_field:, touched_field_map:)

--- a/app/views/work_packages/progress/modal.html.erb
+++ b/app/views/work_packages/progress/modal.html.erb
@@ -1,0 +1,5 @@
+<%=
+  turbo_frame_tag("work_package_progress_modal") do
+    render(progress_modal_component)
+  end
+%>

--- a/spec/controllers/work_packages/progress_controller_spec.rb
+++ b/spec/controllers/work_packages/progress_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe WorkPackages::ProgressController do
       params["work_package"]["remaining_hours"] = "3"
       params["work_package"]["remaining_hours_touched"] = "true"
 
-      get("new", params:, as: :turbo_stream)
+      get("new", params:)
 
       assigned_work_package = assigns(:work_package)
       expect(assigned_work_package).to be_new_record
@@ -88,7 +88,7 @@ RSpec.describe WorkPackages::ProgressController do
         params["work_package"]["remaining_hours"] = "3"
         params["work_package"]["remaining_hours_touched"] = "true"
 
-        get("new", params:, as: :turbo_stream)
+        get("new", params:)
 
         assigned_work_package = assigns(:work_package)
         expect(progress_errors(assigned_work_package)).to match(
@@ -106,7 +106,7 @@ RSpec.describe WorkPackages::ProgressController do
         params["work_package"]["remaining_hours"] = "3"
         params["work_package"]["remaining_hours_touched"] = "true"
 
-        get("new", params:, as: :turbo_stream)
+        get("new", params:)
 
         assigned_work_package = assigns(:work_package)
         expect(progress_errors(assigned_work_package)).to be_empty
@@ -133,7 +133,7 @@ RSpec.describe WorkPackages::ProgressController do
       params["work_package"]["estimated_hours"] = "50h"
       params["work_package"]["estimated_hours_touched"] = "true"
 
-      get("edit", params:, as: :turbo_stream)
+      get("edit", params:)
 
       assigned_work_package = assigns(:work_package)
       expect(assigned_work_package.estimated_hours).to eq(50)
@@ -151,7 +151,7 @@ RSpec.describe WorkPackages::ProgressController do
         params["work_package"]["estimated_hours"] = "50h"
         params["work_package"]["estimated_hours_touched"] = "true"
 
-        get("edit", params:, as: :turbo_stream)
+        get("edit", params:)
 
         assigned_work_package = assigns(:work_package)
         expect(progress_errors(assigned_work_package)).to be_empty
@@ -167,7 +167,7 @@ RSpec.describe WorkPackages::ProgressController do
         params["work_package"]["estimated_hours"] = "50h"
         params["work_package"]["estimated_hours_touched"] = "true"
 
-        get("edit", params:, as: :turbo_stream)
+        get("edit", params:)
 
         assigned_work_package = assigns(:work_package)
         expect(progress_errors(assigned_work_package)).to match(


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65303

Same PR as https://github.com/opf/openproject/pull/19404, but targeting `release/16.2`.

# What are you trying to accomplish?

When there are errors on the work package when saving the progress tracking values, the errors unrelated to the progress fields are not visible, leaving the user confused as why their progress values could not be saved.

This PR adds those errors in a top banner (flash message).

## Screenshots

# What approach did you choose and why?

Refactor the way the progress modal is rendered so that the action to render a flash message through turbo stream can be used, and then extract the errors unrelated to the progress values to display them in the flash

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
