### PR TITLE
'SCIM-client' instead of 'SCIM client'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,34 +129,34 @@ en:
         label_token: "Token"
         one_time_hint: "This is the only time you will see this token. Make sure to copy it now."
       delete_scim_client_dialog_component:
-        title: "Delete SCIM client"
-        heading: "Are you sure you want to delete this SCIM client?"
-        description: "Users managed by this SCIM client can no longer be updated by it."
+        title: "Delete SCIM-client"
+        heading: "Are you sure you want to delete this SCIM-client?"
+        description: "Users managed by this SCIM-client can no longer be updated by it."
       edit:
-        label_delete_scim_client: "Delete SCIM client"
+        label_delete_scim_client: "Delete SCIM-client"
       form:
         auth_provider_description: "This is the service that users added by the SCIM provider will use to authenticate in OpenProject."
-        authentication_method_description_html: "This is how the SCIM client authenticates at OpenProject. Please ensure that OAuth tokens include the <code>scim_v2</code> scope."
-        description_html: 'Please refer to our <a href="%{docs_url}">documentation on configuring SCIM clients</a> for more information on these configuration options.'
-        jwt_sub_description_html: 'For example, for Keycloak, this is the UUID of the service account  associated with the SCIM client. Consult <a href="%{docs_url}">our documentation</a> to learn how to find  the subject claim for your use case.'
+        authentication_method_description_html: "This is how the SCIM-client authenticates at OpenProject. Please ensure that OAuth tokens include the <code>scim_v2</code> scope."
+        description_html: 'Please refer to our <a href="%{docs_url}">documentation on configuring SCIM-clients</a> for more information on these configuration options.'
+        jwt_sub_description_html: 'For example, for Keycloak, this is the UUID of the service account  associated with the SCIM-client. Consult <a href="%{docs_url}">our documentation</a> to learn how to find  the subject claim for your use case.'
         name_description: "Choose a name that will help other admins better understand why this client was configured."
       index:
-        description: "SCIM clients configured here are able to interact with OpenProject SCIM server API to provision, update, and deprovision user accounts and groups."
-        label_create_button: "Add SCIM client"
+        description: "SCIM-clients configured here are able to interact with OpenProject SCIM server API to provision, update, and deprovision user accounts and groups."
+        label_create_button: "Add SCIM-client"
       new:
-        title: "New SCIM client"
+        title: "New SCIM-client"
       revoke_static_token_dialog_component:
         confirm_button: "Revoke"
         title: "Revoke static token"
         heading: "Are you sure you want to revoke this token?"
-        description: "The SCIM client that uses this token will no longer be able to access OpenProject's SCIM server API."
+        description: "The SCIM-client that uses this token will no longer be able to access OpenProject's SCIM server API."
       table_component:
         blank_slate:
-          title: "No SCIM clients configured yet"
+          title: "No SCIM-clients configured yet"
           description: "Add clients to see them here"
         user_count: "Users"
       token_list_component:
-        description: "The tokens you generate here can be passed by a SCIM client to access the OpenProject SCIM API."
+        description: "The tokens you generate here can be passed by a SCIM-client to access the OpenProject SCIM API."
         heading: "Tokens"
         label_add_token: "Token"
         label_aria_add_token: "Add token"
@@ -1032,7 +1032,7 @@ en:
         attribute_name: "Attribute"
         help_text: "Help text"
       auth_provider:
-        scim_clients: "SCIM clients"
+        scim_clients: "SCIM-clients"
       capability:
         context: "Context"
       changeset:
@@ -1730,8 +1730,8 @@ en:
         one: "Role"
         other: "Roles"
       scim_client:
-        one: "SCIM client"
-        other: "SCIM clients"
+        one: "SCIM-client"
+        other: "SCIM-clients"
       status: "Work package status"
       token/api:
         one: Access token
@@ -2291,7 +2291,7 @@ en:
         title: "Single Sign-On for Nextcloud Storage"
         description: "Enable seamless and secure authentication for your Nextcloud storage with Single Sign-On. Simplify access management and enhance user convenience."
       scim_api:
-        title: "SCIM clients"
+        title: "SCIM-clients"
         description: "Automate user management in OpenProject by seamlessly integrating external identity services like Microsoft Entra or Keycloak through our SCIM Server API. Available starting with the Enterprise corporate plan."
       virus_scanning:
         description: "Ensure uploaded files in OpenProject are scanned for viruses before being accessible by other users."

--- a/spec/features/admin/scim_clients/create_spec.rb
+++ b/spec/features/admin/scim_clients/create_spec.rb
@@ -30,13 +30,13 @@
 
 require "spec_helper"
 
-RSpec.describe "Creating a SCIM client", :js, :selenium, driver: :firefox_de do
+RSpec.describe "Creating a SCIM-client", :js, :selenium, driver: :firefox_de do
   shared_let(:admin) { create(:admin, preferences: { time_zone: "Etc/UTC" }) }
   shared_let(:oidc_provider) { create(:oidc_provider) }
 
   current_user { admin }
 
-  it "can create a SCIM client authenticating through JWT", :aggregate_failures, with_ee: [:scim_api] do
+  it "can create a SCIM-client authenticating through JWT", :aggregate_failures, with_ee: [:scim_api] do
     visit new_admin_scim_client_path
 
     expect(page).to be_axe_clean.within("#content")
@@ -51,29 +51,29 @@ RSpec.describe "Creating a SCIM client", :js, :selenium, driver: :firefox_de do
     expect(page).to have_text("Name can't be blank")
     expect(page).to have_text("Subject claim can't be blank")
 
-    fill_in "Name", with: "My SCIM Client"
+    fill_in "Name", with: "My SCIM-Client"
     fill_in "Subject claim", with: "123-abc-456-def"
     click_on("Create")
-    wait_for { ScimClient.find_by(name: "My SCIM Client") }.not_to be_nil
+    wait_for { ScimClient.find_by(name: "My SCIM-Client") }.not_to be_nil
 
-    created_client = ScimClient.find_by(name: "My SCIM Client")
+    created_client = ScimClient.find_by(name: "My SCIM-Client")
     expect(page).to have_current_path(edit_admin_scim_client_path(created_client, first_time_setup: true))
     expect(created_client.auth_provider_id).to eq(oidc_provider.id)
     expect(created_client.authentication_method).to eq("sso")
     expect(created_client.auth_provider_link&.external_id).to eq("123-abc-456-def")
   end
 
-  it "can create a SCIM client authenticating through client credentials", with_ee: [:scim_api] do
+  it "can create a SCIM-client authenticating through client credentials", with_ee: [:scim_api] do
     visit new_admin_scim_client_path
 
-    fill_in "Name", with: "My SCIM Client"
+    fill_in "Name", with: "My SCIM-client"
     select oidc_provider.display_name, from: "Authentication provider"
     select "OAuth 2.0 client credentials", from: "Authentication method"
 
     click_on("Create")
-    wait_for { ScimClient.find_by(name: "My SCIM Client") }.not_to be_nil
+    wait_for { ScimClient.find_by(name: "My SCIM-client") }.not_to be_nil
 
-    created_client = ScimClient.find_by(name: "My SCIM Client")
+    created_client = ScimClient.find_by(name: "My SCIM-client")
     expect(page).to have_current_path(edit_admin_scim_client_path(created_client, first_time_setup: true))
 
     page.within_modal("Client credentials created") do
@@ -84,17 +84,17 @@ RSpec.describe "Creating a SCIM client", :js, :selenium, driver: :firefox_de do
     end
   end
 
-  it "can create a SCIM client authenticating through a static access token", with_ee: [:scim_api] do
+  it "can create a SCIM-client authenticating through a static access token", with_ee: [:scim_api] do
     visit new_admin_scim_client_path
 
-    fill_in "Name", with: "My SCIM Client"
+    fill_in "Name", with: "My SCIM-client"
     select oidc_provider.display_name, from: "Authentication provider"
     select "Static access token", from: "Authentication method"
 
     click_on("Create")
-    wait_for { ScimClient.find_by(name: "My SCIM Client") }.not_to be_nil
+    wait_for { ScimClient.find_by(name: "My SCIM-client") }.not_to be_nil
 
-    created_client = ScimClient.find_by(name: "My SCIM Client")
+    created_client = ScimClient.find_by(name: "My SCIM-client")
     expect(page).to have_current_path(edit_admin_scim_client_path(created_client, first_time_setup: true))
 
     page.within_modal("Token created") do

--- a/spec/features/admin/scim_clients/index_spec.rb
+++ b/spec/features/admin/scim_clients/index_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Listing SCIM clients", :js, :selenium, driver: :firefox_de do
+RSpec.describe "Listing SCIM-clients", :js, :selenium, driver: :firefox_de do
   shared_let(:admin) { create(:admin, preferences: { time_zone: "Etc/UTC" }) }
 
   current_user { admin }
@@ -46,12 +46,12 @@ RSpec.describe "Listing SCIM clients", :js, :selenium, driver: :firefox_de do
       expect(page).to have_no_test_selector("Admin::ScimClients::TableComponent")
 
       within(".SubHeader") do
-        expect(page).to have_no_link("SCIM client")
+        expect(page).to have_no_link("SCIM-client")
       end
     end
   end
 
-  context "when there are no SCIM clients", with_ee: [:scim_api] do
+  context "when there are no SCIM-clients", with_ee: [:scim_api] do
     it "renders a proper blank slate" do
       visit admin_scim_clients_path
 
@@ -64,14 +64,14 @@ RSpec.describe "Listing SCIM clients", :js, :selenium, driver: :firefox_de do
       end
 
       within(".SubHeader") do
-        click_on "SCIM client"
+        click_on "SCIM-client"
       end
 
       expect(page).to have_current_path(new_admin_scim_client_path)
     end
   end
 
-  context "when there are SCIM clients", with_ee: [:scim_api] do
+  context "when there are SCIM-clients", with_ee: [:scim_api] do
     let!(:sso_client) { create(:scim_client) }
 
     it "renders a proper clients table" do

--- a/spec/features/admin/scim_clients/index_spec.rb
+++ b/spec/features/admin/scim_clients/index_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Listing SCIM clients", :js, :selenium, driver: :firefox_de do
 
       expect(page).not_to have_enterprise_banner
       within_test_selector("Admin::ScimClients::TableComponent") do
-        expect(page).to have_content("No SCIM clients configured yet")
+        expect(page).to have_content("No SCIM-clients configured yet")
         expect(page).to have_content("Add clients to see them here")
       end
 

--- a/spec/features/admin/scim_clients/update_spec.rb
+++ b/spec/features/admin/scim_clients/update_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Updating a SCIM client", :js, :selenium, driver: :firefox_de do
+RSpec.describe "Updating a SCIM-client", :js, :selenium, driver: :firefox_de do
   shared_let(:admin) { create(:admin, preferences: { time_zone: "Etc/UTC" }) }
   shared_let(:auth_provider) { create(:oidc_provider) }
 
@@ -48,7 +48,7 @@ RSpec.describe "Updating a SCIM client", :js, :selenium, driver: :firefox_de do
 
   current_user { admin }
 
-  it "can update a SCIM client authenticating through JWT", :aggregate_failures, with_ee: [:scim_api] do
+  it "can update a SCIM-client authenticating through JWT", :aggregate_failures, with_ee: [:scim_api] do
     visit edit_admin_scim_client_path(sso_scim_client)
     expect(page).to be_axe_clean.within("#content")
 
@@ -72,12 +72,12 @@ RSpec.describe "Updating a SCIM client", :js, :selenium, driver: :firefox_de do
     visit edit_admin_scim_client_path(sso_scim_client)
 
     within(".PageHeader") { click_on "Delete" }
-    page.within_modal("Delete SCIM client") { click_on "Delete" }
+    page.within_modal("Delete SCIM-client") { click_on "Delete" }
     expect(page).to have_current_path(admin_scim_clients_path)
     expect(ScimClient.where(id: sso_scim_client.id)).to be_empty
   end
 
-  it "can update a SCIM client authenticating through client credentials", :aggregate_failures, with_ee: [:scim_api] do
+  it "can update a SCIM-client authenticating through client credentials", :aggregate_failures, with_ee: [:scim_api] do
     visit edit_admin_scim_client_path(oauth_client_scim_client)
     expect(page).to be_axe_clean.within("#content")
 
@@ -101,12 +101,12 @@ RSpec.describe "Updating a SCIM client", :js, :selenium, driver: :firefox_de do
     expect(page).to have_no_field("Client secret")
 
     within(".PageHeader") { click_on "Delete" }
-    page.within_modal("Delete SCIM client") { click_on "Delete" }
+    page.within_modal("Delete SCIM-client") { click_on "Delete" }
     expect(page).to have_current_path(admin_scim_clients_path)
     expect(ScimClient.where(id: oauth_client_scim_client.id)).to be_empty
   end
 
-  it "can update a SCIM client authenticating through a static access token", :aggregate_failures, with_ee: [:scim_api] do
+  it "can update a SCIM-client authenticating through a static access token", :aggregate_failures, with_ee: [:scim_api] do
     visit edit_admin_scim_client_path(token_scim_client)
     expect(page).to be_axe_clean.within("#content")
 
@@ -159,7 +159,7 @@ RSpec.describe "Updating a SCIM client", :js, :selenium, driver: :firefox_de do
     end
 
     within(".PageHeader") { click_on "Delete" }
-    page.within_modal("Delete SCIM client") { click_on "Delete" }
+    page.within_modal("Delete SCIM-client") { click_on "Delete" }
     expect(page).to have_current_path(admin_scim_clients_path)
     expect(ScimClient.where(id: token_scim_client.id)).to be_empty
   end


### PR DESCRIPTION
# Ticket

N/A - approached by @MayaBerd 

# What are you trying to accomplish?

Consistently write 'SCIM-client' instead of 'SCIM client'