### PR TITLE
[65626] Use WorkPackage::InfoLine and top-align rows in my time tracking border box table

### DIFF
--- a/app/components/op_primer/border_box_table_component.sass
+++ b/app/components/op_primer/border_box_table_component.sass
@@ -6,11 +6,17 @@
   &--row-item
     word-break: break-word
 
+  &--heading
+    align-self: center
+
   &--row-action,
   &--heading-action
     display: flex
-    align-items: center
+    align-items: flex-start
     justify-content: flex-end
+
+  &--row-action
+    margin-top: -6px // Moving the button slightly to the top, so that the icon aligns visually with the other columns
 
 @media screen and (min-width: $breakpoint-md)
   .op-border-box-grid
@@ -18,7 +24,7 @@
     grid-auto-columns: minmax(0, 1fr)
     grid-auto-flow: column
     justify-content: flex-start
-    align-items: center
+    align-items: flex-start
 
     &--heading,
     &--row-item

--- a/frontend/src/global_styles/content/_comments.sass
+++ b/frontend/src/global_styles/content/_comments.sass
@@ -27,8 +27,6 @@
 //++
 
 .comments
-  margin: 1rem 0
-
   .author
     margin: 0
 

--- a/modules/storages/app/components/storages/admin/storage_row_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storage_row_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  grid_layout("op-storage-list--row", tag: :div, align_items: :center) do |grid|
+  grid_layout("op-storage-list--row", tag: :div) do |grid|
     grid.with_area(:name, tag: :div, mr: 3, classes: "ellipsis") do
       concat(render(Primer::Beta::Link.new(href: url_helpers.edit_admin_settings_storage_path(storage), font_weight: :bold, mr: 1, data: { "test-selector": "storage-name" })) { storage.name })
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65626

# What are you trying to accomplish?
Align items in BorderBox Tabel to the top

## Screenshots

<img width="1689" height="182" alt="Bildschirmfoto 2025-08-11 um 12 31 01" src="https://github.com/user-attachments/assets/a47ae9e2-6ca8-420b-bde9-cf72d552c7c9" />
