### PR TITLE
[#66089] Fix Firefox caret positioning

### DIFF
--- a/app/components/work_package_types/pattern_input.sass
+++ b/app/components/work_package_types/pattern_input.sass
@@ -4,6 +4,11 @@
     overflow: hidden
     height: var(--control-medium-size)
 
+    .-browser-firefox &
+      // Must be set to prevent Firefox from displaying the caret in incorrect places.
+      // See https://bugzilla.mozilla.org/show_bug.cgi?id=904846
+      white-space: pre-wrap
+
     &:focus,
     &:focus-visible
       border-color: var(--focus-outlineColor) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66089

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The caret should now behave correctly in Firefox for all cases.

I used a [jsfiddle](https://jsfiddle.net/1d2gf7r4/102/) to reproduce the bug in an environment that is as lightweight as possible. In the end, a tiny CSS fix was all it took. 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
