### PR TITLE
Fix calendar rendering when wrapper is still hidden

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/my/time-tracking.controller.ts
@@ -64,6 +64,10 @@ export default class MyTimeTrackingController extends Controller {
 
     if (this.hasCalendarTarget && this.viewModeValue === 'calendar') {
       this.initializeCalendar();
+
+      // The stimulus controller gets initialized before the content wrapper is fully shown
+      // so its height might not be set correctly yet.
+      setTimeout(() => this.calendar.updateSize(), 25);
     }
 
     // handle dialog close event


### PR DESCRIPTION
Stimulus controllers engage before the wrapper is shown, this apparently has changed recently with the module loading changes. This causes rendering to not be correct yet, and we need to update fullcalendar's size again.

https://community.openproject.org/work_packages/66340
