### PR TITLE
Request voluntary groups claim when group sync is enabled

### DIFF
--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -158,7 +158,14 @@ module OpenIDConnect
 
     def to_h
       claims = self.claims.presence || "{}"
+      claims = add_groups_claim(JSON.parse(claims)).to_json
       super.merge(claims:, acr_values:)
+    end
+
+    def add_groups_claim(claims)
+      claims = { "id_token" => { groups_claim => nil } }.deep_merge(claims) if sync_groups
+
+      claims
     end
   end
 end

--- a/modules/openid_connect/spec/models/provider_spec.rb
+++ b/modules/openid_connect/spec/models/provider_spec.rb
@@ -31,11 +31,14 @@ require "spec_helper"
 
 RSpec.describe OpenIDConnect::Provider do
   let(:provider) do
-    create(:oidc_provider, options: {
-             "grant_types_supported" => supported_grant_types
-           })
+    create(:oidc_provider, options: { "grant_types_supported" => supported_grant_types },
+                           claims:,
+                           sync_groups:,
+                           groups_claim: "the-groups")
   end
   let(:supported_grant_types) { %w[authorization_code implicit] }
+  let(:claims) { "" }
+  let(:sync_groups) { false }
 
   describe "#token_exchange_capable?" do
     subject { provider.token_exchange_capable? }
@@ -100,6 +103,46 @@ RSpec.describe OpenIDConnect::Provider do
 
       it "prefers prefixes over regular expressions" do
         expect(subject).to eq([/^a(.+)$/])
+      end
+    end
+  end
+
+  describe "#to_h" do
+    subject { provider.to_h }
+
+    it "includes empty claims by default" do
+      expect(subject[:claims]).to eq("{}")
+    end
+
+    context "when claims were defined" do
+      let(:claims) { '{"id_token":{"taste":null}}' }
+
+      it "includes the defined claims" do
+        expect(subject[:claims]).to eq(claims)
+      end
+    end
+
+    context "when group sync is enabled" do
+      let(:sync_groups) { true }
+
+      it "requests the groups claim as voluntary" do
+        expect(subject[:claims]).to eq('{"id_token":{"the-groups":null}}')
+      end
+
+      context "and when other claims were defined manually" do
+        let(:claims) { '{"id_token":{"taste":null}}' }
+
+        it "merges the manual claims and the groups claim" do
+          expect(subject[:claims]).to eq('{"id_token":{"the-groups":null,"taste":null}}')
+        end
+      end
+
+      context "and when the groups claim was defined manually" do
+        let(:claims) { '{"id_token":{"the-groups":{"essential":true}}}' }
+
+        it "takes the manual definition of the groups claim with precedence" do
+          expect(subject[:claims]).to eq(claims)
+        end
       end
     end
   end


### PR DESCRIPTION
This is intended as a best practice, to indicate to an IDP, that a groups claim would be needed.

# Ticket
https://community.openproject.org/wp/58408