### PR TITLE
render comments alongside journals

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -8,130 +8,25 @@
       if show_comment_container?
         journal_container.with_row do
           render(
-            border_box_container(
-              padding: :condensed,
-              "aria-label": I18n.t("activities.work_packages.activity_tab.commented"),
-              data: {
-                "anchor-activity-id": journal.sequence_version,
-                "anchor-comment-id": journal.id
-              },
-              classes: container_classes
+            WorkPackages::ActivitiesTab::Journals::ItemComponent::NoteComment.new(
+              journal:,
+              filter:,
+              grouped_emoji_reactions:,
+              state:
             )
-          ) do |border_box_component|
-            border_box_component.with_header(
-              px: 2, py: 1,
-              data: { test_selector: "op-journal-notes-header" },
-              classes: comment_header_classes
-            ) do
-              flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
-                header_container.with_column(
-                  flex_layout: true,
-                  classes: "work-packages-activities-tab-journals-item-component--header-start-container ellipsis"
-                ) do |header_start_container|
-                  header_start_container.with_column(mr: 2) do
-                    render Users::AvatarComponent.new(user: journal.user, show_name: false, size: :mini)
-                  end
-                  header_start_container.with_column(
-                    mr: 1, flex_layout: true,
-                    classes: "work-packages-activities-tab-journals-item-component--user-name-container hidden-for-desktop"
-                  ) do |user_name_container|
-                    user_name_container.with_row(classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis") do
-                      truncated_user_name(journal.user)
-                    end
-                    user_name_container.with_row do
-                      render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) { format_time(journal.created_at) }
-                    end
-                  end
-                  header_start_container.with_column(
-                    mr: 1,
-                    classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis hidden-for-mobile"
-                  ) do
-                    truncated_user_name(journal.user, hover_card: true)
-                  end
-                  if journal.initial?
-                    header_start_container.with_column(
-                      mr: 1,
-                      classes: "work-packages-activities-tab-journals-item-component-details--journal-type hidden-for-mobile"
-                    ) do
-                      render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) do
-                        I18n.t("activities.work_packages.activity_tab.created_on")
-                      end
-                    end
-                  end
-                  header_start_container.with_column(mr: 1, classes: "hidden-for-mobile") do
-                    activity_anchor_link(journal)
-                  end
-                end
-                header_container.with_column(flex_layout: true, align_items: :center) do |header_end_container|
-                  if has_unread_notifications?
-                    header_end_container.with_column(mr: 2) do
-                      render(
-                        Primer::Beta::Octicon.new(
-                          :"dot-fill", # color is set via CSS as requested by UI/UX Team
-                          classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
-                          size: :small,
-                          data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
-                        )
-                      )
-                    end
-                  end
-
-                  if journal.internal?
-                    header_end_container.with_column(mr: 2) do
-                      render(
-                        Primer::Beta::Octicon.new(
-                          :lock,
-                          classes: "work-packages-activities-tab-journals-item-component--internal-icon",
-                          size: :small,
-                          aria: { label: I18n.t("activities.work_packages.activity_tab.internal_journal") },
-                          data: { test_selector: "op-journal-internal-icon" },
-                          color: (journal.internal? ? :attention : :default)
-                        )
-                      )
-                    end
-                  end
-
-                  header_end_container.with_column(
-                    ml: 1,
-                    classes: "work-packages-activities-tab-journals-item-component--action-menu"
-                  ) do
-                    render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-wp-journal-#{journal.id}-action-menu" })) do |menu|
-                      menu.with_show_button(
-                        icon: "kebab-horizontal",
-                        "aria-label": I18n.t(:button_actions),
-                        scheme: :invisible
-                      )
-                      copy_url_action_item(menu)
-                      edit_action_item(menu) if allowed_to_edit?
-                      quote_action_item(menu) if journal.notes.present? && allowed_to_quote?
-                    end
-                  end
-                end
-              end
-            end
-            border_box_component.with_body(
-              classes: comment_body_classes,
-              data: { test_selector: "op-journal-notes-body" }
-            ) do
-              if noop?
-                render(Primer::Beta::Text.new(font_style: :italic, color: :subtle, mt: 1)) do
-                  I18n.t(:"journals.changes_retracted")
-                end
-              else
-                case state
-                when :show
-                  render(
-                    WorkPackages::ActivitiesTab::Journals::ItemComponent::Show.new(
-                      journal:, filter:,
-                      grouped_emoji_reactions:
-                    )
-                  )
-                when :edit
-                  render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Edit.new(journal:, filter:))
-                end
-              end
-            end
-          end
+          )
+        end
+      end
+      comment_details.each do |detail|
+        journal_container.with_row do
+          render(
+            WorkPackages::ActivitiesTab::Journals::ItemComponent::CommentView.new(
+              comment: comment_for(detail),
+              parent_journal: journal,
+              filter:,
+              state:
+            )
+          )
         end
       end
       journal_container.with_row do

--- a/app/components/work_packages/activities_tab/journals/item_component.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component.rb
@@ -62,36 +62,28 @@ module WorkPackages
           }
         end
 
-        def container_classes
-          [].tap do |classes|
-            if journal.internal?
-              classes << "work-packages-activities-tab-journals-item-component--container__internal-comment"
+        def comment_details
+          journal.details.filter_map do |detail|
+            if detail.first.start_with?("comment")
+              journal.render_detail(detail)
             end
           end
         end
 
-        def comment_header_classes
-          [].tap do |classes|
-            if journal.internal?
-              classes << "work-packages-activities-tab-journals-item-component--header__internal-comment"
-            end
-          end
-        end
+        def comment_for(detail)
+          detail = JSON.parse(detail)
+          # we probably don't want a query here, so think of a way of preloading these
+          comment = Comment.find_by(id: detail["comment_id"])
 
-        def comment_body_classes
-          ["work-packages-activities-tab-journals-item-component--journal-notes-body"].tap do |classes|
-            if journal.internal?
-              classes << "work-packages-activities-tab-journals-item-component--journal-notes-body__internal-comment"
-            end
+          if comment.nil?
+            I18n.t("activities.work_packages.activity_tab.comment_not_found")
+          else
+            comment
           end
         end
 
         def show_comment_container?
-          (journal.notes.present? || noop?) && filter != :only_changes
-        end
-
-        def noop?
-          journal.noop?
+          (journal.notes.present? || journal.noop?) && filter != :only_changes
         end
 
         def updated?
@@ -106,69 +98,6 @@ module WorkPackages
 
         def notification_on_details?
           has_unread_notifications? && journal.notes.blank?
-        end
-
-        def allowed_to_edit?
-          journal.editable_by?(User.current)
-        end
-
-        def allowed_to_quote?
-          User.current.allowed_in_project?(:add_work_package_comments, journal.journable.project)
-        end
-
-        def copy_url_action_item(menu)
-          menu.with_item(label: t("button_copy_link_to_clipboard"),
-                         tag: :button,
-                         content_arguments: {
-                           data: {
-                             action: "click->work-packages--activities-tab--item#copyActivityUrlToClipboard"
-                           }
-                         }) do |item|
-            item.with_leading_visual_icon(icon: :copy)
-          end
-        end
-
-        def edit_action_item(menu)
-          menu.with_item(label: edit_action_label,
-                         href: edit_work_package_activity_path(journal.journable, journal, filter:),
-                         content_arguments: {
-                           data: { turbo_stream: true, test_selector: "op-wp-journal-#{journal.id}-edit" }
-                         }) do |item|
-            item.with_leading_visual_icon(icon: :pencil)
-          end
-        end
-
-        def edit_action_label
-          if journal.user == User.current
-            t("js.label_edit_comment")
-          else
-            t("js.label_moderate_comment")
-          end
-        end
-
-        def quote_action_item(menu)
-          menu.with_item(label: t("js.label_quote_comment"),
-                         tag: :button,
-                         content_arguments: {
-                           data: quote_action_data_attributes
-                         }) do |item|
-            item.with_leading_visual_icon(icon: :quote)
-          end
-        end
-
-        def quote_action_data_attributes # rubocop:disable Metrics/AbcSize
-          {
-            test_selector: "op-wp-journal-#{journal.id}-quote",
-            controller: quote_comments_stimulus_controller,
-            action: "click->#{quote_comments_stimulus_controller}#quote:prevent",
-            quote_comments_stimulus_controller("-content-param") => journal.notes,
-            quote_comments_stimulus_controller("-user-id-param") => journal.user_id,
-            quote_comments_stimulus_controller("-user-name-param") => journal.user.name,
-            quote_comments_stimulus_controller("-is-internal-param") => journal.internal?,
-            quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
-            quote_comments_stimulus_controller("-#{internal_comment_stimulus_controller}-outlet") => add_comment_component_dom_selector, # rubocop:disable Layout/LineLength
-            quote_comments_stimulus_controller("-#{editor_stimulus_controller}-outlet") => index_component_dom_selector
-          }
         end
       end
     end

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.html.erb
@@ -25,7 +25,7 @@
                   scheme: button_scheme(reaction),
                   color: :default,
                   bg: counter_color(reaction),
-                  id: "overlay-#{journal.id}-#{reaction}",
+                  id: "overlay-#{model.id}-#{reaction}",
                   test_selector: "overlay-reaction-#{reaction}",
                   tag: :a,
                   href: href(reaction:),

--- a/app/components/work_packages/activities_tab/journals/item_component/add_reactions.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/add_reactions.rb
@@ -37,10 +37,11 @@ module WorkPackages
         include OpTurbo::Streamable
         include WorkPackages::ActivitiesTab::StimulusControllers
 
-        def initialize(journal:, grouped_emoji_reactions:)
+        def initialize(model:, grouped_emoji_reactions:)
           super
 
-          @journal = journal
+          @model = model
+          @is_comment = model.is_a?(Comment)
           @grouped_emoji_reactions = grouped_emoji_reactions || {}
         end
 
@@ -50,7 +51,9 @@ module WorkPackages
 
         private
 
-        attr_reader :journal, :grouped_emoji_reactions
+        attr_reader :model, :grouped_emoji_reactions
+
+        def comment? = @is_comment
 
         def counter_color(reaction)
           reacted_by_current_user?(reaction) ? :accent : nil
@@ -69,11 +72,14 @@ module WorkPackages
         def href(reaction:)
           return if current_user_cannot_react?
 
-          toggle_reaction_work_package_activity_path(journal.journable.id, id: journal.id, reaction:)
+          toggle_reaction_work_package_activity_path(work_package.id, id: model.id, reaction:, is_comment: comment?)
         end
 
-        def work_package = journal.journable
-        def wrapper_uniq_by = journal.id
+        def work_package
+          @work_package ||= model.is_a?(Comment) ? model.commented : model.journable
+        end
+
+        def wrapper_uniq_by = model.id
 
         def current_user_can_react?
           User.current.allowed_in_work_package?(:add_work_package_comments, work_package)

--- a/app/components/work_packages/activities_tab/journals/item_component/comment_view.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/comment_view.html.erb
@@ -1,0 +1,124 @@
+<%=
+  render(
+    border_box_container(
+      padding: :condensed,
+      "aria-label": I18n.t("activities.work_packages.activity_tab.commented"),
+      data: {
+        "anchor-activity-id": parent_journal.sequence_version,
+        "anchor-comment-id": comment.id
+      },
+      classes: container_classes
+    )
+  ) do |border_box_component|
+    border_box_component.with_header(
+      px: 2, py: 1,
+      data: { test_selector: "op-journal-notes-header" },
+      classes: comment_header_classes
+    ) do
+      flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
+        header_container.with_column(
+          flex_layout: true,
+          classes: "work-packages-activities-tab-journals-item-component--header-start-container ellipsis"
+        ) do |header_start_container|
+          header_start_container.with_column(mr: 2) do
+            render Users::AvatarComponent.new(user: comment.author, show_name: false, size: :mini)
+          end
+          header_start_container.with_column(
+            mr: 1, flex_layout: true,
+            classes: "work-packages-activities-tab-journals-item-component--user-name-container hidden-for-desktop"
+          ) do |user_name_container|
+            user_name_container.with_row(classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis") do
+              truncated_user_name(comment.author)
+            end
+            user_name_container.with_row do
+              render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) { format_time(comment.created_at) }
+            end
+          end
+          header_start_container.with_column(
+            mr: 1,
+            classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis hidden-for-mobile"
+          ) do
+            truncated_user_name(comment.author, hover_card: true)
+          end
+          header_start_container.with_column(mr: 1, classes: "hidden-for-mobile") do
+            activity_anchor_link(parent_journal)
+          end
+        end
+        header_container.with_column(flex_layout: true, align_items: :center) do |header_end_container|
+          if has_unread_notifications?
+            header_end_container.with_column(mr: 2) do
+              render(
+                Primer::Beta::Octicon.new(
+                  :"dot-fill", # color is set via CSS as requested by UI/UX Team
+                  classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
+                  size: :small,
+                  data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
+                )
+              )
+            end
+          end
+
+          if comment.internal?
+            header_end_container.with_column(mr: 2) do
+              render(
+                Primer::Beta::Octicon.new(
+                  :lock,
+                  classes: "work-packages-activities-tab-journals-item-component--internal-icon",
+                  size: :small,
+                  aria: { label: I18n.t("activities.work_packages.activity_tab.internal_journal") },
+                  data: { test_selector: "op-journal-internal-icon" },
+                  color: (comment.internal? ? :attention : :default)
+                )
+              )
+            end
+          end
+
+          header_end_container.with_column(
+            ml: 1,
+            classes: "work-packages-activities-tab-journals-item-component--action-menu"
+          ) do
+            render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-wp-journal-#{comment.id}-action-menu" })) do |menu|
+              menu.with_show_button(
+                icon: "kebab-horizontal",
+                "aria-label": I18n.t(:button_actions),
+                scheme: :invisible
+              )
+              copy_url_action_item(menu)
+              # edit_action_item(menu) if allowed_to_edit?
+              # quote_action_item(menu) if allowed_to_quote?
+            end
+          end
+        end
+      end
+    end
+    border_box_component.with_body(
+      classes: comment_body_classes,
+      data: { test_selector: "op-journal-notes-body" }
+    ) do
+      case state
+      when :show
+        component_wrapper do
+          flex_layout do |comment_container|
+            comment_container.with_row do
+              render(Primer::Box.new(mt: 1, classes: "op-uc-container")) do
+                format_text(comment, :text)
+              end
+            end
+            comment_container.with_row(flex_layout: true) do |reactions_container|
+              reactions_container.with_column do
+                # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(model: comment, grouped_emoji_reactions:))
+                " + "
+              end
+              reactions_container.with_column do
+                # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(journal:, grouped_emoji_reactions:))
+                "🚀"
+              end
+            end
+          end
+        end
+      when :edit
+        # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Edit.new(journal:, filter:))
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/activities_tab/journals/item_component/comment_view.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/comment_view.html.erb
@@ -1,123 +1,123 @@
 <%=
-  render(
-    border_box_container(
-      padding: :condensed,
-      "aria-label": I18n.t("activities.work_packages.activity_tab.commented"),
-      data: {
-        "anchor-activity-id": parent_journal.sequence_version,
-        "anchor-comment-id": comment.id
-      },
-      classes: container_classes
-    )
-  ) do |border_box_component|
-    border_box_component.with_header(
-      px: 2, py: 1,
-      data: { test_selector: "op-journal-notes-header" },
-      classes: comment_header_classes
-    ) do
-      flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
-        header_container.with_column(
-          flex_layout: true,
-          classes: "work-packages-activities-tab-journals-item-component--header-start-container ellipsis"
-        ) do |header_start_container|
-          header_start_container.with_column(mr: 2) do
-            render Users::AvatarComponent.new(user: comment.author, show_name: false, size: :mini)
-          end
-          header_start_container.with_column(
-            mr: 1, flex_layout: true,
-            classes: "work-packages-activities-tab-journals-item-component--user-name-container hidden-for-desktop"
-          ) do |user_name_container|
-            user_name_container.with_row(classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis") do
-              truncated_user_name(comment.author)
+  component_wrapper do
+    render(
+      border_box_container(
+        padding: :condensed,
+        "aria-label": I18n.t("activities.work_packages.activity_tab.commented"),
+        data: {
+          "anchor-activity-id": parent_journal.sequence_version,
+          "anchor-comment-id": comment.id
+        },
+        classes: container_classes
+      )
+    ) do |border_box_component|
+      border_box_component.with_header(
+        px: 2, py: 1,
+        data: { test_selector: "op-journal-notes-header" },
+        classes: comment_header_classes
+      ) do
+        flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
+          header_container.with_column(
+            flex_layout: true,
+            classes: "work-packages-activities-tab-journals-item-component--header-start-container ellipsis"
+          ) do |header_start_container|
+            header_start_container.with_column(mr: 2) do
+              render Users::AvatarComponent.new(user: comment.author, show_name: false, size: :mini)
             end
-            user_name_container.with_row do
-              render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) { format_time(comment.created_at) }
+            header_start_container.with_column(
+              mr: 1, flex_layout: true,
+              classes: "work-packages-activities-tab-journals-item-component--user-name-container hidden-for-desktop"
+            ) do |user_name_container|
+              user_name_container.with_row(classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis") do
+                truncated_user_name(comment.author)
+              end
+              user_name_container.with_row do
+                render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) { format_time(comment.created_at) }
+              end
+            end
+            header_start_container.with_column(
+              mr: 1,
+              classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis hidden-for-mobile"
+            ) do
+              truncated_user_name(comment.author, hover_card: true)
+            end
+            header_start_container.with_column(mr: 1, classes: "hidden-for-mobile") do
+              activity_anchor_link(parent_journal)
             end
           end
-          header_start_container.with_column(
-            mr: 1,
-            classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis hidden-for-mobile"
-          ) do
-            truncated_user_name(comment.author, hover_card: true)
-          end
-          header_start_container.with_column(mr: 1, classes: "hidden-for-mobile") do
-            activity_anchor_link(parent_journal)
-          end
-        end
-        header_container.with_column(flex_layout: true, align_items: :center) do |header_end_container|
-          if has_unread_notifications?
-            header_end_container.with_column(mr: 2) do
-              render(
-                Primer::Beta::Octicon.new(
-                  :"dot-fill", # color is set via CSS as requested by UI/UX Team
-                  classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
-                  size: :small,
-                  data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
+          header_container.with_column(flex_layout: true, align_items: :center) do |header_end_container|
+            if has_unread_notifications?
+              header_end_container.with_column(mr: 2) do
+                render(
+                  Primer::Beta::Octicon.new(
+                    :"dot-fill", # color is set via CSS as requested by UI/UX Team
+                    classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
+                    size: :small,
+                    data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
+                  )
                 )
-              )
+              end
             end
-          end
 
-          if comment.internal?
-            header_end_container.with_column(mr: 2) do
-              render(
-                Primer::Beta::Octicon.new(
-                  :lock,
-                  classes: "work-packages-activities-tab-journals-item-component--internal-icon",
-                  size: :small,
-                  aria: { label: I18n.t("activities.work_packages.activity_tab.internal_journal") },
-                  data: { test_selector: "op-journal-internal-icon" },
-                  color: (comment.internal? ? :attention : :default)
+            if comment.internal?
+              header_end_container.with_column(mr: 2) do
+                render(
+                  Primer::Beta::Octicon.new(
+                    :lock,
+                    classes: "work-packages-activities-tab-journals-item-component--internal-icon",
+                    size: :small,
+                    aria: { label: I18n.t("activities.work_packages.activity_tab.internal_journal") },
+                    data: { test_selector: "op-journal-internal-icon" },
+                    color: (comment.internal? ? :attention : :default)
+                  )
                 )
-              )
+              end
             end
-          end
 
-          header_end_container.with_column(
-            ml: 1,
-            classes: "work-packages-activities-tab-journals-item-component--action-menu"
-          ) do
-            render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-wp-journal-#{comment.id}-action-menu" })) do |menu|
-              menu.with_show_button(
-                icon: "kebab-horizontal",
-                "aria-label": I18n.t(:button_actions),
-                scheme: :invisible
-              )
-              copy_url_action_item(menu)
-              # edit_action_item(menu) if allowed_to_edit?
-              # quote_action_item(menu) if allowed_to_quote?
+            header_end_container.with_column(
+              ml: 1,
+              classes: "work-packages-activities-tab-journals-item-component--action-menu"
+            ) do
+              render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-wp-journal-#{comment.id}-action-menu" })) do |menu|
+                menu.with_show_button(
+                  icon: "kebab-horizontal",
+                  "aria-label": I18n.t(:button_actions),
+                  scheme: :invisible
+                )
+                copy_url_action_item(menu)
+                # edit_action_item(menu) if allowed_to_edit?
+                # quote_action_item(menu) if allowed_to_quote?
+              end
             end
           end
         end
       end
-    end
-    border_box_component.with_body(
-      classes: comment_body_classes,
-      data: { test_selector: "op-journal-notes-body" }
-    ) do
-      case state
-      when :show
-        component_wrapper do
-          flex_layout do |comment_container|
-            comment_container.with_row do
-              render(Primer::Box.new(mt: 1, classes: "op-uc-container")) do
-                format_text(comment, :text)
+      border_box_component.with_body(
+        classes: comment_body_classes,
+        data: { test_selector: "op-journal-notes-body" }
+      ) do
+        case state
+        when :show
+          component_wrapper do
+            flex_layout do |comment_container|
+              comment_container.with_row do
+                render(Primer::Box.new(mt: 1, classes: "op-uc-container")) do
+                  format_text(comment, :text)
+                end
               end
-            end
-            comment_container.with_row(flex_layout: true) do |reactions_container|
-              reactions_container.with_column do
-                # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(model: comment, grouped_emoji_reactions:))
-                " + "
-              end
-              reactions_container.with_column do
-                # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(journal:, grouped_emoji_reactions:))
-                "🚀"
+              comment_container.with_row(flex_layout: true) do |reactions_container|
+                reactions_container.with_column do
+                  render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(model: comment, grouped_emoji_reactions:))
+                end
+                reactions_container.with_column do
+                  render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(model: comment, grouped_emoji_reactions:))
+                end
               end
             end
           end
+        when :edit
+          # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Edit.new(journal:, filter:))
         end
-      when :edit
-        # render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Edit.new(journal:, filter:))
       end
     end
   end

--- a/app/components/work_packages/activities_tab/journals/item_component/comment_view.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/comment_view.rb
@@ -51,6 +51,15 @@ module WorkPackages
 
         attr_reader :comment, :parent_journal, :state, :filter
 
+        def wrapper_uniq_by = comment.id
+
+        def grouped_emoji_reactions
+          EmojiReactions::GroupedQueries.grouped_emoji_reactions_by_reactable(
+            reactable_id: [comment.id],
+            reactable_type: "Comment"
+          )[comment.id]
+        end
+
         def container_classes
           [].tap do |classes|
             if comment.internal?

--- a/app/components/work_packages/activities_tab/journals/item_component/comment_view.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/comment_view.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module ActivitiesTab
+    module Journals
+      class ItemComponent::CommentView < ApplicationComponent
+        include ApplicationHelper
+        include OpPrimer::ComponentHelpers
+        include OpTurbo::Streamable
+        include WorkPackages::ActivitiesTab::SharedHelpers
+        include WorkPackages::ActivitiesTab::StimulusControllers
+
+        def initialize(comment:, parent_journal:, filter:, state: :show)
+          super
+
+          @comment = comment
+          @parent_journal = parent_journal
+          @filter = filter
+          @state = state
+        end
+
+        private
+
+        attr_reader :comment, :parent_journal, :state, :filter
+
+        def container_classes
+          [].tap do |classes|
+            if comment.internal?
+              classes << "work-packages-activities-tab-journals-item-component--container__internal-comment"
+            end
+          end
+        end
+
+        def comment_header_classes
+          [].tap do |classes|
+            if comment.internal?
+              classes << "work-packages-activities-tab-journals-item-component--header__internal-comment"
+            end
+          end
+        end
+
+        def comment_body_classes
+          ["work-packages-activities-tab-journals-item-component--journal-notes-body"].tap do |classes|
+            if comment.internal?
+              classes << "work-packages-activities-tab-journals-item-component--journal-notes-body__internal-comment"
+            end
+          end
+        end
+
+        def has_unread_notifications?
+          parent_journal.has_unread_notifications_for_user?(User.current)
+        end
+
+        # def allowed_to_edit?
+        #   journal.editable_by?(User.current)
+        # end
+
+        # def allowed_to_quote?
+        #   User.current.allowed_in_project?(:add_work_package_comments, journal.journable.project)
+        # end
+
+        def copy_url_action_item(menu)
+          menu.with_item(label: t("button_copy_link_to_clipboard"),
+                         tag: :button,
+                         content_arguments: {
+                           data: {
+                             action: "click->work-packages--activities-tab--item#copyActivityUrlToClipboard"
+                           }
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :copy)
+          end
+        end
+
+        # def edit_action_item(menu)
+        #   menu.with_item(label: edit_action_label,
+        #                  href: edit_work_package_activity_path(journal.journable, journal, filter:),
+        #                  content_arguments: {
+        #                    data: { turbo_stream: true, test_selector: "op-wp-journal-#{journal.id}-edit" }
+        #                  }) do |item|
+        #     item.with_leading_visual_icon(icon: :pencil)
+        #   end
+        # end
+
+        # def edit_action_label
+        #   if journal.user == User.current
+        #     t("js.label_edit_comment")
+        #   else
+        #     t("js.label_moderate_comment")
+        #   end
+        # end
+
+        # def quote_action_item(menu)
+        #   menu.with_item(label: t("js.label_quote_comment"),
+        #                  tag: :button,
+        #                  content_arguments: {
+        #                    data: quote_action_data_attributes
+        #                  }) do |item|
+        #     item.with_leading_visual_icon(icon: :quote)
+        #   end
+        # end
+
+        # def quote_action_data_attributes
+        #   {
+        #     test_selector: "op-wp-journal-#{journal.id}-quote",
+        #     controller: quote_comments_stimulus_controller,
+        #     action: "click->#{quote_comments_stimulus_controller}#quote:prevent",
+        #     quote_comments_stimulus_controller("-content-param") => journal.notes,
+        #     quote_comments_stimulus_controller("-user-id-param") => journal.user_id,
+        #     quote_comments_stimulus_controller("-user-name-param") => journal.user.name,
+        #     quote_comments_stimulus_controller("-is-internal-param") => journal.internal?,
+        #     quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
+        #     quote_comments_stimulus_controller("-#{internal_comment_stimulus_controller}-outlet") => add_comment_component_dom_selector, # rubocop:disable Layout/LineLength
+        #     quote_comments_stimulus_controller("-#{editor_stimulus_controller}-outlet") => index_component_dom_selector
+        #   }
+        # end
+      end
+    end
+  end
+end

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -56,7 +56,7 @@ module WorkPackages
         end
 
         def journal_details
-          @journal_details ||= journal.details
+          @journal_details ||= journal.details.reject { |key, _| key.start_with?("comment") }
         end
 
         def has_details?

--- a/app/components/work_packages/activities_tab/journals/item_component/note_comment.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/note_comment.html.erb
@@ -1,0 +1,127 @@
+<%=
+  render(
+    border_box_container(
+      padding: :condensed,
+      "aria-label": I18n.t("activities.work_packages.activity_tab.commented"),
+      data: {
+        "anchor-activity-id": journal.sequence_version,
+        "anchor-comment-id": journal.id
+      },
+      classes: container_classes
+    )
+  ) do |border_box_component|
+    border_box_component.with_header(
+      px: 2, py: 1,
+      data: { test_selector: "op-journal-notes-header" },
+      classes: comment_header_classes
+    ) do
+      flex_layout(align_items: :center, justify_content: :space_between) do |header_container|
+        header_container.with_column(
+          flex_layout: true,
+          classes: "work-packages-activities-tab-journals-item-component--header-start-container ellipsis"
+        ) do |header_start_container|
+          header_start_container.with_column(mr: 2) do
+            render Users::AvatarComponent.new(user: journal.user, show_name: false, size: :mini)
+          end
+          header_start_container.with_column(
+            mr: 1, flex_layout: true,
+            classes: "work-packages-activities-tab-journals-item-component--user-name-container hidden-for-desktop"
+          ) do |user_name_container|
+            user_name_container.with_row(classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis") do
+              truncated_user_name(journal.user)
+            end
+            user_name_container.with_row do
+              render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) { format_time(journal.created_at) }
+            end
+          end
+          header_start_container.with_column(
+            mr: 1,
+            classes: "work-packages-activities-tab-journals-item-component--user-name ellipsis hidden-for-mobile"
+          ) do
+            truncated_user_name(journal.user, hover_card: true)
+          end
+          if journal.initial?
+            header_start_container.with_column(
+              mr: 1,
+              classes: "work-packages-activities-tab-journals-item-component-details--journal-type hidden-for-mobile"
+            ) do
+              render(Primer::Beta::Text.new(font_size: :small, color: :subtle, mt: 1)) do
+                I18n.t("activities.work_packages.activity_tab.created_on")
+              end
+            end
+          end
+          header_start_container.with_column(mr: 1, classes: "hidden-for-mobile") do
+            activity_anchor_link(journal)
+          end
+        end
+        header_container.with_column(flex_layout: true, align_items: :center) do |header_end_container|
+          if has_unread_notifications?
+            header_end_container.with_column(mr: 2) do
+              render(
+                Primer::Beta::Octicon.new(
+                  :"dot-fill", # color is set via CSS as requested by UI/UX Team
+                  classes: "work-packages-activities-tab-journals-item-component--notification-dot-icon",
+                  size: :small,
+                  data: { test_selector: "op-journal-unread-notification", "op-ian-center-update-immediate": true }
+                )
+              )
+            end
+          end
+
+          if journal.internal?
+            header_end_container.with_column(mr: 2) do
+              render(
+                Primer::Beta::Octicon.new(
+                  :lock,
+                  classes: "work-packages-activities-tab-journals-item-component--internal-icon",
+                  size: :small,
+                  aria: { label: I18n.t("activities.work_packages.activity_tab.internal_journal") },
+                  data: { test_selector: "op-journal-internal-icon" },
+                  color: (journal.internal? ? :attention : :default)
+                )
+              )
+            end
+          end
+
+          header_end_container.with_column(
+            ml: 1,
+            classes: "work-packages-activities-tab-journals-item-component--action-menu"
+          ) do
+            render(Primer::Alpha::ActionMenu.new(data: { test_selector: "op-wp-journal-#{journal.id}-action-menu" })) do |menu|
+              menu.with_show_button(
+                icon: "kebab-horizontal",
+                "aria-label": I18n.t(:button_actions),
+                scheme: :invisible
+              )
+              copy_url_action_item(menu)
+              edit_action_item(menu) if allowed_to_edit?
+              quote_action_item(menu) if journal.notes.present? && allowed_to_quote?
+            end
+          end
+        end
+      end
+    end
+    border_box_component.with_body(
+      classes: comment_body_classes,
+      data: { test_selector: "op-journal-notes-body" }
+    ) do
+      if journal.noop?
+        render(Primer::Beta::Text.new(font_style: :italic, color: :subtle, mt: 1)) do
+          I18n.t(:"journals.changes_retracted")
+        end
+      else
+        case state
+        when :show
+          render(
+            WorkPackages::ActivitiesTab::Journals::ItemComponent::Show.new(
+              journal:, filter:,
+              grouped_emoji_reactions:
+            )
+          )
+        when :edit
+          render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Edit.new(journal:, filter:))
+        end
+      end
+    end
+  end
+%>

--- a/app/components/work_packages/activities_tab/journals/item_component/note_comment.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/note_comment.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module ActivitiesTab
+    module Journals
+      class ItemComponent::NoteComment < ApplicationComponent
+        include ApplicationHelper
+        include OpPrimer::ComponentHelpers
+        include OpTurbo::Streamable
+        include WorkPackages::ActivitiesTab::SharedHelpers
+        include WorkPackages::ActivitiesTab::StimulusControllers
+
+        def initialize(journal:, filter:, grouped_emoji_reactions:, state: :show)
+          super
+
+          @journal = journal
+          @filter = filter
+          @grouped_emoji_reactions = grouped_emoji_reactions
+          @state = state
+        end
+
+        private
+
+        attr_reader :journal, :state, :filter, :grouped_emoji_reactions
+
+        def container_classes
+          [].tap do |classes|
+            if journal.internal?
+              classes << "work-packages-activities-tab-journals-item-component--container__internal-comment"
+            end
+          end
+        end
+
+        def comment_header_classes
+          [].tap do |classes|
+            if journal.internal?
+              classes << "work-packages-activities-tab-journals-item-component--header__internal-comment"
+            end
+          end
+        end
+
+        def comment_body_classes
+          ["work-packages-activities-tab-journals-item-component--journal-notes-body"].tap do |classes|
+            if journal.internal?
+              classes << "work-packages-activities-tab-journals-item-component--journal-notes-body__internal-comment"
+            end
+          end
+        end
+
+        def has_unread_notifications?
+          journal.has_unread_notifications_for_user?(User.current)
+        end
+
+        def allowed_to_edit?
+          journal.editable_by?(User.current)
+        end
+
+        def allowed_to_quote?
+          User.current.allowed_in_project?(:add_work_package_comments, journal.journable.project)
+        end
+
+        def copy_url_action_item(menu)
+          menu.with_item(label: t("button_copy_link_to_clipboard"),
+                         tag: :button,
+                         content_arguments: {
+                           data: {
+                             action: "click->work-packages--activities-tab--item#copyActivityUrlToClipboard"
+                           }
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :copy)
+          end
+        end
+
+        def edit_action_item(menu)
+          menu.with_item(label: edit_action_label,
+                         href: edit_work_package_activity_path(journal.journable, journal, filter:),
+                         content_arguments: {
+                           data: { turbo_stream: true, test_selector: "op-wp-journal-#{journal.id}-edit" }
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :pencil)
+          end
+        end
+
+        def edit_action_label
+          if journal.user == User.current
+            t("js.label_edit_comment")
+          else
+            t("js.label_moderate_comment")
+          end
+        end
+
+        def quote_action_item(menu)
+          menu.with_item(label: t("js.label_quote_comment"),
+                         tag: :button,
+                         content_arguments: {
+                           data: quote_action_data_attributes
+                         }) do |item|
+            item.with_leading_visual_icon(icon: :quote)
+          end
+        end
+
+        def quote_action_data_attributes # rubocop:disable Metrics/AbcSize
+          {
+            test_selector: "op-wp-journal-#{journal.id}-quote",
+            controller: quote_comments_stimulus_controller,
+            action: "click->#{quote_comments_stimulus_controller}#quote:prevent",
+            quote_comments_stimulus_controller("-content-param") => journal.notes,
+            quote_comments_stimulus_controller("-user-id-param") => journal.user_id,
+            quote_comments_stimulus_controller("-user-name-param") => journal.user.name,
+            quote_comments_stimulus_controller("-is-internal-param") => journal.internal?,
+            quote_comments_stimulus_controller("-text-wrote-param") => I18n.t(:text_wrote),
+            quote_comments_stimulus_controller("-#{internal_comment_stimulus_controller}-outlet") => add_comment_component_dom_selector, # rubocop:disable Layout/LineLength
+            quote_comments_stimulus_controller("-#{editor_stimulus_controller}-outlet") => index_component_dom_selector
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.html.erb
@@ -9,7 +9,7 @@
                 scheme: button_scheme(data[:users]),
                 color: :default,
                 bg: counter_color(data[:users]),
-                id: "#{journal.id}-#{reaction}",
+                id: "#{model.id}-#{reaction}",
                 test_selector: "reaction-#{reaction}",
                 tag: :a,
                 href: href(reaction:),

--- a/app/components/work_packages/activities_tab/journals/item_component/reactions.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/reactions.rb
@@ -37,19 +37,25 @@ module WorkPackages
         include OpTurbo::Streamable
         include WorkPackages::ActivitiesTab::StimulusControllers
 
-        def initialize(journal:, grouped_emoji_reactions:)
+        def initialize(model:, grouped_emoji_reactions:)
           super
 
-          @journal = journal
+          @model = model
+          @is_comment = model.is_a?(Comment)
           @grouped_emoji_reactions = grouped_emoji_reactions
         end
 
         private
 
-        attr_reader :journal, :grouped_emoji_reactions
+        attr_reader :model, :grouped_emoji_reactions
 
-        def wrapper_uniq_by = journal.id
-        def work_package = journal.journable
+        def wrapper_uniq_by = model.id
+
+        def comment? = @is_comment
+
+        def work_package
+          @work_package ||= model.is_a?(Comment) ? model.commented : model.journable
+        end
 
         def counter_color(users)
           reacted_by_current_user?(users) ? :accent : nil
@@ -87,7 +93,7 @@ module WorkPackages
         def href(reaction:)
           return if current_user_cannot_react?
 
-          toggle_reaction_work_package_activity_path(journal.journable.id, id: journal.id, reaction:)
+          toggle_reaction_work_package_activity_path(work_package.id, id: model.id, reaction:, is_comment: comment?)
         end
 
         def current_user_can_react?

--- a/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component/show.html.erb
@@ -9,10 +9,10 @@
         end
         journal_container.with_row(flex_layout: true) do |reactions_container|
           reactions_container.with_column do
-            render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(journal:, grouped_emoji_reactions:))
+            render(WorkPackages::ActivitiesTab::Journals::ItemComponent::AddReactions.new(model: journal, grouped_emoji_reactions:))
           end
           reactions_container.with_column do
-            render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(journal:, grouped_emoji_reactions:))
+            render(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(model: journal, grouped_emoji_reactions:))
           end
         end
       end

--- a/app/contracts/emoji_reactions/base_contract.rb
+++ b/app/contracts/emoji_reactions/base_contract.rb
@@ -68,6 +68,8 @@ module EmojiReactions
         user.allowed_in_work_package?(:add_work_package_comments, model.reactable)
       when Journal
         user.allowed_in_work_package?(:add_work_package_comments, model.reactable.journable)
+      when Comment
+        user.allowed_in_work_package?(:add_work_package_comments, model.reactable.commented)
       else
         false
       end

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -147,19 +147,32 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def toggle_reaction # rubocop:disable Metrics/AbcSize
+    is_comment = params[:is_comment] == "true"
+    reactable = is_comment ? Comment.find_by(id: params[:id]) : @journal
+
     emoji_reaction_service = EmojiReactions::ToggleEmojiReactionService
       .call(user: User.current,
-            reactable: @journal,
+            reactable: reactable,
             reaction: params[:reaction])
 
     emoji_reaction_service.on_success do
-      update_via_turbo_stream(
-        component: WorkPackages::ActivitiesTab::Journals::ItemComponent::Show.new(
-          journal: @journal,
-          filter: params[:filter]&.to_sym || :all,
-          grouped_emoji_reactions: grouped_emoji_reactions_for_journal
+      if is_comment
+        update_via_turbo_stream(
+          component: WorkPackages::ActivitiesTab::Journals::ItemComponent::CommentView.new(
+            comment: reactable,
+            parent_journal: @journal,
+            filter: params[:filter]&.to_sym || :all
+          )
         )
-      )
+      else
+        update_via_turbo_stream(
+          component: WorkPackages::ActivitiesTab::Journals::ItemComponent::Show.new(
+            journal: @journal,
+            filter: params[:filter]&.to_sym || :all,
+            grouped_emoji_reactions: grouped_emoji_reactions_for_journal
+          )
+        )
+      end
     end
 
     emoji_reaction_service.on_failure do
@@ -353,7 +366,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
     @work_package.journals.each do |journal|
       update_via_turbo_stream(
         component: WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions.new(
-          journal:,
+          model: journal,
           grouped_emoji_reactions: wp_journal_emoji_reactions[journal.id] || {}
         )
       )

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -52,6 +52,11 @@ class Comment < ApplicationRecord
     save!
   end
 
+  # We should properly implement internal behaviour
+  def internal?
+    false
+  end
+
   private
 
   def send_comment_added_event

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
         changed: "changed"
         created: "created"
         commented: "commented"
+        comment_not_found: "Comment deleted"
         internal_comment: Internal comment
         internal_journal: Internal comments are visible to a limited group of members.
         unsaved_changes_confirmation_message: You have unsaved changes. Are you sure you want to close the editor?
@@ -4424,8 +4425,6 @@ en:
   text_journal_changed_plain: "%{label} changed from %{old} %{linebreak}to %{new}"
   text_journal_changed_no_detail: "%{label} updated"
   text_journal_changed_with_diff: "%{label} changed (%{link})"
-  text_journal_comment_added: "%{label} '%{value}' added"
-  text_journal_comment_deleted: "%{label} deleted"
   text_journal_deleted: "%{label} deleted (%{old})"
   text_journal_deleted_subproject: "%{label} %{old}"
   text_journal_deleted_with_diff: "%{label} deleted (%{link})"

--- a/lib/open_project/journal_formatter/comment.rb
+++ b/lib/open_project/journal_formatter/comment.rb
@@ -29,16 +29,33 @@
 #++
 
 class OpenProject::JournalFormatter::Comment < JournalFormatter::Base
-  def render(key, values, _options = { html: true })
-    _id = key.to_s.sub("comments_", "").to_i
+  def render(key, values, _options)
+    id = key.to_s.sub("comments_", "").to_i
+    old_value, value, comment = format_details(id, values)
 
-    label = label("comment")
-    _old_value, current_value = values
+    render_comment_detail_text(value, old_value, comment)
+  end
 
-    if current_value.blank?
-      I18n.t(:text_journal_comment_deleted, label:)
-    else
-      I18n.t(:text_journal_comment_added, label:, value: current_value)
-    end
+  private
+
+  def format_details(id, values)
+    old_value, current_value = values
+    [
+      old_value,
+      current_value,
+      find_comment(id)
+    ]
+  end
+
+  def render_comment_detail_text(value, old_value, comment)
+    {
+      comment_id: comment.id,
+      value: value,
+      old_value: old_value
+    }.to_json
+  end
+
+  def find_comment(id)
+    Comment.find_by(id: id)
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/61751

# What are you trying to accomplish?

Work package comments showing up as comments

## Screenshots

_Coming soon™_

# What approach did you choose and why?

to be better described~
But for now I have done a bunch of duplication

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
