### PR TITLE
Disable pattern input

### DIFF
--- a/app/components/work_package_types/pattern_input.html.erb
+++ b/app/components/work_package_types/pattern_input.html.erb
@@ -93,9 +93,10 @@ See COPYRIGHT and LICENSE files for more details.
       render(
         Primer::BaseComponent.new(
           tag: :div,
-          contenteditable: true,
+          contenteditable: !disabled,
+          disabled:,
           border: true, border_radius: 2, p: 1,
-          classes: "op-pattern-input--text-field",
+          classes: "op-pattern-input--text-field FormControl-input",
           data: {
             action: "keydown->pattern-input#input_keydown
                    input->pattern-input#input_change

--- a/app/components/work_package_types/pattern_input.html.erb
+++ b/app/components/work_package_types/pattern_input.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(
     FormControl.new(
-      input: @input,
+      input:,
       classes: "op-pattern-input",
       "data-controller": "pattern-input",
       "data-pattern-input-pattern-initial-value": @value,
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
   ) do
 %>
   <%= content_tag(:div, **@field_wrap_arguments) do %>
-    <%= @input.builder.hidden_field(name, value: @value, data: { "pattern-input-target": "formInput" }) %>
+    <%= input.builder.hidden_field(name, value: @value, data: { "pattern-input-target": "formInput" }) %>
 
     <template data-pattern-input-target="tokenTemplate">
       <%= render(Primer::Beta::Label.new(tag: :span, scheme: :accent, data: { role: :token, prop: "__placeholder" })) %>
@@ -94,14 +94,15 @@ See COPYRIGHT and LICENSE files for more details.
         Primer::BaseComponent.new(
           tag: :div,
           contenteditable: true,
-          border: true, border_radius: 2, p: 1, classes: "op-pattern-input--text-field",
-          "data-pattern-input-target": "content",
+          border: true, border_radius: 2, p: 1,
+          classes: "op-pattern-input--text-field",
           data: {
             action: "keydown->pattern-input#input_keydown
                    input->pattern-input#input_change
                    mouseup->pattern-input#input_mouseup
                    focus->pattern-input#input_focus
-                   blur->pattern-input#input_blur"
+                   blur->pattern-input#input_blur",
+            "pattern-input-target": "content",
           }
         )
       )

--- a/app/components/work_package_types/pattern_input.rb
+++ b/app/components/work_package_types/pattern_input.rb
@@ -32,15 +32,16 @@ module WorkPackageTypes
   class PatternInput < Primer::Forms::BaseComponent
     prepend Primer::OpenProject::Forms::WrappedInput
 
-    attr_reader :input
+    attr_reader :input, :disabled
 
     delegate :name, to: :input
 
-    def initialize(input:, value:, suggestions:)
+    def initialize(input:, value:, suggestions:, disabled:)
       super()
       @input = input
       @value = value
       @suggestions = suggestions
+      @disabled = disabled
     end
 
     def suggestions_for_stimulus

--- a/app/components/work_package_types/pattern_input.rb
+++ b/app/components/work_package_types/pattern_input.rb
@@ -32,7 +32,9 @@ module WorkPackageTypes
   class PatternInput < Primer::Forms::BaseComponent
     prepend Primer::OpenProject::Forms::WrappedInput
 
-    delegate :name, to: :@input
+    attr_reader :input
+
+    delegate :name, to: :input
 
     def initialize(input:, value:, suggestions:)
       super()

--- a/app/forms/work_package_types/subject_configuration_form.rb
+++ b/app/forms/work_package_types/subject_configuration_form.rb
@@ -55,7 +55,7 @@ module WorkPackageTypes
         toggleable_group.pattern_input(
           name: :pattern,
           value: model.pattern,
-          hidden: !enterprise?,
+          disabled: !enterprise?,
           suggestions: model.suggestions,
           label: I18n.t("types.edit.subject_configuration.pattern.label"),
           caption: pattern_input_caption,

--- a/lib/primer/open_project/forms/dsl/pattern_input.rb
+++ b/lib/primer/open_project/forms/dsl/pattern_input.rb
@@ -33,19 +33,20 @@ module Primer
     module Forms
       module Dsl
         class PatternInput < Primer::Forms::Dsl::Input
-          attr_reader :name, :label, :value, :suggestions
+          attr_reader :name, :label, :value, :suggestions, :disabled
 
-          def initialize(name:, label:, value:, suggestions:, **system_arguments)
+          def initialize(name:, label:, value:, suggestions:, disabled: false, **system_arguments)
             @name = name
             @label = label
             @value = value
             @suggestions = suggestions
+            @disabled = disabled
 
             super(**system_arguments)
           end
 
           def to_component
-            WorkPackageTypes::PatternInput.new(input: self, value:, suggestions:)
+            WorkPackageTypes::PatternInput.new(input: self, value:, suggestions:, disabled:)
           end
 
           def type


### PR DESCRIPTION
Instead of hiding the pattern input when the enterprise token is missing, we just disable it when the token is missing.

# Ticket
https://community.openproject.org/wp/64290