### PR TITLE
Bug/66425 side menu my time tracking doesn t take user to current day

### DIFF
--- a/modules/costs/app/components/my/time_tracking/list_component.rb
+++ b/modules/costs/app/components/my/time_tracking/list_component.rb
@@ -98,13 +98,15 @@ module My
         end
       end
 
-      def collapsed?(date)
+      def collapsed?(date) # rubocop:disable Metrics/AbcSize
         return false if mode == :day
+        return false if mode.in?(%i[week workweek]) && range.exclude?(Date.current)
+        return false if mode == :month && range.exclude?(Date.current.beginning_of_week)
 
-        if range.include?(Date.current)
-          !date.today?
+        if mode == :month
+          Date.current.cweek != date.cweek
         else
-          false
+          !date.today?
         end
       end
 

--- a/modules/costs/app/controllers/my/time_tracking_controller.rb
+++ b/modules/costs/app/controllers/my/time_tracking_controller.rb
@@ -118,11 +118,7 @@ module My
     end
 
     def current_date
-      case mode
-      when :day then Time.zone.today
-      when :week, :workweek then Time.zone.today.beginning_of_week(week_start_day)
-      when :month then Time.zone.today.beginning_of_month
-      end
+      Time.zone.today
     end
 
     def load_time_entries(time_scope)

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -144,7 +144,7 @@ module Costs
 
       menu :global_menu,
            :my_time_tracking,
-           { controller: "/my/time_tracking", action: "index" },
+           { controller: "/my/time_tracking", action: "index", date: "today" },
            after: :my_page,
            caption: :label_my_time_tracking,
            if: ->(*) do

--- a/modules/costs/spec/controllers/my/time_tracking_controller_spec.rb
+++ b/modules/costs/spec/controllers/my/time_tracking_controller_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe My::TimeTrackingController do
   end
 
   describe "GET /my/time-tracking/week" do
-    it "without a date param it uses the beginning of current week" do
+    it "without a date param it uses the current day" do
       get :index, params: { mode: :week }
-      expect(assigns(:date)).to eq(Date.current.beginning_of_week)
+      expect(assigns(:date)).to eq(Date.current)
     end
 
     it "with a date param it uses the given date" do
@@ -127,16 +127,16 @@ RSpec.describe My::TimeTrackingController do
       expect(assigns(:date)).to eq(Date.parse("2023-12-31"))
     end
 
-    it "with an invalid date param it uses the beginning of current week" do
+    it "with an invalid date param it uses the current day" do
       get :index, params: { mode: :week, date: "invalid-date" }
-      expect(assigns(:date)).to eq(Date.current.beginning_of_week)
+      expect(assigns(:date)).to eq(Date.current)
     end
   end
 
   describe "GET /my/time-tracking/month" do
-    it "without a date param it uses the beginning of current month" do
+    it "without a date param it uses the current day" do
       get :index, params: { mode: :month }
-      expect(assigns(:date)).to eq(Date.current.beginning_of_month)
+      expect(assigns(:date)).to eq(Date.current)
     end
 
     it "with a date param it uses the given date" do
@@ -144,9 +144,9 @@ RSpec.describe My::TimeTrackingController do
       expect(assigns(:date)).to eq(Date.parse("2023-12-31"))
     end
 
-    it "with an invalid date param it uses the beginning of current month" do
+    it "with an invalid date param it uses the current day" do
       get :index, params: { mode: :month, date: "invalid-date" }
-      expect(assigns(:date)).to eq(Date.current.beginning_of_month)
+      expect(assigns(:date)).to eq(Date.current)
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/66425
# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

# What approach did you choose and why?
- Do not use start of week date when no date is provided, but use today
- Sidetrack: I found that in the month view nothing is ever collapsed, so I fixed this as well

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
