### PR TITLE
allow external PRs to trigger SaaS tests

### DIFF
--- a/.github/workflows/downstream-ci.yml
+++ b/.github/workflows/downstream-ci.yml
@@ -3,12 +3,17 @@ on:
   push:
     branches:
       - dev
-      - release/*
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'help/**'
-  pull_request:
+  # We run this in the less privileged mode to allow external PRs to use this workflow.
+  # This means the workflow will be executed on the base branch, making sure only our own workflow logic is used.
+  pull_request_target:
     types: [opened, reopened, synchronize]
+    branches:
+      - dev
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - 'help/**'
@@ -38,7 +43,21 @@ jobs:
         #   * the name of the core branch that has to be checked out downstream to run the tests
         #   * that is either dev, release/16.1 (for instance), or the pull request's branch name
         run: |
-          if [[ ! "${{ github.base_ref || github.ref_name }}" =~ dev|release/.+ ]]; then
+          echo Triggering downstream workflow
+          REF=''
+          CORE_REF=''
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo the workflow was triggered by a pull request targetting the dev or a release branch
+            REF="${{ github.base_ref }}"
+            CORE_REF="${{ github.event.pull_request.head.ref }}"
+          else
+            echo the workflow was triggered by a push to the dev or a release branch
+            REF="${{ github.ref_name }}"
+            CORE_REF="$REF"
+          fi
+
+          if [[ ! "$REF" =~ dev|release/.+ ]]; then
             echo "Base branch is not dev or release branch. Cannot check downstream tests."
             exit 0
           fi
@@ -46,4 +65,4 @@ jobs:
           curl -i --fail-with-body -H"authorization: Bearer $TOKEN" \
             -XPOST -H"Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/$REPOSITORY/actions/workflows/$WORKFLOW_ID/dispatches \
-            -d '{"ref": "${{ github.base_ref || github.ref_name }}", "inputs": { "core_ref" : "${{ github.ref_name }}" }}'
+            -d '{"ref": "$REF", "inputs": { "core_ref" : "$CORE_REF" }}'


### PR DESCRIPTION
changing the event to pull_request_target checks out the branch's (i.e. release or dev) code instead of the PR's code. This is fine in this case because we don't actually use any of the code. We just trigger another workflow. As for security, this is also fine. The reason this is not allowed for external PRs, and why we need to use pull_request_target rather than pull_request, is that there is a risk that the external PR's code wants to read and leak secrets. Using pull_request_target prevents that. Now the downstream workflow will still check out this external PR's branch. But it won't make use of any of the workflows. It's actually testing the code. So there is no risk here.

