### PR TITLE
[#66471] Enable calculation of admin only calculated values on change of non admin only field values by non admins

### DIFF
--- a/app/services/projects/concerns/set_calculated_custom_field_values.rb
+++ b/app/services/projects/concerns/set_calculated_custom_field_values.rb
@@ -50,7 +50,18 @@ module Projects::Concerns
 
     def update_calculated_value_custom_fields
       changed_cf_ids = model.custom_values.select(&:changed?).map(&:custom_field_id)
-      affected_cfs = model.available_custom_fields.affected_calculated_fields(changed_cf_ids)
+
+      # Using unscope(where: :admin_only) to fix an issue when non admin user
+      # edits a custom field which is used by an admin only calculated value
+      # field. Without this unscoping, admin only value and all fields
+      # referencing it (recursively) will not be recalculated and there will
+      # even be no place for that recalculatin to be triggered unless an admin
+      # edits same value again.
+      #
+      # This may need to be handled differently to make it work for other custom
+      # field containers, like WorkPackage. User custom fields also has
+      # admin_only check.
+      affected_cfs = model.available_custom_fields.unscope(where: :admin_only).affected_calculated_fields(changed_cf_ids)
 
       model.calculate_custom_fields(affected_cfs)
     end

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -554,14 +554,8 @@ RSpec.describe Projects::SetAttributesService, type: :model do
             expect(subject.result.custom_value_attributes).to eq(
               cf_static.id => "3",
               cf_calculated1.id => "21",
-              cf_calculated3.id => "-6"
-            )
-
-            expect(subject.result.custom_value_attributes(all: true)).to eq(
-              cf_static.id => "3",
-              cf_calculated1.id => "21",
-              cf_calculated2.id => "-6",
-              cf_calculated3.id => "-6"
+              cf_calculated2.id => "231",
+              cf_calculated3.id => "3003"
             )
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66471

# What are you trying to accomplish?
Make admin only calculated field values get calculated on change of non admin only custom field value by non admin user

# What approach did you choose and why?
A hacky one

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
