### PR TITLE
[chore] add shared examples for files info query tests

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/share_point/share_point_registry.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/share_point_registry.rb
@@ -71,6 +71,7 @@ module Storages
           namespace("queries") do
             register(:download_link, Queries::DownloadLinkQuery)
             register(:file_info, Queries::FileInfoQuery)
+            register(:files_info, Queries::FilesInfoQuery)
             register(:files, Queries::FilesQuery)
             register(:user, OneDrive::Queries::UserQuery)
           end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
@@ -40,72 +40,81 @@ module Storages
             let(:user) { create(:user) }
             let(:auth_strategy) { Registry["nextcloud.authentication.user_bound"].call(user, storage) }
             let(:storage) do
-              create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)
+              create(:nextcloud_storage_with_local_connection,
+                     :as_not_automatically_managed,
+                     oauth_client_token_user: user)
             end
-
             let(:input_data) { Input::FilesInfo.build(file_ids:).value! }
 
-            subject { described_class.new(storage) }
+            it_behaves_like "adapter files_info_query: basic query setup"
 
-            describe "#call" do
+            context "with an empty array of file ids" do
+              let(:file_ids) { [] }
+              let(:file_infos) { [] }
+
+              it_behaves_like "adapter files_info_query: successful list response"
+            end
+
+            context "with outbound request successful", vcr: "nextcloud/files_info_query_success" do
               let(:file_ids) { %w[182 203 222] }
-
-              context "without outbound request involved" do
-                context "with an empty array of file ids" do
-                  let(:file_ids) { [] }
-
-                  it "returns an empty array" do
-                    result = subject.call(auth_strategy:, input_data:)
-
-                    expect(result).to be_success
-                    expect(result.value!).to eq([])
-                  end
-                end
+              let(:file_infos) do
+                [
+                  Results::StorageFileInfo.new(
+                    status: "Forbidden",
+                    status_code: 403,
+                    id: "182"
+                  ),
+                  Results::StorageFileInfo.new(
+                    status: "Forbidden",
+                    status_code: 403,
+                    id: "203"
+                  ),
+                  Results::StorageFileInfo.new(
+                    status: "OK",
+                    status_code: 200,
+                    id: "222",
+                    name: "Screenshot 2023-08-15 at 3.00.54 PM.jpg",
+                    created_at: Time.parse("1970-01-01T00:00:00Z"),
+                    last_modified_at: Time.parse("2023-08-16T12:06:20Z"),
+                    mime_type: "image/jpeg",
+                    size: 81944,
+                    owner_name: "member",
+                    owner_id: "member",
+                    permissions: "RMGDNVW",
+                    location: "/OpenProject/Scrum%20project%20%282%29/Screenshot%202023-08-15%20at%203.00.54%20PM.jpg"
+                  )
+                ]
               end
 
-              context "with outbound request successful", vcr: "nextcloud/files_info_query_success" do
-                context "with an array of file ids" do
-                  it "must return an array of file information when called" do
-                    result = subject.call(auth_strategy:, input_data:)
-                    expect(result).to be_success
+              it_behaves_like "adapter files_info_query: successful list response"
+            end
 
-                    file_infos = result.value!
-                    expect(file_infos.size).to eq(3)
-                    expect(file_infos).to all(be_a(Results::StorageFileInfo))
-                  end
-                end
+            context "with outbound request not found", vcr: "nextcloud/files_info_query_not_found" do
+              let(:file_ids) { %w[1234] }
+              let(:file_infos) { [Results::StorageFileInfo.new(status: "Not Found", status_code: 404, id: "1234")] }
+
+              it_behaves_like "adapter files_info_query: successful list response"
+            end
+
+            context "with multiple file IDs, with different errors",
+                    vcr: "nextcloud/files_info_query_only_one_not_authorized" do
+              let(:file_ids) { %w[182 1234] }
+              let(:file_infos) do
+                [
+                  Results::StorageFileInfo.new(
+                    status: "Forbidden",
+                    status_code: 403,
+                    id: "182"
+                  ),
+                  Results::StorageFileInfo.new(
+                    status: "Not Found",
+                    status_code: 404,
+                    id: "1234"
+                  )
+                ]
               end
 
-              context "with outbound request not found" do
-                context "with a single file id", vcr: "nextcloud/files_info_query_not_found" do
-                  let(:file_ids) { %w[1234] }
-
-                  it "returns an HTTP 200 with individual status code per file ID" do
-                    result = subject.call(auth_strategy:, input_data:)
-                    expect(result).to be_success
-
-                    file_infos = result.value!
-                    expect(file_infos.size).to eq(1)
-                    expect(file_infos.first.to_h).to include(status: "Not Found", status_code: 404)
-                  end
-                end
-              end
-
-              context "with outbound request not authorized" do
-                context "with multiple file IDs, one of which is not authorized",
-                        vcr: "nextcloud/files_info_query_only_one_not_authorized" do
-                  let(:file_ids) { %w[182 1234] }
-
-                  it "returns an HTTP 200 with individual status code per file ID" do
-                    result = subject.call(auth_strategy:, input_data:)
-                    expect(result).to be_success
-
-                    file_infos = result.value!
-                    expect(file_infos.size).to eq(2)
-                    expect(file_infos.map(&:status_code)).to contain_exactly(403, 404)
-                  end
-                end
-              end
+              it_behaves_like "adapter files_info_query: successful list response"
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
@@ -50,14 +50,14 @@ module Storages
 
             context "with an empty array of file ids" do
               let(:file_ids) { [] }
-              let(:file_infos) { [] }
+              let(:expected_file_infos) { [] }
 
               it_behaves_like "adapter files_info_query: successful list response"
             end
 
-            context "with outbound request successful", vcr: "nextcloud/files_info_query_success" do
+            context "with several file ids", vcr: "nextcloud/files_info_query_success" do
               let(:file_ids) { %w[182 203 222] }
-              let(:file_infos) do
+              let(:expected_file_infos) do
                 [
                   Results::StorageFileInfo.new(
                     status: "Forbidden",
@@ -89,9 +89,9 @@ module Storages
               it_behaves_like "adapter files_info_query: successful list response"
             end
 
-            context "with outbound request not found", vcr: "nextcloud/files_info_query_not_found" do
+            context "with not existent file id requested", vcr: "nextcloud/files_info_query_not_found" do
               let(:file_ids) { %w[1234] }
-              let(:file_infos) { [Results::StorageFileInfo.new(status: "Not Found", status_code: 404, id: "1234")] }
+              let(:expected_file_infos) { [Results::StorageFileInfo.new(status: "Not Found", status_code: 404, id: "1234")] }
 
               it_behaves_like "adapter files_info_query: successful list response"
             end
@@ -99,7 +99,7 @@ module Storages
             context "with multiple file IDs, with different errors",
                     vcr: "nextcloud/files_info_query_only_one_not_authorized" do
               let(:file_ids) { %w[182 1234] }
-              let(:file_infos) do
+              let(:expected_file_infos) do
                 [
                   Results::StorageFileInfo.new(
                     status: "Forbidden",

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_info_query_spec.rb
@@ -42,118 +42,104 @@ module Storages
             let(:auth_strategy) { Registry["one_drive.authentication.user_bound"].call(user, storage) }
             let(:input_data) { Input::FilesInfo.build(file_ids:).value! }
 
-            subject(:query) { described_class.new(storage) }
+            it_behaves_like "adapter files_info_query: basic query setup"
 
-            describe "#call" do
-              it "responds with correct parameters" do
-                expect(described_class).to respond_to(:call)
+            context "with an empty array of file ids" do
+              let(:file_ids) { [] }
+              let(:file_infos) { [] }
 
-                method = described_class.method(:call)
-                expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq auth_strategy], %i[keyreq input_data])
+              it_behaves_like "adapter files_info_query: successful list response"
+            end
+
+            context "with outbound requests successful", vcr: "one_drive/files_info_query_success" do
+              let(:file_ids) do
+                %w(
+                  01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU
+                  01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU
+                  01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA
+                )
+              end
+              let(:file_infos) do
+                [
+                  Results::StorageFileInfo.new(
+                    status: "ok",
+                    status_code: 200,
+                    id: "01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU",
+                    name: "Folder with spaces",
+                    size: 35141,
+                    mime_type: "application/x-op-directory",
+                    created_at: Time.parse("2023-09-26T14:38:57Z"),
+                    last_modified_at: Time.parse("2023-09-26T14:38:57Z"),
+                    owner_name: "Eric Schubert",
+                    owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    last_modified_by_name: "Eric Schubert",
+                    last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    location: "/Folder%20with%20spaces"
+                  ),
+                  Results::StorageFileInfo.new(
+                    status: "ok",
+                    status_code: 200,
+                    id: "01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU",
+                    name: "Document.docx",
+                    size: 22514,
+                    mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    created_at: Time.parse("2023-09-26T14:40:58Z"),
+                    last_modified_at: Time.parse("2023-09-26T14:42:03Z"),
+                    owner_name: "Eric Schubert",
+                    owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    last_modified_by_name: "Eric Schubert",
+                    last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    location: "/Folder/Document.docx"
+                  ),
+                  Results::StorageFileInfo.new(
+                    status: "ok",
+                    status_code: 200,
+                    id: "01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA",
+                    name: "NextcloudHub.md",
+                    size: 1095,
+                    mime_type: "application/octet-stream",
+                    created_at: Time.parse("2023-09-26T14:45:25Z"),
+                    last_modified_at: Time.parse("2023-09-26T14:46:13Z"),
+                    owner_name: "Eric Schubert",
+                    owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    last_modified_by_name: "Eric Schubert",
+                    last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    location: "/Folder/Subfolder/NextcloudHub.md"
+                  )
+                ]
               end
 
-              context "without outbound request involved" do
-                context "with an empty array of file ids" do
-                  let(:file_ids) { [] }
+              it_behaves_like "adapter files_info_query: successful list response"
+            end
 
-                  it "returns an empty array" do
-                    result = query.call(auth_strategy:, input_data:)
-
-                    expect(result).to be_success
-                    expect(result.value!).to eq([])
-                  end
-                end
+            context "with one outbound request returning not found", vcr: "one_drive/files_info_query_one_not_found" do
+              let(:file_ids) { %w[01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU not_existent] }
+              let(:file_infos) do
+                [
+                  Results::StorageFileInfo.new(
+                    status: "ok",
+                    status_code: 200,
+                    id: "01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU",
+                    name: "Document.docx",
+                    size: 22514,
+                    mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    created_at: Time.parse("2023-09-26T14:40:58Z"),
+                    last_modified_at: Time.parse("2023-09-26T14:42:03Z"),
+                    owner_name: "Eric Schubert",
+                    owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    last_modified_by_name: "Eric Schubert",
+                    last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
+                    location: "/Folder/Document.docx"
+                  ),
+                  Results::StorageFileInfo.new(
+                    status: :not_found,
+                    status_code: 404,
+                    id: "not_existent"
+                  )
+                ]
               end
 
-              context "with outbound requests successful", vcr: "one_drive/files_info_query_success" do
-                context "with an array of file ids" do
-                  let(:file_ids) do
-                    %w(
-                      01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU
-                      01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU
-                      01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA
-                    )
-                  end
-
-                  # rubocop:disable RSpec/ExampleLength
-                  it "must return an array of file information when called" do
-                    result = query.call(auth_strategy:, input_data:)
-                    expect(result).to be_success
-
-                    file_infos = result.value!
-                    expect(file_infos.size).to eq(3)
-                    expect(file_infos).to all(be_a(Results::StorageFileInfo))
-                    expect(file_infos.map(&:to_h))
-                      .to eq([{
-                               status: "ok",
-                               status_code: 200,
-                               id: "01AZJL5PKU2WV3U3RKKFF2A7ZCWVBXRTEU",
-                               name: "Folder with spaces",
-                               size: 35141,
-                               mime_type: "application/x-op-directory",
-                               created_at: Time.parse("2023-09-26T14:38:57Z"),
-                               last_modified_at: Time.parse("2023-09-26T14:38:57Z"),
-                               owner_name: "Eric Schubert",
-                               owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
-                               last_modified_by_name: "Eric Schubert",
-                               last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
-                               permissions: nil,
-                               location: "/Folder%20with%20spaces"
-                             },
-                              {
-                                status: "ok",
-                                status_code: 200,
-                                id: "01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU",
-                                name: "Document.docx",
-                                size: 22514,
-                                mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                                created_at: Time.parse("2023-09-26T14:40:58Z"),
-                                last_modified_at: Time.parse("2023-09-26T14:42:03Z"),
-                                owner_name: "Eric Schubert",
-                                owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
-                                last_modified_by_name: "Eric Schubert",
-                                last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
-                                permissions: nil,
-                                location: "/Folder/Document.docx"
-                              },
-                              {
-                                status: "ok",
-                                status_code: 200,
-                                id: "01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA",
-                                name: "NextcloudHub.md",
-                                size: 1095,
-                                mime_type: "application/octet-stream",
-                                created_at: Time.parse("2023-09-26T14:45:25Z"),
-                                last_modified_at: Time.parse("2023-09-26T14:46:13Z"),
-                                owner_name: "Eric Schubert",
-                                owner_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
-                                last_modified_by_name: "Eric Schubert",
-                                last_modified_by_id: "0a0d38a9-a59b-4245-93fa-0d2cf727f17a",
-                                permissions: nil,
-                                location: "/Folder/Subfolder/NextcloudHub.md"
-                              }])
-                  end
-                  # rubocop:enable RSpec/ExampleLength
-                end
-              end
-
-              context "with one outbound request returning not found", vcr: "one_drive/files_info_query_one_not_found" do
-                context "with an array of file ids" do
-                  let(:file_ids) { %w[01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU not_existent] }
-
-                  it "must return an array of file information when called" do
-                    result = query.call(auth_strategy:, input_data:)
-                    expect(result).to be_success
-                    file_infos = result.value!
-
-                    expect(file_infos.size).to eq(2)
-                    expect(file_infos).to all(be_a(Results::StorageFileInfo))
-                    expect(file_infos[1].id).to eq("not_existent")
-                    expect(file_infos[1].status).to eq(:not_found)
-                    expect(file_infos[1].status_code).to eq(404)
-                  end
-                end
-              end
+              it_behaves_like "adapter files_info_query: successful list response"
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_info_query_spec.rb
@@ -46,7 +46,7 @@ module Storages
 
             context "with an empty array of file ids" do
               let(:file_ids) { [] }
-              let(:file_infos) { [] }
+              let(:expected_file_infos) { [] }
 
               it_behaves_like "adapter files_info_query: successful list response"
             end
@@ -59,7 +59,7 @@ module Storages
                   01AZJL5PNCQCEBFI3N7JGZSX5AOX32Z3LA
                 )
               end
-              let(:file_infos) do
+              let(:expected_file_infos) do
                 [
                   Results::StorageFileInfo.new(
                     status: "ok",
@@ -114,7 +114,7 @@ module Storages
 
             context "with one outbound request returning not found", vcr: "one_drive/files_info_query_one_not_found" do
               let(:file_ids) { %w[01AZJL5PJTICED3C5YSVAY6NWTBNA2XERU not_existent] }
-              let(:file_infos) do
+              let(:expected_file_infos) do
                 [
                   Results::StorageFileInfo.new(
                     status: "ok",

--- a/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/share_point/queries/files_info_query_spec.rb
@@ -46,7 +46,7 @@ module Storages
 
             context "with an empty array of file ids" do
               let(:file_ids) { [] }
-              let(:file_infos) { [] }
+              let(:expected_file_infos) { [] }
 
               it_behaves_like "adapter files_info_query: successful list response"
             end
@@ -60,7 +60,7 @@ module Storages
                   #{drive_id}||01ANJ53W5UJK2CQO6IY5HLBVYBVNJ4TKHZ
                 ]
               end
-              let(:file_infos) do
+              let(:expected_file_infos) do
                 [
                   Results::StorageFileInfo.new(
                     status: "ok",
@@ -116,7 +116,7 @@ module Storages
             context "with one outbound request returning not found", vcr: "share_point/files_info_query_one_not_found" do
               let(:drive_id) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw" }
               let(:file_ids) { %W[#{drive_id}||01ANJ53W4ELLSQL3JZHNA2MHKKHKAUQWNS #{drive_id}||not_existent] }
-              let(:file_infos) do
+              let(:expected_file_infos) do
                 [
                   Results::StorageFileInfo.new(
                     status: "ok",

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/files_info_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/files_info_query_examples.rb
@@ -52,8 +52,7 @@ RSpec.shared_examples_for "adapter files_info_query: successful list response" d
 
     response = result.value!
     expect(response).to be_an(Array)
-    response.each { expect(it).to be_a(Storages::Adapters::Results::StorageFileInfo) }
-    expect(response.size).to eq(file_infos.size)
-    expect(response).to eq(file_infos)
+    expect(response).to all(be_a(Storages::Adapters::Results::StorageFileInfo))
+    expect(response).to eq(expected_file_infos)
   end
 end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/files_info_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/files_info_query_examples.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.shared_examples_for "adapter files_info_query: basic query setup" do
+  it "is registered as queries.files_info" do
+    expect(Storages::Adapters::Registry
+             .resolve("#{storage}.queries.files_info")).to eq(described_class)
+  end
+
+  it "responds to #call with correct parameters" do
+    expect(described_class).to respond_to(:call)
+
+    method = described_class.method(:call)
+    expect(method.parameters).to contain_exactly(%i[keyreq storage],
+                                                 %i[keyreq auth_strategy],
+                                                 %i[keyreq input_data])
+  end
+end
+
+RSpec.shared_examples_for "adapter files_info_query: successful list response" do
+  it "returns an array of file info objects" do
+    result = described_class.call(storage:, auth_strategy:, input_data:)
+
+    expect(result).to be_success
+
+    response = result.value!
+    expect(response).to be_an(Array)
+    response.each { expect(it).to be_a(Storages::Adapters::Results::StorageFileInfo) }
+    expect(response.size).to eq(file_infos.size)
+    expect(response).to eq(file_infos)
+  end
+end


### PR DESCRIPTION
# What are you trying to accomplish?
- use shared examples to make test setups of query tests similar