### PR TITLE
[65626] Use WorkPackage::InfoLine in TimeEntry table

### DIFF
--- a/modules/costs/app/components/my/time_tracking/time_entry_row.rb
+++ b/modules/costs/app/components/my/time_tracking/time_entry_row.rb
@@ -77,10 +77,14 @@ module My
       end
 
       def subject
-        render(Primer::Beta::Link.new(href: project_work_package_path(time_entry.project, time_entry.work_package),
-                                      underline: true)) do
-          "##{time_entry.work_package.id}"
-        end + " - #{time_entry.work_package.subject}"
+        render(Primer::OpenProject::FlexLayout.new) do |flex|
+          flex.with_row do
+            render(WorkPackages::InfoLineComponent.new(work_package: time_entry.work_package))
+          end
+          flex.with_row do
+            render(Primer::Beta::Text.new(font_weight: :semibold)) { time_entry.work_package.subject }
+          end
+        end
       end
 
       def project


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65626

# What are you trying to accomplish?
Use existing component for timeTracking list

⚠️ This is not fixing the alignment issue mentioned in the ticket

## Screenshots
<img width="1441" height="274" alt="Bildschirmfoto 2025-07-29 um 15 05 27" src="https://github.com/user-attachments/assets/dfb94314-c8c2-4ded-a6d8-bea25b7a259a" />
