### PR TITLE
Distinguish between mobile and desktop logo in auto theme switching

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -321,7 +321,7 @@ module ApplicationHelper
       # Theme will be set by inline script before body renders to prevent flickering
       { auto_theme_switcher_mode_value: User.current.pref.theme,
         auto_theme_switcher_desktop_light_high_contrast_logo_class: "op-logo--link_high_contrast",
-        auto_theme_switcher_mobile_light_high_contrast_logo_class: "op-logo--icon_white" }
+        auto_theme_switcher_mobile_white_logo_class: "op-logo--icon_white" }
     else
       mode, _theme_suffix = User.current.pref.theme.split("_", 2)
       {

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -40,13 +40,13 @@ export default class AutoThemeSwitcher extends Controller {
   };
 
   static targets = ['desktopLogo', 'mobileLogo'];
-  static classes = ['desktopLightHighContrastLogo', 'mobileLightHighContrastLogo'];
+  static classes = ['desktopLightHighContrastLogo', 'mobileWhiteLogo'];
 
   declare readonly modeValue:OpThemeMode;
   declare readonly desktopLogoTarget:HTMLLinkElement;
   declare readonly mobileLogoTarget:HTMLLinkElement;
   declare readonly desktopLightHighContrastLogoClass:string;
-  declare readonly mobileLightHighContrastLogoClass:string;
+  declare readonly mobileWhiteLogoClass:string;
 
   connect() {
     if (this.modeValue !== 'sync_with_os') return;
@@ -65,16 +65,16 @@ export default class AutoThemeSwitcher extends Controller {
     this.applySystemTheme();
   }
 
+  highContrastModeChanged():void {
+    this.applySystemTheme();
+  }
+
   isLightMode():void {
     window.OpenProject.theme.applyThemeToBody('light');
   }
 
   notLightMode():void {
     window.OpenProject.theme.applyThemeToBody('dark');
-  }
-
-  highContrastModeChanged():void {
-    this.applySystemTheme();
   }
 
   private applySystemTheme():void {
@@ -85,6 +85,6 @@ export default class AutoThemeSwitcher extends Controller {
   private updateOpLogoContrast():void {
     const prefersSystemLightHighContrast = window.OpenProject.theme.prefersSystemLightHighContrast();
     this.desktopLogoTarget.classList.toggle(this.desktopLightHighContrastLogoClass, prefersSystemLightHighContrast);
-    this.mobileLogoTarget.classList.toggle(this.mobileLightHighContrastLogoClass, prefersSystemLightHighContrast);
+    this.mobileLogoTarget.classList.toggle(this.mobileWhiteLogoClass, !prefersSystemLightHighContrast);
   }
 }

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -55,7 +55,7 @@ module Redmine::MenuManager::TopMenuHelper
   end
 
   def render_logo
-    mode_class = "op-logo--link_high_contrast" unless User.current.pref.light_high_contrast_theme?
+    mode_class = "op-logo--link_high_contrast" if User.current.pref.light_high_contrast_theme?
     content_tag :div, class: "op-logo" do
       link_to(I18n.t("label_home"),
               configurable_home_url,


### PR DESCRIPTION
https://community.openproject.org/wp/66448

Hotfix #19920 On mobile, only a white/blue icon icon is displayed.

