### PR TITLE
[66482] Insufficient space between Close and Save buttons on Log time modal

### DIFF
--- a/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
@@ -11,9 +11,9 @@
         ) %>
   <% end %>
   <% d.with_footer(variant: :large) do %>
-    <% flex_layout(justify_content: :flex_end, classes: "time-entry-dialog-footer-buttons") do |flex| %>
+    <%= grid_layout("time-entry-dialog-footer", tag: :div) do |grid| %>
       <% if can_delete_time_entry? %>
-        <% flex.with_column do %>
+        <% grid.with_area("delete") do %>
           <%= render(
                 Primer::Beta::Button.new(
                   scheme: :danger,
@@ -29,11 +29,12 @@
               ) { t("button_delete") } %>
         <% end %>
       <% end %>
-      <% flex.with_column(classes: "time-entry-button-push") %>
-      <% flex.with_column do %>
+      <% grid.with_area("cancel") do %>
         <%= render(
               Primer::Beta::Button.new(data: { "close-dialog-id": "time-entry-dialog" })
             ) { I18n.t("button_cancel") } %>
+        <% end %>
+        <% grid.with_area("confirm") do %>
         <%= render(
               Primer::Beta::Button.new(
                 scheme: :primary,

--- a/modules/costs/app/components/time_entries/entry_dialog_component.sass
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.sass
@@ -28,12 +28,12 @@
  / ++
  /
 
-.time-entry-dialog-footer-buttons
+.time-entry-dialog-footer
   width: 100%
-
-.time-entry-button-push
-  margin-left: auto
-
+  display: grid
+  grid-gap: var(--stack-gap-condensed)
+  grid-template-columns: auto 1fr auto auto
+  grid-template-areas: "delete . cancel confirm"
 
 .time-entry-dialog-form-spacing
   row-gap: var(--stack-gap-normal)


### PR DESCRIPTION

# Ticket
https://community.openproject.org/wp/66482

# What are you trying to accomplish?
Use CSS grid for cleaner layout and apply correct spacing between buttons

## Screenshots

<img width="496" height="118" alt="Bildschirmfoto 2025-08-11 um 11 28 35" src="https://github.com/user-attachments/assets/0c04d11e-05de-42c8-bd39-fb0a0e95f051" />
