### PR TITLE
[66407] Wrong fg color for quick add button on top bar

### DIFF
--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -97,8 +97,7 @@ ul.SegmentedControl,
 
   svg
     align-self: center
-    
-.Button.op-app-header--primer-button
+
 // Prototypical CKEditor adjustments to better match Primer styles
 .ck-editor-primer-adjusted
   .ck-toolbar

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -90,7 +90,8 @@ ul.SegmentedControl,
   color: var(--header-item-font-color)
 
   &.Button--primary
-    color: var(--button--primary-font-color)
+    svg
+      color: var(--button--primary-font-color)
 
 .Button.op-app-header--primer-button
   min-width: var(--control-medium-size)

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -89,6 +89,9 @@ ul.SegmentedControl,
   align-self: center
   color: var(--header-item-font-color)
 
+  &.Button--primary
+    color: var(--button--primary-font-color)
+
 .Button.op-app-header--primer-button
   min-width: var(--control-medium-size)
 

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -84,22 +84,21 @@ ul.SegmentedControl,
       flex-direction: column
       row-gap: 1rem
 
-.Button.op-app-header--primer-button:not(.Button--primary),
-.Button.op-app-header--primer-button:not(.Button--primary) svg
-  color: var(--header-item-font-color)
-  align-self: center
-
-.Button.op-app-header--primer-button.Button--primary,
-.Button.op-app-header--primer-button.Button--primary svg
-  color: var(--button--primary-font-color)
-  align-self: center
-
 .Button.op-app-header--primer-button
+  align-self: center
   min-width: var(--control-medium-size)
 
   &:hover
     color: var(--header-item-font-hover-color)
 
+  &:not(.Button--primary),
+  &:not(.Button--primary) svg
+    color: var(--header-item-font-color)
+
+  svg
+    align-self: center
+    
+.Button.op-app-header--primer-button
 // Prototypical CKEditor adjustments to better match Primer styles
 .ck-editor-primer-adjusted
   .ck-toolbar

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -84,14 +84,15 @@ ul.SegmentedControl,
       flex-direction: column
       row-gap: 1rem
 
-.Button.op-app-header--primer-button,
-.Button.op-app-header--primer-button svg
-  align-self: center
+.Button.op-app-header--primer-button:not(.Button--primary),
+.Button.op-app-header--primer-button:not(.Button--primary) svg
   color: var(--header-item-font-color)
+  align-self: center
 
-  &.Button--primary
-    svg
-      color: var(--button--primary-font-color)
+.Button.op-app-header--primer-button.Button--primary,
+.Button.op-app-header--primer-button.Button--primary svg
+  color: var(--button--primary-font-color)
+  align-self: center
 
 .Button.op-app-header--primer-button
   min-width: var(--control-medium-size)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66407

# What are you trying to accomplish?
Set fontcolor for primary buttons in app header
