### PR TITLE
[#66388] Global search border radius mismatch when expanded  

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -89,7 +89,7 @@ $search-input-height: 30px
     &.-expanded
       width: $search-input-width-expanded
       background: var(--overlay-bgColor)
-      border-radius: 4px
+      border-radius: var(--borderRadius-medium)
       .ng-input input.global-search--input, .ng-clear-wrapper
         color: var(--body-font-color) !important
     .ng-dropdown-header

--- a/frontend/src/global_styles/content/_autocomplete_primerized.sass
+++ b/frontend/src/global_styles/content/_autocomplete_primerized.sass
@@ -29,7 +29,7 @@
 .ng-select
   &.ng-select--primerized
     .ng-select-container
-      border-radius: 6px
+      border-radius: var(--borderRadius-medium)
       min-height: 32px !important
 
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/66388

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

## Before
<img width="1080" height="148" alt="image" src="https://github.com/user-attachments/assets/40ecc34b-13c0-4700-8f9f-43e1ad07b63a" />

## After
<img width="1112" height="190" alt="image" src="https://github.com/user-attachments/assets/46d521e4-db66-4941-9327-53ea65fdb9b8" />


