### PR TITLE
Implementation/64349 show calculated values on project overview page on project save update calculated value

### DIFF
--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -40,7 +40,8 @@ module CustomFields::CustomFieldRendering
     "date" => "CustomFields::Inputs::Date",
     "bool" => "CustomFields::Inputs::Bool",
     "user" => "CustomFields::Inputs::SingleUserSelectList",
-    "version" => "CustomFields::Inputs::SingleVersionSelectList"
+    "version" => "CustomFields::Inputs::SingleVersionSelectList",
+    "calculated_value" => "CustomFields::Inputs::CalculatedValue"
   ).freeze
 
   MULTI_VALUE_INPUT_CLASS_NAMES = OpenProject::MultiKeyHash.expand(

--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -31,6 +31,24 @@
 module CustomFields::CustomFieldRendering
   include ActiveSupport::Concern
 
+  SINGLE_VALUE_INPUT_CLASS_NAMES = OpenProject::MultiKeyHash.expand(
+    %w[string link] => "CustomFields::Inputs::String",
+    "text" => "CustomFields::Inputs::Text",
+    "int" => "CustomFields::Inputs::Int",
+    "float" => "CustomFields::Inputs::Float",
+    %w[hierarchy list] => "CustomFields::Inputs::SingleSelectList",
+    "date" => "CustomFields::Inputs::Date",
+    "bool" => "CustomFields::Inputs::Bool",
+    "user" => "CustomFields::Inputs::SingleUserSelectList",
+    "version" => "CustomFields::Inputs::SingleVersionSelectList"
+  ).freeze
+
+  MULTI_VALUE_INPUT_CLASS_NAMES = OpenProject::MultiKeyHash.expand(
+    ["hierarchy", "list"] => "CustomFields::Inputs::MultiSelectList",
+    "user" => "CustomFields::Inputs::MultiUserSelectList",
+    "version" => "CustomFields::Inputs::MultiVersionSelectList"
+  ).freeze
+
   def render_custom_fields(form:)
     custom_fields.each do |custom_field|
       form.fields_for(:custom_field_values) do |builder|
@@ -73,42 +91,20 @@ module CustomFields::CustomFieldRendering
   # - hierarchy should not use a flat list
 
   def single_value_custom_field_input(builder, custom_field)
-    form_args = form_arguments(custom_field)
+    input_class_name = SINGLE_VALUE_INPUT_CLASS_NAMES[custom_field.field_format]
 
-    case custom_field.field_format
-    when "string", "link"
-      CustomFields::Inputs::String.new(builder, **form_args)
-    when "text"
-      CustomFields::Inputs::Text.new(builder, **form_args)
-    when "int"
-      CustomFields::Inputs::Int.new(builder, **form_args)
-    when "float"
-      CustomFields::Inputs::Float.new(builder, **form_args)
-    when "hierarchy", "list"
-      CustomFields::Inputs::SingleSelectList.new(builder, **form_args)
-    when "date"
-      CustomFields::Inputs::Date.new(builder, **form_args)
-    when "bool"
-      CustomFields::Inputs::Bool.new(builder, **form_args)
-    when "user"
-      CustomFields::Inputs::SingleUserSelectList.new(builder, **form_args)
-    when "version"
-      CustomFields::Inputs::SingleVersionSelectList.new(builder, **form_args)
+    if input_class_name
+      input_class_name.constantize.new(builder, **form_arguments(custom_field))
     else
       raise "Unhandled custom field format #{custom_field.field_format}"
     end
   end
 
   def multi_value_custom_field_input(builder, custom_field)
-    form_args = form_arguments(custom_field)
+    input_class_name = MULTI_VALUE_INPUT_CLASS_NAMES[custom_field.field_format]
 
-    case custom_field.field_format
-    when "hierarchy", "list"
-      CustomFields::Inputs::MultiSelectList.new(builder, **form_args)
-    when "user"
-      CustomFields::Inputs::MultiUserSelectList.new(builder, **form_args)
-    when "version"
-      CustomFields::Inputs::MultiVersionSelectList.new(builder, **form_args)
+    if input_class_name
+      input_class_name.constantize.new(builder, **form_arguments(custom_field))
     else
       raise "Unhandled custom field format #{custom_field.field_format}"
     end

--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -94,6 +94,8 @@ module CustomFields::CustomFieldRendering
       CustomFields::Inputs::SingleUserSelectList.new(builder, **form_args)
     when "version"
       CustomFields::Inputs::SingleVersionSelectList.new(builder, **form_args)
+    else
+      raise "Unhandled custom field format #{custom_field.field_format}"
     end
   end
 
@@ -107,6 +109,8 @@ module CustomFields::CustomFieldRendering
       CustomFields::Inputs::MultiUserSelectList.new(builder, **form_args)
     when "version"
       CustomFields::Inputs::MultiVersionSelectList.new(builder, **form_args)
+    else
+      raise "Unhandled custom field format #{custom_field.field_format}"
     end
   end
 end

--- a/app/forms/custom_fields/inputs/calculated_value.rb
+++ b/app/forms/custom_fields/inputs/calculated_value.rb
@@ -34,6 +34,6 @@ class CustomFields::Inputs::CalculatedValue < CustomFields::Inputs::Base::Input
   end
 
   def input_attributes
-    super.merge({ readonly: true })
+    super.merge({ disabled: true })
   end
 end

--- a/app/forms/custom_fields/inputs/calculated_value.rb
+++ b/app/forms/custom_fields/inputs/calculated_value.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CustomFields::Inputs::CalculatedValue < CustomFields::Inputs::Base::Input
+  form do |custom_value_form|
+    custom_value_form.text_field(**input_attributes)
+  end
+
+  def input_attributes
+    super.merge({ readonly: true })
+  end
+end

--- a/app/models/acts_as_customizable/calculated_value.rb
+++ b/app/models/acts_as_customizable/calculated_value.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ActsAsCustomizable::CalculatedValue
+  extend ActiveSupport::Concern
+
+  included do
+    def calculate_custom_fields(custom_fields)
+      return if custom_fields.empty?
+
+      unless custom_fields.all?(&:field_format_calculated_value?)
+        fail ArgumentError,
+             "Expected array of calculated value custom fields"
+      end
+
+      given = calculated_value_fields_referenced_values(custom_fields)
+      to_compute = custom_fields.to_h { [it.column_name, it.formula_str_without_patterns] }
+
+      calculator = CustomField::CalculatedValue.calculator_instance
+      calculator.store(given)
+      result = calculator.solve(to_compute).reject { |_, value| value == :undefined }
+
+      self.custom_field_values = custom_fields.to_h { [it.id, result[it.column_name]] }
+    end
+
+    private
+
+    def calculated_value_fields_referenced_values(custom_fields)
+      given_cf_ids = custom_fields.flat_map(&:formula_referenced_custom_field_ids).uniq - custom_fields.map(&:id)
+
+      custom_field_values
+        .select { it.custom_field_id.in?(given_cf_ids) }
+        .to_h { [it.custom_field.column_name, it.typed_value] }
+    end
+  end
+end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -52,6 +52,8 @@ class CustomField < ApplicationRecord
   scope :hierarchy_root_and_children, -> { includes(hierarchy_root: { children: :children }) }
   scope :required, -> { where(is_required: true) }
 
+  scope :field_format_calculated_value, -> { where(field_format: "calculated_value") }
+
   acts_as_list scope: [:type]
 
   validates :field_format, presence: true

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -114,6 +114,12 @@ module CustomField::CalculatedValue
       end
     end
 
+    # Returns `formula_string` with all custom field references detokenized so that they are parseable by Dentaku.
+    # For example, for `2 + {{cf_12}} + {{cf_4}}` it returns `2 + cf_12 + cf_4`.
+    def formula_str_without_patterns
+      formula_string.gsub(/\{\{(cf_\d+)}}/, '\1')
+    end
+
     private
 
     def calculator
@@ -149,12 +155,6 @@ module CustomField::CalculatedValue
     # For a formula like `2 + {{cf_12}} + {{cf_4}}` it returns `[12, 4]`.
     def cf_ids_used_in_formula(formula_str)
       formula_str.scan(/(?<=\{\{cf_)\d+(?=}})/).map(&:to_i).uniq
-    end
-
-    # Returns `formula_string` with all custom field references detokenized so that they are parseable by Dentaku.
-    # For example, for `2 + {{cf_12}} + {{cf_4}}` it returns `2 + cf_12 + cf_4`.
-    def formula_str_without_patterns
-      formula_string.gsub(/\{\{(cf_\d+)}}/, '\1')
     end
   end
 end

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -50,7 +50,7 @@ module CustomField::CalculatedValue
     def affected_calculated_fields(changed_cf_ids)
       return [] if changed_cf_ids.empty?
 
-      to_check = select(&:field_format_calculated_value?)
+      to_check = field_format_calculated_value
 
       # include calculated value fields themselves
       all_affected, to_check = to_check.partition { it.id.in?(changed_cf_ids) }

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -39,6 +39,10 @@ module CustomField::CalculatedValue
   # Field formats that can be used within a formula.
   FIELD_FORMATS_FOR_FORMULA = %w[int float calculated_value].freeze
 
+  def self.calculator_instance
+    Dentaku::Calculator.new(case_sensitive: true)
+  end
+
   included do
     validate :validate_formula, if: :field_format_calculated_value?
 
@@ -122,13 +126,9 @@ module CustomField::CalculatedValue
 
     private
 
-    def calculator
-      Dentaku::Calculator.new(case_sensitive: true)
-    end
-
     def valid_formula_syntax?
       # Attempt to parse the formula. If no error is returned, the formula is syntactically valid.
-      calculator.ast(formula_str_without_patterns)
+      CustomField::CalculatedValue.calculator_instance.ast(formula_str_without_patterns)
       true
     rescue Dentaku::ParseError, Dentaku::TokenizerError
       false

--- a/app/models/custom_value/calculated_value_strategy.rb
+++ b/app/models/custom_value/calculated_value_strategy.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
+  include ActionView::Helpers::NumberHelper
+
+  def typed_value
+    if value.present?
+      integer_value? ? value.to_i : value.to_f
+    end
+  end
+
+  def formatted_value
+    integer_value? ? value.to_s : number_with_delimiter(value.to_s)
+  end
+
+  def validate_type_of_value
+    Kernel.Float(value)
+    nil
+  rescue StandardError
+    :not_a_number
+  end
+
+  private
+
+  def integer_value?
+    value && value =~ /\A\d+\z/
+  end
+end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -283,7 +283,6 @@ class PermittedParams
                                                 :templated,
                                                 :status_code,
                                                 :status_explanation,
-                                                custom_fields: [],
                                                 work_package_custom_field_ids: [],
                                                 type_ids: [],
                                                 enabled_module_names: [])

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -31,6 +31,8 @@
 module Projects::CustomFields
   extend ActiveSupport::Concern
 
+  include ActsAsCustomizable::CalculatedValue
+
   attr_accessor :_limit_custom_fields_validation_to_section_id
 
   included do

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -549,7 +549,7 @@ class WorkPackage < ApplicationRecord
   private_class_method :available_custom_fields_from_db
 
   def self.available_custom_field_key(work_package)
-    :"#work_package_custom_fields_#{work_package.project_id}_#{work_package.type_id}"
+    :"work_package_custom_fields_#{work_package.project_id}_#{work_package.type_id}"
   end
 
   private_class_method :available_custom_field_key

--- a/app/services/projects/concerns/set_calculated_custom_field_values.rb
+++ b/app/services/projects/concerns/set_calculated_custom_field_values.rb
@@ -42,7 +42,7 @@ module Projects::Concerns
       custom_field_value_params = params[:custom_field_values]
       return params unless custom_field_value_params
 
-      calculated_field_ids = model.all_available_custom_fields.select(&:field_format_calculated_value?).map(&:id)
+      calculated_field_ids = model.all_available_custom_fields.field_format_calculated_value.pluck(:id)
       custom_field_value_params = custom_field_value_params.reject { |id, _| id.to_s.to_i.in?(calculated_field_ids) }
 
       params.merge(custom_field_values: custom_field_value_params)

--- a/app/services/projects/concerns/set_calculated_custom_field_values.rb
+++ b/app/services/projects/concerns/set_calculated_custom_field_values.rb
@@ -42,7 +42,7 @@ module Projects::Concerns
       custom_field_value_params = params[:custom_field_values]
       return params unless custom_field_value_params
 
-      calculated_field_ids = model.available_custom_fields.select(&:field_format_calculated_value?).map(&:id)
+      calculated_field_ids = model.all_available_custom_fields.select(&:field_format_calculated_value?).map(&:id)
       custom_field_value_params = custom_field_value_params.reject { |id, _| id.to_s.to_i.in?(calculated_field_ids) }
 
       params.merge(custom_field_values: custom_field_value_params)

--- a/app/services/projects/concerns/set_calculated_custom_field_values.rb
+++ b/app/services/projects/concerns/set_calculated_custom_field_values.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Concerns
+  module SetCalculatedCustomFieldValues
+    private
+
+    def set_attributes(params)
+      super(params_except_calculated_fields(params)).tap do
+        update_calculated_value_custom_fields
+      end
+    end
+
+    def params_except_calculated_fields(params)
+      custom_field_value_params = params[:custom_field_values]
+      return params unless custom_field_value_params
+
+      calculated_field_ids = model.available_custom_fields.select(&:field_format_calculated_value?).map(&:id)
+      custom_field_value_params = custom_field_value_params.reject { |id, _| id.to_s.to_i.in?(calculated_field_ids) }
+
+      params.merge(custom_field_values: custom_field_value_params)
+    end
+
+    def update_calculated_value_custom_fields
+      changed_cf_ids = model.custom_values.select(&:changed?).map(&:custom_field_id)
+      affected_cfs = model.available_custom_fields.affected_calculated_fields(changed_cf_ids)
+
+      model.calculate_custom_fields(affected_cfs)
+    end
+  end
+end

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -30,6 +30,8 @@
 
 module Projects
   class SetAttributesService < ::BaseServices::SetAttributes
+    prepend Projects::Concerns::SetCalculatedCustomFieldValues
+
     private
 
     def set_attributes(params)

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -97,5 +97,6 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      order: 13,
                                                      enabled: lambda do
                                                        OpenProject::FeatureDecisions.calculated_value_project_attribute_active?
-                                                     end)
+                                                     end,
+                                                     formatter: "CustomValue::CalculatedValueStrategy")
 end

--- a/lib/open_project/multi_key_hash.rb
+++ b/lib/open_project/multi_key_hash.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  # Utility class to expand hash keys that are arrays into multiple keys
+  module MultiKeyHash
+    def self.expand(**hash)
+      hash.each_with_object({}) do |(keys, value), expanded|
+        Array(keys).each do |key|
+          expanded[key] = value
+        end
+      end
+    end
+  end
+end

--- a/lib/open_project/multi_key_hash.rb
+++ b/lib/open_project/multi_key_hash.rb
@@ -29,7 +29,13 @@
 #++
 
 module OpenProject
-  # Utility class to expand hash keys that are arrays into multiple keys
+  # Utility class to expand hash keys that are arrays into multiple keys.
+  #
+  # Example usage:
+  #   MultiKeyHash.expand(
+  #     %w[key1 key2] => "value for both key1 and key2",
+  #     "key3"        => "value for key3"
+  #   )
   module MultiKeyHash
     def self.expand(**hash)
       hash.each_with_object({}) do |(keys, value), expanded|

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -59,6 +59,10 @@ FactoryBot.define do
       RequestStore.store.delete_if { |key, _| key.to_s.include?("_custom_fields") }
     end
 
+    trait :admin_only do
+      admin_only { true }
+    end
+
     trait :multi_value do
       multi_value { true }
     end

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -83,6 +83,7 @@ FactoryBot.define do
 
     trait :calculated_value do
       field_format { "calculated_value" }
+      formula { "2 + 2" }
     end
 
     trait :float do

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
 
     after(:create) do
       # As the request store keeps track of the created custom fields
-      RequestStore.clear!
+      RequestStore.store.delete_if { |key, _| key.to_s.include?("_custom_fields") }
     end
 
     trait :multi_value do

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
@@ -220,6 +220,44 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
         it_behaves_like "a rich text custom field input"
       end
+
+      describe "with calculated value CFs" do
+        shared_examples "a calculated value custom field input" do
+          it "shows the correct value if given" do
+            overview_page.open_edit_dialog_for_section(section)
+
+            dialog.within_async_content(close_after_yield: true) do
+              expect(page).to have_field(custom_field.name, disabled: true, with: expected_initial_value)
+            end
+          end
+
+          it "shows a blank input if no value is given" do
+            custom_field.custom_values.destroy_all
+
+            overview_page.open_edit_dialog_for_section(section)
+
+            dialog.within_async_content(close_after_yield: true) do
+              expect(page).to have_field(custom_field.name, disabled: true, with: expected_blank_value)
+            end
+          end
+        end
+
+        describe "using int" do
+          let(:custom_field) { calculated_from_int_project_custom_field }
+          let(:expected_blank_value) { "" }
+          let(:expected_initial_value) { 234 }
+
+          it_behaves_like "a calculated value custom field input"
+        end
+
+        describe "using int and float" do
+          let(:custom_field) { calculated_from_int_and_float_project_custom_field }
+          let(:expected_blank_value) { "" }
+          let(:expected_initial_value) { 15185.088 }
+
+          it_behaves_like "a calculated value custom field input"
+        end
+      end
     end
 
     describe "with single select fields" do

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/render_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/render_spec.rb
@@ -125,6 +125,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
       expect(containers[4].text).to include("Date field")
       expect(containers[5].text).to include("Link field")
       expect(containers[6].text).to include("Text field")
+      expect(containers[7].text).to include("Calculated field using int")
+      expect(containers[8].text).to include("Calculated field using int and float")
     end
 
     boolean_project_custom_field.move_to_bottom
@@ -140,7 +142,9 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
       expect(containers[3].text).to include("Date field")
       expect(containers[4].text).to include("Link field")
       expect(containers[5].text).to include("Text field")
-      expect(containers[6].text).to include("Boolean field")
+      expect(containers[6].text).to include("Calculated field using int")
+      expect(containers[7].text).to include("Calculated field using int and float")
+      expect(containers[8].text).to include("Boolean field")
     end
   end
 

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
   before do
     login_as member_with_project_attributes_edit_permissions
-    overview_page.visit_page
   end
 
   describe "with correct updating behaviour" do
@@ -48,7 +47,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
       shared_examples "a custom field checkbox" do
         it "sets the value to true if checked" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -69,6 +68,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "sets the value to false if unchecked" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_content "Yes"
           end
@@ -86,6 +87,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "does not change the value if untouched" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_content "Yes"
           end
@@ -105,7 +108,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
       shared_examples "a custom field input" do
         it "saves the value properly" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -145,6 +148,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "removes the value properly" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_content expected_initial_value
           end
@@ -202,6 +207,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "blanks the value if referenced value gets removed" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(calculated_value_custom_field) do
             expect(page).to have_content expected_initial_calculated_value
           end
@@ -221,7 +228,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
       shared_examples "a rich text custom field input" do
         it "saves the value properly" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -261,6 +268,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "removes the value properly" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_text(expected_initial_value)
           end
@@ -366,7 +375,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
       shared_examples "a select field" do
         it "saves the value properly" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -407,6 +416,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "removes the value properly" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_text first_option
           end
@@ -457,7 +468,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
           end
 
           it "saves selected user group properly" do
-            custom_field.custom_values.destroy_all
+            custom_field.custom_values.delete_all
 
             overview_page.visit_page
 
@@ -481,7 +492,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
           end
 
           it "saves selected placeholer user properly" do
-            custom_field.custom_values.destroy_all
+            custom_field.custom_values.delete_all
 
             overview_page.visit_page
 
@@ -506,7 +517,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
       shared_examples "a autocomplete multi select field" do
         it "saves single selected values properly" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -527,7 +538,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "saves multi selected values properly" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -551,6 +562,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "removes deselected values properly" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_text first_option
             expect(page).to have_text second_option
@@ -570,6 +583,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "does not remove values when not touching the init values" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_text first_option
             expect(page).to have_text second_option
@@ -590,6 +605,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "removes all values when clearing the input" do
+          overview_page.visit_page
+
           overview_page.within_custom_field_container(custom_field) do
             expect(page).to have_text first_option
             expect(page).to have_text second_option
@@ -609,7 +626,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         end
 
         it "adds values properly to init values" do
-          custom_field.custom_values.destroy_all
+          custom_field.custom_values.delete_all
 
           overview_page.visit_page
 
@@ -684,7 +701,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
           end
 
           it "saves selected user groups properly" do
-            custom_field.custom_values.destroy_all
+            custom_field.custom_values.delete_all
 
             overview_page.visit_page
 
@@ -714,7 +731,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
           end
 
           it "shows only placeholder users from this project" do
-            custom_field.custom_values.destroy_all
+            custom_field.custom_values.delete_all
 
             overview_page.visit_page
 

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/validation_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/validation_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js, :sele
           expect(containers[4].text).to include("Date field")
           expect(containers[5].text).to include("Link field")
           expect(containers[6].text).to include("Text field")
+          expect(containers[7].text).to include("Calculated field using int")
+          expect(containers[8].text).to include("Calculated field using int and float")
 
           expect(page).to have_no_text(boolean_project_custom_field_activated_in_other_project.name)
         end
@@ -83,6 +85,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js, :sele
           expect(containers[4].text).to include("Date field")
           expect(containers[5].text).to include("Link field")
           expect(containers[6].text).to include("Text field")
+          expect(containers[7].text).to include("Calculated field using int")
+          expect(containers[8].text).to include("Calculated field using int and float")
 
           expect(page).to have_no_text(boolean_project_custom_field_activated_in_other_project.name)
         end
@@ -333,6 +337,27 @@ RSpec.describe "Edit project custom fields on project overview page", :js, :sele
         let(:field) { FormFields::Primerized::EditorFormField.new(custom_field) }
 
         it_behaves_like "a custom field input"
+      end
+
+      describe "with calculated value CFs" do
+        before do
+          # prevent calculation from happening
+          integer_project_custom_field.custom_values.delete_all
+        end
+
+        describe "using int" do
+          let(:custom_field) { calculated_from_int_project_custom_field }
+          let(:field) { FormFields::Primerized::InputField.new(custom_field) }
+
+          it_behaves_like "a custom field input"
+        end
+
+        describe "using int and float" do
+          let(:custom_field) { calculated_from_int_and_float_project_custom_field }
+          let(:field) { FormFields::Primerized::InputField.new(custom_field) }
+
+          it_behaves_like "a custom field input"
+        end
       end
     end
 

--- a/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/shared_context.rb
@@ -177,6 +177,36 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
     field
   end
 
+  let!(:calculated_from_int_project_custom_field) do
+    field = create(
+      :calculated_value_project_custom_field,
+      :skip_validations,
+      formula: "{{cf_#{integer_project_custom_field.id}}} * 2",
+      projects: [project],
+      name: "Calculated field using int",
+      project_custom_field_section: section_for_input_fields
+    )
+
+    create(:custom_value, customized: project, custom_field: field, value: 234)
+
+    field
+  end
+
+  let!(:calculated_from_int_and_float_project_custom_field) do
+    field = create(
+      :calculated_value_project_custom_field,
+      :skip_validations,
+      formula: "{{cf_#{float_project_custom_field.id}}} * {{cf_#{integer_project_custom_field.id}}}",
+      projects: [project],
+      name: "Calculated field using int and float",
+      project_custom_field_section: section_for_input_fields
+    )
+
+    create(:custom_value, customized: project, custom_field: field, value: 123 * 123.456)
+
+    field
+  end
+
   let!(:list_project_custom_field) do
     field = create(:list_project_custom_field, projects: [project],
                                                name: "List field",
@@ -273,7 +303,14 @@ RSpec.shared_context "with seeded projects, members and project custom fields" d
     ]
   end
 
-  let(:all_fields) { input_fields + select_fields + multi_select_fields }
+  let!(:calculated_value_fields) do
+    [
+      calculated_from_int_project_custom_field,
+      calculated_from_int_and_float_project_custom_field
+    ]
+  end
+
+  let(:all_fields) { input_fields + select_fields + multi_select_fields + calculated_value_fields }
 
   let!(:boolean_project_custom_field_activated_in_other_project) do
     create(:boolean_project_custom_field, projects: [other_project],

--- a/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Show project custom fields on project overview page", :js do
         overview_page.within_custom_field_section_container(section_for_input_fields) do
           fields = page.all(".op-project-custom-field-container")
 
-          expect(fields.size).to eq(7)
+          expect(fields.size).to eq(9)
 
           expect(fields[0].text).to include("Boolean field")
           expect(fields[1].text).to include("String field")
@@ -93,6 +93,8 @@ RSpec.describe "Show project custom fields on project overview page", :js do
           expect(fields[4].text).to include("Date field")
           expect(fields[5].text).to include("Link field")
           expect(fields[6].text).to include("Text field")
+          expect(fields[7].text).to include("Calculated field using int")
+          expect(fields[8].text).to include("Calculated field using int and float")
         end
 
         overview_page.within_custom_field_section_container(section_for_select_fields) do
@@ -124,7 +126,7 @@ RSpec.describe "Show project custom fields on project overview page", :js do
         overview_page.within_custom_field_section_container(section_for_input_fields) do
           fields = page.all(".op-project-custom-field-container")
 
-          expect(fields.size).to eq(7)
+          expect(fields.size).to eq(9)
 
           expect(fields[0].text).to include("Boolean field")
           expect(fields[1].text).to include("Integer field")
@@ -132,7 +134,9 @@ RSpec.describe "Show project custom fields on project overview page", :js do
           expect(fields[3].text).to include("Date field")
           expect(fields[4].text).to include("Link field")
           expect(fields[5].text).to include("Text field")
-          expect(fields[6].text).to include("String field")
+          expect(fields[6].text).to include("Calculated field using int")
+          expect(fields[7].text).to include("Calculated field using int and float")
+          expect(fields[8].text).to include("String field")
         end
       end
     end
@@ -566,6 +570,72 @@ RSpec.describe "Show project custom fields on project overview page", :js do
             end
 
             overview_page.expect_text_not_truncated(text_project_custom_field)
+          end
+        end
+      end
+    end
+
+    describe "with calculated value CFs" do
+      describe "with value set by user" do
+        it "shows the correct value for the project custom field if given" do
+          overview_page.visit_page
+
+          overview_page.within_project_attributes_sidebar do
+            overview_page.within_custom_field_container(calculated_from_int_project_custom_field) do
+              expect(page).to have_text "Calculated field using int"
+              expect(page).to have_text "234"
+            end
+
+            overview_page.within_custom_field_container(calculated_from_int_and_float_project_custom_field) do
+              expect(page).to have_text "Calculated field using int and float"
+              expect(page).to have_text "15,185.088"
+            end
+          end
+        end
+      end
+
+      describe "with value unset by user" do
+        before do
+          calculated_from_int_project_custom_field.custom_values.where(customized: project).first.update!(value: "")
+          calculated_from_int_and_float_project_custom_field.custom_values.where(customized: project).first.update!(value: "")
+        end
+
+        it "shows the correct value for the project custom field if given" do
+          overview_page.visit_page
+
+          overview_page.within_project_attributes_sidebar do
+            overview_page.within_custom_field_container(calculated_from_int_project_custom_field) do
+              expect(page).to have_text "Calculated field using int"
+              expect(page).to have_text I18n.t("placeholders.default")
+            end
+
+            overview_page.within_custom_field_container(calculated_from_int_and_float_project_custom_field) do
+              expect(page).to have_text "Calculated field using int and float"
+              expect(page).to have_text I18n.t("placeholders.default")
+            end
+          end
+        end
+      end
+
+      describe "with no value set by user" do
+        before do
+          calculated_from_int_project_custom_field.custom_values.where(customized: project).destroy_all
+          calculated_from_int_and_float_project_custom_field.custom_values.where(customized: project).destroy_all
+        end
+
+        it "shows an N/A text for the project custom field if no value given" do
+          overview_page.visit_page
+
+          overview_page.within_project_attributes_sidebar do
+            overview_page.within_custom_field_container(calculated_from_int_project_custom_field) do
+              expect(page).to have_text "Calculated field using int"
+              expect(page).to have_text I18n.t("placeholders.default")
+            end
+
+            overview_page.within_custom_field_container(calculated_from_int_and_float_project_custom_field) do
+              expect(page).to have_text "Calculated field using int and float"
+              expect(page).to have_text I18n.t("placeholders.default")
+            end
           end
         end
       end

--- a/spec/forms/custom_fields/custom_field_rendering_spec.rb
+++ b/spec/forms/custom_fields/custom_field_rendering_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CustomFields::CustomFieldRendering do
+  let(:form_class) do
+    Class.new do
+      include CustomFields::CustomFieldRendering
+
+      attr_reader :model
+    end
+  end
+
+  let(:form_instance) { form_class.new }
+  let(:model) { instance_double(ApplicationRecord) }
+  let(:builder) { instance_double(ActionView::Helpers::FormBuilder) }
+
+  before do
+    allow(form_instance).to receive(:model).and_return(model)
+  end
+
+  describe "#custom_field_input" do
+    let(:custom_field) { build(:custom_field, field_format:, multi_value:) }
+    let(:form_args) { { custom_field:, object: model } }
+
+    context "for single value custom field" do
+      let(:multi_value) { false }
+
+      {
+        "string" => CustomFields::Inputs::String,
+        "link" => CustomFields::Inputs::String,
+        "text" => CustomFields::Inputs::Text,
+        "int" => CustomFields::Inputs::Int,
+        "float" => CustomFields::Inputs::Float,
+        "hierarchy" => CustomFields::Inputs::SingleSelectList,
+        "list" => CustomFields::Inputs::SingleSelectList,
+        "date" => CustomFields::Inputs::Date,
+        "bool" => CustomFields::Inputs::Bool,
+        "user" => CustomFields::Inputs::SingleUserSelectList,
+        "version" => CustomFields::Inputs::SingleVersionSelectList,
+        "calculated_value" => CustomFields::Inputs::CalculatedValue
+      }.each do |format, input_class|
+        context "for supported format '#{format}'" do
+          let(:input) { instance_double(input_class) }
+          let(:field_format) { format }
+          let(:extra_args) { { foo: "bar" } }
+
+          before do
+            allow(form_instance).to receive(:additional_custom_field_input_arguments).and_return(extra_args)
+          end
+
+          it "instantiates #{class_name} with builder and form arguments" do
+            allow(input_class).to receive(:new).with(builder, **form_args, **extra_args).and_return(input)
+            expect(form_instance.send(:custom_field_input, builder, custom_field)).to eq(input)
+          end
+        end
+      end
+
+      context "for unsupported format" do
+        let(:field_format) { "unknown" }
+
+        it "raises an error" do
+          expect do
+            form_instance.send(:custom_field_input, builder, custom_field)
+          end.to raise_error("Unhandled custom field format unknown")
+        end
+      end
+    end
+
+    context "for multi value custom field" do
+      let(:multi_value) { true }
+
+      {
+        "hierarchy" => CustomFields::Inputs::MultiSelectList,
+        "list" => CustomFields::Inputs::MultiSelectList,
+        "user" => CustomFields::Inputs::MultiUserSelectList,
+        "version" => CustomFields::Inputs::MultiVersionSelectList
+      }.each do |format, input_class|
+        context "for supported format '#{format}'" do
+          let(:input) { instance_double(input_class) }
+          let(:field_format) { format }
+          let(:extra_args) { { foo: "bar" } }
+
+          before do
+            allow(form_instance).to receive(:additional_custom_field_input_arguments).and_return(extra_args)
+          end
+
+          it "instantiates #{class_name} with builder and form arguments" do
+            allow(input_class).to receive(:new).with(builder, **form_args, **extra_args).and_return(input)
+            expect(form_instance.send(:custom_field_input, builder, custom_field)).to eq(input)
+          end
+        end
+      end
+
+      context "for unsupported format" do
+        let(:field_format) { "unknown" }
+
+        it "raises an error" do
+          expect do
+            form_instance.send(:custom_field_input, builder, custom_field)
+          end.to raise_error("Unhandled custom field format unknown")
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/custom_fields/inputs/calculated_value_spec.rb
+++ b/spec/forms/custom_fields/inputs/calculated_value_spec.rb
@@ -28,12 +28,26 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class CustomFields::Inputs::CalculatedValue < CustomFields::Inputs::Base::Input
-  form do |custom_value_form|
-    custom_value_form.text_field(**input_attributes)
+require "spec_helper"
+
+RSpec.describe CustomFields::Inputs::CalculatedValue, type: :forms, with_flag: { calculated_value_project_attribute: true } do
+  include_context "with rendered custom field input form"
+
+  let(:custom_field) { create(:calculated_value_project_custom_field, name: "Calculated value field", formula: "1 + 1") }
+
+  it_behaves_like "rendering label with help text", "Calculated value field"
+
+  context "without a value" do
+    it "renders field" do
+      expect(rendered_form).to have_field "Calculated value field", type: :number, disabled: true, with: ""
+    end
   end
 
-  def input_attributes
-    super.merge({ type: "number", step: :any, disabled: true })
+  context "with a value" do
+    let(:value) { 78.23 }
+
+    it "renders field" do
+      expect(rendered_form).to have_field "Calculated value field", type: :number, disabled: true, with: "78.23"
+    end
   end
 end

--- a/spec/lib/open_project/multi_key_hash_spec.rb
+++ b/spec/lib/open_project/multi_key_hash_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::MultiKeyHash do
+  describe ".expand" do
+    it "expands a single key" do
+      expect(described_class.expand(foo: 1)).to eq({ foo: 1 })
+    end
+
+    it "expands an array key into multiple keys" do
+      expect(described_class.expand(%i[a b] => 3, c: 4)).to eq({ a: 3, b: 3, c: 4 })
+    end
+
+    it "returns empty hash for empty input" do
+      expect(described_class.expand).to eq({})
+    end
+
+    it "handles string keys" do
+      expect(described_class.expand(%w[foo bar] => 7)).to eq({ "foo" => 7, "bar" => 7 })
+    end
+
+    it "handles integer keys" do
+      expect(described_class.expand([1, 2] => 8)).to eq({ 1 => 8, 2 => 8 })
+    end
+
+    it "handles nil as a key" do
+      expect(described_class.expand([nil, :foo] => 10)).to eq({ nil => 10, foo: 10 })
+    end
+
+    it "handles nested arrays as keys" do
+      expect(described_class.expand([%i[a b], :c] => 9)).to eq({ %i[a b] => 9, c: 9 })
+    end
+
+    it "overwrites duplicate keys with last value" do
+      expect(described_class.expand(%i[foo bar] => 1, %i[foo baz] => 2)).to eq({ foo: 2, bar: 1, baz: 2 })
+    end
+  end
+end

--- a/spec/models/acts_as_customizable/calculated_value_spec.rb
+++ b/spec/models/acts_as_customizable/calculated_value_spec.rb
@@ -1,0 +1,348 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_value_project_attribute: true } do
+  let(:model_class) do
+    Class.new do
+      include ActsAsCustomizable::CalculatedValue
+
+      attr_accessor :custom_field_values
+    end
+  end
+
+  let(:instance) { model_class.new }
+
+  before do
+    allow(instance).to receive_messages(custom_field_values:, :custom_field_values= => nil)
+  end
+
+  def ref(custom_field) = "{{cf_#{custom_field.id}}}"
+
+  describe "#calculate_custom_fields" do
+    context "when calling with empty array" do
+      let(:custom_field_values) { [:foo] }
+
+      it "doesn't calculate anything" do
+        instance.calculate_custom_fields([])
+
+        expect(instance).not_to have_received(:custom_field_values=)
+      end
+    end
+
+    context "when calling with non calculated value custom fields" do
+      let(:custom_field_values) { [:foo] }
+
+      it "raises an exception when" do
+        expect do
+          instance.calculate_custom_fields([build(:integer_project_custom_field)])
+        end.to raise_error(ArgumentError, "Expected array of calculated value custom fields")
+      end
+
+      it "doesn't calculate anything" do
+        begin
+          instance.calculate_custom_fields([build(:integer_project_custom_field)])
+        rescue ArgumentError
+          # ignore
+        end
+
+        expect(instance).not_to have_received(:custom_field_values=)
+      end
+    end
+
+    describe "operations" do
+      let(:cfs) do
+        {
+          add: build_stubbed(:calculated_value_project_custom_field, formula: "1 + 2"),
+          sub: build_stubbed(:calculated_value_project_custom_field, formula: "2 - 3"),
+          mul: build_stubbed(:calculated_value_project_custom_field, formula: "3 * 4"),
+          div: build_stubbed(:calculated_value_project_custom_field, formula: "5 / 4"),
+          mod: build_stubbed(:calculated_value_project_custom_field, formula: "6 % 5"),
+          percent: build_stubbed(:calculated_value_project_custom_field, formula: "6 + 7%"),
+          group: build_stubbed(:calculated_value_project_custom_field, formula: "2 * (1 + 2)")
+        }
+      end
+
+      let(:custom_field_values) { [] }
+
+      it "handles all available operations" do
+        instance.calculate_custom_fields(cfs.values)
+
+        expect(instance).to have_received(:custom_field_values=)
+          .with(
+            cfs[:add].id => 3,
+            cfs[:sub].id => -1,
+            cfs[:mul].id => 12,
+            cfs[:div].id => 5/4r,
+            cfs[:mod].id => 1,
+            cfs[:percent].id => 607/100r,
+            cfs[:group].id => 6
+          )
+      end
+    end
+
+    describe "division by zero" do
+      let(:cf_div) { build_stubbed(:calculated_value_project_custom_field, formula: "5 / 0") }
+      let(:cf_mod) { build_stubbed(:calculated_value_project_custom_field, formula: "5 % 0") }
+      let(:cf_add) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 2") }
+
+      let(:custom_field_values) { [] }
+
+      it "blanks field with division by zero, but calculates other field" do
+        instance.calculate_custom_fields([cf_div, cf_add])
+
+        expect(instance).to have_received(:custom_field_values=)
+          .with(
+            cf_div.id => nil,
+            cf_add.id => 3
+          )
+      end
+
+      it "blanks field with modulo zero, but calculates other field" do
+        instance.calculate_custom_fields([cf_mod, cf_add])
+
+        # https://github.com/rubysolo/dentaku/pull/322
+        begin
+          Dentaku::Calculator.new.evaluate("1 % 0")
+
+          expect(instance).to have_received(:custom_field_values=)
+            .with(
+              cf_mod.id => nil,
+              cf_add.id => 3
+            )
+
+          fail "TODO: remove alternative check"
+        rescue ZeroDivisionError
+          expect(instance).to have_received(:custom_field_values=)
+            .with(
+              cf_mod.id => nil,
+              cf_add.id => nil
+            )
+        end
+      end
+    end
+
+    context "when calling with custom fields referencing constant fields" do
+      let(:cf_a) { build_stubbed(:integer_project_custom_field) }
+      let(:cf_b) { build_stubbed(:integer_project_custom_field) }
+
+      let(:cf1) { build_stubbed(:calculated_value_project_custom_field, formula: "#{ref cf_a} + #{ref cf_b}") }
+      let(:cf2) { build_stubbed(:calculated_value_project_custom_field, formula: "#{ref cf_a} * #{ref cf_b}") }
+
+      let(:custom_field_values) do
+        {
+          cf_a => 2,
+          cf_b => 3
+        }.map { |custom_field, value| build_stubbed(:custom_value, custom_field:, value:) }
+      end
+
+      it "calculates values for requested fields" do
+        instance.calculate_custom_fields([cf1])
+        expect(instance).to have_received(:custom_field_values=).with(cf1.id => 2 + 3).once
+
+        instance.calculate_custom_fields([cf2])
+        expect(instance).to have_received(:custom_field_values=).with(cf2.id => 2 * 3).once
+
+        instance.calculate_custom_fields([cf1, cf2])
+        expect(instance).to have_received(:custom_field_values=).with(cf1.id => 2 + 3, cf2.id => 2 * 3).once
+      end
+    end
+
+    context "when calling with custom fields referencing other calculated fields" do
+      let(:cf1) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 1") }
+      let(:cf2) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 2") }
+      let(:cf3) { build_stubbed(:calculated_value_project_custom_field, formula: "#{ref cf1} * #{ref cf2}") }
+
+      let(:custom_field_values) do
+        {
+          cf1 => 5,
+          cf2 => 7,
+          cf3 => 9
+        }.map { |custom_field, value| build_stubbed(:custom_value, custom_field:, value:) }
+      end
+
+      it "calculates only requested fields in proper order using old values for unrequested fields" do
+        instance.calculate_custom_fields([cf1])
+        expect(instance).to have_received(:custom_field_values=).with(cf1.id => 2).once
+
+        instance.calculate_custom_fields([cf2])
+        expect(instance).to have_received(:custom_field_values=).with(cf2.id => 3).once
+
+        instance.calculate_custom_fields([cf3])
+        expect(instance).to have_received(:custom_field_values=).with(cf3.id => 5 * 7).once
+
+        instance.calculate_custom_fields([cf1, cf2])
+        expect(instance).to have_received(:custom_field_values=).with(cf1.id => 2, cf2.id => 3).once
+
+        instance.calculate_custom_fields([cf1, cf3])
+        expect(instance).to have_received(:custom_field_values=).with(cf1.id => 2, cf3.id => 2 * 7).once
+
+        instance.calculate_custom_fields([cf2, cf3])
+        expect(instance).to have_received(:custom_field_values=).with(cf2.id => 3, cf3.id => 5 * 3).once
+
+        instance.calculate_custom_fields([cf1, cf2, cf3])
+        expect(instance).to have_received(:custom_field_values=).with(cf1.id => 2, cf2.id => 3, cf3.id => 2 * 3).once
+      end
+    end
+
+    context "when calling with custom fields referencing missing or unavailable values" do
+      let(:cf_missing) { build_stubbed(:integer_project_custom_field) }
+      let(:cf_unavailable) { build_stubbed(:integer_project_custom_field) }
+
+      let(:cf_using_missing) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + #{ref cf_missing}") }
+      let(:cf_using_unavailable) { build_stubbed(:calculated_value_project_custom_field, formula: "2 + #{ref cf_unavailable}") }
+      let(:cf_other) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 2") }
+
+      let(:custom_field_values) do
+        {
+          cf_missing => nil
+        }.map { |custom_field, value| build_stubbed(:custom_value, custom_field:, value:) }
+      end
+
+      it "blanks erroneous fields and calculates valid ones" do
+        instance.calculate_custom_fields([cf_using_missing, cf_using_unavailable, cf_other])
+        expect(instance).to have_received(:custom_field_values=).with(
+          cf_using_missing.id => nil,
+          cf_using_unavailable.id => nil,
+          cf_other.id => 3
+        )
+      end
+    end
+
+    context "when calling with custom fields having circular reference" do
+      let(:cf_a) { build_stubbed(:integer_project_custom_field) }
+      let(:cf_b) { build_stubbed(:integer_project_custom_field) }
+      let(:cf_c) { build_stubbed(:integer_project_custom_field) }
+      let(:cf_d) { build_stubbed(:integer_project_custom_field) }
+
+      let(:cf1) { build_stubbed(:calculated_value_project_custom_field) }
+      let(:cf2) { build_stubbed(:calculated_value_project_custom_field) }
+      let(:cf3) { build_stubbed(:calculated_value_project_custom_field) }
+      let(:cf4) { build_stubbed(:calculated_value_project_custom_field) }
+
+      let(:custom_field_values) do
+        {
+          cf_a => 2,
+          cf_b => 3,
+          cf_c => 5,
+          cf_d => 7,
+          cf1 => 11,
+          cf2 => 13,
+          cf3 => 17,
+          cf4 => 19
+        }.map { |custom_field, value| build_stubbed(:custom_value, custom_field:, value:) }
+      end
+
+      before do
+        {
+          cf1 => "#{ref cf_a} * #{ref cf2}",
+          cf2 => "#{ref cf_b} * #{ref cf3}",
+          cf3 => "#{ref cf1} * #{ref cf4}",
+          cf4 => "#{ref cf_c} * #{ref cf_d}"
+        }.each do |cf, formula|
+          cf.formula = formula
+        end
+      end
+
+      it "blanks them when requested to calculate fields that lead to recursion" do
+        instance.calculate_custom_fields([cf1, cf2, cf3])
+
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => nil, cf2.id => nil, cf3.id => nil)
+      end
+
+      it "blanks also unrelated fields when requested to calculate fields that lead to recursion" do
+        instance.calculate_custom_fields([cf1, cf2, cf3, cf4])
+
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => nil, cf2.id => nil, cf3.id => nil, cf4.id => nil)
+      end
+
+      it "calculates values when there is no recursion in fields requested to calculate (one field)" do
+        instance.calculate_custom_fields([cf1])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => 2 * 13).once
+
+        instance.calculate_custom_fields([cf2])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf2.id => 3 * 17).once
+
+        instance.calculate_custom_fields([cf3])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf3.id => 11 * 19).once
+
+        instance.calculate_custom_fields([cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf4.id => 5 * 7).once
+      end
+
+      it "calculates values when there is no recursion in fields requested to calculate (two fields)" do
+        instance.calculate_custom_fields([cf1, cf2])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => 2 * 3 * 17, cf2.id => 3 * 17).once
+
+        instance.calculate_custom_fields([cf1, cf3])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => 2 * 13, cf3.id => 2 * 13 * 19).once
+
+        instance.calculate_custom_fields([cf1, cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => 2 * 13, cf4.id => 5 * 7).once
+
+        instance.calculate_custom_fields([cf2, cf3])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf2.id => 3 * 11 * 19, cf3.id => 11 * 19).once
+
+        instance.calculate_custom_fields([cf2, cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf2.id => 3 * 17, cf4.id => 5 * 7).once
+
+        instance.calculate_custom_fields([cf3, cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf3.id => 5 * 7 * 11, cf4.id => 5 * 7).once
+      end
+
+      it "calculates values when there is no recursion in fields requested to calculate (three fields)" do
+        instance.calculate_custom_fields([cf1, cf2, cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => 2 * 3 * 17, cf2.id => 3 * 17, cf4.id => 5 * 7).once
+
+        instance.calculate_custom_fields([cf1, cf3, cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf1.id => 2 * 13, cf3.id => 2 * 5 * 7 * 13, cf4.id => 5 * 7).once
+
+        instance.calculate_custom_fields([cf2, cf3, cf4])
+        expect(instance).to have_received(:custom_field_values=)
+          .with(cf2.id => 3 * 5 * 7 * 11, cf3.id => 5 * 7 * 11, cf4.id => 5 * 7).once
+      end
+    end
+  end
+end

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -33,6 +33,141 @@ require "spec_helper"
 RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_project_attribute: true } do
   subject(:custom_field) { create(:calculated_value_project_custom_field, formula: "1 + 1") }
 
+  describe ".affected_calculated_fields" do
+    let(:scope) { CustomField }
+
+    def ref(custom_field) = "{{cf_#{custom_field.id}}}"
+
+    context "given simple formulas" do
+      shared_let(:cf_a) { create(:integer_project_custom_field, default_value: 1) }
+      shared_let(:cf_b) { create(:integer_project_custom_field, default_value: 2) }
+      shared_let(:cf_c) { create(:integer_project_custom_field, default_value: 3) }
+      shared_let(:cf_d) { create(:integer_project_custom_field, default_value: 4) }
+      shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} * 2") }
+      shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} + #{ref cf_b}") }
+      shared_let(:cf3) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_b} * 2") }
+      shared_let(:cf4) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_c} * 2") }
+
+      it "returns an empty array if argument is empty" do
+        expect(scope.affected_calculated_fields([])).to eq([])
+      end
+
+      it "returns an empty array when passing non referenced constant field ids" do
+        expect(scope.affected_calculated_fields([cf_d.id])).to eq([])
+      end
+
+      it "returns an empty array when passing non existing field id" do
+        expect(scope.affected_calculated_fields([-1, -2])).to eq([])
+      end
+
+      it "returns referencing fields when passing referenced constant field ids" do
+        expect(scope.affected_calculated_fields([cf_a.id])).to contain_exactly(cf1, cf2)
+        expect(scope.affected_calculated_fields([cf_b.id])).to contain_exactly(cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_c.id])).to contain_exactly(cf4)
+        expect(scope.affected_calculated_fields([cf_a.id, cf_b.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_a.id, cf_c.id])).to contain_exactly(cf1, cf2, cf4)
+        expect(scope.affected_calculated_fields([cf_b.id, cf_c.id])).to contain_exactly(cf2, cf3, cf4)
+        expect(scope.affected_calculated_fields([cf_a.id, cf_b.id, cf_c.id])).to contain_exactly(cf1, cf2, cf3, cf4)
+      end
+
+      it "returns referencing fields once when passing referenced constant field ids multiple times" do
+        expect(scope.affected_calculated_fields([cf_a.id] * 5)).to contain_exactly(cf1, cf2)
+        expect(scope.affected_calculated_fields([cf_a.id, cf_b.id] * 5)).to contain_exactly(cf1, cf2, cf3)
+      end
+
+      it "returns fields themselves when passing calculated field ids" do
+        expect(scope.affected_calculated_fields([cf1.id])).to contain_exactly(cf1)
+        expect(scope.affected_calculated_fields([cf2.id])).to contain_exactly(cf2)
+        expect(scope.affected_calculated_fields([cf3.id])).to contain_exactly(cf3)
+        expect(scope.affected_calculated_fields([cf4.id])).to contain_exactly(cf4)
+      end
+
+      it "returns fields once when passing mixture of calculated and constant field ids" do
+        expect(scope.affected_calculated_fields([cf_a.id, cf1.id])).to contain_exactly(cf1, cf2)
+      end
+
+      context "when scope doesn't include some values" do
+        let(:scope) { CustomField.where(id: [cf2, cf3]) }
+
+        it "receives referencing fields when passing referenced constant field ids" do
+          expect(scope.affected_calculated_fields([cf_a.id])).to contain_exactly(cf2)
+          expect(scope.affected_calculated_fields([cf_b.id])).to contain_exactly(cf2, cf3)
+          expect(scope.affected_calculated_fields([cf_c.id])).to be_empty
+          expect(scope.affected_calculated_fields([cf_a.id, cf_b.id])).to contain_exactly(cf2, cf3)
+          expect(scope.affected_calculated_fields([cf_a.id, cf_c.id])).to contain_exactly(cf2)
+          expect(scope.affected_calculated_fields([cf_b.id, cf_c.id])).to contain_exactly(cf2, cf3)
+          expect(scope.affected_calculated_fields([cf_a.id, cf_b.id, cf_c.id])).to contain_exactly(cf2, cf3)
+        end
+
+        it "receives fields themselves when passing calculated field ids" do
+          expect(scope.affected_calculated_fields([cf1.id])).to be_empty
+          expect(scope.affected_calculated_fields([cf2.id])).to contain_exactly(cf2)
+          expect(scope.affected_calculated_fields([cf3.id])).to contain_exactly(cf3)
+          expect(scope.affected_calculated_fields([cf4.id])).to be_empty
+        end
+      end
+    end
+
+    context "given formulas referencing other calculated fields" do
+      shared_let(:cf_a) { create(:integer_project_custom_field, default_value: 1) }
+      shared_let(:cf_b) { create(:integer_project_custom_field, default_value: 2) }
+      shared_let(:cf_c) { create(:integer_project_custom_field, default_value: 3) }
+      shared_let(:cf_d) { create(:integer_project_custom_field, default_value: 4) }
+
+      shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} + #{ref cf_b}") }
+      shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf1} * #{ref cf_c}") }
+      shared_let(:cf3) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf2} * #{ref cf_d}") }
+
+      it "receives referencing fields when passing referenced constant field ids" do
+        expect(scope.affected_calculated_fields([cf_a.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_b.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_c.id])).to contain_exactly(cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_d.id])).to contain_exactly(cf3)
+      end
+
+      context "when scope doesn't include some values" do
+        let(:scope) { CustomField.where(id: [cf1, cf3]) }
+
+        it "receives referencing fields when passing referenced constant field ids" do
+          expect(scope.affected_calculated_fields([cf_a.id])).to contain_exactly(cf1)
+          expect(scope.affected_calculated_fields([cf_b.id])).to contain_exactly(cf1)
+          expect(scope.affected_calculated_fields([cf_c.id])).to be_empty
+          expect(scope.affected_calculated_fields([cf_d.id])).to contain_exactly(cf3)
+        end
+      end
+    end
+
+    context "if given formulas with circular references" do
+      let!(:cf_a) { create(:integer_project_custom_field, default_value: 1) }
+      let!(:cf_b) { create(:integer_project_custom_field, default_value: 2) }
+      let!(:cf_c) { create(:integer_project_custom_field, default_value: 3) }
+
+      let!(:cf1) { create(:calculated_value_project_custom_field) }
+      let!(:cf2) { create(:calculated_value_project_custom_field) }
+      let!(:cf3) { create(:calculated_value_project_custom_field) }
+
+      before do
+        {
+          cf1 => "#{ref cf_a} + #{ref cf2}",
+          cf2 => "#{ref cf_b} + #{ref cf3}",
+          cf3 => "#{ref cf_c} + #{ref cf1}"
+        }.each do |cf, formula|
+          cf.formula = formula
+          cf.save!(validate: false)
+        end
+      end
+
+      it "does not enter infinite loop and returns all affected fields" do
+        expect(scope.affected_calculated_fields([cf_a.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_b.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf_c.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf1.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf2.id])).to contain_exactly(cf1, cf2, cf3)
+        expect(scope.affected_calculated_fields([cf3.id])).to contain_exactly(cf1, cf2, cf3)
+      end
+    end
+  end
+
   describe "#usable_custom_field_references_for_formula" do
     let!(:int) { create(:project_custom_field, :integer, default_value: 4, is_for_all: true) }
     let!(:float) { create(:project_custom_field, :float, default_value: 5.5, is_for_all: true) }

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -175,6 +175,26 @@ RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_proje
     end
   end
 
+  describe "#formula_str_without_patterns" do
+    it "returns an empty string if no formula is set" do
+      subject.formula = nil
+
+      expect(subject.formula_str_without_patterns).to eq("")
+    end
+
+    it "returns the formula as is if formula doesn't reference custom fields" do
+      subject.formula = "2 + 2"
+
+      expect(subject.formula_str_without_patterns).to eq("2 + 2")
+    end
+
+    it "returns ids if formula references custom fields" do
+      subject.formula = "1 * {{cf_7}} + {{cf_42}}"
+
+      expect(subject.formula_str_without_patterns).to eq("1 * cf_7 + cf_42")
+    end
+  end
+
   describe "#formula_referenced_custom_field_ids" do
     it "returns an empty array if no formula is set" do
       subject.formula = nil

--- a/spec/models/custom_value/calculated_value_strategy_spec.rb
+++ b/spec/models/custom_value/calculated_value_strategy_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CustomValue::CalculatedValueStrategy do
+  let(:instance) { described_class.new(custom_value) }
+  let(:custom_value) { instance_double(CustomValue, value:) }
+
+  describe "#typed_value" do
+    subject { instance.typed_value }
+
+    context "when value is a float string" do
+      let(:value) { "3.14" }
+
+      it { is_expected.to be(3.14) }
+    end
+
+    context "when value is an int string" do
+      let(:value) { "42" }
+
+      it { is_expected.to be(42) }
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#formatted_value" do
+    subject { instance.formatted_value }
+
+    context "when value is a float string" do
+      let(:value) { "3.14" }
+
+      it "is the float string" do
+        expect(subject).to eql value
+      end
+
+      it "is localized" do
+        I18n.with_locale(:de) do
+          expect(subject).to eql "3,14"
+        end
+      end
+    end
+
+    context "when value is an int string" do
+      let(:value) { "42" }
+
+      it "is the int string" do
+        expect(subject).to eql value
+      end
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it "is a blank string" do
+        expect(subject).to eql value
+      end
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it "is a blank string" do
+        expect(subject).to eql ""
+      end
+    end
+  end
+
+  describe "#validate_type_of_value" do
+    subject { instance.validate_type_of_value }
+
+    context "when value is a float string in decimal notation" do
+      let(:value) { "3.14" }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is a float string in exp. notation" do
+      let(:value) { "5.0e-14" }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is a positive int string" do
+      let(:value) { "10" }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is a negative int string" do
+      let(:value) { "-10" }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is not a float string" do
+      let(:value) { "banana" }
+
+      it "rejects" do
+        expect(subject).to be(:not_a_number)
+      end
+    end
+
+    context "when value is a float" do
+      let(:value) { 3.14 }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is an int" do
+      let(:value) { 3 }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -61,10 +61,6 @@ RSpec.describe Projects::SetAttributesService, type: :model do
   end
 
   describe "call" do
-    let(:call_attributes) do
-      {}
-    end
-
     before do
       allow(project)
         .to receive(:valid?)
@@ -312,6 +308,250 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           end
 
           include_examples "setting status attributes"
+        end
+      end
+
+      describe "calculated custom fields", with_flag: { calculated_value_project_attribute: true } do
+        shared_let(:project) { create(:project) }
+
+        before do
+          # Both User.current and :select_project_custom_fields for ProjectCustomField.visible
+          User.current = user
+          mock_permissions_for(user) do |mock|
+            mock.allow_in_project(:select_project_custom_fields, project:)
+          end
+        end
+
+        def ref(custom_field) = "{{cf_#{custom_field.id}}}"
+
+        context "when trying to explicitly set values of calculated custom fields" do
+          let!(:cf_static) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_calculated) do
+            create(:calculated_value_project_custom_field,
+                   projects: [project], formula: "1 + 1")
+          end
+
+          let(:call_attributes) do
+            {
+              custom_field_values: {
+                cf_static.id => 3,
+                cf_calculated.id => 4
+              }
+            }
+          end
+
+          before do
+            create(:custom_value, customized: project, custom_field: cf_static, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_calculated, value: -6)
+          end
+
+          it "doesn't allow to assign calculated value" do
+            expect(subject.result.custom_value_attributes).to eq(cf_static.id => "3", cf_calculated.id => "-6")
+          end
+        end
+
+        context "when setting value of field referenced in calculated values" do
+          let!(:cf_static) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_calculated1) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_static} * 7")
+          end
+          let!(:cf_calculated2) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_calculated1} * 11")
+          end
+
+          let(:call_attributes) do
+            {
+              custom_field_values: {
+                cf_static.id => 3
+              }
+            }
+          end
+
+          before do
+            create(:custom_value, customized: project, custom_field: cf_static, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_calculated1, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated2, value: -6)
+          end
+
+          it "calculates all values" do
+            expect(subject.result.custom_value_attributes).to eq(
+              cf_static.id => "3",
+              cf_calculated1.id => "21",
+              cf_calculated2.id => "231"
+            )
+          end
+        end
+
+        context "when removing value of field referenced in calculated values" do
+          let!(:cf_static) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_calculated1) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_static} * 7")
+          end
+          let!(:cf_calculated2) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_calculated1} * 11")
+          end
+
+          let(:call_attributes) do
+            {
+              custom_field_values: {
+                cf_static.id => nil
+              }
+            }
+          end
+
+          before do
+            create(:custom_value, customized: project, custom_field: cf_static, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_calculated1, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated2, value: -6)
+          end
+
+          it "blanks all values" do
+            expect(subject.result.custom_value_attributes).to eq(
+              cf_static.id => nil,
+              cf_calculated1.id => nil,
+              cf_calculated2.id => nil
+            )
+          end
+        end
+
+        context "when setting value of only part of fields referenced in calculated values" do
+          let!(:cf_a) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_b) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_c) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_calculated1) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project], formula: "#{ref cf_a} * 7")
+          end
+          let!(:cf_calculated2) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project], formula: "#{ref cf_b} * 11")
+          end
+          let!(:cf_calculated3) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project], formula: "#{ref cf_c} * 13")
+          end
+
+          let(:call_attributes) do
+            {
+              custom_field_values: {
+                cf_a.id => 3,
+                cf_b.id => -5
+              }
+            }
+          end
+
+          before do
+            create(:custom_value, customized: project, custom_field: cf_a, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_b, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_c, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_calculated1, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated2, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated3, value: -6)
+          end
+
+          it "calculates only values referenced by changed field" do
+            expect(subject.result.custom_value_attributes).to eq(
+              cf_a.id => "3",
+              cf_b.id => "-5",
+              cf_c.id => "-5",
+              cf_calculated1.id => "21",
+              cf_calculated2.id => "-6",
+              cf_calculated3.id => "-6"
+            )
+          end
+        end
+
+        context "when intermediate calculated value field is not enabled" do
+          let!(:cf_static) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_calculated1) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_static} * 7")
+          end
+          let!(:cf_calculated2) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   formula: "#{ref cf_calculated1} * 11")
+          end
+          let!(:cf_calculated3) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_calculated2} * 13")
+          end
+
+          let(:call_attributes) do
+            {
+              custom_field_values: {
+                cf_static.id => 3
+              }
+            }
+          end
+
+          before do
+            create(:custom_value, customized: project, custom_field: cf_static, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_calculated1, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated2, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated3, value: -6)
+          end
+
+          it "calculates only accessible values" do
+            expect(subject.result.custom_value_attributes).to eq(
+              cf_static.id => "3",
+              cf_calculated1.id => "21",
+              cf_calculated2.id => "-6",
+              cf_calculated3.id => "-6"
+            )
+          end
+        end
+
+        context "when intermediate calculated value field is for admin only" do
+          let!(:cf_static) { create(:integer_project_custom_field, projects: [project]) }
+          let!(:cf_calculated1) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_static} * 7")
+          end
+          let!(:cf_calculated2) do
+            create(:calculated_value_project_custom_field, :skip_validations, :admin_only,
+                   projects: [project],
+                   formula: "#{ref cf_calculated1} * 11")
+          end
+          let!(:cf_calculated3) do
+            create(:calculated_value_project_custom_field, :skip_validations,
+                   projects: [project],
+                   formula: "#{ref cf_calculated2} * 13")
+          end
+
+          let(:call_attributes) do
+            {
+              custom_field_values: {
+                cf_static.id => 3
+              }
+            }
+          end
+
+          before do
+            create(:custom_value, customized: project, custom_field: cf_static, value: -5)
+            create(:custom_value, customized: project, custom_field: cf_calculated1, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated2, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_calculated3, value: -6)
+          end
+
+          it "calculates only accessible values" do
+            expect(subject.result.custom_value_attributes).to eq(
+              cf_static.id => "3",
+              cf_calculated1.id => "21",
+              cf_calculated2.id => "-6",
+              cf_calculated3.id => "-6"
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64349

# What are you trying to accomplish?
Perform recursive calculation of calculated value custom fields when referenced field values change
Display calculated values in overview and custom field form

# Notes
Created PR to dentaku as `x % 0` leads to ZeroDivisionError for both `solve` and `solve!` (should be dentaku specific in second case) https://github.com/rubysolo/dentaku/pull/322
Tried methods ready for efficiently triggering recalculation based on other changes (`affected_calculated_fields` separately for when formula changes)
Directly assigning values to calculated fields is prevented on `SetAttributesService` level, as doing it on acts_as_customizable seemed much more involved with introducing modes/states
Output preserves integers to be displayed as integers (without fractional part)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
