### PR TITLE
[#65762] User with view and edit meetings permissions cannot edit a meeting  

### DIFF
--- a/modules/meeting/app/components/meetings/index/dialog_component.rb
+++ b/modules/meeting/app/components/meetings/index/dialog_component.rb
@@ -45,11 +45,8 @@ module Meetings
     private
 
     def render?
-      if @project
-        User.current.allowed_in_project?(:create_meetings, @project)
-      else
-        User.current.allowed_in_any_project?(:create_meetings)
-      end
+      permission = @meeting.persisted? ? :edit_meetings : :create_meetings
+      @project ? User.current.allowed_in_project?(permission, @project) : User.current.allowed_in_any_project?(permission)
     end
 
     def title

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.html.erb
@@ -8,16 +8,16 @@
       header.with_description { page_description }
       header.with_breadcrumbs(breadcrumb_items)
 
-      if render_create_button?
-        header.with_action_menu(
-          menu_arguments: { anchor_align: :end },
-          button_arguments: { icon: "kebab-horizontal",
-                              classes: "hide-when-print",
-                              "aria-label": "Menu",
-                              data: {
-                                "test-selector": "recurring-meeting-action-menu"
-                              } }
-        ) do |menu, _button|
+      header.with_action_menu(
+        menu_arguments: { anchor_align: :end },
+        button_arguments: { icon: "kebab-horizontal",
+                            classes: "hide-when-print",
+                            "aria-label": "Menu",
+                            data: {
+                              "test-selector": "recurring-meeting-action-menu"
+                            } }
+      ) do |menu, _button|
+        if edit_meeting?
           menu.with_item(
             label: I18n.t(:label_recurring_meeting_series_edit),
             icon: :gear,
@@ -31,49 +31,49 @@
           ) do |item|
             item.with_leading_visual_icon(icon: :pencil)
           end
+        end
 
+        menu.with_item(
+          label: t(:label_icalendar_download),
+          href: download_ics_project_recurring_meeting_path(@project, @meeting)
+        ) do |item|
+          item.with_leading_visual_icon(icon: :calendar)
+        end
+
+        if send_emails?
           menu.with_item(
-            label: t(:label_icalendar_download),
-            href: download_ics_project_recurring_meeting_path(@project, @meeting)
+            label: t("meeting.label_mail_all_participants"),
+            href: notify_project_recurring_meeting_path(@project, @meeting),
+            form_arguments: { method: :post }
           ) do |item|
-            item.with_leading_visual_icon(icon: :calendar)
+            item.with_leading_visual_icon(icon: :mail)
           end
+        end
 
-          if send_emails?
-            menu.with_item(
-              label: t("meeting.label_mail_all_participants"),
-              href: notify_project_recurring_meeting_path(@project, @meeting),
-              form_arguments: { method: :post }
-            ) do |item|
-              item.with_leading_visual_icon(icon: :mail)
-            end
+        if end_meeting?
+          menu.with_item(
+            label: t(:label_recurring_meeting_series_end),
+            href: end_series_dialog_project_recurring_meeting_path(@project, @meeting),
+            tag: :a,
+            content_arguments: {
+              data: { controller: "async-dialog" }
+            }
+          ) do |item|
+            item.with_leading_visual_icon(icon: :"x-circle")
           end
+        end
 
-          if !@meeting.has_ended? && @meeting.start_time.to_date < Time.zone.today
-            menu.with_item(
-              label: t(:label_recurring_meeting_series_end),
-              href: end_series_dialog_project_recurring_meeting_path(@project, @meeting),
-              tag: :a,
-              content_arguments: {
-                data: { controller: "async-dialog" }
-              }
-            ) do |item|
-              item.with_leading_visual_icon(icon: :"x-circle")
-            end
-          end
-
-          if User.current.allowed_in_project?(:delete_meetings, @project)
-            menu.with_item(
-              label: I18n.t(:label_recurring_meeting_series_delete),
-              href: delete_dialog_project_recurring_meeting_path(@project, @meeting),
-              scheme: :danger,
-              tag: :a,
-              content_arguments: {
-                data: { controller: "async-dialog" }
-              }
-            ) do |item|
-              item.with_leading_visual_icon(icon: :trash)
-            end
+        if delete_meeting?
+          menu.with_item(
+            label: I18n.t(:label_recurring_meeting_series_delete),
+            href: delete_dialog_project_recurring_meeting_path(@project, @meeting),
+            scheme: :danger,
+            tag: :a,
+            content_arguments: {
+              data: { controller: "async-dialog" }
+            }
+          ) do |item|
+            item.with_leading_visual_icon(icon: :trash)
           end
         end
       end

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
@@ -41,12 +41,20 @@ module RecurringMeetings
       @project = meeting.project
     end
 
-    def render_create_button?
+    def edit_meeting?
       if @project
-        User.current.allowed_in_project?(:create_meetings, @project)
+        User.current.allowed_in_project?(:edit_meetings, @project)
       else
-        User.current.allowed_in_any_project?(:create_meetings)
+        User.current.allowed_in_any_project?(:edit_meetings)
       end
+    end
+
+    def end_meeting?
+      !@meeting.has_ended? && @meeting.start_time.to_date < Time.zone.today && edit_meeting?
+    end
+
+    def delete_meeting?
+      User.current.allowed_in_project?(:delete_meetings, @project)
     end
 
     def send_emails?

--- a/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings/schedule_controller.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 module RecurringMeetings
   class ScheduleController < ApplicationController
-    authorize_with_permission :create_meetings, global: true
-
     around_action :with_user_time_zone
-    before_action :build_meeting
+    before_action :require_login, :build_meeting
+    no_authorization_required! :humanize_schedule
 
     def humanize_schedule
       text = @recurring_meeting.human_frequency_schedule

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "Recurring meetings CRUD",
   context "with view permissions only" do
     let(:current_user) { other_user }
 
-    it "does not allow to act on the recurring meeting" do
+    it "does not allow to act on the recurring meeting, except for downloading the ical event" do
       show_page.visit!
 
       expect(page).to have_no_button "Open"
@@ -229,7 +229,11 @@ RSpec.describe "Recurring meetings CRUD",
       show_page.expect_planned_meeting date: "01/07/2025 01:30 PM"
       show_page.expect_planned_meeting date: "01/14/2025 01:30 PM"
 
-      expect(page).not_to have_test_selector "recurring-meeting-action-menu"
+      page.find_test_selector("recurring-meeting-action-menu").click
+      page.find(".Overlay")
+      page.within(".Overlay") do
+        expect(page).to have_css(".ActionListItem-label", count: 1)
+      end
     end
   end
 end

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_schedule_spec.rb
@@ -57,60 +57,60 @@ RSpec.describe "Recurring meetings schedule text",
     response
   end
 
-  before do
-    login_as(current_user)
-  end
-
-  describe "setting schedule" do
-    it "returns the update text" do
-      expect(subject).to have_http_status(:ok)
-      expect(subject.body).to include("Every day at 10:00 AM")
+  describe "when logged in" do
+    before do
+      login_as(current_user)
     end
 
-    context "when changing the frequency and interval" do
-      let(:frequency) { "weekly" }
-      let(:interval) { "2" }
-
+    describe "setting schedule" do
       it "returns the update text" do
-        expect(subject).to have_http_status(:ok)
-        expect(subject.body).to include("Every 2 weeks on Thursday at 10:00 AM")
-      end
-    end
-
-    context "when changing the interval" do
-      let(:interval) { "2" }
-
-      it "returns the update text" do
-        expect(subject).to have_http_status(:ok)
-        expect(subject.body).to include("Every 2 days at 10:00 AM")
-      end
-    end
-
-    context "when leaving the interval empty" do
-      let(:interval) { "" }
-
-      it "falls back to the default" do
         expect(subject).to have_http_status(:ok)
         expect(subject.body).to include("Every day at 10:00 AM")
       end
-    end
 
-    context "when requesting with turbo" do
-      let(:format) { :turbo_stream }
+      context "when changing the frequency and interval" do
+        let(:frequency) { "weekly" }
+        let(:interval) { "2" }
 
-      it "returns an update turbo stream" do
-        expect(subject).to have_http_status(:ok)
-        expect(subject.body).to include("turbo-stream")
-        expect(subject.body).to include("Every day at 10:00 AM")
+        it "returns the update text" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("Every 2 weeks on Thursday at 10:00 AM")
+        end
+      end
+
+      context "when changing the interval" do
+        let(:interval) { "2" }
+
+        it "returns the update text" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("Every 2 days at 10:00 AM")
+        end
+      end
+
+      context "when leaving the interval empty" do
+        let(:interval) { "" }
+
+        it "falls back to the default" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("Every day at 10:00 AM")
+        end
+      end
+
+      context "when requesting with turbo" do
+        let(:format) { :turbo_stream }
+
+        it "returns an update turbo stream" do
+          expect(subject).to have_http_status(:ok)
+          expect(subject.body).to include("turbo-stream")
+          expect(subject.body).to include("Every day at 10:00 AM")
+        end
       end
     end
   end
 
-  context "when user has no permissions to access" do
-    let(:current_user) { create(:user) }
-
+  context "when not logged in" do
     it "does not allow to request it" do
-      expect(subject).to have_http_status(:forbidden)
+      expect(subject).to have_http_status(:found)
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/65762

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Always show the kebab menu for a recurring meeting with at least the option to download ical events
- Check against `:edit_meetings` to show the edit meeting series option
- Check against either `:edit_meetings` or `:create_meetings` to show the dialog form, depending on which action opened it - this was not allowed before, causing the bug mentioned in the WP