### PR TITLE
Reskin groups index with using Primer components

### DIFF
--- a/app/components/groups/row_component.rb
+++ b/app/components/groups/row_component.rb
@@ -28,26 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
-
-RSpec.describe "group memberships through groups page", :js do
-  shared_let(:admin) { create(:admin) }
-  let!(:group) { create(:group, lastname: "Bob's Team") }
-
-  let(:groups_page) { Pages::Groups.new }
-
-  context "as an admin" do
-    before do
-      allow(User).to receive(:current).and_return admin
+module Groups
+  class RowComponent < OpPrimer::BorderBoxRowComponent
+    def name
+      render(Primer::Beta::Link.new(href: edit_group_path(model), font_weight: :bold)) { model.name }
     end
 
-    it "I can see groups" do
-      groups_page.visit!
-      expect(groups_page).to have_group "Bob's Team"
+    def user_count
+      model.users.count
+    end
 
-      click_on "Bob's Team"
-
-      expect(page).to have_current_path(edit_group_path(group))
+    def created_at
+      helpers.format_date(model.created_at)
     end
   end
 end

--- a/app/components/groups/table_component.rb
+++ b/app/components/groups/table_component.rb
@@ -28,26 +28,49 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
+module Groups
+  class TableComponent < OpPrimer::BorderBoxTableComponent
+    columns :name, :user_count, :created_at
+    mobile_labels :user_count, :created_at
 
-RSpec.describe "group memberships through groups page", :js do
-  shared_let(:admin) { create(:admin) }
-  let!(:group) { create(:group, lastname: "Bob's Team") }
-
-  let(:groups_page) { Pages::Groups.new }
-
-  context "as an admin" do
-    before do
-      allow(User).to receive(:current).and_return admin
+    def mobile_title
+      Group.model_name.human(count: 2)
     end
 
-    it "I can see groups" do
-      groups_page.visit!
-      expect(groups_page).to have_group "Bob's Team"
+    def row_class
+      RowComponent
+    end
 
-      click_on "Bob's Team"
+    def headers
+      [
+        [:name, { caption: Group.human_attribute_name(:name) }],
+        [:user_count, { caption: t(".user_count") }],
+        [:created_at, { caption: Group.human_attribute_name(:created_at) }]
+      ]
+    end
 
-      expect(page).to have_current_path(edit_group_path(group))
+    def render_blank_slate
+      render(Primer::Beta::Blankslate.new(border: false)) do |component|
+        component.with_visual_icon(icon: blank_icon, size: :medium) if blank_icon
+        component.with_heading(tag: :h2) { blank_title }
+        component.with_description { blank_description }
+        component.with_primary_action(label: t(:label_group_new), tag: :a, href: new_group_path) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          t("activerecord.models.group")
+        end
+      end
+    end
+
+    def blank_title
+      t(".blank_slate.title")
+    end
+
+    def blank_description
+      t(".blank_slate.description")
+    end
+
+    def blank_icon
+      :people
     end
   end
 end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -32,6 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { t(:label_group_plural) }
+    header.with_description { t(".description") }
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t("label_administration") },
        { href: admin_settings_users_path, text: t(:label_user_and_permission) },
@@ -54,60 +55,4 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<% if @groups.any? %>
-  <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table class="generic-table" data-controller="table-highlighting">
-        <colgroup>
-          <col>
-          <col>
-          <col data-highlight="false">
-        </colgroup>
-        <thead>
-          <tr>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= Group.model_name.human %>
-                  </span>
-                </div>
-              </div>
-            </th>
-            <th>
-              <div class="generic-table--sort-header-outer">
-                <div class="generic-table--sort-header">
-                  <span>
-                    <%= t(:label_user_plural) %>
-                  </span>
-                </div>
-              </div>
-            </th>
-            <th><div class="generic-table--empty-header"></div></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @groups.each do |group| %>
-            <tr>
-              <td><%= link_to h(group), action: "edit", id: group %></td>
-              <td><%= group.users.size %></td>
-              <td class="buttons">
-                <%= link_to "", group,
-                            data: { confirm: t(:text_are_you_sure) },
-                            method: :delete,
-                            class: "icon icon-delete",
-                            title: t(:button_delete) %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-
-    </div>
-  </div>
-<% else %>
-  <%= no_results_box(
-        action_url: new_group_path,
-        display_action: true
-      ) %>
-<% end %>
+<%= render(Groups::TableComponent.new(rows: @groups)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,8 +405,12 @@ en:
 
   groups:
     index:
-      no_results_title_text: There are currently no groups.
-      no_results_content_text: Create a new group
+      description: By grouping users together, you can add them as members to the same projects or assign the same global roles to them.
+    table_component:
+      blank_slate:
+        description: You can define groups of users with specific names
+        title: No groups set up yet
+      user_count: User count
     users:
       no_results_title_text: There are currently no users part of this group.
     memberships:

--- a/spec/support/pages/groups.rb
+++ b/spec/support/pages/groups.rb
@@ -52,18 +52,8 @@ module Pages
       group(group_name).add_user! user_name
     end
 
-    def delete_group!(name)
-      accept_alert do
-        find_group(name).find("a[data-method=delete]").click
-      end
-    end
-
-    def find_group(name)
-      find("tr", text: name)
-    end
-
     def has_group?(name)
-      has_selector? "tr", text: name
+      has_selector? ".op-border-box-grid--row-item", text: name
     end
 
     def group(group_name)


### PR DESCRIPTION
Using most of the design language that we have been using in other primerized index views as well, but not changing functionality compared to the previous version.

This is a side change performed alongside other changes to the groups view, where we also started introducing primer components.
