### PR TITLE
[66134] Move the Buy now teaser in the header to the left

### DIFF
--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -96,8 +96,8 @@ module Redmine::MenuManager::TopMenuHelper
 
   def render_top_menu_right
     capture do
-      concat render_quick_add_menu
       concat render_top_menu_teaser
+      concat render_quick_add_menu
       concat render_notification_top_menu_node
       concat render_help_top_menu_node
       concat render_user_top_menu_node


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66134

# What are you trying to accomplish?
Change position of buy now teaser

## Screenshots
<img width="1180" height="387" alt="Bildschirmfoto 2025-08-05 um 14 16 25" src="https://github.com/user-attachments/assets/83c96101-424c-4c30-bbf6-c414126e89d9" />
