### PR TITLE
[#64697] Status tag is positioned too close to the title in pdf 

### DIFF
--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -89,30 +89,21 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
   def write_wp_title!(work_package)
     badge_text = work_package.status.name.downcase
     offset = 2
+    style = styles.page_heading
     with_margin(styles.page_heading_margins) do
       pdf.formatted_text(
         [
-          wp_title_formatted_text(work_package),
+          wp_title_formatted_text(work_package, style),
           { text: " " },
-          prawn_badge(badge_text, wp_status_prawn_color(work_package), offset:)
+          prawn_badge(badge_text, wp_status_prawn_color(work_package), offset:, line_height: style[:size])
         ],
-        styles.page_heading.merge({ draw_text_callback: prawn_badge_draw_text_callback(badge_text, offset) })
+        style.merge({ draw_text_callback: prawn_badge_draw_text_callback(badge_text, offset) })
       )
     end
   end
 
-  def wp_title_formatted_text(work_package)
-    styles.page_heading.merge({ text: heading, link: url_helpers.work_package_url(work_package) })
-  end
-
-  def prawn_badge_draw_text_callback(badge_text, offset)
-    # prawn does not support vertical alignment of text fragments, so we need to adjust the y position of the badge
-    ->(text, opts) do
-      if text.include? badge_text
-        opts[:at][1] += offset
-      end
-      pdf.draw_text!(text, opts)
-    end
+  def wp_title_formatted_text(work_package, style)
+    style.merge({ text: heading, link: url_helpers.work_package_url(work_package) })
   end
 
   def heading

--- a/lib/open_project/patches/prawn_badge.rb
+++ b/lib/open_project/patches/prawn_badge.rb
@@ -1,3 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 module OpenProject::Patches::PrawnBadgePatch
   def fragment_measurements=(fragment)
     super

--- a/lib/open_project/patches/prawn_badge.rb
+++ b/lib/open_project/patches/prawn_badge.rb
@@ -1,0 +1,15 @@
+module OpenProject::Patches::PrawnBadgePatch
+  def fragment_measurements=(fragment)
+    super
+
+    # If the fragment is a badge, we need to adjust the line height
+    callbacks = fragment.callback_objects
+    callbacks.each do |obj|
+      if obj.respond_to?(:badge_line_height)
+        fragment.line_height = obj.badge_line_height
+      end
+    end
+  end
+end
+
+Prawn::Text::Formatted::Arranger.prepend(OpenProject::Patches::PrawnBadgePatch)

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   let(:expected_details) do
     result = [
       "#{type.name} ##{work_package.id} - #{work_package.subject}",
-      " ", (Prawn::Text::NBSP * 3) + work_package.status.name.downcase + (Prawn::Text::NBSP * 3), # badge & padding
+      " ", exporter.prawn_badge_text_stuffing(work_package.status.name.downcase), # badge & padding
       "People",
       "Assignee", user.name,
       "Accountable", user.name,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64697

# What are you trying to achieve?

We draw the status badge background in a callback function of prawnPDF for formatted text. This feature measures the height of a text fragment only by taking the font size for each line. Is the badge on a line of its own the badge drawing is too close to the line above. This should not be the case.

# What approach did you choose and why?

- [x] Patch prawn to return the line height for a badge fragment as specified (plus 2 for the badge border), not by font height. So the background drawing always has the necessary space. If the badge is on the same line, the line height is as the outer (larger) text anyways.
- [x] Stop wrapping the badge if it is of more than one word, e.g. "in progress" by replacing spaces with non-breaking spaces
- [x] moved prawn_badge_draw_text_callback to the badge source file, as it belongs to it

# Merge checklist

- [x] Added/updated tests
- [x] Tested major PDF readers