### PR TITLE
Ensure we reload patches

### DIFF
--- a/config/initializers/10-load_patches.rb
+++ b/config/initializers/10-load_patches.rb
@@ -28,10 +28,11 @@
 
 Rails.application.reloader.to_prepare do
   # Do not place any patches within this file. Add a file to lib/open_project/patches
-  require "open_project/patches"
+  load File.expand_path("../../lib/open_project/patches.rb", __dir__)
 
-  # Whatever ruby file is placed in lib/open_project/patches is required
+  # Whatever ruby file is placed in lib/open_project/patches is loaded (not required)
+  # to ensure patches are re-applied on each reload
   Dir.glob(File.expand_path("../../lib/open_project/patches/*.rb", __dir__)).each do |path|
-    require path
+    load path
   end
 end


### PR DESCRIPTION
We `require` patch files despite being in a reloader, they are never reloaded as `require` runs once. this should fix the PageHeader reload causing the patch to vanish