### PR TITLE
Improve link_translate helper

### DIFF
--- a/app/components/enterprise_edition/upsell_buttons_component.rb
+++ b/app/components/enterprise_edition/upsell_buttons_component.rb
@@ -114,8 +114,8 @@ module EnterpriseEdition
     end
 
     def enterprise_link
-      href_value = OpenProject::Static::Links.links.dig(:enterprise_features, feature_key, :href)
-      default_value = OpenProject::Static::Links.links.dig(:enterprise_features, :default, :href)
+      href_value = OpenProject::Static::Links.url_for(:enterprise_features, feature_key)
+      default_value = OpenProject::Static::Links.url_for(:enterprise_features, :default)
 
       href_value || default_value
     end

--- a/app/forms/scim_clients/form.rb
+++ b/app/forms/scim_clients/form.rb
@@ -30,6 +30,8 @@
 
 module ScimClients
   class Form < ApplicationForm
+    include Redmine::I18n
+
     form do |client_form|
       client_form.text_field(
         name: :name,
@@ -79,8 +81,9 @@ module ScimClients
           name: :jwt_sub,
           label: ScimClient.human_attribute_name(:jwt_sub),
           required: true,
-          caption: I18n.t("admin.scim_clients.form.jwt_sub_description_html",
-                          docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_jwt_authetication_method)).html_safe,
+          caption: link_translate("admin.scim_clients.form.jwt_sub_description", links: {
+                                    docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_jwt_authetication_method)
+                                  }),
           input_width: :large
         )
       end

--- a/app/forms/scim_clients/form.rb
+++ b/app/forms/scim_clients/form.rb
@@ -81,9 +81,9 @@ module ScimClients
           name: :jwt_sub,
           label: ScimClient.human_attribute_name(:jwt_sub),
           required: true,
-          caption: link_translate("admin.scim_clients.form.jwt_sub_description", links: {
-                                    docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_jwt_authetication_method)
-                                  }),
+          caption: link_translate("admin.scim_clients.form.jwt_sub_description",
+                                  links: { docs_url: %i[sysadmin_docs scim_jwt_authetication_method] },
+                                  external: true),
           input_width: :large
         )
       end

--- a/app/forms/work_package_types/subject_configuration_form.rb
+++ b/app/forms/work_package_types/subject_configuration_form.rb
@@ -87,7 +87,7 @@ module WorkPackageTypes
 
     def pattern_input_caption
       link_translate("types.edit.subject_configuration.pattern.caption", links: {
-                       attributes_url: ::OpenProject::Static::Links.url_for(:enterprise_features, :work_package_subject_generation)
+                       attributes_url: %i[enterprise_features work_package_subject_generation]
                      })
     end
   end

--- a/app/forms/work_package_types/subject_configuration_form.rb
+++ b/app/forms/work_package_types/subject_configuration_form.rb
@@ -30,6 +30,8 @@
 
 module WorkPackageTypes
   class SubjectConfigurationForm < ApplicationForm
+    include Redmine::I18n
+
     form do |subject_form|
       subject_form.radio_button_group(name: :subject_configuration) do |group|
         group.radio_button(
@@ -84,17 +86,9 @@ module WorkPackageTypes
     end
 
     def pattern_input_caption
-      I18n.t(
-        "types.edit.subject_configuration.pattern.caption_with_supported_attributes_link",
-        link: make_link(
-          ::OpenProject::Static::Links.url_for(:enterprise_features, :work_package_subject_generation),
-          I18n.t("types.edit.subject_configuration.pattern.supported_attributes_link")
-        )
-      ).html_safe
-    end
-
-    def make_link(href, link_text)
-      render(Primer::Beta::Link.new(href:, target: "_blank", underline: true)) { link_text }
+      link_translate("types.edit.subject_configuration.pattern.caption", links: {
+                       attributes_url: ::OpenProject::Static::Links.url_for(:enterprise_features, :work_package_subject_generation)
+                     })
     end
   end
 end

--- a/app/views/admin/scim_clients/edit.html.erb
+++ b/app/views/admin/scim_clients/edit.html.erb
@@ -33,9 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { @scim_client.name }
     header.with_description do
-      link_translate("admin.scim_clients.form.description", links: {
-        docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim)
-      })
+      link_translate("admin.scim_clients.form.description", links: { docs_url: %i[sysadmin_docs scim] }, external: true)
     end
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },

--- a/app/views/admin/scim_clients/edit.html.erb
+++ b/app/views/admin/scim_clients/edit.html.erb
@@ -32,8 +32,11 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { @scim_client.name }
-    header.with_description { t("admin.scim_clients.form.description_html",
-                                docs_url:  ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim)) }
+    header.with_description do
+      link_translate("admin.scim_clients.form.description", links: {
+        docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim)
+      })
+    end
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },
        { href: admin_settings_authentication_path, text: t(:label_authentication) },

--- a/app/views/admin/scim_clients/new.html.erb
+++ b/app/views/admin/scim_clients/new.html.erb
@@ -32,7 +32,11 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(".title") }
-    header.with_description { t("admin.scim_clients.form.description_html", docs_url:  ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim)) }
+    header.with_description do
+      link_translate("admin.scim_clients.form.description", links: {
+        docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim)
+      })
+    end
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },
        { href: admin_settings_authentication_path, text: t(:label_authentication) },

--- a/app/views/admin/scim_clients/new.html.erb
+++ b/app/views/admin/scim_clients/new.html.erb
@@ -33,9 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(".title") }
     header.with_description do
-      link_translate("admin.scim_clients.form.description", links: {
-        docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :scim)
-      })
+      link_translate("admin.scim_clients.form.description", links: { docs_url: %i[sysadmin_docs scim] }, external: true)
     end
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },

--- a/app/views/user_mailer/activation_limit_reached.html.erb
+++ b/app/views/user_mailer/activation_limit_reached.html.erb
@@ -38,10 +38,10 @@ See COPYRIGHT and LICENSE files for more details.
     <span><%= t("mail_user_activation_limit_reached.steps.label") %></span>
     <ul>
         <li>
-            <%= link_translate("mail_user_activation_limit_reached.steps.a", links: { upgrade_url: OpenProject::Enterprise.upgrade_url }).html_safe %>
+            <%= link_translate("mail_user_activation_limit_reached.steps.a", links: { upgrade_url: OpenProject::Enterprise.upgrade_url }) %>
         </li>
         <li>
-            <%= link_translate("mail_user_activation_limit_reached.steps.b", links: { users_url: users_url }).html_safe %>
+            <%= link_translate("mail_user_activation_limit_reached.steps.b", links: { users_url: users_url }) %>
         </li>
     </ul>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,8 +137,8 @@ en:
       form:
         auth_provider_description: "This is the service that users added by the SCIM provider will use to authenticate in OpenProject."
         authentication_method_description_html: "This is how the SCIM-client authenticates at OpenProject. Please ensure that OAuth tokens include the <code>scim_v2</code> scope."
-        description_html: 'Please refer to our <a href="%{docs_url}">documentation on configuring SCIM-clients</a> for more information on these configuration options.'
-        jwt_sub_description_html: 'For example, for Keycloak, this is the UUID of the service account  associated with the SCIM-client. Consult <a href="%{docs_url}">our documentation</a> to learn how to find  the subject claim for your use case.'
+        description: "Please refer to our [documentation on configuring SCIM-clients](docs_url) for more information on these configuration options."
+        jwt_sub_description: "For example, for Keycloak, this is the UUID of the service account  associated with the SCIM-client. Consult [our documentation](docs_url) to learn how to find  the subject claim for your use case."
         name_description: "Choose a name that will help other admins better understand why this client was configured."
       index:
         description: "SCIM-clients configured here are able to interact with OpenProject SCIM server API to provision, update, and deprovision user accounts and groups."
@@ -774,9 +774,8 @@ en:
             project: "Project"
         pattern:
           label: "Subject pattern"
-          caption_with_supported_attributes_link: Create patterns by adding text, or type "/" to search for %{link}.
+          caption: Create patterns by adding text, or type "/" to search for [supported attributes](attributes_url).
           insert_as_text: "No attributes found. Add as text: \"%{word}\""
-          supported_attributes_link: "supported attributes"
       export_configuration:
         tab: "Generate PDF"
         intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -111,9 +111,9 @@ module Redmine
     #
     # @param i18n_key [String] The I18n key to translate.
     # @param links [Hash] Link names mapped to URLs.
-    # @param target [String] optional HTML target attribute for the links.
+    # @param external [Boolean] Whether the links should be opened as external links, i.e. in a new tab (default: false)
     # @param underline [Boolean] Whether to underline links inserted into the text (default: true)
-    def link_translate(i18n_key, links: {}, locale: ::I18n.locale, target: nil, underline: true)
+    def link_translate(i18n_key, links: {}, locale: ::I18n.locale, external: false, underline: true)
       translation = ::I18n.t(i18n_key.to_s, locale:)
       result = translation.scan(link_regex).inject(translation) do |t, matches|
         link, text, key = matches
@@ -124,7 +124,11 @@ module Redmine
                else
                  String(link_reference)
                end
-        link_tag = render(Primer::Beta::Link.new(href:, target:, underline:)) { text }
+        target = external ? "_blank" : nil
+        link_tag = render(Primer::Beta::Link.new(href:, target:, underline:)) do |l|
+          l.with_trailing_visual_icon(icon: :"link-external") if external
+          text
+        end
 
         t.sub(link, link_tag)
       end

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -117,7 +117,7 @@ module Redmine
       result = translation.scan(link_regex).inject(translation) do |t, matches|
         link, text, key = matches
         href = String(links[key.to_sym])
-        link_tag = content_tag(:a, text, href:, target:)
+        link_tag = render(Primer::Beta::Link.new(href:, target:)) { text }
 
         t.sub(link, link_tag)
       end

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -116,7 +116,13 @@ module Redmine
       translation = ::I18n.t(i18n_key.to_s, locale:)
       result = translation.scan(link_regex).inject(translation) do |t, matches|
         link, text, key = matches
-        href = String(links[key.to_sym])
+        link_reference = links[key.to_sym]
+        href = case link_reference
+               when Array
+                 OpenProject::Static::Links.url_for(*link_reference)
+               else
+                 String(link_reference)
+               end
         link_tag = render(Primer::Beta::Link.new(href:, target:)) { text }
 
         t.sub(link, link_tag)

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -112,7 +112,8 @@ module Redmine
     # @param i18n_key [String] The I18n key to translate.
     # @param links [Hash] Link names mapped to URLs.
     # @param target [String] optional HTML target attribute for the links.
-    def link_translate(i18n_key, links: {}, locale: ::I18n.locale, target: nil)
+    # @param underline [Boolean] Whether to underline links inserted into the text (default: true)
+    def link_translate(i18n_key, links: {}, locale: ::I18n.locale, target: nil, underline: true)
       translation = ::I18n.t(i18n_key.to_s, locale:)
       result = translation.scan(link_regex).inject(translation) do |t, matches|
         link, text, key = matches
@@ -123,7 +124,7 @@ module Redmine
                else
                  String(link_reference)
                end
-        link_tag = render(Primer::Beta::Link.new(href:, target:)) { text }
+        link_tag = render(Primer::Beta::Link.new(href:, target:, underline:)) { text }
 
         t.sub(link, link_tag)
       end

--- a/lookbook/docs/patterns/04-links.md.erb
+++ b/lookbook/docs/patterns/04-links.md.erb
@@ -22,3 +22,7 @@ Links that are part of a paragraph or continuous text must be **underlined**. Th
 For links in form captions and PageHeader descriptions, this is done automatically. Otherwise, it has to be done [manually](https://primer.style/view-components/lookbook/inspect/primer/beta/link/default) by setting `underline: true`.
 
 <%= embed OpenProject::Common::LinkPreview, :inline %>
+
+## Technical notes
+
+The module `Redmine::I18n` offers a helper called `link_translate` that can be used to render inline links inside translated text. This method ensures that the guidelines above are respected.

--- a/modules/auth_saml/app/forms/saml/providers/request_attributes_form.rb
+++ b/modules/auth_saml/app/forms/saml/providers/request_attributes_form.rb
@@ -55,9 +55,9 @@ module Saml
               caption: link_translate(
                 "saml.instructions.documentation_link",
                 links: {
-                  docs_url: ::OpenProject::Static::Links[:sysadmin_docs][:saml][:href]
+                  docs_url: %i[sysadmin_docs saml]
                 },
-                target: "_blank"
+                external: true
               )
             ) do |list|
               Saml::Defaults::ATTRIBUTE_FORMATS.each do |format|

--- a/modules/auth_saml/app/views/saml/providers/edit.html.erb
+++ b/modules/auth_saml/app/views/saml/providers/edit.html.erb
@@ -15,9 +15,9 @@
     <%= link_translate(
           "saml.instructions.documentation_link",
           links: {
-            docs_url: ::OpenProject::Static::Links[:sysadmin_docs][:saml][:href]
+            docs_url: %i[sysadmin_docs saml]
           },
-          target: "_blank"
+          external: true
         ) %>
   <% end %>
 <% end %>

--- a/modules/auth_saml/app/views/saml/providers/new.html.erb
+++ b/modules/auth_saml/app/views/saml/providers/new.html.erb
@@ -13,9 +13,9 @@
     <%= link_translate(
           "saml.instructions.documentation_link",
           links: {
-            docs_url: ::OpenProject::Static::Links[:sysadmin_docs][:saml][:href]
+            docs_url: %i[sysadmin_docs saml]
           },
-          target: "_blank"
+          external: true
         ) %>
   <% end %>
 <% end %>

--- a/modules/openid_connect/app/components/openid_connect/providers/claims_form.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/claims_form.rb
@@ -40,9 +40,7 @@ module OpenIDConnect
           label: OpenIDConnect::Provider.human_attribute_name(:claims),
           caption: link_translate(
             "openid_connect.instructions.claims",
-            links: {
-              docs_url: ::OpenProject::Static::Links[:sysadmin_docs][:oidc_claims][:href]
-            }
+            links: { docs_url: %i[sysadmin_docs oidc_claims] }
           ),
           disabled: provider.seeded_from_env?,
           required: false,
@@ -54,9 +52,7 @@ module OpenIDConnect
           label: OpenIDConnect::Provider.human_attribute_name(:acr_values),
           caption: link_translate(
             "openid_connect.instructions.acr_values",
-            links: {
-              docs_url: ::OpenProject::Static::Links[:sysadmin_docs][:oidc_acr_values][:href]
-            }
+            links: { docs_url: %i[sysadmin_docs oidc_acr_values] }
           ),
           disabled: provider.seeded_from_env?,
           required: false,

--- a/modules/openid_connect/app/components/openid_connect/providers/client_details_form.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/client_details_form.rb
@@ -59,7 +59,8 @@ module OpenIDConnect
             "openid_connect.instructions.scope",
             links: {
               docs_url: "https://openid.net/specs/openid-connect-basic-1_0.html#Scopes"
-            }
+            },
+            external: true
           ),
           disabled: provider.seeded_from_env?,
           required: false,

--- a/modules/openid_connect/app/components/openid_connect/providers/group_mapping_form.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/group_mapping_form.rb
@@ -70,9 +70,9 @@ module OpenIDConnect
             name: :group_regexes,
             rows: 5,
             label: I18n.t("openid_connect.providers.label_group_regexes"),
-            caption: link_translate("openid_connect.instructions.group_regexes", links: {
-                                      docs_url: ::OpenProject::Static::Links.url_for(:sysadmin_docs, :oidc_groups)
-                                    }),
+            caption: link_translate("openid_connect.instructions.group_regexes",
+                                    links: { docs_url: %i[sysadmin_docs oidc_groups] },
+                                    external: true),
             disabled: provider.seeded_from_env?,
             required: false,
             input_width: :large,

--- a/spec/lib/open_project/static/links_spec.rb
+++ b/spec/lib/open_project/static/links_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::Static::Links do
+  describe ".url_for" do
+    subject { described_class.url_for(*args) }
+
+    let(:args) { %i[enterprise_features board_view] }
+
+    it "resolves the URL stored in the href" do
+      expect(subject).to eq("https://www.openproject.org/docs/user-guide/agile-boards/#action-boards-enterprise-add-on")
+    end
+  end
+end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -188,7 +188,7 @@ module OpenProject
     describe "link_translation" do
       let(:locale) { :en }
       let(:urls) do
-        { url_1: "http://openproject.com/foobar", url_2: "/baz" }
+        { url_1: "http://openproject.com/foo", url_2: "/baz" }
       end
 
       before do
@@ -202,8 +202,8 @@ module OpenProject
         translated = link_translate :translation_with_a_link, links: urls
 
         expect(translated).to eq(
-          'There is a <a href="http://openproject.com/foobar" data-view-component="true" class="Link">link</a> in this' +
-          ' translation! Maybe even <a href="/baz" data-view-component="true" class="Link">two</a>?'
+          'There is a <a href="http://openproject.com/foo" data-view-component="true" class="Link Link--underline">link</a>' +
+          ' in this translation! Maybe even <a href="/baz" data-view-component="true" class="Link Link--underline">two</a>?'
         )
       end
 
@@ -214,8 +214,8 @@ module OpenProject
           translated = link_translate(:translation_with_a_link, links: urls, locale:)
 
           expect(translated).to eq(
-            'There is a <a href="http://openproject.com/foobar" data-view-component="true" class="Link">link</a> in this' +
-            ' translation! Maybe even <a href="/baz" data-view-component="true" class="Link">two</a>?'
+            'There is a <a href="http://openproject.com/foo" data-view-component="true" class="Link Link--underline">link</a>' +
+            ' in this translation! Maybe even <a href="/baz" data-view-component="true" class="Link Link--underline">two</a>?'
           )
           expect(I18n).to have_received(:t).with(anything, locale:)
         end
@@ -236,8 +236,8 @@ module OpenProject
           translated = link_translate :translation_with_a_link, links: urls
 
           expect(translated).to eq(
-            'There is a <a href="https://example.com/a-b" data-view-component="true" class="Link">link</a> in this' +
-            ' translation! Maybe even <a href="/a-c" data-view-component="true" class="Link">two</a>?'
+            'There is a <a href="https://example.com/a-b" data-view-component="true" class="Link Link--underline">link</a>' +
+            ' in this translation! Maybe even <a href="/a-c" data-view-component="true" class="Link Link--underline">two</a>?'
           )
         end
       end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -202,8 +202,8 @@ module OpenProject
         translated = link_translate :translation_with_a_link, links: urls
 
         expect(translated).to eq(
-          "There is a <a href=\"http://openproject.com/foobar\">link</a> in this translation!" +
-          " Maybe even <a href=\"/baz\">two</a>?"
+          'There is a <a href="http://openproject.com/foobar" data-view-component="true" class="Link">link</a> in this' +
+          ' translation! Maybe even <a href="/baz" data-view-component="true" class="Link">two</a>?'
         )
       end
 
@@ -214,9 +214,10 @@ module OpenProject
           translated = link_translate(:translation_with_a_link, links: urls, locale:)
 
           expect(translated).to eq(
-            "There is a <a href=\"http://openproject.com/foobar\">link</a> in this translation!" +
-            " Maybe even <a href=\"/baz\">two</a>?"
+            'There is a <a href="http://openproject.com/foobar" data-view-component="true" class="Link">link</a> in this' +
+            ' translation! Maybe even <a href="/baz" data-view-component="true" class="Link">two</a>?'
           )
+          expect(I18n).to have_received(:t).with(anything, locale:)
         end
       end
     end


### PR DESCRIPTION
We now use this helper in more places and make sure it renders primer links that can optionally be localized, if they originate from our static links.

### Ticket

https://community.openproject.org/wp/66029