### PR TITLE
[#65927] Remove call to removed `bootstrap` method

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs/model.js
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/model.js
@@ -388,10 +388,6 @@ RB.Model = (function ($) {
         this.open();
       }
 
-      window.OpenProject.getPluginContext().then((pluginContext) => {
-        pluginContext.bootstrap(this.$[0]);
-      });
-
       this.refreshed();
     },
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65927

# What are you trying to accomplish?

Fixes JS errors in console on creating a Story in Backlogs module.

## Screenshots

# What approach did you choose and why?

Removes call to `PluginContext#bootstrap`, which was removed in ac3940634732a1b7a24cc3929e960b493732c381 (#16431).

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
