### PR TITLE
docs: add section for installing OpenProject via WSL on Windows

### DIFF
--- a/docs/installation-and-operations/installation/packaged/README.md
+++ b/docs/installation-and-operations/installation/packaged/README.md
@@ -506,3 +506,13 @@ Here are some pointers to related documentation that you will need to get starte
 
 - [Set up outgoing email notifications (SMTP, sendmail)](../../configuration/outbound-emails/)
 - [Integrate an external authentication provider (LDAP/AD, SAML, OpenID)](../../../system-admin-guide/authentication/)
+
+## Installation on Windows via WSL
+
+OpenProject can be installed on Windows using the Windows Subsystem for Linux (WSL) with a supported Linux distribution such as Ubuntu 22.04. Please note:
+
+- You should install WSL 2 for best performance and compatibility.
+- Follow the standard installation instructions as you would on Ubuntu.
+- Some features, such as email notifications or service auto-start, may require additional setup or elevated privileges.
+
+For more details, see [Microsoft's guide to WSL](https://learn.microsoft.com/en-us/windows/wsl/).


### PR DESCRIPTION
This PR adds a new section to the packaged installation README detailing how to install OpenProject on Windows using WSL (Windows Subsystem for Linux). This addition aims to help Windows users follow a supported setup path and avoid potential compatibility issues.

# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add documentation to help Windows users install OpenProject using WSL, which is mentioned but not clearly described in the current instructions.

## Screenshots
N/A – This is a text-only documentation update.

# What approach did you choose and why?
I followed the format used in other installation sections of the README to keep consistency and ensure users following Ubuntu install instructions understand how to apply them via WSL.

# Merge checklist

- [ ] Added/updated tests
- [X] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
