### PR TITLE
[#66221] NoMethodError on Storages::CopyProjectFoldersJob#perform

### DIFF
--- a/modules/storages/app/services/storages/file_links/copy_file_links_service.rb
+++ b/modules/storages/app/services/storages/file_links/copy_file_links_service.rb
@@ -111,11 +111,13 @@ module Storages
         # We need this due to inconsistencies of how we represent the File Path
         target_location_map.transform_keys! { |key| key.starts_with?("/") ? key : "/#{key}" }
 
-        source_files.to_h do |info|
-          target = info.clean_location.gsub(@source.managed_project_folder_path, @target.managed_project_folder_path)
+        source_files.filter_map do |info|
+          # in case file has been deleted location is nil
+          next nil if info.location.blank?
 
+          target = info.clean_location.gsub(@source.managed_project_folder_path, @target.managed_project_folder_path)
           [info.id.to_s, target_location_map[target]&.id || id]
-        end
+        end.to_h
       end
 
       def auth_strategy


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/66221

# What are you trying to accomplish?
I am trying to make copying of file links and files during project copying more reliable.

# What approach did you choose and why?
If there is no location in files_info result, then there is no attempt of copying file link and file. So, we skip "broken" file links(no file on the storage side) and copy only "healthy" (file is present on the storage side) ones. In Nextcloud case when file has been deleted files_info contains result with 403 forbidden.

# Merge checklist

- [x] Added/updated tests
