### PR TITLE
[#66613] Projects list with URL project attribute cannot be exported

### DIFF
--- a/app/models/exports/formatters/link_formatter.rb
+++ b/app/models/exports/formatters/link_formatter.rb
@@ -39,6 +39,8 @@ module Exports
         ApplicationController.helpers.link_to(@href, @href)
       end
 
+      delegate :blank?, to: :@href
+
       def to_s
         @href
       end

--- a/app/models/projects/exports/pdf.rb
+++ b/app/models/projects/exports/pdf.rb
@@ -116,9 +116,10 @@ module Projects::Exports
       file = Tempfile.new(filename)
       pdf.render_file(file.path)
       @page_count += pdf.page_count
-      delete_all_resized_images
       file.close
       file
+    ensure
+      delete_all_resized_images
     end
 
     def write_after_pages!

--- a/app/models/projects/exports/pdf_export/report.rb
+++ b/app/models/projects/exports/pdf_export/report.rb
@@ -158,7 +158,11 @@ module Projects::Exports::PDFExport
       value = format_attribute(project, value_name, :pdf)
       return nil if hide_empty_attributes? && value.blank?
 
-      value = make_link_href_cell(url_helpers.project_url(project), value) if value_name == :id
+      if value.is_a?(::Exports::Formatters::LinkFormatter)
+        value = get_cf_link_cell(value)
+      elsif value_name == :id
+        value = make_link_href_cell(url_helpers.project_url(project), value)
+      end
       [
         { content: caption }.merge(styles.project_attributes_table_label_cell),
         value || ""

--- a/app/models/work_package/pdf_export/document_generator.rb
+++ b/app/models/work_package/pdf_export/document_generator.rb
@@ -61,6 +61,8 @@ class WorkPackage::PDFExport::DocumentGenerator < Exports::Exporter
   rescue StandardError => e
     Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
     error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+  ensure
+    delete_all_resized_images
   end
 
   def render_doc

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -214,9 +214,10 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
     file = Tempfile.new(filename)
     pdf.render_file(file.path)
     @page_count += pdf.page_count
-    delete_all_resized_images
     file.close
     file
+  ensure
+    delete_all_resized_images
   end
 
   def write_after_pages!

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -61,6 +61,8 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
   rescue StandardError => e
     Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
     error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+  ensure
+    delete_all_resized_images
   end
 
   def setup_page!

--- a/modules/meeting/app/workers/meetings/pdf/common/exporter.rb
+++ b/modules/meeting/app/workers/meetings/pdf/common/exporter.rb
@@ -61,6 +61,8 @@ module Meetings::PDF::Common
     rescue StandardError => e
       Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
       error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+    ensure
+      delete_all_resized_images
     end
 
     def setup_page!

--- a/spec/models/projects/exporter/exportable_project_context.rb
+++ b/spec/models/projects/exporter/exportable_project_context.rb
@@ -38,8 +38,9 @@ RSpec.shared_context "with a project with an arrangement of custom fields" do
   shared_let(:string_cf) { create(:string_project_custom_field, position: 7) }
   shared_let(:date_cf) { create(:date_project_custom_field, position: 8) }
   shared_let(:hidden_cf) { create(:string_project_custom_field, position: 9, admin_only: true) }
+  shared_let(:link_cf) { create(:link_project_custom_field, position: 10) }
 
-  let!(:not_used_string_cf) { create(:string_project_custom_field, position: 10) }
+  let!(:not_used_string_cf) { create(:string_project_custom_field, position: 11) }
 
   shared_let(:system_version) { create(:version, sharing: "system") }
 
@@ -70,7 +71,8 @@ RSpec.shared_context "with a project with an arrangement of custom fields" do
                       string_cf.id => "Some small text",
                       date_cf.id => Time.zone.today,
                       user_cf.id => other_user.id,
-                      hidden_cf.id => "hidden"
+                      hidden_cf.id => "hidden",
+                      link_cf.id => "https://www.example.com"
                     })
     project.save!(validate: false)
 

--- a/spec/models/projects/exports/pdf_spec.rb
+++ b/spec/models/projects/exports/pdf_spec.rb
@@ -127,10 +127,12 @@ RSpec.describe Projects::Exports::PDF do
         "4.5"
       when "text"
         "Some  long  text"
-      when "string", "list", "link"
+      when "string", "list"
         "Some small text"
       when "date"
         format_date(Time.zone.today)
+      when "link"
+        "https://www.example.com"
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/66613

# What are you trying to achieve?

Link CFs must be handled extra for PDF tables, to avoid the following error
`The PDF export could not be saved: Prawn::Errors::UnrecognizedTableContent`

# What approach did you choose and why?

Handle Link CFs the extra way

# Merge checklist

- [x] Added/updated tests
- [x] Tested major PDF readers
