### PR TITLE
Select the correct OP Logo when color mode is automatically switched

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -319,7 +319,9 @@ module ApplicationHelper
   def user_theme_data_attributes
     if User.current.pref.sync_with_os_theme?
       # Theme will be set by inline script before body renders to prevent flickering
-      { auto_theme_switcher_mode_value: User.current.pref.theme }
+      { auto_theme_switcher_mode_value: User.current.pref.theme,
+        auto_theme_switcher_desktop_light_high_contrast_logo_class: "op-logo--link_high_contrast",
+        auto_theme_switcher_mobile_light_high_contrast_logo_class: "op-logo--icon_white" }
     else
       mode, _theme_suffix = User.current.pref.theme.split("_", 2)
       {

--- a/frontend/src/app/core/setup/globals/theme-utils.ts
+++ b/frontend/src/app/core/setup/globals/theme-utils.ts
@@ -28,7 +28,7 @@
  * ++
  */
 
-export type OpTheme = 'light' | 'light_high_contrast' | 'dark';
+export type OpTheme = 'light' | 'light_high_contrast' | 'dark' | 'dark_high_contrast';
 
 export class ThemeUtils {
   public applySystemThemeImmediately():void {
@@ -37,11 +37,23 @@ export class ThemeUtils {
   }
 
   public detectSystemTheme():OpTheme {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    return this.prefersSystemLightMode() ? 'light' : 'dark';
+  }
+
+  public prefersSystemLightHighContrast():boolean {
+    return this.prefersSystemLightMode() && this.prefersSystemHighContrast();
+  }
+
+  public prefersSystemLightMode():boolean {
+    return window.matchMedia('(prefers-color-scheme: light)').matches;
+  }
+
+  public prefersSystemHighContrast():boolean {
+    return window.matchMedia('(prefers-contrast: more)').matches;
   }
 
   public applyThemeToBody(theme:OpTheme):void {
-    const increaseContrast = window.matchMedia('(prefers-contrast: more)').matches;
+    const increaseContrast = this.prefersSystemHighContrast();
     const body = document.body;
 
     switch (theme) {

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -30,13 +30,23 @@
 
 import { Controller } from '@hotwired/stimulus';
 import { useMatchMedia } from 'stimulus-use';
+import { type OpTheme } from 'core-app/core/setup/globals/theme-utils';
+
+type OpThemeMode = OpTheme | 'sync_with_os';
 
 export default class AutoThemeSwitcher extends Controller {
   static values = {
     mode: String,
   };
 
-  declare readonly modeValue:string;
+  static targets = ['desktopLogo', 'mobileLogo'];
+  static classes = ['desktopLightHighContrastLogo', 'mobileLightHighContrastLogo'];
+
+  declare readonly modeValue:OpThemeMode;
+  declare readonly desktopLogoTarget:HTMLLinkElement;
+  declare readonly mobileLogoTarget:HTMLLinkElement;
+  declare readonly desktopLightHighContrastLogoClass:string;
+  declare readonly mobileLightHighContrastLogoClass:string;
 
   connect() {
     if (this.modeValue !== 'sync_with_os') return;
@@ -47,6 +57,12 @@ export default class AutoThemeSwitcher extends Controller {
         highContrastMode: '(prefers-contrast: more)',
       },
     });
+
+    this.applySystemTheme();
+  }
+
+  lightModeChanged():void {
+    this.applySystemTheme();
   }
 
   isLightMode():void {
@@ -58,6 +74,17 @@ export default class AutoThemeSwitcher extends Controller {
   }
 
   highContrastModeChanged():void {
+    this.applySystemTheme();
+  }
+
+  private applySystemTheme():void {
     window.OpenProject.theme.applySystemThemeImmediately();
+    this.updateOpLogoContrast();
+  }
+
+  private updateOpLogoContrast():void {
+    const prefersSystemLightHighContrast = window.OpenProject.theme.prefersSystemLightHighContrast();
+    this.desktopLogoTarget.classList.toggle(this.desktopLightHighContrastLogoClass, prefersSystemLightHighContrast);
+    this.mobileLogoTarget.classList.toggle(this.mobileLightHighContrastLogoClass, prefersSystemLightHighContrast);
   }
 }

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -55,17 +55,21 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_logo
+    mode_class = "op-logo--link_high_contrast" unless User.current.pref.light_high_contrast_theme?
     content_tag :div, class: "op-logo" do
-      mode_class = User.current.pref.light_high_contrast_theme? ? "op-logo--link_high_contrast" : ""
       link_to(I18n.t("label_home"),
               configurable_home_url,
-              class: "op-logo--link #{mode_class}")
+              data: { auto_theme_switcher_target: "desktopLogo" },
+              class: ["op-logo--link", mode_class].compact)
     end
   end
 
   def render_logo_icon
     mode_class = "op-logo--icon_white" unless User.current.pref.light_high_contrast_theme?
-    link_to(I18n.t("label_home"), configurable_home_url, class: ["op-logo", "op-logo--icon", "op-logo--link", mode_class])
+    link_to(I18n.t("label_home"),
+            configurable_home_url,
+            data: { auto_theme_switcher_target: "mobileLogo" },
+            class: ["op-logo", "op-logo--icon", "op-logo--link", mode_class].compact)
   end
 
   def render_waffle_menu_logo_icon


### PR DESCRIPTION
https://community.openproject.org/work_packages/66448

Update the logo link classes based on contrast settings. LightHighContrast has the dark logo and all other modes use the white logo

[auto-logo-switch.webm](https://github.com/user-attachments/assets/d3c44d85-8ac2-4322-83bc-82e93f5e3e9c)
