### PR TITLE
run IfcConvert in working dir to ensure it is writable

### DIFF
--- a/modules/bim/app/services/bim/ifc_models/view_converter_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/view_converter_service.rb
@@ -131,17 +131,20 @@ module Bim
           # write the default exclude parameter to only exclude
           # IfcOpeningElements.
           # https://github.com/IfcOpenShell/IfcOpenShell/wiki#ifconvert
-          Open3.capture2e("IfcConvert",
-                          "--use-element-guids",
-                          "--no-progress",
-                          "--verbose",
-                          "--threads",
-                          "4",
-                          ifc_filepath,
-                          target_file,
-                          "--exclude",
-                          "entities",
-                          "IfcOpeningElement")
+          Open3.capture2e(
+            "IfcConvert",
+            "--use-element-guids",
+            "--no-progress",
+            "--verbose",
+            "--threads",
+            "4",
+            ifc_filepath,
+            target_file,
+            "--exclude",
+            "entities",
+            "IfcOpeningElement",
+            chdir: working_directory
+          )
         end
       end
 


### PR DESCRIPTION
WP [#65872](https://community.openproject.org/projects/openproject/work_packages/65872/activity)

This had been fixed in 15.5.1 (https://github.com/opf/openproject/pull/18796) but somehow did not make it to the next release branch (16.0) and has been broken (again) ever since.

This PR applies that bug fix again on release/16.2 so it can be released with the next release.