### PR TITLE
[65616] Wrong selected menu, when moving from my page to a WP page

### DIFF
--- a/frontend/src/app/core/setup/globals/global-listeners.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners.ts
@@ -81,12 +81,18 @@ export function initializeGlobalListeners():void {
     document.body.classList.toggle('zen-mode', event.detail.active);
   });
 
+  let wasAngularPage = !!document.querySelector('openproject-base');
+
   window.addEventListener('popstate', () => {
-    // If you're returning to Angular, force full reload
-    const shouldReload = document.querySelector('openproject-base');
-    if (shouldReload) {
+    const isNowAngularPage = !!document.querySelector('openproject-base');
+
+    if (!wasAngularPage && isNowAngularPage) {
+      // Transitioned from non-Angular to Angular — force reload
       window.location.reload();
     }
+
+    // Update for the next navigation
+    wasAngularPage = isNowAngularPage;
   });
   // Jump to the element given by location.hash, if present
   const { hash } = window.location;

--- a/frontend/src/app/core/setup/globals/global-listeners.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners.ts
@@ -81,6 +81,13 @@ export function initializeGlobalListeners():void {
     document.body.classList.toggle('zen-mode', event.detail.active);
   });
 
+  window.addEventListener('popstate', () => {
+    // If you're returning to Angular, force full reload
+    const shouldReload = document.querySelector('openproject-base');
+    if (shouldReload) {
+      window.location.reload();
+    }
+  });
   // Jump to the element given by location.hash, if present
   const { hash } = window.location;
   if (hash && hash.startsWith('#')) {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65616

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When navigating back from a Turbo-rendered (Rails) page to an Angular-rendered page would result in a broken or partially-rendered UI. The problem occurred because Turbo restores a cached DOM snapshot without triggering a full page reload, preventing Angular from reinitializing properly. 

# What approach did you choose and why?
We add a `popstate` listener to detect browser back/forward navigation. If the current page includes the `openproject-base` Angular component, we force a hard reload using `window.location.reload()` to ensure Angular is bootstrapped cleanly.

