### PR TITLE
Do not defer jQuery loading, remove `turbo:load` hacks

### DIFF
--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -49,6 +49,8 @@ module FrontendAssetHelper
   # or referencing the running CLI proxy that hosts the assets in memory.
   def include_frontend_assets
     capture do
+      concat nonced_javascript_include_tag variable_asset_path("jquery.js"), skip_pipeline: true
+
       %w(polyfills.js main.js).each do |file|
         concat nonced_javascript_include_tag variable_asset_path(file), skip_pipeline: true, type: "module"
       end

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -45,14 +45,12 @@ See COPYRIGHT and LICENSE files for more details.
                  { label: WikiPage.human_attribute_name(:parent_title), include_blank: false, container_class: "-wide" } %>
   </div>
 
-  <%= nonced_javascript_tag defer: true do -%>
-    window.addEventListener('turbo:load', () => {
-      jQuery(function() {
-          var parent_select = jQuery('#wiki_page_parent_id');
-          parent_select.attr('size', parent_select.children().length);
-        }
-      ));
-    });
+  <%= nonced_javascript_tag  do -%>
+    jQuery(function() {
+        var parent_select = jQuery('#wiki_page_parent_id');
+        parent_select.attr('size', parent_select.children().length);
+      }
+    ));
   <% end -%>
   <%= submit_tag t(:button_save), class: "button -primary" %>
 <% end %>

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -67,7 +67,13 @@
                 "src/assets/sass"
               ]
             },
-            "scripts": []
+            "scripts": [
+              {
+                "input": "node_modules/jquery/dist/jquery.min.js",
+                "inject": false,
+                "bundleName": "jquery"
+              }
+            ]
           },
           "configurations": {
             "production": {

--- a/modules/backlogs/app/views/rb_burndown_charts/_burndown.html.erb
+++ b/modules/backlogs/app/views/rb_burndown_charts/_burndown.html.erb
@@ -27,114 +27,112 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= nonced_javascript_tag defer: true do %>
-  window.addEventListener('turbo:load', () => {
-    jQuery(function ($) {
-      var Burndown = {
-        datasets: <%= dataseries(burndown).to_json.html_safe %> ,
-        previousPoint: null,
+<%= nonced_javascript_tag do %>
+  jQuery(function ($) {
+    var Burndown = {
+      datasets: <%= dataseries(burndown).to_json.html_safe %> ,
+      previousPoint: null,
 
-        setDatasetColor: function () {
-          var i = 0;
+      setDatasetColor: function () {
+        var i = 0;
 
-          $.each(Burndown.datasets, function (key, val) {
-            val.color = i;
-            val.points = {show: false, radius: 2};
-            val.lines = {show: true};
-            ++i;
+        $.each(Burndown.datasets, function (key, val) {
+          val.color = i;
+          val.points = {show: false, radius: 2};
+          val.lines = {show: true};
+          ++i;
+        });
+      },
+
+      plotAccordingToChoices: function () {
+        var data = [];
+
+        $('.burndown_control').find("input:checked").each(function () {
+          var key = $(this).attr('value');
+
+          if (key && Burndown.datasets[key]) {
+            data.push(Burndown.datasets[key]);
+          }
+        });
+
+        if (data.length === 0) { //in order to render an empty graph if no data is selected
+          data.push({data : []});
+        }
+
+        Burndown.plot(data);
+      },
+
+      plot: function (data) {
+        if (data.length > 0) {
+          $.plot($(".burndown_chart"), data, {
+            yaxis: { min: 0,
+              ticks: [ <%= yaxis_labels(burndown) %> ] },
+            xaxis: {
+              ticks: [ <%= xaxis_labels(burndown) %> ],
+              tickDecimals: 0,
+              max: <%= burndown.days.length + 1 %>,
+              min: 1
+            },
+            grid: { hoverable: true, clickable: true }
           });
-        },
+        }
+      },
 
-        plotAccordingToChoices: function () {
-          var data = [];
+      showTooltip: function(x, y, contents) {
+         $('<div id="tooltip">' + contents + '</div>').css( {
+             position: 'absolute',
+             display: 'none',
+             top: y + 5,
+             left: x + 5,
+             border: '1px solid #fdd',
+             padding: '2px',
+             'background-color': '#fee',
+             opacity: 0.80
+         }).appendTo("body").css('z-index', 2000).fadeIn(200);
+      },
 
-          $('.burndown_control').find("input:checked").each(function () {
-            var key = $(this).attr('value');
+      showTooltipOnHover: function (event, pos, item) {
 
-            if (key && Burndown.datasets[key]) {
-              data.push(Burndown.datasets[key]);
-            }
-          });
+        if (item) {
+          if (Burndown.previousPoint != item.dataIndex) {
+            Burndown.previousPoint = item.dataIndex;
 
-          if (data.length === 0) { //in order to render an empty graph if no data is selected
-            data.push({data : []});
-          }
-
-          Burndown.plot(data);
-        },
-
-        plot: function (data) {
-          if (data.length > 0) {
-            $.plot($(".burndown_chart"), data, {
-              yaxis: { min: 0,
-                ticks: [ <%= yaxis_labels(burndown) %> ] },
-              xaxis: {
-                ticks: [ <%= xaxis_labels(burndown) %> ],
-                tickDecimals: 0,
-                max: <%= burndown.days.length + 1 %>,
-                min: 1
-              },
-              grid: { hoverable: true, clickable: true }
-            });
-          }
-        },
-
-        showTooltip: function(x, y, contents) {
-          $('<div id="tooltip">' + contents + '</div>').css( {
-              position: 'absolute',
-              display: 'none',
-              top: y + 5,
-              left: x + 5,
-              border: '1px solid #fdd',
-              padding: '2px',
-              'background-color': '#fee',
-              opacity: 0.80
-          }).appendTo("body").css('z-index', 2000).fadeIn(200);
-        },
-
-        showTooltipOnHover: function (event, pos, item) {
-
-          if (item) {
-            if (Burndown.previousPoint != item.dataIndex) {
-              Burndown.previousPoint = item.dataIndex;
-
-              $("#tooltip").remove();
-              var x = item.datapoint[0].toFixed(0),
-                  y = item.datapoint[1].toFixed(0);
-
-              Burndown.showTooltip(item.pageX, item.pageY,
-                                  item.series.label + ": " + y);
-            }
-          }
-          else {
             $("#tooltip").remove();
-            Burndown.previousPoint = null;
-          }
-        },
+            var x = item.datapoint[0].toFixed(0),
+                y = item.datapoint[1].toFixed(0);
 
-        init: function () {
-          Burndown.setDatasetColor();
-
-          $('.burndown_control input').click(Burndown.plotAccordingToChoices);
-          $(".burndown_chart").bind("plothover", Burndown.showTooltipOnHover);
-
-          Burndown.plotAccordingToChoices();
-        },
-
-        saveInit: function() {
-          // Ensure $.plot is defined before progressing.
-          // This static page might already be ready but the webpack required
-          // jquery.flot.js file might not be loaded yet.
-
-          if ($.plot) {
-            this.init();
-          } else {
-            setTimeout(() => { this.saveInit()}, 50);
+            Burndown.showTooltip(item.pageX, item.pageY,
+                                 item.series.label + ": " + y);
           }
         }
-      };
+        else {
+          $("#tooltip").remove();
+          Burndown.previousPoint = null;
+        }
+      },
 
-      Burndown.saveInit();
-    });
+      init: function () {
+        Burndown.setDatasetColor();
+
+        $('.burndown_control input').click(Burndown.plotAccordingToChoices);
+        $(".burndown_chart").bind("plothover", Burndown.showTooltipOnHover);
+
+        Burndown.plotAccordingToChoices();
+      },
+
+      saveInit: function() {
+        // Ensure $.plot is defined before progressing.
+        // This static page might already be ready but the webpack required
+        // jquery.flot.js file might not be loaded yet.
+
+        if ($.plot) {
+          this.init();
+        } else {
+          setTimeout(() => { this.saveInit()}, 50);
+        }
+      }
+    };
+
+    Burndown.saveInit();
   });
 <% end %>

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/_form.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/_form.html.erb
@@ -53,102 +53,100 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% if OpenProject::Configuration.direct_uploads? %>
 
-<%= nonced_javascript_tag defer: true do %>
-  window.addEventListener('turbo:load', () => {
-    jQuery(document).ready(function() {
-      var setDirectUploadFileName = function () {
-        var fileNameField = jQuery('input[type=file]')
-        var fileName = '';
-        if (fileNameField.length > 0 && fileNameField[0].files && fileNameField[0].files[0]) {
-          fileName = fileNameField[0].files[0].name;
-        }
+<%= nonced_javascript_tag do %>
+  jQuery(document).ready(function() {
+    var setDirectUploadFileName = function () {
+      var fileNameField = jQuery('input[type=file]')
+      var fileName = '';
+      if (fileNameField.length > 0 && fileNameField[0].files && fileNameField[0].files[0]) {
+        fileName = fileNameField[0].files[0].name;
+      }
 
-        <%# Reset the form validity %>
-        <%# See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity %>
-        fileNameField[0].setCustomValidity('');
+      <%# Reset the form validity %>
+      <%# See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity %>
+      fileNameField[0].setCustomValidity('');
 
-        var titleField = jQuery("#bim_ifc_models_ifc_model_title");
+      var titleField = jQuery("#bim_ifc_models_ifc_model_title");
 
-        <%# When creating a new model, there is no titleField. %>
-        var titleFieldValue = '';
-        if (titleField.length > 0) {
-          titleFieldValue = jQuery("#bim_ifc_models_ifc_model_title").val();
-        };
-
-        var title = '';
-        if (titleFieldValue.length > 0) {
-          title = titleFieldValue;
-        } else {
-          title = fileName;
-        }
-
-        return jQuery.ajax({
-          type: "post",
-          url: "<%= set_direct_upload_file_name_bcf_project_ifc_models_path %>",
-          dataType: "json",
-          xhrFields: {
-            withCredentials: true
-          },
-          data: {
-            title: title,
-            isDefault: jQuery("#bim_ifc_models_ifc_model_is_default").is(":checked") ? 1 : 0,
-            filesize: fileNameField[0].files[0].size
-          },
-          statusCode: {
-            401: function(resp, status, error) {
-              document.location.reload(); // reload to make user login again
-            }
-          },
-          error: function(jqXHR, ajaxOptions, errorThrown) {
-            if (jqXHR.status == 422) {
-              var errorMessage = jqXHR.responseJSON.error;
-              fileNameField[0].setCustomValidity(errorMessage);
-              fileNameField[0].reportValidity();
-            }
-          }
-        });
+      <%# When creating a new model, there is no titleField. %>
+      var titleFieldValue = '';
+      if (titleField.length > 0) {
+        titleFieldValue = jQuery("#bim_ifc_models_ifc_model_title").val();
       };
-      jQuery("#bim_ifc_models_ifc_model_is_default").change(function(e){
-        setDirectUploadFileName();
-      });
-      jQuery("input[type=file]").change(function(e){
-        setDirectUploadFileName();
 
-        <%# rebuild form to post to S3 directly %>
-        if (jQuery("input[name=authenticity_token]").length === 1) {
-          jQuery("input[name=authenticity_token]").remove();
-          jQuery("input[name=_method]").remove();
+      var title = '';
+      if (titleFieldValue.length > 0) {
+        title = titleFieldValue;
+      } else {
+        title = fileName;
+      }
 
-          var url = jQuery("input[name=uri]").val();
-
-          jQuery("form").attr("action", url);
-          jQuery("form").attr("enctype", "multipart/form-data");
-
-          jQuery("input[name=uri]").remove();
-
-          jQuery("form").submit(function() {
-            jQuery("#bim_ifc_models_ifc_model_title").prop("disabled", "disabled");
-          });
+      return jQuery.ajax({
+        type: "post",
+        url: "<%= set_direct_upload_file_name_bcf_project_ifc_models_path %>",
+        dataType: "json",
+        xhrFields: {
+          withCredentials: true
+        },
+        data: {
+          title: title,
+          isDefault: jQuery("#bim_ifc_models_ifc_model_is_default").is(":checked") ? 1 : 0,
+          filesize: fileNameField[0].files[0].size
+        },
+        statusCode: {
+          401: function(resp, status, error) {
+            document.location.reload(); // reload to make user login again
+          }
+        },
+        error: function(jqXHR, ajaxOptions, errorThrown) {
+          if (jqXHR.status == 422) {
+            var errorMessage = jqXHR.responseJSON.error;
+            fileNameField[0].setCustomValidity(errorMessage);
+            fileNameField[0].reportValidity();
+          }
         }
       });
-      <% unless @ifc_model.new_record? %>
-        <%# The titleField might have changed AFTER selecting a file. Therefore,
-            we need to intercept form submits to first send the file name etc and
-            then submit.
-
-            Also, we need take care not to end up in a submit loop. So prevent it to
-            be submitted several times. %>
-        var submitted = false;
-        var form = jQuery("form#edit_bim_ifc_models_ifc_model_<%= @ifc_model.id %>")
-        form.submit((e) => {
-          if (submitted) { return };
-
-          e.preventDefault();
-          setDirectUploadFileName().always(() => form.submit());
-          submitted = true;
-        });
-      <% end %>
+    };
+    jQuery("#bim_ifc_models_ifc_model_is_default").change(function(e){
+      setDirectUploadFileName();
     });
+    jQuery("input[type=file]").change(function(e){
+      setDirectUploadFileName();
+
+      <%# rebuild form to post to S3 directly %>
+      if (jQuery("input[name=authenticity_token]").length === 1) {
+        jQuery("input[name=authenticity_token]").remove();
+        jQuery("input[name=_method]").remove();
+
+        var url = jQuery("input[name=uri]").val();
+
+        jQuery("form").attr("action", url);
+        jQuery("form").attr("enctype", "multipart/form-data");
+
+        jQuery("input[name=uri]").remove();
+
+        jQuery("form").submit(function() {
+          jQuery("#bim_ifc_models_ifc_model_title").prop("disabled", "disabled");
+        });
+      }
+    });
+    <% unless @ifc_model.new_record? %>
+      <%# The titleField might have changed AFTER selecting a file. Therefore,
+          we need to intercept form submits to first send the file name etc and
+          then submit.
+
+          Also, we need take care not to end up in a submit loop. So prevent it to
+          be submitted several times. %>
+      var submitted = false;
+      var form = jQuery("form#edit_bim_ifc_models_ifc_model_<%= @ifc_model.id %>")
+      form.submit((e) => {
+        if (submitted) { return };
+
+        e.preventDefault();
+        setDirectUploadFileName().always(() => form.submit());
+        submitted = true;
+      });
+    <% end %>
   });
 <% end %>
 

--- a/modules/documents/app/views/documents/index.html.erb
+++ b/modules/documents/app/views/documents/index.html.erb
@@ -93,12 +93,10 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 <% end %>
 
-<%= nonced_javascript_tag defer: true do %>
-  window.addEventListener('turbo:load', () => {
-    jQuery(function($) {
-      $('.submit-this-form').click(function() {
-        $(this).closest('form').submit();
-      });
+<%= nonced_javascript_tag do %>
+  jQuery(function($) {
+    $('.submit-this-form').click(function() {
+      $(this).closest('form').submit();
     });
   });
 <% end %>


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

This PR removes jQuery loading deferrals and eliminates turbo:load event listeners from the codebase. The changes simplify JavaScript initialization by allowing jQuery to load synchronously and removing the need to wrap code in Turbo event handlers.

- Removes `defer: true` from `nonced_javascript_tag` calls across multiple view files
- Eliminates `window.addEventListener('turbo:load', ...)` wrappers around jQuery initialization code - **EXCEPT in `base.html.erb` where we also rely on `window.OpenProject` being defined.**
- Configures Angular build to include jQuery as a separate bundle and includes it directly in the frontend asset helper.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
