### PR TITLE
Add budgets widget to portfolio overview page

### DIFF
--- a/modules/budgets/app/models/budget.rb
+++ b/modules/budgets/app/models/budget.rb
@@ -120,6 +120,11 @@ class Budget < ApplicationRecord
     supplementary_amount + material_budget + labor_budget + budget_added_by_children
   end
 
+  def children_budgets_count
+    # TODO: Efficient with query
+    child_budget_relations.includes(:child_budget).sum { |rel| 1 + rel.child_budget.children_budgets_count }
+  end
+
   def budget_added_by_children
     # TODO: Efficient with query
     @budget_added_by_children ||= child_budget_relations.add.includes(:child_budget).sum do |rel|

--- a/modules/budgets/spec/models/budget_spec.rb
+++ b/modules/budgets/spec/models/budget_spec.rb
@@ -31,13 +31,19 @@
 require_relative "../spec_helper"
 
 RSpec.describe Budget do
-  let(:budget) { build(:budget, project:) }
-  let(:type) { create(:type_feature) }
-  let(:project) { create(:project_with_types) }
-  let(:user) { create(:user) }
+  shared_let(:user) { create(:user) }
+  shared_let(:project) { create(:project_with_types) }
+
+  before_all do
+    set_factory_default(:user, user)
+    set_factory_default(:project, project)
+    set_factory_default(:project_with_types, project)
+  end
+
+  let(:budget) { build(:budget) }
 
   describe "destroy" do
-    let(:work_package) { create(:work_package, project:) }
+    let(:work_package) { create(:work_package) }
 
     before do
       budget.author = user
@@ -47,9 +53,14 @@ RSpec.describe Budget do
       budget.destroy
     end
 
-    it { expect(Budget.find_by_id(budget.id)).to be_nil }
-    it { expect(WorkPackage.find_by_id(work_package.id)).to eq(work_package) }
-    it { expect(work_package.reload.budget).to be_nil }
+    it "deletes the budget" do
+      expect(described_class.find_by(id: budget.id)).to be_nil
+      expect(work_package.reload.budget).to be_nil
+    end
+
+    it "does not delete the associated work packages" do
+      expect(WorkPackage.find_by(id: work_package.id)).to eq(work_package)
+    end
   end
 
   describe "#existing_material_budget_item_attributes=" do
@@ -59,7 +70,7 @@ RSpec.describe Budget do
       budget.material_budget_items.reload.first
     end
 
-    context "allowed to edit budgets" do
+    context "when allowed to edit budgets" do
       before do
         mock_permissions_for(User.current) do |mock|
           mock.allow_in_project :edit_budgets, project:
@@ -82,6 +93,28 @@ RSpec.describe Budget do
           expect(existing_material_budget_item)
             .to be_destroyed
         end
+      end
+    end
+  end
+
+  describe "#children_budgets_count" do
+    context "without any budget relations" do
+      it { expect(budget.children_budgets_count).to eq(0) }
+    end
+
+    context "with one child budget relation" do
+      let!(:child_budget) { create(:budget) }
+      let!(:budget_relation) { create(:budget_relation, parent_budget: budget, child_budget:) }
+
+      it { expect(budget.children_budgets_count).to eq(1) }
+
+      context "with also a grandchild budget relation" do
+        let!(:grandchild_budget) { create(:budget) }
+        let!(:grandchild_budget_relation) do
+          create(:budget_relation, parent_budget: child_budget, child_budget: grandchild_budget)
+        end
+
+        it { expect(budget.children_budgets_count).to eq(2) }
       end
     end
   end

--- a/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.html.erb
+++ b/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.html.erb
@@ -34,13 +34,67 @@ See COPYRIGHT and LICENSE files for more details.
       render(Primer::OpenProject::BorderBox::CollapsibleHeader.new(box: component)) do |header|
         header.with_title do
           concat(render(Primer::Beta::Octicon.new(icon: :"op-budget", color: :muted, mr: 2)))
-          concat(render(Primer::Beta::Text.new) {"Budget"})
+          concat(render(Primer::Beta::Text.new) { "Budget" })
         end
       end
     end
 
     component.with_row do
+      helpers.stimulus_chartjs_canvas(
+        type: :pie,
+        data: {
+          labels: [
+            "Zugeteilt (unverbaucht)",
+            "Ausgegeben",
+            "Verfügbar"
+          ],
+          datasets: [
+            {
+              data: [
+                project_budgets.allocated_unused,
+                project_budgets.spent_on_children,
+                project_budgets.available
+              ]
+            }
+          ]
+        },
+        options: {
+          animation: {
+            animateRotate: false
+          },
+          borderWidth: 0,
+          plugins: {
+            legend: {
+              position: "bottom",
+              labels: {
+                usePointStyle: true
+              }
+            },
+            datalabels: {
+              display: false
+            }
+          }
+        }
+      )
+    end
 
+    component.with_row do
+      flex_layout(justify_content: :space_between) do |layout|
+        layout.with_column do
+          # TODO: replace with proper i18n
+          if project_budgets.children_budgets_count.positive?
+            render(Primer::Beta::Text.new(color: :muted)) do
+              "Schließt #{pluralize(project_budgets.children_budgets_count, 'Teilbudget')} ein"
+            end
+          end
+        end
+
+        layout.with_column do
+          render(Primer::Beta::Link.new(href: projects_list_with_budgets_columns_path)) do
+            render(Primer::Beta::Text.new(font_weight: :bold)) { "Alle anzeigen" }
+          end
+        end
+      end
     end
   end
 %>

--- a/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.rb
+++ b/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.rb
@@ -34,6 +34,36 @@ module Overviews
       class BudgetsComponent < ApplicationComponent
         include OpPrimer::ComponentHelpers
         include ApplicationHelper
+
+        attr_reader :project, :project_budgets
+
+        def initialize(model = nil, project:, **)
+          super(model, **)
+
+          @project = project
+          @project_budgets = ::Budgets::ProjectBudgets.new(project)
+        end
+
+        def projects_list_with_budgets_columns_path
+          projects_path(
+            columns: [
+              "name",
+              Queries::Projects::Selects::BudgetPlanned,
+              Queries::Projects::Selects::BudgetAllocated,
+              Queries::Projects::Selects::BudgetSpent,
+              Queries::Projects::Selects::BudgetAvailable
+            ].map { column_key(it) }.join(" "),
+            filters: [
+              "#{Queries::Projects::Filters::ActiveFilter.key} = t",
+              "#{Queries::Projects::Filters::AncestorOrSelfFilter.key} = #{project.id}"
+            ].join("&"),
+            query_id: "active"
+          )
+        end
+
+        def column_key(column)
+          column.respond_to?(:key) ? column.key.to_s : column
+        end
       end
     end
   end


### PR DESCRIPTION

# Ticket

https://community.openproject.org/wp/65783

# What are you trying to accomplish?

Fill the budgets widget on protfolio overview page with a pie chart of bugdet allocations / spent / available and a link to the projects list with budget informative columns.

## Screenshots

**From [figma](https://www.figma.com/design/6pUebKnRnTycVr8NucCw0B/BMDS-Hackathon?node-id=171-12238&t=1UW61IiEk3AyFiGx-0)**
<img width="442" height="566" alt="image" src="https://github.com/user-attachments/assets/859705bf-64c7-4675-9d17-c847d521cd36" />

**Actual**
Nothing allocated yet:
<img width="344" height="451" alt="image" src="https://github.com/user-attachments/assets/2f48dfce-65c4-4211-a7b2-5a5336c4e9a1" />

# What approach did you choose and why?


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
