### PR TITLE
[66426] Project overview: Add a '+ Widget' primary button to subheader

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3388,6 +3388,8 @@ en:
   label_watched_work_packages: "Watched work packages"
   label_what_is_this: "What is this?"
   label_week: "Week"
+  label_widget: "Widget"
+  label_widget_new: "New widget"
   label_wiki_content_added: "Wiki page added"
   label_wiki_content_updated: "Wiki page updated"
   label_wiki_toc: "Table of Contents"

--- a/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, Injector } from '@angular/core';
+import {
+  Injectable,
+  Injector,
+  OnDestroy,
+} from '@angular/core';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { AddGridWidgetModalComponent } from 'core-app/shared/components/grids/widgets/add/add.modal';
 import { GridWidgetResource } from 'core-app/features/hal/resources/grid-widget-resource';
@@ -14,8 +18,10 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { GridResource } from 'core-app/features/hal/resources/grid-resource';
 
 @Injectable()
-export class GridAddWidgetService {
+export class GridAddWidgetService implements OnDestroy {
   text = { add: this.i18n.t('js.grid.add_widget') };
+
+  private boundListener = this.createNewWidget.bind(this);
 
   constructor(
     readonly opModalService:OpModalService,
@@ -27,6 +33,11 @@ export class GridAddWidgetService {
     readonly resize:GridResizeService,
     readonly i18n:I18nService,
   ) {
+    document.addEventListener('overview:addWidget', this.boundListener);
+  }
+
+  ngOnDestroy():void {
+    document.removeEventListener('overiew:addWidget', this.boundListener);
   }
 
   public isAddable(area:GridArea) {
@@ -125,5 +136,10 @@ export class GridAddWidgetService {
 
   public get isAllowed() {
     return this.layout.gridResource && this.layout.gridResource.updateImmediately;
+  }
+
+  private createNewWidget():void {
+    const newGap = new GridGap(1, 2, 1, 2, 'row');
+    void this.widget(newGap);
   }
 }

--- a/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
@@ -37,7 +37,7 @@ export class GridAddWidgetService implements OnDestroy {
   }
 
   ngOnDestroy():void {
-    document.removeEventListener('overiew:addWidget', this.boundListener);
+    document.removeEventListener('overview:addWidget', this.boundListener);
   }
 
   public isAddable(area:GridArea) {

--- a/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/add-widget.service.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef, inject,
   Injectable,
   Injector,
   OnDestroy,
@@ -19,20 +20,22 @@ import { GridResource } from 'core-app/features/hal/resources/grid-resource';
 
 @Injectable()
 export class GridAddWidgetService implements OnDestroy {
+  readonly opModalService = inject(OpModalService);
+  readonly injector = inject(Injector);
+  readonly halResource = inject(HalResourceService);
+  readonly layout = inject(GridAreaService);
+  readonly drag = inject(GridDragAndDropService);
+  readonly move = inject(GridMoveService);
+  readonly resize = inject(GridResizeService);
+  readonly i18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   text = { add: this.i18n.t('js.grid.add_widget') };
 
   private boundListener = this.createNewWidget.bind(this);
 
-  constructor(
-    readonly opModalService:OpModalService,
-    readonly injector:Injector,
-    readonly halResource:HalResourceService,
-    readonly layout:GridAreaService,
-    readonly drag:GridDragAndDropService,
-    readonly move:GridMoveService,
-    readonly resize:GridResizeService,
-    readonly i18n:I18nService,
-  ) {
+
+  constructor() {
     document.addEventListener('overview:addWidget', this.boundListener);
   }
 
@@ -52,7 +55,7 @@ export class GridAddWidgetService implements OnDestroy {
       .select(area)
       .then(async (widgetResource) => {
         if (this.layout.isGap(area)) {
-          this.addLine(area as GridGap);
+          this.addLine(area);
         }
 
         const newArea = new GridWidgetArea(widgetResource);
@@ -138,8 +141,9 @@ export class GridAddWidgetService implements OnDestroy {
     return this.layout.gridResource && this.layout.gridResource.updateImmediately;
   }
 
-  private createNewWidget():void {
+  private async createNewWidget():Promise<void> {
     const newGap = new GridGap(1, 2, 1, 2, 'row');
-    void this.widget(newGap);
+    await this.widget(newGap);
+    this.cdRef.detectChanges();
   }
 }

--- a/frontend/src/app/shared/components/grids/widgets/add/add.modal.ts
+++ b/frontend/src/app/shared/components/grids/widgets/add/add.modal.ts
@@ -27,7 +27,7 @@ export class AddGridWidgetModalComponent extends OpModalComponent implements OnI
     cancel_button: this.i18n.t('js.button_cancel'),
   };
 
-  public chosenWidget:WidgetRegistration;
+  public chosenWidget?:WidgetRegistration;
 
   public eeShowBanners = false;
 

--- a/frontend/src/stimulus/controllers/dynamic/overview/add-widgets.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/overview/add-widgets.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class AddWidgetsController extends Controller {
+  private addWidget():void {
+    document.dispatchEvent(
+      new CustomEvent('overview:addWidget'),
+    );
+  }
+}

--- a/modules/overviews/app/views/overviews/overviews/show.html.erb
+++ b/modules/overviews/app/views/overviews/overviews/show.html.erb
@@ -55,4 +55,23 @@
   end
 %>
 
+<%=
+  if User.current.allowed_in_project?(:manage_overview, @project)
+    render(Primer::OpenProject::SubHeader.new) do |subheader|
+      subheader.with_action_button(
+        scheme: :primary,
+        leading_icon: :plus,
+        label: t(:label_widget_new),
+        data: {
+          controller: "overview--add-widgets",
+          action: "click->overview--add-widgets#addWidget"
+        },
+        test_selector: "overview--add-widgets-button"
+      ) do
+        t(:label_widget)
+      end
+    end
+  end
+%>
+
 <openproject-base></openproject-base>

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 
 require_relative "../support/pages/overview"
 
-RSpec.describe "Overview page managing", :js, :selenium do
+RSpec.describe "Overview page managing", :js do
   let!(:type) { create(:type) }
   let!(:project) { create(:project, types: [type], description: "My **custom** description") }
   let!(:open_status) { create(:default_status) }

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -60,87 +60,155 @@ RSpec.describe "Overview page managing", :js, :selenium do
     create(:user,
            member_with_permissions: { project => permissions })
   end
+
+  let(:user_without_permission) do
+    create(:user,
+           member_with_permissions: {
+             project => %i[
+               view_members
+               view_work_packages
+               add_work_packages
+               save_queries
+               manage_public_queries
+             ]
+           })
+  end
+
   let(:overview_page) do
     Pages::Overview.new(project)
   end
 
-  before do
-    login_as user
+  context "as a user with permission" do
+    before do
+      login_as user
 
-    overview_page.visit!
+      overview_page.visit!
+    end
+
+    it "renders the default view, allows altering and saving" do
+      description_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(1)")
+      status_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(2)")
+      overview_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(3)")
+      members_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(4)")
+
+      description_area.expect_to_exist
+      status_area.expect_to_exist
+      overview_area.expect_to_exist
+      members_area.expect_to_exist
+      description_area.expect_to_span(1, 1, 3, 2)
+      status_area.expect_to_span(1, 2, 2, 3)
+      overview_area.expect_to_span(3, 1, 4, 3)
+      members_area.expect_to_span(2, 2, 3, 3)
+
+      # The widgets load their respective contents
+      within description_area.area do
+        expect(page)
+          .to have_content("My custom description")
+      end
+
+      # within top-left area, add an additional widget
+      overview_page.add_widget(1, 1, :row, "Work packages table")
+      # Actually there are two success messages displayed currently. One for the grid getting updated and one
+      # for the query assigned to the new widget being created. A user will not notice it but the automated
+      # browser can get confused. Therefore we dismiss it twice.
+      overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+
+      # Fixing flaky spec: for some reason, the second request to load the table is not executed until
+      # some activity happens on the page. Sending an enter key to trigger the second request.
+      page.find("body").send_keys(:enter)
+
+      overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+
+      table_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(5)")
+      table_area.expect_to_span(1, 1, 2, 2)
+
+      # A useless resizing shows no message and does not alter the size
+      table_area.resize_to(1, 1)
+
+      overview_page.expect_no_toaster message: I18n.t("js.notice_successful_update")
+
+      table_area.expect_to_span(1, 1, 2, 2)
+
+      table_area.resize_to(1, 2)
+
+      overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+
+      # Resizing leads to the table area now spanning a larger area
+      table_area.expect_to_span(1, 1, 2, 3)
+
+      within table_area.area do
+        expect(page)
+          .to have_content(created_work_package.subject)
+        expect(page)
+          .to have_content(assigned_work_package.subject)
+      end
+
+      sleep(0.1)
+
+      # Reloading kept the user's values
+      visit home_path
+      overview_page.visit!
+
+      ## Because of the added column and the resizing the other widgets have moved down
+      # For unknown, undesired reasons, the project description no longer spans two rows.
+      # This happens when resizing the table area.
+      description_area.expect_to_span(2, 1, 3, 2)
+      status_area.expect_to_span(2, 2, 3, 3)
+      overview_area.expect_to_span(4, 1, 5, 3)
+      members_area.expect_to_span(3, 2, 4, 3)
+      table_area.expect_to_span(1, 1, 2, 3)
+    end
+
+    it "can add a new widget via a primary button" do
+      description_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(1)")
+      status_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(2)")
+      overview_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(3)")
+      members_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(4)")
+
+      description_area.expect_to_exist
+      status_area.expect_to_exist
+      overview_area.expect_to_exist
+      members_area.expect_to_exist
+
+      description_area.expect_to_span(1, 1, 3, 2)
+      status_area.expect_to_span(1, 2, 2, 3)
+      overview_area.expect_to_span(3, 1, 4, 3)
+      members_area.expect_to_span(2, 2, 3, 3)
+
+      page.find_test_selector("overview--add-widgets-button").click
+
+      within(".spot-modal") do
+        expect(page).to have_content(I18n.t("js.grid.add_widget"))
+
+        SeleniumHubWaiter.wait unless using_cuprite?
+
+        page.find('[data-test-selector="op-grid--addable-widget"]', text: "Members").click
+      end
+
+      second_members_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(5)")
+      second_members_area.expect_to_span(1, 1, 2, 2)
+
+      description_area.expect_to_span(2, 1, 4, 2)
+      status_area.expect_to_span(1, 2, 3, 3)
+      overview_area.expect_to_span(4, 1, 5, 3)
+      members_area.expect_to_span(3, 2, 4, 3)
+    end
   end
 
-  it "renders the default view, allows altering and saving" do
-    description_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(1)")
-    status_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(2)")
-    overview_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(3)")
-    members_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(4)")
+  context "as a user without permission" do
+    before do
+      login_as user_without_permission
 
-    description_area.expect_to_exist
-    status_area.expect_to_exist
-    overview_area.expect_to_exist
-    members_area.expect_to_exist
-    description_area.expect_to_span(1, 1, 3, 2)
-    status_area.expect_to_span(1, 2, 2, 3)
-    overview_area.expect_to_span(3, 1, 4, 3)
-    members_area.expect_to_span(2, 2, 3, 3)
-
-    # The widgets load their respective contents
-    within description_area.area do
-      expect(page)
-        .to have_content("My custom description")
+      overview_page.visit!
     end
 
-    # within top-left area, add an additional widget
-    overview_page.add_widget(1, 1, :row, "Work packages table")
-    # Actually there are two success messages displayed currently. One for the grid getting updated and one
-    # for the query assigned to the new widget being created. A user will not notice it but the automated
-    # browser can get confused. Therefore we dismiss it twice.
-    overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+    it "does not show the option to add widgets" do
+      # Neither hover effects
+      overview_page.expect_unable_to_add_widget(1, 1, :column, nil)
+      overview_page.expect_unable_to_add_widget(1, 1, :row, nil)
 
-    # Fixing flaky spec: for some reason, the second request to load the table is not executed until
-    # some activity happens on the page. Sending an enter key to trigger the second request.
-    page.find("body").send_keys(:enter)
-
-    overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
-
-    table_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(5)")
-    table_area.expect_to_span(1, 1, 2, 2)
-
-    # A useless resizing shows no message and does not alter the size
-    table_area.resize_to(1, 1)
-
-    overview_page.expect_no_toaster message: I18n.t("js.notice_successful_update")
-
-    table_area.expect_to_span(1, 1, 2, 2)
-
-    table_area.resize_to(1, 2)
-
-    overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
-
-    # Resizing leads to the table area now spanning a larger area
-    table_area.expect_to_span(1, 1, 2, 3)
-
-    within table_area.area do
-      expect(page)
-        .to have_content(created_work_package.subject)
-      expect(page)
-        .to have_content(assigned_work_package.subject)
+      # nor a create button are shown
+      expect(page).to have_no_test_selector("overview--add-widgets-button")
     end
-
-    sleep(0.1)
-
-    # Reloading kept the user's values
-    visit home_path
-    overview_page.visit!
-
-    ## Because of the added column and the resizing the other widgets have moved down
-    # For unknown, undesired reasons, the project description no longer spans two rows.
-    # This happens when resizing the table area.
-    description_area.expect_to_span(2, 1, 3, 2)
-    status_area.expect_to_span(2, 2, 3, 3)
-    overview_area.expect_to_span(4, 1, 5, 3)
-    members_area.expect_to_span(3, 2, 4, 3)
-    table_area.expect_to_span(1, 1, 2, 3)
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66426

# What are you trying to accomplish?
Creaate a button to add a new widget at the top left of the overview page

## Screenshots

![Aug-13-2025 11-17-20](https://github.com/user-attachments/assets/7f5e2a1a-319d-48f0-9dc4-851541f1b030)
