### PR TITLE
Add an option to automatically sync the color mode with the operating system preference

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -295,7 +295,7 @@ module ApplicationHelper
       [I18n.t("themes.light"), "light"],
       [I18n.t("themes.light_high_contrast"), "light_high_contrast"],
       [I18n.t("themes.dark"), "dark"],
-      [I18n.t("themes.sync_with_system"), "sync_with_system"]
+      [I18n.t("themes.sync_with_os"), "sync_with_os"]
     ]
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -317,13 +317,8 @@ module ApplicationHelper
 
   def user_theme_data_attributes
     if User.current.pref.sync_with_system_theme?
-      # Default to light mode initially before System theme is applied
-      # FIXME: Causes flickering on page navigation and load
-      {
-        color_mode: "light",
-        light_theme: "light",
-        auto_theme_switcher_mode_value: User.current.pref.theme
-      }
+      # Theme will be set by inline script before body renders to prevent flickering
+      { auto_theme_switcher_mode_value: User.current.pref.theme }
     else
       mode, _theme_suffix = User.current.pref.theme.split("_", 2)
       {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -244,8 +244,8 @@ module ApplicationHelper
     css = ["theme-#{OpenProject::CustomStyles::Design.identifier}"]
 
     if controller_path && action_name
-      css << ("controller-#{controller_path}")
-      css << ("action-#{action_name}")
+      css << "controller-#{controller_path}"
+      css << "action-#{action_name}"
     end
 
     if EnterpriseToken.hide_banners?
@@ -294,7 +294,8 @@ module ApplicationHelper
     [
       [I18n.t("themes.light"), "light"],
       [I18n.t("themes.light_high_contrast"), "light_high_contrast"],
-      [I18n.t("themes.dark"), "dark"]
+      [I18n.t("themes.dark"), "dark"],
+      [I18n.t("themes.sync_with_system"), "sync_with_system"]
     ]
   end
 
@@ -305,7 +306,7 @@ module ApplicationHelper
 
   def body_data_attributes(local_assigns)
     {
-      controller: "application hover-card-trigger beforeunload",
+      controller: "application auto-theme-switcher hover-card-trigger beforeunload",
       relative_url_root: root_path,
       overflowing_identifier: ".__overflowing_body",
       rendered_at: Time.zone.now.iso8601,
@@ -315,11 +316,21 @@ module ApplicationHelper
   end
 
   def user_theme_data_attributes
-    mode, _theme_suffix = User.current.pref.theme.split("_", 2)
-    {
-      color_mode: mode,
-      "#{mode}_theme": User.current.pref.theme
-    }
+    if User.current.pref.sync_with_system_theme?
+      # Default to light mode initially before System theme is applied
+      # FIXME: Causes flickering on page navigation and load
+      {
+        color_mode: "light",
+        light_theme: "light",
+        auto_theme_switcher_mode_value: User.current.pref.theme
+      }
+    else
+      mode, _theme_suffix = User.current.pref.theme.split("_", 2)
+      {
+        color_mode: mode,
+        "#{mode}_theme": User.current.pref.theme
+      }
+    end
   end
 
   def highlight_default_language(lang_options)

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -131,7 +131,7 @@ class UserPreference < ApplicationRecord
   end
 
   def sync_with_system_theme?
-    theme == "sync_with_system"
+    theme == "sync_with_os"
   end
 
   def high_contrast_theme?

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -130,6 +130,10 @@ class UserPreference < ApplicationRecord
     super.presence || Setting.user_default_theme
   end
 
+  def sync_with_system_theme?
+    theme == "sync_with_system"
+  end
+
   def high_contrast_theme?
     theme.end_with?("high_contrast")
   end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -40,6 +40,30 @@ See COPYRIGHT and LICENSE files for more details.
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
   <%# Disable prefetching for now %>
   <meta name="turbo-prefetch" content="false">
+  <%# Apply system theme immediately to prevent flickering %>
+  <% if User.current.pref.sync_with_system_theme? %>
+    <%= nonced_javascript_tag do %>
+      // Apply system theme before body renders to prevent flickering
+      // This duplicates logic from AutoThemeSwitcher controller for immediate execution
+      (function() {
+        const theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        const body = document.body;
+
+        switch (theme) {
+          case 'dark':
+            body.setAttribute('data-color-mode', 'dark');
+            body.setAttribute('data-dark-theme', 'dark');
+            body.removeAttribute('data-light-theme');
+            break;
+          case 'light':
+            body.setAttribute('data-color-mode', 'light');
+            body.setAttribute('data-light-theme', 'light');
+            body.removeAttribute('data-dark-theme');
+            break;
+        }
+      })();
+    <% end %>
+  <% end %>
 </head>
 <%= content_tag :body,
                 class: "#{body_css_classes}  __overflowing_element_container __overflowing_body",

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -46,10 +46,10 @@ See COPYRIGHT and LICENSE files for more details.
       // Apply system theme before body renders to prevent flickering
       // This duplicates logic from AutoThemeSwitcher controller for immediate execution
       (function() {
-        const theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        const colorModePreference = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
         const body = document.body;
 
-        switch (theme) {
+        switch (colorModePreference) {
           case 'dark':
             body.setAttribute('data-color-mode', 'dark');
             body.setAttribute('data-dark-theme', 'dark');
@@ -57,8 +57,10 @@ See COPYRIGHT and LICENSE files for more details.
             break;
           case 'light':
             body.setAttribute('data-color-mode', 'light');
-            body.setAttribute('data-light-theme', 'light');
+            body.setAttribute('data-light-theme', window.matchMedia('(prefers-contrast: more)').matches ? 'light_high_contrast' : 'light');
             body.removeAttribute('data-dark-theme');
+            break;
+          default: // Do nothing
             break;
         }
       })();

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -44,25 +44,8 @@ See COPYRIGHT and LICENSE files for more details.
   <% if User.current.pref.sync_with_system_theme? %>
     <%= nonced_javascript_tag do %>
       // Apply system theme before body renders to prevent flickering
-      // This duplicates logic from AutoThemeSwitcher controller for immediate execution
       (function() {
-        const colorModePreference = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-        const body = document.body;
-
-        switch (colorModePreference) {
-          case 'dark':
-            body.setAttribute('data-color-mode', 'dark');
-            body.setAttribute('data-dark-theme', 'dark');
-            body.removeAttribute('data-light-theme');
-            break;
-          case 'light':
-            body.setAttribute('data-color-mode', 'light');
-            body.setAttribute('data-light-theme', window.matchMedia('(prefers-contrast: more)').matches ? 'light_high_contrast' : 'light');
-            body.removeAttribute('data-dark-theme');
-            break;
-          default: // Do nothing
-            break;
-        }
+        window.OpenProject.theme.applySystemThemeImmediately();
       })();
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,7 +742,7 @@ en:
     dark: "Dark"
     light: "Light"
     light_high_contrast: "Light high contrast"
-    sync_with_system: "Sync with system"
+    sync_with_system: "Auto (system default)"
 
   types:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,6 +742,7 @@ en:
     dark: "Dark"
     light: "Light"
     light_high_contrast: "Light high contrast"
+    sync_with_system: "Sync with system"
 
   types:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,7 +742,7 @@ en:
     dark: "Dark"
     light: "Light"
     light_high_contrast: "Light high contrast"
-    sync_with_system: "Auto (system default)"
+    sync_with_os: "Automatic (match OS colour mode)"
 
   types:
     index:

--- a/config/schemas/user_preferences.schema.json
+++ b/config/schemas/user_preferences.schema.json
@@ -11,7 +11,7 @@
                 },
                 "theme": {
                   "type": "string",
-                  "enum": ["light", "light_high_contrast", "dark", "sync_with_system"]
+                  "enum": ["light", "light_high_contrast", "dark", "sync_with_os"]
                 },
                 "disable_keyboard_shortcuts": {
                     "type": "boolean"

--- a/config/schemas/user_preferences.schema.json
+++ b/config/schemas/user_preferences.schema.json
@@ -11,7 +11,7 @@
                 },
                 "theme": {
                   "type": "string",
-                  "enum": ["light", "light_high_contrast", "dark"]
+                  "enum": ["light", "light_high_contrast", "dark", "sync_with_system"]
                 },
                 "disable_keyboard_shortcuts": {
                     "type": "boolean"

--- a/frontend/src/app/core/setup/globals/openproject.ts
+++ b/frontend/src/app/core/setup/globals/openproject.ts
@@ -30,6 +30,7 @@ import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-conte
 import { input, InputState } from '@openproject/reactivestates';
 import { getMetaElement, GlobalHelpers } from 'core-app/core/setup/globals/global-helpers';
 import { firstValueFrom } from 'rxjs';
+import { ThemeUtils } from './theme-utils';
 
 export type OpenProjectPageState = 'pristine'|'edited'|'submitted';
 
@@ -40,6 +41,11 @@ export class OpenProject {
   public pluginContext:InputState<OpenProjectPluginContext> = input<OpenProjectPluginContext>();
 
   public helpers = new GlobalHelpers();
+
+  /**
+   * Theme utilities for system theme detection and application
+   */
+  public theme = new ThemeUtils();
 
   /** Globally setable variable whether the page was edited or submitted */
   pageState:OpenProjectPageState = 'pristine';

--- a/frontend/src/app/core/setup/globals/theme-utils.ts
+++ b/frontend/src/app/core/setup/globals/theme-utils.ts
@@ -28,35 +28,35 @@
  * ++
  */
 
-import { Controller } from '@hotwired/stimulus';
-import { useMatchMedia } from 'stimulus-use';
-import { ThemeUtils } from 'core-app/core/setup/globals/theme-utils';
+export type OpTheme = 'light' | 'light_high_contrast' | 'dark';
 
-export default class AutoThemeSwitcher extends Controller {
-  static values = {
-    mode: String,
-  };
-
-  declare readonly modeValue:string;
-  private themeUtils:ThemeUtils;
-
-  connect() {
-    if (this.modeValue !== 'sync_with_os') return;
-
-    this.themeUtils = new ThemeUtils();
-
-    useMatchMedia(this, {
-      mediaQueries: {
-        lightMode: '(prefers-color-scheme: light)',
-      },
-    });
+export class ThemeUtils {
+  public applySystemThemeImmediately():void {
+    const theme = this.detectSystemTheme();
+    this.applyThemeToBody(theme);
   }
 
-  isLightMode():void {
-    this.themeUtils.applyThemeToBody('light');
+  public detectSystemTheme():OpTheme {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
-  notLightMode():void {
-    this.themeUtils.applyThemeToBody('dark');
+  public applyThemeToBody(theme:OpTheme):void {
+    const increaseContrast = window.matchMedia('(prefers-contrast: more)').matches;
+    const body = document.body;
+
+    switch (theme) {
+      case 'dark':
+        body.setAttribute('data-color-mode', 'dark');
+        body.setAttribute('data-dark-theme', 'dark');
+        body.removeAttribute('data-light-theme');
+        break;
+      case 'light':
+        body.setAttribute('data-color-mode', 'light');
+        body.setAttribute('data-light-theme', increaseContrast ? 'light_high_contrast' : 'light');
+        body.removeAttribute('data-dark-theme');
+        break;
+      default: // Do nothing
+        break;
+    }
   }
 }

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -33,13 +33,12 @@ import { BlockNoteView } from "@blocknote/mantine";
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from "@blocknote/react";
 import { dummyBlockSpec, getDefaultOpenProjectSlashMenuItems, openProjectWorkPackageBlockSpec } from "op-blocknote-extensions";
 import { useEffect, useState } from "react";
+import { OpTheme } from "../stimulus/controllers/auto-theme-switcher.controller";
 
 export interface OpBlockNoteContainerProps {
   inputField: HTMLInputElement;
   inputText?: string;
 }
-
-type OpTheme = "light" | "dark";
 
 const schema = BlockNoteSchema.create({
   blockSpecs: {

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -33,7 +33,7 @@ import { BlockNoteView } from "@blocknote/mantine";
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from "@blocknote/react";
 import { dummyBlockSpec, getDefaultOpenProjectSlashMenuItems, openProjectWorkPackageBlockSpec } from "op-blocknote-extensions";
 import { useEffect, useState } from "react";
-import { OpTheme } from "../stimulus/controllers/auto-theme-switcher.controller";
+import { OpTheme } from "core-app/core/setup/globals/theme-utils";
 
 export interface OpBlockNoteContainerProps {
   inputField: HTMLInputElement;

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -31,7 +31,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { useMatchMedia } from 'stimulus-use';
 
-export type OpTheme = 'light' | 'dark';
+export type OpTheme = 'light' | 'light_high_contrast' | 'dark';
 
 export default class AutoThemeSwitcher extends Controller {
   static values = {
@@ -69,11 +69,15 @@ export default class AutoThemeSwitcher extends Controller {
         break;
       case 'light':
         body.setAttribute('data-color-mode', 'light');
-        body.setAttribute('data-light-theme', 'light');
+        body.setAttribute('data-light-theme', this.increaseContrast ? 'light_high_contrast' : 'light');
         body.removeAttribute('data-dark-theme');
         break;
       default: // Do nothing
         break;
     }
+  }
+
+  private get increaseContrast():boolean {
+    return window.matchMedia('(prefers-contrast: more)').matches;
   }
 }

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -30,7 +30,6 @@
 
 import { Controller } from '@hotwired/stimulus';
 import { useMatchMedia } from 'stimulus-use';
-import { ThemeUtils } from 'core-app/core/setup/globals/theme-utils';
 
 export default class AutoThemeSwitcher extends Controller {
   static values = {
@@ -38,12 +37,9 @@ export default class AutoThemeSwitcher extends Controller {
   };
 
   declare readonly modeValue:string;
-  private themeUtils:ThemeUtils;
 
   connect() {
     if (this.modeValue !== 'sync_with_os') return;
-
-    this.themeUtils = new ThemeUtils();
 
     useMatchMedia(this, {
       mediaQueries: {
@@ -53,10 +49,10 @@ export default class AutoThemeSwitcher extends Controller {
   }
 
   isLightMode():void {
-    this.themeUtils.applyThemeToBody('light');
+    window.OpenProject.theme.applyThemeToBody('light');
   }
 
   notLightMode():void {
-    this.themeUtils.applyThemeToBody('dark');
+    window.OpenProject.theme.applyThemeToBody('dark');
   }
 }

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -1,0 +1,79 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import { useMatchMedia } from 'stimulus-use';
+
+export type OpTheme = 'light' | 'dark';
+
+export default class AutoThemeSwitcher extends Controller {
+  static values = {
+    mode: String,
+  };
+
+  declare readonly modeValue:string;
+
+  connect() {
+    if (this.modeValue !== 'sync_with_system') return;
+
+    useMatchMedia(this, {
+      mediaQueries: {
+        lightMode: '(prefers-color-scheme: light)',
+      },
+    });
+  }
+
+  isLightMode():void {
+    this.applyTheme('light');
+  }
+
+  notLightMode():void {
+    this.applyTheme('dark');
+  }
+
+  private applyTheme(theme:OpTheme):void {
+    const body = document.body;
+
+    switch (theme) {
+      case 'dark':
+        body.setAttribute('data-color-mode', 'dark');
+        body.setAttribute('data-dark-theme', 'dark');
+        body.removeAttribute('data-light-theme');
+        break;
+      case 'light':
+        body.setAttribute('data-color-mode', 'light');
+        body.setAttribute('data-light-theme', 'light');
+        body.removeAttribute('data-dark-theme');
+        break;
+      default: // Do nothing
+        break;
+    }
+  }
+}

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -41,7 +41,7 @@ export default class AutoThemeSwitcher extends Controller {
   declare readonly modeValue:string;
 
   connect() {
-    if (this.modeValue !== 'sync_with_system') return;
+    if (this.modeValue !== 'sync_with_os') return;
 
     useMatchMedia(this, {
       mediaQueries: {

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -26,6 +26,7 @@ import StemsController from './controllers/dynamic/work-packages/activities-tab/
 import EditorController from './controllers/dynamic/work-packages/activities-tab/editor.controller';
 
 import AutoSubmit from '@stimulus-components/auto-submit';
+import AutoThemeSwitcher from './controllers/auto-theme-switcher.controller';
 import { OpenProjectStimulusApplication } from 'core-stimulus/openproject-stimulus-application';
 import { Application } from '@hotwired/stimulus';
 import { BeforeunloadController } from './controllers/beforeunload.controller';
@@ -63,6 +64,7 @@ OpenProjectStimulusApplication.preregister('work-packages--activities-tab--polli
 OpenProjectStimulusApplication.preregister('work-packages--activities-tab--stems', StemsController);
 OpenProjectStimulusApplication.preregister('work-packages--activities-tab--editor', EditorController);
 OpenProjectStimulusApplication.preregister('beforeunload', BeforeunloadController);
+OpenProjectStimulusApplication.preregister('auto-theme-switcher', AutoThemeSwitcher);
 
 const instance = OpenProjectStimulusApplication.start();
 window.Stimulus = instance;

--- a/spec/features/my/interface_spec.rb
+++ b/spec/features/my/interface_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "My account Interface settings",
+               :js, :selenium do
+  let(:user) { create(:user) }
+
+  before do
+    login_as(user)
+    visit my_account_path
+  end
+
+  it "allows the user to specify their preferred colour mode" do
+    click_on "Interface"
+
+    select "Light", from: "Colour mode"
+    click_on "Update look and feel"
+
+    expect(page).to have_css("body[data-color-mode='light'][data-light-theme='light']")
+
+    select "Dark", from: "Colour mode"
+    click_on "Update look and feel"
+
+    expect(page).to have_css("body[data-color-mode='dark'][data-dark-theme='dark']")
+
+    select "Automatic (match OS colour mode)", from: "Colour mode"
+    click_on "Update look and feel"
+
+    expect(page).to have_css("body[data-auto-theme-switcher-mode-value='sync_with_os']")
+  end
+
+  describe "Automatic (match OS colour mode)" do
+    context "with OS in dark mode", driver: :chrome_dark_mode do
+      it "syncs with OS colour mode" do
+        click_on "Interface"
+
+        select "Dark", from: "Colour mode"
+        click_on "Update look and feel"
+
+        expect(page).to have_css("body[data-color-mode='dark'][data-dark-theme='dark']")
+      end
+    end
+  end
+end

--- a/spec/features/my/interface_spec.rb
+++ b/spec/features/my/interface_spec.rb
@@ -77,12 +77,5 @@ RSpec.describe "My account Interface settings",
         expect(page).to have_css("body[data-color-mode='dark'][data-dark-theme='dark']")
       end
     end
-
-    context "with OS contrasting mode", driver: :firefox_light_high_contrast do
-      it "syncs with OS colour mode" do
-        set_automatic_mode_with_reload
-        expect(page).to have_css("body[data-color-mode='light'][data-light-theme='light_high_contrast']")
-      end
-    end
   end
 end

--- a/spec/features/my/interface_spec.rb
+++ b/spec/features/my/interface_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe "My account Interface settings",
 
     expect(page).to have_css("body[data-color-mode='light'][data-light-theme='light']")
 
+    select "Light high contrast", from: "Colour mode"
+    click_on "Update look and feel"
+
+    expect(page).to have_css("body[data-color-mode='light'][data-light-theme='light_high_contrast']")
+
     select "Dark", from: "Colour mode"
     click_on "Update look and feel"
 
@@ -59,14 +64,24 @@ RSpec.describe "My account Interface settings",
   end
 
   describe "Automatic (match OS colour mode)" do
+    def set_automatic_mode_with_reload
+      click_on "Interface"
+
+      select "Automatic (match OS colour mode)", from: "Colour mode"
+      click_on "Update look and feel"
+    end
+
     context "with OS in dark mode", driver: :chrome_dark_mode do
       it "syncs with OS colour mode" do
-        click_on "Interface"
-
-        select "Dark", from: "Colour mode"
-        click_on "Update look and feel"
-
+        set_automatic_mode_with_reload
         expect(page).to have_css("body[data-color-mode='dark'][data-dark-theme='dark']")
+      end
+    end
+
+    context "with OS contrasting mode", driver: :firefox_light_high_contrast do
+      it "syncs with OS colour mode" do
+        set_automatic_mode_with_reload
+        expect(page).to have_css("body[data-color-mode='light'][data-light-theme='light_high_contrast']")
       end
     end
   end

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -130,3 +130,7 @@ register_chrome "en", name: :chrome_revit_add_in do |options|
 end
 
 register_chrome "en", name: :chrome_new_york_time_zone, override_time_zone: "America/New_York"
+
+register_chrome "en", name: :chrome_dark_mode do |options|
+  options.add_argument("--force-dark-mode")
+end

--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -60,3 +60,8 @@ end
 register_firefox "en"
 # Register german locale for custom field decimal test
 register_firefox "de"
+
+register_firefox "en", name: :firefox_light_high_contrast do |profile, _options|
+  # 2 = more, 1 = less, 0 = no-preference, 3 = forced-colors only
+  profile["layout.css.prefers-contrast.content-override"] = 2
+end

--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -60,8 +60,3 @@ end
 register_firefox "en"
 # Register german locale for custom field decimal test
 register_firefox "de"
-
-register_firefox "en", name: :firefox_light_high_contrast do |profile, _options|
-  # 2 = more, 1 = less, 0 = no-preference, 3 = forced-colors only
-  profile["layout.css.prefers-contrast.content-override"] = 2
-end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/66397

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Adds an option to automatically sync the color mode with the operating system preference including contrast (only light high contrast supported as of this PR)

**Reviewer note:** _Supporting "dark high contrast" and separating "contrast settings" will be in separate PRs_

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

[auto-theme-switcher.webm](https://github.com/user-attachments/assets/b479dc61-75aa-4456-b832-147b0c8a0819)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Leverage the `matchMedia` browser API to detect the user preference and set the corresponding theme: (1) as an inline script in `head` to run before the body renders. This prevents flickering as the theme as updated. (2) An `auto-theme-switcher` stimulus controller listening to OS theme & contrast changes via [useMatchMedia](https://github.com/stimulus-use/stimulus-use/blob/main/docs/use-match-media.md) hooks

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
