### PR TITLE
add workspace_type enum to project

### DIFF
--- a/app/components/projects/new_component.html.erb
+++ b/app/components/projects/new_component.html.erb
@@ -51,6 +51,7 @@ See COPYRIGHT and LICENSE files for more details.
         container.with_row(mb: 3) do
           render(
             Primer::Forms::FormList.new(
+              Projects::Settings::TypeForm.new(f),
               Projects::Settings::NameForm.new(f),
               Projects::Settings::RelationsForm.new(f),
               Projects::Settings::CustomFieldsForm.new(f)

--- a/app/contracts/projects/copy_contract.rb
+++ b/app/contracts/projects/copy_contract.rb
@@ -29,7 +29,7 @@
 #++
 
 module Projects
-  class CopyContract < BaseContract
+  class CopyContract < CreateContract
     protected
 
     def validate_model?

--- a/app/contracts/projects/create_contract.rb
+++ b/app/contracts/projects/create_contract.rb
@@ -30,7 +30,12 @@
 
 module Projects
   class CreateContract < BaseContract
+    attribute :workspace_type do
+      validate_workspace_type_included
+    end
+
     include AdminWritableTimestamps
+
     # Projects update their updated_at timestamp due to awesome_nested_set
     # so allowing writing here would be useless.
     allow_writable_timestamps :created_at
@@ -44,6 +49,12 @@ module Projects
     end
 
     protected
+
+    def validate_workspace_type_included
+      # TODO: differentiate on allowed types based on permissions.
+      # Permissions will need to be added: project, program, portfolio.
+      errors.add(:workspace_type, :blank) if model.workspace_type.nil?
+    end
 
     def collect_available_custom_field_attributes
       model.all_visible_custom_fields.map(&:attribute_name)

--- a/app/forms/projects/settings/type_form.rb
+++ b/app/forms/projects/settings/type_form.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+module Projects
+  module Settings
+    class TypeForm < ApplicationForm
+      form do |f|
+        f.hidden name: :workspace_type,
+                 value: Project.workspace_types[:project]
+      end
+    end
+  end
+end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -297,7 +297,7 @@ class PermittedParams
 
   def new_project
     params
-      .expect(project: %i[name parent_id])
+      .expect(project: %i[name parent_id workspace_type])
       .merge(custom_field_values(:project))
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,6 +48,12 @@ class Project < ApplicationRecord
   # reserved identifiers
   RESERVED_IDENTIFIERS = %w[new menu queries export_list_modal].freeze
 
+  enum :workspace_type, {
+    project: "project",
+    program: "program",
+    portfolio: "portfolio"
+  }
+
   has_many :members, -> {
     # TODO: check whether this should
     # remain to be limited to User only

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -152,8 +152,7 @@ module DemoData
       seed_data.lookup("types") || []
     end
 
-    def project_attributes
-      parent = Project.find_by(identifier: project_data.lookup("parent"))
+    def project_attributes # rubocop:disable Metrics/AbcSize
       {
         name: project_data.lookup("name"),
         identifier: project_data.lookup("identifier"),
@@ -162,7 +161,8 @@ module DemoData
         description: project_data.lookup("description"),
         enabled_module_names: project_data.lookup("modules"),
         types: Type.all,
-        parent:
+        parent: Project.find_by(identifier: project_data.lookup("parent")),
+        workspace_type: Project.workspace_types[:project]
       }
     end
   end

--- a/app/seeders/development_data/projects_seeder.rb
+++ b/app/seeders/development_data/projects_seeder.rb
@@ -112,7 +112,8 @@ module DevelopmentData
         name: project_name(identifier),
         identifier:,
         enabled_module_names: project_modules,
-        types: Type.all
+        types: Type.all,
+        workspace_type: Project.workspace_types[:project]
       }
     end
 

--- a/db/migrate/20250731144436_add_workspace_type_to_project.rb
+++ b/db/migrate/20250731144436_add_workspace_type_to_project.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddWorkspaceTypeToProject < ActiveRecord::Migration[8.0]
+  def change
+    change_table :projects, bulk: false do |t|
+      t.string :workspace_type, null: false, default: "project", index: true
+      t.change_default :workspace_type, from: "project", to: nil
+    end
+
+    change_table :project_journals, bulk: false do |t|
+      t.string :workspace_type, null: false, default: "project"
+      t.change_default :workspace_type, from: "project", to: nil
+    end
+  end
+end

--- a/lib/api/v3/projects/create_form_api.rb
+++ b/lib/api/v3/projects/create_form_api.rb
@@ -37,7 +37,11 @@ module API
             end
           end
 
-          post &::API::V3::Utilities::Endpoints::CreateForm.new(model: Project)
+          post &::API::V3::Utilities::Endpoints::CreateForm.new(model: Project,
+                                                                params_modifier: ->(attributes) {
+                                                                  attributes[:workspace_type] = Project.workspace_types[:project]
+                                                                  attributes
+                                                                })
                                                            .mount
         end
       end

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -40,7 +40,11 @@ module API
                                                                        })
                                                                   .mount
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Project)
+          post &::API::V3::Utilities::Endpoints::Create.new(model: Project,
+                                                            params_modifier: ->(attributes) {
+                                                              attributes[:workspace_type] = Project.workspace_types[:project]
+                                                              attributes
+                                                            })
                                                        .mount
 
           mount ::API::V3::Projects::Schemas::ProjectSchemaAPI

--- a/spec/contracts/projects/create_contract_spec.rb
+++ b/spec/contracts/projects/create_contract_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Projects::CreateContract do
                   public: project_public,
                   parent: project_parent,
                   status_code: project_status_code,
-                  status_explanation: project_status_explanation)
+                  status_explanation: project_status_explanation,
+                  workspace_type: project_workspace_type)
     end
     let(:global_permissions) { [:add_project] }
     let(:validated_contract) do
@@ -52,6 +53,30 @@ RSpec.describe Projects::CreateContract do
 
     context "if the identifier is nil" do
       let(:project_identifier) { nil }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "if workspace_type is nil" do
+      let(:project_workspace_type) { nil }
+
+      it_behaves_like "contract is invalid", workspace_type: %i(blank)
+    end
+
+    context "if workspace type is 'project'" do
+      let(:project_workspace_type) { "project" }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "if workspace type is 'program'" do
+      let(:project_workspace_type) { "program" }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "if workspace type is 'portfolio'" do
+      let(:project_workspace_type) { "portfolio" }
 
       it_behaves_like "contract is valid"
     end

--- a/spec/contracts/projects/create_contract_spec.rb
+++ b/spec/contracts/projects/create_contract_spec.rb
@@ -53,9 +53,7 @@ RSpec.describe Projects::CreateContract do
     context "if the identifier is nil" do
       let(:project_identifier) { nil }
 
-      it "is replaced for new project" do
-        expect_valid(true)
-      end
+      it_behaves_like "contract is valid"
     end
 
     describe "permissions" do

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -29,8 +29,11 @@
 #++
 
 require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
 
 RSpec.shared_examples_for "project contract" do
+  include_context "ModelContract shared context"
+
   let(:current_user) { build_stubbed(:user) }
 
   before do
@@ -89,68 +92,48 @@ RSpec.shared_examples_for "project contract" do
     assignable_parents
   end
 
-  def expect_valid(valid, symbols = {})
-    expect(contract.validate).to eq(valid)
-
-    symbols.each do |key, arr|
-      expect(contract.errors.symbols_for(key)).to match_array arr
-    end
-  end
-
-  shared_examples "is valid" do
-    it "is valid" do
-      expect_valid(true)
-    end
-  end
-
-  it_behaves_like "is valid"
+  it_behaves_like "contract is valid"
 
   context "if the name is nil" do
     let(:project_name) { nil }
 
-    it "is invalid" do
-      expect_valid(false, name: %i(blank))
-    end
+    it_behaves_like "contract is invalid", name: %i(blank)
   end
 
   context "if the description is nil" do
     let(:project_description) { nil }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "if the parent is nil" do
     let(:project_parent) { nil }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "if the parent is not in the set of assignable_parents" do
     let(:parent_assignable) { false }
 
-    it "is invalid" do
-      expect_valid(false, parent: %i(does_not_exist))
-    end
+    it_behaves_like "contract is invalid", parent: %i(does_not_exist)
   end
 
   context "if active is nil" do
     let(:project_active) { nil }
 
-    it "is invalid" do
-      expect_valid(false, active: %i(blank))
-    end
+    it_behaves_like "contract is invalid", active: %i(blank)
   end
 
   context "if status code is nil" do
     let(:project_status_code) { nil }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "if status explanation is nil" do
     let(:project_status_explanation) { nil }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "if status code is invalid" do
@@ -166,70 +149,62 @@ RSpec.shared_examples_for "project contract" do
       code_attributes.instance_variable_set(:@value, bogus_project_status_code)
     end
 
-    it "is invalid" do
-      expect_valid(false, status: %i(inclusion))
-    end
+    it_behaves_like "contract is invalid", status: %i(inclusion)
   end
 
   context "when the identifier consists of only letters" do
     let(:project_identifier) { "abc" }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "when the identifier consists of letters followed by numbers" do
     let(:project_identifier) { "abc12" }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "when the identifier consists of letters followed by numbers with a hyphen in between" do
     let(:project_identifier) { "abc-12" }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "when the identifier consists of letters followed by numbers with an underscore in between" do
     let(:project_identifier) { "abc_12" }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "when the identifier consists of numbers followed by letters with a hyphen in between" do
     let(:project_identifier) { "12-abc" }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "when the identifier consists of numbers followed by letters with an underscore in between" do
     let(:project_identifier) { "12_abc" }
 
-    it_behaves_like "is valid"
+    it_behaves_like "contract is valid"
   end
 
   context "when the identifier consists of only numbers" do
     let(:project_identifier) { "12" }
 
-    it "is invalid" do
-      expect_valid(false, identifier: %i(invalid))
-    end
+    it_behaves_like "contract is invalid", identifier: %i(invalid)
   end
 
   context "when the identifier consists of a reserved word" do
     let(:project_identifier) { "new" }
 
-    it "is invalid" do
-      expect_valid(false, identifier: %i(exclusion))
-    end
+    it_behaves_like "contract is invalid", identifier: %i(exclusion)
   end
 
   context "if the user lacks permission" do
     let(:global_permissions) { [] }
     let(:project_permissions) { [] }
 
-    it "is invalid" do
-      expect_valid(false, base: %i(error_unauthorized))
-    end
+    it_behaves_like "contract is invalid", base: %i(error_unauthorized)
   end
 
   describe "assignable_values" do

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -52,6 +52,7 @@ RSpec.shared_examples_for "project contract" do
   let(:project_public) { true }
   let(:project_status_code) { "on_track" }
   let(:project_status_explanation) { "some explanation" }
+  let(:project_workspace_type) { "project" }
   let(:project_parent) do
     build_stubbed(:project)
   end

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -66,9 +66,7 @@ RSpec.describe Projects::UpdateContract do
     context "if the identifier is nil" do
       let(:project_identifier) { nil }
 
-      it "is replaced for new project" do
-        expect_valid(false, identifier: %i(blank))
-      end
+      it_behaves_like "contract is invalid", identifier: %i(blank)
     end
 
     describe "permissions" do
@@ -85,26 +83,23 @@ RSpec.describe Projects::UpdateContract do
           context "and only project_custom_fields are changed" do
             let(:project_changed) { false }
 
-            it_behaves_like "is valid"
+            it_behaves_like "contract is valid"
           end
 
           context "and other project attributes are changed too" do
             let(:project_changed) { true }
 
-            it "is invalid" do
-              expect_valid(false, { name: %i(error_readonly),
-                                    parent_id: %i(error_readonly),
-                                    identifier: %i(error_readonly) })
-            end
+            it_behaves_like "contract is invalid",
+                            name: %i(error_readonly),
+                            parent_id: %i(error_readonly),
+                            identifier: %i(error_readonly)
           end
         end
 
         context "when project_attributes_only flag is false" do
           let(:options) { { project_attributes_only: false } }
 
-          it "is invalid" do
-            expect_valid(false, base: %i(error_unauthorized))
-          end
+          it_behaves_like "contract is invalid", name: %i(error_readonly)
         end
       end
 
@@ -112,9 +107,7 @@ RSpec.describe Projects::UpdateContract do
         context "when project_attributes_only flag is true" do
           let(:options) { { project_attributes_only: true } }
 
-          it "is invalid" do
-            expect_valid(false, base: %i(error_unauthorized))
-          end
+          it_behaves_like "contract user is unauthorized"
         end
 
         context "when project_attributes_only flag is false" do
@@ -123,7 +116,7 @@ RSpec.describe Projects::UpdateContract do
           context "and only project attributes are changed" do
             let(:project_changed) { true }
 
-            it_behaves_like "is valid"
+            it_behaves_like "contract is valid"
           end
 
           context "and project_custom_fields are changed too" do
@@ -134,7 +127,7 @@ RSpec.describe Projects::UpdateContract do
             end
 
             it "is invalid" do
-              expect_valid(false, "custom_field_#{custom_field.id}": %i(error_readonly))
+              expect_contract_invalid("custom_field_#{custom_field.id}": %i(error_readonly))
             end
           end
         end
@@ -149,11 +142,10 @@ RSpec.describe Projects::UpdateContract do
           context "and only project attributes are changed" do
             let(:project_changed) { true }
 
-            it "is invalid" do
-              expect_valid(false, { name: %i(error_readonly),
-                                    parent_id: %i(error_readonly),
-                                    identifier: %i(error_readonly) })
-            end
+            it_behaves_like "contract is invalid",
+                            name: %i(error_readonly),
+                            parent_id: %i(error_readonly),
+                            identifier: %i(error_readonly)
           end
 
           context "and only project_custom_fields are changed" do
@@ -163,7 +155,7 @@ RSpec.describe Projects::UpdateContract do
               project.custom_field_values = { custom_field.id => "1" }
             end
 
-            it_behaves_like "is valid"
+            it_behaves_like "contract is valid"
           end
 
           context "when both project attributes and project custom_fields are changed" do
@@ -173,11 +165,10 @@ RSpec.describe Projects::UpdateContract do
               project.custom_field_values = { custom_field.id => "1" }
             end
 
-            it "is invalid" do
-              expect_valid(false, { name: %i(error_readonly),
-                                    parent_id: %i(error_readonly),
-                                    identifier: %i(error_readonly) })
-            end
+            it_behaves_like "contract is invalid",
+                            name: %i(error_readonly),
+                            parent_id: %i(error_readonly),
+                            identifier: %i(error_readonly)
           end
         end
 
@@ -187,7 +178,7 @@ RSpec.describe Projects::UpdateContract do
           context "and only project attributes are changed" do
             let(:project_changed) { true }
 
-            it_behaves_like "is valid"
+            it_behaves_like "contract is valid"
           end
 
           context "and project_custom_fields are changed too" do
@@ -197,7 +188,7 @@ RSpec.describe Projects::UpdateContract do
               project.custom_field_values = { custom_field.id => "1" }
             end
 
-            it_behaves_like "is valid"
+            it_behaves_like "contract is valid"
           end
         end
       end
@@ -206,9 +197,7 @@ RSpec.describe Projects::UpdateContract do
         let(:project_permissions) { [] }
         let(:options) { { project_attributes_only: true } }
 
-        it "is invalid" do
-          expect_valid(false, base: %i(error_unauthorized))
-        end
+        it_behaves_like "contract user is unauthorized"
       end
     end
 

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Projects::UpdateContract do
                     active: project_active,
                     public: project_public,
                     status_code: project_status_code,
-                    status_explanation: project_status_explanation).tap do |p|
+                    status_explanation: project_status_explanation,
+                    workspace_type: project_workspace_type).tap do |p|
         allow(p).to receive_messages(available_custom_fields: [custom_field],
                                      all_available_custom_fields: [custom_field])
         next unless project_changed
@@ -67,6 +68,14 @@ RSpec.describe Projects::UpdateContract do
       let(:project_identifier) { nil }
 
       it_behaves_like "contract is invalid", identifier: %i(blank)
+    end
+
+    context "if workspace_type is changed" do
+      before do
+        project.workspace_type = "portfolio"
+      end
+
+      it_behaves_like "contract is invalid", workspace_type: :error_readonly
     end
 
     describe "permissions" do

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -43,6 +43,7 @@ FactoryBot.define do
     enabled_module_names { OpenProject::AccessControl.available_project_modules }
     public { false }
     templated { false }
+    workspace_type { "project" }
 
     callback(:after_build) do |project, evaluator|
       disabled_modules = Array(evaluator.disable_modules).map(&:to_s)

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -261,19 +261,19 @@ RSpec.describe PermittedParams do
     let(:hash_key) { "project" }
 
     context "with minimal params" do
-      let(:hash) { { "name" => "Brand New Project" } }
+      let(:hash) { { "name" => "Brand New Project", "workspace_type" => "project" } }
 
       it_behaves_like "allows params"
     end
 
     context "with parent_id" do
-      let(:hash) { { "name" => "Brand New Project", "parent_id" => "19" } }
+      let(:hash) { { "name" => "Brand New Project", "workspace_type" => "project", "parent_id" => "19" } }
 
       it_behaves_like "allows params"
     end
 
     context "with custom_field_values" do
-      let(:hash) { { "name" => "Brand New Project", "custom_field_values" => { "4" => "21" } } }
+      let(:hash) { { "name" => "Brand New Project", "workspace_type" => "project", "custom_field_values" => { "4" => "21" } } }
 
       it_behaves_like "allows params"
     end

--- a/spec/models/projects/reorder_nested_set_spec.rb
+++ b/spec/models/projects/reorder_nested_set_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Project, "reordering of nested set" do
     it "still resorts them" do
       expect(subject.reload.pluck(:name)).to eq %w[ParentA C e F ParentB B D]
 
-      described_class.create!(parent: parent_project_a, name: "A")
+      create(:project, parent: parent_project_a, name: "A")
 
       expect(subject.reload.pluck(:name)).to eq %w[ParentA A C e F ParentB B D]
     end

--- a/spec/services/projects/create_service_integration_spec.rb
+++ b/spec/services/projects/create_service_integration_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe Projects::CreateService, "integration", type: :model do
   let(:new_project) { service_result.result }
   let(:service_result) { instance.call(**attributes) }
 
-  before do
-    login_as(user)
-  end
+  current_user { user }
 
   describe "writing created_at timestamp" do
     shared_let(:user) { create(:admin) }
@@ -47,7 +45,8 @@ RSpec.describe Projects::CreateService, "integration", type: :model do
     let(:attributes) do
       {
         name: "test",
-        created_at:
+        created_at:,
+        workspace_type: "project"
       }
     end
 

--- a/spec/services/projects/set_attributes_service_integration_spec.rb
+++ b/spec/services/projects/set_attributes_service_integration_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe Projects::SetAttributesService, "integration", type: :model do
   end
   let(:contract) { Projects::CreateContract }
   let(:instance) { described_class.new(user:, model: project, contract_class: contract) }
-  let(:attributes) { {} }
+  let(:attributes) { { workspace_type: "project" } }
   let(:project) { Project.new }
   let(:service_result) do
     instance.call(attributes)
   end
 
   describe "with a project name starting with numbers" do
-    let(:attributes) { { name: "100 Project A" } }
+    let(:attributes) { super().merge(name: "100 Project A") }
 
     it "creates an identifier including the numbers" do
       expect(service_result).to be_success


### PR DESCRIPTION
# Ticket

https://community.openproject.com/wp/66295

# What are you trying to accomplish?

Introduce an `workspace_type` column to projects without breaking the system. This does not change the system's behaviour in any way. The new models cannot be created yet but from the console, program and portfolio can be created.

# Merge checklist

- [x] Added/updated tests
