### PR TITLE
Add a `today` option for the today link instead of fixed date

### DIFF
--- a/modules/costs/app/components/my/time_tracking/sub_header_component.rb
+++ b/modules/costs/app/components/my/time_tracking/sub_header_component.rb
@@ -54,7 +54,7 @@ module My
       end
 
       def today_href
-        my_time_tracking_path(date: Date.current, view_mode:, mode:)
+        my_time_tracking_path(date: "today", view_mode:, mode:)
       end
 
       def previous_attrs # rubocop:disable Metrics/AbcSize

--- a/modules/costs/app/controllers/my/time_tracking_controller.rb
+++ b/modules/costs/app/controllers/my/time_tracking_controller.rb
@@ -81,10 +81,14 @@ module My
 
     def parsed_date
       if params[:date].present?
-        begin
-          Date.iso8601(params[:date])
-        rescue StandardError
-          nil
+        if params[:date] == "today"
+          current_date
+        else
+          begin
+            Date.iso8601(params[:date])
+          rescue StandardError
+            nil
+          end
         end
       end
     end

--- a/modules/costs/config/routes.rb
+++ b/modules/costs/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
         constraints: {
           mode: /day|week|workweek|month/,
           view_mode: /list|calendar/,
-          date: /\d{4}-\d{2}-\d{2}/
+          date: /(\d{4}-\d{2}-\d{2}|today)/
         }
     get "/time-tracking/refresh" => "time_tracking#refresh",
         as: :time_tracking_refresh


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/65966/activity

# What are you trying to accomplish?
Apparently, some people leave their browser window on the time tracking page open forever and then they expect the today link to still link to "today" and not the date, when they last interacted with the page.