### PR TITLE
Use model.customizable? to see if a model implements custom fields

### DIFF
--- a/app/services/journals/create_service/customizable.rb
+++ b/app/services/journals/create_service/customizable.rb
@@ -31,7 +31,7 @@
 class Journals::CreateService
   class Customizable < Association
     def associated?
-      journable.respond_to?(:customizable?)
+      journable.customizable?
     end
 
     def cleanup_predecessor(predecessor)


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Using `journable.respond_to?(:customizable?)` is problematic, because even though it can return true, calling `journable.customizable?` still can be false.

# What approach did you choose and why?
 Use `journable.customizable?` because that is the right way to ask a model if it implements custom fields.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
