### PR TITLE
Bump ngx-cookie-service to ^20.0.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -95,7 +95,7 @@
         "ng-dynamic-component": "^10.7.0",
         "ng2-charts": "^4.1.1",
         "ng2-dragula": "^5.1.0",
-        "ngx-cookie-service": "^14.0.0",
+        "ngx-cookie-service": "^20.0.1",
         "observable-array": "0.0.4",
         "op-blocknote-extensions": "github:opf/op-blocknote-extensions",
         "pako": "^2.0.3",
@@ -19472,15 +19472,16 @@
       }
     },
     "node_modules/ngx-cookie-service": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-14.0.1.tgz",
-      "integrity": "sha512-PHjpA/bpp1ZgvQ2AWdXA6oxPQgE9k0WljQ7tvUH/u0Acl6p6akzF8kWlQiWxkgR3hBs7xB3paIsTk6GKdtakMg==",
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-20.0.1.tgz",
+      "integrity": "sha512-XTPrW/5ihI3DvTljDj14E501fouHdiONCnd1SPhvqyHNHjvKECFWuTzOpcHrWl9X1ZOKfOG/uXW8G8fINcL9fQ==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.8.0"
       },
       "peerDependencies": {
-        "@angular/common": "^14.0.0",
-        "@angular/core": "^14.0.0"
+        "@angular/common": "^20.0.0",
+        "@angular/core": "^20.0.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -39514,11 +39515,11 @@
       }
     },
     "ngx-cookie-service": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-14.0.1.tgz",
-      "integrity": "sha512-PHjpA/bpp1ZgvQ2AWdXA6oxPQgE9k0WljQ7tvUH/u0Acl6p6akzF8kWlQiWxkgR3hBs7xB3paIsTk6GKdtakMg==",
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-20.0.1.tgz",
+      "integrity": "sha512-XTPrW/5ihI3DvTljDj14E501fouHdiONCnd1SPhvqyHNHjvKECFWuTzOpcHrWl9X1ZOKfOG/uXW8G8fINcL9fQ==",
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.8.0"
       }
     },
     "node-addon-api": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -149,7 +149,7 @@
     "ng-dynamic-component": "^10.7.0",
     "ng2-charts": "^4.1.1",
     "ng2-dragula": "^5.1.0",
-    "ngx-cookie-service": "^14.0.0",
+    "ngx-cookie-service": "^20.0.1",
     "observable-array": "0.0.4",
     "op-blocknote-extensions": "github:opf/op-blocknote-extensions",
     "pako": "^2.0.3",


### PR DESCRIPTION
⚠️ **ng2-charts 20.0.1** is the [version compatible with the nearest Angular version to ours](https://github.com/stevermeister/ngx-cookie-service?tab=readme-ov-file#supported-versions), Angular 19.
