### PR TITLE
ensure compatible structure on ORing relations

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/available_work_packages_on_create_api.rb
+++ b/modules/costs/lib/api/v3/time_entries/available_work_packages_on_create_api.rb
@@ -40,8 +40,7 @@ module API
 
         helpers do
           def allowed_scope
-            WorkPackage.where(id: WorkPackage.allowed_to(User.current, :log_own_time))
-                       .or(WorkPackage.where(project_id: Project.allowed_to(User.current, :log_time)))
+            WorkPackage.allowed_to_log_time(User.current)
           end
         end
 

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -173,7 +173,7 @@ module Costs
 
     activity_provider :time_entries, class_name: "Activities::TimeEntryActivityProvider", default: false
 
-    patches %i[Project User PermittedParams]
+    patches %i[Project User PermittedParams WorkPackage]
     patch_with_namespace :BasicData, :SettingSeeder
     patch_with_namespace :ActiveSupport, :NumberHelper, :NumberToCurrencyConverter
 

--- a/modules/costs/lib/costs/patches/work_package_patch.rb
+++ b/modules/costs/lib/costs/patches/work_package_patch.rb
@@ -1,4 +1,6 @@
-#-- copyright
+# frozen_string_literal: true
+
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -24,30 +26,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module TimeEntries::Scopes
-  module Ongoing
-    extend ActiveSupport::Concern
+module Costs::Patches::WorkPackagePatch
+  extend ActiveSupport::Concern
 
-    class_methods do
-      def ongoing
-        TimeEntry.where(ongoing: true)
-      end
-
-      def visible_ongoing(user = User.current)
-        TimeEntry
-          .where(
-            entity_type: "WorkPackage",
-            entity_id: WorkPackage.allowed_to_log_time(user).select(:id),
-            user:,
-            ongoing: true
-          )
-      end
-
-      def not_ongoing
-        TimeEntry.where(ongoing: false)
-      end
-    end
+  included do
+    scopes :allowed_to_log_time
   end
 end

--- a/modules/costs/spec/models/time_entries/scopes/ongoing_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/ongoing_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe TimeEntries::Scopes::Ongoing do
+  let(:user) { create(:user) }
+  let(:project) { create(:project, public: false) }
+  let(:work_package) { create(:work_package, project: project) }
+  let(:ongoing_time_entry) { create(:time_entry, user:, entity: work_package, ongoing: true) }
+  let(:work_package_role) { create(:work_package_role, permissions: work_package_permissions) }
+
+  subject { TimeEntry.visible_ongoing(user) }
+
+  shared_context "for the default use case" do
+    context "when the user has log_own_time permission directly on the work package" do
+      let(:work_package_permissions) { [:log_own_time] }
+
+      before do
+        create(:member, project: project, entity: work_package, user:, roles: [work_package_role])
+      end
+
+      it "returns the visible, ongoing time entry" do
+        expect(subject).to contain_exactly(ongoing_time_entry)
+      end
+    end
+  end
+
+  context "in regular instances", with_settings: { large_instance_wp_allowed_to_sql: false } do
+    include_context "for the default use case"
+  end
+
+  context "in large instances", with_settings: { large_instance_wp_allowed_to_sql: true } do
+    include_context "for the default use case"
+  end
+end

--- a/modules/costs/spec/models/work_packages/scopes/allowed_to_log_time_spec.rb
+++ b/modules/costs/spec/models/work_packages/scopes/allowed_to_log_time_spec.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::Scopes::AllowedToLogTime do
+  shared_let(:non_admin) { create(:user) }
+  shared_let(:admin) { create(:admin) }
+  shared_let(:project_status) { true }
+  shared_let(:private_project) { create(:project, public: false, active: project_status) }
+  shared_let(:public_project) { create(:project, public: true, active: project_status) }
+
+  shared_let(:work_package_in_public_project) { create(:work_package, project: public_project) }
+  shared_let(:work_package_in_private_project) { create(:work_package, project: private_project) }
+  shared_let(:other_work_package_in_private_project) { create(:work_package, project: private_project) }
+
+  let(:project_permissions) { [] }
+  let(:project_role) { create(:project_role, permissions: project_permissions) }
+
+  let(:work_package_permissions) { [] }
+  let(:work_package_role) { create(:work_package_role, permissions: work_package_permissions) }
+
+  let(:non_member_permissions) { [] }
+  let!(:non_member_role) { create(:non_member, permissions: non_member_permissions) }
+
+  let(:action) { project_or_work_package_action }
+  let(:project_or_work_package_action) { :log_own_time }
+
+  subject { WorkPackage.allowed_to_log_time(user) }
+
+  context "when the user is an admin" do
+    let(:user) { admin }
+
+    it "returns all work packages" do
+      expect(subject).to contain_exactly(
+        work_package_in_public_project,
+        work_package_in_private_project,
+        other_work_package_in_private_project
+      )
+    end
+
+    context "when the project is archived" do
+      before do
+        public_project.update!(active: false)
+        private_project.update!(active: false)
+      end
+
+      it "returns no work packages" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when the user is locked" do
+      before do
+        user.locked!
+      end
+
+      it "returns no work packages" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when the costs module is disabled" do
+      before do
+        private_project.enabled_module_names = private_project.enabled_module_names - ["costs"]
+      end
+
+      it "excludes work packages where the module is disabled in" do
+        expect(subject).to contain_exactly(work_package_in_public_project)
+      end
+    end
+  end
+
+  context "when the user is a non admin, logged in user" do
+    let(:user) { non_admin }
+
+    shared_context "for a non admin, logged in user" do
+      context "when the user has log_own_time permission directly on the work package" do
+        let(:work_package_permissions) { [:log_own_time] }
+
+        before do
+          create(:member,
+                 project: private_project,
+                 entity: work_package_in_private_project,
+                 user:,
+                 roles: [work_package_role])
+        end
+
+        it "returns the authorized work package" do
+          expect(subject).to contain_exactly(work_package_in_private_project)
+        end
+
+        context "when the project is archived" do
+          before do
+            public_project.update!(active: false)
+            private_project.update!(active: false)
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the module is inactive in the project" do
+          before do
+            public_project.enabled_modules = []
+            private_project.enabled_modules = []
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the user is locked" do
+          before do
+            user.locked!
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+      end
+
+      context "when the user has the log_own_time permission on the project the work package belongs to" do
+        let(:project_permissions) { [:log_own_time] }
+
+        before do
+          create(:member,
+                 project: private_project,
+                 user:,
+                 roles: [project_role])
+        end
+
+        it "returns the authorized work packages" do
+          expect(subject).to contain_exactly(
+            work_package_in_private_project,
+            other_work_package_in_private_project
+          )
+        end
+
+        context "when the project is archived" do
+          before do
+            public_project.update!(active: false)
+            private_project.update!(active: false)
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the module is inactive in the project" do
+          before do
+            public_project.enabled_modules = []
+            private_project.enabled_modules = []
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the user is locked" do
+          before do
+            user.locked!
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+      end
+
+      context "when the user has the log_time permission on the project the work package belongs to" do
+        let(:project_permissions) { [:log_time] }
+
+        before do
+          create(:member,
+                 project: private_project,
+                 user:,
+                 roles: [project_role])
+        end
+
+        it "returns the authorized work packages" do
+          expect(subject).to contain_exactly(
+            work_package_in_private_project,
+            other_work_package_in_private_project
+          )
+        end
+
+        context "when the project is archived" do
+          before do
+            public_project.update!(active: false)
+            private_project.update!(active: false)
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the module is inactive in the project" do
+          before do
+            public_project.enabled_modules = []
+            private_project.enabled_modules = []
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+
+        context "when the user is locked" do
+          before do
+            user.locked!
+          end
+
+          it "returns no work packages" do
+            expect(subject).to be_empty
+          end
+        end
+      end
+
+      context "when the user has a different permission on the project, but log_own_time on a specific work package" do
+        let(:project_permissions) { [:view_work_packages] }
+        let(:work_package_permissions) { %i[log_own_time] }
+
+        before do
+          create(:member, project: private_project, entity: work_package_in_private_project, user:, roles: [work_package_role])
+          create(:member, project: private_project, user:, roles: [project_role])
+        end
+
+        it "returns the authorized work packages" do
+          expect(subject).to contain_exactly(
+            work_package_in_private_project
+          )
+        end
+      end
+
+      context "when the user isn`t member in the project" do
+        before do
+          non_member_role.save!
+        end
+
+        context "with the non member role having the permission" do
+          let(:non_member_permissions) { [:log_own_time] }
+
+          it "returns work packages in the public project" do
+            expect(subject).to contain_exactly(work_package_in_public_project)
+          end
+        end
+
+        context "with the non member role lacking the permission" do
+          let(:non_member_permissions) { [] }
+
+          it "is empty" do
+            expect(subject).to be_empty
+          end
+        end
+      end
+    end
+
+    context "in non large instances", with_settings: { large_instance_wp_allowed_to_sql: false } do
+      include_context "for a non admin, logged in user"
+    end
+
+    context "in large instances", with_settings: { large_instance_wp_allowed_to_sql: true } do
+      include_context "for a non admin, logged in user"
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/66405

# What are you trying to accomplish?

Fix TimeEntries.ongoing scope in case `Setting.large_instance_wp_allowed_to_sql = true`. This failed since the two AR::Relation objects that are ORed are structurally incompatible (`WorkPackage.allowed_to` having a `from`).

This is fixed inelegantly by a subquery.

Since the same code was used twice now, the code is extracted into a scope.

# Merge checklist

- [x] Added/updated tests
