### PR TITLE
[#66233] Meeting email info text is not in a muted colour  

### DIFF
--- a/modules/meeting/app/components/meetings/side_panel/notifications_button_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/notifications_button_component.html.erb
@@ -47,13 +47,13 @@ See COPYRIGHT and LICENSE files for more details.
 
       flex_layout do |flex|
         flex.with_row do
-          concat(render(Primer::Beta::Text.new(font_weight: :semibold)) { "#{state} " })
-          concat(render(Primer::Beta::Text.new) { description })
+          concat(render(Primer::Beta::Text.new(font_weight: :semibold, color: :subtle)) { "#{state} " })
+          concat(render(Primer::Beta::Text.new(color: :subtle)) { description })
         end
 
         unless show_button?
           flex.with_row(mt: 2) do
-            render(Primer::Beta::Text.new) { additional_text }
+            render(Primer::Beta::Text.new(color: :subtle)) { additional_text }
           end
         end
       end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/66233
