### PR TITLE
Bump ng2-charts to ^8.0.0

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -26,11 +26,9 @@
               "jquery",
               "contra/emitter",
               "crossvent",
-              "chart.js",
               "create-point-cb",
               "core-vendor/enjoyhint",
-              "tablesorter",
-              "chartjs-plugin-datalabels"
+              "tablesorter"
             ],
             "preserveSymlinks": true,
             "outputPath": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,7 @@
         "@xeokit/xeokit-bim-viewer": "2.5.1-beta-28",
         "autoprefixer": "^10.4.19",
         "byte-base64": "^1.1.0",
-        "chart.js": "4.3.0",
+        "chart.js": "4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
         "codemirror": "^5.62.0",
         "copy-text-to-clipboard": "^3.0.0",
@@ -10635,14 +10635,15 @@
       "license": "MIT"
     },
     "node_modules/chart.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.0.tgz",
-      "integrity": "sha512-ynG0E79xGfMaV2xAHdbhwiPLczxnNNnasrmPEXriXsPJGjmhOBYzFVEsB65w2qMDz+CaBJJuJD0inE/ab/h36g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
-        "pnpm": ">=7"
+        "pnpm": ">=8"
       }
     },
     "node_modules/chartjs-plugin-datalabels": {
@@ -33212,9 +33213,9 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chart.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.0.tgz",
-      "integrity": "sha512-ynG0E79xGfMaV2xAHdbhwiPLczxnNNnasrmPEXriXsPJGjmhOBYzFVEsB65w2qMDz+CaBJJuJD0inE/ab/h36g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "requires": {
         "@kurkle/color": "^0.3.0"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -97,7 +97,7 @@
         "moment-timezone": "^0.5.45",
         "mousetrap": "~1.6.3",
         "ng-dynamic-component": "^10.7.0",
-        "ng2-charts": "^4.1.1",
+        "ng2-charts": "^8.0.0",
         "ng2-dragula": "^5.1.0",
         "ngx-cookie-service": "^20.0.1",
         "observable-array": "0.0.4",
@@ -19391,17 +19391,19 @@
       }
     },
     "node_modules/ng2-charts": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-4.1.1.tgz",
-      "integrity": "sha512-iHwXDbmX86lfeH8VRcsaW2tJATsuAZo4kvvC/Yk2l35zOHjevja1qBvO6BAibiDazi9r9aS6ZRJOqWPsz1pP2w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-8.0.0.tgz",
+      "integrity": "sha512-nofsNHI2Zt+EAwT+BJBVg0kgOhNo9ukO4CxULlaIi7VwZSr7I1km38kWSoU41Oq6os6qqIh5srnL+CcV+RFPFA==",
+      "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.15",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": ">=14.0.0",
-        "@angular/common": ">=14.0.0",
-        "@angular/core": ">=14.0.0",
+        "@angular/cdk": ">=19.0.0",
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "@angular/platform-browser": ">=19.0.0",
         "chart.js": "^3.4.0 || ^4.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
@@ -39457,9 +39459,9 @@
       }
     },
     "ng2-charts": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-4.1.1.tgz",
-      "integrity": "sha512-iHwXDbmX86lfeH8VRcsaW2tJATsuAZo4kvvC/Yk2l35zOHjevja1qBvO6BAibiDazi9r9aS6ZRJOqWPsz1pP2w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-8.0.0.tgz",
+      "integrity": "sha512-nofsNHI2Zt+EAwT+BJBVg0kgOhNo9ukO4CxULlaIi7VwZSr7I1km38kWSoU41Oq6os6qqIh5srnL+CcV+RFPFA==",
       "requires": {
         "lodash-es": "^4.17.15",
         "tslib": "^2.3.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -153,7 +153,7 @@
     "moment-timezone": "^0.5.45",
     "mousetrap": "~1.6.3",
     "ng-dynamic-component": "^10.7.0",
-    "ng2-charts": "^4.1.1",
+    "ng2-charts": "^8.0.0",
     "ng2-dragula": "^5.1.0",
     "ngx-cookie-service": "^20.0.1",
     "observable-array": "0.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,7 +125,7 @@
     "@xeokit/xeokit-bim-viewer": "2.5.1-beta-28",
     "autoprefixer": "^10.4.19",
     "byte-base64": "^1.1.0",
-    "chart.js": "4.3.0",
+    "chart.js": "4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",
     "codemirror": "^5.62.0",
     "copy-text-to-clipboard": "^3.0.0",

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -64,18 +64,7 @@ export class WorkPackageEmbeddedGraphComponent {
     }
   }
 
-  private getHexColor(index:number):string {
-    const tealColor= getComputedStyle(document.body).getPropertyValue('--data-teal-color-emphasis');
-    const orangeFont1Color= getComputedStyle(document.body).getPropertyValue('--data-orange-color-emphasis');
-    const hexColors = [
-      tealColor,
-      orangeFont1Color,
-    ];
-    return hexColors[index % hexColors.length];
-  }
-
   private updateChartData() {
-    const borderColor= getComputedStyle(document.body).getPropertyValue('--borderColor-muted');
     let uniqLabels = _.uniq(this.datasets.reduce((array, dataset) => {
       const groups = (dataset.groups || []).map((group) => group.value) as any;
       return array.concat(groups);
@@ -90,10 +79,6 @@ export class WorkPackageEmbeddedGraphComponent {
       return {
         label: dataset.label,
         data: uniqLabels.map((label) => countMap[label] || 0),
-        borderColor,
-        backgroundColor: this.chartType === 'bar' || this.chartType === 'horizontalBar'
-          ? uniqLabels.map((_, i) => this.getHexColor(i))
-          : undefined,
       };
     });
 

--- a/frontend/src/app/shared/components/work-package-graphs/openproject-work-package-graphs.module.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/openproject-work-package-graphs.module.ts
@@ -37,9 +37,9 @@ import { WpGraphConfigurationFiltersTabInnerComponent } from 'core-app/shared/co
 import { WpGraphConfigurationSettingsTabInnerComponent } from 'core-app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab-inner.component';
 import { WorkPackageEmbeddedGraphComponent } from 'core-app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component';
 import { WorkPackageOverviewGraphComponent } from 'core-app/shared/components/work-package-graphs/overview/wp-overview-graph.component';
-import * as ChartDataLabels from 'chartjs-plugin-datalabels';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
-import { NgChartsModule } from 'ng2-charts';
+import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 @NgModule({
   imports: [
@@ -49,7 +49,7 @@ import { NgChartsModule } from 'ng2-charts';
 
     OpenprojectWorkPackagesModule,
 
-    NgChartsModule,
+    BaseChartDirective,
     OpenprojectTabsModule,
   ],
   declarations: [
@@ -74,16 +74,8 @@ import { NgChartsModule } from 'ng2-charts';
     WorkPackageEmbeddedGraphComponent,
     WorkPackageOverviewGraphComponent,
   ],
+  providers: [
+    provideCharts(withDefaultRegisterables(ChartDataLabels)),
+  ],
 })
-export class OpenprojectWorkPackageGraphsModule {
-  constructor() {
-    // By this seemingly useless statement, the plugin is registered with Chart.
-    // Simply importing it will have it removed probably by angular tree shaking
-    // so it will not be active. The current default of the plugin is to be enabled
-    // by default. This will be changed in the future:
-    // https://github.com/chartjs/chartjs-plugin-datalabels/issues/42
-    //
-    // eslint-ignore-next-line @typescript-eslint/no-unused-expressions
-    ChartDataLabels;
-  }
-}
+export class OpenprojectWorkPackageGraphsModule {} // eslint-disable-line @typescript-eslint/no-extraneous-class


### PR DESCRIPTION
- **Bump ng2-charts to ^8.0.0**
- **Update imports**
- Revert A11y-related Chart colour changes (89135ae36c25c8887f23505719843a35215e4280, #19608)

⚠️ **ng2-charts 8.0.0** is the [version compatible with the nearest Angular version to ours](https://github.com/valor-software/ng2-charts?tab=readme-ov-file#angular-version-compatibility-table), Angular 19.
