### PR TITLE
Bug/66403 poor performance on initial request to notifications center

### DIFF
--- a/app/components/notifications/index_page_header_component.rb
+++ b/app/components/notifications/index_page_header_component.rb
@@ -61,21 +61,26 @@ module Notifications
     def current_section
       return @current_section if defined?(@current_section)
 
-      @current_section = Notifications::Menu
-                           .new(params:, current_user: User.current)
+      @current_section = notifications_menu
                            .selected_menu_group
     end
 
     def current_item
       return @current_item if defined?(@current_item)
 
-      @current_item = Notifications::Menu
-                        .new(params:, current_user: User.current)
+      @current_item = notifications_menu
                         .selected_menu_item
     end
 
     def first_menu_item?
       current_item&.href == notifications_path
+    end
+
+    def notifications_menu
+      # Instantiating the Notifications::Menu is currently costly as it fires
+      # three database queries right away.
+      @notifications_menu ||= Notifications::Menu
+                              .new(params:, current_user: User.current)
     end
   end
 end

--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -45,13 +45,11 @@ module WorkPackages::Scopes
         elsif user.anonymous?
           where(project_id: Project.allowed_to(user, permissions))
         else
-          allowed_via_wp_membership = allowed_to_member_relation(user, permissions).select(arel_table[:id]).arel
-          allowed_via_project_membership = Project.unscoped.allowed_to(user, permissions).select(:id)
+          allowed_via_wp_membership = allowed_to_member_relation(user, permissions)
+          allowed_via_project_membership = Project.unscoped.allowed_to(user, permissions)
 
-          with(
-            allowed_work_packages: allowed_via_wp_membership,
-            allowed_projects: allowed_via_project_membership
-          ).where("work_packages.project_id IN (SELECT id FROM allowed_projects) OR work_packages.id IN (SELECT id FROM allowed_work_packages)")
+          where(project_id: allowed_via_project_membership.select(:id))
+            .or(where(id: allowed_via_wp_membership.select(arel_table[:id])))
         end
       end
 
@@ -72,7 +70,6 @@ module WorkPackages::Scopes
           .joins(member_roles: :role)
           .joins(allowed_to_role_permission_join(permissions))
           .where(member_conditions(user))
-          .select(arel_table[:id])
       end
 
       def allowed_to_enabled_module_join(permissions) # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/66403

# What are you trying to accomplish?

Improve the performance of the notification center. The main culprit there are three SQL statements:
* fetch the number of all notifications
* fetch the number of notifications per reason
* fetch the number of notifications per project

Each statement gets the notifications and for that needs to know the visible work packages. Getting them is the part of the query that leads to the performance problem. 

```
SELECT
	COUNT(*)
FROM
	"notifications"
WHERE
	"notifications"."recipient_id" = 86481
	AND "notifications"."resource_type" = 'WorkPackage'
	AND "notifications"."resource_id" IN (
		WITH
			"allowed_work_packages" AS (
				SELECT
					"work_packages"."id"
				FROM
					"members"
					INNER JOIN "work_packages" ON "members"."entity_id" = "work_packages"."id"
					INNER JOIN "projects" ON "projects"."active" = TRUE
					AND "projects"."id" = "work_packages"."project_id"
					INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
					AND "enabled_modules"."name" IN ('work_package_tracking')
					AND "projects"."active" = TRUE
					INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
					INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
					INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
					AND (
						FALSE
						OR "role_permissions"."permission" = 'view_work_packages'
						AND "enabled_modules"."name" = 'work_package_tracking'
					)
				WHERE
					"members"."user_id" = 86481
					AND "members"."entity_type" = 'WorkPackage'
			),
			"allowed_projects" AS (
				SELECT
					"projects"."id"
				FROM
					"projects"
				WHERE
					"projects"."id" IN (
						(
							(
								SELECT
									"projects"."id"
								FROM
									"members"
									INNER JOIN "projects" ON "projects"."active" = TRUE
									AND "members"."project_id" = "projects"."id"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
									INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
								WHERE
									"members"."user_id" = 86481
									AND "members"."entity_id" IS NULL
									AND "members"."entity_type" IS NULL
							)
							UNION ALL
							(
								SELECT
									"projects"."id"
								FROM
									"projects"
									INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
									AND "enabled_modules"."name" IN ('work_package_tracking')
									AND "projects"."active" = TRUE
									INNER JOIN "roles" ON "roles"."builtin" = 1
									AND "projects"."active"
									AND "projects"."public"
									AND NOT (
										EXISTS (
											SELECT
												1
											FROM
												"members"
											WHERE
												"members"."user_id" = 86481
												AND "members"."entity_id" IS NULL
												AND "members"."entity_type" IS NULL
												AND "members"."project_id" = "projects"."id"
										)
									)
									INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
									AND (
										FALSE
										OR "role_permissions"."permission" = 'view_work_packages'
										AND "enabled_modules"."name" = 'work_package_tracking'
									)
							)
						)
					)
			)
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			(
				WORK_PACKAGES.PROJECT_ID IN (
					SELECT
						ID
					FROM
						ALLOWED_PROJECTS
				)
				OR WORK_PACKAGES.ID IN (
					SELECT
						ID
					FROM
						ALLOWED_WORK_PACKAGES
				)
			)
	)
	AND "notifications"."recipient_id" = 86481
	AND (NOTIFICATIONS.READ_IAN IN ('f'))
```

Although it should result in the similar execution plan, having CTEs defined in the subquery leads to a full table scan on work packages which might take a lot of time if there are millions of work packages in.

There are a whole number of possible solutions but in this PR the simple approach of avoiding CTEs which is only called from one place each was taken. So instead of a CTE simple subqueries are employed. Again, that should be equal to using a CTE but the query planner thinks otherwise.

```
SELECT
	COUNT("notifications".*)
FROM
	"notifications"
WHERE
	"notifications"."recipient_id" = 86481
	AND "notifications"."resource_type" = 'WorkPackage'
	AND "notifications"."resource_id" IN (
		SELECT
			"work_packages"."id"
		FROM
			"work_packages"
		WHERE
			(
				"work_packages"."project_id" IN (
					SELECT
						"projects"."id"
					FROM
						"projects"
					WHERE
						"projects"."id" IN (
							(
								(
									SELECT
										"projects"."id"
									FROM
										"members"
										INNER JOIN "projects" ON "projects"."active" = TRUE
										AND "members"."project_id" = "projects"."id"
										INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
										AND "enabled_modules"."name" IN ('work_package_tracking')
										AND "projects"."active" = TRUE
										INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
										INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
										INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
										AND (
											FALSE
											OR "role_permissions"."permission" = 'view_work_packages'
											AND "enabled_modules"."name" = 'work_package_tracking'
										)
									WHERE
										"members"."user_id" = 86481
										AND "members"."entity_id" IS NULL
										AND "members"."entity_type" IS NULL
								)
								UNION ALL
								(
									SELECT
										"projects"."id"
									FROM
										"projects"
										INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
										AND "enabled_modules"."name" IN ('work_package_tracking')
										AND "projects"."active" = TRUE
										INNER JOIN "roles" ON "roles"."builtin" = 1
										AND "projects"."active"
										AND "projects"."public"
										AND NOT (
											EXISTS (
												SELECT
													1
												FROM
													"members"
												WHERE
													"members"."user_id" = 86481
													AND "members"."entity_id" IS NULL
													AND "members"."entity_type" IS NULL
													AND "members"."project_id" = "projects"."id"
											)
										)
										INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
										AND (
											FALSE
											OR "role_permissions"."permission" = 'view_work_packages'
											AND "enabled_modules"."name" = 'work_package_tracking'
										)
								)
							)
						)
				)
				OR "work_packages"."id" IN (
					SELECT
						"work_packages"."id"
					FROM
						"members"
						INNER JOIN "work_packages" ON "members"."entity_id" = "work_packages"."id"
						INNER JOIN "projects" ON "projects"."active" = TRUE
						AND "projects"."id" = "work_packages"."project_id"
						INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id"
						AND "enabled_modules"."name" IN ('work_package_tracking')
						AND "projects"."active" = TRUE
						INNER JOIN "member_roles" ON "member_roles"."member_id" = "members"."id"
						INNER JOIN "roles" ON "roles"."id" = "member_roles"."role_id"
						INNER JOIN "role_permissions" ON "roles"."id" = "role_permissions"."role_id"
						AND (
							FALSE
							OR "role_permissions"."permission" = 'view_work_packages'
							AND "enabled_modules"."name" = 'work_package_tracking'
						)
					WHERE
						"members"."user_id" = 86481
						AND "members"."entity_type" = 'WorkPackage'
				)
			)
	)
	AND "notifications"."recipient_id" = 86481
	AND (NOTIFICATIONS.READ_IAN IN ('f'))
```

On my machine, a request that took 350ms now takes 30ms.

Since during the whole of the initial call to notification center three similar SQL statements are executed (fetch the number of all notifications, fetch the number of notifications per reason and fetch the number of notifications per project), this saves quite a bit of time.   


