### PR TITLE
Fix project type

### DIFF
--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -56,7 +56,7 @@ module Projects
     # only validate custom fields of the touched section
 
     validate :validate_user_allowed_to_manage
-    attribute :type
+    attribute :project_type
 
     def valid?(context = :saving_custom_fields) = super
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -185,7 +185,7 @@ class ProjectsController < ApplicationController
 
   def new_blank
     @new_project = @parent&.children&.build || Project.new
-    @new_project.project_type = params[:type] if params[:project_type].present?
+    @new_project.project_type = params[:project_type] if params[:project_type].present?
 
     render layout: "no_menu"
   end
@@ -197,7 +197,7 @@ class ProjectsController < ApplicationController
       .call(target_project_params: params.permit(:parent_id).to_h, attributes_only: true)
       .result
 
-    @new_project.type = params[:type] if params[:type].present?
+    @new_project.project_type = params[:project_type] if params[:project_type].present?
 
     render layout: "no_menu"
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -185,7 +185,7 @@ class ProjectsController < ApplicationController
 
   def new_blank
     @new_project = @parent&.children&.build || Project.new
-    @new_project.type = params[:type] if params[:type].present?
+    @new_project.project_type = params[:type] if params[:project_type].present?
 
     render layout: "no_menu"
   end

--- a/app/forms/projects/settings/type_form.rb
+++ b/app/forms/projects/settings/type_form.rb
@@ -33,16 +33,16 @@ module Projects
       form do |f|
         if model.new_record?
           # Hide the type field when creating a new project, as the type is determined via GET parameter.
-          f.hidden(name: :type)
+          f.hidden(name: :project_type)
         else
           # Offer changing the type of existing projects when editing them. Otherwise, there would be no way
           # for users to change the type of project.
           f.select_list(
-            name: :type,
-            label: attribute_name(:type)
+            name: :project_type,
+            label: attribute_name(:project_type)
           ) do |list|
-            Project.types.each_key do |label|
-              list.option(label: I18n.t("activerecord.attributes.project.type_enum.#{label}"), value: label)
+            Project.project_types.each_key do |label|
+              list.option(label: I18n.t("activerecord.attributes.project.project_type_enum.#{label}"), value: label)
             end
           end
         end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -298,7 +298,7 @@ class PermittedParams
 
   def new_project
     params
-      .expect(project: %i[name parent_id type])
+      .expect(project: %i[name parent_id project_type])
       .merge(custom_field_values(:project))
   end
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -283,7 +283,7 @@ class PermittedParams
                                                 :templated,
                                                 :status_code,
                                                 :status_explanation,
-                                                :type,
+                                                :project_type,
                                                 custom_fields: [],
                                                 work_package_custom_field_ids: [],
                                                 type_ids: [],

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -46,12 +46,11 @@ class Project < ApplicationRecord
   # reserved identifiers
   RESERVED_IDENTIFIERS = %w[new menu queries export_list_modal].freeze
 
-  enum :type, {
-    project: 0,
-    program: 1,
-    portfolio: 2
+  enum :project_type, {
+    project: "project",
+    program: "program",
+    portfolio: "portfolio"
   }
-  self.inheritance_column = nil
 
   has_many :members, -> {
     # TODO: check whether this should

--- a/app/models/queries/projects/filters/type_filter.rb
+++ b/app/models/queries/projects/filters/type_filter.rb
@@ -30,7 +30,9 @@
 
 class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
   def allowed_values
-    @allowed_values ||= Project.types.map { |name, id| [I18n.t("activerecord.attributes.project.type_enum.#{name}"), id] }
+    @allowed_values ||= Project.project_types.map do |name, id|
+      [I18n.t("activerecord.attributes.project.project_type_enum.#{name}"), id]
+    end
   end
 
   def type
@@ -38,11 +40,11 @@ class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
   end
 
   def self.key
-    :type
+    :project_type
   end
 
   def where
-    operator_strategy.sql_for_field(values, Project.table_name, :type)
+    operator_strategy.sql_for_field(values, Project.table_name, :project_type)
   end
 
   def human_name

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -29,10 +29,9 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t("label_project_new") %>
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    new_label = case @new_project.type
-                when "portfolio"
+    new_label = if @new_project.portfolio?
                   t(:label_project_portfolio_new)
-                when "program"
+                elsif @new_project.program?
                   t(:label_project_program_new)
                 else
                   t(:label_project_new)

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -79,7 +79,7 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
             ->(project) {
               { controller: "/projects", action: :new, project_id: nil, project_type: "portfolio", parent_id: project&.id }
             },
-            caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.portfolio") },
+            caption: ->(_) { I18n.t("activerecord.attributes.project.project_type_enum.portfolio") },
             icon: "briefcase",
             html: {
               aria: { label: I18n.t(:label_project_portfolio_new) },
@@ -94,7 +94,7 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
             ->(project) {
               { controller: "/projects", action: :new, project_id: nil, project_type: "program", parent_id: project&.id }
             },
-            caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.program") },
+            caption: ->(_) { I18n.t("activerecord.attributes.project.project_type_enum.program") },
             icon: "versions",
             html: {
               aria: { label: I18n.t(:label_project_program_new) },

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -77,7 +77,7 @@ end
 Redmine::MenuManager.map :quick_add_menu do |menu|
   menu.push :new_portfolio,
             ->(project) {
-              { controller: "/projects", action: :new, project_id: nil, type: "portfolio", parent_id: project&.id }
+              { controller: "/projects", action: :new, project_id: nil, project_type: "portfolio", parent_id: project&.id }
             },
             caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.portfolio") },
             icon: "briefcase",
@@ -92,7 +92,7 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
 
   menu.push :new_program,
             ->(project) {
-              { controller: "/projects", action: :new, project_id: nil, type: "program", parent_id: project&.id }
+              { controller: "/projects", action: :new, project_id: nil, project_type: "program", parent_id: project&.id }
             },
             caption: ->(_) { I18n.t("activerecord.attributes.project.type_enum.program") },
             icon: "versions",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1117,8 +1117,8 @@ en:
         queries: "Queries"
         status_code: "Project status"
         status_explanation: "Project status description"
-        type: "Organizational entity type"
-        type_enum:
+        project_type: "Organizational entity type"
+        project_type_enum:
           project: "Project"
           program: "Program"
           portfolio: "Portfolio"

--- a/db/migrate/20250715154952_migrate_project_type.rb
+++ b/db/migrate/20250715154952_migrate_project_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class MigrateProjectType < ActiveRecord::Migration[8.0]
+  def up
+    add_column :projects, :project_type, :string, null: false, default: "project"
+    execute <<~SQL.squish
+      UPDATE projects SET project_type = CASE type
+        WHEN 2 THEN 'portfolio'
+        WHEN 1 THEN 'program'
+        ELSE 'project'
+      END;
+    SQL
+    remove_column :projects, :type
+  end
+
+  def down
+    add_column :projects, :type, :integer, default: 0, null: false
+    execute <<~SQL.squish
+      UPDATE projects SET type = CASE project_type
+        WHEN 'portfolio' THEN 2
+        WHEN 'program' THEN 1
+        ELSE 0
+      END;
+    SQL
+    remove_column :projects, :project_type
+  end
+end

--- a/frontend/src/app/core/state/projects/project.model.ts
+++ b/frontend/src/app/core/state/projects/project.model.ts
@@ -22,7 +22,7 @@ export interface IProject {
   name:string;
   public:boolean;
   active:boolean;
-  type:string;
+  project_type:string;
   statusExplanation:IFormattable;
   description:IFormattable;
 

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -176,7 +176,7 @@ export class ProjectAutocompleterComponent extends OpAutocompleterComponent<IPro
 
         filteredURL.searchParams.set('pageSize', params.pageSize?.toString() || '-1');
         filteredURL.searchParams.set('offset', params.offset?.toString() || '1');
-        filteredURL.searchParams.set('select', 'elements/id,elements/name,elements/type,elements/identifier,elements/self,elements/ancestors,total,count,pageSize');
+        filteredURL.searchParams.set('select', 'elements/id,elements/name,elements/project_type,elements/identifier,elements/self,elements/ancestors,total,count,pageSize');
 
         return this
           .http

--- a/frontend/src/app/shared/components/header-project-select/insert-in-list.ts
+++ b/frontend/src/app/shared/components/header-project-select/insert-in-list.ts
@@ -26,7 +26,7 @@ export const insertInList = (
         disabled: false,
         children: [],
         position: 0,
-        type: project.type,
+        type: project.project_type,
       },
     ];
   }
@@ -58,7 +58,7 @@ export const insertInList = (
       disabled: true,
       children: insertInList(projects, project, [], visibleAncestors.slice(1)),
       position: 0,
-      type: project.type,
+      type: project.project_type,
     },
   ];
 };

--- a/frontend/src/app/shared/components/project-include/insert-in-list.ts
+++ b/frontend/src/app/shared/components/project-include/insert-in-list.ts
@@ -26,7 +26,7 @@ export const insertInList = (
         disabled: false,
         children: [],
         position: 0,
-        type: project.type,
+        type: project.project_type,
       },
     ];
   }
@@ -53,7 +53,7 @@ export const insertInList = (
       disabled: true,
       children: insertInList(projects, project, [], visibleAncestors.slice(1)),
       position: 0,
-      type: ancestorProject.type,
+      type: ancestorProject.project_type,
     },
   ];
 };

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -70,7 +70,7 @@ export class SearchableProjectListService {
       select: [
         'elements/id',
         'elements/name',
-        'elements/type',
+        'elements/project_type',
         'elements/identifier',
         'elements/self',
         'elements/ancestors',

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -187,7 +187,7 @@ module API
 
         property :active
         property :public
-        property :type
+        property :project_type
 
         formattable_property :description,
                              cache_if: current_user_view_allowed_lambda

--- a/lib/api/v3/projects/project_sql_representer.rb
+++ b/lib/api/v3/projects/project_sql_representer.rb
@@ -124,16 +124,7 @@ module API
 
         property :public
 
-        property :type,
-                 representation: ->(*) {
-                   <<~SQL.squish
-                     CASE
-                     WHEN type = 0 then 'project'
-                     WHEN type = 1 then 'program'
-                     WHEN type = 2 then 'portfolio'
-                     END
-                   SQL
-                 }
+        property :project_type
       end
     end
   end

--- a/spec/models/queries/projects/filters/type_filter_spec.rb
+++ b/spec/models/queries/projects/filters/type_filter_spec.rb
@@ -32,24 +32,29 @@ require "spec_helper"
 
 RSpec.describe Queries::Projects::Filters::TypeFilter do
   it_behaves_like "basic query filter" do
-    let(:class_key) { :type }
+    let(:class_key) { :project_type }
     let(:type) { :list }
     let(:model) { Project }
-    let(:attribute) { :type }
-    let(:values) { ["1"] }
+    let(:attribute) { :project_type }
+    let(:values) { ["program"] }
     let(:admin) { build_stubbed(:admin) }
     let(:user) { build_stubbed(:user) }
 
     before do
-      allow(Project).to receive(:types).and_return({ "project" => 0, "program" => 1, "portfolio" => 2 })
-      allow(I18n).to receive(:t).with("activerecord.attributes.project.type_enum.project").and_return("Project")
-      allow(I18n).to receive(:t).with("activerecord.attributes.project.type_enum.program").and_return("Program")
-      allow(I18n).to receive(:t).with("activerecord.attributes.project.type_enum.portfolio").and_return("Portfolio")
+      allow(Project).to receive(:project_types).and_return({
+                                                             "project" => "project",
+                                                             "program" => "program",
+                                                             "portfolio" => "portfolio"
+                                                           })
+      allow(I18n).to receive(:t).with("label_project_type").and_return("Organizational entity type")
+      allow(I18n).to receive(:t).with("activerecord.attributes.project.project_type_enum.project").and_return("Project")
+      allow(I18n).to receive(:t).with("activerecord.attributes.project.project_type_enum.program").and_return("Program")
+      allow(I18n).to receive(:t).with("activerecord.attributes.project.project_type_enum.portfolio").and_return("Portfolio")
     end
 
     describe "#allowed_values" do
       it "is a list of the possible values" do
-        expect(instance.allowed_values.map(&:second)).to contain_exactly(0, 1, 2)
+        expect(instance.allowed_values.map(&:second)).to contain_exactly("portfolio", "program", "project")
       end
     end
   end


### PR DESCRIPTION
Use `project_type` instead of `type` for the enum, so we do not accidentally trigger STI behavior and other weirdnesses.

@EinLama has started to put together a list of usages:

representers:

representers:

- [x] `lib/api/v3/projects/project_representer.rb`
- [x] `lib/api/v3/projects/project_sql_representer.rb`

Contracts, forms, controller, model, filter:

- [x] `app/contracts/projects/base_contract.rb`
- [x] `app/controllers/projects_controller.rb`
- [x] `app/forms/projects/settings/type_form.rb`
- [x] `app/models/permitted_params.rb`
- [x] `app/models/project.rb`
- [x] `app/models/queries/projects/filters/type_filter.rb`
- [x] `spec/models/queries/projects/filters/type_filter_spec.rb`

Views
- [x] `app/views/projects/new.html.erb`

Quick menu:

- [x] `config/initializers/menus.rb`

Frontend displaying the icon in the project list:

- [x] `frontend/src/app/core/state/projects/project.model.ts`
- [x] `frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts`
- [x] `frontend/src/app/shared/components/header-project-select/insert-in-list.ts`
- [x] `frontend/src/app/shared/components/project-include/insert-in-list.ts`
- [x] `frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts`