### PR TITLE
Set ServiceAccount#logged? to true.

### DIFF
--- a/app/models/service_account.rb
+++ b/app/models/service_account.rb
@@ -43,7 +43,7 @@ class ServiceAccount < User
 
   def available_custom_fields = []
 
-  def logged? = false
+  def logged? = true
 
   def builtin? = true
 


### PR DESCRIPTION
Semantically it should be true. ServiceAccount can be logged in the API context at least.

