### PR TITLE
[66121] UI improvements for exisiting project "Overview" page

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -41,7 +41,6 @@
     --ck-color-panel-background: var(--overlay-bgColor);
     --ck-color-input-background: var(--overlay-bgColor);
     --status-selector-border-color: var(--button-default-borderColor-rest);
-    --grid-background-color: var(--bgColor-inset);
     --button--active-border-color: var(--button-default-borderColor-rest);
     --button--font-color: var(--button-default-fgColor-rest);
     --button--background-hover-color: var(--button-default-bgColor-hover);

--- a/app/views/homescreen/blocks/_administration.html.erb
+++ b/app/views/homescreen/blocks/_administration.html.erb
@@ -1,57 +1,59 @@
 <%= render "homescreen/blocks/header", title: t(:label_administration) %>
 
-<ul class="widget-box--arrow-links">
-  <li>
-    <%= link_to t(:label_project_plural), projects_path,
-                title: t(:label_project_plural) %>
-  </li>
-  <li>
-    <%= link_to t(:label_user_plural), users_path,
-                title: t(:label_user_plural) %>
-  </li>
-  <li>
-    <%= link_to t(:label_group_plural), groups_path,
-                title: t(:label_group_plural) %>
-  </li>
-  <li>
-    <%= link_to t(:label_role_and_permissions), roles_path,
-                title: t(:label_role_and_permissions) %>
+<div class="op-widget-box--body">
+  <ul class="widget-box--arrow-links">
+    <li>
+      <%= link_to t(:label_project_plural), projects_path,
+                  title: t(:label_project_plural) %>
+    </li>
+    <li>
+      <%= link_to t(:label_user_plural), users_path,
+                  title: t(:label_user_plural) %>
+    </li>
+    <li>
+      <%= link_to t(:label_group_plural), groups_path,
+                  title: t(:label_group_plural) %>
+    </li>
+    <li>
+      <%= link_to t(:label_role_and_permissions), roles_path,
+                  title: t(:label_role_and_permissions) %>
 
-  </li>
-  <li>
-    <%= link_to t(:label_work_package_types), types_path,
-                title: t(:label_work_package_types) %>
-  </li>
-  <li>
-    <%= link_to t(:label_work_package_status), statuses_path,
-                title: t(:label_work_package_status) %>
-  </li>
-  <li>
-    <%= link_to t(:label_workflow_plural), workflows_path,
-                title: t(:label_workflow_plural) %>
+    </li>
+    <li>
+      <%= link_to t(:label_work_package_types), types_path,
+                  title: t(:label_work_package_types) %>
+    </li>
+    <li>
+      <%= link_to t(:label_work_package_status), statuses_path,
+                  title: t(:label_work_package_status) %>
+    </li>
+    <li>
+      <%= link_to t(:label_workflow_plural), workflows_path,
+                  title: t(:label_workflow_plural) %>
 
-  </li>
-  <li>
-    <%= link_to t("attributes.custom_values"), custom_fields_path,
-                title: t("attributes.custom_values") %>
+    </li>
+    <li>
+      <%= link_to t("attributes.custom_values"), custom_fields_path,
+                  title: t("attributes.custom_values") %>
 
-  </li>
-  <li>
-    <%= link_to t(:label_system_settings), admin_settings_general_path,
-                title: t(:label_system_settings) %>
-  </li>
-  <li>
-    <%= link_to t(:label_custom_style), custom_style_path,
-                title: t(:label_custom_style) %>
-  </li>
-  <%= call_hook(:homescreen_administration_links) %>
-</ul>
+    </li>
+    <li>
+      <%= link_to t(:label_system_settings), admin_settings_general_path,
+                  title: t(:label_system_settings) %>
+    </li>
+    <li>
+      <%= link_to t(:label_custom_style), custom_style_path,
+                  title: t(:label_custom_style) %>
+    </li>
+    <%= call_hook(:homescreen_administration_links) %>
+  </ul>
 
-<%= content_tag :div, class: "security-badge--container" do %>
-  <%= content_tag :object, nil, data: security_badge_url, type: "image/svg+xml" %>
-  <%= link_to "",
-              ::OpenProject::Static::Links[:security_badge_documentation][:href],
-              title: t(:label_what_is_this),
-              class: "security-badge--help-icon icon-context icon-help1",
-              target: "_blank" %>
-<% end if display_security_badge_graphic? %>
+  <%= content_tag :div, class: "security-badge--container" do %>
+    <%= content_tag :object, nil, data: security_badge_url, type: "image/svg+xml" %>
+    <%= link_to "",
+                ::OpenProject::Static::Links[:security_badge_documentation][:href],
+                title: t(:label_what_is_this),
+                class: "security-badge--help-icon icon-context icon-help1",
+                target: "_blank", rel: "noopener" %>
+  <% end if display_security_badge_graphic? %>
+</div>

--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -1,49 +1,51 @@
 <%= render "homescreen/blocks/header", title: t("homescreen.blocks.community") %>
 
-<ul class="widget-box--arrow-links">
-  <li>
-    <%= static_link_to :user_guides %>
-  </li>
-  <li>
-    <%= static_link_to :shortcuts %>
-  </li>
-  <li>
-    <%= static_link_to :forums %></li>
-  <li>
-    <%= static_link_to (EnterpriseToken.active? ? :enterprise_support : :enterprise_support_as_community) %>
-  </li>
-  <li>
-    <%= link_to(
-          t("label_openproject_website"), "#{OpenProject::Static::Links.links[:website][:href]}/?utm_source=unknown&utm_medium=op-instance&utm_campaign=website-home-screen",
-          { aria: { label: t("label_openproject_website") },
-            target: "_blank",
-            title: t("label_openproject_website") }
-        ) %>
-  </li>
-  <li>
-    <%= link_to(
-          t("homescreen.links.newsletter"), "#{OpenProject::Static::Links.links[:newsletter][:href]}/?utm_source=unknown&utm_medium=op-instance&utm_campaign=newsletter-home-screen",
-          { aria: { label: t("homescreen.links.newsletter") },
-            target: "_blank",
-            title: t("homescreen.links.newsletter") }
-        ) %>
-  </li>
-  <li>
-    <%= static_link_to :blog %>
-  </li>
-  <li>
-    <%= static_link_to :release_notes %>
-  </li>
-  <li>
-    <%= static_link_to :report_bug %>
-  </li>
-  <li>
-    <%= static_link_to :roadmap %>
-  </li>
-  <li>
-    <%= static_link_to :crowdin %>
-  </li>
-  <li>
-    <%= static_link_to :api_docs %>
-  </li>
-</ul>
+<div class="op-widget-box--body">
+  <ul class="widget-box--arrow-links">
+    <li>
+      <%= static_link_to :user_guides %>
+    </li>
+    <li>
+      <%= static_link_to :shortcuts %>
+    </li>
+    <li>
+      <%= static_link_to :forums %></li>
+    <li>
+      <%= static_link_to (EnterpriseToken.active? ? :enterprise_support : :enterprise_support_as_community) %>
+    </li>
+    <li>
+      <%= link_to(
+            t("label_openproject_website"), "#{OpenProject::Static::Links.links[:website][:href]}/?utm_source=unknown&utm_medium=op-instance&utm_campaign=website-home-screen",
+            { aria: { label: t("label_openproject_website") },
+              target: "_blank",
+              title: t("label_openproject_website"), rel: "noopener" }
+          ) %>
+    </li>
+    <li>
+      <%= link_to(
+            t("homescreen.links.newsletter"), "#{OpenProject::Static::Links.links[:newsletter][:href]}/?utm_source=unknown&utm_medium=op-instance&utm_campaign=newsletter-home-screen",
+            { aria: { label: t("homescreen.links.newsletter") },
+              target: "_blank",
+              title: t("homescreen.links.newsletter"), rel: "noopener" }
+          ) %>
+    </li>
+    <li>
+      <%= static_link_to :blog %>
+    </li>
+    <li>
+      <%= static_link_to :release_notes %>
+    </li>
+    <li>
+      <%= static_link_to :report_bug %>
+    </li>
+    <li>
+      <%= static_link_to :roadmap %>
+    </li>
+    <li>
+      <%= static_link_to :crowdin %>
+    </li>
+    <li>
+      <%= static_link_to :api_docs %>
+    </li>
+  </ul>
+</div>

--- a/app/views/homescreen/blocks/_my_account.html.erb
+++ b/app/views/homescreen/blocks/_my_account.html.erb
@@ -1,14 +1,16 @@
 <%= render "homescreen/blocks/header", title: t("label_my_account") %>
 
-<ul class="widget-box--arrow-links">
-  <li>
-    <%= link_to t(:label_profile), my_account_path, title: t(:label_profile) %>
-  </li>
-  <li>
-    <%= link_to t(:"my_page.label"), my_page_path,
-                title: t(:"my_page.label") %>
-  </li>
-  <li>
-    <%= link_to t(:button_change_password), my_password_path, title: t(:button_change_password) %>
-  </li>
-</ul>
+<div class="op-widget-box--body">
+  <ul class="widget-box--arrow-links">
+    <li>
+      <%= link_to t(:label_profile), my_account_path, title: t(:label_profile) %>
+    </li>
+    <li>
+      <%= link_to t(:"my_page.label"), my_page_path,
+                  title: t(:"my_page.label") %>
+    </li>
+    <li>
+      <%= link_to t(:button_change_password), my_password_path, title: t(:button_change_password) %>
+    </li>
+  </ul>
+</div>

--- a/app/views/homescreen/blocks/_new_features.html.erb
+++ b/app/views/homescreen/blocks/_new_features.html.erb
@@ -1,3 +1,5 @@
 <%= render "homescreen/blocks/header", title: t(:label_new_features) %>
 
-<opce-homescreen-new-features-block></opce-homescreen-new-features-block>
+<div class="op-widget-box--body">
+  <opce-homescreen-new-features-block></opce-homescreen-new-features-block>
+</div>

--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -1,16 +1,19 @@
 <%= render "homescreen/blocks/header", title: t(:label_news_latest) %>
-<% unless @news.empty? %>
-  <ul class="widget-box--arrow-links">
-  <% @news.each do |news| %>
-    <li class="widget-box--arrow-multiline">
-      <%= avatar(news.author, class: "widget-box--avatar news-author-avatar hidden-for-mobile") %>
-      <div class="widget-box--project">
-        <%= link_to_project(news.project) + ": " %>
-        <%= link_to h(news.title), news_path(news) %>
-      </div>
-      <div class="widget-box--author news-author"><%= authoring_at format_date(news.created_at), news.author %></div>
-      <p class="widget-box--additional-info"><%= news.summary %></p>
-    </li>
+
+<div class="op-widget-box--body">
+  <% unless @news.empty? %>
+    <ul class="widget-box--arrow-links">
+    <% @news.each do |news| %>
+      <li class="widget-box--arrow-multiline">
+        <%= avatar(news.author, class: "widget-box--avatar news-author-avatar hidden-for-mobile") %>
+        <div class="widget-box--project">
+          <%= "#{link_to_project(news.project)}: " %>
+          <%= link_to h(news.title), news_path(news) %>
+        </div>
+        <div class="widget-box--author news-author"><%= authoring_at format_date(news.created_at), news.author %></div>
+        <p class="widget-box--additional-info"><%= news.summary %></p>
+      </li>
+    <% end %>
+    </ul>
   <% end %>
-  </ul>
-<% end %>
+</div>

--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -7,7 +7,7 @@
       <li class="widget-box--arrow-multiline">
         <%= avatar(news.author, class: "widget-box--avatar news-author-avatar hidden-for-mobile") %>
         <div class="widget-box--project">
-          <%= "#{link_to_project(news.project)}: " %>
+          <%= safe_join([link_to_project(news.project), ": "]) %>
           <%= link_to h(news.title), news_path(news) %>
         </div>
         <div class="widget-box--author news-author"><%= authoring_at format_date(news.created_at), news.author %></div>

--- a/app/views/homescreen/blocks/_projects.html.erb
+++ b/app/views/homescreen/blocks/_projects.html.erb
@@ -1,57 +1,59 @@
 <%= render "homescreen/blocks/header", title: t(:label_project_plural) %>
 
-<% if @favorite_projects.any? %>
-  <p class="widget-box--additional-info"><%= t("projects.lists.favored") %></p>
-  <ul class="widget-box--arrow-links">
-    <% @favorite_projects.each do |project| %>
+<div class="op-widget-box--body">
+  <% if @favorite_projects.any? %>
+    <p class="widget-box--additional-info"><%= t("projects.lists.favored") %></p>
+    <ul class="widget-box--arrow-links">
+      <% @favorite_projects.each do |project| %>
+        <li>
+          <%= render(
+                Primer::Beta::Octicon.new(
+                  icon: "star-fill",
+                  classes: "op-primer--star-icon",
+                  "aria-label": I18n.t(:label_favorite)
+                )
+              ) %>
+
+          <%= link_to project, project_path(project),
+                      title: short_project_description(project),
+                      data: { test_selector: "favorite-project" } %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @newest_projects.empty? %>
+    <p class="widget-box--additional-info">
+      <%= t("homescreen.additional.no_visible_projects") %>
+    </p>
+  <% else %>
+    <p class="widget-box--additional-info"><%= t("homescreen.additional.projects") %></p>
+    <ul class="widget-box--arrow-links">
+      <% @newest_projects.each do |project| %>
       <li>
-        <%= render(
-              Primer::Beta::Octicon.new(
-                icon: "star-fill",
-                classes: "op-primer--star-icon",
-                "aria-label": I18n.t(:label_favorite)
-              )
-            ) %>
-
-        <%= link_to project, project_path(project),
-                    title: short_project_description(project),
-                    data: { test_selector: "favorite-project" } %>
+        <%= link_to project, project_path(project), title: short_project_description(project) %>
+        <small>(<%= format_date(project.created_at) %>)</small>
       </li>
-    <% end %>
-  </ul>
-<% end %>
-
-<% if @newest_projects.empty? %>
-  <p class="widget-box--additional-info">
-    <%= t("homescreen.additional.no_visible_projects") %>
-  </p>
-<% else %>
-  <p class="widget-box--additional-info"><%= t("homescreen.additional.projects") %></p>
-  <ul class="widget-box--arrow-links">
-    <% @newest_projects.each do |project| %>
-    <li>
-      <%= link_to project, project_path(project), title: short_project_description(project) %>
-      <small>(<%= format_date(project.created_at) %>)</small>
-    </li>
-    <% end %>
-  </ul>
-<% end %>
-
-<div class="widget-box--blocks--buttons">
-  <% if User.current.allowed_globally?(:add_project) %>
-    <%= link_to new_project_path,
-                { class: "button -primary",
-                  aria: { label: t(:label_project_new) },
-                  title: t(:label_project_new) } do %>
-      <%= op_icon("button--icon icon-add") %>
-      <span class="button--text"><%= Project.model_name.human %></span>
-    <% end %>
+      <% end %>
+    </ul>
   <% end %>
 
-  <%# If any project exists %>
-  <% unless @newest_projects.empty? %>
-    <%= link_to t(:label_project_view_all), projects_path,
-                class: "button -highlight-inverted",
-                title: t(:label_project_view_all) %>
-  <% end %>
+  <div class="widget-box--blocks--buttons">
+    <% if User.current.allowed_globally?(:add_project) %>
+      <%= link_to new_project_path,
+                  { class: "button -primary",
+                    aria: { label: t(:label_project_new) },
+                    title: t(:label_project_new) } do %>
+        <%= op_icon("button--icon icon-add") %>
+        <span class="button--text"><%= Project.model_name.human %></span>
+      <% end %>
+    <% end %>
+
+    <%# If any project exists %>
+    <% unless @newest_projects.empty? %>
+      <%= link_to t(:label_project_view_all), projects_path,
+                  class: "button -highlight-inverted",
+                  title: t(:label_project_view_all) %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/homescreen/blocks/_users.html.erb
+++ b/app/views/homescreen/blocks/_users.html.erb
@@ -1,23 +1,25 @@
 <%= render "homescreen/blocks/header", title: t(:label_user_plural) %>
 
-<p class="widget-box--additional-info"><%= t("homescreen.additional.users") %></p>
+<div class="op-widget-box--body">
+    <p class="widget-box--additional-info"><%= t("homescreen.additional.users") %></p>
 
-<% unless @newest_users.empty? %>
-<ul class="widget-box--arrow-links">
-  <% @newest_users.each do |user| %>
-    <li>
-      <%= link_to_user user %>
-      <small>(<%= format_date(user.created_at) %>)</small>
-    </li>
-  <% end %>
-</ul>
-<% end %>
-
-<div class="widget-box--buttons">
-  <% if User.current.admin? %>
-    <%= link_to new_user_path, class: "button -primary" do %>
-      <%= op_icon("button--icon icon-add") %>
-      <span class="button--text"><%= t(:label_invite_user) %></span>
+    <% unless @newest_users.empty? %>
+    <ul class="widget-box--arrow-links">
+      <% @newest_users.each do |user| %>
+        <li>
+          <%= link_to_user user %>
+          <small>(<%= format_date(user.created_at) %>)</small>
+        </li>
+      <% end %>
+    </ul>
     <% end %>
-  <% end %>
+
+    <div class="widget-box--buttons">
+      <% if User.current.admin? %>
+        <%= link_to new_user_path, class: "button -primary" do %>
+          <%= op_icon("button--icon icon-add") %>
+          <span class="button--text"><%= t(:label_invite_user) %></span>
+        <% end %>
+      <% end %>
+    </div>
 </div>

--- a/app/views/homescreen/blocks/_welcome.html.erb
+++ b/app/views/homescreen/blocks/_welcome.html.erb
@@ -1,5 +1,7 @@
 <%= render "homescreen/blocks/header", title: Setting.welcome_title.presence || organization_name %>
 
-<div class="wiki op-uc-container">
-  <%= format_text(Setting.welcome_text, headings: false) %>
+<div class="op-widget-box--body">
+  <div class="wiki op-uc-container">
+    <%= format_text(Setting.welcome_text, headings: false) %>
+  </div>
 </div>

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% @homescreen[:blocks].each do |block| %>
     <% if block[:if].nil? || instance_eval(&block[:if]) %>
       <div class="widget-box <%= block[:partial] %>">
-      <%= render partial: "homescreen/blocks/#{block[:partial]}", locals: block[:locals] || {} %>
+        <%= render partial: "homescreen/blocks/#{block[:partial]}", locals: block[:locals] || {} %>
       </div>
     <% end %>
   <% end %>

--- a/frontend/src/app/shared/components/grids/grid/grid.component.html
+++ b/frontend/src/app/shared/components/grids/grid/grid.component.html
@@ -22,13 +22,6 @@
          (cdkDragDropped)="drag.drop()"
          [cdkDragDisabled]="isMobileDevice || !drag.isDraggable">
 
-      <span *ngIf="drag.isDraggable"
-            class="grid--area-drag-handle
-                   icon
-                   icon-drag-handle
-                   hidden-for-mobile"
-            [hidden]="isMobileDevice"
-            cdkDragHandle></span>
 
       <ndc-dynamic [ndcDynamicComponent]="widgetComponent(area)"
                    [ndcDynamicInputs]="widgetComponentInput(area)"
@@ -83,11 +76,14 @@
        [style.grid-column-start]="gap.gridStartColumn"
        [style.grid-column-end]="gap.gridEndColumn"
        [id]="gap.guid"
-       (mouseover)="layout.setMousedOverArea(gap)">
+       >
     <div class="grid--widget-add -gap"
          *ngIf="add.isAllowed"
          [title]="add.addText"
          (click)="addWidget(gap)">
+      <span
+      [textContent]="add.addText"></span>
+      {{ add.addText }}
     </div>
   </div>
 

--- a/frontend/src/app/shared/components/grids/grid/grid.component.html
+++ b/frontend/src/app/shared/components/grids/grid/grid.component.html
@@ -47,7 +47,7 @@
        [ngClass] = "{'-drop-target': drag.currentlyDragging,
                      '-drop-only': drag.isDropOnlyArea(area),
                      '-resize-target': resize.isTarget(area),
-                     '-addable': add.isAddable(area),
+                     '-addable': true,
                      '-help-mode': layout.inHelpMode}"
        [style.grid-row-start]="area.gridStartRow"
        [style.grid-row-end]="area.gridEndRow"
@@ -62,6 +62,12 @@
          *ngIf="add.isAllowed"
          [title]="add.addText"
          (click)="addWidget(area)">
+
+    <svg plus-icon size="small"></svg>
+    <span
+      class="grid--widget-add-help-text"
+      [textContent]="add.addText">
+    </span>
     </div>
   </div>
 
@@ -76,14 +82,13 @@
        [style.grid-column-start]="gap.gridStartColumn"
        [style.grid-column-end]="gap.gridEndColumn"
        [id]="gap.guid"
+       (mouseover)="layout.setMousedOverArea(gap)"
        >
     <div class="grid--widget-add -gap"
          *ngIf="add.isAllowed"
          [title]="add.addText"
          (click)="addWidget(gap)">
-      <span
-      [textContent]="add.addText"></span>
-      {{ add.addText }}
+      <svg plus-icon size="small"></svg>
     </div>
   </div>
 

--- a/frontend/src/app/shared/components/grids/grid/grid.component.html
+++ b/frontend/src/app/shared/components/grids/grid/grid.component.html
@@ -22,17 +22,16 @@
          (cdkDragDropped)="drag.drop()"
          [cdkDragDisabled]="isMobileDevice || !drag.isDraggable">
 
-
       <ndc-dynamic [ndcDynamicComponent]="widgetComponent(area)"
                    [ndcDynamicInputs]="widgetComponentInput(area)"
                    [ndcDynamicOutputs]="widgetComponentOutput(area)">
       </ndc-dynamic>
     </div>
     <op-resizer *ngIf="resize.isResizable"
-             [customHandler]="true"
-             (resizeFinished)="resize.end(area)"
-             (resizeStarted)="resize.start(area)"
-             (move)="resize.moving()">
+                [customHandler]="true"
+                (resizeFinished)="resize.end(area)"
+                (resizeStarted)="resize.start(area)"
+                (move)="resize.moving()">
       <div class="grid--resizer">
         <i class="icon-resizer-bottom-right hidden-for-mobile"
            aria-hidden="true">
@@ -55,19 +54,24 @@
        [style.grid-column-end]="area.gridEndColumn"
        cdkDropList
        [id]="area.guid"
+       tabindex="0"
        (mouseover)="layout.setMousedOverArea(area)"
+       (focus)="layout.setMousedOverArea(area)"
        [cdkDropListData]="area"
        [cdkDropListConnectedTo]="layout.gridAreaIds">
     <div class="grid--widget-add"
          *ngIf="add.isAllowed"
          [title]="add.addText"
-         (click)="addWidget(area)">
+         tabindex="0"
+         (click)="addWidget(area)"
+         (keyup.enter)="addWidget(area)"
+         (keyup.space)="addWidget(area)">
 
-    <svg plus-icon size="small"></svg>
-    <span
-      class="grid--widget-add-help-text"
-      [textContent]="add.addText">
-    </span>
+      <svg plus-icon size="small"></svg>
+      <span
+        class="grid--widget-add-help-text"
+        [textContent]="add.addText">
+      </span>
     </div>
   </div>
 
@@ -82,12 +86,16 @@
        [style.grid-column-start]="gap.gridStartColumn"
        [style.grid-column-end]="gap.gridEndColumn"
        [id]="gap.guid"
+       tabindex="0"
        (mouseover)="layout.setMousedOverArea(gap)"
-       >
+       (focus)="layout.setMousedOverArea(gap)">
     <div class="grid--widget-add -gap"
          *ngIf="add.isAllowed"
          [title]="add.addText"
-         (click)="addWidget(gap)">
+         tabindex="0"
+         (click)="addWidget(gap)"
+         (keyup.enter)="addWidget(gap)"
+         (keyup.space)="addWidget(gap)">
       <svg plus-icon size="small"></svg>
     </div>
   </div>

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.html
@@ -20,7 +20,7 @@
   </span>
 </ng-template>
 
-<div class="grid--widget-content -custom-text -allow-inner-overflow">
+<div class="op-widget-box--body -custom-text -allow-inner-overflow">
   <div class="inline-edit--container inplace-edit">
     <edit-form-portal
       *ngIf="active"

--- a/frontend/src/app/shared/components/grids/widgets/documents/documents.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/documents/documents.component.html
@@ -8,7 +8,7 @@
   </widget-menu>
 </widget-header>
 
-<div class="grid--widget-content">
+<div class="op-widget-box--body">
   <op-no-results *ngIf="noEntries"
                  [title]="text.noResults">
   </op-no-results>

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.html
@@ -1,12 +1,11 @@
 <h3 class="op-widget-box--header"
     data-test-selector="op-widget-box--header"
     [ngClass]="{ '-editable': isRenameable }">
-  <span
-        class="grid--area-drag-handle
-               icon
-               icon-drag-handle
-               hidden-for-mobile"
-        cdkDragHandle></span>
+  <svg grabber-icon
+       size="small"
+       cdkDragHandle
+       class="grid--area-drag-handle hidden-for-mobile"></svg>
+
   <ng-content select="[slot=prepend]"></ng-content>
 
   <editable-toolbar-title [title]="name"

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.html
@@ -1,7 +1,12 @@
 <h3 class="op-widget-box--header"
     data-test-selector="op-widget-box--header"
     [ngClass]="{ '-editable': isRenameable }">
-
+  <span
+        class="grid--area-drag-handle
+               icon
+               icon-drag-handle
+               hidden-for-mobile"
+        cdkDragHandle></span>
   <ng-content select="[slot=prepend]"></ng-content>
 
   <editable-toolbar-title [title]="name"

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.html
@@ -1,7 +1,8 @@
 <h3 class="op-widget-box--header"
     data-test-selector="op-widget-box--header"
     [ngClass]="{ '-editable': isRenameable }">
-  <svg grabber-icon
+  <svg *ngIf="drag.isDraggable"
+       grabber-icon
        size="small"
        cdkDragHandle
        class="grid--area-drag-handle hidden-for-mobile"></svg>

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.ts
@@ -30,6 +30,7 @@ import {
   ChangeDetectionStrategy, Component, EventEmitter, Input, Output,
 } from '@angular/core';
 import { GridAreaService } from 'core-app/shared/components/grids/grid/area.service';
+import { GridDragAndDropService } from 'core-app/shared/components/grids/grid/drag-and-drop.service';
 
 @Component({
   selector: 'widget-header',
@@ -45,7 +46,10 @@ export class WidgetHeaderComponent {
 
   @Output() onRenamed = new EventEmitter<string>();
 
-  constructor(readonly layout:GridAreaService) {
+  constructor(
+    readonly layout:GridAreaService,
+    readonly drag:GridDragAndDropService,
+  ) {
 
   }
 

--- a/frontend/src/app/shared/components/grids/widgets/members/members.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/members/members.component.html
@@ -12,7 +12,7 @@
   </widget-menu>
 </widget-header>
 
-<div class="grid--widget-content">
+<div class="op-widget-box--body">
   <op-no-results *ngIf="noMembers"
               [title]="text.noResults">
   </op-no-results>
@@ -37,24 +37,23 @@
        class="op-members-widget--notification">
     {{moreMembersText}}
   </div>
-</div>
-
-<div class="op-members-widget--grid--widget-footer">
-  <a *ngIf="membersAddable$ | async"
-     [href]="projectMembershipsPath + '?show_add_members=true'"
-     class="button -primary">
-    <i class="button--icon icon-add" aria-hidden="true"></i>
-    <span class="button--text"
-          [textContent]="text.add">
+  <div class="op-members-widget--grid--widget-footer">
+    <a *ngIf="membersAddable$ | async"
+       [href]="projectMembershipsPath + '?show_add_members=true'"
+       class="button -primary">
+      <i class="button--icon icon-add" aria-hidden="true"></i>
+      <span class="button--text"
+            [textContent]="text.add">
     </span>
-  </a>
+    </a>
 
-  <a *ngIf="!noMembers"
-     [href]="projectMembershipsPath"
-     class="button -highlight-inverted">
-    <i class="button--icon icon-group" aria-hidden="true"></i>
-    <span class="button--text"
-          [textContent]="text.viewAll">
+    <a *ngIf="!noMembers"
+       [href]="projectMembershipsPath"
+       class="button -highlight-inverted">
+      <i class="button--icon icon-group" aria-hidden="true"></i>
+      <span class="button--text"
+            [textContent]="text.viewAll">
     </span>
-  </a>
+    </a>
+  </div>
 </div>

--- a/frontend/src/app/shared/components/grids/widgets/news/news.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/news/news.component.html
@@ -9,14 +9,14 @@
   </widget-menu>
 
 </widget-header>
-<div class="grid--widget-content">
+<div class="op-widget-box--body">
   <op-no-results
-    *ngIf="noEntries" 
+    *ngIf="noEntries"
     [title]="text.noResults"
   ></op-no-results>
   <ul class="widget-box--arrow-links">
     <li
-      class="widget-box--arrow-multiline" 
+      class="widget-box--arrow-multiline"
       *ngFor="let news of entries"
     >
       <op-principal
@@ -36,12 +36,12 @@
         ></a>
       </div>
       <div
-        *ngIf="news.author" 
+        *ngIf="news.author"
         class="widget-box--author news-author"
         [innerHTML]="text.addedBy(news)"
       ></div>
       <p
-        *ngIf="news.summary" 
+        *ngIf="news.summary"
         [textContent]="news.summary"
         class="widget-box--additional-info"
       ></p>

--- a/frontend/src/app/shared/components/grids/widgets/project-description/project-description.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-description/project-description.component.html
@@ -12,7 +12,7 @@
   </widget-menu>
 </widget-header>
 
-<div class="grid--widget-content -allow-inner-overflow">
+<div class="op-widget-box--body -allow-inner-overflow">
   <edit-form *ngIf="(project$ | async) as project"
              [resource]="project">
     <op-editable-attribute-field [resource]="project"

--- a/frontend/src/app/shared/components/grids/widgets/project-favorites/widget-project-favorites.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-favorites/widget-project-favorites.component.html
@@ -8,7 +8,7 @@
   </widget-menu>
 </widget-header>
 
-<div *ngIf="(projects$ | async) as projects" class="grid--widget-content">
+<div *ngIf="(projects$ | async) as projects" class="op-widget-box--body">
   <div class="op-header-project-select--no-favorites" *ngIf="projects.length === 0">
     <svg
       class="op-header-project-select--no-favorites-icon"

--- a/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
@@ -12,7 +12,7 @@
   </widget-menu>
 </widget-header>
 
-<div class="grid--widget-content -allow-inner-overflow">
+<div class="op-widget-box--body -allow-inner-overflow">
   <edit-form *ngIf="(project$ | async) as project" [resource]="project">
     <div class="project-status--container">
       <op-editable-attribute-field [resource]="project"

--- a/frontend/src/app/shared/components/grids/widgets/subprojects/subprojects.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/subprojects/subprojects.component.html
@@ -8,7 +8,7 @@
   </widget-menu>
 </widget-header>
 
-<div class="grid--widget-content">
+<div class="op-widget-box--body">
   <op-no-results *ngIf="noEntries"
               [title]="text.noResults">
   </op-no-results>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.html
@@ -9,13 +9,15 @@
   </widget-time-entries-current-user-menu>
 </widget-header>
 
-<op-time-entries-calendar
-  (entries)="updateEntries($event)"
-  [displayedDays]="displayedDays"
-></op-time-entries-calendar>
+<div class="op-widget-box--body">
+  <op-time-entries-calendar
+    (entries)="updateEntries($event)"
+    [displayedDays]="displayedDays"
+  ></op-time-entries-calendar>
 
-<ng-container>
-  <div class="total-hours">
-    <p>Total: <span [textContent]="total"></span></p>
-  </div>
-</ng-container>
+  <ng-container>
+    <div class="total-hours">
+      <p>Total: <span [textContent]="total"></span></p>
+    </div>
+  </ng-container>
+</div>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -8,103 +8,105 @@
   </widget-menu>
 </widget-header>
 
-<op-no-results *ngIf="noEntries"
-            [title]="text.noResults">
-</op-no-results>
+<div class="op-widget-box--body">
+  <op-no-results *ngIf="noEntries"
+              [title]="text.noResults">
+  </op-no-results>
 
-<ng-container *ngIf="!noEntries">
-  <div class="total-hours">
-    <p>Total: <span [textContent]="total"></span></p>
-  </div>
+  <ng-container *ngIf="!noEntries">
+    <div class="total-hours">
+      <p>Total: <span [textContent]="total"></span></p>
+    </div>
 
-  <div class="generic-table--results-container" *ngIf="entriesLoaded && anyEntries">
-    <table class="generic-table time-entries">
-      <colgroup>
-        <col>
-        <col>
-        <col>
-        <col>
-        <col data-highlight="false">
-      </colgroup>
-      <thead class="-sticky">
-        <tr>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <span [textContent]="schema.activity.name"></span>
+    <div class="generic-table--results-container" *ngIf="entriesLoaded && anyEntries">
+      <table class="generic-table time-entries">
+        <colgroup>
+          <col>
+          <col>
+          <col>
+          <col>
+          <col data-highlight="false">
+        </colgroup>
+        <thead class="-sticky">
+          <tr>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span [textContent]="schema.activity.name"></span>
+                </div>
               </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <span [textContent]="schema.entity.name"></span>
+            </th>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span [textContent]="schema.entity.name"></span>
+                </div>
               </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <span [textContent]="schema.comment.name"></span>
+            </th>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span [textContent]="schema.comment.name"></span>
+                </div>
               </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <span [textContent]="schema.hours.name"></span>
+            </th>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span [textContent]="schema.hours.name"></span>
+                </div>
               </div>
-            </div>
-          </th>
-          <th><div class="generic-table--empty-header"></div></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="time-entry" *ngFor="let item of rows">
-          <td class="activity"
-              *ngIf="item.entry"
-              [textContent]="activityName(item.entry)">
-          </td>
-          <td colspan="3"
-              *ngIf="item.sum">
-            <strong [textContent]="item.date"></strong>
-          </td>
-          <td class="subject"
-              *ngIf="item.entry && item.entry.entity">
-              {{projectName(item.entry)}} - <a [href]="entityPath(item.entry)" [textContent]="entityName(item.entry)"></a>
-          </td>
-          <td class="subject"
-              *ngIf="item.entry && !item.entry.entity"
-              [textContent]="projectName(item.entry)">
-          </td>
-          <td class="comments"
-              *ngIf="item.entry"
-              [textContent]="comment(item.entry)">
-          </td>
-          <td class="hours"
-              *ngIf="item.entry"
-              [textContent]="hours(item.entry)">
-          </td>
-          <td class="hours"
-              *ngIf="item.sum">
-            <em [textContent]="item.sum"></em>
-          </td>
-          <td class="buttons">
-            <a *ngIf="item.entry && item.entry.updateImmediately"
-               (click)="editTimeEntry(item.entry)"
-               [title]="text.edit"
-               attr.data-test-selector="edit-time-entry-{{ item.entry.id }}"
-            >
-              <op-icon icon-classes="icon-context icon-edit"></op-icon>
-            </a>
-            <a *ngIf="item.entry && item.entry.delete"
-               (click)="deleteIfConfirmed($event, item.entry)"
-               [title]="text.delete" >
-              <op-icon icon-classes="icon-context icon-delete"></op-icon>
-            </a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</ng-container>
+            </th>
+            <th><div class="generic-table--empty-header"></div></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="time-entry" *ngFor="let item of rows">
+            <td class="activity"
+                *ngIf="item.entry"
+                [textContent]="activityName(item.entry)">
+            </td>
+            <td colspan="3"
+                *ngIf="item.sum">
+              <strong [textContent]="item.date"></strong>
+            </td>
+            <td class="subject"
+                *ngIf="item.entry && item.entry.entity">
+                {{projectName(item.entry)}} - <a [href]="entityPath(item.entry)" [textContent]="entityName(item.entry)"></a>
+            </td>
+            <td class="subject"
+                *ngIf="item.entry && !item.entry.entity"
+                [textContent]="projectName(item.entry)">
+            </td>
+            <td class="comments"
+                *ngIf="item.entry"
+                [textContent]="comment(item.entry)">
+            </td>
+            <td class="hours"
+                *ngIf="item.entry"
+                [textContent]="hours(item.entry)">
+            </td>
+            <td class="hours"
+                *ngIf="item.sum">
+              <em [textContent]="item.sum"></em>
+            </td>
+            <td class="buttons">
+              <a *ngIf="item.entry && item.entry.updateImmediately"
+                 (click)="editTimeEntry(item.entry)"
+                 [title]="text.edit"
+                 attr.data-test-selector="edit-time-entry-{{ item.entry.id }}"
+              >
+                <op-icon icon-classes="icon-context icon-edit"></op-icon>
+              </a>
+              <a *ngIf="item.entry && item.entry.delete"
+                 (click)="deleteIfConfirmed($event, item.entry)"
+                 [title]="text.delete" >
+                <op-icon icon-classes="icon-context icon-delete"></op-icon>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </ng-container>
+</div>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -93,14 +93,19 @@
             <td class="buttons">
               <a *ngIf="item.entry && item.entry.updateImmediately"
                  (click)="editTimeEntry(item.entry)"
+                 (keyup.enter)="editTimeEntry(item.entry)"
+                 (keyup.space)="editTimeEntry(item.entry)"
+                 tabindex="0"
                  [title]="text.edit"
-                 attr.data-test-selector="edit-time-entry-{{ item.entry.id }}"
-              >
+                 attr.data-test-selector="edit-time-entry-{{ item.entry.id }}">
                 <op-icon icon-classes="icon-context icon-edit"></op-icon>
               </a>
               <a *ngIf="item.entry && item.entry.delete"
+                 tabindex="0"
                  (click)="deleteIfConfirmed($event, item.entry)"
-                 [title]="text.delete" >
+                 (keyup.enter)="deleteIfConfirmed($event, item.entry)"
+                 (keyup.space)="deleteIfConfirmed($event, item.entry)"
+                 [title]="text.delete">
                 <op-icon icon-classes="icon-context icon-delete"></op-icon>
               </a>
             </td>

--- a/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.html
@@ -8,14 +8,16 @@
   </widget-menu>
 </widget-header>
 
-<ng-container *ngIf="{hasCapability: hasCapability$ | async} as context">
-  <div class="op-toast -error" *ngIf="context.hasCapability === false">
-    <span [textContent]="text.missing_permission"></span>
-  </div>
+<div class="op-widget-box--body">
+  <ng-container *ngIf="{hasCapability: hasCapability$ | async} as context">
+    <div class="op-toast -error" *ngIf="context.hasCapability === false">
+      <span [textContent]="text.missing_permission"></span>
+    </div>
 
-  <op-wp-calendar
-    *ngIf="context.hasCapability === true"
-    [showMeetings]="true"
-    [static]="true"
-  ></op-wp-calendar>
-</ng-container>
+    <op-wp-calendar
+      *ngIf="context.hasCapability === true"
+      [showMeetings]="true"
+      [static]="true"
+    ></op-wp-calendar>
+  </ng-container>
+</div>

--- a/frontend/src/app/shared/components/grids/widgets/wp-graph/wp-graph.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-graph/wp-graph.component.html
@@ -9,7 +9,7 @@
   </widget-wp-graph-menu>
 </widget-header>
 
-<op-wp-embedded-graph class='grid--widget-content -no-overflow'
+<op-wp-embedded-graph class='op-widget-box--body -no-overflow'
                    [datasets]="datasets"
                    [chartType]="chartType">
 </op-wp-embedded-graph>

--- a/frontend/src/app/shared/components/grids/widgets/wp-overview/wp-overview.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-overview/wp-overview.component.html
@@ -9,6 +9,6 @@
 </widget-header>
 
 <opce-wp-overview-graph
-    class='grid--widget-content -no-overflow'
+    class='op-widget-box--body -no-overflow'
     [groupBy]="'type'">
 </opce-wp-overview-graph>

--- a/frontend/src/app/shared/components/grids/widgets/wp-table/wp-table.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/wp-table/wp-table.component.html
@@ -7,7 +7,9 @@
   </widget-wp-table-menu>
 </widget-header>
 
-<wp-embedded-table [queryId]="queryId"
-                   [configuration]="configuration"
-                   *ngIf="queryId">
-</wp-embedded-table>
+<div class="op-widget-box--body">
+  <wp-embedded-table [queryId]="queryId"
+                     [configuration]="configuration"
+                     *ngIf="queryId">
+  </wp-embedded-table>
+</div>

--- a/frontend/src/app/shared/components/icon/icon.module.ts
+++ b/frontend/src/app/shared/components/icon/icon.module.ts
@@ -57,6 +57,8 @@ import {
   EyeIconComponent,
   EyeClosedIconComponent,
   ArrowLeftIconComponent,
+  GrabberIconComponent,
+  PlusIconComponent,
 } from '@openproject/octicons-angular';
 
 @NgModule({
@@ -121,6 +123,8 @@ import {
     EyeIconComponent,
     EyeClosedIconComponent,
     ArrowLeftIconComponent,
+    GrabberIconComponent,
+    PlusIconComponent,
   ],
   declarations: [
     OpIconComponent,
@@ -186,6 +190,8 @@ import {
     EyeIconComponent,
     EyeClosedIconComponent,
     ArrowLeftIconComponent,
+    GrabberIconComponent,
+    PlusIconComponent,
   ],
 })
 export class IconModule {}

--- a/frontend/src/app/shared/components/op-context-menu/icon-triggered-context-menu/icon-triggered-context-menu.component.html
+++ b/frontend/src/app/shared/components/op-context-menu/icon-triggered-context-menu/icon-triggered-context-menu.component.html
@@ -1,3 +1,3 @@
 <a href="#">
-  <op-icon icon-classes="icon-show-more-horizontal"></op-icon>
+  <svg kebab-horizontal-icon size="small"></svg>
 </a>

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -139,7 +139,7 @@ export class WorkPackageEmbeddedGraphComponent {
             backdropColor: this.isRadarChart() ? backdropColor : 'transparent',
             font: {
               weight: 'bold',
-              size: 16,
+              size: 14,
             },
           },
         },
@@ -177,7 +177,7 @@ export class WorkPackageEmbeddedGraphComponent {
           color: bodyFontColor,
           font: {
             weight: 'bold',
-            size: 16,
+            size: 14,
           },
         },
       },

--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -8,10 +8,6 @@ $grid--widget-padding: 20px 20px 20px 20px
 @mixin grid--commons
   display: grid
 
-body.widget-grid-layout
-  #content, page-header
-    background-color: var(--grid-background-color)
-
 .grid--container
   @include grid--commons
 
@@ -35,10 +31,6 @@ body.widget-grid-layout
 
     .widget-box
       min-height: 200px
-      padding: $grid--widget-padding
-
-    &:hover icon-triggered-context-menu
-      visibility: visible
 
   &.-resizing
     @include modifying--placeholder
@@ -49,6 +41,7 @@ body.widget-grid-layout
     flex-direction: column
     justify-content: center
     align-items: center
+    border: 1px dashed var(--borderColor-default)
 
   &.-placeholder
     @include modifying--placeholder
@@ -72,9 +65,6 @@ body.widget-grid-layout
   .op-widget-box--header
     display: flex
     gap: var(--base-size-6)
-
-  icon-triggered-context-menu
-    visibility: hidden
 
   &.-drop-target,
   &.-passive
@@ -106,20 +96,11 @@ body.widget-grid-layout
     opacity: 1
 
 .grid--area-drag-handle
-  margin-left: -19px
-  padding-right: 1px
-  padding-top: 4px
-  margin-top: 4px
-  opacity: 0
   cursor: grab
-  float: left
 
   &:before
     padding: 0
     color: var(--fgColor-muted)
-
-  .grid--area.-widgeted:hover &
-    opacity: 1
 
 .grid--area-content
   height: 100%
@@ -143,6 +124,7 @@ body.widget-grid-layout
 
 .grid--widget-content
   height: 100%
+  padding: var(--stack-padding-normal)
   overflow-x: auto
   overflow-y: auto
 
@@ -205,10 +187,6 @@ body.widget-grid-layout
   border-radius: 50%
   opacity: 0
 
-  &:before
-    @include icon-font-common
-    @include icon-mixin-add
-
   &.-gap
     width: 100%
     height: 100%
@@ -221,7 +199,7 @@ body.widget-grid-layout
     &:before
       font-size: 0.75rem
 
-  .grid--area.-addable:hover &, .grid--area.-addable.-help-mode &
+  .grid--area.-addable &, .grid--area.-addable.-help-mode &
     opacity: 1
     transition: opacity 1s ease
 
@@ -244,7 +222,6 @@ body.widget-grid-layout
   padding: 20px 5px
   cursor: pointer
   background: none
-  transition: background 4s ease
 
   &:hover
     background: var(--gray-light)

--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -64,7 +64,7 @@ $grid--widget-padding: 20px 20px 20px 20px
 
   .op-widget-box--header
     display: flex
-    gap: var(--base-size-6)
+    padding-left: 0
 
   &.-drop-target,
   &.-passive
@@ -96,11 +96,11 @@ $grid--widget-padding: 20px 20px 20px 20px
     opacity: 1
 
 .grid--area-drag-handle
+  opacity: 0
   cursor: grab
 
-  &:before
-    padding: 0
-    color: var(--fgColor-muted)
+  .grid--area.-widgeted:hover &
+    opacity: 1
 
 .grid--area-content
   height: 100%
@@ -122,51 +122,6 @@ $grid--widget-padding: 20px 20px 20px 20px
   &.cdk-drag-placeholder
     visibility: hidden
 
-.grid--widget-content
-  height: 100%
-  padding: var(--stack-padding-normal)
-  overflow-x: auto
-  overflow-y: auto
-
-  &.-no-overflow
-    overflow-x: hidden
-    overflow-y: hidden
-    display: block
-
-  &.-allow-inner-overflow
-    .wiki
-      overflow-y: auto
-      @include styled-scroll-bar
-
-  // styles specific to the custom-text widget
-  &.-custom-text
-    a.inplace-editing--trigger-link
-      color: inherit
-      text-decoration: none
-
-    .op-ckeditor--wrapper
-      margin-bottom: 0
-
-    .ck-editor__top
-      position: sticky
-      top: 0
-
-    .inplace-edit--controls
-      position: initial
-
-      i
-        float: initial
-        padding: 0
-
-    edit-field-controls
-      display: flex
-      position: sticky
-      bottom: 0
-      justify-content: flex-end
-
-    .textarea-wrapper
-      margin-bottom: 0
-
 .grid--widget-limited-text
   max-height: 5rem
   position: relative
@@ -183,11 +138,10 @@ $grid--widget-padding: 20px 20px 20px 20px
 
 .grid--widget-add
   padding: 15px
-  background-color: var(--bgColor-neutral-emphasis)
-  border-radius: 50%
-  opacity: 0
+  color: var(--fgColor-muted)
 
   &.-gap
+    opacity: 0
     width: 100%
     height: 100%
     display: flex
@@ -196,15 +150,15 @@ $grid--widget-padding: 20px 20px 20px 20px
     padding: 0
     border-radius: initial
 
-    &:before
-      font-size: 0.75rem
+    svg
+      color: var(--fgColor-muted)
 
-  .grid--area.-addable &, .grid--area.-addable.-help-mode &
+  .grid--widget-add-help-text
+    margin-left: 4px
+
+  .grid--area.-addable &,
+  .grid--area.-addable.-help-mode &
     opacity: 1
-    transition: opacity 1s ease
-
-  .grid--area.-addable:hover &
-    transition-delay: 0.3s
 
 .grid--widget-remove
   float: right
@@ -222,10 +176,6 @@ $grid--widget-padding: 20px 20px 20px 20px
   padding: 20px 5px
   cursor: pointer
   background: none
-
-  &:hover
-    background: var(--gray-light)
-    transition: background 1s ease
 
   &:last-of-type
     border-bottom: none

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -106,8 +106,55 @@ $widget-box--enumeration-width: 20px
       grid-template-columns: auto auto
       grid-column-gap: 20px
 
+.op-widget-box--body
+  height: 100%
+  padding: var(--stack-padding-normal)
+  overflow-x: auto
+  overflow-y: auto
+
+  &.-no-overflow
+    overflow-x: hidden
+    overflow-y: hidden
+    display: block
+
+  &.-allow-inner-overflow
+    .wiki
+      overflow-y: auto
+      @include styled-scroll-bar
+
+  // styles specific to the custom-text widget
+  &.-custom-text
+    a.inplace-editing--trigger-link
+      color: inherit
+      text-decoration: none
+
+    .op-ckeditor--wrapper
+      margin-bottom: 0
+
+    .ck-editor__top
+      position: sticky
+      top: 0
+
+    .inplace-edit--controls
+      position: initial
+
+      i
+        float: initial
+        padding: 0
+
+    edit-field-controls
+      display: flex
+      position: sticky
+      bottom: 0
+      justify-content: flex-end
+
+    .textarea-wrapper
+      margin-bottom: 0
+
 .op-widget-box--header
   font-weight: var(--base-text-weight-bold)
+  font-size: var(--body-font-size)
+  color: var(--fgColor-muted)
   display: flex
   align-items: center
   border-bottom: var(--borderWidth-thin) solid var(--borderColor-default)
@@ -115,7 +162,8 @@ $widget-box--enumeration-width: 20px
   background-color: var(--bgColor-muted)
 
   .help-text--entry
-    vertical-align: 2px
+    vertical-align: -1px
+    margin-right: 4px
 
 .op-widget-box--header-title
   vertical-align: middle
@@ -125,12 +173,15 @@ $widget-box--enumeration-width: 20px
 
   // Ensure style for read-only widget headers
   .editable-toolbar-title--fixed,
-  .toolbar--editable-toolbar
-    color: var(--fgColor-default)
+  .toolbar--editable-toolbar,
+  .editable-toolbar-title--input
     font-size: var(--body-font-size)
-    letter-spacing: 1px
-    text-transform: uppercase
     font-weight: var(--base-text-weight-bold)
+    color: var(--fgColor-muted) !important
+    padding: 0 !important
+
+  .toolbar--editable-toolbar
+    height: 20px
 
 .widget-box--arrow-links
   list-style: none

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -64,7 +64,6 @@ $widget-box--enumeration-width: 20px
   .widget-box
     position: relative
     @include widget-box--style
-    padding: 20px
     min-height: 250px
     word-wrap: break-word
     overflow: hidden
@@ -109,12 +108,11 @@ $widget-box--enumeration-width: 20px
 
 .op-widget-box--header
   font-weight: var(--base-text-weight-bold)
-  font-size: 1.25rem
   display: flex
-  margin-top: 4px
-  margin-bottom: 13px
-  border-bottom: none
-  padding-bottom: 0
+  align-items: center
+  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default)
+  padding: var(--stack-padding-normal)
+  background-color: var(--bgColor-muted)
 
   .help-text--entry
     vertical-align: 2px

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -83,8 +83,9 @@
 @mixin widget-box--style
   background: var(--body-background)
   margin: 10px
-  border: 1px solid var(--borderColor-default)
+  border: var(--borderWidth-thin) solid var(--borderColor-default)
   box-shadow: 0px 1px 5px 0px rgba(0,0,0,0.1)
+  border-radius: var(--borderRadius-medium)
 
 @mixin widget-box--hover-style
   box-shadow: 0px 1px 20px 0px rgba(0,0,0,0.1)

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -123,7 +123,6 @@
   --status-selector-bg-color: #F99601;
   --status-selector-border-color: transparent;
   --warn:#C92A2A;
-  --grid-background-color: #F3F6F8;
   --avatar-border-color: transparent;
   --list-item-hover--border-color: transparent;
   --list-item-hover--color: var(--accent-color);

--- a/modules/dashboards/spec/features/members_principals_spec.rb
+++ b/modules/dashboards/spec/features/members_principals_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Dashboard page members", :js do
     # within top-right area, add an additional widget
     dashboard_page.add_widget(1, 1, :within, "Members")
 
-    members_block = page.find(".widget-box", text: "MEMBERS")
+    members_block = page.find(".widget-box", text: "Members")
 
     within(members_block) do
       user_link = find("op-principal a", text: user.name)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66121

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

- [x] Make the background white in Light mode: bgColor-default
- [x] Style the existing widgets to look as close to Primer border boxes as possible (but still using the current thing).
  - Rounded corners
  - Keep the current inline editing functionality
  - The more button (three dots) should always appear (not on hover)
  - The header should use the Border Box-style header background colour (to adapt properly to Dark mode).
  - Style the "add widgets" placeholder so that it's a click zone.

⚠️ The changes also affect the home screen, since the widgets there use the same classes as the overview page widgets.

## Screenshots


<img width="1981" height="1224" alt="Bildschirmfoto 2025-08-12 um 14 49 27" src="https://github.com/user-attachments/assets/0f23091a-6757-40d0-909f-24299129072e" />

<img width="1980" height="1121" alt="Bildschirmfoto 2025-08-12 um 14 51 14" src="https://github.com/user-attachments/assets/ffc400cd-9841-414e-a295-7c86b664e1a3" />