### PR TITLE
Bug/65021 copying project fails with internal error lock version null

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -77,12 +77,4 @@ class ApplicationRecord < ActiveRecord::Base
 
     ActiveRecord::Base.connection.select_value(union_query)
   end
-
-  def self.skip_optimistic_locking(&)
-    original_lock_optimistically = ActiveRecord::Base.lock_optimistically
-    ActiveRecord::Base.lock_optimistically = false
-    yield
-  ensure
-    ActiveRecord::Base.lock_optimistically = original_lock_optimistically
-  end
 end

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -250,28 +250,10 @@ class Meeting < ApplicationRecord
         top
       end
 
-      # Disable optimistic locking in order to avoid causing `StaleObjectError`.
-      MeetingAgendaItem.skip_optimistic_locking do
-        MeetingAgendaItem.import(
-          changed_items,
-          on_duplicate_key_update: {
-            conflict_target: [:id],
-            columns: %i[meeting_id
-                        author_id
-                        title
-                        notes
-                        position
-                        duration_in_minutes
-                        start_time
-                        end_time
-                        created_at
-                        updated_at
-                        work_package_id
-                        item_type
-                        lock_version]
-          }
-        )
-      end
+      MeetingAgendaItem.upsert_all(
+        changed_items.map(&:attributes),
+        unique_by: :id
+      )
     end
   end
 

--- a/modules/meeting/app/models/meeting_agenda_item.rb
+++ b/modules/meeting/app/models/meeting_agenda_item.rb
@@ -67,7 +67,6 @@ class MeetingAgendaItem < ApplicationRecord
             allow_nil: true
 
   before_validation :add_to_latest_meeting_section
-  after_create :trigger_meeting_agenda_item_time_slots_calculation
   after_save :trigger_meeting_agenda_item_time_slots_calculation, if: Proc.new { |item|
     item.duration_in_minutes_previously_changed? || item.position_previously_changed?
   }

--- a/modules/meeting/spec/models/meeting_agenda_item_spec.rb
+++ b/modules/meeting/spec/models/meeting_agenda_item_spec.rb
@@ -347,7 +347,10 @@ RSpec.describe MeetingAgendaItem do
         duration_in_minutes: 10
       )
     end
-    let(:meeting_time) { meeting.start_time }
+    let(:meeting_time) do
+      meeting.reload
+      meeting.start_time
+    end
 
     context "when creating agenda items" do
       before do

--- a/modules/meeting/spec/models/meeting_agenda_item_spec.rb
+++ b/modules/meeting/spec/models/meeting_agenda_item_spec.rb
@@ -30,6 +30,8 @@
 
 require_relative "../spec_helper"
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.describe MeetingAgendaItem do
   let(:meeting_attributes) { {} }
   let(:meeting) { build_stubbed(:meeting, **meeting_attributes) }
@@ -321,6 +323,132 @@ RSpec.describe MeetingAgendaItem do
         end
 
         it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe "automatic updates to the start and end time", :aggregate_failures do
+    let(:user) { create(:user) }
+    let(:meeting) { create(:meeting, start_time: Time.current) }
+    let(:section) { create(:meeting_section, meeting:) }
+    let(:first_agenda_item) do
+      described_class.create(
+        title: "First item",
+        meeting:,
+        author: user,
+        duration_in_minutes: 15
+      )
+    end
+    let(:second_agenda_item) do
+      described_class.create(
+        title: "First item",
+        meeting:,
+        author: user,
+        duration_in_minutes: 10
+      )
+    end
+    let(:meeting_time) { meeting.start_time }
+
+    context "when creating agenda items" do
+      before do
+        first_agenda_item.reload
+        second_agenda_item.reload
+      end
+
+      it "updates time slots" do
+        expect(first_agenda_item.start_time).to eq(meeting_time)
+        expect(first_agenda_item.end_time).to eq(meeting_time + first_agenda_item.duration_in_minutes.minutes)
+        expect(second_agenda_item.start_time).to eq(meeting_time + first_agenda_item.duration_in_minutes.minutes)
+        expect(second_agenda_item.end_time).to eq(meeting_time +
+                                                  first_agenda_item.duration_in_minutes.minutes +
+                                                  second_agenda_item.duration_in_minutes.minutes)
+      end
+    end
+
+    context "when updating agenda items" do
+      before do
+        first_agenda_item.reload
+        second_agenda_item.reload
+      end
+
+      context "when changing duration" do
+        it "updates time slots" do
+          expect do
+            first_agenda_item.update(duration_in_minutes: 30)
+            first_agenda_item.reload
+            second_agenda_item.reload
+          end
+            .to not_change { first_agenda_item.start_time }
+                  .and change(first_agenda_item, :end_time)
+                         .from(meeting_time + 15.minutes)
+                         .to(meeting_time + 30.minutes)
+                         .and change(second_agenda_item, :start_time)
+                                .from(meeting_time + 15.minutes)
+                                .to(meeting_time + 30.minutes)
+                                .and change(second_agenda_item, :end_time)
+                                       .from(meeting_time + 15.minutes + second_agenda_item.duration_in_minutes.minutes)
+                                       .to(meeting_time + 30.minutes + second_agenda_item.duration_in_minutes.minutes)
+        end
+      end
+
+      context "when changing position" do
+        it "updates time slots for all items" do
+          expect do
+            second_agenda_item.update(position: 1)
+
+            first_agenda_item.reload
+            second_agenda_item.reload
+          end
+            .to change(first_agenda_item, :start_time)
+                  .from(meeting_time)
+                  .to(meeting_time + second_agenda_item.duration_in_minutes.minutes)
+                  .and change(first_agenda_item, :end_time)
+                         .from(meeting_time + first_agenda_item.duration_in_minutes.minutes)
+                         .to(meeting_time +
+                             second_agenda_item.duration_in_minutes.minutes +
+                             first_agenda_item.duration_in_minutes.minutes)
+                         .and change(second_agenda_item, :start_time)
+                                .from(meeting_time + first_agenda_item.duration_in_minutes.minutes)
+                                .to(meeting_time)
+                                .and change(second_agenda_item, :end_time)
+                                       .from(meeting_time +
+                                             second_agenda_item.duration_in_minutes.minutes +
+                                             first_agenda_item.duration_in_minutes.minutes)
+                                       .to(meeting_time + second_agenda_item.duration_in_minutes.minutes)
+        end
+      end
+
+      context "when changing other attributes" do
+        it "does not update time slots" do
+          expect do
+            first_agenda_item.update(title: "New title")
+            first_agenda_item.reload
+          end
+            .to not_change { first_agenda_item.start_time }
+                  .and(not_change { first_agenda_item.end_time })
+        end
+      end
+    end
+
+    context "when destroying an agenda item" do
+      before do
+        first_agenda_item.reload
+        second_agenda_item.reload
+      end
+
+      it "updates time slots for remaining items" do
+        expect do
+          first_agenda_item.destroy
+          second_agenda_item.reload
+        end
+          .to change(second_agenda_item, :start_time)
+                .from(meeting_time + first_agenda_item.duration_in_minutes.minutes)
+                .to(meeting_time)
+                .and change(second_agenda_item, :end_time)
+                       .from(meeting_time +
+                             first_agenda_item.duration_in_minutes.minutes +
+                             second_agenda_item.duration_in_minutes.minutes)
+                       .to(meeting_time + second_agenda_item.duration_in_minutes.minutes)
       end
     end
   end

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -582,15 +582,18 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
     end
 
     context "when the work package has comments and changesets" do
+      let(:work_package) do
+        create(:work_package,
+               project:,
+               author: admin,
+               journals: {
+                 5.days.ago => { user: admin },
+                 4.days.ago => { user: admin, notes: "First comment by admin" },
+                 3.days.ago => { user: admin, notes: "Second comment by admin" }
+               }).tap(&:reload)
+      end
+
       before do
-        # for some reason the journal is set to the "Anonymous"
-        # although the work_package is created by the admin
-        # so we need to update the journal to the admin manually to simulate the real world case
-        work_package.journals.first.update!(user: admin)
-
-        create(:work_package_journal, user: admin, notes: "First comment by admin", journable: work_package, version: 2)
-        create(:work_package_journal, user: admin, notes: "Second comment by admin", journable: work_package, version: 3)
-
         wp_page.visit!
         wp_page.wait_for_activity_tab
       end

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -281,7 +281,10 @@ module Components
 
           check_internal_comment_checkbox if internal
 
-          page.find_test_selector("op-submit-work-package-journal-form").click if save
+          if save
+            page.find_test_selector("op-submit-work-package-journal-form").click
+            wait_for_network_idle
+          end
         end
 
         if save

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -97,6 +97,7 @@ module Pages
     end
 
     def wait_for_activity_tab
+      wait_for_network_idle
       wait_for { page }.to have_test_selector("op-wp-activity-tab")
       # ensure stimulus controller is mounted
       expect(page).to have_css('[data-stimulus-controller-connected="true"]')


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65021

# What are you trying to accomplish?

Keep the current behaviour of updating agenda items' start and end date but avoid setting a class_attribute which is not thread-safe. To that end, `MeetingAgendaItem.import` has been replaced by `MeetingAgendaItem.upsert_all`. Specs have been added to safeguard the behaviour. 

The dangerous method for toggling `lock_optimistically` has been removed.

There is still a behaviour in there that looks problematic. The upsert statement updates neither `lock_version` nor `updated_at` on the elements that were updated. This behaviour existed before. But since the items are actually updated, their timestamp should be updated as well.

# Merge checklist

- [x] Added/updated tests