### PR TITLE
Refactoring: PDF export rename parameter

### DIFF
--- a/app/components/work_packages/exports/generate/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/generate/modal_dialog_component.html.erb
@@ -80,11 +80,11 @@
           }
         ) do
           render Primer::Alpha::TextField.new(
-            name: :footer_text_right,
-            label: I18n.t("pdf_generator.dialog.footer_right.label"),
-            caption: I18n.t("pdf_generator.dialog.footer_right.caption"),
+            name: :footer_text,
+            label: I18n.t("pdf_generator.dialog.footer_center.label"),
+            caption: I18n.t("pdf_generator.dialog.footer_center.caption"),
             visually_hide_label: false,
-            value: default_footer_text_right
+            value: default_footer_text
           )
         end
         modal_body.with_row(

--- a/app/components/work_packages/exports/generate/modal_dialog_component.rb
+++ b/app/components/work_packages/exports/generate/modal_dialog_component.rb
@@ -50,7 +50,7 @@ module WorkPackages
           work_package.subject
         end
 
-        def default_footer_text_right
+        def default_footer_text
           work_package.project.name
         end
 

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -120,7 +120,7 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
   end
 
   def footer_title
-    options[:footer_text_right]
+    options[:footer_text]
   end
 
   def title

--- a/modules/meeting/app/components/meetings/exports/modal_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/exports/modal_dialog_component.html.erb
@@ -69,12 +69,12 @@
         end
         modal_body.with_row(mt: 3) do
           render Primer::Alpha::TextField.new(
-            id: "pdf_footer_text_right",
-            name: :footer_text_right,
+            id: "pdf_footer_text",
+            name: :footer_text,
             label: I18n.t("meeting.export_pdf_dialog.footer_text.label"),
             caption: I18n.t("meeting.export_pdf_dialog.footer_text.caption"),
             visually_hide_label: false,
-            value: default_footer_text_right
+            value: default_footer_text
           )
         end
       end

--- a/modules/meeting/app/components/meetings/exports/modal_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/exports/modal_dialog_component.rb
@@ -44,7 +44,7 @@ module Meetings
         @project = project
       end
 
-      def default_footer_text_right
+      def default_footer_text
         @project.name
       end
     end

--- a/modules/meeting/app/workers/meetings/pdf/exporter.rb
+++ b/modules/meeting/app/workers/meetings/pdf/exporter.rb
@@ -138,7 +138,7 @@ module Meetings::PDF
     end
 
     def footer_title
-      options[:footer_text_right] || project_title
+      options[:footer_text] || project_title
     end
 
     def title_datetime

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -278,7 +278,7 @@ en:
         caption: If your agenda outcomes contain confidential information, you can choose to not include them in the export.
       footer_text:
         label: Footer text
-        caption: This text will appear on every page on the right of the footer.
+        caption: This text will appear on every page at the center of the footer.
       submit_button: Download
 
   meeting_section:

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_export_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_export_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Meetings Export PDF",
       attachments: "0",
       backlog: "0",
       outcomes: "0",
-      footer_text_right: project.name
+      footer_text: project.name
     }
   end
   let(:expected_params) do
@@ -124,11 +124,11 @@ RSpec.describe "Meetings Export PDF",
 
   context "with custom footer text" do
     let(:expected_params) do
-      default_expected_params.merge(footer_text_right: "Custom Footer Text")
+      default_expected_params.merge(footer_text: "Custom Footer Text")
     end
 
     it "can submit the export dialog with options" do
-      show_page.fill_in "pdf_footer_text_right", with: "Custom Footer Text"
+      show_page.fill_in "pdf_footer_text", with: "Custom Footer Text"
       generate!
     end
   end

--- a/modules/meeting/spec/workers/meetings/pdf/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/pdf/exporter_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Meetings::PDF::Exporter do
           outcomes: "1",
           backlog: "1",
           attachments: "1",
-          footer_text_right: "Custom Footer Text"
+          footer_text: "Custom Footer Text"
         }
       end
 

--- a/spec/features/work_packages/generate_pdf_spec.rb
+++ b/spec/features/work_packages/generate_pdf_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "work package generate PDF dialog", :js do
         hyphenation: "false",
         hyphenation_language: "en",
         template: "attributes",
-        footer_text_right: project.name,
+        footer_text: project.name,
         page_orientation: "portrait"
       }
     end
@@ -140,7 +140,7 @@ RSpec.describe "work package generate PDF dialog", :js do
   context "with hyphenation" do
     let(:expected_params) do
       {
-        footer_text_right: "Custom Footer Text",
+        footer_text: "Custom Footer Text",
         template: "attributes",
         hyphenation: "true",
         hyphenation_language: "de"
@@ -150,7 +150,7 @@ RSpec.describe "work package generate PDF dialog", :js do
     it "downloads with options" do
       check("Hyphenation")
       select "Deutsch", from: "hyphenation_language"
-      fill_in "footer_text_right", with: "Custom Footer Text"
+      fill_in "footer_text", with: "Custom Footer Text"
       generate!
     end
   end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   end
   let(:options) do
     {
-      footer_text_right: project.name
+      footer_text: project.name
     }
   end
   let(:exporter) do


### PR DESCRIPTION
The parameter was called footer_text_right, but the text is placed in the middle of the footer => rename to match.