### PR TITLE
implementation/66460 Automatically sync the contrast mode with the OS preference change

### DIFF
--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -44,6 +44,7 @@ export default class AutoThemeSwitcher extends Controller {
     useMatchMedia(this, {
       mediaQueries: {
         lightMode: '(prefers-color-scheme: light)',
+        highContrastMode: '(prefers-contrast: more)',
       },
     });
   }
@@ -54,5 +55,9 @@ export default class AutoThemeSwitcher extends Controller {
 
   notLightMode():void {
     window.OpenProject.theme.applyThemeToBody('dark');
+  }
+
+  highContrastModeChanged():void {
+    window.OpenProject.theme.applySystemThemeImmediately();
   }
 }


### PR DESCRIPTION
https://community.openproject.org/work_packages/66460

Listen to OS contrast mode changes and `applySystemThemeImmediately()` without requiring a page refresh


https://github.com/user-attachments/assets/cd1d7874-a145-4b24-ae2c-da7b93eb0d77

