### PR TITLE
Rely on `AutoThemeSwitcherController#connect()` to set initial theme in place of inline head script

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -40,15 +40,6 @@ See COPYRIGHT and LICENSE files for more details.
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
   <%# Disable prefetching for now %>
   <meta name="turbo-prefetch" content="false">
-  <%# Apply system theme immediately to prevent flickering %>
-  <% if User.current.pref.sync_with_os_theme? %>
-    <%= nonced_javascript_tag do %>
-      // Apply system theme before body renders to prevent flickering
-      (function() {
-        window.OpenProject.theme.applySystemThemeImmediately();
-      })();
-    <% end %>
-  <% end %>
 </head>
 <%= content_tag :body,
                 class: "#{body_css_classes}  __overflowing_element_container __overflowing_body",


### PR DESCRIPTION
https://community.openproject.org/work_packages/66588

~We cannot rely on `window.OpenProject.theme` global var as it's not loaded in time. We would have to duplicate an inline script.~ It's possible to defer `window.OpenPoject` loading (see https://github.com/opf/openproject/pull/19922#discussion_r2276570130)

~However, it seems that it is sufficient to just set the initial theme on [`AutoThemeSwitcherController#connect()`](https://github.com/opf/openproject/blob/1907fa77cb1913c9c5899582d3ed9cdf5ebd1952/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts#L61) - introduced in #19920~

```js
  Uncaught TypeError: can't access property "theme",  window.OpenProject is undefined
```

<img width="2385" height="91" alt="Screenshot 2025-08-14 at 1 45 15 PM" src="https://github.com/user-attachments/assets/64b87d21-5511-4906-b47a-8a2e3b50b54c" />
