### PR TITLE
[66374] in my spent time widget the hover card is barely legible in dark mode

### DIFF
--- a/frontend/src/global_styles/content/_tooltip.sass
+++ b/frontend/src/global_styles/content/_tooltip.sass
@@ -32,8 +32,9 @@
   border-bottom-right-radius: 3px
 
 .ui-tooltip.ui-widget-content
-  border: 1px solid #c5c5c5
+  border: 1px solid var(--borderColor-default)
   background: var(--body-background)
+  color: var(--body-font-color)
   opacity: 1
 
 .tooltip--map


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66374

# What are you trying to accomplish?
Use Primer color for font and border colors of tooltip

## Screenshots

<img width="442" height="455" alt="Screenshot 2025-08-04 at 17 13 33" src="https://github.com/user-attachments/assets/69a93367-beaa-4c11-a890-107a11eea407" />
