### PR TITLE
Show storage configuration in health status download

### DIFF
--- a/modules/storages/app/controllers/storages/admin/health_status_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/health_status_controller.rb
@@ -78,6 +78,7 @@ module Storages
         {
           storage: @storage.name,
           storage_type: @storage.to_s,
+          configuration: @storage.non_confidential_configuration,
           ran_at: timestamp
         }.merge(@report.to_h).to_yaml(stringify_names: true)
       end

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -42,7 +42,6 @@ module Storages
       AUTHENTICATION_METHOD_OAUTH2_SSO = "oauth2_sso"
     ].freeze
 
-    store_attribute :provider_fields, :automatically_managed, :boolean
     store_attribute :provider_fields, :username, :string
     store_attribute :provider_fields, :password, :string
     store_attribute :provider_fields, :group, :string
@@ -52,6 +51,10 @@ module Storages
     store_attribute :provider_fields, :token_exchange_scope, :string
 
     def self.short_provider_name = :nextcloud
+
+    def self.non_confidential_provider_fields
+      super + %i[username group group_folder authentication_method storage_audience token_exchange_scope]
+    end
 
     def oauth_configuration
       Adapters::Providers::Nextcloud::OAuthConfiguration.new(self)

--- a/modules/storages/app/models/storages/one_drive_storage.rb
+++ b/modules/storages/app/models/storages/one_drive_storage.rb
@@ -41,6 +41,10 @@ module Storages
 
     def self.short_provider_name = :one_drive
 
+    def self.non_confidential_provider_fields
+      super + %i[tenant_id drive_id]
+    end
+
     def self.allowed_by_enterprise_token?
       EnterpriseToken.allows_to?(:one_drive_sharepoint_file_storage)
     end

--- a/modules/storages/app/models/storages/share_point_storage.rb
+++ b/modules/storages/app/models/storages/share_point_storage.rb
@@ -45,9 +45,12 @@ module Storages
       Rails.env.local?
     end
 
-    store_attribute :provider_fields, :tenant_id, :string
-
     def self.short_provider_name = :share_point
+
+    def self.non_confidential_provider_fields
+      super + %i[tenant_id]
+    end
+
     def audience = nil
 
     def authenticate_via_idp? = false

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -104,6 +104,10 @@ module Storages
         split_reason = text.split(/[|:]/)
         split_reason[index].strip if split_reason.length > index
       end
+
+      def non_confidential_provider_fields
+        %i[automatically_managed health_notifications_enabled]
+      end
     end
 
     delegate :short_provider_name, :allowed_by_enterprise_token?, :disallowed_by_enterprise_token?, to: :class
@@ -169,6 +173,16 @@ module Storages
     def automatic_management_new_record? = raise Errors::SubclassResponsibility
 
     def provider_fields_defaults = raise Errors::SubclassResponsibility
+
+    def non_confidential_configuration
+      provider_fields.symbolize_keys
+                     .slice(*self.class.non_confidential_provider_fields)
+                     .merge(
+                       host:,
+                       oauth_client_id: oauth_client&.client_id,
+                       oauth_application_client_id: oauth_application&.uid
+                     )
+    end
 
     def provider_type_nextcloud?
       is_a?(NextcloudStorage)

--- a/modules/storages/spec/controllers/storages/admin/health_status_controller_spec.rb
+++ b/modules/storages/spec/controllers/storages/admin/health_status_controller_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Storages::Admin::HealthStatusController do
       expect(yaml["storage"]).to eq storage.name
       expect(yaml["storage_type"]).to eq storage.to_s
       expect(yaml.dig("base_configuration", "storage_configured", "state")).to eq("failure")
+      expect(yaml.dig("configuration", "host")).to eq(storage.host)
     end
   end
 

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -94,6 +94,13 @@ FactoryBot.define do
     authentication_method { "two_way_oauth2" }
     storage_audience { nil }
 
+    trait :with_oauth_configured do
+      after(:create) do |storage, _evaluator|
+        create(:oauth_client, integration: storage)
+        create(:oauth_application, integration: storage)
+      end
+    end
+
     trait :oidc_sso_enabled do
       storage_audience { "nextcloud" }
       authentication_method { "oauth2_sso" }

--- a/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
+++ b/modules/storages/spec/models/storages/nextcloud_storage_spec.rb
@@ -235,4 +235,35 @@ RSpec.describe Storages::NextcloudStorage do
       expect(storage.provider_fields_defaults).to eq({ automatic_management_enabled: true, username: "OpenProject" })
     end
   end
+
+  describe "#non_confidential_configuration" do
+    subject { storage.non_confidential_configuration }
+
+    let(:storage) { create(:nextcloud_storage, :with_oauth_configured) }
+
+    it "returns the expected hash" do
+      expect(subject).to eq(
+        authentication_method: "two_way_oauth2",
+        health_notifications_enabled: true,
+        host: storage.host,
+        oauth_application_client_id: storage.oauth_application.uid,
+        oauth_client_id: storage.oauth_client.client_id
+      )
+    end
+
+    context "when the storage is set-up for SSO" do
+      let(:storage) { create(:nextcloud_storage, :oidc_sso_enabled) }
+
+      it "returns the expected hash" do
+        expect(subject).to eq(
+          authentication_method: "oauth2_sso",
+          health_notifications_enabled: true,
+          host: storage.host,
+          storage_audience: "nextcloud",
+          oauth_application_client_id: nil,
+          oauth_client_id: nil
+        )
+      end
+    end
+  end
 end

--- a/modules/storages/spec/models/storages/one_drive_storage_spec.rb
+++ b/modules/storages/spec/models/storages/one_drive_storage_spec.rb
@@ -72,4 +72,22 @@ RSpec.describe Storages::OneDriveStorage do
       end
     end
   end
+
+  describe "#non_confidential_configuration" do
+    subject { storage.non_confidential_configuration }
+
+    let(:storage) { create(:one_drive_storage_configured) }
+
+    it "returns the expected hash" do
+      expect(subject).to eq(
+        automatically_managed: false,
+        health_notifications_enabled: true,
+        host: storage.host,
+        drive_id: storage.drive_id,
+        tenant_id: storage.tenant_id,
+        oauth_application_client_id: storage.oauth_application.uid,
+        oauth_client_id: storage.oauth_client.client_id
+      )
+    end
+  end
 end


### PR DESCRIPTION
Limiting that to non-confidential configuration, so that people do not leak passwords or similar to us, when they use the report to request support.
On the other hand, we include as many other details as possible, to get as much of an idea on how the storage could be misconfigured as possible.

# Ticket
https://community.openproject.org/wp/64477

### Checklist

* [x] Added tests