### PR TITLE
[65547] Close mobile sidebar menu by outside click

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -136,7 +136,8 @@ See COPYRIGHT and LICENSE files for more details.
         </div>
       </div>
     <% end %>
-    <div class="content-overlay"></div>
+    <div class="content-overlay"
+         data-action="click->menus--main-toggle#toggleNavigation"></div>
     <%= content_tag :main, id: "content-wrapper", class: initial_classes, data: stimulus_content_data do %>
       <%= render partial: "layouts/flashes" %>
       <% if show_onboarding_modal? %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65547

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Close the sidebar menu when clicking on content overlay
