### PR TITLE
TS type fixes: rehabilitate `npm run generate-typings`

### DIFF
--- a/frontend/src/app/features/hal/resources/hal-resource.ts
+++ b/frontend/src/app/features/hal/resources/hal-resource.ts
@@ -259,7 +259,7 @@ export class HalResource {
     });
   }
 
-  protected $loadResource(force = false):Promise<this> {
+  $loadResource(force = false):Promise<this> {
     if (!force) {
       if (this.$loaded) {
         return Promise.resolve(this);

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -38,7 +38,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { CalendarOptions, DateSelectArg, EventApi, EventDropArg, EventInput } from '@fullcalendar/core';
-import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -143,7 +143,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
 
   calendarOptions$ = new Subject<CalendarOptions>();
 
-  draggingItem$ = new BehaviorSubject<EventDragStartArg|undefined>(undefined);
+  draggingItem$:BehaviorSubject<EventDragStartArg|undefined> = new BehaviorSubject(undefined);
 
   globalDraggingItem$ = combineLatest([
     this.draggingItem$,
@@ -176,7 +176,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       }),
     );
 
-  dropzone$ = combineLatest([
+  dropzone$:Observable<{ dragging:EventDragStartArg|undefined; isHovering:boolean; canDrop:boolean }> = combineLatest([
     this.draggingItem$,
     this.dropzoneHovered$,
     this.dropzoneAllowed$,

--- a/frontend/src/app/shared/components/grids/widgets/wp-graph/wp-graph.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/wp-graph/wp-graph.component.ts
@@ -77,7 +77,7 @@ export class WidgetWpGraphComponent extends AbstractWidgetComponent implements O
       });
   }
 
-  public get chartOptions() {
+  public get chartOptions():ChartOptions {
     return this.graphConfiguration.chartOptions;
   }
 

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, SimpleChanges } from '@angular/core';
 import { WorkPackageTableConfiguration } from 'core-app/features/work-packages/components/wp-table/wp-table-configuration';
-import { ChartOptions } from 'chart.js';
+import { ChartOptions, Plugin } from 'chart.js';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { GroupObject } from 'core-app/features/hal/resources/wp-collection-resource';
 import DataLabelsPlugin from 'chartjs-plugin-datalabels';
@@ -38,7 +38,7 @@ export class WorkPackageEmbeddedGraphComponent {
 
   public chartData:ChartDataSet[] = [];
 
-  public chartPlugins = [DataLabelsPlugin];
+  public chartPlugins:Plugin[] = [DataLabelsPlugin];
 
   public internalChartOptions:ChartOptions;
 

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -34,7 +34,7 @@ import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlock
 import { dummyBlockSpec, getDefaultOpenProjectSlashMenuItems, openProjectWorkPackageBlockSpec } from "op-blocknote-extensions";
 import { useEffect, useState } from "react";
 
-interface OpBlockNoteContainerProps {
+export interface OpBlockNoteContainerProps {
   inputField: HTMLInputElement;
   inputText?: string;
 }

--- a/modules/documents/frontend/module/hal/resources/document-resource.ts
+++ b/modules/documents/frontend/module/hal/resources/document-resource.ts
@@ -41,6 +41,6 @@ class DocumentBaseResource extends HalResource {
     private attachmentsBackend = false;
 }
 
-export const DocumentResource = Attachable(DocumentBaseResource);
+export type DocumentResource = DocumentBaseResource & InstanceType<ReturnType<typeof Attachable>>;
 
-export type DocumentResource = DocumentBaseResource;
+export const DocumentResource: typeof DocumentBaseResource & ReturnType<typeof Attachable> = Attachable(DocumentBaseResource);


### PR DESCRIPTION
# Ticket

n/a

# What approach did you choose and why?

Fix various errors relating to method visibility, reexporting of external types. Encountered when running `npm run generate-typings`.

<details><summary>Details</summary>

```
> openproject-frontend@0.1.0 generate-typings
> tsc -d -p src/tsconfig.app.json

src/app/features/hal/resources/activity-comment-resource.ts:48:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

48 export const ActivityCommentResource = Attachable(ActivityCommentBaseResource);
                ~~~~~~~~~~~~~~~~~~~~~~~

src/app/features/hal/resources/grid-resource.ts:76:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

76 export const GridResource = Attachable(GridBaseResource);
                ~~~~~~~~~~~~

src/app/features/hal/resources/help-text-resource.ts:43:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

43 export const HelpTextResource = Attachable(HelpTextBaseResource);
                ~~~~~~~~~~~~~~~~

src/app/features/hal/resources/meeting-resource.ts:42:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

42 export const MeetingResource = Attachable(MeetingBaseResource);
                ~~~~~~~~~~~~~~~

src/app/features/hal/resources/mixins/attachable-mixin.ts:37:17 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

37 export function Attachable<TBase extends Constructor<HalResource>>(Base:TBase) {
                   ~~~~~~~~~~

src/app/features/hal/resources/post-resource.ts:42:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

42 export const PostResource = Attachable(PostBaseResource);
                ~~~~~~~~~~~~

src/app/features/hal/resources/wiki-page-resource.ts:40:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

40 export const WikiPageResource = Attachable(WikiPageBaseResource);
                ~~~~~~~~~~~~~~~~

src/app/features/hal/resources/work-package-resource.ts:285:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

285 export const WorkPackageResource = Attachable(WorkPackageBaseResource);
                 ~~~~~~~~~~~~~~~~~~~

src/app/features/plugins/linked/budgets/hal/resources/budget-resource.ts:38:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

38 export const BudgetResource = Attachable(BudgetBaseResource);
                ~~~~~~~~~~~~~~

src/app/features/plugins/linked/openproject-documents/hal/resources/document-resource.ts:44:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

44 export const DocumentResource = Attachable(DocumentBaseResource);
                ~~~~~~~~~~~~~~~~

src/app/features/team-planner/team-planner/planner/team-planner.component.ts:146:3 - error TS4029: Public property 'draggingItem$' of exported class has or is using name 'EventDragArg' from external module "/Users/alexbcoles/git-repos/openproject/frontend/node_modules/@fullcalendar/interaction/index" but cannot be named.

146   draggingItem$ = new BehaviorSubject<EventDragStartArg|undefined>(undefined);
      ~~~~~~~~~~~~~

src/app/features/team-planner/team-planner/planner/team-planner.component.ts:179:3 - error TS4029: Public property 'dropzone$' of exported class has or is using name 'EventDragArg' from external module "/Users/alexbcoles/git-repos/openproject/frontend/node_modules/@fullcalendar/interaction/index" but cannot be named.

179   dropzone$ = combineLatest([
      ~~~~~~~~~

src/stimulus/controllers/dynamic/block-note.controller.ts:55:3 - error TS4053: Return type of public method from exported class has or is using name 'OpBlockNoteContainerProps' from external module "/Users/alexbcoles/git-repos/openproject/frontend/src/react/OpBlockNoteContainer" but cannot be named.

55   BlockNoteReactContainer() {
     ~~~~~~~~~~~~~~~~~~~~~~~

../modules/documents/frontend/module/hal/resources/document-resource.ts:44:14 - error TS2742: The inferred type of 'DocumentResource' cannot be named without a reference to '../../../../../../frontend/node_modules/@angular/core'. This is likely not portable. A type annotation is necessary.

44 export const DocumentResource = Attachable(DocumentBaseResource);
                ~~~~~~~~~~~~~~~~

../modules/documents/frontend/module/hal/resources/document-resource.ts:44:14 - error TS2742: The inferred type of 'DocumentResource' cannot be named without a reference to '../../../../../../frontend/node_modules/@openproject/reactivestates/dist'. This is likely not portable. A type annotation is necessary.

44 export const DocumentResource = Attachable(DocumentBaseResource);
                ~~~~~~~~~~~~~~~~

../modules/documents/frontend/module/hal/resources/document-resource.ts:44:14 - error TS4094: Property '$loadResource' of exported class expression may not be private or protected.

44 export const DocumentResource = Attachable(DocumentBaseResource);
                ~~~~~~~~~~~~~~~~


Found 16 errors in 13 files.

Errors  Files
     1  src/app/features/hal/resources/activity-comment-resource.ts:48
     1  src/app/features/hal/resources/grid-resource.ts:76
     1  src/app/features/hal/resources/help-text-resource.ts:43
     1  src/app/features/hal/resources/meeting-resource.ts:42
     1  src/app/features/hal/resources/mixins/attachable-mixin.ts:37
     1  src/app/features/hal/resources/post-resource.ts:42
     1  src/app/features/hal/resources/wiki-page-resource.ts:40
     1  src/app/features/hal/resources/work-package-resource.ts:285
     1  src/app/features/plugins/linked/budgets/hal/resources/budget-resource.ts:38
     1  src/app/features/plugins/linked/openproject-documents/hal/resources/document-resource.ts:44
     2  src/app/features/team-planner/team-planner/planner/team-planner.component.ts:146
     1  src/stimulus/controllers/dynamic/block-note.controller.ts:55
     3  ../modules/documents/frontend/module/hal/resources/document-resource.ts:44
```

</details> 


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
