### PR TITLE
Fix usage of acr_values and claims

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,8 +36,8 @@ GIT
 
 GIT
   remote: https://github.com/opf/omniauth-openid-connect.git
-  revision: 3d5fec65072fb4566fb975a9cbe401d758d22317
-  ref: 3d5fec65072fb4566fb975a9cbe401d758d22317
+  revision: e923d9dd14fa4ca04b98720ac2185807b263f5ed
+  ref: e923d9dd14fa4ca04b98720ac2185807b263f5ed
   specs:
     omniauth-openid-connect (0.4.1)
       addressable (~> 2.5)
@@ -560,7 +560,7 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.13.3)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -709,7 +709,7 @@ GEM
       reline (>= 0.4.2)
     iso8601 (0.13.0)
     jmespath (1.6.2)
-    json (2.13.1)
+    json (2.13.2)
     json-jwt (1.16.7)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -1677,7 +1677,7 @@ CHECKSUMS
   excon (1.2.8) sha256=150f57a0f3919b8d2b3f74535596f9876389c6dde157e0bfac8f26631eb135d0
   factory_bot (6.5.4) sha256=4707fb7d80a7c14d71feb069460587bfc342e4ff1ef28097e0ad69d5ddfce613
   factory_bot_rails (6.5.0) sha256=4a7b61635424a57cc60412a18b72b9dcfb02fabfce2c930447a01dce8b37c0a2
-  faraday (2.13.3) sha256=e9571e7a4ada595b385da5fc749edf7b11dc6aa9d98ab63286c3f28dc4ac01b7
+  faraday (2.13.4) sha256=c719ff52cfd0dbaeca79dd83ed3aeea3f621032abf8bc959d1c05666157cac26
   faraday-follow_redirects (0.3.0) sha256=d92d975635e2c7fe525dd494fcd4b9bb7f0a4a0ec0d5f4c15c729530fdb807f9
   faraday-net_http (3.4.1) sha256=095757fae7872b94eac839c08a1a4b8d84fd91d6886cfbe75caa2143de64ab3b
   fastimage (2.3.1) sha256=23c629f1f3e7d61bcfcc06c25b3d2418bc6bf41d2e615dbf5132c0e3b63ecce9
@@ -1740,7 +1740,7 @@ CHECKSUMS
   irb (1.15.2) sha256=222f32952e278da34b58ffe45e8634bf4afc2dc7aa9da23fed67e581aa50fdba
   iso8601 (0.13.0) sha256=298c2b15b7be5fa95a1372813d36a2257656cd8e906dfbc1f5cb409851425aa2
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.13.1) sha256=8e7cf4bb44a789ac5fc62869c7187986251c3172d9bdfa60b92c63d6ecab0ffc
+  json (2.13.2) sha256=02e1f118d434c6b230a64ffa5c8dee07e3ec96244335c392eaed39e1199dbb68
   json-jwt (1.16.7) sha256=ccabff4c6d1a14276b23178e8bebe513ef236399b72a0b886d7ed94800d172a5
   json-schema (4.3.1) sha256=d5e68dc32b94408d0b06ad04f9382ccbb6fe5a44910e066f8547f56c471a7825
   json_schemer (2.4.0) sha256=56cb6117bb5748d925b33ad3f415b513d41d25d0bbf57fe63c0a78ff05597c24

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -8,7 +8,7 @@ gem 'omniauth-openid_connect-providers',
 
 gem 'omniauth-openid-connect',
     git: 'https://github.com/opf/omniauth-openid-connect.git',
-    ref: '3d5fec65072fb4566fb975a9cbe401d758d22317'
+    ref: 'e923d9dd14fa4ca04b98720ac2185807b263f5ed'
 
 group :opf_plugins do
     # included so that engines can reference OpenProject::Version

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -155,5 +155,10 @@ module OpenIDConnect
         [/(.+)/]
       end
     end
+
+    def to_h
+      claims = self.claims.presence || "{}"
+      super.merge(claims:, acr_values:)
+    end
   end
 end

--- a/modules/openid_connect/spec/factories/oidc_provider_factory.rb
+++ b/modules/openid_connect/spec/factories/oidc_provider_factory.rb
@@ -35,19 +35,16 @@ FactoryBot.define do
     limit_self_registration { true }
     creator factory: :user
 
-    options do
-      {
-        "issuer" => "https://keycloak.local/realms/master",
-        "jwks_uri" => "https://keycloak.local/realms/master/protocol/openid-connect/certs",
-        "client_id" => "https://openproject.local",
-        "client_secret" => "9AWjVC3A4U1HLrZuSP4xiwHfw6zmgECn",
-        "oidc_provider" => "custom",
-        "token_endpoint" => "https://keycloak.local/realms/master/protocol/openid-connect/token",
-        "userinfo_endpoint" => "https://keycloak.local/realms/master/protocol/openid-connect/userinfo",
-        "end_session_endpoint" => "https://keycloak.local/realms/master/protocol/openid-connect/logout",
-        "authorization_endpoint" => "https://keycloak.local/realms/master/protocol/openid-connect/auth"
-      }
-    end
+    host { "https://keycloak.local" }
+    issuer { "https://keycloak.local/realms/master" }
+    jwks_uri { "https://keycloak.local/realms/master/protocol/openid-connect/certs" }
+    client_id { "https://openproject.local" }
+    client_secret { "9AWjVC3A4U1HLrZuSP4xiwHfw6zmgECn" }
+    oidc_provider { "custom" }
+    token_endpoint { "https://keycloak.local/realms/master/protocol/openid-connect/token" }
+    userinfo_endpoint { "https://keycloak.local/realms/master/protocol/openid-connect/userinfo" }
+    end_session_endpoint { "https://keycloak.local/realms/master/protocol/openid-connect/logout" }
+    authorization_endpoint { "https://keycloak.local/realms/master/protocol/openid-connect/auth" }
 
     trait :token_exchange_capable do
       callback(:after_build) do |provider|

--- a/modules/openid_connect/spec/lib/open_project/openid_connect_spec.rb
+++ b/modules/openid_connect/spec/lib/open_project/openid_connect_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::OpenIDConnect do
+  describe ".providers" do
+    subject { described_class.providers.map(&:to_h) }
+
+    it { is_expected.to be_empty }
+
+    context "when there is a provider" do
+      let!(:provider) { create(:oidc_provider, claims:, acr_values:) }
+      let(:claims) do
+        {
+          id_token: {
+            taste: {
+              essential: true,
+              values: ["sweet", "bitter", "salty"]
+            }
+          }
+        }.to_json
+      end
+      let(:acr_values) { "silver gold" }
+
+      it "configures basic attributes", :aggregate_failures do
+        config = subject.first
+
+        expect(config[:issuer]).to eq(provider.issuer)
+        expect(config[:name]).to eq(provider.slug.to_sym)
+      end
+
+      it "configures client_options", :aggregate_failures do
+        client_options = subject.first.fetch(:client_options)
+
+        expect(client_options[:identifier]).to eq(provider.client_id)
+        expect(client_options[:secret]).to eq(provider.client_secret)
+        expect(client_options[:redirect_uri]).to eq(provider.callback_url)
+
+        %i[host authorization_endpoint token_endpoint userinfo_endpoint jwks_uri end_session_endpoint].each do |attr|
+          expect(client_options[attr]).to eq(provider.public_send(attr))
+        end
+      end
+
+      it "even has config for claims and acr_values (regression #66217)" do
+        config = subject.first
+
+        expect(config[:claims]).to eq(provider.claims)
+        expect(config[:acr_values]).to eq(provider.acr_values)
+      end
+
+      context "and when the claims are empty" do
+        let(:claims) { "" }
+
+        it "configures claims to be an empty JSON object" do
+          config = subject.first
+          expect(config[:claims]).to eq("{}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously it was possible to configure them through the UI, but they were not passed into configuration of the Omniauth provider at all.

Correct configuration also uncovered a bug in omniauth-openid-connect that was fixed through an update of the gem.

# Ticket
https://community.openproject.org/wp/66217