### PR TITLE
Fix building `config/frontend_assets.manifest.json`

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -16,6 +16,7 @@
         "build": {
           "builder": "@angular-builders/custom-esbuild:application",
           "options": {
+            "plugins": ["./esbuild/plugins.ts"],
             "allowedCommonJsDependencies": [
               "dom-plane",
               "pako",

--- a/frontend/esbuild/plugins.ts
+++ b/frontend/esbuild/plugins.ts
@@ -32,7 +32,7 @@ import type { Plugin } from 'esbuild';
 
 const customConfigPlugin:Plugin = {
   name: 'custom-config',
-  setup({ initialOptions:options }) {
+  setup({ initialOptions: options }) {
     if (options.chunkNames === '[name]-[hash]') { // named chunks
       options.chunkNames = '[dir]/[name]-[hash]';
     }

--- a/frontend/esbuild/plugins.ts
+++ b/frontend/esbuild/plugins.ts
@@ -1,0 +1,42 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import type { Plugin } from 'esbuild';
+
+const customConfigPlugin:Plugin = {
+  name: 'custom-config',
+  setup({ initialOptions:options }) {
+    if (options.chunkNames === '[name]-[hash]') { // named chunks
+      options.chunkNames = '[dir]/[name]-[hash]';
+    }
+  }
+}
+
+export default [customConfigPlugin];

--- a/lib/open_project/assets.rb
+++ b/lib/open_project/assets.rb
@@ -69,27 +69,29 @@ module OpenProject
       # Rebuilds the manifest file
       def rebuild_manifest!
         # Remove index html
-        FileUtils.remove File.join(frontend_asset_path, "index2.html"), force: true
+        FileUtils.remove frontend_asset_path.join("index2.html"), force: true
 
         # Create map of asset chunk name to current hash
-        manifest = {}
-        OpenProject::Assets.current_assets.each do |filename|
-          md = filename.match /\A([^.]+)-(\w+)\.(\w+)\z/
+        manifest = current_assets.filter_map do |asset|
+          name = asset.basename(asset.extname).to_s
+          case name.match(/\A(?<unhashed_name>[^.]+)[-\.][A-Z0-9]{8}\z/)
+          in unhashed_name: "chunk"
+            [asset, asset]
+          in unhashed_name:
+            [asset.parent.join(unhashed_name + asset.extname), asset]
+          else
+            nil # Non-hashed asset: no-op
+          end
+        end.to_h
 
-          # Non-hashed asset
-          next if md.nil?
-
-          chunk_name = "#{md[1]}.#{md[3]}"
-          manifest[chunk_name] = filename
-        end
-
-        File.write(manifest_path, manifest.to_json)
+        manifest_path.write manifest.to_json
       end
 
       def current_assets
-        Dir.glob(OpenProject::Assets.frontend_asset_path + "*")
-          .select { |f| File.file? f }
-          .map { |f| File.basename(f) }
+        frontend_asset_path
+          .glob("**/*")
+          .select(&:file?)
+          .map { it.relative_path_from(frontend_asset_path) }
       end
     end
   end

--- a/lib/open_project/assets.rb
+++ b/lib/open_project/assets.rb
@@ -73,12 +73,12 @@ module OpenProject
 
         # Create map of asset chunk name to current hash
         manifest = current_assets.filter_map do |asset|
-          name = asset.basename(asset.extname).to_s
+          name, extname = split_basename(asset)
           case name.match(/\A(?<unhashed_name>[^.]+)[-\.][A-Z0-9]{8}\z/)
           in unhashed_name: "chunk"
             [asset, asset]
           in unhashed_name:
-            [asset.parent.join(unhashed_name + asset.extname), asset]
+            [asset.parent.join(unhashed_name + extname), asset]
           else
             nil # Non-hashed asset: no-op
           end
@@ -92,6 +92,19 @@ module OpenProject
           .glob("**/*")
           .select(&:file?)
           .map { it.relative_path_from(frontend_asset_path) }
+      end
+
+      def split_basename(pathname)
+        ext1 = pathname.extname
+        base = pathname.basename(ext1)
+
+        if ext1 == ".map"
+          ext2 = base.extname
+          base = base.basename(ext2)
+          [base.to_s, ext2 + ext1]
+        else
+          [base.to_s, ext1]
+        end
       end
     end
   end

--- a/lib/open_project/assets.rb
+++ b/lib/open_project/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -51,7 +53,7 @@ module OpenProject
       end
 
       def load_manifest
-        @manifest ||= begin
+        @load_manifest ||= begin
           JSON.parse File.read(manifest_path)
         rescue StandardError => e
           Rails.logger.error "Failed to read frontend manifest file: #{e}."


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Follow up from #19132 

There are still a number of issues with the the generated `config/frontend_assets.manifest.json` when running `rake assets:precompile`. These issues may lead to deployment problems.

- _when named chunks are disabled (`npm build:fast`),_ esbuild will emit chunks named with the default format `chunk.HASH.js`. However, a single `chunk.js` entry is currently created in the manifest.
- _when named chunks are enabled (`npm build`),_ there may be naming collisions when resolving the non-hashed filename for a hashed asset. This is a particular issue with dynamic imports, e.g. there is `es.js` (CKEditor translations) and `es.js` (other locale data) but only one entry being created in the manifest.

This PR ensures that:

- non-named chunks are handled correctly: the hash is preserved. As such, key and value in the Manifest are the same. Example:

  `"chunk-JVYZ3IWG.js": "chunk-JVYZ3IWG.js",`

- named chunks are now prefixed with the current directory. Example:

   `"node_modules/codemirror/lib/codemirror.js": "node_modules/codemirror/lib/codemirror-7R6XY4NV.js",`
   `"src/app/core/errors/appsignal/appsignal-dependency.js": "src/app/core/errors/appsignal/appsignal-dependency-RMOIBVG5.js",`

- the correct mappings are also created for sourcemaps. Example:

   `"src/locales/af.js.map": "src/locales/af-P3LPJOCW.js.map",`



# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
