### PR TITLE
Fix registration of auth providers through register_auth_providers

### DIFF
--- a/app/models/plugin_auth_provider.rb
+++ b/app/models/plugin_auth_provider.rb
@@ -28,44 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AuthProvider < ApplicationRecord
-  belongs_to :creator, class_name: "User"
+class PluginAuthProvider < AuthProvider
+  class << self
+    def create_for_plugin(config)
+      slug = config[:name]
+      display_name = config[:display_name] || slug
 
-  has_many :scim_clients, dependent: :restrict_with_error
-
-  has_many :user_auth_provider_links, dependent: :destroy
-  has_many :users,
-           -> { where(type: "User") },
-           through: :user_auth_provider_links,
-           source: :principal
-
-  validates :display_name, presence: true
-  validates :display_name, uniqueness: true
-
-  after_destroy :unset_direct_provider
-
-  def user_count
-    @user_count ||= user_auth_provider_links.count
+      find_or_create_by!(slug:) do |provider|
+        provider.available = false
+        provider.display_name = display_name.to_s
+        provider.creator = User.system
+      end
+    end
   end
 
   def human_type
-    raise NotImplementedError
-  end
-
-  def auth_url
-    root_url = OpenProject::StaticRouting::StaticUrlHelpers.new.root_url
-    URI.join(root_url, "auth/#{slug}/").to_s
-  end
-
-  def callback_url
-    URI.join(auth_url, "callback").to_s
-  end
-
-  protected
-
-  def unset_direct_provider
-    if Setting.omniauth_direct_login_provider == slug
-      Setting.omniauth_direct_login_provider = ""
-    end
+    "Plug-in-based authentication provider"
   end
 end

--- a/docs/development/create-omniauth-plugin/README.md
+++ b/docs/development/create-omniauth-plugin/README.md
@@ -103,6 +103,19 @@ module OmniAuth
 You can register any number of providers using different strategies (or the same) with different options.
 For instance you could configure two OpenID Connect providers using the same strategy (OpenIDConnect) but with different options according to the service to be used (e.g. Google vs Microsoft).
 
+OpenProject expects a database entry in the `auth_providers` table to be stored for each provider registered for SSO login (via subclasses of the
+`AuthProvider` model), so that they can be referenced, for example by users logging in through those providers.
+By default the call to `register_auth_providers` will make sure that a record exists for each registered provider.
+However, if your plugin manages configuration of each provider in such a subclass itself, you can pass `persist: false`, to indicate that:
+
+```ruby
+register_auth_providers(persist: false) do
+  strategy :my_advanced_auth_plugin_strategy do
+    # ...
+  end
+end
+```
+
 ### Add your plugin to Gemfile.plugins
 
 All that’s that left to do is declaring your plugin in the file `Gemfile.plugins` in your OpenProject application’s root directory.

--- a/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
+++ b/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
@@ -28,14 +28,24 @@
 
 module OpenProject::Plugins
   module AuthPlugin
-    def register_auth_providers(&)
+    def register_auth_providers(persist: true, &)
+      builder = ProviderBuilder.new
       initializer "#{engine_name}.middleware" do |app|
-        builder = ProviderBuilder.new
         builder.instance_eval(&)
 
         app.config.middleware.use OmniAuth::FlexibleBuilder do
           builder.new_strategies.each do |strategy|
             provider strategy
+          end
+        end
+      end
+
+      config.to_prepare do
+        if persist
+          builder.provider_callbacks.each do |callback|
+            callback.call.each do |config|
+              PluginAuthProvider.create_for_plugin(config)
+            end
           end
         end
       end
@@ -125,10 +135,16 @@ module OpenProject::Plugins
         AuthPlugin.strategies[key] = [providers]
         new_strategies << strategy
       end
+
+      provider_callbacks.push(providers)
     end
 
     def new_strategies
       @new_strategies ||= []
+    end
+
+    def provider_callbacks
+      @provider_callbacks ||= []
     end
   end
 end

--- a/modules/auth_plugins/spec/requests/auth_plugins_spec.rb
+++ b/modules/auth_plugins/spec/requests/auth_plugins_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe OpenProject::Plugins::AuthPlugin, with_ee: %i[sso_auth_providers]
     without_partial_double_verification do
       allow(dummy_engine_klass).to receive(:engine_name).and_return("foobar")
       allow(dummy_engine_klass).to receive(:initializer) { |_, &block| app.instance_eval(&block) }
+      allow(dummy_engine_klass).to receive_message_chain(:config, :to_prepare) { |_, &block| # rubocop:disable RSpec/MessageChain
+        block.call
+      }
     end
   end
 
@@ -97,7 +100,11 @@ RSpec.describe OpenProject::Plugins::AuthPlugin, with_ee: %i[sso_auth_providers]
       expect(strategies.keys.to_a).to eq %i[strategy_a strategy_b]
     end
 
-    it "registers register each strategy (i.e. middleware) only once" do
+    it "persists all strategies in the database" do
+      expect(PluginAuthProvider.pluck(:slug)).to contain_exactly("a1", "a2", "b1", "c1")
+    end
+
+    it "registers each strategy (i.e. middleware) only once" do
       expect(middlewares.size).to eq 2
       expect(middlewares).to eq %i[strategy_a strategy_b]
     end

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -37,7 +37,7 @@ module OpenProject
         auth_provider-saml.png
       )
 
-      register_auth_providers do
+      register_auth_providers(persist: false) do
         strategy :saml do
           OpenProject::AuthSaml.configuration.values.map do |h|
             # Remember saml session values when logging in user

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -60,7 +60,7 @@ module OpenProject::OpenIDConnect
 
     class_inflection_override("openid_connect" => "OpenIDConnect")
 
-    register_auth_providers do
+    register_auth_providers(persist: false) do
       OmniAuth::OpenIDConnect::Providers.configure custom_options: %i[
         display_name?
         icon?


### PR DESCRIPTION
This is the only and official API to register an auth provider. However, so far it was optional to create a database entry in the `auth_providers` table and only OIDC and SAML did that.

On the other hand, we added expectations about auth providers have
a database entry in more and more places of the codebase.

Now making sure that every auth provider is represented in the database.

# Ticket
https://community.openproject.org/wp/65892