### PR TITLE
restrict query props on /projects for bots

### DIFF
--- a/app/views/homescreen/robots.text.erb
+++ b/app/views/homescreen/robots.text.erb
@@ -40,3 +40,7 @@ Disallow: /activity
 Disallow: <%= search_path %>
 Disallow: /project_queries/configure_view_modal
 Disallow: /projects/export_list_modal
+<%# Generally allow /projects but disallow those links that change columns, sort order or per page settings %>
+Disallow: /projects?*columns=
+Disallow: /projects?*sortBy=
+Disallow: /projects?*per_page=


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Reduce the load on /projects by preventing bots to call links having columns, sortBy or per_page properties in their query props.

