### PR TITLE
Fix Stimulus UsersController missing target error

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/admin/users.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/users.controller.ts
@@ -18,6 +18,8 @@ export default class UsersController extends Controller {
 
   declare readonly authSourceFieldsTarget:HTMLElement;
 
+  declare readonly hasAuthSourceFieldsTarget:boolean;
+
   toggleAuthenticationFields(evt:{ target:HTMLSelectElement }):void {
     this.passwordAuthSelectedValue = evt.target.value === '';
   }
@@ -26,7 +28,9 @@ export default class UsersController extends Controller {
     if (this.hasPasswordFieldsTarget) {
       this.toggleHiddenAndDisabled(this.passwordFieldsTarget, !this.passwordAuthSelectedValue);
     }
-    this.toggleHiddenAndDisabled(this.authSourceFieldsTarget, this.passwordAuthSelectedValue);
+    if (this.hasAuthSourceFieldsTarget) {
+      this.toggleHiddenAndDisabled(this.authSourceFieldsTarget, this.passwordAuthSelectedValue);
+    }
   }
 
   private toggleHiddenAndDisabled(target:HTMLElement, hiddenAndDisabled:boolean) {


### PR DESCRIPTION
# Ticket

N/A

No ticket - spotted while debugging an unrelated issue.

# What are you trying to accomplish?

Handle the case where `authSourceFields` target is not defined, e.g. if `UsersHelper#can_users_have_auth_source? #=> false`.

## Screenshots

<img width="378" height="148" alt="Screenshot 2025-07-23 at 11 43 23" src="https://github.com/user-attachments/assets/fc3a6b15-b3cb-4d93-96af-d1407760583f" />

# What approach did you choose and why?


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
