### PR TITLE
fix custom_field_values to depend on all value

### DIFF
--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -342,9 +342,7 @@ RSpec.describe "Projects copy", :js,
       end
 
       context "with non-admin user" do
-        it "does not show invisible fields in the form and but still activates them" do
-          pending "Admin-only project attributes currently prevent users from creating projects (OP#64479)"
-
+        it "does not show invisible fields in the form but still activates them" do
           expect(page).to have_heading "Copy project \"#{project.name}\""
 
           expect(page).to have_no_content "Text for Admins only"

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Project, "customizable" do
               .to eq("foo")
             expect(project.custom_value_for(bool_custom_field).typed_value)
               .to be_truthy
-            expect(project.custom_value_for(list_custom_field).typed_value)
+            expect(project.custom_value_for(list_custom_field))
               .to be_nil
           end
 

--- a/spec/requests/api/v3/projects/update_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_resource_spec.rb
@@ -147,18 +147,20 @@ RSpec.describe "API v3 Project resource update", content_type: :json do
       end
 
       it "does not set the cf value" do
-        expect(project.reload.custom_values)
-          .to be_empty
+        expect(project.reload.custom_values.find_by(custom_field: admin_only_custom_field))
+          .to have_attributes(value: nil)
       end
 
       context "when the hidden field has a value already" do
-        it "does not change the cf value" do
-          project.custom_field_values = { admin_only_custom_field.id => "1234" }
-          project.save
-          patch path, body.to_json
+        before do
+          project.update!(custom_field_values: { admin_only_custom_field.id => "1234" })
 
-          expect(project.reload.custom_values.find_by(custom_field: admin_only_custom_field).value)
-            .to eq "1234"
+          patch path, body.to_json
+        end
+
+        it "does not change the cf value" do
+          expect(project.reload.custom_values.find_by(custom_field: admin_only_custom_field))
+            .to have_attributes(value: "1234")
         end
       end
 

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -505,6 +505,12 @@ RSpec.describe Projects::SetAttributesService, type: :model do
             expect(subject.result.custom_value_attributes).to eq(
               cf_static.id => "3",
               cf_calculated1.id => "21",
+              cf_calculated3.id => "-6"
+            )
+
+            expect(subject.result.custom_value_attributes(all: true)).to eq(
+              cf_static.id => "3",
+              cf_calculated1.id => "21",
               cf_calculated2.id => "-6",
               cf_calculated3.id => "-6"
             )
@@ -546,6 +552,12 @@ RSpec.describe Projects::SetAttributesService, type: :model do
 
           it "calculates only accessible values" do
             expect(subject.result.custom_value_attributes).to eq(
+              cf_static.id => "3",
+              cf_calculated1.id => "21",
+              cf_calculated3.id => "-6"
+            )
+
+            expect(subject.result.custom_value_attributes(all: true)).to eq(
               cf_static.id => "3",
               cf_calculated1.id => "21",
               cf_calculated2.id => "-6",


### PR DESCRIPTION
Otherwise `all` flag affects only first invocation

Accidentally allows copying admin only fields (references https://community.openproject.org/wp/64479)