### PR TITLE
Correct labels array indentation.

### DIFF
--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -60,9 +60,9 @@ services:
     networks:
       - external
     labels:
-    - "traefik.enable=true"
-    - "traefik.http.routers.openproject-assets.rule=Host(`openproject-assets.local`)"
-    - "traefik.http.routers.openproject-assets.entrypoints=websecure"
+      - "traefik.enable=true"
+      - "traefik.http.routers.openproject-assets.rule=Host(`openproject-assets.local`)"
+      - "traefik.http.routers.openproject-assets.entrypoints=websecure"
 
 # You need to define the same external network
 # that is defined in the TLS proxy compose file


### PR DESCRIPTION
# What are you trying to accomplish?
Fix indentation of labels array in `docker/dev/tls/docker-compose.core-override.example.yml` to be as everywhere else.