### PR TITLE
[64181] Add SharePoint storage contract

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/share_point/share_point_contract.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/share_point_contract.rb
@@ -32,15 +32,22 @@ module Storages
   module Adapters
     module Providers
       module SharePoint
-        SharePointRegistry = Dry::Container::Namespace.new("share_point") do
-          namespace("authentication") do
-            register(:userless, ->(use_cache = true) { Input::Strategy.build(key: :oauth_client_credentials, use_cache:) })
-            register(:user_bound, ->(user, storage = nil) { Input::Strategy.build(key: :oauth_user_token, user:, storage:) })
-          end
+        class SharePointContract < ::ModelContract
+          attribute :name
+          validates :name, presence: true, length: { maximum: 255 }
 
-          namespace("contracts") do
-            register(:storage, SharePointContract)
-          end
+          attribute :host
+          validates :host, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
+
+          attribute :site_id
+          validates :site_id,
+                    presence: true,
+                    format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
+
+          attribute :library_id
+          validates :library_id,
+                    presence: true,
+                    format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/share_point_contract.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/share_point_contract.rb
@@ -38,16 +38,12 @@ module Storages
 
           attribute :host
           validates :host, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
+          validates :host,
+                    format: { with: %r{\Ahttps://[^/]+/sites/[^/]+(/.*)?\z}i,
+                              message: I18n.t("activerecord.errors.messages.invalid_sharepoint_url") }
 
           attribute :site_id
-          validates :site_id,
-                    presence: true,
-                    format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
-
           attribute :library_id
-          validates :library_id,
-                    presence: true,
-                    format: { with: /\A(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|consumers)\z/i }
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/share_point_contract.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/share_point_contract.rb
@@ -41,9 +41,6 @@ module Storages
           validates :host,
                     format: { with: %r{\Ahttps://[^/]+/sites/[^/]+(/.*)?\z}i,
                               message: I18n.t("activerecord.errors.messages.invalid_sharepoint_url") }
-
-          attribute :site_id
-          attribute :library_id
         end
       end
     end

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -30,7 +30,8 @@
 
 module Storages
   class SharePointStorage < Storage
-    store_attribute :provider_fields, :tenant_id, :string
+    store_attribute :provider_fields, :site_id, :string
+    store_attribute :provider_fields, :library_id, :string
 
     def self.visible? = false
 

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -30,7 +30,7 @@
 
 module Storages
   class SharePointStorage < Storage
-    def self.visible? = false
+    def self.visible? = true
 
     def self.short_provider_name = :share_point
     def audience = nil

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -30,9 +30,6 @@
 
 module Storages
   class SharePointStorage < Storage
-    store_attribute :provider_fields, :site_id, :string
-    store_attribute :provider_fields, :library_id, :string
-
     def self.visible? = false
 
     def self.short_provider_name = :share_point

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -30,7 +30,11 @@
 
 module Storages
   class SharePointStorage < Storage
-    def self.visible? = true
+    # For now SharePoint is visible only in tests.
+    # This is to prevent it from being shown in the UI, as it is not ready yet.
+    def self.visible?
+      Rails.env.test?
+    end
 
     def self.short_provider_name = :share_point
     def audience = nil

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -34,10 +34,11 @@ en:
         site: "Site ID"
         library: "Library ID"
         name: "Name"
-        host: "Host"
+        host: "Sharepoint Site URL"
     errors:
       messages:
         invalid_host_url: is not a valid URL.
+        invalid_sharepoint_url: is not a valid SharePoint site, library, or document URL.
         not_linked_to_project: is not linked to project.
       models:
         storages/file_link:

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -22,6 +22,11 @@ en:
         project_folder_mode: Project folder mode
         storage: Storage
         storage_url: Storage URL
+      storages/share_point_storage:
+        host: Sharepoint Site URL
+        library: Library ID
+        name: Name
+        site: Site ID
       storages/storage:
         authentication_method: Authentication Method
         creator: Creator
@@ -30,11 +35,6 @@ en:
         name: Name
         provider_type: Provider type
         tenant: Directory (tenant) ID
-      storages/share_point_storage:
-        site: "Site ID"
-        library: "Library ID"
-        name: "Name"
-        host: "Sharepoint Site URL"
     errors:
       messages:
         invalid_host_url: is not a valid URL.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -30,6 +30,11 @@ en:
         name: Name
         provider_type: Provider type
         tenant: Directory (tenant) ID
+      storages/share_point_storage:
+        site: "Site ID"
+        library: "Library ID"
+        name: "Name"
+        host: "Host"
     errors:
       messages:
         invalid_host_url: is not a valid URL.

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+module Storages
+  module Adapters
+    module Providers
+      module SharePoint
+        RSpec.describe SharePointContract, :storage_server_helpers, :webmock do
+          let(:current_user) { create(:admin) }
+          let(:storage) { build(:share_point_storage, host: "https://openproject.sharepoint.com ") }
+
+          # As the SharePointContract is selected by the BaseContract to make writable attributes available,
+          # the BaseContract needs to be instantiated here.
+          subject(:contract) { Storages::BaseContract.new(storage, current_user) }
+
+          it "is valid with all required attributes" do
+            expect(subject).to be_valid
+          end
+
+          context "with missing name" do
+            before do
+              storage.name = nil
+            end
+
+            it "is not valid" do
+              expect(subject).not_to be_valid
+              expect(subject.errors[:name]).to be_present
+            end
+          end
+
+          describe "host" do
+            context "with valid host" do
+              before do
+                storage.host = "https://exmaple.com/"
+              end
+
+              it "must be valid" do
+                expect(contract).to be_valid
+              end
+            end
+
+            context "with invalid host" do
+              before do
+                storage.host = "not-a-url"
+              end
+
+              it "is not valid" do
+                expect(subject).not_to be_valid
+                expect(subject.errors[:host]).to be_present
+              end
+            end
+          end
+
+          context "with missing site_id" do
+            before do
+              storage.site_id = nil
+            end
+
+            it "is not valid" do
+              expect(subject).not_to be_valid
+              expect(subject.errors[:site_id]).to be_present
+            end
+          end
+
+          context "with invalid site_id" do
+            before do
+              storage.site_id = "not-a-guid"
+            end
+
+            it "is not valid" do
+              expect(subject).not_to be_valid
+              expect(subject.errors[:site_id]).to be_present
+            end
+          end
+
+          context "with missing library_id" do
+            before do
+              storage.library_id = nil
+            end
+
+            it "is not valid" do
+              expect(subject).not_to be_valid
+              expect(subject.errors[:library_id]).to be_present
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
@@ -37,7 +37,7 @@ module Storages
       module SharePoint
         RSpec.describe SharePointContract, :storage_server_helpers, :webmock do
           let(:current_user) { create(:admin) }
-          let(:storage) { build(:share_point_storage, host: "https://openproject.sharepoint.com") }
+          let(:storage) { build(:share_point_storage) }
 
           # Ensure that the SharePointStorage is visible for the contract tests
           # but not to show it on the UI
@@ -63,58 +63,42 @@ module Storages
           end
 
           describe "host" do
-            context "with valid host" do
-              before do
-                storage.host = "https://exmaple.com/"
-              end
-
-              it "must be valid" do
+            context "with valid SharePoint site url" do
+              it "is valid" do
                 expect(contract).to be_valid
               end
             end
 
-            context "with invalid host" do
+            context "with valid SharePoint library url" do
+              before do
+                storage.host = "https://openproject.sharepoint.com/sites/ProjectX/Documents/Report.rdl"
+              end
+
+              it "is valid" do
+                expect(contract).to be_valid
+              end
+            end
+
+            context "with invalid url" do
               before do
                 storage.host = "not-a-url"
               end
 
               it "is not valid" do
                 expect(subject).not_to be_valid
-                expect(subject.errors[:host]).to be_present
+                expect(subject.errors[:host]).to include("is invalid.")
               end
             end
-          end
 
-          context "with missing site_id" do
-            before do
-              storage.site_id = nil
-            end
+            context "with invalid sharepoint structure" do
+              before do
+                storage.host = "https://openproject.sharepoint.com/invalidpath"
+              end
 
-            it "is not valid" do
-              expect(subject).not_to be_valid
-              expect(subject.errors[:site_id]).to be_present
-            end
-          end
-
-          context "with invalid site_id" do
-            before do
-              storage.site_id = "not-a-guid"
-            end
-
-            it "is not valid" do
-              expect(subject).not_to be_valid
-              expect(subject.errors[:site_id]).to be_present
-            end
-          end
-
-          context "with missing library_id" do
-            before do
-              storage.library_id = nil
-            end
-
-            it "is not valid" do
-              expect(subject).not_to be_valid
-              expect(subject.errors[:library_id]).to be_present
+              it "is not valid" do
+                expect(subject).not_to be_valid
+                expect(subject.errors[:host]).to include("is not a valid SharePoint site, library, or document URL.")
+              end
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
@@ -37,7 +37,11 @@ module Storages
       module SharePoint
         RSpec.describe SharePointContract, :storage_server_helpers, :webmock do
           let(:current_user) { create(:admin) }
-          let(:storage) { build(:share_point_storage, host: "https://openproject.sharepoint.com ") }
+          let(:storage) { build(:share_point_storage, host: "https://openproject.sharepoint.com") }
+
+          # Ensure that the SharePointStorage is visible for the contract tests
+          # but not to show it on the UI
+          before { allow(::Storages::SharePointStorage).to receive(:visible?).and_return(true) }
 
           # As the SharePointContract is selected by the BaseContract to make writable attributes available,
           # the BaseContract needs to be instantiated here.

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
@@ -39,10 +39,6 @@ module Storages
           let(:current_user) { create(:admin) }
           let(:storage) { build(:share_point_storage) }
 
-          # Ensure that the SharePointStorage is visible for the contract tests
-          # but not to show it on the UI
-          before { allow(::Storages::SharePointStorage).to receive(:visible?).and_return(true) }
-
           # As the SharePointContract is selected by the BaseContract to make writable attributes available,
           # the BaseContract needs to be instantiated here.
           subject(:contract) { Storages::BaseContract.new(storage, current_user) }

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
@@ -37,7 +37,7 @@ module Storages
       module SharePoint
         RSpec.describe SharePointContract, :storage_server_helpers, :webmock do
           let(:current_user) { create(:admin) }
-          let(:storage) { build(:share_point_storage, provider_type: "Storages::SharePointStorage") }
+          let(:storage) { build(:share_point_storage) }
 
           # Ensure that the SharePointStorage is visible for the contract tests
           # but not to show it on the UI

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/share_point_contract_spec.rb
@@ -37,7 +37,7 @@ module Storages
       module SharePoint
         RSpec.describe SharePointContract, :storage_server_helpers, :webmock do
           let(:current_user) { create(:admin) }
-          let(:storage) { build(:share_point_storage) }
+          let(:storage) { build(:share_point_storage, provider_type: "Storages::SharePointStorage") }
 
           # Ensure that the SharePointStorage is visible for the contract tests
           # but not to show it on the UI

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -223,4 +223,21 @@ FactoryBot.define do
              token_type: "bearer")
     end
   end
+
+  factory :share_point_storage,
+          parent: :storage,
+          class: "::Storages::SharePointStorage" do
+    host { nil }
+    site_id { SecureRandom.uuid }
+    library_id { SecureRandom.uuid }
+    automatically_managed { false }
+
+    trait :as_automatically_managed do
+      automatically_managed { true }
+    end
+
+    trait :with_tenant_id do
+      tenant_id { SecureRandom.uuid }
+    end
+  end
 end

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -228,8 +228,6 @@ FactoryBot.define do
           parent: :storage,
           class: "::Storages::SharePointStorage" do
     host { "https://openproject.sharepoint.com/sites/ProjectX" }
-    site_id { SecureRandom.uuid }
-    library_id { SecureRandom.uuid }
     automatically_managed { false }
 
     trait :as_automatically_managed do

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -227,7 +227,7 @@ FactoryBot.define do
   factory :share_point_storage,
           parent: :storage,
           class: "::Storages::SharePointStorage" do
-    host { nil }
+    host { "https://openproject.sharepoint.com/sites/ProjectX" }
     site_id { SecureRandom.uuid }
     library_id { SecureRandom.uuid }
     automatically_managed { false }


### PR DESCRIPTION
# Ticket
[64181](https://community.openproject.org/work_packages/64181)

# What are you trying to accomplish?
Introduces `SharePointContract` for validating SharePoint storage attributes and registers it in the SharePoint registry. Updates `SharePointStorage` to store `site_id` and `library_id`, adds relevant translations, and provides factory and spec for SharePoint storage contract validation.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
