### PR TITLE
[65090] Migrate waffle icon from a normal menu to a overlapping lateral menu

### DIFF
--- a/app/views/custom_styles/_inline_css_logo.erb
+++ b/app/views/custom_styles/_inline_css_logo.erb
@@ -37,9 +37,9 @@ See COPYRIGHT and LICENSE files for more details.
                asset_path("logo_openproject_white_big.png")
              end
 
-  logo_only_url = asset_path("icon_logo.svg")
+  logo_short_url = asset_path("icon_logo.svg")
 
-  logo_only_dark_url = asset_path("icon_logo_white.svg")
+  logo_short_dark_url = asset_path("icon_logo_white.svg")
 
   high_contrast_logo_url = if isRu
                              asset_path("logo-black-bg-ua.png")
@@ -52,12 +52,12 @@ See COPYRIGHT and LICENSE files for more details.
   if apply_custom_styles?
     if CustomStyle.current.logo.present?
       logo_url = custom_style_logo_path(digest: CustomStyle.current.digest, filename: CustomStyle.current.logo_identifier)
-      logo_only_url = logo_url
-      logo_only_dark_url = logo_url
+      logo_short_url = logo_url
+      logo_short_dark_url = logo_url
     elsif CustomStyle.current.theme_logo.present?
       logo_url = asset_path(CustomStyle.current.theme_logo)
-      logo_only_url = logo_url
-      logo_only_dark_url = logo_url
+      logo_short_url = logo_url
+      logo_short_dark_url = logo_url
     end
 
     if isRu && logo_url == asset_path("logo_openproject.png")
@@ -70,12 +70,12 @@ See COPYRIGHT and LICENSE files for more details.
     background-image: url(<%= logo_url %>);
   }
 
-  .op-logo-only {
-    background-image: url(<%= logo_only_url %>);
+  .op-logo-short {
+    background-image: url(<%= logo_short_url %>);
   }
 
-  .op-logo-only_dark {
-    background-image: url(<%= logo_only_dark_url %>);
+  .op-logo-short_dark {
+    background-image: url(<%= logo_short_dark_url %>);
   }
 
   .op-logo--link_high_contrast {

--- a/app/views/custom_styles/_inline_css_logo.erb
+++ b/app/views/custom_styles/_inline_css_logo.erb
@@ -37,9 +37,9 @@ See COPYRIGHT and LICENSE files for more details.
                asset_path("logo_openproject_white_big.png")
              end
 
-  logo_short_url = asset_path("icon_logo.svg")
+  logo_icon_url = asset_path("icon_logo.svg")
 
-  logo_short_dark_url = asset_path("icon_logo_white.svg")
+  logo_icon_dark_url = asset_path("icon_logo_white.svg")
 
   high_contrast_logo_url = if isRu
                              asset_path("logo-black-bg-ua.png")
@@ -52,12 +52,12 @@ See COPYRIGHT and LICENSE files for more details.
   if apply_custom_styles?
     if CustomStyle.current.logo.present?
       logo_url = custom_style_logo_path(digest: CustomStyle.current.digest, filename: CustomStyle.current.logo_identifier)
-      logo_short_url = logo_url
-      logo_short_dark_url = logo_url
+      logo_icon_url = logo_url
+      logo_icon_dark_url = logo_url
     elsif CustomStyle.current.theme_logo.present?
       logo_url = asset_path(CustomStyle.current.theme_logo)
-      logo_short_url = logo_url
-      logo_short_dark_url = logo_url
+      logo_icon_url = logo_url
+      logo_icon_dark_url = logo_url
     end
 
     if isRu && logo_url == asset_path("logo_openproject.png")
@@ -70,12 +70,12 @@ See COPYRIGHT and LICENSE files for more details.
     background-image: url(<%= logo_url %>);
   }
 
-  .op-logo-short {
-    background-image: url(<%= logo_short_url %>);
+  .op-logo-icon {
+    background-image: url(<%= logo_icon_url %>);
   }
 
-  .op-logo-short_dark {
-    background-image: url(<%= logo_short_dark_url %>);
+  .op-logo-icon_dark {
+    background-image: url(<%= logo_icon_dark_url %>);
   }
 
   .op-logo--link_high_contrast {

--- a/app/views/custom_styles/_inline_css_logo.erb
+++ b/app/views/custom_styles/_inline_css_logo.erb
@@ -51,15 +51,28 @@ See COPYRIGHT and LICENSE files for more details.
     elsif CustomStyle.current.theme_logo.present?
       logo_url = asset_path(CustomStyle.current.theme_logo)
     end
-    
+
     if isRu && logo_url == asset_path("logo_openproject.png")
       logo_url = asset_path("logo-black-bg-ua.png")
     end
   end
+  logo_only_url = if logo_url == asset_path("logo_openproject_white_big.png")
+                    asset_path("icon_logo.svg")
+                  else
+                    logo_url
+                  end
   %>
 
   .op-logo--link {
     background-image: url(<%= logo_url %>);
+  }
+
+  .op-logo-only {
+    background-image: url(<%= logo_only_url %>);
+  }
+
+  .op-logo-only_dark {
+    background-image: url(<%= asset_path("icon_logo_white.svg") %>);
   }
 
   .op-logo--link_high_contrast {

--- a/app/views/custom_styles/_inline_css_logo.erb
+++ b/app/views/custom_styles/_inline_css_logo.erb
@@ -37,6 +37,10 @@ See COPYRIGHT and LICENSE files for more details.
                asset_path("logo_openproject_white_big.png")
              end
 
+  logo_only_url = asset_path("icon_logo.svg")
+
+  logo_only_dark_url = asset_path("icon_logo_white.svg")
+
   high_contrast_logo_url = if isRu
                              asset_path("logo-black-bg-ua.png")
                            else
@@ -48,19 +52,18 @@ See COPYRIGHT and LICENSE files for more details.
   if apply_custom_styles?
     if CustomStyle.current.logo.present?
       logo_url = custom_style_logo_path(digest: CustomStyle.current.digest, filename: CustomStyle.current.logo_identifier)
+      logo_only_url = logo_url
+      logo_only_dark_url = logo_url
     elsif CustomStyle.current.theme_logo.present?
       logo_url = asset_path(CustomStyle.current.theme_logo)
+      logo_only_url = logo_url
+      logo_only_dark_url = logo_url
     end
 
     if isRu && logo_url == asset_path("logo_openproject.png")
       logo_url = asset_path("logo-black-bg-ua.png")
     end
   end
-  logo_only_url = if logo_url == asset_path("logo_openproject_white_big.png")
-                    asset_path("icon_logo.svg")
-                  else
-                    logo_url
-                  end
   %>
 
   .op-logo--link {
@@ -72,7 +75,7 @@ See COPYRIGHT and LICENSE files for more details.
   }
 
   .op-logo-only_dark {
-    background-image: url(<%= asset_path("icon_logo_white.svg") %>);
+    background-image: url(<%= logo_only_dark_url %>);
   }
 
   .op-logo--link_high_contrast {

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -160,13 +160,11 @@ Redmine::MenuManager.map :global_menu do |menu|
   menu.push :home,
             { controller: "/homescreen", action: "index" },
             icon: "home",
-            context: :modules,
             first: true
 
   menu.push :my_page,
             { controller: "/my/page", action: "show" },
             after: :home,
-            context: :modules,
             icon: "person",
             caption: I18n.t("my_page.label")
 

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -88,16 +88,6 @@ Redmine::MenuManager.map :top_menu do |menu|
             if: ->(*) do
               User.current.logged?
             end
-
-  menu.push :my_time_tracking,
-            { controller: "/my/time_tracking", action: "index" },
-            after: :my_page,
-            context: :my,
-            caption: :label_my_time_tracking,
-            if: ->(*) do
-              User.current.allowed_in_any_project?(:log_own_time) || User.current.allowed_in_any_project?(:log_time)
-            end,
-            icon: :stopwatch
 end
 
 Redmine::MenuManager.map :quick_add_menu do |menu|

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -84,7 +84,10 @@ Redmine::MenuManager.map :top_menu do |menu|
             context: :my,
             after: :home,
             icon: "person",
-            caption: I18n.t("my_page.label")
+            caption: I18n.t("my_page.label"),
+            if: ->(*) do
+              User.current.logged?
+            end
 
   menu.push :my_time_tracking,
             { controller: "/my/time_tracking", action: "index" },

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -72,6 +72,29 @@ Redmine::MenuManager.map :top_menu do |menu|
             html: { accesskey: OpenProject::AccessKeys.key_for(:help),
                     title: I18n.t("label_help"),
                     target: "_blank" }
+
+  menu.push :home,
+            { controller: "/homescreen", action: "index" },
+            context: :my,
+            icon: "home",
+            first: true
+
+  menu.push :my_page,
+            { controller: "/my/page", action: "show" },
+            context: :my,
+            after: :home,
+            icon: "person",
+            caption: I18n.t("my_page.label")
+
+  menu.push :my_time_tracking,
+            { controller: "/my/time_tracking", action: "index" },
+            after: :my_page,
+            context: :my,
+            caption: :label_my_time_tracking,
+            if: ->(*) do
+              User.current.allowed_in_any_project?(:log_own_time) || User.current.allowed_in_any_project?(:log_time)
+            end,
+            icon: :stopwatch
 end
 
 Redmine::MenuManager.map :quick_add_menu do |menu|
@@ -137,11 +160,13 @@ Redmine::MenuManager.map :global_menu do |menu|
   menu.push :home,
             { controller: "/homescreen", action: "index" },
             icon: "home",
+            context: :modules,
             first: true
 
   menu.push :my_page,
             { controller: "/my/page", action: "show" },
             after: :home,
+            context: :modules,
             icon: "person",
             caption: I18n.t("my_page.label")
 

--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -11,6 +11,9 @@
     height: 100%
     min-width: 0px
 
+  &--items
+    margin-left: 0
+
   &--item-dropdown-indicator
     display: inline-flex
     justify-content: center

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -12,7 +12,7 @@
     background: no-repeat center
     background-size: contain
 
-  &-short, &-short_dark
+  &-icon, &-icon_dark
     margin-left: 0.5rem
     height: 32px
     background: no-repeat left center

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -12,7 +12,7 @@
     background: no-repeat center
     background-size: contain
 
-  &-only, &-only_dark
+  &-short, &-short_dark
     margin-left: 0.5rem
     height: 32px
     background: no-repeat left center

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -12,5 +12,14 @@
     background: no-repeat center
     background-size: contain
 
+  &-only, &-only_dark
+    margin-left: 0.5rem
+    width: 100%
+    display: block
+    height: 32px
+    text-indent: -9999em
+    background: no-repeat left center
+    background-size: contain
+
   @media screen and (max-width: 850px)
     display: none

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -14,10 +14,7 @@
 
   &-only, &-only_dark
     margin-left: 0.5rem
-    width: 100%
-    display: block
     height: 32px
-    text-indent: -9999em
     background: no-repeat left center
     background-size: contain
 

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -67,6 +67,10 @@ ul.SegmentedControl,
   .ToggleSwitch-statusIcon
     display: none
 
+.op-app-header--modules-menu-header
+  .Overlay-headerContentWrap
+    align-items: center
+
 .Overlay
   &--size-large-portrait
     --overlay-height: 800px !important

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -67,10 +67,6 @@ ul.SegmentedControl,
   .ToggleSwitch-statusIcon
     display: none
 
-.op-app-header--modules-menu-header
-  .Overlay-headerContentWrap
-    align-items: center
-
 .Overlay
   &--size-large-portrait
     --overlay-height: 800px !important

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -206,10 +206,10 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_menu_item_group(menu, item_group)
     menu.with_body do
-      render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items", id: "op-app-header--modules-menu-list")) do |component|
-        component.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
+      render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items", id: "op-app-header--modules-menu-list")) do |list|
+        list.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
         item_group[:items].each do |item|
-          component.with_item(
+          list.with_item(
             href: url_for(item.url),
             label: item.caption,
             test_selector: "op-menu--item-action"

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -56,6 +56,13 @@ module Redmine::MenuManager::TopMenuHelper
     end
   end
 
+  def render_logo_only
+    mode_class = User.current.pref.theme === "dark" ? "op-logo-only_dark" : "op-logo-only"
+    content_tag :div, class: mode_class do
+      nil
+    end
+  end
+
   def render_top_menu_search
     content_tag :div, class: "op-app-search" do
       render_global_search_input
@@ -185,6 +192,9 @@ module Redmine::MenuManager::TopMenuHelper
                               title: I18n.t("label_modules"),
                               test_selector: "op-app-header--modules-menu-button",
                               "aria-label": I18n.t("label_modules"))
+        menu.with_header do
+          render_logo_only
+        end
 
         item_groups.each do |item_group|
           render_menu_item_group(menu, item_group)
@@ -195,7 +205,7 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_menu_item_group(menu, item_group)
     menu.with_body do
-      render(Primer::Alpha::ActionList.new) do |component|
+      render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items")) do |component|
         component.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
         item_group[:items].each do |item|
           component.with_item(

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -174,9 +174,11 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_module_top_menu_node(item_groups = module_top_menu_item_groups)
     unless item_groups.empty?
-      render Primer::Alpha::ActionMenu.new(classes: "op-app-menu--item",
-                                           menu_id: "op-app-header--modules-menu",
-                                           anchor_align: :end) do |menu|
+      render Primer::Alpha::Dialog.new(classes: "op-app-menu--item",
+                                       title: "waffle menu",
+                                       visually_hide_title: true,
+                                       menu_id: "op-app-header--modules-menu",
+                                       position: :left) do |menu|
         menu.with_show_button(icon: "op-grid-menu",
                               scheme: :invisible,
                               classes: "op-app-menu--item-action op-app-header--primer-button",
@@ -192,16 +194,17 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_menu_item_group(menu, item_group)
-    menu.with_group do |menu_group|
-      menu_group.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
-
-      item_group[:items].each do |item|
-        menu_group.with_item(
-          href: url_for(item.url),
-          label: item.caption,
-          test_selector: "op-menu--item-action"
-        ) do |menu_item|
-          menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
+    menu.with_body do
+      render(Primer::Alpha::ActionList.new) do |component|
+        component.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
+        item_group[:items].each do |item|
+          component.with_item(
+            href: url_for(item.url),
+            label: item.caption,
+            test_selector: "op-menu--item-action"
+          ) do |menu_item|
+            menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
+          end
         end
       end
     end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -56,8 +56,8 @@ module Redmine::MenuManager::TopMenuHelper
     end
   end
 
-  def render_logo_short
-    mode_class = User.current.pref.theme === "dark" ? "op-logo-short_dark" : "op-logo-short"
+  def render_logo_icon
+    mode_class = User.current.pref.theme === "dark" ? "op-logo-icon_dark" : "op-logo-icon"
     render Primer::BaseComponent.new(tag: :div, classes: mode_class)
   end
 
@@ -193,7 +193,7 @@ module Redmine::MenuManager::TopMenuHelper
                                 "aria-controls": "op-app-header--modules-menu-list",
                                 "aria-label": I18n.t("label_modules"))
         dialog.with_header(classes: "op-app-header--modules-menu-header") do
-          render_logo_short
+          render_logo_icon
         end
 
         item_groups.each do |item_group|

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -182,7 +182,7 @@ module Redmine::MenuManager::TopMenuHelper
   def render_module_top_menu_node(item_groups = module_top_menu_item_groups)
     unless item_groups.empty?
       render Primer::Alpha::Dialog.new(classes: "op-app-menu--item",
-                                       title:  I18n.t("label_modules"),
+                                       title: I18n.t("label_modules"),
                                        visually_hide_title: true,
                                        menu_id: "op-app-header--modules-menu",
                                        position: :left) do |dialog|

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -212,15 +212,13 @@ module Redmine::MenuManager::TopMenuHelper
       ) do |list|
         list.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
 
-        items_by_context = item_group[:items].group_by(&:context)
-        my_items = items_by_context[:my] || []
-        module_items = items_by_context[:modules] || []
+        my_items, remaining_items = item_group[:items].partition { |item| item.context == :my }
 
         render_action_list_items(list, my_items)
 
-        list.with_divider if my_items.any? && module_items.any?
+        list.with_divider if my_items.any? && remaining_items.any?
 
-        render_action_list_items(list, module_items)
+        render_action_list_items(list, remaining_items)
       end
     end
   end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -187,12 +187,12 @@ module Redmine::MenuManager::TopMenuHelper
                                        menu_id: "op-app-header--modules-menu",
                                        position: :left) do |dialog|
         dialog.with_show_button(icon: "op-grid-menu",
-                              scheme: :invisible,
-                              classes: "op-app-menu--item-action op-app-header--primer-button",
-                              title: I18n.t("label_modules"),
-                              "aria-controls": "op-app-header--modules-menu-list",
-                              test_selector: "op-app-header--modules-menu-button",
-                              "aria-label": I18n.t("label_modules"))
+                                scheme: :invisible,
+                                classes: "op-app-menu--item-action op-app-header--primer-button",
+                                title: I18n.t("label_modules"),
+                                test_selector: "op-app-header--modules-menu-button",
+                                "aria-controls": "op-app-header--modules-menu-list",
+                                "aria-label": I18n.t("label_modules"))
         dialog.with_header(classes: "op-app-header--modules-menu-header") do
           render_logo_short
         end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -206,37 +206,33 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_dialog_item_group(dialog, item_group)
     dialog.with_body do
-      render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items", id: "op-app-header--modules-menu-list")) do |list|
+      render Primer::Alpha::ActionList.new(
+        classes: "op-app-menu--items",
+        id: "op-app-header--modules-menu-list"
+      ) do |list|
         list.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
 
-        # Group items by context
         items_by_context = item_group[:items].group_by(&:context)
         my_items = items_by_context[:my] || []
-        modules_items = items_by_context[:modules] || []
+        module_items = items_by_context[:modules] || []
 
-        # Render :my context items
-        my_items.each do |item|
-          list.with_item(
-            href: url_for(item.url),
-            label: item.caption,
-            test_selector: "op-menu--item-action"
-          ) do |menu_item|
-            menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
-          end
-        end
+        render_action_list_items(list, my_items)
 
-        list.with_divider if my_items.any? && modules_items.any?
+        list.with_divider if my_items.any? && module_items.any?
 
-        # Render :modules context items
-        modules_items.each do |item|
-          list.with_item(
-            href: url_for(item.url),
-            label: item.caption,
-            test_selector: "op-menu--item-action"
-          ) do |menu_item|
-            menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
-          end
-        end
+        render_action_list_items(list, module_items)
+      end
+    end
+  end
+
+  def render_action_list_items(list, items)
+    items.each do |item|
+      list.with_item(
+        href: url_for(item.url),
+        label: item.caption,
+        test_selector: "op-menu--item-action"
+      ) do |menu_item|
+        menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
       end
     end
   end

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -56,8 +56,8 @@ module Redmine::MenuManager::TopMenuHelper
     end
   end
 
-  def render_logo_only
-    mode_class = User.current.pref.theme === "dark" ? "op-logo-only_dark" : "op-logo-only"
+  def render_logo_short
+    mode_class = User.current.pref.theme === "dark" ? "op-logo-short_dark" : "op-logo-short"
     content_tag :div, class: mode_class do
       nil
     end
@@ -182,30 +182,30 @@ module Redmine::MenuManager::TopMenuHelper
   def render_module_top_menu_node(item_groups = module_top_menu_item_groups)
     unless item_groups.empty?
       render Primer::Alpha::Dialog.new(classes: "op-app-menu--item",
-                                       title: "waffle menu",
+                                       title:  I18n.t("label_modules"),
                                        visually_hide_title: true,
                                        menu_id: "op-app-header--modules-menu",
-                                       position: :left) do |menu|
-        menu.with_show_button(icon: "op-grid-menu",
+                                       position: :left) do |dialog|
+        dialog.with_show_button(icon: "op-grid-menu",
                               scheme: :invisible,
                               classes: "op-app-menu--item-action op-app-header--primer-button",
                               title: I18n.t("label_modules"),
                               "aria-controls": "op-app-header--modules-menu-list",
                               test_selector: "op-app-header--modules-menu-button",
                               "aria-label": I18n.t("label_modules"))
-        menu.with_header(classes: "op-app-header--modules-menu-header") do
-          render_logo_only
+        dialog.with_header(classes: "op-app-header--modules-menu-header") do
+          render_logo_short
         end
 
         item_groups.each do |item_group|
-          render_menu_item_group(menu, item_group)
+          render_dialog_item_group(dialog, item_group)
         end
       end
     end
   end
 
-  def render_menu_item_group(menu, item_group)
-    menu.with_body do
+  def render_dialog_item_group(dialog, item_group)
+    dialog.with_body do
       render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items", id: "op-app-header--modules-menu-list")) do |list|
         list.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
         item_group[:items].each do |item|

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -190,6 +190,7 @@ module Redmine::MenuManager::TopMenuHelper
                               scheme: :invisible,
                               classes: "op-app-menu--item-action op-app-header--primer-button",
                               title: I18n.t("label_modules"),
+                              "aria-controls": "op-app-header--modules-menu-list",
                               test_selector: "op-app-header--modules-menu-button",
                               "aria-label": I18n.t("label_modules"))
         menu.with_header do
@@ -205,7 +206,7 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_menu_item_group(menu, item_group)
     menu.with_body do
-      render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items")) do |component|
+      render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items", id: "op-app-header--modules-menu-list")) do |component|
         component.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
         item_group[:items].each do |item|
           component.with_item(

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -208,7 +208,27 @@ module Redmine::MenuManager::TopMenuHelper
     dialog.with_body do
       render(Primer::Alpha::ActionList.new(classes: "op-app-menu--items", id: "op-app-header--modules-menu-list")) do |list|
         list.with_heading(title: item_group[:title], align_items: :flex_start) if item_group[:title]
-        item_group[:items].each do |item|
+
+        # Group items by context
+        items_by_context = item_group[:items].group_by(&:context)
+        my_items = items_by_context[:my] || []
+        modules_items = items_by_context[:modules] || []
+
+        # Render :my context items
+        my_items.each do |item|
+          list.with_item(
+            href: url_for(item.url),
+            label: item.caption,
+            test_selector: "op-menu--item-action"
+          ) do |menu_item|
+            menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
+          end
+        end
+
+        list.with_divider if my_items.any? && modules_items.any?
+
+        # Render :modules context items
+        modules_items.each do |item|
           list.with_item(
             href: url_for(item.url),
             label: item.caption,
@@ -234,7 +254,8 @@ module Redmine::MenuManager::TopMenuHelper
 
   # Menu items for the modules top menu
   def more_top_menu_items
-    split_top_menu_into_main_or_more_menus[:modules]
+    split = split_top_menu_into_main_or_more_menus
+    split[:modules] + split[:my]
   end
 
   def module_top_menu_item_groups

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -193,7 +193,7 @@ module Redmine::MenuManager::TopMenuHelper
                               "aria-controls": "op-app-header--modules-menu-list",
                               test_selector: "op-app-header--modules-menu-button",
                               "aria-label": I18n.t("label_modules"))
-        menu.with_header do
+        menu.with_header(classes: "op-app-header--modules-menu-header") do
           render_logo_only
         end
 

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -58,9 +58,7 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_logo_short
     mode_class = User.current.pref.theme === "dark" ? "op-logo-short_dark" : "op-logo-short"
-    content_tag :div, class: mode_class do
-      nil
-    end
+    render Primer::BaseComponent.new(tag: :div, classes: mode_class)
   end
 
   def render_top_menu_search
@@ -184,6 +182,7 @@ module Redmine::MenuManager::TopMenuHelper
       render Primer::Alpha::Dialog.new(classes: "op-app-menu--item",
                                        title: I18n.t("label_modules"),
                                        visually_hide_title: true,
+                                       size: :small,
                                        menu_id: "op-app-header--modules-menu",
                                        position: :left) do |dialog|
         dialog.with_show_button(icon: "op-grid-menu",

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -151,6 +151,17 @@ module Costs
              User.current.allowed_in_any_project?(:log_own_time) || User.current.allowed_in_any_project?(:log_time)
            end,
            icon: :stopwatch
+
+      menu :top_menu,
+           :my_time_tracking,
+           { controller: "/my/time_tracking", action: "index" },
+           after: :my_page,
+           context: :my,
+           caption: :label_my_time_tracking,
+           if: ->(*) do
+             User.current.allowed_in_any_project?(:log_own_time) || User.current.allowed_in_any_project?(:log_time)
+           end,
+           icon: :stopwatch
     end
 
     initializer "costs.settings" do

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -153,8 +153,8 @@ RSpec.describe "Top menu items", :js do
       end
 
       context "when not login_required", with_settings: { login_required: false } do
-        it "displays only projects, activity, news, my page and home" do
-          has_menu_items? project_item, activity_item, news_item, home_item, my_page_item
+        it "displays only projects, activity, news and home" do
+          has_menu_items? project_item, activity_item, news_item, home_item
         end
       end
     end

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe "Top menu items", :js do
     shared_let(:news_item) { menu_link_item.new(I18n.t(:label_news_plural), news_index_path) }
     shared_let(:reporting_item) { menu_link_item.new(I18n.t(:cost_reports_title), "/cost_reports") }
     shared_let(:meetings_item) { menu_link_item.new(I18n.t(:label_meeting_plural), "/meetings") }
+    shared_let(:my_page_item) { menu_link_item.new(I18n.t("my_page.label"), my_page_path) }
+    shared_let(:home_item) { menu_link_item.new(I18n.t(:label_home), home_path) }
 
     shared_let(:all_items) do
       [
@@ -93,7 +95,9 @@ RSpec.describe "Top menu items", :js do
         boards_item,
         news_item,
         reporting_item,
-        meetings_item
+        meetings_item,
+        my_page_item,
+        home_item
       ]
     end
 
@@ -123,7 +127,7 @@ RSpec.describe "Top menu items", :js do
 
     context "as a regular user" do
       it "only displays projects, activity and news" do
-        has_menu_items? project_item, activity_item, news_item
+        has_menu_items? project_item, activity_item, news_item, home_item, my_page_item
       end
     end
 
@@ -148,7 +152,7 @@ RSpec.describe "Top menu items", :js do
 
       context "when not login_required", with_settings: { login_required: false } do
         it "displays only projects, activity and news" do
-          has_menu_items? project_item, activity_item, news_item
+          has_menu_items? project_item, activity_item, news_item, home_item, my_page_item
         end
       end
     end

--- a/spec/features/menu_items/top_menu_item_spec.rb
+++ b/spec/features/menu_items/top_menu_item_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe "Top menu items", :js do
     shared_let(:meetings_item) { menu_link_item.new(I18n.t(:label_meeting_plural), "/meetings") }
     shared_let(:my_page_item) { menu_link_item.new(I18n.t("my_page.label"), my_page_path) }
     shared_let(:home_item) { menu_link_item.new(I18n.t(:label_home), home_path) }
+    shared_let(:my_time_tracking_item) { menu_link_item.new(I18n.t(:label_my_time_tracking), "/my/time-tracking") }
 
     shared_let(:all_items) do
       [
@@ -97,7 +98,8 @@ RSpec.describe "Top menu items", :js do
         reporting_item,
         meetings_item,
         my_page_item,
-        home_item
+        home_item,
+        my_time_tracking_item
       ]
     end
 
@@ -126,7 +128,7 @@ RSpec.describe "Top menu items", :js do
     end
 
     context "as a regular user" do
-      it "only displays projects, activity and news" do
+      it "only displays projects, activity, news, my page and home" do
         has_menu_items? project_item, activity_item, news_item, home_item, my_page_item
       end
     end
@@ -151,7 +153,7 @@ RSpec.describe "Top menu items", :js do
       end
 
       context "when not login_required", with_settings: { login_required: false } do
-        it "displays only projects, activity and news" do
+        it "displays only projects, activity, news, my page and home" do
           has_menu_items? project_item, activity_item, news_item, home_item, my_page_item
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65090
https://community.openproject.org/wp/65564

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
While clicking on waffle icon, it will open a primer dialog instead of an action menu.
Add Home, My page, My time tracking menu items to waffle menu.

## Screenshots
Before:
<img width="278" height="457" alt="Screenshot 2025-07-17 at 15 15 28" src="https://github.com/user-attachments/assets/a85c903f-8db1-4120-a501-19bd9107ac5e" />

After:
<img width="597" height="574" alt="Screenshot 2025-07-17 at 15 12 27" src="https://github.com/user-attachments/assets/d2bb0d4b-bd79-4ebd-a2ba-ec295834bbe9" />

