### PR TITLE
[#65886] Fix Settings multi-lang input

### DIFF
--- a/frontend/src/app/core/setup/globals/global-listeners/settings.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/settings.ts
@@ -1,3 +1,5 @@
+import { ICKEditorInstance } from 'core-app/shared/components/editor/components/ckeditor/ckeditor.types';
+
 /**
  * Move from legacy app/assets/javascripts/application.js.erb
  *
@@ -32,10 +34,10 @@ export function listenToSettingChanges() {
     const id:string = self.attr('id') || '';
     const settingName = id.replace('lang-for-', '');
     const newLang = self.val() as string;
-    const textAreaId = `#settings-${settingName}`;
-    const textArea = jQuery(textAreaId);
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
-    const editor = jQuery(`opce-ckeditor-augmented-textarea[data-textarea-selector='"${textAreaId}"'`).data('editor');
+    const textAreaId = `settings-${settingName}`;
+    const textArea = jQuery(`#${textAreaId}`);
+    const augmentedTextarea = jQuery(`opce-ckeditor-augmented-textarea[data-text-area-id='"${textAreaId}"']`);
+    const editor = augmentedTextarea.data('editor') as ICKEditorInstance;
 
     return {
       id, settingName, newLang, textArea, editor,
@@ -57,7 +59,7 @@ export function listenToSettingChanges() {
     .change(function () {
       const data = langSelectSwitchData(this);
 
-      const storedValue = jQuery(`#${data.id}-${data.newLang}`).val();
+      const storedValue = jQuery(`#${data.id}-${data.newLang}`).val()!.toString();
 
       data.editor.setData(storedValue);
       data.textArea.attr('name', `settings[${data.settingName}][${data.newLang}]`);

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor.types.ts
@@ -25,7 +25,7 @@ export interface ICKEditorInstance {
 
   state:string;
 
-  getData(options:{ trim:boolean }):string;
+  getData(options?:{ trim:boolean }):string;
 
   setData(content:string):void;
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65886

# What are you trying to accomplish?

Fixes broken multi-language input in Administration > Email Notifications, User Settings.

## Screenshots

### User Settings > User Consent

<img width="1224" height="306" alt="Screenshot 2025-07-15 at 19 15 59" src="https://github.com/user-attachments/assets/c324f56e-264c-4d51-98fa-9796f1283e39" />

### Email Notifications > Emails Header & Footer Settings

https://github.com/user-attachments/assets/fd52f91f-e154-41f5-baf8-b433620d8f63

# What approach did you choose and why?

The simplest possible fix.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
