### PR TITLE
Add custom legend to budget widgets

### DIFF
--- a/modules/budgets/app/models/budgets/project_budgets.rb
+++ b/modules/budgets/app/models/budgets/project_budgets.rb
@@ -37,7 +37,7 @@ module Budgets
       @project = project
     end
 
-    delegate :any?, to: :budgets
+    delegate :any?, :none?, to: :budgets
 
     def children_budgets_count
       @children_budgets_count ||= budgets.sum(&:children_budgets_count)

--- a/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.html.erb
+++ b/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.html.erb
@@ -39,43 +39,90 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
+    # TODO: hide if user does not have permissions to see budgets :view_budgets
+    # TODO: hide charts if the budgets module is inactive (even if budgets records are present)
     component.with_row do
-      helpers.stimulus_chartjs_canvas(
-        type: :pie,
-        data: {
-          labels: [
-            "Zugeteilt (unverbaucht)",
-            "Ausgegeben",
-            "Verfügbar"
-          ],
-          datasets: [
-            {
-              data: [
-                project_budgets.allocated_unused,
-                project_budgets.spent_on_children,
-                project_budgets.available
-              ]
-            }
-          ]
-        },
-        options: {
-          animation: {
-            animateRotate: false
-          },
-          borderWidth: 0,
-          plugins: {
-            legend: {
-              position: "bottom",
-              labels: {
-                usePointStyle: true
-              }
-            },
-            datalabels: {
-              display: false
-            }
-          }
-        }
-      )
+      if project_budgets.none?
+        disabled = !User.current.allowed_in_project?(:edit_budgets, project)
+        flex_layout(style: "gap: 1rem;") do |no_budgets_row|
+          no_budgets_row.with_row do
+            render(
+              Primer::Beta::Button.new(
+                mt: 2,
+                leading_icon: :plus,
+                tag: :a,
+                disabled:,
+                href: new_projects_budget_path(project)
+              )
+            ) do |button|
+              button.with_leading_visual_icon(icon: :plus)
+              t(:label_budget)
+            end
+          end
+          if disabled
+            no_budgets_row.with_row do
+              render(Primer::Beta::Text.new(color: :muted)) do
+                if project.module_enabled?(:budgets)
+                  "Du hast keine Berechtigung, um Budgets zu erstellen."
+                else
+                  "Budget Modul ist nicht aktiviert."
+                end
+              end
+            end
+          end
+        end
+      else
+        flex_layout(style: "gap: 2rem;") do |layout|
+          layout.with_row do
+            content_tag(:div, style: "position: relative; max-width: 300px; max-height: 300px; margin: 0 auto;") do
+              helpers.stimulus_chartjs_canvas(
+                type: :pie,
+                data: {
+                  labels: chart_data.map(&:label),
+                  datasets: [
+                    {
+                      data: chart_data.map(&:value),
+                      backgroundColor: chart_data.map(&:color)
+                    }
+                  ]
+                },
+                options: {
+                  animation: {
+                    animateRotate: false
+                  },
+                  borderWidth: 0,
+                  plugins: {
+                    legend: {
+                      display: false
+                    },
+                    datalabels: {
+                      display: false
+                    }
+                  }
+                }
+              )
+            end
+          end
+
+          layout.with_row(flex_layout: true, justify_content: :space_between) do |legend_row|
+            legend_row.with_column do
+              render(Primer::Beta::Text.new(font_weight: :bold)) do
+                "Geplant: #{budget_formatted_amount(project_budgets.planned)}"
+              end
+            end
+
+            legend_row.with_column(flex_layout: true, style: "gap: 8px;") do |legend_column|
+              chart_data.each do |budget_info|
+                legend_column.with_row do
+                  concat(content_tag(:span, "", style: "display: inline-block; width: 16px; height: 16px; border-radius: 50%; background-color: #{budget_info.color}; margin-right: 8px; vertical-align: middle;"))
+                  concat(render(Primer::Beta::Text.new) { "#{budget_info.label}: " })
+                  concat(render(Primer::Beta::Text.new(font_weight: :bold)) { budget_formatted_amount(budget_info.value) })
+                end
+              end
+            end
+          end
+        end
+      end
     end
 
     component.with_row do

--- a/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.rb
+++ b/modules/overviews/app/components/overviews/portfolios/widgets/budgets_component.rb
@@ -37,6 +37,8 @@ module Overviews
 
         attr_reader :project, :project_budgets
 
+        BudgetInfo = Data.define(:label, :value, :color)
+
         def initialize(model = nil, project:, **)
           super(model, **)
 
@@ -59,6 +61,18 @@ module Overviews
             ].join("&"),
             query_id: "active"
           )
+        end
+
+        def chart_data
+          @chart_data ||= [
+            BudgetInfo.new(label: "Zugeteilt (unverbaucht)", value: project_budgets.allocated_unused, color: "#113B6F"),
+            BudgetInfo.new(label: "Ausgegeben", value: project_budgets.spent_on_children, color: "#FBA728"),
+            BudgetInfo.new(label: "Verfügbar", value: project_budgets.available, color: "#26A59A")
+          ]
+        end
+
+        def budget_formatted_amount(amount)
+          number_to_currency(amount, precision: 0)
         end
 
         def column_key(column)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65783

# What are you trying to accomplish?

Use a custom legend so that the total planned budget and different amounts are displayed.

Use colors from figma.

## Screenshots

Got:

<img width="503" height="561" alt="image" src="https://github.com/user-attachments/assets/2bc3cc6c-8ad0-430b-8379-fe7e5975c796" />

Blank slate when the budgets does not exist, with variations if permissions are insufficient (which would lead to 403) or module is inactive (which would lead to 404).

<img width="501" height="196" alt="image" src="https://github.com/user-attachments/assets/624ec30f-dd2b-420d-8a61-278efe8a7f8f" />

<img width="506" height="231" alt="image" src="https://github.com/user-attachments/assets/1fdbd706-0b25-430d-87f1-5d3357df843d" />

<img width="507" height="235" alt="image" src="https://github.com/user-attachments/assets/58c84e06-7440-42f5-87f3-7c57a654f3c8" />


Actual Figma: 

<img width="595" height="568" alt="image" src="https://github.com/user-attachments/assets/8643f976-9741-4e73-b0ae-b1362f32a743" />


# What approach did you choose and why?

Taking a lot of shortcuts with inline css style, which is quite pleasant to write actually.

Shortcomings:
- the graph is not responsive
- ~no placeholder text if no budgets in project~
- no check for `:view_budgets` permission allowed or for `:budgets` module enabled: pie charts are always shown if some budgets are present in the project
- no i18n (all in German)

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
