### PR TITLE
[66128] 'Invite user' menu is missing an icon

### DIFF
--- a/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
@@ -76,7 +76,7 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
         label: item.caption,
         test_selector: "op-menu--item-action"
       ) do |menu_item|
-        menu_item.with_leading_visual_icon(icon: :plus)
+        menu_item.with_leading_visual_icon(icon: item.icon)
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66128

# What are you trying to accomplish?
Use provided icon instead of fixed "plus"

## Screenshots
<img width="248" height="487" alt="Bildschirmfoto 2025-07-29 um 13 58 07" src="https://github.com/user-attachments/assets/1f894eab-52d2-4053-a404-1d7ac280a9dc" />
