### PR TITLE
[66301] "Sign in" in new right side modal is off on Chrome (Ubuntu)

### DIFF
--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -34,8 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
       ) do %>
     <%= back_url_to_current_page_hidden_field_tag %>
 
-    <div class="grid-block grid-block_double-column login-form__credentials-wrapper">
-      <div class="form--field login-form__username -required">
+    <div class="grid-block">
+      <div class="form--field -required">
         <%= styled_label_tag "username-pulldown", User.human_attribute_name(:login) %>
         <div class="form--field-container">
           <%= styled_text_field_tag "username", nil, id: "username-pulldown", tabindex: 1, autocapitalize: "none" %>

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -54,7 +54,6 @@ See COPYRIGHT and LICENSE files for more details.
           <% end %>
         </div>
       </div>
-      <div class="grid-block">
       <div class="form--field -required">
         <%= styled_label_tag "password-pulldown", User.human_attribute_name(:password) %>
         <div class="form--field-container">
@@ -73,9 +72,8 @@ See COPYRIGHT and LICENSE files for more details.
           <% end %>
         </div>
       </div>
-      </div>
-
-      <div class="grid-block">
+    </div>
+    <div class="grid-block">
       <div class="form--field">
         <label class="form--label" for="login-pulldown">
           &nbsp;
@@ -83,9 +81,7 @@ See COPYRIGHT and LICENSE files for more details.
         <input type="submit" name="login" id="login-pulldown"
                value="<%= t(:button_login) %>" class="button -primary button_no-margin" tabindex="1">
       </div>
-      </div>
     </div>
-
     <%= render partial: "account/auth_providers" %>
   <% end %>
 </div>

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -34,8 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
       ) do %>
     <%= back_url_to_current_page_hidden_field_tag %>
 
-    <div class="grid-block grid-block_double-column">
-      <div class="form--field -required">
+    <div class="grid-block grid-block_double-column login-form__credentials-wrapper">
+      <div class="form--field login-form__username -required">
         <%= styled_label_tag "username-pulldown", User.human_attribute_name(:login) %>
         <div class="form--field-container">
           <%= styled_text_field_tag "username", nil, id: "username-pulldown", tabindex: 1, autocapitalize: "none" %>

--- a/frontend/src/global_styles/content/_accounts.sass
+++ b/frontend/src/global_styles/content/_accounts.sass
@@ -103,6 +103,9 @@
     margin-top: 1em
     margin-bottom: 10px
 
+  .grid-block_double-column .form--field:first-of-type
+    flex-basis: 50%
+
 #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
 

--- a/frontend/src/global_styles/content/_accounts.sass
+++ b/frontend/src/global_styles/content/_accounts.sass
@@ -103,12 +103,6 @@
     margin-top: 1em
     margin-bottom: 10px
 
-#nav-login-content
-  .login-form__credentials-wrapper
-    gap: 1rem
-    .login-form__username
-      padding-right: 0
-
 #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
 

--- a/frontend/src/global_styles/content/_accounts.sass
+++ b/frontend/src/global_styles/content/_accounts.sass
@@ -103,9 +103,6 @@
     margin-top: 1em
     margin-bottom: 10px
 
-  .grid-block_double-column .form--field:first-of-type
-    flex-basis: 50%
-
 #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
 

--- a/frontend/src/global_styles/content/_accounts.sass
+++ b/frontend/src/global_styles/content/_accounts.sass
@@ -103,6 +103,12 @@
     margin-top: 1em
     margin-bottom: 10px
 
+#nav-login-content
+  .login-form__credentials-wrapper
+    gap: 1rem
+    .login-form__username
+      padding-right: 0
+
 #nav-login-content .login-auth-providers.no-pwd
   margin-top: 0
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66301

# What approach did you choose and why?
Set flex-basis of username field.