### PR TITLE
OneDrive provider type fix

### DIFF
--- a/app/controllers/oauth_clients_controller.rb
+++ b/app/controllers/oauth_clients_controller.rb
@@ -236,7 +236,7 @@ class OAuthClientsController < ApplicationController
   end
 
   def one_drive?
-    @oauth_client&.integration&.provider_type == ::Storages::Storage::PROVIDER_TYPE_ONE_DRIVE
+    @oauth_client&.integration&.provider_type == ::Storages::OneDriveStorage.name
   end
 
   def get_redirect_uri


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
This fixes an issue with the OneDrive provider type comparison: the class name `::Storages::OneDriveStorage.name` should be used instead of the constant `::Storages::Storage::PROVIDER_TYPE_ONE_DRIVE`.
