### PR TITLE
Creates the FilesQuery and Reuses the OneDrive User Query

### DIFF
--- a/modules/storages/app/common/storages/adapters/adapter_types.rb
+++ b/modules/storages/app/common/storages/adapters/adapter_types.rb
@@ -36,6 +36,7 @@ module Storages
       # We need to move the definition of ParentFolder to mean something like Folder
       Location = AdapterTypes.Constructor(Peripherals::ParentFolder)
       StorageFileInstance = AdapterTypes.Instance(Results::StorageFile)
+      FileAncestorInstance = AdapterTypes.Instance(Results::StorageFileAncestor)
       SemanticVersionType = AdapterTypes.Constructor(SemanticVersion, SemanticVersion.method(:parse))
       HTTPVerb = AdapterTypes::Nominal::Symbol.constrained(included_in: %i(post put))
     end

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_query.rb
@@ -106,14 +106,14 @@ module Storages
                 last = list.last
                 prefix = last.nil? || last.location[-1] != "/" ? "/" : ""
                 location = "#{last&.location}#{prefix}#{item}"
-                list.append(forge_ancestor(location))
+                list.append(forge_ancestor(CGI.unescape(location)))
               end
             end
 
             # The ancestors are simply derived objects from the parents location string. Until we have real information
             # from the nextcloud API about the path to the parent, we need to derive name, location and forge an ID.
             def forge_ancestor(location)
-              Results::StorageFile.new(id: Digest::SHA256.hexdigest(location), name: name(location), location:)
+              Results::StorageFileAncestor.new(name: name(location), location:)
             end
 
             def name(location)

--- a/modules/storages/app/common/storages/adapters/providers/one_drive/queries/files_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/one_drive/queries/files_query.rb
@@ -77,11 +77,11 @@ module Storages
             end
 
             def storage_files(json_files)
-              files = json_files.map { |json| @transformer.transform(json).value_or(nil) }
+              files = json_files.filter_map { |json| @transformer.transform(json).value_or(nil) }
 
               parent_reference = json_files.first[:parentReference]
               Results::StorageFileCollection
-                .build(files: files.compact, parent: parent(parent_reference), ancestors: forge_ancestors(parent_reference))
+                .build(files: files, parent: parent(parent_reference), ancestors: forge_ancestors(parent_reference))
             end
 
             def empty_response(http, folder)

--- a/modules/storages/app/common/storages/adapters/providers/one_drive/queries/files_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/one_drive/queries/files_query.rb
@@ -102,7 +102,8 @@ module Storages
               _, _, name = parent_reference[:path].gsub(/.*root:/, "").rpartition "/"
 
               if name.empty?
-                root(parent_reference[:id])
+                Results::StorageFile.new(id: parent_reference[:id], name: "Root", location: "/",
+                                         permissions: %i[readable writeable])
               else
                 @transformer.parent_transform(id: parent_reference[:id], name:, location: parent_reference)
               end
@@ -112,17 +113,13 @@ module Storages
               path_elements = parent_reference[:path].gsub(/.+root:/, "").split("/")
 
               path_elements[0..-2].map do |component|
-                next root(Digest::SHA256.hexdigest("i_am_root")) if component.blank?
+                next root if component.blank?
 
-                Results::StorageFile.new(
-                  id: Digest::SHA256.hexdigest(component),
-                  name: component,
-                  location: UrlBuilder.path(component)
-                )
+                Results::StorageFileAncestor.new(name: component, location: component)
               end
             end
 
-            def root(id) = Results::StorageFile.new(name: "Root", location: "/", id:, permissions: %i[readable writeable])
+            def root = Results::StorageFileAncestor.new(name: "Root", location: "/")
 
             def children_url_for(folder)
               return UrlBuilder.url(base_uri, "/root/children") if folder.root?

--- a/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
@@ -61,7 +61,7 @@ module Storages
             URI(@storage.host)
           end
 
-          def drive_and_location(location)
+          def split_identifier(location)
             drive_id, item_id = location.to_s.split(SharePointStorage::IDENTIFIER_SEPARATOR)
             { drive_id:, location: Peripherals::ParentFolder.new(item_id || "/") }
           end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
@@ -53,6 +53,14 @@ module Storages
 
           private
 
+          def site_name
+            host_uri.path&.split("/")&.last
+          end
+
+          def host_uri
+            URI(@storage.host)
+          end
+
           def drive_and_location(location)
             drive_id, item_id = location.to_s.split(SharePointStorage::IDENTIFIER_SEPARATOR)
             { drive_id:, location: Peripherals::ParentFolder.new(item_id || "/") }

--- a/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
@@ -49,7 +49,16 @@ module Storages
             @storage = storage
           end
 
+          def base_uri = @storage.uri
+
           private
+
+          def drive_and_location(location)
+            drive_id, item_id = location.to_s.split(SharePointStorage::IDENTIFIER_SEPARATOR)
+            { drive_id:, location: Peripherals::ParentFolder.new(item_id || "/") }
+          end
+
+          def request_uri = raise Errors::SubclassResponsibility
 
           # @param error [Results::Error]
           # @return [void]

--- a/modules/storages/app/common/storages/adapters/providers/share_point/queries/files_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/queries/files_query.rb
@@ -46,7 +46,7 @@ module Storages
               if folder.root?
                 Internal::ListsQuery.call(storage: @storage, http:)
               else
-                Internal::ChildrenQuery.call(storage: @storage, http:, **drive_and_location(folder))
+                Internal::ChildrenQuery.call(storage: @storage, http:, **split_identifier(folder))
               end
             end
           end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/queries/internal/children_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/queries/internal/children_query.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+#-- copyright
+#++
+
+module Storages
+  module Adapters
+    module Providers
+      module SharePoint
+        module Queries
+          module Internal
+            class ChildrenQuery < Base
+              FIELDS = "?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference"
+
+              def self.call(storage:, http:, drive_id:, location:)
+                new(storage).call(drive_id:, http:, location:)
+              end
+
+              def initialize(storage)
+                super
+                @transformer = StorageFileTransformer.new(site_name)
+              end
+
+              def call(http:, drive_id:, location:)
+                handle_response(http.get(request_uri(drive_id, location) + FIELDS)).bind { parse_response(it) }
+              end
+
+              private
+
+              def request_uri(drive_id, location)
+                if location.root?
+                  UrlBuilder.url(base_uri, "/v1.0/drives/#{drive_id}/root/children")
+                else
+                  UrlBuilder.url(base_uri, "/v1.0/drives/#{drive_id}/items/#{location.path}/children")
+                end
+              end
+
+              def handle_response(response)
+                error = Results::Error.new(source: self.class, payload: response)
+
+                case response
+                in { status: 200..299 }
+                  Success(response.json(symbolize_keys: true)[:value])
+                in { status: 400 }
+                  Failure(error.with(code: :request_error))
+                in { status: 404 }
+                  Failure(error.with(code: :not_found))
+                in { status: 403 }
+                  Failure(error.with(code: :forbidden))
+                in { status: 401 }
+                  Failure(error.with(code: :unauthorized))
+                else
+                  Failure(error.with(code: :error))
+                end
+              end
+
+              def parse_response(json)
+                files = json.filter_map { @transformer.transform(it).value_or(nil) }
+                entry = json.first
+
+                Results::StorageFileCollection.build(
+                  files:,
+                  parent: @transformer.parent_transform(entry),
+                  ancestors: forge_ancestors(entry[:parentReference], entry[:webUrl])
+                )
+              end
+
+              def forge_ancestors(parent_reference, web_url)
+                # 1. This is a query on a drive, so we will always have the site root.
+                # 2. Then this can be a drive root or a folder query
+                #   a. Drive Root we need to add it to the ancestors.
+                drive_name = CGI.unescape(web_url.gsub(/.*#{site_name}\//, "").split("/").first)
+                list = parent_reference[:path].gsub(/.*root:/, "").split("/")[0..-2] # Last item is the parent
+
+                list.each_with_object([site_root]) do |component, ancestors|
+                  if component.blank?
+                    ancestors.unshift drive_root(parent_reference[:driveId], drive_name)
+                  end
+                end
+              end
+
+              def drive_root(drive_id, name)
+                Results::StorageFile.new(
+                  name:,
+                  location: UrlBuilder.path("/#{name}"),
+                  id: "#{drive_id}||",
+                  permissions: %i[readable writeable]
+                )
+              end
+
+              def site_root
+                Results::StorageFile.new(
+                  name: site_name,
+                  location: "/",
+                  id: Digest::SHA256.hexdigest("i_am_root"),
+                  permissions: %i[readable writeable]
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/queries/internal/lists_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/queries/internal/lists_query.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages
+  module Adapters
+    module Providers
+      module SharePoint
+        module Queries
+          module Internal
+            class ListsQuery < Base
+              FIELDS = "?$expand=drive&$select=id,name,drive"
+
+              def self.call(storage:, http:)
+                new(storage).call(http)
+              end
+
+              def call(http)
+                handle_response(http.get(request_uri + FIELDS)).fmap { parse_response(it) }
+              end
+
+              private
+
+              def handle_response(response)
+                error = Results::Error.new(source: self, payload: response)
+
+                case response
+                in { status: 200..299 }
+                  Success(response.json(symbolize_keys: true))
+                in { status: 400 }
+                  Failure(error.with(code: :request_error))
+                in { status: 404 }
+                  Failure(error.with(code: :not_found))
+                in { status: 403 }
+                  Failure(error.with(code: :forbidden))
+                in { status: 401 }
+                  Failure(error.with(code: :unauthorized))
+                else
+                  Failure(error.with(code: :error))
+                end
+              end
+
+              def parse_response(json)
+                json[:value].filter_map do |entry|
+                  Results::StorageFile.build(
+                    name: entry[:name],
+                    id: entry.dig(:drive, :id),
+                    mime_type: "application/x-op-drive",
+                    location: "/drives/#{entry.dig(:drive, :id)}",
+                    permissions: %i[readable writeable]
+                  ).value_or { nil }
+                end
+              end
+
+              def request_uri
+                storage_host = URI(@storage.host)
+                URI.join(base_uri.origin, "/v1.0/sites/#{storage_host.host}:#{storage_host.path}:/lists").to_s
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/share_point_registry.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/share_point_registry.rb
@@ -62,6 +62,11 @@ module Storages
           namespace("validators") do
             register(:connection, Validators::ConnectionValidator)
           end
+
+          namespace("queries") do
+            register(:files, Queries::FilesQuery)
+            register(:user, OneDrive::Queries::UserQuery)
+          end
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/storage_file_transformer.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/storage_file_transformer.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+#++
+
+module Storages
+  module Adapters
+    module Providers
+      module SharePoint
+        class StorageFileTransformer
+          attr_reader :site_name
+
+          def initialize(site_name)
+            @site_name = site_name
+          end
+
+          def transform(json)
+            Results::StorageFile.build(
+              id: compose_id(json),
+              name: json[:name],
+              size: json[:size],
+              mime_type: mime_type(json),
+              location: extract_location(json),
+              created_at: Time.zone.parse(json.dig(:fileSystemInfo, :createdDateTime)),
+              last_modified_at: Time.zone.parse(json.dig(:fileSystemInfo, :lastModifiedDateTime)),
+              created_by_name: json.dig(:createdBy, :user, :displayName),
+              last_modified_by_name: json.dig(:lastModifiedBy, :user, :displayName),
+              permissions: %i[readable writeable]
+            )
+          end
+
+          def parent_transform(json)
+            Results::StorageFile.new(
+              name: json.dig(:parentReference, :name),
+              id: compose_parent_id(json[:parentReference]),
+              location: extract_parent_location(json),
+              permissions: %i[readable writeable]
+            )
+          end
+
+          private
+
+          def mime_type(entry)
+            return "application/x-op-directory" if entry.key? :folder
+
+            entry.dig(:file, :mimeType)
+          end
+
+          def extract_location(json)
+            json[:webUrl].gsub(/.*#{site_name}/, "")
+          end
+
+          def extract_parent_location(json)
+            rindex = UrlBuilder.path(json[:name]).length * -1
+            extract_location(json)[0...rindex]
+          end
+
+          def compose_id(json)
+            "#{json.dig(:parentReference, :driveId)}#{SharePointStorage::IDENTIFIER_SEPARATOR}#{json[:id]}"
+          end
+
+          def compose_parent_id(parent)
+            item_id = parent[:path].ends_with?("root:") ? nil : parent[:id]
+
+            "#{parent[:driveId]}#{SharePointStorage::IDENTIFIER_SEPARATOR}#{item_id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/storage_file_transformer.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/storage_file_transformer.rb
@@ -1,6 +1,31 @@
 # frozen_string_literal: true
 
 #-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
 #++
 
 module Storages
@@ -36,6 +61,19 @@ module Storages
               location: extract_parent_location(json),
               permissions: %i[readable writeable]
             )
+          end
+
+          def bare_transform(json)
+            Results::StorageFile.new(
+              name: json[:name],
+              id: compose_id(json),
+              location: extract_location(json),
+              permissions: %i[readable writeable]
+            )
+          end
+
+          def build_ancestor(name, location)
+            Results::StorageFileAncestor.new(name:, location: CGI.unescape(location))
           end
 
           private

--- a/modules/storages/app/common/storages/adapters/results/storage_file_ancestor.rb
+++ b/modules/storages/app/common/storages/adapters/results/storage_file_ancestor.rb
@@ -30,33 +30,13 @@
 
 module Storages
   module Adapters
-    module Providers
-      module SharePoint
-        module Commands
-          class CreateFolderCommand < Base
-            # @param auth_strategy [Result(Input::Strategy)]
-            # @param input_data [Input::CreateFolder]
-            def call(auth_strategy:, input_data:)
-              Authentication[auth_strategy].call(storage: @storage) do |_http|
-                # Input data has: folder name, parent_location
-                # Parent Location here need to be eiter a Drive
-                #   Or a pair of Drive + Parent Folder
-                Rails.logger.debug request_uri(**drive_and_location(input_data.parent_location))
-              end
-            end
-
-            private
-
-            def request_uri(drive_id:, location:)
-              last_fragment = if location.root?
-                                ["/root/children"]
-                              else
-                                ["/items", parent_location.path, "/children"]
-                              end
-
-              UrlBuilder.url(base_uri, "/drives/", drive_id, *last_fragment)
-            end
-          end
+    module Results
+      class StorageFileAncestor < StorageFile
+        def initialize(name:, location:)
+          super(name:,
+                location: UrlBuilder.path(location),
+                id: Digest::SHA256.hexdigest(name),
+                permissions: %i[readable writeable])
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/results/storage_file_collection_contract.rb
+++ b/modules/storages/app/common/storages/adapters/results/storage_file_collection_contract.rb
@@ -35,7 +35,7 @@ module Storages
         params do
           required(:files).array(AdapterTypes::StorageFileInstance)
           required(:parent).filled(AdapterTypes::StorageFileInstance)
-          required(:ancestors).array(AdapterTypes::StorageFileInstance)
+          required(:ancestors).array(AdapterTypes::FileAncestorInstance)
         end
       end
     end

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -62,6 +62,10 @@ module Storages
       end
     end
 
+    def configuration_checks
+      { all: true }
+    end
+
     def uri
       @uri ||= URI("https://graph.microsoft.com").normalize
     end

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -30,6 +30,8 @@
 
 module Storages
   class SharePointStorage < Storage
+    IDENTIFIER_SEPARATOR = "||"
+
     PROVIDER_FIELDS_DEFAULTS = {
       automatically_managed: false,
       automatic_management_enabled: false
@@ -37,11 +39,13 @@ module Storages
 
     store_attribute :provider_fields, :tenant_id, :string
 
-    # For now SharePoint is visible only for development and tests.
+    # For now SharePoint is visible only in tests.
     # This is to prevent it from being shown in the UI, as it is not ready yet.
     def self.visible?
       Rails.env.local?
     end
+
+    store_attribute :provider_fields, :tenant_id, :string
 
     def self.short_provider_name = :share_point
     def audience = nil
@@ -56,6 +60,10 @@ module Storages
       else
         %w[inactive manual]
       end
+    end
+
+    def uri
+      @uri ||= URI("https://graph.microsoft.com").normalize
     end
 
     def oauth_configuration = Adapters::Providers::SharePoint::OAuthConfiguration.new(self)

--- a/modules/storages/app/services/storages/storage_files_service.rb
+++ b/modules/storages/app/services/storages/storage_files_service.rb
@@ -39,7 +39,6 @@ module Storages
         auth_strategy = strategy(storage, user)
 
         info "Requesting all the files under folder #{folder} for #{storage.name}"
-        info "auth_strategy: #{auth_strategy}"
 
         input_data = Adapters::Input::Files.build(folder:).value_or { return add_validation_error(it) }
 

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_query_spec.rb
@@ -55,7 +55,7 @@ module Storages
               let(:files_result) do
                 # FIXME: nextcloud files query currently does not correctly returns modifier and creation date.
                 Results::StorageFileCollection.new(
-                  [
+                  files: [
                     Results::StorageFile.new(id: "555",
                                              name: "Folder",
                                              size: 232167,
@@ -87,17 +87,17 @@ module Storages
                                              location: "/%c3%9cml%c3%a6%c3%bbts",
                                              permissions: %i[readable writeable])
                   ],
-                  Results::StorageFile.new(id: "385",
-                                           name: "Root",
-                                           size: 252777,
-                                           mime_type: "application/x-op-directory",
-                                           created_at: nil,
-                                           last_modified_at: Time.zone.parse("2024-08-09T11:53:42Z"),
-                                           created_by_name: "Mara Jade",
-                                           last_modified_by_name: nil,
-                                           location: "/",
-                                           permissions: %i[readable writeable]),
-                  []
+                  parent: Results::StorageFile.new(id: "385",
+                                                   name: "Root",
+                                                   size: 252777,
+                                                   mime_type: "application/x-op-directory",
+                                                   created_at: nil,
+                                                   last_modified_at: Time.zone.parse("2024-08-09T11:53:42Z"),
+                                                   created_by_name: "Mara Jade",
+                                                   last_modified_by_name: nil,
+                                                   location: "/",
+                                                   permissions: %i[readable writeable]),
+                  ancestors: []
                 )
               end
 
@@ -108,7 +108,7 @@ module Storages
               let(:folder) { "/Folder/Nested Folder" }
               let(:files_result) do
                 Results::StorageFileCollection.new(
-                  [
+                  files: [
                     Results::StorageFile.new(id: "603",
                                              name: "giphy.gif",
                                              size: 184726,
@@ -140,23 +140,19 @@ module Storages
                                              location: "/Folder/Nested%20Folder/todo.txt",
                                              permissions: %i[readable writeable])
                   ],
-                  Results::StorageFile.new(id: "601",
-                                           name: "Nested Folder",
-                                           size: 231045,
-                                           mime_type: "application/x-op-directory",
-                                           created_at: nil,
-                                           last_modified_at: Time.zone.parse("2024-08-09T11:53:42Z"),
-                                           created_by_name: "Mara Jade",
-                                           last_modified_by_name: nil,
-                                           location: "/Folder/Nested%20Folder",
-                                           permissions: %i[readable writeable]),
-                  [
-                    Results::StorageFile.new(id: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
-                                             name: "Root",
-                                             location: "/"),
-                    Results::StorageFile.new(id: "0da2f1cf70005eaeb08333802726c2928503d975e4a70cbdd1a28313cded20ae",
-                                             name: "Folder",
-                                             location: "/Folder")
+                  parent: Results::StorageFile.new(id: "601",
+                                                   name: "Nested Folder",
+                                                   size: 231045,
+                                                   mime_type: "application/x-op-directory",
+                                                   created_at: nil,
+                                                   last_modified_at: Time.zone.parse("2024-08-09T11:53:42Z"),
+                                                   created_by_name: "Mara Jade",
+                                                   last_modified_by_name: nil,
+                                                   location: "/Folder/Nested%20Folder",
+                                                   permissions: %i[readable writeable]),
+                  ancestors: [
+                    Results::StorageFileAncestor.new(name: "Root", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Folder", location: "/Folder")
                   ]
                 )
               end
@@ -168,24 +164,20 @@ module Storages
               let(:folder) { "/Folder with spaces/very empty folder" }
               let(:files_result) do
                 Results::StorageFileCollection.new(
-                  [],
-                  Results::StorageFile.new(id: "571",
-                                           name: "very empty folder",
-                                           size: 0,
-                                           mime_type: "application/x-op-directory",
-                                           created_at: nil,
-                                           last_modified_at: Time.zone.parse("2024-08-09T11:52:04Z"),
-                                           created_by_name: "Mara Jade",
-                                           last_modified_by_name: nil,
-                                           location: "/Folder%20with%20spaces/very%20empty%20folder",
-                                           permissions: %i[readable writeable]),
-                  [
-                    Results::StorageFile.new(id: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
-                                             name: "Root",
-                                             location: "/"),
-                    Results::StorageFile.new(id: "c8776f1f6dd36c023c6615d39f01a71d68dd1707b232115b7a4f58bc6da94e2e",
-                                             name: "Folder with spaces",
-                                             location: "/Folder%20with%20spaces")
+                  files: [],
+                  parent: Results::StorageFile.new(id: "571",
+                                                   name: "very empty folder",
+                                                   size: 0,
+                                                   mime_type: "application/x-op-directory",
+                                                   created_at: nil,
+                                                   last_modified_at: Time.zone.parse("2024-08-09T11:52:04Z"),
+                                                   created_by_name: "Mara Jade",
+                                                   last_modified_by_name: nil,
+                                                   location: "/Folder%20with%20spaces/very%20empty%20folder",
+                                                   permissions: %i[readable writeable]),
+                  ancestors: [
+                    Results::StorageFileAncestor.new(name: "Root", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Folder with spaces", location: "/Folder with spaces")
                   ]
                 )
               end
@@ -197,7 +189,7 @@ module Storages
               let(:folder) { "/Ümlæûts" }
               let(:files_result) do
                 Results::StorageFileCollection.new(
-                  [
+                  files: [
                     Results::StorageFile.new(id: "564",
                                              name: "Anrüchiges deutsches Dokument.docx",
                                              size: 19720,
@@ -219,20 +211,18 @@ module Storages
                                              location: "/%c3%9cml%c3%a6%c3%bbts/data",
                                              permissions: %i[readable writeable])
                   ],
-                  Results::StorageFile.new(id: "562",
-                                           name: "Ümlæûts",
-                                           size: 19720,
-                                           mime_type: "application/x-op-directory",
-                                           created_at: nil,
-                                           last_modified_at: Time.zone.parse("2024-08-09T11:51:48Z"),
-                                           created_by_name: "Mara Jade",
-                                           last_modified_by_name: nil,
-                                           location: "/%c3%9cml%c3%a6%c3%bbts",
-                                           permissions: %i[readable writeable]),
-                  [
-                    Results::StorageFile.new(id: "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1",
-                                             name: "Root",
-                                             location: "/")
+                  parent: Results::StorageFile.new(id: "562",
+                                                   name: "Ümlæûts",
+                                                   size: 19720,
+                                                   mime_type: "application/x-op-directory",
+                                                   created_at: nil,
+                                                   last_modified_at: Time.zone.parse("2024-08-09T11:51:48Z"),
+                                                   created_by_name: "Mara Jade",
+                                                   last_modified_by_name: nil,
+                                                   location: "/%c3%9cml%c3%a6%c3%bbts",
+                                                   permissions: %i[readable writeable]),
+                  ancestors: [
+                    Results::StorageFileAncestor.new(name: "Root", location: "/")
                   ]
                 )
               end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_query_spec.rb
@@ -122,13 +122,8 @@ module Storages
                                                    location: "/Folder/Subfolder",
                                                    permissions: %i[readable writeable]),
                   ancestors: [
-                    Results::StorageFile.new(id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
-                                             name: "Root",
-                                             location: "/",
-                                             permissions: %i[readable writeable]),
-                    Results::StorageFile.new(id: "74ccd43303847f2655300641a934959cdb11689ce171aa0f00faa92917fbd340",
-                                             name: "Folder",
-                                             location: "/Folder")
+                    Results::StorageFileAncestor.new(name: "Root", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Folder", location: "/Folder")
                   ]
                 ).value!
               end
@@ -146,13 +141,8 @@ module Storages
                                                    location: "/Folder%20with%20spaces/very%20empty%20folder",
                                                    permissions: %i[readable writeable]),
                   ancestors: [
-                    Results::StorageFile.new(id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
-                                             name: "Root",
-                                             location: "/",
-                                             permissions: %i[readable writeable]),
-                    Results::StorageFile.new(id: "58bde0c7931c8f95bb1bf525471146090630cb72827cb1e63dcaab3a9adce763",
-                                             name: "Folder with spaces",
-                                             location: "/Folder%20with%20spaces")
+                    Results::StorageFileAncestor.new(name: "Root", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Folder with spaces", location: "/Folder with spaces")
                   ]
                 ).value!
               end
@@ -183,13 +173,8 @@ module Storages
                                                    location: "/Folder/%C3%9Cml%C3%A6%C3%BBts",
                                                    permissions: %i[readable writeable]),
                   ancestors: [
-                    Results::StorageFile.new(id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
-                                             name: "Root",
-                                             location: "/",
-                                             permissions: %i[readable writeable]),
-                    Results::StorageFile.new(id: "74ccd43303847f2655300641a934959cdb11689ce171aa0f00faa92917fbd340",
-                                             name: "Folder",
-                                             location: "/Folder")
+                    Results::StorageFileAncestor.new(name: "Root", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Folder", location: "/Folder")
                   ]
                 ).value!
               end

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_query_spec.rb
@@ -120,14 +120,14 @@ module Storages
             end
 
             context "when requesting a drive", vcr: "share_point/files_query_drive" do
-              let(:folder) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||" }
+              let(:folder) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||/" }
               let(:files_result) do
                 Results::StorageFileCollection.new(
                   files: [
                     Results::StorageFile.new(
                       id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S",
                       name: "data",
-                      size: 760,
+                      size: 12605,
                       mime_type: "application/x-op-directory",
                       created_at: Time.zone.parse("2025-04-07 12:02:26Z"),
                       last_modified_at: Time.zone.parse("2025-04-07 12:02:26Z"),
@@ -168,12 +168,7 @@ module Storages
                     permissions: %i[readable writeable]
                   ),
                   ancestors: [
-                    Results::StorageFile.new(
-                      id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
-                      name: "OPTest",
-                      location: "/",
-                      permissions: %i[readable writeable]
-                    )
+                    Results::StorageFileAncestor.new(name: "OPTest", location: "/")
                   ]
                 )
               end
@@ -183,12 +178,24 @@ module Storages
 
             context "when requesting an folder", vcr: "share_point/files_query_folder" do
               let(:folder) do
-                "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S"
+                "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||data"
               end
 
               let(:files_result) do
                 Results::StorageFileCollection.new(
                   files: [
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W6DBDYX553L4REYNOMUI6XVMTO6",
+                      name: "subfolder",
+                      size: 11845,
+                      mime_type: "application/x-op-directory",
+                      location: "/Marcello%20VCR/data/subfolder",
+                      created_at: Time.zone.parse("2025-07-28 15:03:27.000000000 UTC +00:00"),
+                      last_modified_at: Time.zone.parse("2025-07-28 15:03:27.000000000 UTC +00:00"),
+                      created_by_name: "Eric Schubert",
+                      last_modified_by_name: "Eric Schubert",
+                      permissions: %i[readable writeable]
+                    ),
                     Results::StorageFile.new(
                       id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W26P5RNXU7V2JBKCVQQAGGTO46A",
                       name: "edge one_drive_health_report_2025-07-22T16_03_25Z.txt",
@@ -209,18 +216,69 @@ module Storages
                     permissions: %i[readable writeable]
                   ),
                   ancestors: [
+                    Results::StorageFileAncestor.new(name: "OPTest", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Marcello VCR", location: "/Marcello VCR")
+                  ]
+                )
+              end
+
+              it_behaves_like "adapter files_query: successful files response"
+            end
+
+            context "when requesting a sub folder", vcr: "share_point/files_query_sub_folder" do
+              let(:folder) do
+                "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||data/subfolder"
+              end
+              let(:files_result) do
+                Results::StorageFileCollection.new(
+                  files: [
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||",
-                      name: "Marcello VCR",
-                      location: "/Marcello%20VCR",
-                      permissions: %i[readable writeable]
-                    ),
-                    Results::StorageFile.new(
-                      id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
-                      name: "OPTest",
-                      location: "/",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W7MUYDYQAA3WVEYDJQNZVSKNPGD",
+                      name: "fw13-easy-effects.json",
+                      size: 11845,
+                      mime_type: "application/json",
+                      created_at: Time.zone.parse("2025-07-28 15:06:31.000000000 UTC +00:00"),
+                      last_modified_at: Time.zone.parse("2025-07-28 15:06:31.000000000 UTC +00:00"),
+                      created_by_name: "Eric Schubert",
+                      last_modified_by_name: "Eric Schubert",
+                      location: "/Marcello%20VCR/data/subfolder/fw13-easy-effects.json",
                       permissions: %i[readable writeable]
                     )
+                  ],
+                  parent: Results::StorageFile.new(
+                    id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W6DBDYX553L4REYNOMUI6XVMTO6",
+                    name: "subfolder",
+                    location: "/Marcello%20VCR/data/subfolder",
+                    permissions: %i[readable writeable]
+                  ),
+                  ancestors: [
+                    Results::StorageFileAncestor.new(name: "OPTest", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Marcello VCR", location: "/Marcello VCR"),
+                    Results::StorageFileAncestor.new(name: "data", location: "/Marcello VCR/data")
+                  ]
+                )
+              end
+
+              it_behaves_like "adapter files_query: successful files response"
+            end
+
+            context "when requesting an empty folder", vcr: "share_point/files_query_empty_folder" do
+              let(:folder) do
+                "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||empty"
+              end
+
+              let(:files_result) do
+                Results::StorageFileCollection.new(
+                  files: [],
+                  parent: Results::StorageFile.new(
+                    id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W2MWJ6SKEZPHFGIAAB325KYYMPE",
+                    name: "empty",
+                    location: "/Marcello%20VCR/empty",
+                    permissions: %i[readable writeable]
+                  ),
+                  ancestors: [
+                    Results::StorageFileAncestor.new(name: "OPTest", location: "/"),
+                    Results::StorageFileAncestor.new(name: "Marcello VCR", location: "/Marcello VCR")
                   ]
                 )
               end

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_query_spec.rb
@@ -38,72 +38,73 @@ module Storages
         module Queries
           RSpec.describe FilesQuery, :webmock do
             let(:user) { create(:admin) }
-            let(:storage) { create(:share_point_storage, oauth_client_token_user: user) }
+            let(:storage) { create(:share_point_dev_storage, oauth_client_token_user: user) }
 
             let(:auth_strategy) { Registry["share_point.authentication.userless"].call(false) }
             let(:input_data) { Input::Files.build(folder:).value! }
 
             it_behaves_like "adapter files_query: basic query setup"
 
-            context "when parent folder is root, return a list of drives", vcr: "share_point/files_query_root" do
+            # rubocop:disable Layout/LineLength
+            context "when parent folder is root", vcr: "share_point/files_query_root" do
               let(:folder) { "/" }
               let(:files_result) do
                 Results::StorageFileCollection.new(
                   files: [
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK||",
                       name: "OpenProject",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK",
+                      location: "/OpenProject",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw||",
                       name: "Shared Documents",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw",
+                      location: "/Shared%20Documents",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol||",
                       name: "Selected Permissions",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol",
+                      location: "/Selected%20Permissions",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_||",
                       name: "Chris document library",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_",
+                      location: "/Chris%20document%20library",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX||",
                       name: "Marcello AMPF",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX",
+                      location: "/Marcello%20AMPF",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn||",
                       name: "Dominic",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn",
+                      location: "/Dominic",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95||",
                       name: "Markus",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95",
+                      location: "/Markus",
                       permissions: %i[readable writeable]
                     ),
                     Results::StorageFile.new(
-                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW",
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||",
                       name: "Marcello VCR",
                       mime_type: "application/x-op-drive",
-                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW",
+                      location: "/Marcello%20VCR",
                       permissions: %i[readable writeable]
                     )
                   ],
@@ -117,6 +118,128 @@ module Storages
 
               it_behaves_like "adapter files_query: successful files response"
             end
+
+            context "when requesting a drive", vcr: "share_point/files_query_drive" do
+              let(:folder) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||" }
+              let(:files_result) do
+                Results::StorageFileCollection.new(
+                  files: [
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S",
+                      name: "data",
+                      size: 760,
+                      mime_type: "application/x-op-directory",
+                      created_at: Time.zone.parse("2025-04-07 12:02:26Z"),
+                      last_modified_at: Time.zone.parse("2025-04-07 12:02:26Z"),
+                      created_by_name: "Eric Schubert",
+                      last_modified_by_name: "Eric Schubert",
+                      location: "/Marcello%20VCR/data",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W2MWJ6SKEZPHFGIAAB325KYYMPE",
+                      name: "empty",
+                      size: 0,
+                      mime_type: "application/x-op-directory",
+                      created_at: Time.zone.parse("2025-07-28 08:46:36Z"),
+                      last_modified_at: Time.zone.parse("2025-07-28 08:46:36Z"),
+                      created_by_name: "Eric Schubert",
+                      last_modified_by_name: "Eric Schubert",
+                      location: "/Marcello%20VCR/empty",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53WZVLAWJSVFKOFF3HLYZPMPUK6HI",
+                      name: "simply_oidc.jpg",
+                      size: 56483,
+                      mime_type: "image/jpeg",
+                      created_at: Time.zone.parse("2025-04-07 12:02:42Z"),
+                      last_modified_at: Time.zone.parse("2025-04-07 12:02:42Z"),
+                      created_by_name: "Eric Schubert",
+                      last_modified_by_name: "Eric Schubert",
+                      location: "/Marcello%20VCR/simply_oidc.jpg",
+                      permissions: %i[readable writeable]
+                    )
+                  ],
+                  parent: Results::StorageFile.new(
+                    id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||",
+                    name: "Marcello VCR",
+                    location: "/Marcello%20VCR",
+                    permissions: %i[readable writeable]
+                  ),
+                  ancestors: [
+                    Results::StorageFile.new(
+                      id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
+                      name: "OPTest",
+                      location: "/",
+                      permissions: %i[readable writeable]
+                    )
+                  ]
+                )
+              end
+
+              it_behaves_like "adapter files_query: successful files response"
+            end
+
+            context "when requesting an folder", vcr: "share_point/files_query_folder" do
+              let(:folder) do
+                "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S"
+              end
+
+              let(:files_result) do
+                Results::StorageFileCollection.new(
+                  files: [
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W26P5RNXU7V2JBKCVQQAGGTO46A",
+                      name: "edge one_drive_health_report_2025-07-22T16_03_25Z.txt",
+                      size: 760,
+                      mime_type: "text/plain",
+                      location: "/Marcello%20VCR/data/edge%20one_drive_health_report_2025-07-22T16_03_25Z.txt",
+                      created_at: Time.zone.parse("2025-07-28 08:45:30.000000000 UTC +00:00"),
+                      last_modified_at: Time.zone.parse("2025-07-28 08:45:30.000000000 UTC +00:00"),
+                      created_by_name: "Eric Schubert",
+                      last_modified_by_name: "Eric Schubert",
+                      permissions: %i[readable writeable]
+                    )
+                  ],
+                  parent: Results::StorageFile.new(
+                    id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S",
+                    name: "data",
+                    location: "/Marcello%20VCR/data",
+                    permissions: %i[readable writeable]
+                  ),
+                  ancestors: [
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||",
+                      name: "Marcello VCR",
+                      location: "/Marcello%20VCR",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "a1d45ff742d2175c095f0a7173f93fc3fc23664a953ceae6778fe15398818c2d",
+                      name: "OPTest",
+                      location: "/",
+                      permissions: %i[readable writeable]
+                    )
+                  ]
+                )
+              end
+
+              it_behaves_like "adapter files_query: successful files response"
+            end
+
+            context "when requesting an unknown file", vcr: "share_point/files_query_file_not_found" do
+              let(:folder) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW||POTATO" }
+
+              it_behaves_like "adapter files_query: not found", Internal::ChildrenQuery
+            end
+
+            context "when requestion an unknown drive", vcr: "share_point/files_query_drive_not_found" do
+              let(:folder) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvPoTaTO" }
+
+              it_behaves_like "adapter files_query: not found", Internal::ChildrenQuery
+            end
+            # rubocop:enable Layout/LineLength
           end
         end
       end

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_query_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+module Storages
+  module Adapters
+    module Providers
+      module SharePoint
+        module Queries
+          RSpec.describe FilesQuery, :webmock do
+            let(:user) { create(:admin) }
+            let(:storage) { create(:share_point_storage, oauth_client_token_user: user) }
+
+            let(:auth_strategy) { Registry["share_point.authentication.userless"].call(false) }
+            let(:input_data) { Input::Files.build(folder:).value! }
+
+            it_behaves_like "adapter files_query: basic query setup"
+
+            context "when parent folder is root, return a list of drives", vcr: "share_point/files_query_root" do
+              let(:folder) { "/" }
+              let(:files_result) do
+                Results::StorageFileCollection.new(
+                  files: [
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK",
+                      name: "OpenProject",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw",
+                      name: "Shared Documents",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol",
+                      name: "Selected Permissions",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_",
+                      name: "Chris document library",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX",
+                      name: "Marcello AMPF",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn",
+                      name: "Dominic",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95",
+                      name: "Markus",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95",
+                      permissions: %i[readable writeable]
+                    ),
+                    Results::StorageFile.new(
+                      id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW",
+                      name: "Marcello VCR",
+                      mime_type: "application/x-op-drive",
+                      location: "/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW",
+                      permissions: %i[readable writeable]
+                    )
+                  ],
+                  parent: Results::StorageFile.new(id: "1269877d26360587caf07834bc72ee3ad3c3698f1651bf85d8562e7fda19aa0f",
+                                                   name: "OPTest",
+                                                   location: "/",
+                                                   permissions: %i[readable writeable]),
+                  ancestors: []
+                )
+              end
+
+              it_behaves_like "adapter files_query: successful files response"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -234,4 +234,29 @@ FactoryBot.define do
       tenant_id { SecureRandom.uuid }
     end
   end
+
+
+  factory :share_point_dev_storage, parent: :storage, class: "::Storages::SharePointStorage" do
+    tenant_id { ENV.fetch("SHARE_POINT_TEST_TENANT_ID", "e36f1dbc-fdae-427e-b61b-0d96ddfb81a4") }
+    host { ENV.fetch("SHARE_POINT_TEST_HOST", "https://ymt6d.sharepoint.com/sites/OPTest") }
+
+    transient do
+      oauth_client_token_user { association :user }
+    end
+
+    after(:create) do |storage, evaluator|
+      create(:oauth_client,
+             client_id: ENV.fetch("SHARE_POINT_TEST_OAUTH_CLIENT_ID", "MISSING_SHARE_POINT_TEST_OAUTH_CLIENT_ID"),
+             client_secret: ENV.fetch("SHARE_POINT_TEST_OAUTH_CLIENT_SECRET", "MISSING_SHARE_POINT_TEST_OAUTH_CLIENT_SECRET"),
+             integration: storage)
+
+      create(:oauth_client_token,
+             oauth_client: storage.oauth_client,
+             user: evaluator.oauth_client_token_user,
+             access_token: ENV.fetch("SHARE_POINT_TEST_OAUTH_CLIENT_ACCESS_TOKEN", "SHARE_POINT_TEST_OAUTH_CLIENT_ACCESS_TOKEN"),
+             refresh_token: ENV.fetch("SHARE_POINT_TEST_OAUTH_CLIENT_REFRESH_TOKEN",
+                                      "MISSING_SHARE_POINT_TEST_OAUTH_CLIENT_REFRESH_TOKEN"),
+             token_type: "bearer")
+    end
+  end
 end

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -235,7 +235,6 @@ FactoryBot.define do
     end
   end
 
-
   factory :share_point_dev_storage, parent: :storage, class: "::Storages::SharePointStorage" do
     tenant_id { ENV.fetch("SHARE_POINT_TEST_TENANT_ID", "e36f1dbc-fdae-427e-b61b-0d96ddfb81a4") }
     host { ENV.fetch("SHARE_POINT_TEST_HOST", "https://ymt6d.sharepoint.com/sites/OPTest") }

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_drive.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_drive.yml
@@ -37,13 +37,13 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - e5593e6d-10b8-42ee-8f15-ad820ac10500
+      - 4ec08b8c-2cdf-48f6-bf34-fb9b9c080a00
       X-Ms-Ests-Server:
-      - 2.1.21415.7 - FRC ProdSlices
+      - 2.1.21415.8 - WEULR1 ProdSlices
       X-Ms-Srs:
       - 1.P
       Content-Security-Policy-Report-Only:
-      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-OAM6X5AYz9ocAqYPChlwQw'
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-2ejqtDi2cHtAbTKF6HGh9g'
         'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
         https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
         https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
@@ -52,18 +52,18 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=ArsDHMmFgLZOhbsMGLIx3LVZ-dCOAQAAAMkwGeAOAAAA; expires=Wed, 27-Aug-2025
-        08:50:18 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+      - fpc=AneMM3AJvplMqyQbGUyyx6lZ-dCOAQAAAKyAGuAOAAAA; expires=Thu, 28-Aug-2025
+        08:43:24 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
         path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
         secure; samesite=none; httponly
       Date:
-      - Mon, 28 Jul 2025 08:50:17 GMT
+      - Tue, 29 Jul 2025 08:43:24 GMT
       Content-Length:
-      - '1927'
+      - '1932'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Mon, 28 Jul 2025 08:50:18 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:24 GMT
 - request:
     method: get
     uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
@@ -94,26 +94,26 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 60b70375-811f-401d-b92d-f9e890b2b95a
+      - 51333f1f-b882-49a7-9c19-9feaa14a4087
       Client-Request-Id:
-      - 60b70375-811f-401d-b92d-f9e890b2b95a
+      - 51333f1f-b882-49a7-9c19-9feaa14a4087
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000167"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000400"}}'
       Splogid:
-      - 6926b6a1-e079-0000-7566-ad884651cd18
+      - 6a78b6a1-9046-0000-7534-c585c9f58701
       Date:
-      - Mon, 28 Jul 2025 08:50:18 GMT
+      - Tue, 29 Jul 2025 08:43:24 GMT
     body:
       encoding: UTF-8
       string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{8DA9DCAF-43E4-419C-B52E-F1303A0D3372},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"id":"01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"name":"data","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
-        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data","fileSystemInfo":{"createdDateTime":"2025-04-07T12:02:26Z","lastModifiedDateTime":"2025-04-07T12:02:26Z"},"folder":{"childCount":1},"size":760},{"@odata.etag":"\"{257DB24C-2F13-4C39-8000-3BD7558C31E4},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data","fileSystemInfo":{"createdDateTime":"2025-04-07T12:02:26Z","lastModifiedDateTime":"2025-04-07T12:02:26Z"},"folder":{"childCount":2},"size":12605},{"@odata.etag":"\"{257DB24C-2F13-4C39-8000-3BD7558C31E4},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"id":"01ANJ53W2MWJ6SKEZPHFGIAAB325KYYMPE","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"name":"empty","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
         VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/empty","fileSystemInfo":{"createdDateTime":"2025-07-28T08:46:36Z","lastModifiedDateTime":"2025-07-28T08:46:36Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{992C5835-AA54-4B71-B3AF-197B1F4578E8},2\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"id":"01ANJ53WZVLAWJSVFKOFF3HLYZPMPUK6HI","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"name":"simply_oidc.jpg","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
         VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/simply_oidc.jpg","file":{"hashes":{"quickXorHash":"qzqT/ZJgJnvhu77aF+2RcdH62Sc="},"mimeType":"image/jpeg"},"fileSystemInfo":{"createdDateTime":"2025-04-07T12:02:42Z","lastModifiedDateTime":"2025-04-07T12:02:42Z"},"size":56483}]}'
-  recorded_at: Mon, 28 Jul 2025 08:50:18 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:25 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_drive.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_drive.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - e5593e6d-10b8-42ee-8f15-ad820ac10500
+      X-Ms-Ests-Server:
+      - 2.1.21415.7 - FRC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-OAM6X5AYz9ocAqYPChlwQw'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=ArsDHMmFgLZOhbsMGLIx3LVZ-dCOAQAAAMkwGeAOAAAA; expires=Wed, 27-Aug-2025
+        08:50:18 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 28 Jul 2025 08:50:17 GMT
+      Content-Length:
+      - '1927'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 28 Jul 2025 08:50:18 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 60b70375-811f-401d-b92d-f9e890b2b95a
+      Client-Request-Id:
+      - 60b70375-811f-401d-b92d-f9e890b2b95a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000167"}}'
+      Splogid:
+      - 6926b6a1-e079-0000-7566-ad884651cd18
+      Date:
+      - Mon, 28 Jul 2025 08:50:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{8DA9DCAF-43E4-419C-B52E-F1303A0D3372},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"data","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data","fileSystemInfo":{"createdDateTime":"2025-04-07T12:02:26Z","lastModifiedDateTime":"2025-04-07T12:02:26Z"},"folder":{"childCount":1},"size":760},{"@odata.etag":"\"{257DB24C-2F13-4C39-8000-3BD7558C31E4},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53W2MWJ6SKEZPHFGIAAB325KYYMPE","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"empty","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/empty","fileSystemInfo":{"createdDateTime":"2025-07-28T08:46:36Z","lastModifiedDateTime":"2025-07-28T08:46:36Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{992C5835-AA54-4B71-B3AF-197B1F4578E8},2\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53WZVLAWJSVFKOFF3HLYZPMPUK6HI","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"simply_oidc.jpg","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/simply_oidc.jpg","file":{"hashes":{"quickXorHash":"qzqT/ZJgJnvhu77aF+2RcdH62Sc="},"mimeType":"image/jpeg"},"fileSystemInfo":{"createdDateTime":"2025-04-07T12:02:42Z","lastModifiedDateTime":"2025-04-07T12:02:42Z"},"size":56483}]}'
+  recorded_at: Mon, 28 Jul 2025 08:50:18 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_drive_not_found.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_drive_not_found.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - ff7ffdad-33a4-4cd2-8757-b3b10f337d00
+      X-Ms-Ests-Server:
+      - 2.1.21415.7 - FRC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-VdWfibjRfWm-a8iXEyCQBw'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AmU5JebootlLq_w0JEw_Kv1Z-dCOAQAAAJlvGeAOAAAA; expires=Wed, 27-Aug-2025
+        13:18:18 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 28 Jul 2025 13:18:18 GMT
+      Content-Length:
+      - '1927'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 28 Jul 2025 13:18:18 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvPoTaTO/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 04a7154e-197c-4ffc-b9ea-cfdc125ce2a4
+      Client-Request-Id:
+      - 04a7154e-197c-4ffc-b9ea-cfdc125ce2a4
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"008","RoleInstance":"FR3PEPF00000DD3"}}'
+      Splogid:
+      - bf35b6a1-603c-0000-7566-a3bc946874bc
+      Date:
+      - Mon, 28 Jul 2025 13:18:18 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"itemNotFound","message":"Item not found"}}'
+  recorded_at: Mon, 28 Jul 2025 13:18:18 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_empty_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_empty_folder.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - c793650a-7cc1-42f4-b175-50636543f000
+      X-Ms-Ests-Server:
+      - 2.1.21415.7 - NEULR1 ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-o3yU83OQvFJqBmxoqe4LjQ'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AlV2DsLJ-jBLn3oPM6k1qcJZ-dCOAQAAAK6AGuAOAAAA; expires=Thu, 28-Aug-2025
+        08:43:26 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Tue, 29 Jul 2025 08:43:25 GMT
+      Content-Length:
+      - '1935'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Tue, 29 Jul 2025 08:43:26 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/empty:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 7d40873b-70fe-44e7-9227-c78c4cc5bc7a
+      Client-Request-Id:
+      - 7d40873b-70fe-44e7-9227-c78c4cc5bc7a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001EE"}}'
+      Splogid:
+      - 6a78b6a1-a0a9-0000-7534-c94564ab7f1c
+      Date:
+      - Tue, 29 Jul 2025 08:43:26 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[]}'
+  recorded_at: Tue, 29 Jul 2025 08:43:26 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/empty?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 0fe7f69c-2896-4b5b-bd74-3549ed87ca96
+      Client-Request-Id:
+      - 0fe7f69c-2896-4b5b-bd74-3549ed87ca96
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001EE"}}'
+      Splogid:
+      - 6a78b6a1-a0b5-0000-7534-cf59e5c2a115
+      Date:
+      - Tue, 29 Jul 2025 08:43:26 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","@odata.etag":"\"{257DB24C-2F13-4C39-8000-3BD7558C31E4},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53W2MWJ6SKEZPHFGIAAB325KYYMPE","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"empty","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"Marcello
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/empty","fileSystemInfo":{"createdDateTime":"2025-07-28T08:46:36Z","lastModifiedDateTime":"2025-07-28T08:46:36Z"},"folder":{"childCount":0},"size":0}'
+  recorded_at: Tue, 29 Jul 2025 08:43:27 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_file_not_found.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_file_not_found.yml
@@ -37,13 +37,13 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - b2ce4ada-b8ef-46c7-8cf4-c9b83db6a500
+      - e0ae382e-610b-4540-bf8e-b647a3c60100
       X-Ms-Ests-Server:
-      - 2.1.21415.7 - FRC ProdSlices
+      - 2.1.21415.8 - SEC ProdSlices
       X-Ms-Srs:
       - 1.P
       Content-Security-Policy-Report-Only:
-      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-GFNiZX_zRLvj3WVU7ogLeQ'
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-8nuxlo41p8YUlOGBkvr0QA'
         'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
         https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
         https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
@@ -52,21 +52,21 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=AkeDXHb9l0ZCgY-m-IGrBzhZ-dCOAQAAAG5tGeAOAAAA; expires=Wed, 27-Aug-2025
-        13:09:03 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+      - fpc=AgPm81TOrBRGsI8ii7mxCF5Z-dCOAQAAALCAGuAOAAAA; expires=Thu, 28-Aug-2025
+        08:43:28 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
         path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
         secure; samesite=none; httponly
       Date:
-      - Mon, 28 Jul 2025 13:09:02 GMT
+      - Tue, 29 Jul 2025 08:43:27 GMT
       Content-Length:
-      - '1932'
+      - '1927'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Mon, 28 Jul 2025 13:09:03 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:28 GMT
 - request:
     method: get
-    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/items/POTATO/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/POTATO:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
     body:
       encoding: US-ASCII
       string: ''
@@ -87,7 +87,8 @@ http_interactions:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
       Content-Encoding:
       - gzip
       Vary:
@@ -95,17 +96,18 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 8470c2a4-e9b1-480a-84c2-8abf72f91adf
+      - 82303d0a-e686-47d0-a59d-4a1aa1aed489
       Client-Request-Id:
-      - 8470c2a4-e9b1-480a-84c2-8abf72f91adf
+      - 82303d0a-e686-47d0-a59d-4a1aa1aed489
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"008","RoleInstance":"FR3PEPF00000DD5"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001DD"}}'
       Splogid:
-      - 3735b6a1-60b6-0000-7566-a31011c0b744
+      - 6b78b6a1-c0a3-0000-7534-c1315b3a5d62
       Date:
-      - Mon, 28 Jul 2025 13:09:03 GMT
+      - Tue, 29 Jul 2025 08:43:30 GMT
     body:
       encoding: UTF-8
-      string: '{"error":{"code":"itemNotFound","message":"Item not found"}}'
-  recorded_at: Mon, 28 Jul 2025 13:09:03 GMT
+      string: '{"error":{"code":"itemNotFound","message":"The resource could not be
+        found."}}'
+  recorded_at: Tue, 29 Jul 2025 08:43:30 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_file_not_found.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_file_not_found.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - b2ce4ada-b8ef-46c7-8cf4-c9b83db6a500
+      X-Ms-Ests-Server:
+      - 2.1.21415.7 - FRC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-GFNiZX_zRLvj3WVU7ogLeQ'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AkeDXHb9l0ZCgY-m-IGrBzhZ-dCOAQAAAG5tGeAOAAAA; expires=Wed, 27-Aug-2025
+        13:09:03 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 28 Jul 2025 13:09:02 GMT
+      Content-Length:
+      - '1932'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 28 Jul 2025 13:09:03 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/items/POTATO/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 8470c2a4-e9b1-480a-84c2-8abf72f91adf
+      Client-Request-Id:
+      - 8470c2a4-e9b1-480a-84c2-8abf72f91adf
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"008","RoleInstance":"FR3PEPF00000DD5"}}'
+      Splogid:
+      - 3735b6a1-60b6-0000-7566-a31011c0b744
+      Date:
+      - Mon, 28 Jul 2025 13:09:03 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"itemNotFound","message":"Item not found"}}'
+  recorded_at: Mon, 28 Jul 2025 13:09:03 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_folder.yml
@@ -37,13 +37,13 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - 6f542d99-7f2f-4466-952f-c400dbe06600
+      - c12f7d67-2767-4164-958c-d4f8d09e0900
       X-Ms-Ests-Server:
-      - 2.1.21415.7 - WEULR1 ProdSlices
+      - 2.1.21415.7 - FRC ProdSlices
       X-Ms-Srs:
       - 1.P
       Content-Security-Policy-Report-Only:
-      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-bFUy_yd93jzFa_VHsmlc9Q'
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-8T8VddmPKbxuBtV34nnbfg'
         'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
         https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
         https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
@@ -52,21 +52,21 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=AkC9kJWBJE5Li_QcJSA9Au1Z-dCOAQAAAM4xGeAOAAAA; expires=Wed, 27-Aug-2025
-        08:54:39 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+      - fpc=AhLF2dL16qVCocHKKe9nTY5Z-dCOAQAAAKqAGuAOAAAA; expires=Thu, 28-Aug-2025
+        08:43:22 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
         path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
         secure; samesite=none; httponly
       Date:
-      - Mon, 28 Jul 2025 08:54:38 GMT
+      - Tue, 29 Jul 2025 08:43:22 GMT
       Content-Length:
-      - '1937'
+      - '1931'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Mon, 28 Jul 2025 08:54:39 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:22 GMT
 - request:
     method: get
-    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/items/01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/data:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
     body:
       encoding: US-ASCII
       string: ''
@@ -94,19 +94,21 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 8a564d27-6add-4786-a344-17d748e93119
+      - '09215f41-a3b7-4d85-a577-aeeb31269189'
       Client-Request-Id:
-      - 8a564d27-6add-4786-a344-17d748e93119
+      - '09215f41-a3b7-4d85-a577-aeeb31269189'
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000350"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000CB7"}}'
       Splogid:
-      - a926b6a1-801c-0000-7566-a04034d05092
+      - 6978b6a1-80ab-0000-7534-cc12511848cf
       Date:
-      - Mon, 28 Jul 2025 08:54:39 GMT
+      - Tue, 29 Jul 2025 08:43:22 GMT
     body:
       encoding: UTF-8
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{DB627F5E-F5D3-42D2-A156-10018D3773C0},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{7EF108C3-6BF7-49E4-86B9-9447AF564DDE},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53W6DBDYX553L4REYNOMUI6XVMTO6","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"subfolder","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S","name":"data","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/data","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data/subfolder","fileSystemInfo":{"createdDateTime":"2025-07-28T15:03:27Z","lastModifiedDateTime":"2025-07-28T15:03:27Z"},"folder":{"childCount":1},"size":11845},{"@odata.etag":"\"{DB627F5E-F5D3-42D2-A156-10018D3773C0},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"id":"01ANJ53W26P5RNXU7V2JBKCVQQAGGTO46A","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"name":"edge one_drive_health_report_2025-07-22T16_03_25Z.txt","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S","name":"data","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/data","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data/edge%20one_drive_health_report_2025-07-22T16_03_25Z.txt","file":{"hashes":{"quickXorHash":"dUZdSj55kRInUxY0kvoKq2xFSLk="},"mimeType":"text/plain"},"fileSystemInfo":{"createdDateTime":"2025-07-28T08:45:30Z","lastModifiedDateTime":"2025-07-28T08:45:30Z"},"size":760}]}'
-  recorded_at: Mon, 28 Jul 2025 08:54:39 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:22 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_folder.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 6f542d99-7f2f-4466-952f-c400dbe06600
+      X-Ms-Ests-Server:
+      - 2.1.21415.7 - WEULR1 ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-bFUy_yd93jzFa_VHsmlc9Q'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AkC9kJWBJE5Li_QcJSA9Au1Z-dCOAQAAAM4xGeAOAAAA; expires=Wed, 27-Aug-2025
+        08:54:39 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 28 Jul 2025 08:54:38 GMT
+      Content-Length:
+      - '1937'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 28 Jul 2025 08:54:39 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/items/01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 8a564d27-6add-4786-a344-17d748e93119
+      Client-Request-Id:
+      - 8a564d27-6add-4786-a344-17d748e93119
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000350"}}'
+      Splogid:
+      - a926b6a1-801c-0000-7566-a04034d05092
+      Date:
+      - Mon, 28 Jul 2025 08:54:39 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{DB627F5E-F5D3-42D2-A156-10018D3773C0},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53W26P5RNXU7V2JBKCVQQAGGTO46A","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"edge one_drive_health_report_2025-07-22T16_03_25Z.txt","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W5P3SUY3ZCDTRA3KLXRGA5A2M3S","name":"data","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/data","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data/edge%20one_drive_health_report_2025-07-22T16_03_25Z.txt","file":{"hashes":{"quickXorHash":"dUZdSj55kRInUxY0kvoKq2xFSLk="},"mimeType":"text/plain"},"fileSystemInfo":{"createdDateTime":"2025-07-28T08:45:30Z","lastModifiedDateTime":"2025-07-28T08:45:30Z"},"size":760}]}'
+  recorded_at: Mon, 28 Jul 2025 08:54:39 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_root.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_root.yml
@@ -37,13 +37,13 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - 2151528f-3b78-4c06-af47-5418b6440400
+      - 94211292-5035-40b4-b9d5-2d3ec48a7e00
       X-Ms-Ests-Server:
-      - 2.1.21415.7 - SEC ProdSlices
+      - 2.1.21415.7 - FRC ProdSlices
       X-Ms-Srs:
       - 1.P
       Content-Security-Policy-Report-Only:
-      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-LLJhckFDSgu1DYtB3fvK-g'
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-aKvJ90PEOpqPhZmq6TTwDg'
         'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
         https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
         https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
@@ -52,18 +52,18 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=AkhqyVRZf9VOqEbrBAV5PXFZ-dCOAQAAAGYiFOAOAAAA; expires=Sat, 23-Aug-2025
-        12:47:35 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+      - fpc=AnUMhhQ9eI9EqAraBLDAbNRZ-dCOAQAAAMowGeAOAAAA; expires=Wed, 27-Aug-2025
+        08:50:19 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
         path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
         secure; samesite=none; httponly
       Date:
-      - Thu, 24 Jul 2025 12:47:35 GMT
+      - Mon, 28 Jul 2025 08:50:19 GMT
       Content-Length:
       - '1925'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Thu, 24 Jul 2025 12:47:35 GMT
+  recorded_at: Mon, 28 Jul 2025 08:50:19 GMT
 - request:
     method: get
     uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
@@ -95,53 +95,53 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 516e4e68-f5a2-4665-8f98-0171e66f50ce
+      - d94669a4-95fb-4044-83e9-bb9677994772
       Client-Request-Id:
-      - 516e4e68-f5a2-4665-8f98-0171e66f50ce
+      - d94669a4-95fb-4044-83e9-bb9677994772
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC9"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000DC1"}}'
       Splogid:
-      - 66eab4a1-e040-0000-7380-7fa7ad0849a5
+      - 6926b6a1-b0ac-0000-7534-cd98012d4302
       Odata-Version:
       - '4.0'
       Date:
-      - Thu, 24 Jul 2025 12:47:35 GMT
+      - Mon, 28 Jul 2025 08:50:19 GMT
     body:
       encoding: UTF-8
       string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
         for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-06-18T11:42:21Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,21\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,21\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
         Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2024-08-09T11:53:52Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
         Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,4\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,4\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
         Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2024-08-12T16:45:41Z","name":"Selected
         Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
         Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
         document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
         testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
         document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
         Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,4\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,4\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
         AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-04-09T16:01:59Z","name":"Marcello
         (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
         Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
-        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-07-22T17:22:13Z","name":"Marcello
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-07-28T08:46:36Z","name":"Marcello
         (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
         Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,8\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,8\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
         Requests"}]}'
-  recorded_at: Thu, 24 Jul 2025 12:47:35 GMT
+  recorded_at: Mon, 28 Jul 2025 08:50:19 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_root.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_root.yml
@@ -37,13 +37,13 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - 94211292-5035-40b4-b9d5-2d3ec48a7e00
+      - f3ad4781-1388-4b40-bb8b-2652a5c00100
       X-Ms-Ests-Server:
-      - 2.1.21415.7 - FRC ProdSlices
+      - 2.1.21415.8 - SEC ProdSlices
       X-Ms-Srs:
       - 1.P
       Content-Security-Policy-Report-Only:
-      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-aKvJ90PEOpqPhZmq6TTwDg'
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-fH6wc7iK1SrI0ov5b3ye1Q'
         'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
         https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
         https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
@@ -52,18 +52,18 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=AnUMhhQ9eI9EqAraBLDAbNRZ-dCOAQAAAMowGeAOAAAA; expires=Wed, 27-Aug-2025
-        08:50:19 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+      - fpc=AoAJXZgaqChJngrC4Q2zUZ5Z-dCOAQAAAKmAGuAOAAAA; expires=Thu, 28-Aug-2025
+        08:43:21 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
         path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
         secure; samesite=none; httponly
       Date:
-      - Mon, 28 Jul 2025 08:50:19 GMT
+      - Tue, 29 Jul 2025 08:43:20 GMT
       Content-Length:
       - '1925'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Mon, 28 Jul 2025 08:50:19 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:21 GMT
 - request:
     method: get
     uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
@@ -95,53 +95,53 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - d94669a4-95fb-4044-83e9-bb9677994772
+      - fda8b138-8b1e-437d-bd5b-b3bb9b5deaa9
       Client-Request-Id:
-      - d94669a4-95fb-4044-83e9-bb9677994772
+      - fda8b138-8b1e-437d-bd5b-b3bb9b5deaa9
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000DC1"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001DD"}}'
       Splogid:
-      - 6926b6a1-b0ac-0000-7534-cd98012d4302
+      - 6978b6a1-5068-0000-7534-caba7f047892
       Odata-Version:
       - '4.0'
       Date:
-      - Mon, 28 Jul 2025 08:50:19 GMT
+      - Tue, 29 Jul 2025 08:43:21 GMT
     body:
       encoding: UTF-8
       string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
         for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-06-18T11:42:21Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,21\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,21\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
         Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2024-08-09T11:53:52Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
         Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,4\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,4\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
         Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2024-08-12T16:45:41Z","name":"Selected
         Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
         Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
         document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
         testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
         document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
         Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,4\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,4\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
         AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-04-09T16:01:59Z","name":"Marcello
         (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
         Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
         VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-07-28T08:46:36Z","name":"Marcello
         (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
         Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
         Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
-        Test Owners"}},"quota":{"deleted":0,"remaining":27487787097631,"state":"normal","total":27487790694400,"used":3596769}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,8\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Test Owners"}},"quota":{"deleted":0,"remaining":27487787003556,"state":"normal","total":27487790694400,"used":3690844}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,8\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
         Requests"}]}'
-  recorded_at: Mon, 28 Jul 2025 08:50:19 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:22 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_root.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_root.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 2151528f-3b78-4c06-af47-5418b6440400
+      X-Ms-Ests-Server:
+      - 2.1.21415.7 - SEC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-LLJhckFDSgu1DYtB3fvK-g'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AkhqyVRZf9VOqEbrBAV5PXFZ-dCOAQAAAGYiFOAOAAAA; expires=Sat, 23-Aug-2025
+        12:47:35 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Thu, 24 Jul 2025 12:47:35 GMT
+      Content-Length:
+      - '1925'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Thu, 24 Jul 2025 12:47:35 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.3.4
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 516e4e68-f5a2-4665-8f98-0171e66f50ce
+      Client-Request-Id:
+      - 516e4e68-f5a2-4665-8f98-0171e66f50ce
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC9"}}'
+      Splogid:
+      - 66eab4a1-e040-0000-7380-7fa7ad0849a5
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 24 Jul 2025 12:47:35 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-06-18T11:42:21Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,21\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2024-08-09T11:53:52Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,4\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2024-08-12T16:45:41Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,4\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-04-09T16:01:59Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-07-22T17:22:13Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":47480,"remaining":27487787051559,"state":"normal","total":27487790694400,"used":3595361}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,8\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Thu, 24 Jul 2025 12:47:35 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_sub_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/share_point/files_query_sub_folder.yml
@@ -37,13 +37,13 @@ http_interactions:
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       X-Ms-Request-Id:
-      - c9505a9c-e667-4463-8ca7-b9a6a743b500
+      - 801e4994-fa65-4968-a322-34729db2c800
       X-Ms-Ests-Server:
       - 2.1.21415.7 - NEULR1 ProdSlices
       X-Ms-Srs:
       - 1.P
       Content-Security-Policy-Report-Only:
-      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-cyQfIqqFLw_nwwr-5XGyNQ'
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-6D_qoNbKLX9JypzzRltl2A'
         'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
         https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
         https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
@@ -52,21 +52,21 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Set-Cookie:
-      - fpc=AoG5mtQlIaJJtU0v5wR3ju5Z-dCOAQAAALKAGuAOAAAA; expires=Thu, 28-Aug-2025
-        08:43:31 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+      - fpc=AmHkd5Kz3HVGhrJsTCmkauRZ-dCOAQAAAKqAGuAOAAAA; expires=Thu, 28-Aug-2025
+        08:43:23 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
         path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
         secure; samesite=none; httponly
       Date:
-      - Tue, 29 Jul 2025 08:43:30 GMT
+      - Tue, 29 Jul 2025 08:43:23 GMT
       Content-Length:
-      - '1935'
+      - '1940'
     body:
       encoding: UTF-8
       string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
-  recorded_at: Tue, 29 Jul 2025 08:43:31 GMT
+  recorded_at: Tue, 29 Jul 2025 08:43:23 GMT
 - request:
     method: get
-    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvPoTaTO/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/data/subfolder:/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
     body:
       encoding: US-ASCII
       string: ''
@@ -81,31 +81,32 @@ http_interactions:
       - Bearer <BEARER TOKEN>
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
       Content-Encoding:
       - gzip
-      Vary:
-      - Accept-Encoding
       Strict-Transport-Security:
       - max-age=31536000
       Request-Id:
-      - 4bcaec8e-554a-4b1d-872a-eae53bc692b4
+      - f211d1e3-6605-48ca-a5c3-da65365cf64a
       Client-Request-Id:
-      - 4bcaec8e-554a-4b1d-872a-eae53bc692b4
+      - f211d1e3-6605-48ca-a5c3-da65365cf64a
       X-Ms-Ags-Diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001EE"}}'
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000D30"}}'
       Splogid:
-      - 6b78b6a1-90ce-0000-7534-c35aeefe5ff5
+      - 6978b6a1-80e8-0000-7534-c9cde828a2ae
       Date:
-      - Tue, 29 Jul 2025 08:43:30 GMT
+      - Tue, 29 Jul 2025 08:43:23 GMT
     body:
       encoding: UTF-8
-      string: '{"error":{"code":"itemNotFound","message":"Item not found"}}'
-  recorded_at: Tue, 29 Jul 2025 08:43:31 GMT
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{8807A6EC-1B00-49B5-81A6-0DCD64A6BCC3},1\"","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"id":"01ANJ53W7MUYDYQAA3WVEYDJQNZVSKNPGD","lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"name":"fw13-easy-effects.json","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","id":"01ANJ53W6DBDYX553L4REYNOMUI6XVMTO6","name":"subfolder","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW/root:/data/subfolder","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR/data/subfolder/fw13-easy-effects.json","file":{"hashes":{"quickXorHash":"eA5sv9rqGJI/2/SvuRJJKwFOOw8="},"mimeType":"application/json"},"fileSystemInfo":{"createdDateTime":"2025-07-28T15:06:31Z","lastModifiedDateTime":"2025-07-28T15:06:31Z"},"size":11845}]}'
+  recorded_at: Tue, 29 Jul 2025 08:43:23 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/files_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/files_query_examples.rb
@@ -44,7 +44,7 @@ RSpec.shared_examples_for "adapter files_query: basic query setup" do
 end
 
 RSpec.shared_examples_for "adapter files_query: successful files response" do
-  it "returns a file info object" do
+  it "returns a storage file collection object" do
     result = described_class.call(storage:, auth_strategy:, input_data:)
 
     expect(result).to be_success
@@ -55,7 +55,7 @@ RSpec.shared_examples_for "adapter files_query: successful files response" do
   end
 end
 
-RSpec.shared_examples_for "adapter files_query: not found" do
+RSpec.shared_examples_for "adapter files_query: not found" do |error_source = described_class|
   it "returns a failure" do
     result = described_class.call(storage:, auth_strategy:, input_data:)
 
@@ -63,11 +63,11 @@ RSpec.shared_examples_for "adapter files_query: not found" do
 
     error = result.failure
     expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(described_class)
+    expect(error.source).to eq(error_source)
   end
 end
 
-RSpec.shared_examples_for "adapter files_query: error" do
+RSpec.shared_examples_for "adapter files_query: error" do |error_source = described_class|
   it "returns a failure" do
     result = described_class.call(storage:, auth_strategy:, input_data:)
 
@@ -75,6 +75,6 @@ RSpec.shared_examples_for "adapter files_query: error" do
 
     error = result.failure
     expect(error.code).to eq(:error)
-    expect(error.source).to eq(described_class)
+    expect(error.source).to eq(error_source)
   end
 end


### PR DESCRIPTION
#### Related Work Package: [OP#64186](https://community.openproject.org/projects/document-workflows-stream/work_packages/64186), [OP#64185](https://community.openproject.org/projects/document-workflows-stream/work_packages/64185)

## What?

This PR implements the `FilesQuery` that is used to display the items on the `FilePicker` and feed the `StorageFilesAPI`.

## How?

SharePoint introduces a new level of complexity since we have a set of "special folders", the Document Libraries (drives) and the "file root" should be the SharePoint Site. Therefore we have 2 different queries that deal with querying the site or a specific folder.

We also have another level of complexity: we don't know to which drive a certain folder belongs to using our current understanding of IDs.

For this PR I assumed a composite id including the Drive ID but that's experimental for now.