### PR TITLE
Translate invalid tokens

### DIFF
--- a/app/components/work_package_types/subject_configuration_component.rb
+++ b/app/components/work_package_types/subject_configuration_component.rb
@@ -75,7 +75,9 @@ module WorkPackageTypes
     end
 
     def supported_attributes
-      attribute_tokens = Patterns::TokenPropertyMapper.new.tokens_for_type(model)
+      token_mapper = Patterns::TokenPropertyMapper.new
+      valid_tokens = token_mapper.all_tokens
+      suggestable_tokens = token_mapper.tokens_for_type(model).to_set
 
       result = {
         work_package: {
@@ -92,10 +94,20 @@ module WorkPackageTypes
         }
       }
 
-      attribute_tokens.each_with_object(result) do |token, obj|
-        token_hash = { key: token.key, label: token.label, label_with_context: token.label_with_context }
-        obj[token.context][:tokens] << token_hash
+      valid_tokens.each do |token|
+        result.dig(token.context, :tokens) << token_to_hash(token, enabled: suggestable_tokens.include?(token))
       end
+
+      result
+    end
+
+    def token_to_hash(token, enabled:)
+      {
+        key: token.key,
+        label: token.label,
+        label_with_context: token.label_with_context,
+        enabled:
+      }
     end
 
     def sort_attributes(attributes)

--- a/app/components/work_package_types/subject_configuration_component.rb
+++ b/app/components/work_package_types/subject_configuration_component.rb
@@ -75,9 +75,7 @@ module WorkPackageTypes
     end
 
     def supported_attributes
-      token_mapper = Patterns::TokenPropertyMapper.new
-      valid_tokens = token_mapper.all_tokens
-      suggestable_tokens = token_mapper.tokens_for_type(model).to_set
+      enabled, disabled = Patterns::TokenPropertyMapper.new.partitioned_tokens_for_type(model)
 
       result = {
         work_package: {
@@ -94,9 +92,8 @@ module WorkPackageTypes
         }
       }
 
-      valid_tokens.each do |token|
-        result.dig(token.context, :tokens) << token_to_hash(token, enabled: suggestable_tokens.include?(token))
-      end
+      enabled.each { |token| result.dig(token.context, :tokens) << token_to_hash(token, enabled: true) }
+      disabled.each { |token| result.dig(token.context, :tokens) << token_to_hash(token, enabled: false) }
 
       result
     end

--- a/app/contracts/work_package_types/update_subject_pattern_contract.rb
+++ b/app/contracts/work_package_types/update_subject_pattern_contract.rb
@@ -60,6 +60,9 @@ module WorkPackageTypes
       end
     end
 
-    def flat_valid_token_list = WorkPackageTypes::Patterns::TokenPropertyMapper.new.tokens_for_type(model).map(&:key)
+    def flat_valid_token_list
+      enabled, _disabled = WorkPackageTypes::Patterns::TokenPropertyMapper.new.partitioned_tokens_for_type(model)
+      enabled.map(&:key)
+    end
   end
 end

--- a/app/models/work_package_types/pattern_resolver.rb
+++ b/app/models/work_package_types/pattern_resolver.rb
@@ -40,7 +40,7 @@ module WorkPackageTypes
     end
 
     def resolve(work_package)
-      @tokens = @mapper.tokens_for_type(work_package.type)
+      @tokens, = @mapper.partitioned_tokens_for_type(work_package.type)
 
       @pattern_tokens.inject(@pattern) do |pattern, token|
         pattern.gsub(token.pattern, get_value(work_package, token))

--- a/app/models/work_package_types/patterns/attribute_token.rb
+++ b/app/models/work_package_types/patterns/attribute_token.rb
@@ -54,6 +54,23 @@ module WorkPackageTypes
           :work_package
         end
       end
+
+      # --- Equality overrides ---
+      # We want to make sure that two tokens are considered equal if they represent the attribute. This is regardless
+      # of identity of the methods used to resolve their labels etc.
+
+      def ==(other)
+        eql?(other)
+      end
+
+      def eql?(other)
+        self.class == other.class && key == other.key
+      end
+
+      def hash
+        [self.class, key].hash
+      end
+      # --- END Equality overrides ---
     end
   end
 end

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -69,14 +69,18 @@ module WorkPackageTypes
       ].freeze
       # rubocop:enable Layout/LineLength
 
-      def tokens_for_type(type)
-        [
+      def partitioned_tokens_for_type(type)
+        enabled_tokens = [
           *BASE_ATTRIBUTE_TOKENS,
           *tokenize(work_package_cfs_for(type)),
           *tokenize(project_cfs, "project_"),
           *tokenize(all_work_package_cfs, "parent_")
-        ]
+        ].to_set
+
+        all_tokens.partition { |token| enabled_tokens.include?(token) }
       end
+
+      private
 
       def all_tokens
         [
@@ -86,8 +90,6 @@ module WorkPackageTypes
           *tokenize(all_work_package_cfs, "parent_")
         ]
       end
-
-      private
 
       def default_tokens
         BASE_ATTRIBUTE_TOKENS.each_with_object({ work_package: {}, project: {}, parent: {} }) do |token, obj|

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -78,6 +78,15 @@ module WorkPackageTypes
         ]
       end
 
+      def all_tokens
+        [
+          *BASE_ATTRIBUTE_TOKENS,
+          *tokenize(all_work_package_cfs),
+          *tokenize(project_cfs, "project_"),
+          *tokenize(all_work_package_cfs, "parent_")
+        ]
+      end
+
       private
 
       def default_tokens

--- a/frontend/src/stimulus/controllers/pattern-input.controller.ts
+++ b/frontend/src/stimulus/controllers/pattern-input.controller.ts
@@ -39,7 +39,14 @@ type FilteredSuggestions = Array<{
 
 type TokenElement = HTMLElement&{ dataset:{ role:'token', prop:string } };
 type ListElement = HTMLElement&{ dataset:{ role:'list_item', prop:string } };
-type AttributeToken = { key:string, label:string, label_with_context?:string, insert_as_text?:boolean };
+
+interface AttributeToken {
+  key:string;
+  label:string;
+  label_with_context?:string;
+  insert_as_text?:boolean;
+  enabled:boolean;
+};
 
 const COMPLETION_CHARACTER = '/';
 const TOKEN_REGEX = /{{([0-9A-Za-z_]+)}}/g;
@@ -84,11 +91,13 @@ export default class PatternInputController extends Controller {
   declare readonly insertAsTextTemplateValue:string;
 
   validTokenMap:Record<string, AttributeToken> = {};
+  validSuggestions:Record<string, { title:string, tokens:AttributeToken[] }> = {};
   currentRange:Range|undefined = undefined;
 
   connect() {
     this.validTokenMap = this.flatTokensKeyToLabelWithContext();
     this.contentTarget.innerHTML = this.toHtml(this.patternInitialValue) || ' ';
+    this.populateValidSuggestions();
     this.tagInvalidTokens();
     this.clearSuggestionsFilter();
   }
@@ -433,8 +442,8 @@ export default class PatternInputController extends Controller {
   }
 
   private getFilteredSuggestionsData(word:string):FilteredSuggestions {
-    return Object.keys(this.suggestionsInitialValue).map((key) => {
-      const group = this.suggestionsInitialValue[key];
+    return Object.keys(this.validSuggestions).map((key) => {
+      const group = this.validSuggestions[key];
       return {
         key,
         label: group.title,
@@ -445,9 +454,19 @@ export default class PatternInputController extends Controller {
     }).filter((group) => group.values.length > 0);
   }
 
+  private populateValidSuggestions():void {
+    for (const key of Object.keys(this.suggestionsInitialValue)) {
+      const group = this.suggestionsInitialValue[key];
+      this.validSuggestions[key] = {
+        title: group.title,
+        tokens: group.tokens.filter((token) => token.enabled)
+      };
+    }
+  }
+
   private tagInvalidTokens():void {
     this.contentTarget.querySelectorAll('[data-role="token"]').forEach((element:TokenElement) => {
-      const exists = Object.keys(this.validTokenMap).some((key) => key === element.dataset.prop);
+      const exists = Object.keys(this.validTokenMap).some((key) => this.validTokenMap[key].enabled && key === element.dataset.prop);
 
       if (exists) {
         this.setStyle(element, 'accent');

--- a/frontend/src/stimulus/controllers/pattern-input.controller.ts
+++ b/frontend/src/stimulus/controllers/pattern-input.controller.ts
@@ -466,14 +466,16 @@ export default class PatternInputController extends Controller {
 
   private tagInvalidTokens():void {
     this.contentTarget.querySelectorAll('[data-role="token"]').forEach((element:TokenElement) => {
-      const exists = Object.keys(this.validTokenMap).some((key) => this.validTokenMap[key].enabled && key === element.dataset.prop);
-
-      if (exists) {
+      if (this.isSuggestable(element.dataset.prop)) {
         this.setStyle(element, 'accent');
       } else {
         this.setStyle(element, 'danger');
       }
     });
+  }
+
+  private isSuggestable(token:string):boolean {
+    return Object.keys(this.validTokenMap).some((key) => this.validTokenMap[key].enabled && token === key);
   }
 
   private setStyle(token:TokenElement, style:'accent'|'danger'|'secondary'):void {
@@ -506,9 +508,13 @@ export default class PatternInputController extends Controller {
   private sanitizeContent():void {
     this.contentTarget.childNodes.forEach((node) => {
       if (this.isToken(node)) {
-        this.setStyle(node, 'accent');
-
         const key = node.dataset.prop;
+        if(this.isSuggestable(key)) {
+          this.setStyle(node, 'accent');
+        } else {
+          this.setStyle(node, 'danger');
+        }
+
         if (node.textContent !== this.tokenText(key)) {
           if (this.containsCursor(node)) {
             this.setStyle(node, 'secondary');

--- a/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
       work_package.type.custom_fields << custom_field
     end
   end
+  shared_let(:custom_field_not_on_type) do
+    create(:string_wp_custom_field)
+  end
 
   shared_let(:boolean_custom_field) do
     create(:boolean_wp_custom_field).tap do |custom_field|
@@ -100,37 +103,62 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
     end
   end
 
-  it "multi value fields are supported" do
-    token = described_class.new.tokens_for_type(work_package.type).detect do |t|
-      t.key == :"custom_field_#{mult_list_custom_field.id}"
-    end
-    expect(token.call(work_package)).to eq(%w[A B])
-  end
-
-  it "supports boolean custom fields" do
-    token = described_class.new.tokens_for_type(work_package.type).detect do |t|
-      t.key == :"custom_field_#{boolean_custom_field.id}"
+  describe "#tokens_for_type" do
+    it "multi value fields are supported" do
+      token = described_class.new.tokens_for_type(work_package.type).detect do |t|
+        t.key == :"custom_field_#{mult_list_custom_field.id}"
+      end
+      expect(token.call(work_package)).to eq(%w[A B])
     end
 
-    expect(token.call(work_package)).to be(true)
-  end
+    it "supports boolean custom fields" do
+      token = described_class.new.tokens_for_type(work_package.type).detect do |t|
+        t.key == :"custom_field_#{boolean_custom_field.id}"
+      end
 
-  it "must return nil if custom field is not activated in project" do
-    token = described_class.new.tokens_for_type(work_package.type).detect do |t|
-      t.key == :"custom_field_#{not_activated_custom_field.id}"
+      expect(token.call(work_package)).to be(true)
     end
 
-    expect { token.call(work_package) }.not_to raise_error
-    expect(token.call(work_package)).to eq(:attribute_not_available)
+    it "must return nil if custom field is not activated in project" do
+      token = described_class.new.tokens_for_type(work_package.type).detect do |t|
+        t.key == :"custom_field_#{not_activated_custom_field.id}"
+      end
+
+      expect { token.call(work_package) }.not_to raise_error
+      expect(token.call(work_package)).to eq(:attribute_not_available)
+    end
+
+    it "returns all possible tokens" do
+      cf = string_custom_field
+      tokens = described_class.new.tokens_for_type(work_package.type)
+
+      expect(tokens.first).to be_a(WorkPackageTypes::Patterns::AttributeToken)
+      expect(detect(tokens, :project_status).label).to eq(Project.human_attribute_name(:status_code))
+      expect(detect(tokens, :"custom_field_#{cf.id}").label).to eq(cf.name)
+    end
+
+    it "does not return a token that's not on the correct type" do
+      cf = custom_field_not_on_type
+      tokens = described_class.new.tokens_for_type(work_package.type)
+      expect(detect(tokens, :"custom_field_#{cf.id}")).to be_nil
+    end
   end
 
-  it "returns all possible tokens" do
-    cf = string_custom_field
-    tokens = described_class.new.tokens_for_type(work_package.type)
+  describe "#all_tokens" do
+    it "returns all possible tokens" do
+      cf = string_custom_field
+      tokens = described_class.new.all_tokens
 
-    expect(tokens.first).to be_a(WorkPackageTypes::Patterns::AttributeToken)
-    expect(detect(tokens, :project_status).label).to eq(Project.human_attribute_name(:status_code))
-    expect(detect(tokens, :"custom_field_#{cf.id}").label).to eq(cf.name)
+      expect(tokens.first).to be_a(WorkPackageTypes::Patterns::AttributeToken)
+      expect(detect(tokens, :project_status).label).to eq(Project.human_attribute_name(:status_code))
+      expect(detect(tokens, :"custom_field_#{cf.id}").label).to eq(cf.name)
+    end
+
+    it "returns a token that's not on the correct type" do
+      cf = custom_field_not_on_type
+      tokens = described_class.new.all_tokens
+      expect(detect(tokens, :"custom_field_#{cf.id}").label).to eq(cf.name)
+    end
   end
 
   private


### PR DESCRIPTION
Allowing tokens that are known, but not valid in the current context (e.g. because the type doesn't allow them) to still have a human readable name, while being rendered as invalid tokens.

At the same time, this PR improves highlighting of invalid tokens, by keeping it even after the user started editing the pattern.

# Ticket
https://community.openproject.org/wp/65632

# Screenshots

<img width="383" height="178" alt="image" src="https://github.com/user-attachments/assets/7a7f33ec-f034-4815-8302-ef80ed657a66" />
