### PR TITLE
[#65895] Adding to proposal without extra step

### DIFF
--- a/app/components/portfolio_managements/row_component.rb
+++ b/app/components/portfolio_managements/row_component.rb
@@ -74,10 +74,24 @@ module PortfolioManagements
                           I18n.t("portfolio_proposals.contains_elements", count: project_count)
                         end
 
+          project_ids = proposal.projects.pluck(:id) + [project.id]
+          inputs = project_ids.map do |pid|
+            {
+              name: "portfolio_proposal[project_ids][]",
+              value: pid
+            }
+          end
+
+          inputs << { name: "via_context_menu", value: true }
+
           {
             scheme: :default,
             icon: nil,
-            href: edit_project_portfolio_management_proposal_path(portfolio, proposal, add_project: project.id),
+            href: project_portfolio_management_proposal_path(portfolio, proposal),
+            form_arguments: {
+              inputs:,
+              method: :patch
+            },
             description:,
             label: proposal.name,
             aria: { label: proposal.name }

--- a/app/components/portfolio_managements/row_component.rb
+++ b/app/components/portfolio_managements/row_component.rb
@@ -53,7 +53,7 @@ module PortfolioManagements
     end
 
     def portfolio_proposals
-      PortfolioProposal.where(state: :compose)
+      PortfolioProposal.where(state: :draft)
     end
 
     def may_add_project_to_proposal?(project, proposal)

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -271,11 +271,13 @@ module Projects
         form_arguments = button_options.delete(:form_arguments)
         submenu_entries = button_options.delete(:submenu_entries)
         description = button_options.delete(:description)
+        form_arguments = button_options.delete(:form_arguments)
 
         if submenu_entries.present?
           menu.with_sub_menu_item(scheme:,
                                   label:,
                                   test_selector: "project-list-row--action-menu-item",
+                                  form_arguments:,
                                   content_arguments: button_options) do |sub_menu|
             submenu_entries.each do |sub_menu_item|
               add_menu_item_to_action_menu(sub_menu, sub_menu_item)
@@ -286,6 +288,7 @@ module Projects
                          label:,
                          form_arguments:,
                          test_selector: "project-list-row--action-menu-item",
+                         form_arguments:,
                          content_arguments: button_options) do |item|
             item.with_leading_visual_icon(icon:) if icon
             item.with_description.with_content(description) if description

--- a/app/controllers/portfolio_managements/proposals_controller.rb
+++ b/app/controllers/portfolio_managements/proposals_controller.rb
@@ -95,8 +95,13 @@ class PortfolioManagements::ProposalsController < ApplicationController
 
   def update
     if @proposal.update(proposal_params)
-      flash[:notice] = t(:notice_successful_update)
-      redirect_to project_portfolio_management_proposal_path(@project, @proposal)
+      if params[:via_context_menu]
+        flash.now[:notice] = t(:notice_successful_update)
+        render turbo_stream: turbo_stream.replace("flash-messages", helpers.render_flash_messages)
+      else
+        flash[:notice] = t(:notice_successful_update)
+        redirect_to project_portfolio_management_proposal_path(@project, @proposal)
+      end
     else
       respond_to do |format|
         format.html { render :edit }

--- a/app/controllers/portfolio_managements/proposals_controller.rb
+++ b/app/controllers/portfolio_managements/proposals_controller.rb
@@ -56,8 +56,8 @@ class PortfolioManagements::ProposalsController < ApplicationController
 
   def new
     @proposal = @project.portfolio_proposals.build
-    if params[:add_project].present? && @proposal.project_ids.exclude?(params[:add_project])
-      @proposal.project_ids << params[:add_project]
+    if params[:add_projects].present? && @proposal.project_ids.exclude?(params[:add_projects])
+      @proposal.project_ids.concat(params[:add_projects])
     end
 
     respond_to do |format|
@@ -67,10 +67,6 @@ class PortfolioManagements::ProposalsController < ApplicationController
   end
 
   def edit
-    if params[:add_project].present? && @proposal.project_ids.exclude?(params[:add_project])
-      @proposal.project_ids << params[:add_project]
-    end
-
     respond_to do |format|
       format.html
       format.turbo_stream


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65895

Add projects to portfolio without an extra step via the `#edit` action.

Known problem: flash messages will not show after adding a proposal via context menu.
