### PR TITLE
Fix meeting seeding after backlog

### DIFF
--- a/modules/meeting/app/components/meeting_sections/backlogs/container_component.rb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/container_component.rb
@@ -45,7 +45,7 @@ module MeetingSections
     private
 
     def show?
-      !@meeting.closed? && !@meeting.template?
+      !@meeting.closed? && !@meeting.template? && @backlog
     end
 
     def wrapper_data_attributes

--- a/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
+++ b/modules/meeting/spec/seeders/demo_data/project_seeder_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DemoData::ProjectSeeder do
   subject(:project_seeder) { described_class.new(seed_data.lookup("projects.my-project")) }
 
   let(:work_package) { create(:work_package) }
-  let(:user) { create(:user) }
+  let(:user) { create(:admin) }
   let(:seed_data) do
     data = basic_seed_data.merge(
       Source::SeedData.new(


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/66258

The meeting seeder did not use the service to create the meeting, missing:

- The backlog section
- The user was not set as a participant


# Merge checklist

- [x] Added/updated tests
