### PR TITLE
[#64885] Replace existing Project deletion confirmation page with Danger Dialog

### DIFF
--- a/app/components/projects/delete_dialog_component.html.erb
+++ b/app/components/projects/delete_dialog_component.html.erb
@@ -1,0 +1,64 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(
+    Primer::OpenProject::DangerDialog.new(
+      id:,
+      title: t(:"project.destroy.title", name: @project),
+      form_arguments: {
+        action: project_path(@project),
+        method: :delete,
+        data: { turbo: false }
+      }
+    )
+  ) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { t(:"project.destroy.heading", name: @project) }
+      message.with_description do
+        t("project.destroy.info")
+      end
+    end
+    dialog.with_confirmation_check_box_content(I18n.t(:text_permanent_delete_confirmation_checkbox_label))
+    dialog.with_additional_details(display: :block) do
+%>
+    <p><%= t("project.destroy.confirmation", identifier: @project.identifier) %></p>
+    <ul class="mb-3">
+      <li><%= t("project.destroy.project_delete_result_1") %></li>
+      <% if has_managed_project_folders? %>
+        <li><%= t("project.destroy.project_delete_result_2") %></li>
+      <% end %>
+    </ul>
+    <% if subproject_names.any? %>
+      <%= t("project.destroy.subprojects_confirmation", value: subproject_names.to_sentence) %>
+    <% end %>
+<%
+    end
+  end
+%>

--- a/app/components/projects/settings/index_page_header_component.html.erb
+++ b/app/components/projects/settings/index_page_header_component.html.erb
@@ -109,7 +109,7 @@
           label: t(:button_delete),
           href: confirm_destroy_project_path(@project),
           content_arguments: {
-            data: { turbo: false },
+            data: { turbo_stream: true },
             test_selector: "project-settings--delete"
           }
         ) do |item|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -55,8 +55,6 @@ class ProjectsController < ApplicationController
   include ProjectsHelper
   include Queries::Loading
 
-  helper_method :has_managed_project_folders?
-
   current_menu_item :index do
     :projects
   end
@@ -150,8 +148,8 @@ class ProjectsController < ApplicationController
   # Delete @project
   def destroy
     service_call = ::Projects::ScheduleDeletionService
-                     .new(user: current_user, model: @project)
-                     .call
+                    .new(user: current_user, model: @project)
+                    .call
 
     if service_call.success?
       flash[:notice] = I18n.t("projects.delete.scheduled")
@@ -159,13 +157,11 @@ class ProjectsController < ApplicationController
       flash[:error] = I18n.t("projects.delete.schedule_failed", errors: service_call.errors.full_messages.join("\n"))
     end
 
-    redirect_to projects_path
+    redirect_to projects_path, status: :see_other
   end
 
   def destroy_info
-    @project_to_destroy = @project
-
-    hide_project_in_layout
+    respond_with_dialog Projects::DeleteDialogComponent.new(project: @project)
   end
 
   def deactivate_work_package_attachments
@@ -246,14 +242,6 @@ class ProjectsController < ApplicationController
 
   def find_optional_parent
     @parent = Project.visible(current_user).find(params[:parent_id]) if params[:parent_id].present?
-  end
-
-  def has_managed_project_folders?(project)
-    project.project_storages.any?(&:project_folder_automatic?)
-  end
-
-  def hide_project_in_layout
-    @project = nil
   end
 
   def export_list(query, mime_type)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3892,13 +3892,13 @@ en:
       one: "1 project"
       other: "%{count} projects"
     destroy:
-      confirmation: "If you continue, the project %{identifier} will be permanently destroyed. To confirm this action please introduce the project name in the field below, this will:"
+      confirmation: "If you continue, the project %{identifier} will be permanently destroyed. You will:"
       project_delete_result_1: "Delete all related data."
       project_delete_result_2: "Delete all managed project folders in the attached storages."
-      info: "Deleting the project is an irreversible action."
-      project_verification: "Enter the project's name %{name} to verify the deletion."
+      info: "Deleting the project is an irreversible action. Please proceed with caution."
       subprojects_confirmation: "Its subproject(s): %{value} will also be deleted."
-      title: "Delete the project %{name}"
+      title: "Delete project %{name}"
+      heading: "Permanently delete project %{name}?"
     filters:
       project_phase: "Project phase: %{phase}"
       project_phase_any: "Project phase: Any"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -391,9 +391,9 @@ RSpec.describe ProjectsController do
     let(:project) { create(:project, identifier: "blog") }
 
     it "gets destroy info" do
-      get :destroy_info, params: { id: project.id }
+      get :destroy_info, params: { id: project.id }, format: :turbo_stream
       expect(response).to be_successful
-      expect(response).to render_template "destroy_info"
+      expect(response).to have_turbo_stream action: "dialog", target: "projects-delete-dialog-component"
 
       expect { project.reload }.not_to raise_error
     end

--- a/spec/support/pages/projects/settings/general.rb
+++ b/spec/support/pages/projects/settings/general.rb
@@ -48,7 +48,12 @@ module Pages
 
         def click_copy_action
           page.find_test_selector("project-settings-more-menu").click
-          page.find_test_selector("project-settings--copy").click
+          page.find(:menuitem, "Copy").click # TODO: scope to More menu
+        end
+
+        def click_delete_action
+          page.find_test_selector("project-settings-more-menu").click
+          page.find(:menuitem, "Delete").click # TODO: scope to More menu
         end
 
         def expect_field_label_with_help_text(label_text)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64885

## Screenshots

<img width="501" height="342" alt="Screenshot 2025-07-27 at 16 25 38" src="https://github.com/user-attachments/assets/1027cb49-6519-4b5e-a08b-e5560922b750" />

<img width="496" height="334" alt="Screenshot 2025-07-27 at 16 25 45" src="https://github.com/user-attachments/assets/55c2bbac-1443-4df0-9cef-d88b5e29070f" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
