### PR TITLE
Fix running the docker (TLS) stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     depends_on:
       - db
       - cache
+      - frontend
 
   worker:
     <<: *backend
@@ -77,16 +78,12 @@ services:
   frontend:
     build:
       <<: *frontend-build
-    command: "node --max_old_space_size=8096 ./node_modules/@angular/cli/bin/ng serve --host 0.0.0.0"
+    command: "node --max_old_space_size=8096 ./node_modules/@angular/cli/bin/ng serve --host 0.0.0.0 --allowed-hosts openproject-assets.local"
     volumes:
       - ".:/home/dev/openproject"
       - "${CKEDITOR_BUILD_DIR:-./frontend/src/vendor/ckeditor/}:/home/dev/openproject/frontend/src/vendor/ckeditor/"
-    environment:
-      PROXY_HOSTNAME: backend
     networks:
       - network
-    depends_on:
-      - backend
 
   db:
     image: postgres:17

--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -19,6 +19,7 @@ services:
   backend:
     environment:
       <<: *environment
+      OPENPROJECT_CLI_PROXY: "https://openproject-assets.local"
     networks:
       - external
     volumes:
@@ -27,6 +28,10 @@ services:
       # Mac OS
       # - ~/.step/certs:/etc/ssl/certs
       # - ~/.step/certs:/usr/local/share/ca-certificates
+    labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.openproject.rule=Host(`openproject.local`)"
+    - "traefik.http.routers.openproject.entrypoints=websecure"
 
   worker:
     environment:
@@ -54,11 +59,10 @@ services:
   frontend:
     networks:
       - external
-    # Those label interpreted by traefik to create the correct HTTP router
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.openproject.rule=Host(`${OPENPROJECT_DEV_HOST}`)"
-      - "traefik.http.routers.openproject.entrypoints=websecure"
+    - "traefik.enable=true"
+    - "traefik.http.routers.openproject-assets.rule=Host(`openproject-assets.local`)"
+    - "traefik.http.routers.openproject-assets.entrypoints=websecure"
 
 # You need to define the same external network
 # that is defined in the TLS proxy compose file

--- a/docker/dev/tls/docker-compose.override.example.yml
+++ b/docker/dev/tls/docker-compose.override.example.yml
@@ -8,6 +8,7 @@ services:
           # by connecting to them, and we'd like it to go through traefik, instead
           # of calling the service containers directly.
           - openproject.local
+          - openproject-assets.local
           - nextcloud.local
           - gitlab.local
           - keycloak.local

--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -39,7 +39,7 @@ Then continue the setup:
 cp docker-compose.override.example.yml docker-compose.override.yml
 docker compose run --rm backend setup
 docker compose run --rm frontend npm install
-docker compose up -d frontend
+docker compose up -d backend
 ```
 
 Optional: In case you want to develop on the OpenProject *BIM Edition* you need
@@ -133,19 +133,19 @@ docker compose run --rm frontend npm install
 The docker compose file also has the test containers defined. The easiest way to start only the development stack, use
 
 ```shell
-docker compose up frontend
+docker compose up backend
 ```
 
-If you want to see the backend logs, too.
+If you want to see the frontend logs, too.
 
 ```shell
-docker compose up frontend backend
+docker compose up backend frontend
 ```
 
 Alternatively, if you do want to detach from the process you can use the `-d` option.
 
 ```shell
-docker compose up -d frontend
+docker compose up -d backend
 ```
 
 The logs can still be accessed like this.
@@ -259,8 +259,8 @@ and `443` and redirect those requests to the specific container. To make it happ
 define for your services to your `/etc/hosts`.
 
 ```shell
-127.0.0.1   openproject.local traefik.local
-::1         openproject.local traefik.local
+127.0.0.1   openproject.local openproject-assets.local traefik.local
+::1         openproject.local openproject-assets.local traefik.local
 ```
 
 #### DNS? Where are you?


### PR DESCRIPTION
The latest upgrades to our frontend stack prohibited access through the openproject.local hostname and also caused trouble with the previous setup where the frontend stack would proxy requests to the backend.

Thus the default setup was now changed so that both frontend and backend are exposed to the browser via different hostnames. The main service to start will be the backend, which will redirect requests to certain assets to the frontend service (this was already integrated into the rails routes previously).