### PR TITLE
Bug/66534 argumenterror in versionscontroller show

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1970,7 +1970,7 @@ en:
   button_duplicate: "Duplicate"
   button_duplicate_and_follow: "Duplicate and follow"
   button_edit: "Edit"
-  button_edit_associated_wikipage: "Edit associated Wiki page: %{page_title}"
+  button_edit_associated_wikipage: "Edit associated wiki page: %{page_title}"
   button_expand_all: "Expand all"
   button_favorite: "Add to favorites"
   button_filter: "Filter"

--- a/modules/backlogs/lib/open_project/backlogs/hooks/layout_hook.rb
+++ b/modules/backlogs/lib/open_project/backlogs/hooks/layout_hook.rb
@@ -30,33 +30,6 @@ module OpenProject::Backlogs::Hooks
   class LayoutHook < OpenProject::Hook::ViewListener
     include RbCommonHelper
 
-    def view_versions_show_bottom(context = {})
-      version = context[:version]
-      project = version.project
-
-      return "" unless project.module_enabled? "backlogs"
-
-      snippet = ""
-
-      if User.current.allowed_in_project?(:edit_wiki_pages, project)
-        snippet += '<span id="edit_wiki_page_action">'
-        snippet += link_to I18n.t(:button_edit_wiki),
-                           { controller: "/rb_wikis", action: "edit", project_id: project.id, sprint_id: version.id },
-                           class: "icon icon-edit"
-        snippet += "</span>"
-
-        # This wouldn't be necessary if the schedules plugin didn't disable the
-        # contextual hook
-        snippet += context[:hook_caller].nonced_javascript_tag(<<-JS)
-          (function ($) {
-            $(document).ready(function() {
-              $('#edit_wiki_page_action').detach().appendTo("div.contextual");
-            });
-          }(jQuery))
-        JS
-      end
-    end
-
     def view_my_settings(context = {})
       context[:controller].send(
         :render_to_string,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/66534

# What are you trying to accomplish?

Avoid running into an ArgumentError on calling `nonced_javascript_tag` with an argument. But since the whole code is no longer necessary, the hook implementation can be removed altogether. It is no longer necessary since the link that is intended to be added is by now added via a button in the sub header. 

## Screenshots

<img width="602" height="73" alt="image" src="https://github.com/user-attachments/assets/ac3a7c5d-49bc-4e0f-bb05-c1be3db58111" />
