### PR TITLE
Improve error message for signature validation

### DIFF
--- a/modules/openid_connect/app/services/openid_connect/jwt_parser.rb
+++ b/modules/openid_connect/app/services/openid_connect/jwt_parser.rb
@@ -87,7 +87,7 @@ module OpenIDConnect
 
       provider = OpenIDConnect::Provider.where(available: true).where("options->>'issuer' = ?", issuer).first
       return Failure("The access token issuer is unknown") if provider.blank?
-      return Failure("Unable to validate issuer signature, can't fetch JWKS") if provider.jwks_uri.blank?
+      return Failure("Unable to validate issuer signature, OpenID Connect provider has no JWKS URI.") if provider.jwks_uri.blank?
 
       Success(provider)
     end


### PR DESCRIPTION
This should be a little more actionable for anyone reading the error message.