### PR TITLE
Remove `turbo:load` hacks from `base.html.erb`

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -178,27 +178,27 @@ See COPYRIGHT and LICENSE files for more details.
 <%# Properly decides main menu expanded state and width before its drawn. Fixes flickering side menu
         where menu is first expanded, then being collapsed in angular. %>
 <%= nonced_javascript_tag type: "module" do %>
-  (function($) {
-    // execute these lines to prevent flickering when page loads:
-    var wrapper = $('#wrapper');
-    var savedMainMenuWidth = window.OpenProject.guardedLocalStorage("openProject-mainMenuWidth");
-    var mainMenuCollapsed =  window.OpenProject.guardedLocalStorage("openProject-mainMenuCollapsed");
+  // execute these lines to prevent flickering when page loads:
+  const wrapper = document.getElementById('wrapper');
+  const mainMenuCollapsed = window.OpenProject.guardedLocalStorage('openProject-mainMenuCollapsed');
 
-    if (window.innerWidth < 1012) {
-      // force hide on load for small desktops
-      $('.can-hide-navigation').addClass('hidden-navigation');
-    }
+  let savedMainMenuWidth;
+  if (mainMenuCollapsed === 'true') {
+    savedMainMenuWidth = 0;
+  } else {
+    savedMainMenuWidth = parseInt(window.OpenProject.guardedLocalStorage('openProject-mainMenuWidth'), 10);
+  }
 
-    if (mainMenuCollapsed === 'true') {
-      savedMainMenuWidth = 0;
-    }
+  if (window.innerWidth < 1012) {
+    // force hide on load for small desktops
+    document.querySelector('.can-hide-navigation')?.classList.add('hidden-navigation');
+  }
 
-    if (savedMainMenuWidth || savedMainMenuWidth === 0) {
-      document.documentElement.style.setProperty("--main-menu-width", savedMainMenuWidth + 'px');
-    }
+  if (savedMainMenuWidth >= 0) {
+    document.documentElement.style.setProperty('--main-menu-width', savedMainMenuWidth + 'px');
+  }
 
-    wrapper.show();
-  }(jQuery));
+  wrapper.style.display = '';
 <% end %>
 
 <%= nonced_javascript_tag do %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -177,35 +177,36 @@ See COPYRIGHT and LICENSE files for more details.
 </div>
 <%# Properly decides main menu expanded state and width before its drawn. Fixes flickering side menu
         where menu is first expanded, then being collapsed in angular. %>
-<%= nonced_javascript_tag defer: true do %>
-  // execute these lines to prevent flickering when page loads:
+<%= nonced_javascript_tag type: "module" do %>
+  (function($) {
+    // execute these lines to prevent flickering when page loads:
+    var wrapper = $('#wrapper');
+    var savedMainMenuWidth = window.OpenProject.guardedLocalStorage("openProject-mainMenuWidth");
+    var mainMenuCollapsed =  window.OpenProject.guardedLocalStorage("openProject-mainMenuCollapsed");
 
-  window.addEventListener('turbo:load', () => {
-    (function($) {
-      var wrapper = $('#wrapper');
-      var savedMainMenuWidth = window.OpenProject.guardedLocalStorage("openProject-mainMenuWidth");
-      var mainMenuCollapsed =  window.OpenProject.guardedLocalStorage("openProject-mainMenuCollapsed");
+    if (window.innerWidth < 1012) {
+      // force hide on load for small desktops
+      $('.can-hide-navigation').addClass('hidden-navigation');
+    }
 
-      if (window.innerWidth < 1012) {
-        // force hide on load for small desktops
-        $('.can-hide-navigation').addClass('hidden-navigation');
-      }
+    if (mainMenuCollapsed === 'true') {
+      savedMainMenuWidth = 0;
+    }
 
-      if (mainMenuCollapsed === 'true') {
-        savedMainMenuWidth = 0;
-      }
+    if (savedMainMenuWidth || savedMainMenuWidth === 0) {
+      document.documentElement.style.setProperty("--main-menu-width", savedMainMenuWidth + 'px');
+    }
 
-      if (savedMainMenuWidth || savedMainMenuWidth === 0) {
-        document.documentElement.style.setProperty("--main-menu-width", savedMainMenuWidth + 'px');
-      }
+    wrapper.show();
+  }(jQuery));
+<% end %>
 
-      wrapper.show();
-
-      // Wrapper for page-specific JS from deprecated inline functions
-      // no longer available with CSP.
-      <%= content_for :additional_js_dom_ready %>
-    }(jQuery));
-  });
+<%= nonced_javascript_tag do %>
+  (function($) {
+    // Wrapper for page-specific JS from deprecated inline functions
+    // no longer available with CSP.
+    <%= content_for :additional_js_dom_ready %>
+  }(jQuery));
 <% end %>
 <div class="op-wide-autocomplete-wrapper"></div>
 <%= call_hook :view_layouts_base_body_bottom %>


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Follows on from #19668
Related to #19662 (potential alternative)
 
Removes `turbo:load` hack which resulted in rendering issues (white screens) on form error submission for a number of pages.

`type="module"` rather than `defer` is the correct attribute value in this case: the script will be also be deferred, but in a synchronous execution order - after other `<script type="module">`, e.g. `main.js`.

See also 0e69c9e156f425b56659714092cde667298fb4bf

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

