### PR TITLE
Fix running `ng serve` (alt): Set allowed hosts via environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - db
       - cache
       - frontend
+    ports:
+      - "${PORT:-3000}:3000"
 
   worker:
     <<: *backend
@@ -84,6 +86,10 @@ services:
       - "${CKEDITOR_BUILD_DIR:-./frontend/src/vendor/ckeditor/}:/home/dev/openproject/frontend/src/vendor/ckeditor/"
     networks:
       - network
+    environment:
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: "openproject-assets.local"
+    ports:
+      - "${FE_PORT:-4200}:4200"
 
   db:
     image: postgres:17

--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -28,8 +28,6 @@ services:
       # Mac OS
       # - ~/.step/certs:/etc/ssl/certs
       # - ~/.step/certs:/usr/local/share/ca-certificates
-    ports:
-      - "${PORT:-3000}:3000"
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.openproject.rule=Host(`openproject.local`)"
@@ -59,12 +57,8 @@ services:
       # - ~/.step/certs:/usr/local/share/ca-certificates
 
   frontend:
-    environment:
-      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: "openproject-assets.local"
     networks:
       - external
-    ports:
-      - "${FE_PORT:-4200}:4200"
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.openproject-assets.rule=Host(`openproject-assets.local`)"

--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -28,6 +28,8 @@ services:
       # Mac OS
       # - ~/.step/certs:/etc/ssl/certs
       # - ~/.step/certs:/usr/local/share/ca-certificates
+    ports:
+      - "${PORT:-3000}:3000"
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.openproject.rule=Host(`openproject.local`)"
@@ -61,6 +63,8 @@ services:
       __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: "openproject-assets.local"
     networks:
       - external
+    ports:
+      - "${FE_PORT:-4200}:4200"
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.openproject-assets.rule=Host(`openproject-assets.local`)"

--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -57,6 +57,8 @@ services:
       # - ~/.step/certs:/usr/local/share/ca-certificates
 
   frontend:
+    environment:
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: "openproject-assets.local"
     networks:
       - external
     labels:

--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -213,7 +213,7 @@ or for running a particular test
 docker compose exec backend-test bundle exec rspec path/to/some_spec.rb
 ```
 
-Tests are ran within Selenium containers, on a small local Selenium grid. You can connect to the containers via VNC if
+Tests are run within Selenium containers, on a small local Selenium grid. You can connect to the containers via VNC if
 you want to see what the browsers are doing. `gvncviewer` or `vinagre` on Linux is a good tool for this. Set any port in
 the `docker-compose.override.yml` to access a container of a specific browser. As a default, the `chrome` container is
 exposed on port 5900. The password is `secret` for all.

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -114,7 +114,6 @@
             "development": {
               "buildTarget": "OpenProject:build:development",
               "proxyConfig": "src/proxy.conf.mjs",
-              "allowedHosts": ["openproject-assets.local"],
               "headers": {
                 "Access-Control-Allow-Origin": "*"
               }


### PR DESCRIPTION
**⚠️ ~~Developers will need to manually updated their `docker-compose.override.yml` on merging this PR~~** edit: not anymore

Vite now supports specifying allowed hosts as an `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS`.

Alternative fix to #19687 / a1555af4773510da7644f1ea1a3e5357d42853a2: Only overrides allowed hosts in the development environments that need it (i.e. Docker + TLS stack).

See: https://vite.dev/config/server-options.html#server-allowedhosts
See: vitejs/vite#19325
