### PR TITLE
Automatically switch to dark high contrast if user prefers so

### DIFF
--- a/frontend/src/app/core/setup/globals/theme-utils.ts
+++ b/frontend/src/app/core/setup/globals/theme-utils.ts
@@ -47,7 +47,7 @@ export class ThemeUtils {
     switch (theme) {
       case 'dark':
         body.setAttribute('data-color-mode', 'dark');
-        body.setAttribute('data-dark-theme', 'dark');
+        body.setAttribute('data-dark-theme', increaseContrast ? 'dark_high_contrast' : 'dark');
         body.removeAttribute('data-light-theme');
         break;
       case 'light':

--- a/spec/features/my/interface_spec.rb
+++ b/spec/features/my/interface_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe "My account Interface settings",
 
     expect(page).to have_css("body[data-color-mode='dark'][data-dark-theme='dark']")
 
+    select "Dark high contrast", from: "Colour mode"
+    click_on "Update look and feel"
+
+    expect(page).to have_css("body[data-color-mode='dark'][data-dark-theme='dark_high_contrast']")
+
     select "Automatic (match OS colour mode)", from: "Colour mode"
     click_on "Update look and feel"
 


### PR DESCRIPTION
https://community.openproject.org/wp/66395

Follows #19789

[dhc-auto-theme.webm](https://github.com/user-attachments/assets/ba0093e7-46e9-4f52-8949-071bf6c1a474)

⚠️  _Logo switching will be fixed_ 🫠 