### PR TITLE
Don't set pageState = edited on internal callback, rather on editor focus

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -184,6 +184,11 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
       });
   }
 
+  public editorFocused():void {
+    window.OpenProject.pageState = 'edited';
+    this.editorFocus.emit();
+  }
+
   public async saveForm(evt?:SubmitEvent):Promise<void> {
     if (CkeditorAugmentedTextareaComponent.inFlight.has(this.formElement)) {
       return;
@@ -232,9 +237,11 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     return editor;
   }
 
-  public syncToTextarea() {
-    window.OpenProject.pageState = 'edited';
+  public updateContent(value:string) {
+    this.wrappedTextArea.value = value;
+  }
 
+  public syncToTextarea() {
     try {
       this.wrappedTextArea.value = this.ckEditorInstance.getTransformedContent(true);
     } catch (e) {

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -122,6 +122,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
     attachments: this.I18n.t('js.label_attachments'),
   };
 
+  private focused = false;
+
   // Reference to the actual ckeditor instance component
   @ViewChild(OpCkeditorComponent, { static: true }) private ckEditorInstance:OpCkeditorComponent;
 
@@ -185,8 +187,13 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public editorFocused():void {
-    window.OpenProject.pageState = 'edited';
+    this.focused = true;
     this.editorFocus.emit();
+  }
+
+  public editorBlurred():void {
+    this.focused = false;
+    this.editorBlur.emit();
   }
 
   public async saveForm(evt?:SubmitEvent):Promise<void> {
@@ -238,6 +245,12 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
   }
 
   public updateContent(value:string) {
+    // Update the page state to edited
+    // but only if we're focused in the editor
+    if (this.focused) {
+      window.OpenProject.pageState = 'edited';
+    }
+
     this.wrappedTextArea.value = value;
   }
 

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -7,7 +7,7 @@
     (saveRequested)="saveForm()"
     (editorEscape)="editorEscape.emit()"
     (editorKeyup)="editorKeyup.emit()"
-    (editorBlur)="editorBlur.emit()"
+    (editorBlur)="editorBlurred()"
     (editorFocus)="editorFocused()"
   ></op-ckeditor>
 </div>

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.html
@@ -3,12 +3,12 @@
     [context]="context"
     [content]="initialContent"
     (initializeDone)="setup($event)"
-    (contentChanged)="syncToTextarea()"
+    (contentChanged)="updateContent($event)"
     (saveRequested)="saveForm()"
     (editorEscape)="editorEscape.emit()"
     (editorKeyup)="editorKeyup.emit()"
     (editorBlur)="editorBlur.emit()"
-    (editorFocus)="editorFocus.emit()"
+    (editorFocus)="editorFocused()"
   ></op-ckeditor>
 </div>
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66416

# What are you trying to accomplish?

The editor fired changing the page state too often and early, when content changes due to initialization of the synced text area in case of notifications updating it. Instead, let's assume the user "changed" the content when actively focusing the editor with intent to type.

For that, we separate the contentChanged callback from getting the data fresh on submit