### PR TITLE
[#65865] Offer correct project type for template selection

### DIFF
--- a/app/components/projects/template_select_component.html.erb
+++ b/app/components/projects/template_select_component.html.erb
@@ -49,6 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
       ) do
         template_id_value = template_id
         parent_id_value = parent_id
+        project_type_value = project_type
         render_inline_form(f) do |form|
           form.project_autocompleter(
             name: :template_id,
@@ -60,7 +61,8 @@ See COPYRIGHT and LICENSE files for more details.
               placeholder: I18n.t("label_none_parentheses"),
               filters: [
                 { name: "user_action", operator: "=", values: ["projects/copy"] },
-                { name: "templated", operator: "=", values: ["t"] }
+                { name: "templated", operator: "=", values: ["t"] },
+                { name: "project_type", operator: "=", values: [project_type_value] }
               ],
               data: {
                 action: "change->auto-submit#submit",

--- a/app/components/projects/template_select_component.rb
+++ b/app/components/projects/template_select_component.rb
@@ -34,7 +34,7 @@ module Projects
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    options :template, :parent
+    options :template, :parent, :project_type
 
     private
 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -45,7 +45,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Projects::TemplateSelectComponent.new(
     template: @template,
-    parent: @parent
+    parent: @parent,
+    project_type: @new_project.project_type
   )
 %>
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65865

When creating a new project, you can select another project as a template. We want to make it possible to also create Programs and Portfolios from templates.

* It should be possible to also create Programs and Portfolios from templates.
* When you create a new Project, you should only see existing Project templates as suggestions.
* When you create a new Program, you should only see existing Program templates as suggestions.
* When you create a new Portfolio, you should only see existing Portfolio templates as suggestions.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
