### PR TITLE
[#65866] NoMethodError in GET::API::V3::Queries::QueriesAPI#/queries/id

### DIFF
--- a/app/models/journal/timestamps.rb
+++ b/app/models/journal/timestamps.rb
@@ -72,6 +72,12 @@ module Journal::Timestamps
       timestamp = timestamp.to_time if timestamp.kind_of? Timestamp
       timestamp = timestamp.in_time_zone if timestamp.kind_of? DateTime
 
+      # By default rails will chop off the timezone from a date time parameter and just let
+      # postgresql to use the db session's timezone, which can be different from UTC.
+      # Pass the timestamp as a string including the UTC timezone explicitly, to the query
+      # in order to force postgres to use UTC instead of the session's timezone.
+
+      timestamp = timestamp.utc.to_s
       where(OpenProject::SqlSanitization.sanitize("validity_period @> timestamp with time zone :timestamp", timestamp:))
     end
   end

--- a/spec/models/journal/timestamps_spec.rb
+++ b/spec/models/journal/timestamps_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe Journal::Timestamps do
       end
     end
 
+    describe "when ensuring UTC is passed to the timestamp where condition" do
+      it "converts the timestamp to UTC in the generated SQL" do
+        sql = Time.use_zone("America/New_York") do
+          est_time = Time.zone.parse("2022-08-01 11:30:00")
+          Journal.at_timestamp(est_time).to_sql
+        end
+        expect(sql)
+          .to include(/validity_period @> timestamp with time zone '2022-08-01 15:30:00 UTC'/)
+      end
+    end
+
     describe "when there are journals for Monday, Wednesday, and Friday" do
       let(:before_monday) { "2022-01-01".to_datetime }
       let(:monday) { "2022-08-01".to_datetime }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/65866

# What are you trying to accomplish?
Fix the bug where the timestamp columns could return nil in certain conditions while retrieving historic work package attributes.

## Screenshots

# What approach did you choose and why?
Use the same time format for the column as it is in the where condition when retrieving historic work package journals.
This way we can be sure that the where condition and the case condition in the select are always matching and do not produce any unexpected nil columns.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
