### PR TITLE
[#64106] Lose track of meeting item and switch to template editing when adding a meeting section

### DIFF
--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -198,7 +198,7 @@ module Meetings
         )
         # as the list is updated without displaying the form, the new button needs to be enabled again
         # the new button might be in a disabled state
-        update_new_button_via_turbo_stream(disabled: false) if form_hidden == true
+        update_new_button_via_turbo_stream(disabled: false, meeting:) if form_hidden == true
       end
 
       def update_item_via_turbo_stream(state: :show, meeting_agenda_item: @meeting_agenda_item, display_notes_input: nil)

--- a/modules/meeting/spec/features/meeting_backlogs_spec.rb
+++ b/modules/meeting/spec/features/meeting_backlogs_spec.rb
@@ -409,6 +409,29 @@ RSpec.describe "Meeting Backlogs", :js do
         # delete moved item to check if component is updated properly
         next_occurrence_page.remove_agenda_item(item)
       end
+
+      it "do not change the new button component to the one from the template (Bug #64106)" do
+        next_occurrence_page.visit!
+
+        template_item = next_occurrence.agenda_items.first
+        next_occurrence_page.remove_agenda_item(template_item)
+
+        next_occurrence_page.add_agenda_item_to_backlog do
+          fill_in "Title", with: "Backlog agenda item"
+        end
+        next_occurrence_page.expect_backlog_count(1)
+        next_occurrence_page.within_backlog do
+          next_occurrence_page.expect_agenda_item(title: "Backlog agenda item")
+        end
+
+        next_occurrence_page.check_add_section_path(next_occurrence)
+
+        item = MeetingAgendaItem.find_by(title: "Backlog agenda item")
+        next_occurrence_page.select_action(item, I18n.t(:label_agenda_item_move_to_current_meeting))
+        next_occurrence_page.expect_empty_backlog
+
+        next_occurrence_page.check_add_section_path(next_occurrence)
+      end
     end
   end
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -549,6 +549,19 @@ module Pages::Meetings
       end
     end
 
+    def check_add_section_path(meeting)
+      retry_block do
+        page.within("#meeting-agenda-items-new-button-component") do
+          click_on I18n.t(:button_add)
+
+          add_section_link = find_link("Section")
+          url = add_section_link[:href]
+
+          expect(URI.parse(url).path).to eq(meeting_sections_path(meeting))
+        end
+      end
+    end
+
     def expect_backlog_actions(item, series: false)
       open_menu(item) do
         expect(page).to have_css(".ActionListItem-label", text: "Edit")


### PR DESCRIPTION
This is a follow up to https://github.com/opf/openproject/pull/19450

# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/64106

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
