### PR TITLE
Allow to configure oauth_allow_remapping_of_existing_users via UI

### DIFF
--- a/app/views/admin/settings/authentication_settings/_sso.html.erb
+++ b/app/views/admin/settings/authentication_settings/_sso.html.erb
@@ -57,6 +57,11 @@ See COPYRIGHT and LICENSE files for more details.
           end
         end
 
+        form.check_box(
+          name: :oauth_allow_remapping_of_existing_users,
+          caption: I18n.t("settings.authentication.remapping_existing_users_hint")
+        )
+
         form.submit
       end
     end

--- a/app/views/admin/settings/authentication_settings/_sso.html.erb
+++ b/app/views/admin/settings/authentication_settings/_sso.html.erb
@@ -27,36 +27,38 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%=
-  settings_primer_form_with(scope: :settings,
-                            url: admin_settings_authentication_path(tab: params[:tab]),
-                            method: :patch) do |f|
-    render_inline_settings_form(f) do |form|
-      form.select_list(
-        name: :omniauth_direct_login_provider,
-        input_width: :medium,
-        label: I18n.t(:setting_omniauth_direct_login_provider),
-        caption: I18n.t(
-          "settings.authentication.omniauth_direct_login_hint_html",
-          internal_path: internal_signin_url
-        ).html_safe,
-        include_blank: I18n.t(:label_none_parentheses)
-      ) do |select|
-        AuthProvider
-          .where(available: true)
-          .order("lower(display_name) ASC")
-          .select(:type, :display_name, :slug)
-          .to_a
-          .each do |provider|
-          select.option(
-            value: provider.slug,
-            label: "#{provider.display_name} (#{provider.human_type})",
-            selected: Setting.omniauth_direct_login_provider == provider.slug
-          )
+<% with_enterprise_banner_guard(:sso_auth_providers) do %>
+  <%=
+    settings_primer_form_with(scope: :settings,
+                              url: admin_settings_authentication_path(tab: params[:tab]),
+                              method: :patch) do |f|
+      render_inline_settings_form(f) do |form|
+        form.select_list(
+          name: :omniauth_direct_login_provider,
+          input_width: :medium,
+          label: I18n.t(:setting_omniauth_direct_login_provider),
+          caption: I18n.t(
+            "settings.authentication.omniauth_direct_login_hint_html",
+            internal_path: internal_signin_url
+          ).html_safe,
+          include_blank: I18n.t(:label_none_parentheses)
+        ) do |select|
+          AuthProvider
+            .where(available: true)
+            .order("lower(display_name) ASC")
+            .select(:type, :display_name, :slug)
+            .to_a
+            .each do |provider|
+            select.option(
+              value: provider.slug,
+              label: "#{provider.display_name} (#{provider.human_type})",
+              selected: Setting.omniauth_direct_login_provider == provider.slug
+            )
+          end
         end
-      end
 
-      form.submit
+        form.submit
+      end
     end
-  end
-%>
+  %>
+<% end %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -720,6 +720,7 @@ module Settings
       oauth_allow_remapping_of_existing_users: {
         description: "When set to false, prevent users from other identity providers to take over accounts " \
                      "that exist in OpenProject.",
+        format: :boolean,
         default: true
       },
       omniauth_direct_login_provider: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2225,7 +2225,7 @@ en:
       project_list_sharing: Project List Sharing
       readonly_work_packages: Readonly Work Packages
       scim_api: SCIM server API
-      sso_auth_providers: Single sign-on
+      sso_auth_providers: Single Sign-On
       team_planner_view: Team Planner View
       virus_scanning: Antivirus Scanning
       work_package_query_relation_columns: Work Package Query Relation Columns
@@ -2296,6 +2296,9 @@ en:
       scim_api:
         title: "SCIM clients"
         description: "Automate user management in OpenProject by seamlessly integrating external identity services like Microsoft Entra or Keycloak through our SCIM Server API. Available starting with the Enterprise corporate plan."
+      sso_auth_providers:
+        title: "Single Sign-On (SSO)"
+        description: "Enable users to log in via external SSO providers using SAML or OpenID Connect for seamless access and integration with existing identity systems."
       virus_scanning:
         description: "Ensure uploaded files in OpenProject are scanned for viruses before being accessible by other users."
       placeholder_users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4033,6 +4033,7 @@ en:
   setting_attachment_whitelist: "Attachment upload whitelist"
   setting_email_delivery_method: "Email delivery method"
   setting_emails_salutation: "Address user in emails with"
+  setting_oauth_allow_remapping_of_existing_users: "Allow remapping of existing users"
   setting_sendmail_location: "Location of the sendmail executable"
   setting_smtp_enable_starttls_auto: "Automatically use STARTTLS if available"
   setting_smtp_ssl: "Use SSL connection"
@@ -4216,6 +4217,10 @@ en:
         <br/>
         <strong>Note:</strong> Unless you also disable password logins, with this option enabled,
         users can still log in internally by visiting the <code>%{internal_path}</code> login page.
+      remapping_existing_users_hint: >
+        If enabled, allows any configured identity provider to login existing users based on their email address,
+        even if the user never logged in through that provider before. This can be useful when migrating to a new SSO provider,
+        but is not recommended when using a provider that is not trusted by all users of your instance.
     attachments:
       whitelist_text_html: >
         Define a list of valid file extensions and/or mime types for uploaded files.


### PR DESCRIPTION
This setting was previously inaccessible through the UI, even though it's safe to be exposed to admins and we should give them the option to disable it easily.

# Ticket
https://community.openproject.org/wp/65908