### PR TITLE
[66420] Width of the Cost Report Work Package autocompleter is too narrow

### DIFF
--- a/modules/reporting/lib/widget/filters/work_package.rb
+++ b/modules/reporting/lib/widget/filters/work_package.rb
@@ -50,7 +50,7 @@ class Widget::Filters::WorkPackage < Widget::Filters::Base
                                     searchKey: "subjectOrId"
                                   },
                                   id: "#{filter_class.underscore_name}_select_1",
-                                  class: "filter-value"
+                                  class: "filter-value advanced-filters--ng-select"
 
       content_tag(:span, class: "inline-label") do
         label + box


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66420

## Screenshots
<img width="1544" height="450" alt="Screenshot 2025-08-08 at 09 59 28" src="https://github.com/user-attachments/assets/30eefc55-dac0-4dfe-9494-df5295a25575" />


# What approach did you choose and why?
Make the WP autocompleter filter stretched to the whole available width.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
