### PR TITLE
[#66472] It is not possible to submit calculated value field form by pressing Enter/Return inside formula

### DIFF
--- a/frontend/src/stimulus/controllers/pattern-input.controller.ts
+++ b/frontend/src/stimulus/controllers/pattern-input.controller.ts
@@ -97,6 +97,8 @@ export default class PatternInputController extends Controller {
   input_keydown(event:KeyboardEvent) {
     if (event.key === 'Enter') {
       event.preventDefault();
+      this.formInputTarget.form?.requestSubmit();
+      return;
     }
 
     if (event.key === 'ArrowDown') {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66472

# What are you trying to accomplish?
Allow submitting a form using Enter/Return when pattern input is focused

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
