### PR TITLE
Clarify APIv3 docs

### DIFF
--- a/docs/api/apiv3/tags/categories.yml
+++ b/docs/api/apiv3/tags/categories.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The categories endpoints return collections or single entities of type `Category`. The following tables list the different properties
+  of `Category` entities.
+
   ## Linked Properties
 
   |  Link           | Description                                         | Type          | Constraints | Supported operations |

--- a/docs/api/apiv3/tags/custom_options.yml
+++ b/docs/api/apiv3/tags/custom_options.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The custom options endpoints return collections or single entities of type `CustomOption`. The following tables list the different properties
+  of `CustomOption` entities.
+
   ## Linked Properties
 
   |  Link         | Description               | Type          | Constraints | Supported operations |

--- a/docs/api/apiv3/tags/help_texts.yml
+++ b/docs/api/apiv3/tags/help_texts.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The help texts endpoints return collections or single entities of type `HelpText`. The following tables list the different properties
+  of `HelpText` entities.
+
   ## Linked Properties
 
   |  Link         | Description               | Type          | Constraints | Supported operations |

--- a/docs/api/apiv3/tags/priorities.yml
+++ b/docs/api/apiv3/tags/priorities.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The priorities endpoints return collections or single entities of type `Priority`. The following tables list the different properties
+  of `Priority` entities.
+
   ## Linked Properties
 
   |  Link     | Description                                 | Type          | Constraints           | Supported operations |

--- a/docs/api/apiv3/tags/statuses.yml
+++ b/docs/api/apiv3/tags/statuses.yml
@@ -1,5 +1,8 @@
 name: Statuses
 description: |-
+  The statuses endpoints return collections or single entities of type `Status`. The following tables list the different properties
+  of `Status` entities.
+
   ## Linked Properties
 
   | Link | Description | Type   | Constraints | Supported operations |

--- a/docs/api/apiv3/tags/time_entries.yml
+++ b/docs/api/apiv3/tags/time_entries.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The time entries endpoints return collections or single entities of type `TimeEntry`. The following tables list the different properties
+  of `TimeEntry` entities.
+
   ## Actions
 
   | Link                | Description                                                                | Condition                                                                                           |

--- a/docs/api/apiv3/tags/userpreferences.yml
+++ b/docs/api/apiv3/tags/userpreferences.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The user preferences endpoints return collections or single entities of type `UserPreferences`. The following tables list the different properties
+  of `UserPreferences` entities.
+
   ## Linked Properties
 
   |  Link     | Description                                              | Type           | Constraints           | Supported operations |

--- a/docs/api/apiv3/tags/users.yml
+++ b/docs/api/apiv3/tags/users.yml
@@ -1,6 +1,9 @@
 ---
 name: Users
 description: |-
+  The users endpoints return collections or single entities of type `User`. The following tables list the different properties
+  of `User` entities.
+
   ## Actions
 
   | Link                | Description                                                          | Condition                                                        |

--- a/docs/api/apiv3/tags/work_packages.yml
+++ b/docs/api/apiv3/tags/work_packages.yml
@@ -1,5 +1,8 @@
 ---
 description: |-
+  The work packages endpoints return collections or single entities of type `WorkPackage`. The following tables list the different properties
+  of `WorkPackage` entities.
+
   ## Actions
 
   | Link                | Description                                                              | Condition                              |


### PR DESCRIPTION
When docs started directly in the tables of properties, without any introductory words, the linked tables appeared directly under the headline "ENTITY NAMES" (e.g. "Users"). This gave the wrong impression, that the tables would explain the links and properties of the collection endpoint of those classes.

This was fixed by adding a clarifying introductory paragraph to endpoint docs that didn't have an intro paragraph already.

# Ticket
https://community.openproject.org/wp/43878