### PR TITLE
Bug/66405 poor performance on workpackage visible scope

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -622,6 +622,11 @@ module Settings
       journal_aggregation_time_minutes: {
         default: 5
       },
+      large_instance_wp_allowed_to_sql: {
+        description: "When querying for allowed work packages, use SQL better suited for instances " \
+                     "with a larger set of work packages, projects, members and users",
+        default: false
+      },
       ldap_force_no_page: {
         description: "Force LDAP to respond as a single page, in case paged responses do not work with your server.",
         format: :string,

--- a/docs/installation-and-operations/configuration/environment/README.md
+++ b/docs/installation-and-operations/configuration/environment/README.md
@@ -113,18 +113,26 @@ The default value is also visible for each variable in parenthesis. The followin
 
 ```shell
 OPENPROJECT_ACTIVITY__DAYS__DEFAULT (default=30) Days displayed on project activity
+OPENPROJECT_ADDITIONAL__HOST__NAMES (default=[]) Additional allowed host names for the application.
 OPENPROJECT_AFTER__FIRST__LOGIN__REDIRECT__URL (default=nil) URL users logging in for the first time will be redirected to (e.g., a help screen)
-OPENPROJECT_AFTER__LOGIN__DEFAULT__REDIRECT__URL (default=nil) Override URL to which logged in users are redirected instead of the home page, if no other redirect URL is set
+OPENPROJECT_AFTER__LOGIN__DEFAULT__REDIRECT__URL (default=nil) Override URL to which logged in users are redirected instead of the Home page
+OPENPROJECT_ALLOW__TRACKING__START__AND__END__TIMES (default=false) Allow start and finish times
+OPENPROJECT_ALLOWED__LINK__PROTOCOLS (default=[]) Allowed protocols for links in the WYSIWYG editor and formatted texts
+OPENPROJECT_ANTIVIRUS__SCAN__ACTION (default=:quarantine) Virus scanning action for found infected files
+OPENPROJECT_ANTIVIRUS__SCAN__AVAILABLE (default=true) Virus scanning option selectable in the UI
+OPENPROJECT_ANTIVIRUS__SCAN__MODE (default=:disabled) Virus scanning option for files uploaded to OpenProject
+OPENPROJECT_ANTIVIRUS__SCAN__TARGET (default=nil) The socket or hostname to connect to ClamAV
 OPENPROJECT_APIV3__CORS__ENABLED (default=false) Enable CORS headers for APIv3 server responses
 OPENPROJECT_APIV3__CORS__ORIGINS (default=[]) API V3 Cross-Origin Resource Sharing (CORS) allowed origins
 OPENPROJECT_APIV3__DOCS__ENABLED (default=true) Enable interactive APIv3 documentation as part of the application
 OPENPROJECT_APIV3__ENABLE__BASIC__AUTH (default=true) Enable API token or global basic authentication for APIv3 requests
 OPENPROJECT_APIV3__MAX__PAGE__SIZE (default=1000) Maximum API page size
+OPENPROJECT_APIV3__WRITE__READONLY__ATTRIBUTES (default=false) Allow overriding readonly attributes (e.g. createdAt, updatedAt, author) during the creation of resources via the REST API
 OPENPROJECT_APP__TITLE (default="OpenProject") Application title
 OPENPROJECT_APPSIGNAL__FRONTEND__KEY (default=nil) Appsignal API key for JavaScript error reporting
 OPENPROJECT_ATTACHMENT__MAX__SIZE (default=5120) Attachment max. size
 OPENPROJECT_ATTACHMENT__WHITELIST (default=[]) Attachment upload whitelist
-OPENPROJECT_ATTACHMENTS__GRACE__PERIOD (default=180) Time to wait before uploaded files not attached to any container are removed
+OPENPROJECT_ATTACHMENTS__GRACE__PERIOD (default=180) Time in minutes to wait before uploaded files not attached to any container are removed
 OPENPROJECT_ATTACHMENTS__STORAGE (default=:file) File storage configuration
 OPENPROJECT_ATTACHMENTS__STORAGE__PATH (default=nil) File storage disk location (only applicable for local file storage)
 OPENPROJECT_AUTH__SOURCE__SSO (default=nil) Configuration for Header-based Single Sign-On
@@ -133,8 +141,7 @@ OPENPROJECT_AUTOFETCH__CHANGESETS (default=true) Autofetch repository changes
 OPENPROJECT_AUTOLOGIN (default=0) Autologin
 OPENPROJECT_AUTOLOGIN__COOKIE__NAME (default="autologin") Cookie name for autologin cookie
 OPENPROJECT_AUTOLOGIN__COOKIE__PATH (default="/") Cookie path for autologin cookie
-OPENPROJECT_AUTOLOGIN__COOKIE__SECURE (default=false) Cookie secure mode for autologin cookie
-OPENPROJECT_AVAILABLE__LANGUAGES (default=["en", "de", "fr", "es", "pt", "it", "zh-CN", "ko", "ru"]) Available languages
+OPENPROJECT_AVAILABLE__LANGUAGES (default=["ca", "cs", "de", "el", "en", "es", "fr", "hu", "id", "it", "ja", "ko", "lt", "nl", "no", "pl", "pt-BR", "pt-PT", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "zh-CN", "zh-TW"]) Available languages
 OPENPROJECT_AVATAR__LINK__EXPIRY__SECONDS (default=86400) Cache duration for avatar image API responses
 OPENPROJECT_BACKUP__ATTACHMENT__SIZE__MAX__SUM__MB (default=1024) Maximum limit of attachment size to include into application backups
 OPENPROJECT_BACKUP__DAILY__LIMIT (default=3) Maximum number of application backups allowed per day
@@ -150,7 +157,7 @@ OPENPROJECT_CACHE__EXPIRES__IN__SECONDS (default=nil) Expiration time for memcac
 OPENPROJECT_CACHE__FORMATTED__TEXT (default=true) Cache formatted text
 OPENPROJECT_CACHE__MEMCACHE__SERVER (default=nil) The memcache server host and IP
 OPENPROJECT_CACHE__NAMESPACE (default=nil) Namespace for cache keys, useful when multiple applications use a single memcache server
-OPENPROJECT_COMMIT__FIX__DONE__RATIO (default=100) Progress to apply when commit fixes work package
+OPENPROJECT_CACHE__REDIS__URL (default=nil) URL to the redis cache server
 OPENPROJECT_COMMIT__FIX__KEYWORDS (default="fixes,closes") Keywords to look for in commit for fixing work packages
 OPENPROJECT_COMMIT__FIX__STATUS__ID (default=nil) Assigned status when fixing keyword is found
 OPENPROJECT_COMMIT__LOGS__ENCODING (default="UTF-8") Encoding used to convert commit logs to UTF-8
@@ -158,51 +165,60 @@ OPENPROJECT_COMMIT__LOGTIME__ACTIVITY__ID (default=nil) Activity for logged time
 OPENPROJECT_COMMIT__LOGTIME__ENABLED (default=false) Allow logging time through commit message
 OPENPROJECT_COMMIT__REF__KEYWORDS (default="refs,references,IssueID") Keywords used in commits for referencing work packages
 OPENPROJECT_CONSENT__DECLINE__MAIL (default=nil) Consent contact mail address
-OPENPROJECT_CONSENT__INFO (default={"en"=>"## Consent\n\nYou need to agree to the [privacy and security policy](https://www.openproject.org/data-privacy-and-security/) of this OpenProject instance."}) Consent information text
+OPENPROJECT_CONSENT__INFO (default={"en" => "## Consent\n\nYou need to agree to the [privacy and security policy](https://www.openproject.org/data-privacy-and-security/) of this OpenProject instance."}) Consent information text
 OPENPROJECT_CONSENT__REQUIRED (default=false) Consent required
 OPENPROJECT_CONSENT__TIME (default=nil) Consent time
 OPENPROJECT_COST__REPORTING__CACHE__FILTER__CLASSES (default=true)
+OPENPROJECT_COSTS__CURRENCY (default="EUR") Currency
+OPENPROJECT_COSTS__CURRENCY__FORMAT (default="%n %u") Format of currency
 OPENPROJECT_CROSS__PROJECT__WORK__PACKAGE__RELATIONS (default=true) Allow cross-project work package relations
-OPENPROJECT_CROWDIN__IN__CONTEXT__TRANSLATIONS (default=true) Add crowdin in-context translations helper
 OPENPROJECT_DATABASE__CIPHER__KEY (default=nil) Encryption key for repository credentials
 OPENPROJECT_DATE__FORMAT (default=nil) Date
+OPENPROJECT_DAYS__PER__MONTH (default=20) This will define what is considered a “month” when displaying duration in a more natural way (for example, if a month is 20 days, 60 days would be 3 months.
 OPENPROJECT_DEFAULT__AUTO__HIDE__POPUPS (default=true) Whether to automatically hide success notifications by default
 OPENPROJECT_DEFAULT__COMMENT__SORT__ORDER (default="asc") Default sort order for activities
 OPENPROJECT_DEFAULT__LANGUAGE (default="en") Default language
-OPENPROJECT_DEFAULT__PROJECTS__MODULES (default=["calendar", "board_view", "work_package_tracking", "news", "costs", "wiki"]) Default enabled modules for new projects
+OPENPROJECT_DEFAULT__PROJECTS__MODULES (default=["calendar", "board_view", "work_package_tracking", "gantt", "news", "costs", "wiki"]) Default enabled modules for new projects
 OPENPROJECT_DEFAULT__PROJECTS__PUBLIC (default=false) New projects are public by default
 OPENPROJECT_DEMO__PROJECTS__AVAILABLE (default=false)
+OPENPROJECT_DEMO__VIEW__OF__TYPE__GANTT__SEEDED (default=false)
 OPENPROJECT_DEMO__VIEW__OF__TYPE__TEAM__PLANNER__SEEDED (default=false)
 OPENPROJECT_DEMO__VIEW__OF__TYPE__WORK__PACKAGES__TABLE__SEEDED (default=false)
+OPENPROJECT_DEVELOPMENT__HIGHLIGHT__ENABLED (default=false) Enable highlighting of development environment
 OPENPROJECT_DIFF__MAX__LINES__DISPLAYED (default=1500) Max number of diff lines displayed
 OPENPROJECT_DIRECT__UPLOADS (default=true) Enable direct uploads to AWS S3. Only applicable with enabled Fog / AWS S3 configuration
 OPENPROJECT_DISABLE__BROWSER__CACHE (default=true) Prevent browser from caching any logged-in responses for security reasons
+OPENPROJECT_DISABLE__KEYBOARD__SHORTCUTS (default=false) Whether keyboard short cuts should be disabled (e.g. for better screen reader support)
 OPENPROJECT_DISABLE__PASSWORD__CHOICE (default=false) If enabled a user's password cannot be set to an arbitrary value, but can only be randomized.
-OPENPROJECT_DISABLE__YJIT (default=false) Disables Ruby's YJIT JIT compiler.
 OPENPROJECT_DISABLE__PASSWORD__LOGIN (default=false) Disable internal logins and instead only allow SSO through OmniAuth.
 OPENPROJECT_DISABLED__MODULES (default=[]) A list of module names to prevent access to in the application
 OPENPROJECT_DISPLAY__SUBPROJECTS__WORK__PACKAGES (default=true) Display subprojects work packages on main projects by default
 OPENPROJECT_DROP__OLD__SESSIONS__ON__LOGIN (default=false) Destroy all sessions for current_user on login
 OPENPROJECT_DROP__OLD__SESSIONS__ON__LOGOUT (default=true) Destroy all sessions for current_user on logout
+OPENPROJECT_DURATION__FORMAT (default="hours_only") Format for displaying durations
 OPENPROJECT_EDITION (default="standard") OpenProject edition mode
-OPENPROJECT_EE__MANAGER__VISIBLE (default=true) Show or hide the Enterprise configuration page and enterprise banners
 OPENPROJECT_EE__HIDE__BANNERS (default=false) Hide the Enterprise enterprise banners
+OPENPROJECT_EE__MANAGER__VISIBLE (default=true) Show the Enterprise configuration page
 OPENPROJECT_EMAIL__DELIVERY__CONFIGURATION (default="inapp")
 OPENPROJECT_EMAIL__DELIVERY__METHOD (default=nil) Email delivery method
 OPENPROJECT_EMAIL__LOGIN (default=false) Use email as login
-OPENPROJECT_EMAILS__FOOTER (default={"en"=>""}) Emails footer
-OPENPROJECT_EMAILS__HEADER (default={"en"=>""}) Emails header
+OPENPROJECT_EMAILS__FOOTER (default={"en" => ""}) Emails footer
+OPENPROJECT_EMAILS__HEADER (default={"en" => ""}) Emails header
+OPENPROJECT_EMAILS__SALUTATION (default=:firstname) Address user in emails with
 OPENPROJECT_ENABLE__INTERNAL__ASSETS__SERVER (default=false) Serve assets through the Rails internal asset server
-OPENPROJECT_ENABLED__PROJECTS__COLUMNS (default=["project_status", "public", "created_at", "latest_activity_at", "required_disk_space"]) Visible in project list
+OPENPROJECT_ENABLED__PROJECTS__COLUMNS (default=["favored", "name", "project_status", "public", "created_at", "latest_activity_at", "required_disk_space"]) Columns in a projects list displayed by default
 OPENPROJECT_ENABLED__SCM (default=["subversion", "git"]) Enabled SCM
+OPENPROJECT_ENFORCE__TRACKING__START__AND__END__TIMES (default=false) Require start and finish times
 OPENPROJECT_ENTERPRISE__CHARGEBEE__SITE (default="openproject-enterprise") Site name for EE trial service
 OPENPROJECT_ENTERPRISE__PLAN (default="enterprise-on-premises---basic---euro---1-year") Default EE selected plan
-OPENPROJECT_ENTERPRISE__TRIAL__CREATION__HOST (default="https://augur.openproject.com") Host for EE trial service
-OPENPROJECT_FEATURE__MANAGED__PROJECT__FOLDERS__ACTIVE (default=true)
-OPENPROJECT_FEATURE__MORE__GLOBAL__INDEX__PAGES__ACTIVE (default=true)
-OPENPROJECT_FEATURE__SHOW__CHANGES__ACTIVE (default=true)
-OPENPROJECT_FEATURE__STORAGE__FILE__PICKING__SELECT__ALL__ACTIVE (default=true)
-OPENPROJECT_FEATURE__STORAGE__PROJECT__FOLDERS__ACTIVE (default=true)
+OPENPROJECT_ENTERPRISE__TRIAL__CREATION__HOST (default="https://start.openproject.com") Host for EE trial service
+OPENPROJECT_FEATURE__BLOCK__NOTE__EDITOR__ACTIVE (default=false) Enables the block note editor for rich text fields where available.
+OPENPROJECT_FEATURE__BUILT__IN__OAUTH__APPLICATIONS__ACTIVE (default=false) Allows the display and use of built-in OAuth applications.
+OPENPROJECT_FEATURE__CALCULATED__VALUE__PROJECT__ATTRIBUTE__ACTIVE (default=false) Allows the use of calculated values as a project attribute.
+OPENPROJECT_FEATURE__DEPLOY__TARGETS__ACTIVE (default=false)
+OPENPROJECT_FEATURE__OIDC__GROUP__SYNC__ACTIVE (default=false) Allows to synchronize groups from OpenID Connect providers
+OPENPROJECT_FEATURE__SCIM__API__ACTIVE (default=true) Enables SCIM API.
+OPENPROJECT_FEATURE__STORAGE__FILE__PICKING__SELECT__ALL__ACTIVE (default=false)
 OPENPROJECT_FEEDS__ENABLED (default=true) Enable Feeds
 OPENPROJECT_FEEDS__LIMIT (default=15) Feed content limit
 OPENPROJECT_FILE__MAX__SIZE__DISPLAYED (default=512) Max size of text files displayed inline
@@ -212,32 +228,45 @@ OPENPROJECT_FOG__DOWNLOAD__URL__EXPIRES__IN (default=21600) Expiration time in s
 OPENPROJECT_FORCE__FORMATTING__HELP__LINK (default=nil) You can set a custom URL for the help button in the WYSIWYG editor.
 OPENPROJECT_FORCE__HELP__LINK (default=nil) You can set a custom URL for the help button in application header menu.
 OPENPROJECT_FORCED__SINGLE__PAGE__SIZE (default=250) Forced page size for manually sorted work package views
+OPENPROJECT_GOOD__JOB__CLEANUP__PRESERVED__JOBS__BEFORE__SECONDS__AGO (default=604800)
+OPENPROJECT_GOOD__JOB__ENABLE__CRON (default=true)
+OPENPROJECT_GOOD__JOB__MAX__CACHE (default=10000)
+OPENPROJECT_GOOD__JOB__MAX__THREADS (default=20)
+OPENPROJECT_GOOD__JOB__QUEUES (default="*")
 OPENPROJECT_GRAVATAR__FALLBACK__IMAGE (default="404") Set default gravatar image fallback
 OPENPROJECT_HEALTH__CHECKS__AUTHENTICATION__PASSWORD (default=nil) Add an authentication challenge for the /health_check endpoint
 OPENPROJECT_HEALTH__CHECKS__BACKLOG__THRESHOLD (default=20) Set threshold of outstanding HTTP requests to fail health check
 OPENPROJECT_HEALTH__CHECKS__JOBS__NEVER__RAN__MINUTES__AGO (default=5) Set threshold of outstanding background jobs to fail health check
-OPENPROJECT_HEALTH__CHECKS__JOBS__QUEUE__COUNT__THRESHOLD (default=50) Set threshold of backed up background jobs to fail health check
 OPENPROJECT_HIDDEN__MENU__ITEMS (default={}) Hide menu items in the menu sidebar for each main menu (such as Administration and Projects).
 OPENPROJECT_HOME__URL (default=nil) Override default link when clicking on the top menu logo (Homescreen by default).
-OPENPROJECT_HOST__NAME (default="localhost:3000") Host name
+OPENPROJECT_HOST__NAME (default=nil) Host name
+OPENPROJECT_HOURS__PER__DAY (default=8) This will define what is considered a “day” when displaying duration in a more natural way (for example, if a day is 8 hours, 32 hours would be 4 days).
 OPENPROJECT_HSTS (default=true) Allow disabling of HSTS headers and http -> https redirects
-OPENPROJECT_HTTPS (default=false) Set assumed connection security for the Rails processes
-OPENPROJECT_ICAL__ENABLED (default=true) Enable iCalendar Subscriptions
+OPENPROJECT_HTTPS (default=true) Set assumed connection security for the Rails processes
+OPENPROJECT_HTTPX__CONNECT__TIMEOUT (default=3.0)
+OPENPROJECT_HTTPX__KEEP__ALIVE__TIMEOUT (default=20.0)
+OPENPROJECT_HTTPX__OPERATION__TIMEOUT (default=10.0)
+OPENPROJECT_HTTPX__READ__TIMEOUT (default=3.0)
+OPENPROJECT_HTTPX__REQUEST__TIMEOUT (default=10.0)
+OPENPROJECT_HTTPX__WRITE__TIMEOUT (default=3.0)
+OPENPROJECT_ICAL__ENABLED (default=true) Enable iCalendar subscriptions
 OPENPROJECT_IMPRESSUM__LINK (default=nil) Impressum link to be set, hidden by default
 OPENPROJECT_INSTALLATION__TYPE (default="manual")
 OPENPROJECT_INSTALLATION__UUID (default=nil)
 OPENPROJECT_INTERNAL__PASSWORD__CONFIRMATION (default=true) Require password confirmations for certain administrative actions
 OPENPROJECT_INVITATION__EXPIRATION__DAYS (default=7) Activation email expires after
 OPENPROJECT_JOURNAL__AGGREGATION__TIME__MINUTES (default=5) User actions aggregated within
+OPENPROJECT_LARGE__INSTANCE__WP__ALLOWED__TO__SQL (default=false) When querying for allowed work packages, use SQL better suited for instances with a larger set of work packages, projects, members and users
 OPENPROJECT_LDAP__FORCE__NO__PAGE (default=nil) Force LDAP to respond as a single page, in case paged responses do not work with your server.
 OPENPROJECT_LDAP__GROUPS__DISABLE__SYNC__JOB (default=false) Deactivate regular synchronization job for groups in case scheduled as a separate cronjob
-OPENPROJECT_LDAP__TLS__OPTIONS (default={})
-OPENPROJECT_LDAP__USERS__DISABLE__SYNC__JOB (default=false) Deactive user attributes synchronization from LDAP
+OPENPROJECT_LDAP__USERS__DISABLE__SYNC__JOB (default=false) Deactivate user attributes synchronization from LDAP
 OPENPROJECT_LDAP__USERS__SYNC__STATUS (default=false) Enable user status (locked/unlocked) synchronization from LDAP
-OPENPROJECT_LOG__LEVEL (default="debug") Set the OpenProject logger level
+OPENPROJECT_LOG__LEVEL (default="info") Set the OpenProject logger level
 OPENPROJECT_LOG__REQUESTING__USER (default=false) Log user login, name, and mail address for all requests
-OPENPROJECT_LOGIN__REQUIRED (default=false) Authentication required
-OPENPROJECT_LOGRAGE__FORMATTER (default=nil) Use lograge formatter for outputting logs
+OPENPROJECT_LOGIN__REQUIRED (default=true) Authentication required
+OPENPROJECT_LOGRAGE__ENABLED (default=true) Use lograge formatter for outputting logs
+OPENPROJECT_LOGRAGE__FORMATTER (default="key_value") Lograge formatter to use for outputting logs
+OPENPROJECT_LOOKBOOK__ENABLED (default=false) Enable the Lookbook component documentation tool. Discouraged for production environments.
 OPENPROJECT_LOST__PASSWORD (default=true) Activate or deactivate lost password form
 OPENPROJECT_MAIL__FROM (default="openproject@example.net") Emission email address
 OPENPROJECT_MAIL__HANDLER__API__KEY (default=nil) API key
@@ -248,11 +277,12 @@ OPENPROJECT_MAIL__SUFFIX__SEPARATORS (default="+")
 OPENPROJECT_MAIN__CONTENT__LANGUAGE (default="english") Main content language for PostgreSQL full text features
 OPENPROJECT_MIGRATION__CHECK__ON__EXCEPTIONS (default=true) Check for missing migrations in internal errors
 OPENPROJECT_NEW__PROJECT__USER__ROLE__ID (default=nil) Role given to a non-admin user who creates a project
-OPENPROJECT_OAUTH__ALLOW__REMAPPING__OF__EXISTING__USERS (default=true) When set to false, prevent users from other identity providers to take over accounts connected to another identity provider.
+OPENPROJECT_NOTIFICATIONS__HIDDEN (default=false)
+OPENPROJECT_NOTIFICATIONS__POLLING__INTERVAL (default=60000)
+OPENPROJECT_OAUTH__ALLOW__REMAPPING__OF__EXISTING__USERS (default=true) When set to false, prevent users from other identity providers to take over accounts that exist in OpenProject.
 OPENPROJECT_OMNIAUTH__DIRECT__LOGIN__PROVIDER (default=nil) Clicking on login sends a login request to the specified OmniAuth provider.
 OPENPROJECT_ONBOARDING__ENABLED (default=true) Enable or disable onboarding guided tour for new users
 OPENPROJECT_ONBOARDING__VIDEO__URL (default="https://player.vimeo.com/video/163426858?autoplay=1") Onboarding guide instructional video URL
-OPENPROJECT_OPENID__CONNECT (default={})
 OPENPROJECT_OVERRIDE__BCRYPT__COST__FACTOR (default=nil) Set a custom BCrypt cost factor for deriving a user's bcrypt hash.
 OPENPROJECT_PASSWORD__ACTIVE__RULES (default=["lowercase", "uppercase", "numeric", "special"]) Active character classes
 OPENPROJECT_PASSWORD__COUNT__FORMER__BANNED (default=0) Number of most recently used passwords banned for reuse
@@ -260,49 +290,56 @@ OPENPROJECT_PASSWORD__DAYS__VALID (default=0) Number of days, after which to enf
 OPENPROJECT_PASSWORD__MIN__ADHERED__RULES (default=0) Minimum number of required classes
 OPENPROJECT_PASSWORD__MIN__LENGTH (default=10) Minimum length
 OPENPROJECT_PER__PAGE__OPTIONS (default="20, 100") Objects per page options
+OPENPROJECT_PERCENT__COMPLETE__ON__STATUS__CLOSED (default="no_change") Describes how % complete should change when setting a work package status to a closed one
 OPENPROJECT_PLAIN__TEXT__MAIL (default=false) Plain text mail (no HTML)
-OPENPROJECT_PLUGIN__COSTS (default={"costs_currency"=>"EUR", "costs_currency_format"=>"%n %u"})
-OPENPROJECT_PLUGIN__OPENPROJECT__AUTH__SAML (default={"providers"=>nil})
-OPENPROJECT_PLUGIN__OPENPROJECT__AVATARS (default={"enable_gravatars"=>true, "enable_local_avatars"=>true})
-OPENPROJECT_PLUGIN__OPENPROJECT__BACKLOGS (default={"story_types"=>nil, "task_type"=>nil, "points_burn_direction"=>"up", "wiki_template"=>""})
+OPENPROJECT_PLUGIN__COSTS (default=nil)
+OPENPROJECT_PLUGIN__OPENPROJECT__AUTH__SAML (default={"providers" => nil})
+OPENPROJECT_PLUGIN__OPENPROJECT__AVATARS (default={"enable_gravatars" => true, "enable_local_avatars" => true})
+OPENPROJECT_PLUGIN__OPENPROJECT__BACKLOGS (default={"story_types" => nil, "task_type" => nil, "points_burn_direction" => "up", "wiki_template" => ""})
 OPENPROJECT_PLUGIN__OPENPROJECT__BIM (default={})
 OPENPROJECT_PLUGIN__OPENPROJECT__BOARDS (default=nil)
 OPENPROJECT_PLUGIN__OPENPROJECT__CALENDAR (default=nil)
+OPENPROJECT_PLUGIN__OPENPROJECT__GANTT (default=nil)
+OPENPROJECT_PLUGIN__OPENPROJECT__GITHUB__INTEGRATION (default={"github_user_id" => nil})
 OPENPROJECT_PLUGIN__OPENPROJECT__LDAP__GROUPS (default={})
 OPENPROJECT_PLUGIN__OPENPROJECT__OPENID__CONNECT (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__RECAPTCHA (default={"recaptcha_type"=>"disabled"})
+OPENPROJECT_PLUGIN__OPENPROJECT__RECAPTCHA (default={"recaptcha_type" => "disabled", "response_limit" => 5000})
 OPENPROJECT_PLUGIN__OPENPROJECT__STORAGES (default=nil)
 OPENPROJECT_PLUGIN__OPENPROJECT__TEAM__PLANNER (default=nil)
-OPENPROJECT_PLUGIN__OPENPROJECT__TWO__FACTOR__AUTHENTICATION (default={"active_strategies"=>[], "enforced"=>false, "allow_remember_for_days"=>0})
+OPENPROJECT_PLUGIN__OPENPROJECT__TWO__FACTOR__AUTHENTICATION (default={"active_strategies" => [], "enforced" => false, "allow_remember_for_days" => 0})
 OPENPROJECT_PROJECT__GANTT__QUERY (default=nil) Project portfolio Gantt view
-OPENPROJECT_PROMETHEUS_EXPORT (default: nil) Enable Prometheus export endpoint
 OPENPROJECT_RAILS__ASSET__HOST (default=nil) Custom asset hostname for serving assets (e.g., Cloudfront)
-OPENPROJECT_RAILS__CACHE__STORE (default=:file_store) Set cache store implemenation to use with OpenProject
+OPENPROJECT_RAILS__CACHE__STORE (default=:file_store) Set cache store implementation to use with OpenProject
 OPENPROJECT_RAILS__RELATIVE__URL__ROOT (default="") Set a URL prefix / base path to run OpenProject under, e.g., host.tld/openproject
+OPENPROJECT_RATE__LIMITING (default={}) Configure rate limiting for various endpoint rules. See configuration documentation for details.
 OPENPROJECT_RECAPTCHA__VIA__HCAPTCHA (default=false)
-OPENPROJECT_REGISTRATION__FOOTER (default={"en"=>""}) Registration footer
+OPENPROJECT_REGISTRATION__FOOTER (default={"en" => ""}) Registration footer
 OPENPROJECT_REMOTE__STORAGE__DOWNLOAD__HOST (default=nil) Host the frontend uses to download files, which has to be added to the CSP.
 OPENPROJECT_REMOTE__STORAGE__UPLOAD__HOST (default=nil) Host the frontend uses to upload files to, which has to be added to the CSP.
 OPENPROJECT_REPORT__INCOMING__EMAIL__ERRORS (default=true) Respond to incoming mails with error details
 OPENPROJECT_REPOSITORIES__AUTOMATIC__MANAGED__VENDOR (default=nil) Automatic repository vendor type
 OPENPROJECT_REPOSITORIES__ENCODINGS (default=nil) Repositories encodings
-OPENPROJECT_REPOSITORY__AUTHENTICATION__CACHING__ENABLED (default=true) Enable caching for authentication request of version control software
-OPENPROJECT_REPOSITORY__CHECKOUT__DATA (default={"git"=>{"enabled"=>0}, "subversion"=>{"enabled"=>0}})
+OPENPROJECT_REPOSITORY__CHECKOUT__DATA (default={"git" => {"enabled" => 0}, "subversion" => {"enabled" => 0}})
 OPENPROJECT_REPOSITORY__LOG__DISPLAY__LIMIT (default=100) Maximum number of revisions displayed on file log
 OPENPROJECT_REPOSITORY__STORAGE__CACHE__MINUTES (default=720) Repository disk size cache
 OPENPROJECT_REPOSITORY__TRUNCATE__AT (default=500) Maximum number of files displayed in the repository browser
 OPENPROJECT_REST__API__ENABLED (default=true) Enable REST web service
-OPENPROJECT_SAML (default=nil)
 OPENPROJECT_SCM (default={})
 OPENPROJECT_SCM__GIT__COMMAND (default=nil)
 OPENPROJECT_SCM__LOCAL__CHECKOUT__PATH (default="repositories")
 OPENPROJECT_SCM__SUBVERSION__COMMAND (default=nil)
 OPENPROJECT_SECURITY__BADGE__DISPLAYED (default=true) Display security badge
 OPENPROJECT_SECURITY__BADGE__URL (default="https://releases.openproject.com/v1/check.svg") URL of the update check badge
+OPENPROJECT_SEED__ADMIN__USER__LOCKED (default=false) Lock the created admin user after seeding, so it can not be used for logging in. If set to true, an admin user has to be created manually or through an SSO provider.
 OPENPROJECT_SEED__ADMIN__USER__MAIL (default="admin@example.net") E-mail to set for the initially created admin user.
 OPENPROJECT_SEED__ADMIN__USER__NAME (default="OpenProject Admin") Name to set for the initially created admin user.
 OPENPROJECT_SEED__ADMIN__USER__PASSWORD (default="admin") Password to set for the initially created admin user (Login remains "admin").
 OPENPROJECT_SEED__ADMIN__USER__PASSWORD__RESET (default=true) Whether to force a password reset for the initially created admin user.
+OPENPROJECT_SEED__DESIGN (default=nil) Seed enterprise-edition theme colors and logos through ENV
+OPENPROJECT_SEED__ENTERPRISE__TOKEN (default=nil) Seed enterprise-edition token through ENV
+OPENPROJECT_SEED__LDAP (default=nil) Provide an LDAP connection and sync settings through ENV
+OPENPROJECT_SEED__OIDC__PROVIDER (default={}) Provide a OIDC provider and sync its settings through ENV
+OPENPROJECT_SEED__SAML__PROVIDER (default={}) Provide a SAML provider and sync its settings through ENV
 OPENPROJECT_SELF__REGISTRATION (default=2) Self-registration
 OPENPROJECT_SENDMAIL__ARGUMENTS (default="-i") Arguments to call sendmail with in case it is configured as outgoing email setup
 OPENPROJECT_SENDMAIL__LOCATION (default="/usr/sbin/sendmail") Location of sendmail to call if it is configured as outgoing email setup
@@ -311,9 +348,11 @@ OPENPROJECT_SESSION__TTL (default=120) Session expiry time after inactivity
 OPENPROJECT_SESSION__TTL__ENABLED (default=false) Session expires
 OPENPROJECT_SHOW__COMMUNITY__LINKS (default=true) Enable or disable links to OpenProject community instances
 OPENPROJECT_SHOW__PENDING__MIGRATIONS__WARNING (default=true) Enable or disable warning bar in case of pending migrations
+OPENPROJECT_SHOW__PRODUCT__VERSION (default=true) Show product version information in the administration section
 OPENPROJECT_SHOW__SETTING__MISMATCH__WARNING (default=true) Show mismatched protocol/hostname warning. In cases where they must differ this can be disabled
 OPENPROJECT_SHOW__STORAGE__INFORMATION (default=true) Show available and taken storage information under administration / info
 OPENPROJECT_SHOW__WARNING__BARS (default=true) Render warning bars (pending migrations, deprecation, unsupported browsers)
+OPENPROJECT_SHOW__WORK__PACKAGE__ATTACHMENTS (default=true) Show work package attachments by default.
 OPENPROJECT_SMTP__ADDRESS (default="") SMTP server
 OPENPROJECT_SMTP__AUTHENTICATION (default="plain") SMTP authentication
 OPENPROJECT_SMTP__DOMAIN (default="your.domain.com") SMTP HELO domain
@@ -322,27 +361,30 @@ OPENPROJECT_SMTP__OPENSSL__VERIFY__MODE (default="peer") Globally set verify mod
 OPENPROJECT_SMTP__PASSWORD (default="") SMTP password
 OPENPROJECT_SMTP__PORT (default=587) SMTP port
 OPENPROJECT_SMTP__SSL (default=false) Use SSL connection
+OPENPROJECT_SMTP__TIMEOUT (default=5)
 OPENPROJECT_SMTP__USER__NAME (default="") SMTP username
 OPENPROJECT_SOFTWARE__NAME (default="OpenProject") Override software application name
 OPENPROJECT_SOFTWARE__URL (default="https://www.openproject.org/") Override software application URL
 OPENPROJECT_SQL__SLOW__QUERY__THRESHOLD (default=2000) Time limit in ms after which queries will be logged as slow queries
 OPENPROJECT_START__OF__WEEK (default=nil) Week starts on
-OPENPROJECT_STATSD (default={"host"=>nil, "port"=>8125}) enable statsd metrics (currently puma only) by configuring host
+OPENPROJECT_STATSD (default={"host" => nil, "port" => 8125}) enable statsd metrics (currently puma only) by configuring host
 OPENPROJECT_SYS__API__ENABLED (default=false) Enable internal system API for setting up managed repositories
 OPENPROJECT_SYS__API__KEY (default=nil) Internal system API key for setting up managed repositories
 OPENPROJECT_TIME__FORMAT (default=nil) Time
+OPENPROJECT_TOTAL__PERCENT__COMPLETE__MODE (default="work_weighted_average") Mode in which the total % Complete for work packages in a hierarchy is calculated
+OPENPROJECT_USER__DEFAULT__THEME (default="light")
 OPENPROJECT_USER__DEFAULT__TIMEZONE (default=nil) Users default time zone
 OPENPROJECT_USER__FORMAT (default=:firstname_lastname) Users name format
 OPENPROJECT_USERS__DELETABLE__BY__ADMINS (default=false) User accounts deletable by admins
 OPENPROJECT_USERS__DELETABLE__BY__SELF (default=false) Users allowed to delete their accounts
-OPENPROJECT_WEB (default={"workers"=>2, "timeout"=>120, "wait_timeout"=>10, "min_threads"=>4, "max_threads"=>16}) Web worker count and threads configuration
+OPENPROJECT_WEB (default={"workers" => 2, "timeout" => 120, "wait_timeout" => 30, "min_threads" => 4, "max_threads" => 16}) Web worker count and threads configuration
 OPENPROJECT_WELCOME__ON__HOMESCREEN (default=false) Display welcome block on homescreen
 OPENPROJECT_WELCOME__TEXT (default=nil) Welcome block text
 OPENPROJECT_WELCOME__TITLE (default=nil) Welcome block title
-OPENPROJECT_WORK__PACKAGE__DONE__RATIO (default="field") Calculate the work package done ratio with
-OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__COLUMNS (default=["id", "subject", "type", "status", "assigned_to", "priority"]) Display by default
-OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTED__ATTRIBUTES (default=[]) Default inline highlighted attributes
-OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTING__MODE (default="none") Default highlighting mode
+OPENPROJECT_WORK__PACKAGE__DONE__RATIO (default="field") Progress calculation mode
+OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__COLUMNS (default=["id", "subject", "type", "status", "assigned_to", "priority"])
+OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTED__ATTRIBUTES (default=["status", "priority", "due_date"]) Default inline highlighted attributes
+OPENPROJECT_WORK__PACKAGE__LIST__DEFAULT__HIGHLIGHTING__MODE (default="inline") Default highlighting mode
 OPENPROJECT_WORK__PACKAGE__STARTDATE__IS__ADDDATE (default=false) Use current date as start date for new work packages
 OPENPROJECT_WORK__PACKAGES__BULK__REQUEST__LIMIT (default=10)
 OPENPROJECT_WORK__PACKAGES__PROJECTS__EXPORT__LIMIT (default=500) Work packages / Projects export limit

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -146,6 +146,17 @@ RSpec.describe WorkPackage, ".allowed_to" do
           end
         end
 
+        context "when the module is inactive in the project" do
+          before do
+            public_project.enabled_modules = []
+            private_project.enabled_modules = []
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
         context "when the user is locked" do
           before do
             user.locked!
@@ -177,6 +188,17 @@ RSpec.describe WorkPackage, ".allowed_to" do
           before do
             public_project.update!(active: false)
             private_project.update!(active: false)
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the module is inactive in the project" do
+          before do
+            public_project.enabled_modules = []
+            private_project.enabled_modules = []
           end
 
           it "returns no work packages" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/66405

# What are you trying to accomplish?

Attempting to improve the performance on all the places where `WorkPackages.allowed_to` is called. There are quite a few among them:
* The check for whether a timer is running to display that information in the avatar at the top right corner. This is checked every time the menu is rendered so on every page refresh.
* Fetching the visible work packages to display in the work package table/board/team planner.
* Fetching candidates for the work package autocompleter when setting relations
* Fetching candidates for the work package autocompleter when typing in a comment field in the wp activity
* Fetching notifications

Since not all installations have the same data structure and the query shows good performance metrics on most, a setting is introduced that allows switching to an SQL structure more fit for larger installations (projects, users, members & work packages). In the past, when trying to optimize for larger instances, smaller ones had their performance decreased. With the setting, the best approach can be decided on after deployment.

On the large instance used for testing, the gains are noticeable:
* The times for a request on the root page are roughly halved from 500ms to 270ms.
* The times on a request for 200 WPs via the API drops from 5s to 3s
* The times for autocompletion on typing in a comment field drops from 600ms to 120ms.

However, there are also used cases where the performance is not improved 
* Fetching candidates for the work package autocompleter when setting relations
* Fetching notifications
But the performance on those is also not decreased.

The fix only addresses "normal users", meaning that neither the behaviour for admins nor the one for anonymous is changed. 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
