### PR TITLE
Replace user_ids param with (add|remove|replace)_user_ids

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -95,7 +95,7 @@ class GroupsController < ApplicationController
   def add_users
     service_call = Groups::UpdateService
                    .new(user: current_user, model: @group)
-                   .call(user_ids: @group.user_ids + Array(params[:user_ids]).map(&:to_i))
+                   .call(add_user_ids: Array(params[:user_ids]))
 
     respond_users_altered(service_call)
   end
@@ -105,7 +105,7 @@ class GroupsController < ApplicationController
 
     service_call = Groups::UpdateService
                    .new(user: current_user, model: @group)
-                   .call(user_ids: @group.user_ids - Array(params[:user_id]).map(&:to_i))
+                   .call(remove_user_ids: Array(params[:user_id]))
 
     respond_users_altered(service_call)
   end

--- a/app/controllers/scim_v2/groups_controller.rb
+++ b/app/controllers/scim_v2/groups_controller.rb
@@ -69,7 +69,7 @@ module ScimV2
           raise_result_errors_for_scim(
             Groups::UpdateService
               .new(user: User.current, model: group)
-              .call(user_ids: scim_resource.members&.map(&:value))
+              .call(replace_user_ids: scim_resource.members&.map(&:value))
           )
           group.reload
           group.to_scim(
@@ -89,7 +89,7 @@ module ScimV2
           raise_result_errors_for_scim(
             Groups::UpdateService
               .new(user: User.current, model: group)
-              .call(user_ids:)
+              .call(replace_user_ids: user_ids)
           )
           group.reload
           group.to_scim(

--- a/app/services/groups/set_attributes_service.rb
+++ b/app/services/groups/set_attributes_service.rb
@@ -35,7 +35,7 @@ module Groups
     private
 
     def set_attributes(params)
-      set_users(params) if params.key?(:user_ids)
+      set_users(params)
       set_user_auth_provider_links(params.delete(:identity_url))
       super
     end
@@ -46,23 +46,37 @@ module Groups
     # Note that due to the way we handle members, via a specific AddUsersService
     # the group should no longer simply be saved after group_users have been added.
     def set_users(params)
-      user_ids = (params.delete(:user_ids) || []).map(&:to_i)
+      if params.key?(:replace_user_ids)
+        user_ids = extract_user_ids(params, :replace_user_ids)
+        existing_user_ids = model.group_users.map(&:user_id)
+        added_user_ids = user_ids - existing_user_ids
+        removed_user_ids = existing_user_ids - user_ids
+      else
+        added_user_ids = extract_user_ids(params, :add_user_ids)
+        removed_user_ids = extract_user_ids(params, :remove_user_ids)
+      end
 
-      existing_user_ids = model.group_users.map(&:user_id)
-      build_new_users user_ids - existing_user_ids
-      mark_outdated_users existing_user_ids - user_ids
+      build_new_users(added_user_ids)
+      mark_outdated_users(removed_user_ids)
     end
 
     def build_new_users(new_user_ids)
+      existing_user_ids = model.group_users.to_set(&:user_id)
       new_user_ids.each do |id|
+        next if existing_user_ids.include?(id)
+
         model.group_users.build(user_id: id)
       end
     end
 
     def mark_outdated_users(removed_user_ids)
       removed_user_ids.each do |id|
-        model.group_users.find { |gu| gu.user_id == id }.mark_for_destruction
+        model.group_users.find { |gu| gu.user_id == id }&.mark_for_destruction
       end
+    end
+
+    def extract_user_ids(params, key)
+      (params.delete(key) || []).map(&:to_i)
     end
   end
 end

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -55,7 +57,11 @@ module API
         associated_resources :users,
                              as: :members,
                              skip_render: -> { !current_user.allowed_in_any_project?(:manage_members) },
-                             uncacheable_link: true
+                             uncacheable_link: true,
+                             setter: ->(fragment:, **) do
+                               ids = parse_link_ids_from_fragment(fragment, :user)
+                               represented[:replace_user_ids] = ids
+                             end
       end
     end
   end

--- a/modules/ldap_groups/app/models/ldap_groups/synchronized_group.rb
+++ b/modules/ldap_groups/app/models/ldap_groups/synchronized_group.rb
@@ -79,12 +79,9 @@ module LdapGroups
     def add_members_to_group(new_users)
       user_ids = new_users.map { |user| user_id(user) }
 
-      # Ensure we use pluck to get the current DB version of user_ids
-      current_user_ids = group.group_users.pluck(:user_id)
-
       call = Groups::UpdateService
         .new(user: User.current, model: group)
-        .call(user_ids: (current_user_ids + user_ids).uniq)
+        .call(add_user_ids: user_ids)
 
       call.on_success do
         Rails.logger.debug "[LDAP groups] Added users #{user_ids} to #{group.name}"
@@ -97,12 +94,9 @@ module LdapGroups
     end
 
     def remove_members_from_group(user_ids)
-      # Ensure we use pluck to get the current DB version of user_ids
-      current_user_ids = group.group_users.pluck(:user_id)
-
       call = Groups::UpdateService
         .new(user: User.system, model: group)
-        .call(user_ids: current_user_ids - user_ids)
+        .call(remove_user_ids: user_ids)
 
       call.on_success do
         Rails.logger.debug "[LDAP groups] Removed users #{user_ids} from #{group.name}"

--- a/spec/services/groups/set_attributes_service_spec.rb
+++ b/spec/services/groups/set_attributes_service_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Groups::SetAttributesService, type: :model do
 
       let(:call_attributes) do
         {
-          user_ids: [second_user.id, third_user.id]
+          replace_user_ids: [second_user.id, third_user.id]
         }
       end
 
@@ -173,7 +173,7 @@ RSpec.describe Groups::SetAttributesService, type: :model do
       context "with a persisted record and integer values" do
         let(:call_attributes) do
           {
-            user_ids: [second_user.id, third_user.id]
+            replace_user_ids: [second_user.id, third_user.id]
           }
         end
 
@@ -183,7 +183,40 @@ RSpec.describe Groups::SetAttributesService, type: :model do
       context "with a persisted record and string values" do
         let(:call_attributes) do
           {
-            user_ids: [second_user.id.to_s, third_user.id.to_s]
+            replace_user_ids: [second_user.id.to_s, third_user.id.to_s]
+          }
+        end
+
+        it_behaves_like "updates the users"
+      end
+
+      context "with add_user_ids and remove_user_ids as integer values" do
+        let(:call_attributes) do
+          {
+            remove_user_ids: [first_user.id],
+            add_user_ids: [third_user.id]
+          }
+        end
+
+        it_behaves_like "updates the users"
+      end
+
+      context "with add_user_ids and remove_user_ids as string values" do
+        let(:call_attributes) do
+          {
+            remove_user_ids: [first_user.id.to_s],
+            add_user_ids: [third_user.id.to_s]
+          }
+        end
+
+        it_behaves_like "updates the users"
+      end
+
+      context "with add_user_ids and remove_user_ids, adding an existing user id" do
+        let(:call_attributes) do
+          {
+            remove_user_ids: [first_user.id],
+            add_user_ids: [second_user.id, third_user.id]
           }
         end
 
@@ -201,8 +234,7 @@ RSpec.describe Groups::SetAttributesService, type: :model do
         end
 
         it "does not persist the association" do
-          expect(service_call.result.group_users.all(&:new_record?))
-            .to be_truthy
+          expect(service_call.result.group_users).to all(be_new_record)
         end
       end
     end


### PR DESCRIPTION
Previously it was always necessary to provide a full list of users when calling the service. Now, it's also possible to provide a delta that should be achieved.

This allows to simplify calls to the service, when only the delta is known (e.g. "add this user"). It also makes those calls safer, since the internals of the Groups::UpdateService are already locked through an advisory lock (via BaseContracted), thus concurrent changes to group memberships are serialized properly inside the service. However, previous implementations would have read the current members of a group outside of the service scope, where race conditions could have occured.

# Ticket
https://community.openproject.org/wp/58408