### PR TITLE
[#65925] Fix handling of empty flash messages

### DIFF
--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -65,7 +65,7 @@ module OpTurbo
       end
 
       if method && !action.in?(ACTIONS_WITH_METHOD)
-        raise ArgumentError, "The #{action} action does not supports a method"
+        raise ArgumentError, "The #{action} action does not support a method"
       end
 
       OpTurbo::StreamComponent.new(

--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -33,8 +33,10 @@ module OpTurbo
     # rubocop:enable OpenProject/AddPreviewForViewComponent
 
     INLINE_ACTIONS = %i[dialog flash].freeze
+    private_constant :INLINE_ACTIONS
     # Turbo allows the response method for these actions only:
     ACTIONS_WITH_METHOD = %i[update replace].freeze
+    private_constant :ACTIONS_WITH_METHOD
 
     extend ActiveSupport::Concern
 
@@ -44,6 +46,19 @@ module OpTurbo
       end
     end
 
+    ##
+    # Renders the component as a Turbo Stream.
+    #
+    # The rendered component is wrapped in a `<turbo-stream>` tag.
+    #
+    # @example
+    #   <turbo-stream action="update" method="morph" target="wrapper_key">
+    #     <template><component /></template>
+    #   </turbo-stream>
+    #
+    # @param [ActionView::Context] view_context the view context to render in.
+    # @param [Symbol] action the Turbo Stream action.
+    # @param [String, nil] method the Turbo Stream method (if action is :update or :replace).
     def render_as_turbo_stream(view_context:, action: :update, method: nil, **attributes)
       case action
       when :update, *INLINE_ACTIONS

--- a/app/components/concerns/op_turbo/streamable.rb
+++ b/app/components/concerns/op_turbo/streamable.rb
@@ -44,116 +44,114 @@ module OpTurbo
       end
     end
 
-    included do
-      def render_as_turbo_stream(view_context:, action: :update, method: nil, **attributes)
-        case action
-        when :update, *INLINE_ACTIONS
-          @inner_html_only = true
-          template = render_in(view_context)
-        when :replace
-          template = render_in(view_context)
-        when :remove
-          @wrapper_only = true
-          render_in(view_context)
-          template = nil
-        else
-          raise ArgumentError, "Unsupported action #{action}"
-        end
-
-        if INLINE_ACTIONS.exclude?(action) && !wrapped?
-          raise MissingComponentWrapper,
-                "Wrap your component in a `component_wrapper` block in order to use turbo-stream methods"
-        end
-
-        if method && !action.in?(ACTIONS_WITH_METHOD)
-          raise ArgumentError, "The #{action} action does not supports a method"
-        end
-
-        OpTurbo::StreamComponent.new(
-          action:,
-          method:,
-          target: wrapper_key,
-          template:,
-          **attributes
-        ).render_in(view_context)
+    def render_as_turbo_stream(view_context:, action: :update, method: nil, **attributes)
+      case action
+      when :update, *INLINE_ACTIONS
+        @inner_html_only = true
+        template = render_in(view_context)
+      when :replace
+        template = render_in(view_context)
+      when :remove
+        @wrapper_only = true
+        render_in(view_context)
+        template = nil
+      else
+        raise ArgumentError, "Unsupported action #{action}"
       end
 
-      def insert_as_turbo_stream(component:, view_context:, action: :append)
-        template = component.render_in(view_context)
-
-        # The component being inserted into the target component
-        # needs wrapping, not the target since it isn't the one
-        # that needs to be rendered to perform this turbo stream action.
-        unless component.wrapped?
-          raise MissingComponentWrapper,
-                "Wrap your component in a `component_wrapper` block in order to use turbo-stream methods"
-        end
-
-        OpTurbo::StreamComponent.new(
-          action:,
-          target: insert_target_modified? ? insert_target_modifier_id : wrapper_key,
-          template:
-        ).render_in(view_context)
+      if INLINE_ACTIONS.exclude?(action) && !wrapped?
+        raise MissingComponentWrapper,
+              "Wrap your component in a `component_wrapper` block in order to use turbo-stream methods"
       end
 
-      def component_wrapper(method = nil, tag: "div", **kwargs, &block)
-        @wrapped = true
-
-        wrapper_arguments = { id: wrapper_key }.merge(kwargs)
-
-        if inner_html_only?
-          capture(&block)
-        elsif wrapper_only?
-          method ? send(method, wrapper_arguments) : content_tag(tag, wrapper_arguments)
-        else
-          method ? send(method, wrapper_arguments, &block) : content_tag(tag, wrapper_arguments, &block)
-        end
+      if method && !action.in?(ACTIONS_WITH_METHOD)
+        raise ArgumentError, "The #{action} action does not supports a method"
       end
 
-      def wrapped?
-        !!@wrapped
+      OpTurbo::StreamComponent.new(
+        action:,
+        method:,
+        target: wrapper_key,
+        template:,
+        **attributes
+      ).render_in(view_context)
+    end
+
+    def insert_as_turbo_stream(component:, view_context:, action: :append)
+      template = component.render_in(view_context)
+
+      # The component being inserted into the target component
+      # needs wrapping, not the target since it isn't the one
+      # that needs to be rendered to perform this turbo stream action.
+      unless component.wrapped?
+        raise MissingComponentWrapper,
+              "Wrap your component in a `component_wrapper` block in order to use turbo-stream methods"
       end
 
-      def inner_html_only?
-        !!@inner_html_only
+      OpTurbo::StreamComponent.new(
+        action:,
+        target: insert_target_modified? ? insert_target_modifier_id : wrapper_key,
+        template:
+      ).render_in(view_context)
+    end
+
+    def component_wrapper(method = nil, tag: "div", **kwargs, &)
+      @wrapped = true
+
+      wrapper_arguments = { id: wrapper_key }.merge(kwargs)
+
+      if inner_html_only?
+        capture(&)
+      elsif wrapper_only?
+        method ? send(method, wrapper_arguments) : content_tag(tag, wrapper_arguments)
+      else
+        method ? send(method, wrapper_arguments, &) : content_tag(tag, wrapper_arguments, &)
+      end
+    end
+
+    def wrapped?
+      !!@wrapped
+    end
+
+    def inner_html_only?
+      !!@inner_html_only
+    end
+
+    def wrapper_only?
+      !!@wrapper_only
+    end
+
+    def wrapper_key
+      if wrapper_uniq_by.nil?
+        self.class.wrapper_key
+      else
+        "#{self.class.wrapper_key}-#{wrapper_uniq_by}"
+      end
+    end
+
+    def wrapper_uniq_by
+      # optionally implemented in subclass in order to make the wrapper key unique
+    end
+
+    def insert_target_modified?
+      # optionally overriden (returning true) in subclass in order to indicate thate the insert target
+      # is modified and should not be the root inner html element
+      # insert_target_container needs to be present on component's erb template then
+      false
+    end
+
+    def insert_target_container(tag: "div", class: nil, data: nil, style: nil, &)
+      unless insert_target_modified?
+        raise NotImplementedError,
+              "#insert_target_modified? needs to be implemented and return true if #insert_target_container is " \
+              "used in this component"
       end
 
-      def wrapper_only?
-        !!@wrapper_only
-      end
+      content_tag(tag, id: insert_target_modifier_id, class:, data:, style:, &)
+    end
 
-      def wrapper_key
-        if wrapper_uniq_by.nil?
-          self.class.wrapper_key
-        else
-          "#{self.class.wrapper_key}-#{wrapper_uniq_by}"
-        end
-      end
-
-      def wrapper_uniq_by
-        # optionally implemented in subclass in order to make the wrapper key unique
-      end
-
-      def insert_target_modified?
-        # optionally overriden (returning true) in subclass in order to indicate thate the insert target
-        # is modified and should not be the root inner html element
-        # insert_target_container needs to be present on component's erb template then
-        false
-      end
-
-      def insert_target_container(tag: "div", class: nil, data: nil, style: nil, &block)
-        unless insert_target_modified?
-          raise NotImplementedError,
-                "#insert_target_modified? needs to be implemented and return true if #insert_target_container is " \
-                "used in this component"
-        end
-
-        content_tag(tag, id: insert_target_modifier_id, class:, data:, style:, &block)
-      end
-
-      def insert_target_modifier_id
-        "#{wrapper_key}-insert-target-modifier"
-      end
+    def insert_target_modifier_id
+      "#{wrapper_key}-insert-target-modifier"
     end
   end
 end

--- a/app/components/op_primer/flash_component.rb
+++ b/app/components/op_primer/flash_component.rb
@@ -46,6 +46,12 @@ module OpPrimer
       super
     end
 
+    def render_as_turbo_stream(...)
+      return unless render?
+
+      super
+    end
+
     private
 
     def render?

--- a/app/components/op_turbo/stream_component.html.erb
+++ b/app/components/op_turbo/stream_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <%= content_tag("turbo-stream", action: @action, target: @target, **@turbo_stream_args) do %>
-  <% if @template %>
+  <% if @template.present? %>
     <template>
       <%= @template %>
     </template>

--- a/app/helpers/flash_messages_output_safety_helper.rb
+++ b/app/helpers/flash_messages_output_safety_helper.rb
@@ -35,6 +35,11 @@ module FlashMessagesOutputSafetyHelper
     include ActionView::Helpers::OutputSafetyHelper
   end
 
+  ###
+  # Joins individual flash messages with a Line Break Element.
+  #
+  # @param [String|Array<String>] messages the flash messages to join.
+  # @return [String] the joined messages as an HTML-safe string.
   def join_flash_messages(messages)
     safe_join(Array(messages), "<br />".html_safe)
   end

--- a/app/helpers/flash_messages_output_safety_helper.rb
+++ b/app/helpers/flash_messages_output_safety_helper.rb
@@ -36,10 +36,6 @@ module FlashMessagesOutputSafetyHelper
   end
 
   def join_flash_messages(messages)
-    if messages.respond_to?(:join)
-      safe_join(messages, "<br />".html_safe)
-    else
-      messages
-    end
+    safe_join(Array(messages), "<br />".html_safe)
   end
 end

--- a/spec/components/op_primer/flash_component_spec.rb
+++ b/spec/components/op_primer/flash_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,30 +28,36 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpPrimer
-  class FlashComponent < Primer::Alpha::Banner
-    include ApplicationHelper
-    include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
+require "rails_helper"
 
-    def initialize(**system_arguments)
-      @unique_key = system_arguments.delete(:unique_key)
+RSpec.describe OpPrimer::FlashComponent, type: :component do
+  def render_component(content, ...)
+    render_inline(described_class.new(...).with_content(content))
+  end
 
-      system_arguments[:test_selector] ||= "op-primer-flash-message"
-      system_arguments[:dismiss_scheme] ||= :remove
-      system_arguments[:dismiss_label] ||= I18n.t(:button_close)
-      system_arguments[:data] ||= {}
-      system_arguments[:data]["flash-target"] = "flash"
+  subject(:rendered_component) { render_component(content) }
 
-      @autohide = system_arguments[:scheme] == :success && system_arguments[:dismiss_scheme] != :none
+  context "with content" do
+    let(:content) { "Flash Text" }
 
-      super
+    it "renders an x-banner" do
+      expect(rendered_component).to have_element "x-banner"
     end
 
-    private
+    it "renders the banner text" do
+      expect(rendered_component).to have_css ".Banner-message .Banner-title", text: "Flash Text"
+    end
+  end
 
-    def render?
-      trimmed_content.present?
+  context "with blank content" do
+    let(:content) { " " }
+
+    it "does not render an x-banner" do
+      expect(rendered_component).to have_no_element "x-banner"
+    end
+
+    it "does not render the banner text" do
+      expect(rendered_component).to have_no_css ".Banner-message .Banner-title"
     end
   end
 end

--- a/spec/components/op_turbo/stream_component_spec.rb
+++ b/spec/components/op_turbo/stream_component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OpTurbo::StreamComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  subject(:rendered_component) { render_component(action: "my-action", target: nil, template:) }
+
+  let(:rendered_template) { Nokogiri(rendered_component.to_s).css("turbo-stream template").first&.inner_html&.strip }
+
+  context "with a template" do
+    let(:template) { "Template Content" }
+
+    it "renders a turbo-stream element" do
+      expect(rendered_component).to have_element "turbo-stream", action: "my-action"
+    end
+
+    it "renders a template" do
+      expect(rendered_template).to eq "Template Content"
+    end
+  end
+
+  context "with a blank template" do
+    let(:template) { " " }
+
+    it "renders a turbo-stream element" do
+      expect(rendered_component).to have_element "turbo-stream", action: "my-action"
+    end
+
+    it "does not render a template" do
+      expect(rendered_template).to be_nil
+    end
+  end
+
+  context "with a nil template" do
+    let(:template) { nil }
+
+    it "renders a turbo-stream element" do
+      expect(rendered_component).to have_element "turbo-stream", action: "my-action"
+    end
+
+    it "does not render a template" do
+      expect(rendered_template).to be_nil
+    end
+  end
+end

--- a/spec/helpers/flash_messages_helper_spec.rb
+++ b/spec/helpers/flash_messages_helper_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe FlashMessagesHelper do
       it_behaves_like "rendering a banner", "flash-success", :"check-circle", "zu deiner Information"
     end
 
+    context "with an empty flash message" do
+      before do
+        flash[:info] = "" # rubocop:disable Rails/I18nLocaleTexts
+      end
+
+      it_behaves_like "rendering nothing"
+    end
+
+    context "with a nil flash message" do
+      before do
+        flash[:info] = nil
+      end
+
+      it_behaves_like "rendering nothing"
+    end
+
     context "with an :info flash message" do
       before do
         flash[:info] = "zu deiner Information" # rubocop:disable Rails/I18nLocaleTexts

--- a/spec/helpers/flash_messages_helper_spec.rb
+++ b/spec/helpers/flash_messages_helper_spec.rb
@@ -146,6 +146,22 @@ RSpec.describe FlashMessagesHelper do
       it_behaves_like "rendering nothing"
     end
 
+    context "with an empty flash message" do
+      before do
+        flash[:info] = "" # rubocop:disable Rails/I18nLocaleTexts
+      end
+
+      it_behaves_like "rendering nothing"
+    end
+
+    context "with a nil flash message" do
+      before do
+        flash[:info] = nil
+      end
+
+      it_behaves_like "rendering nothing"
+    end
+
     context "with an :info flash message" do
       before do
         flash[:info] = "zu deiner Information" # rubocop:disable Rails/I18nLocaleTexts

--- a/spec/helpers/flash_messages_output_safety_helper_spec.rb
+++ b/spec/helpers/flash_messages_output_safety_helper_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe FlashMessagesOutputSafetyHelper do
+  subject { helper.join_flash_messages(flash_messages) }
+
+  shared_examples "HTML safety" do
+    it "returns an HTML-safe string" do
+      expect(subject).to be_html_safe
+    end
+  end
+
+  context "when flash_messages is a non-empty Array" do
+    let(:flash_messages) { ["Flash message #1", "Flash message #2"] }
+
+    it "joins the two flash messages" do
+      expect(subject).to eq "Flash message #1<br />Flash message #2"
+    end
+
+    include_examples "HTML safety"
+  end
+
+  context "when flash_messages is a nested Array" do
+    let(:flash_messages) { ["Flash message #1", ["Flash message #2", "Flash message #3"]] }
+
+    it "joins the three flash messages" do
+      expect(subject).to eq "Flash message #1<br />Flash message #2<br />Flash message #3"
+    end
+
+    include_examples "HTML safety"
+  end
+
+  context "when flash_messages is an empty Array" do
+    let(:flash_messages) { [] }
+
+    it "returns an empty String" do
+      expect(subject).to eq ""
+    end
+
+    include_examples "HTML safety"
+  end
+
+  context "when flash_messages is a String" do
+    let(:flash_messages) { "Flash message #1" }
+
+    it "returns the String" do
+      expect(subject).to eq "Flash message #1"
+    end
+
+    include_examples "HTML safety"
+  end
+
+  context "when flash_messages is nil" do
+    let(:flash_messages) { nil }
+
+    it "returns an empty String" do
+      expect(subject).to eq ""
+    end
+
+    include_examples "HTML safety"
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65925

# What are you trying to accomplish?

Fixes an `ActionView::Template::Error in HomescreenController#index` that has emerged in AppSignal logs.

# What approach did you choose and why?

This PR attempts to mitigate possible errors when `ActionDispatch::Flash::FlashHash` values are `nil` or blank. In detail:

- updates `FlashMessagesOutputSafetyHelper#join_flash_messages` to always return a String, mirroring the behaviour of `safe_join` which it calls. _(this should be enough to fix the error in the AppSignal logs)_
- skips `FlashComponent` rendering (via `#render` and `#render_as_turbo_stream` if the content passed is blank. _(I cannot see a use case for rendering blank flash messages)._

This PR also updates `StreamComponent` to skip rendering of the `template` tag if its contents are blank (as opposed to `nil`). This change is not strictly necessary, but I have included it as I think it is a reasonable assumption and unlikely to break anything.


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
