### PR TITLE
✨Fix work package comment attachment parsing

### DIFF
--- a/app/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service.rb
+++ b/app/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service.rb
@@ -67,11 +67,12 @@ module WorkPackages
         def filter_claimable_attachment_ids(ids)
           return [] if ids.blank?
 
-          attachments = Attachment.where(id: ids)
-
-          attachments
-            .select { |att| att.container.nil? || att.container == model }
-            .map { |att| att.id.to_s }
+          Attachment
+            .where(container: nil)
+            .or(Attachment.where(container: model))
+            .where(id: ids)
+            .pluck(:id)
+            .map(&:to_s)
         end
 
         def parser

--- a/app/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service.rb
+++ b/app/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service.rb
@@ -70,7 +70,7 @@ module WorkPackages
           attachments = Attachment.where(id: ids)
 
           attachments
-            .select { |att| att.container.nil? }
+            .select { |att| att.container.nil? || att.container == model }
             .map { |att| att.id.to_s }
         end
 

--- a/spec/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/activities_tab/comment_attachments_claims/set_attributes_service_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe WorkPackages::ActivitiesTab::CommentAttachmentsClaims::SetAttribu
         allow(Attachment).to receive(:where)
           .with(id: [assigned_attachment.id.to_s, unattached_attachment.id.to_s])
           .and_return([assigned_attachment, unattached_attachment])
+        # A second call happens when setting the filtered replacements
+        allow(Attachment).to receive(:where)
+          .with(id: [unattached_attachment.id.to_s])
+          .and_return([unattached_attachment])
       end
 
       it "filters out the assigned attachment and only sets unattached ones" do


### PR DESCRIPTION
Notice this PR is mostly done by cursor GPT 5 high. [original PR](https://github.com/Eric-Guo/openproject/pull/1)

# What are you trying to accomplish?

Enable users to post comments on work packages that include <img> tags referencing existing attachments without encountering a "attachments cannot be changed" error.

## Screenshots

After fix it can including the attachment image.

<img width="2242" height="1474" alt="企业微信截图_8e25d35e-4437-4423-9b85-ad30ca665d66" src="https://github.com/user-attachments/assets/e5e143ff-7f1c-49c5-bc27-69c47a59320a" />

# What approach did you choose and why?

The CommentAttachmentsClaims::SetAttributesService was attempting to claim (assign) attachments referenced in a work package comment. This led to a PropertyConstraintViolation ("附件不能更改") when the referenced attachment was already associated with the work package.

The chosen approach modifies the SetAttributesService to:

Extract all attachment IDs from the comment's HTML.
Filter these IDs to include only attachments that are currently unassigned (i.e., not yet linked to any container).
Pass only these truly "claimable" attachment IDs to the underlying service.
This ensures that existing attachments already linked to the work package are ignored by the claiming process, preventing the validation error, while still allowing the comment to be saved and the image to be displayed from its existing URL.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
