### PR TITLE
Validate _links in API requests

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4779,6 +4779,8 @@ en:
       code_500_missing_enterprise_token: "The request can not be handled due to invalid or missing Enterprise token."
       bad_request:
         emoji_reactions_activity_type_not_supported: "This activity type does not support emoji reactions."
+        invalid_link: "The link under key '%{key}' is not valid."
+        links_not_an_object: "_links must be a JSON object."
       conflict:
         multiple_reminders_not_allowed: |-
           You can only set one reminder at a time for a work package. Please delete or update the existing reminder.

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -42,6 +42,8 @@ module API
       def from_hash(hash, *)
         return super unless hash && hash["_links"]
 
+        validate_links!(hash["_links"])
+
         copied_hash = hash.deep_dup
 
         representable_attrs.find_all do |dfn|
@@ -67,6 +69,15 @@ module API
           link.from_hash(href)
           struct.id
         end
+      end
+
+      def validate_links!(links)
+        raise ::API::Errors::BadRequest.new(I18n.t("api_v3.errors.bad_request.links_not_an_object")) unless links.is_a?(Hash)
+
+        invalid, = links.find { |_, link| !(link.is_a?(Hash) || link.is_a?(Array)) }
+        return if invalid.nil?
+
+        raise ::API::Errors::BadRequest.new(I18n.t("api_v3.errors.bad_request.invalid_link", key: invalid))
       end
 
       module ClassMethods

--- a/spec/lib/api/decorators/linked_resource_spec.rb
+++ b/spec/lib/api/decorators/linked_resource_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::Decorators::LinkedResource do
+  let(:representer) do
+    Class.new(API::Decorators::Single) do
+      include API::Decorators::LinkedResource
+
+      resource_link :foo,
+                    getter: -> { represented["foo"] },
+                    setter: ->(fragment:, **) { represented["foo"] = fragment["href"] }
+    end
+  end
+  let(:represented) { {} }
+  let(:current_user) { create(:user) }
+
+  describe "#from_hash" do
+    subject { representer.new(represented, current_user:).from_hash(input_hash) }
+
+    let(:input_hash) do
+      {
+        "_links" => {
+          "foo" => { "href" => "https://example.com" }
+        }
+      }
+    end
+
+    it "parses the link" do
+      expect { subject }.to change { represented["foo"] }.from(nil).to("https://example.com")
+    end
+
+    context "when passing link as string" do
+      let(:input_hash) do
+        {
+          "_links" => {
+            "foo" => "https://example.com"
+          }
+        }
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(API::Errors::BadRequest)
+      end
+    end
+
+    context "when passing _links as array" do
+      let(:input_hash) do
+        {
+          "_links" => [
+            { "foo" => { "href" => "https://example.com" } }
+          ]
+        }
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(API::Errors::BadRequest)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Respond with a proper HTTP 400 response for some cases of invalid _links formatting in write requests to the API.

# Ticket
https://community.openproject.org/wp/66528