### PR TITLE
fixed typo in postgresql17 guide

### DIFF
--- a/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
+++ b/docs/installation-and-operations/misc/migration-to-postgresql17/README.md
@@ -147,7 +147,7 @@ echo "CREATE DATABASE openproject OWNER openproject;" | docker exec -i postgres 
 Restore your data:
 
 ```bash
-docker exec -i postgres psql -U openprojet -d openproject < openproject.sql
+docker exec -i postgres psql -U openproject -d openproject < openproject.sql
 ```
 
 This imports your backup into the newly created database.


### PR DESCRIPTION
# What are you trying to accomplish?

Fixed a small typo in the _migration to postgresql 17_ guide, which was noted and mentioned by a user.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
