### PR TITLE
Small fixes on relations tab

### DIFF
--- a/app/controllers/work_package_relations_tab_controller.rb
+++ b/app/controllers/work_package_relations_tab_controller.rb
@@ -40,7 +40,7 @@ class WorkPackageRelationsTabController < ApplicationController
         render(component, layout: false)
       end
       format.turbo_stream do
-        replace_via_turbo_stream(component:)
+        replace_via_turbo_stream(component:, method: "morph")
         render turbo_stream: turbo_streams
       end
     end

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
@@ -91,7 +91,7 @@ export class WorkPackageRelationsComponent extends UntilDestroyedMixin implement
         this.untilDestroyed(),
       )
       .subscribe(() => {
-        this.updateRelationsTab();
+        this.updateRelationsTabAndCounter();
       });
 
     /*
@@ -106,11 +106,6 @@ export class WorkPackageRelationsComponent extends UntilDestroyedMixin implement
     to rely on the form action URL.
     */
     document.addEventListener('turbo:submit-end', this.turboFrameListener);
-  }
-
-  public updateCounter() {
-    const url = this.PathHelper.workPackageUpdateCounterPath(this.workPackage.id!, 'relations');
-    void this.turboRequests.request(url);
   }
 
   private async updateFrontendData(event:CustomEvent) {
@@ -133,19 +128,18 @@ export class WorkPackageRelationsComponent extends UntilDestroyedMixin implement
           // Refetch relations
           await this.wpRelations.require(this.workPackage.id!, true);
           this.halEvents.push(this.workPackage, { eventType: 'updated' });
-
-          this.updateCounter();
         }
       }
     }
   }
 
-  private updateRelationsTab() {
+  private updateRelationsTabAndCounter() {
     void this.turboRequests.requestStream(this.turboFrameSrc)
       .then((result) => {
         renderStreamMessage(result.html);
       });
 
-    this.updateCounter();
+    const url = this.PathHelper.workPackageUpdateCounterPath(this.workPackage.id!, 'relations');
+    void this.turboRequests.request(url);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/relations-tab/scroll.controller.ts
@@ -7,10 +7,8 @@ export default class ScrollController extends Controller {
   declare readonly hasScrollToRowTarget:boolean;
 
   scrollToRowTargetConnected() {
-    if (this.hasScrollToRowTarget) {
-      setTimeout(() => {
-        this.scrollToRowTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      });
-    }
+    setTimeout(() => {
+      this.scrollToRowTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
   }
 }


### PR DESCRIPTION
# Ticket

Originally wanted to work on [Feature: Relations tab: Auto-scroll to a newly-created child (#61143)](https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61143/activity) but it was more complicated than expected.

As I fixed some existing issues while working on this, here is a PR.

# What are you trying to accomplish?

Fix small issues on the relations tab:
- fix scrolling to added relation (was broken)
- fix duplicate requests sent to update the relations count

# What approach did you choose and why?

- fix scrolling to added relation (was broken): morph when replacing the relations tab, so that the scroll position is not reset on subsequent updates
- fix duplicate requests sent to update the relations count: remove one of the two calls.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
