### PR TITLE
[#66557] Fix Color Administration 500 error: make `HexCode#rgb_colors` handle invalid hexcodes 

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -122,8 +122,7 @@ module ColorsHelper
   end
 
   def icon_for_color(color, options = {})
-    return unless color
-    return if color.hexcode.blank?
+    return unless color&.valid_attribute?(:hexcode)
 
     style = join_style_arguments(
       "background-color: #{color.hexcode}",

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -43,7 +43,12 @@ class ApplicationRecord < ActiveRecord::Base
   ##
   # Returns whether the given attribute is free of errors
   def valid_attribute?(attribute)
-    valid? # Ensure validations have run
+    errors.clear
+
+    # run validations for specified attribute only.
+    self.class.validators_on(attribute).each do |validator|
+      validator.validate_each(self, attribute, public_send(attribute))
+    end
 
     errors[attribute].empty?
   end

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -37,11 +37,10 @@ class Color < ApplicationRecord
            class_name: "Type",
            dependent: :nullify
 
-  after_initialize :normalize_hexcode
-  before_validation :normalize_hexcode
-
   validates :name, :hexcode, presence: true
 
   validates :name, length: { maximum: 255, unless: lambda { |e| e.name.blank? } }
   validates :hexcode, format: { with: /\A#[0-9A-F]{6}\z/, unless: lambda { |e| e.hexcode.blank? } }
+
+  normalizes :hexcode, with: ::Colors::HexColor::Normalizer
 end

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -39,7 +39,7 @@ class Color < ApplicationRecord
 
   validates :name, :hexcode, presence: true
   validates :name, length: { maximum: 255 }
-  validates :hexcode, format: { with: RGB_HEX_FORMAT, allow_blank: true }
+  validates :hexcode, format: { with: RGB_HEX_FORMAT, message: :hexcode_invalid, allow_blank: true }
 
   normalizes :hexcode, with: ::Colors::HexColor::Normalizer
 end

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -38,9 +38,8 @@ class Color < ApplicationRecord
            dependent: :nullify
 
   validates :name, :hexcode, presence: true
-
-  validates :name, length: { maximum: 255, unless: lambda { |e| e.name.blank? } }
-  validates :hexcode, format: { with: /\A#[0-9A-F]{6}\z/, unless: lambda { |e| e.hexcode.blank? } }
+  validates :name, length: { maximum: 255 }
+  validates :hexcode, format: { with: RGB_HEX_FORMAT, allow_blank: true }
 
   normalizes :hexcode, with: ::Colors::HexColor::Normalizer
 end

--- a/app/models/colors/hex_color.rb
+++ b/app/models/colors/hex_color.rb
@@ -113,20 +113,22 @@ module Colors
       "#%<r>02x%<g>02x%<b>02x" % { r:, g:, b: }
     end
 
-    # rubocop:disable Metrics/AbcSize
-    def normalize_hexcode
-      return unless hexcode.present? && hexcode_changed?
-
-      self.hexcode = hexcode.strip.upcase
-
-      unless hexcode.starts_with? "#"
-        self.hexcode = "##{hexcode}"
+    class Normalizer
+      def self.call(...)
+        new.call(...)
       end
 
-      if hexcode.size == 4 # =~ /#.../
-        self.hexcode = hexcode.gsub(/([^#])/, '\1\1')
+      def call(hex)
+        hex = hex.strip.delete_prefix("#")
+        case hex
+        when /\A[0-9a-fA-F]{3}\z/ # short form: #abc
+          "##{hex.chars.map { |c| c * 2 }.join.upcase}"
+        when /\A[0-9a-fA-F]{6}\z/ # long form: #aabbcc
+          "##{hex.upcase}"
+        else # do nothing
+          hex
+        end
       end
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/models/colors/hex_color.rb
+++ b/app/models/colors/hex_color.rb
@@ -76,11 +76,13 @@ module Colors
     end
 
     ##
-    # Splits the hexcode into rbg color array
+    # Splits the hexcode into rgb color array
     def rgb_colors
       hexcode
-        .delete("#") # Remove trailing #
+        .delete_prefix("#") # Remove leading #
+        .ljust(6, "0") # Pad to at least 6 chars
         .scan(/../) # Pair hex chars
+        .first(3)
         .map(&:hex) # to int
     end
 

--- a/app/models/colors/hex_color.rb
+++ b/app/models/colors/hex_color.rb
@@ -30,6 +30,9 @@
 
 module Colors
   module HexColor
+    RGB_HEX_FORMAT = /\A#[0-9A-F]{6}\z/
+    private_constant :RGB_HEX_FORMAT
+
     ##
     # Get the fill style for this color.
     # If the color is light, use a dark font.

--- a/app/models/design_color.rb
+++ b/app/models/design_color.rb
@@ -45,7 +45,7 @@ class DesignColor < ApplicationRecord
 
   validates :variable, :hexcode, presence: true
   validates :variable, uniqueness: true
-  validates :hexcode, format: { with: RGB_HEX_FORMAT, allow_blank: true }
+  validates :hexcode, format: { with: RGB_HEX_FORMAT, message: :hexcode_invalid, allow_blank: true }
 
   normalizes :hexcode, with: ::Colors::HexColor::Normalizer
 

--- a/app/models/design_color.rb
+++ b/app/models/design_color.rb
@@ -31,7 +31,6 @@
 class DesignColor < ApplicationRecord
   include ::Colors::HexColor
 
-  before_validation :normalize_hexcode
   after_commit -> do
     # CustomStyle.current.updated_at determines the cache key for inline_css
     # in which the CSS color variables will be overwritten. That is why we need
@@ -47,6 +46,8 @@ class DesignColor < ApplicationRecord
   validates :variable, uniqueness: true
   validates :hexcode, :variable, presence: true
   validates :hexcode, format: { with: /\A#[0-9A-F]{6}\z/, unless: lambda { |e| e.hexcode.blank? } }
+
+  normalizes :hexcode, with: ::Colors::HexColor::Normalizer
 
   class << self
     def setables

--- a/app/models/design_color.rb
+++ b/app/models/design_color.rb
@@ -43,9 +43,9 @@ class DesignColor < ApplicationRecord
     end
   end
 
+  validates :variable, :hexcode, presence: true
   validates :variable, uniqueness: true
-  validates :hexcode, :variable, presence: true
-  validates :hexcode, format: { with: /\A#[0-9A-F]{6}\z/, unless: lambda { |e| e.hexcode.blank? } }
+  validates :hexcode, format: { with: RGB_HEX_FORMAT, allow_blank: true }
 
   normalizes :hexcode, with: ::Colors::HexColor::Normalizer
 

--- a/app/views/colors/_form.html.erb
+++ b/app/views/colors/_form.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
     <%= f.text_field :name, required: true, container_class: "-slim" %>
   </div>
   <div class="form--field -required">
-    <label class="form--label"><%= Color.human_attribute_name(:hexcode) %></label>
+    <label class="form--label" for="color_hexcode"><%= Color.human_attribute_name(:hexcode) %></label>
     <span class="form--field-container">
       <span class="form--text-field-container -xslim">
         <%= text_field_tag "color_hexcode",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1059,6 +1059,8 @@ en:
         admin_only: "Admin-only"
       custom_value:
         value: "Value"
+      design_color:
+        variable: "Variable"
       doorkeeper/application:
         uid: "Client ID"
         secret: "Client secret"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1370,6 +1370,7 @@ en:
         odd: "must be odd."
         regex_match_failed: "does not match the regular expression %{expression}."
         regex_invalid: "could not be validated with the associated regular expression."
+        hexcode_invalid: "is not a valid 6-digit hexadecimal color code."
         smaller_than_or_equal_to_max_length: "must be smaller than or equal to maximum length."
         taken: "has already been taken."
         too_long: "is too long (maximum is %{count} characters)."

--- a/spec/features/colors/color_administration_spec.rb
+++ b/spec/features/colors/color_administration_spec.rb
@@ -30,21 +30,113 @@
 
 require "spec_helper"
 
-RSpec.describe "color administration" do
+RSpec.describe "color administration", :js, :selenium do
   shared_let(:admin) { create(:admin) }
 
   before do
     login_as(admin)
-  end
-
-  it "CRUD" do
-    # Only a stub for now
 
     visit colors_path
+  end
 
-    expect(page)
-      .to have_content(I18n.t(:"colors.index.no_results_title_text"))
+  describe "listing colors" do
+    it "shows no results by default" do
+      expect(page).to have_content(I18n.t(:"colors.index.no_results_title_text"))
 
-    click_link I18n.t(:"colors.index.no_results_content_text")
+      click_link I18n.t(:"colors.index.no_results_content_text")
+    end
+  end
+
+  describe "creating colors" do
+    it "creates a color" do
+      within "sub-header" do
+        click_link accessible_name: "New color"
+      end
+
+      fill_in "Name", with: "Vibrant pink"
+      fill_in "Hex code", with: "#FF69B4"
+
+      click_on "Save"
+
+      expect_and_dismiss_flash type: :success, message: "Successful creation."
+
+      within ".color--preview-patch-field" do
+        expect(page).to have_link "Vibrant pink"
+      end
+    end
+
+    it "displays validation errors if color values are invalid" do
+      within "sub-header" do
+        click_link accessible_name: "New color"
+      end
+
+      fill_in "Name", with: "Not so vibrant pink"
+      fill_in "Hex code", with: "11"
+
+      click_on "Save"
+
+      expect_and_dismiss_flash type: :error, message: /not a valid 6-digit hexadecimal color code/
+    end
+  end
+
+  describe "updating colors" do
+    it "creates and updates a color" do
+      within "sub-header" do
+        click_link accessible_name: "New color"
+      end
+
+      fill_in "Name", with: "Dark Purple"
+      fill_in "Hex code", with: "#301934"
+
+      click_on "Save"
+
+      expect_and_dismiss_flash type: :success, message: "Successful creation."
+
+      within ".color--preview-patch-field" do
+        click_on "Dark Purple"
+      end
+
+      expect(page).to have_heading "Dark Purple"
+
+      fill_in "Name", with: "Dark Grape (web safe)"
+      fill_in "Hex code", with: "330033"
+
+      click_on "Save"
+
+      expect_and_dismiss_flash type: :success, message: "Successful update."
+
+      within ".color--preview-patch-field" do
+        expect(page).to have_link "Dark Grape (web safe)"
+      end
+    end
+  end
+
+  describe "deleting colors" do
+    it "creates and deletes a color" do
+      within "sub-header" do
+        click_link accessible_name: "New color"
+      end
+
+      fill_in "Name", with: "Dark Purple"
+      fill_in "Hex code", with: "#301934"
+
+      click_on "Save"
+
+      expect_and_dismiss_flash type: :success, message: "Successful creation."
+
+      within ".color--preview-patch-field" do
+        click_on "Dark Purple"
+      end
+
+      expect(page).to have_heading "Dark Purple"
+
+      within ".PageHeader-actions" do
+        accept_confirm do
+          click_on "Delete"
+        end
+      end
+
+      expect_and_dismiss_flash type: :success, message: "Successful deletion."
+    end
   end
 end

--- a/spec/helpers/colors_helper_spec.rb
+++ b/spec/helpers/colors_helper_spec.rb
@@ -44,4 +44,26 @@ RSpec.describe ColorsHelper do
       expect(helper.hl_background_class("foo_bar", model)).to eq("__hl_background_foo_bar_5")
     end
   end
+
+  describe "#icon_for_color" do
+    context "with nil color" do
+      it "renders nothing" do
+        expect(helper.icon_for_color(nil)).to be_blank
+      end
+    end
+
+    context "with valid color" do
+      it "renders a color preview" do
+        expect(helper.icon_for_color(Color.new(hexcode: "#ff00ff"))).to be_html_eql %{
+          <span class="color--preview " style="background-color: #FF00FF;border-color: #80008050"> </span>
+        }.squish
+      end
+    end
+
+    context "with invalid color (invalid hexcode)" do
+      it "renders nothing" do
+        expect(helper.icon_for_color(Color.new(hexcode: "#ffXXff"))).to be_blank
+      end
+    end
+  end
 end

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe Color do
     end
 
     it "does not allow malformed hexcodes" do
-      expect(subject).not_to allow_values("0#FFFFFF", "#FFFFFF0", "white").for(:hexcode)
+      expect(subject).not_to allow_values("0#FFFFFF", "#FFFFFF0", "white")
+        .for(:hexcode)
+        .with_message("is not a valid 6-digit hexadecimal color code.")
     end
 
     it "allows valid hexcodes" do

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Color do
     describe "name" do
       it "is invalid w/o a name" do
         attributes[:name] = nil
-        color = Color.new(attributes)
+        color = described_class.new(attributes)
 
         expect(color).not_to be_valid
 
@@ -77,7 +77,7 @@ RSpec.describe Color do
 
       it "is invalid w/ a name longer than 255 characters" do
         attributes[:name] = "A" * 500
-        color = Color.new(attributes)
+        color = described_class.new(attributes)
 
         expect(color).not_to be_valid
 
@@ -89,7 +89,7 @@ RSpec.describe Color do
     describe "hexcode" do
       it "is invalid w/o a hexcode" do
         attributes[:hexcode] = nil
-        color = Color.new(attributes)
+        color = described_class.new(attributes)
 
         expect(color).not_to be_valid
 
@@ -98,32 +98,32 @@ RSpec.describe Color do
       end
 
       it "is invalid w/ malformed hexcodes" do
-        expect(Color.new(attributes.merge(hexcode: "0#FFFFFF"))).not_to be_valid
-        expect(Color.new(attributes.merge(hexcode: "#FFFFFF0"))).not_to be_valid
-        expect(Color.new(attributes.merge(hexcode: "white"))).not_to be_valid
+        expect(described_class.new(attributes.merge(hexcode: "0#FFFFFF"))).not_to be_valid
+        expect(described_class.new(attributes.merge(hexcode: "#FFFFFF0"))).not_to be_valid
+        expect(described_class.new(attributes.merge(hexcode: "white"))).not_to be_valid
       end
 
       it "fixes some wrong formats of hexcode automatically" do
-        color = Color.new(attributes.merge(hexcode: "FFCC33"))
+        color = described_class.new(attributes.merge(hexcode: "FFCC33"))
         expect(color).to be_valid
         expect(color.hexcode).to eq("#FFCC33")
 
-        color = Color.new(attributes.merge(hexcode: "#ffcc33"))
+        color = described_class.new(attributes.merge(hexcode: "#ffcc33"))
         expect(color).to be_valid
         expect(color.hexcode).to eq("#FFCC33")
 
-        color = Color.new(attributes.merge(hexcode: "fc3"))
+        color = described_class.new(attributes.merge(hexcode: "fc3"))
         expect(color).to be_valid
         expect(color.hexcode).to eq("#FFCC33")
 
-        color = Color.new(attributes.merge(hexcode: "#fc3"))
+        color = described_class.new(attributes.merge(hexcode: "#fc3"))
         expect(color).to be_valid
         expect(color.hexcode).to eq("#FFCC33")
       end
 
       it "is valid w/ proper hexcodes" do
-        expect(Color.new(attributes.merge(hexcode: "#FFFFFF"))).to be_valid
-        expect(Color.new(attributes.merge(hexcode: "#FF00FF"))).to be_valid
+        expect(described_class.new(attributes.merge(hexcode: "#FFFFFF"))).to be_valid
+        expect(described_class.new(attributes.merge(hexcode: "#FF00FF"))).to be_valid
       end
     end
   end

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe Color do
     end
   end
 
+  describe "normalization" do
+    it "does not normalize non-hexcodes, except to strip whitespace", :aggregate_failures do
+      expect(subject).to normalize(:hexcode).from("").to("")
+      expect(subject).to normalize(:hexcode).from(" ").to("")
+      expect(subject).to normalize(:hexcode).from("11").to("11")
+      expect(subject).to normalize(:hexcode).from("purple").to("purple")
+      expect(subject).to normalize(:hexcode).from("green ").to("green")
+    end
+
+    it "normalizes short hexcodes", :aggregate_failures do
+      expect(subject).to normalize(:hexcode).from(" fc3").to("#FFCC33")
+      expect(subject).to normalize(:hexcode).from("333 ").to("#333333")
+      expect(subject).to normalize(:hexcode).from("#fc3").to("#FFCC33")
+    end
+
+    it "normalizes full hexcodes", :aggregate_failures do
+      expect(subject).to normalize(:hexcode).from(" FFCC33").to("#FFCC33")
+      expect(subject).to normalize(:hexcode).from("#ffcc33 ").to("#FFCC33")
+      expect(subject).to normalize(:hexcode).from("#00CED1").to("#00CED1")
+    end
+  end
+
   describe "- Validations" do
     let(:attributes) do
       { name: "Color No. 1",
@@ -101,24 +123,6 @@ RSpec.describe Color do
         expect(described_class.new(attributes.merge(hexcode: "0#FFFFFF"))).not_to be_valid
         expect(described_class.new(attributes.merge(hexcode: "#FFFFFF0"))).not_to be_valid
         expect(described_class.new(attributes.merge(hexcode: "white"))).not_to be_valid
-      end
-
-      it "fixes some wrong formats of hexcode automatically" do
-        color = described_class.new(attributes.merge(hexcode: "FFCC33"))
-        expect(color).to be_valid
-        expect(color.hexcode).to eq("#FFCC33")
-
-        color = described_class.new(attributes.merge(hexcode: "#ffcc33"))
-        expect(color).to be_valid
-        expect(color.hexcode).to eq("#FFCC33")
-
-        color = described_class.new(attributes.merge(hexcode: "fc3"))
-        expect(color).to be_valid
-        expect(color.hexcode).to eq("#FFCC33")
-
-        color = described_class.new(attributes.merge(hexcode: "#fc3"))
-        expect(color).to be_valid
-        expect(color.hexcode).to eq("#FFCC33")
       end
 
       it "is valid w/ proper hexcodes" do

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -80,55 +80,22 @@ RSpec.describe Color do
     end
   end
 
-  describe "- Validations" do
-    let(:attributes) do
-      { name: "Color No. 1",
-        hexcode: "#FFFFFF" }
+  describe "validations" do
+    it "validates name is present and at most 255 chars" do
+      expect(subject).to validate_presence_of(:name)
+      expect(subject).to validate_length_of(:name).is_at_most(255)
     end
 
-    describe "name" do
-      it "is invalid w/o a name" do
-        attributes[:name] = nil
-        color = described_class.new(attributes)
-
-        expect(color).not_to be_valid
-
-        expect(color.errors[:name]).to be_present
-        expect(color.errors[:name]).to eq(["can't be blank."])
-      end
-
-      it "is invalid w/ a name longer than 255 characters" do
-        attributes[:name] = "A" * 500
-        color = described_class.new(attributes)
-
-        expect(color).not_to be_valid
-
-        expect(color.errors[:name]).to be_present
-        expect(color.errors[:name]).to eq(["is too long (maximum is 255 characters)."])
-      end
+    it "validates hexcode is present" do
+      expect(subject).to validate_presence_of(:hexcode)
     end
 
-    describe "hexcode" do
-      it "is invalid w/o a hexcode" do
-        attributes[:hexcode] = nil
-        color = described_class.new(attributes)
+    it "does not allow malformed hexcodes" do
+      expect(subject).not_to allow_values("0#FFFFFF", "#FFFFFF0", "white").for(:hexcode)
+    end
 
-        expect(color).not_to be_valid
-
-        expect(color.errors[:hexcode]).to be_present
-        expect(color.errors[:hexcode]).to eq(["can't be blank."])
-      end
-
-      it "is invalid w/ malformed hexcodes" do
-        expect(described_class.new(attributes.merge(hexcode: "0#FFFFFF"))).not_to be_valid
-        expect(described_class.new(attributes.merge(hexcode: "#FFFFFF0"))).not_to be_valid
-        expect(described_class.new(attributes.merge(hexcode: "white"))).not_to be_valid
-      end
-
-      it "is valid w/ proper hexcodes" do
-        expect(described_class.new(attributes.merge(hexcode: "#FFFFFF"))).to be_valid
-        expect(described_class.new(attributes.merge(hexcode: "#FF00FF"))).to be_valid
-      end
+    it "allows valid hexcodes" do
+      expect(subject).to allow_values("#FFFFFF", "#FF00FF").for(:hexcode)
     end
   end
 end

--- a/spec/models/colors/hex_color_spec.rb
+++ b/spec/models/colors/hex_color_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Colors::HexColor do
+  let(:color_class) { Data.define(:hexcode).include(described_class) }
+
+  describe "#rgb_colors" do
+    context "when hexcode is valid" do
+      it "returns an RGB array" do
+        expect(color_class.new(hexcode: "#FF69B4").rgb_colors).to eq [255, 105, 180]
+      end
+    end
+
+    context "when hexcode is too short" do
+      it "returns an RGB array, zeroing missing component values" do
+        expect(color_class.new(hexcode: "#ff").rgb_colors).to eq [255, 0, 0]
+      end
+    end
+
+    context "when hexcode is too long" do
+      it "returns an RGB array, dropping extra values" do
+        expect(color_class.new(hexcode: "#ff3366AA").rgb_colors).to eq [255, 51, 102]
+      end
+    end
+
+    context "when hexcode is invalid" do
+      it "returns an RGB array, zeroing invalid component values" do
+        expect(color_class.new(hexcode: "#eeXXcd").rgb_colors).to eq [238, 0, 205]
+      end
+    end
+  end
+
+  describe "#darken" do
+    context "when hexcode is valid" do
+      it "returns the darkened color's hexcode" do
+        expect(color_class.new(hexcode: "#663399").darken(0.5)).to eq "#331a4d"
+      end
+    end
+
+    context "when hexcode is invalid" do
+      it "zeroes missing component values and returns the darkened color's hexcode" do
+        expect(color_class.new(hexcode: "#eeXXcd").darken(0.5)).to eq "#770067"
+      end
+    end
+  end
+
+  describe "#lighten" do
+    context "when hexcode is valid" do
+      it "returns the lightened color's hexcode" do
+        expect(color_class.new(hexcode: "#663399").lighten(0.5)).to eq "#b399cc"
+      end
+    end
+
+    context "when hexcode is invalid" do
+      it "zeroes missing component values and returns the darkened color's hexcode" do
+        expect(color_class.new(hexcode: "#eeXXcd").lighten(0.5)).to eq "#f780e6"
+      end
+    end
+  end
+end

--- a/spec/models/design_color_spec.rb
+++ b/spec/models/design_color_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe DesignColor do
         "#1",
         "#1111111",
         "#HHHHHH"
-      ).for(:hexcode)
+      )
+      .for(:hexcode)
+      .with_message("is not a valid 6-digit hexadecimal color code.")
     end
 
     it "allows valid hexcodes" do

--- a/spec/models/design_color_spec.rb
+++ b/spec/models/design_color_spec.rb
@@ -6,6 +6,28 @@ RSpec.describe DesignColor do
   let(:default_primary) { OpenProject::CustomStyles::Design.variables["primary-button-color"] }
   let(:primary_color) { create(:"design_color_primary-button-color") }
 
+  describe "normalization" do
+    it "does not normalize non-hexcodes, except to strip whitespace", :aggregate_failures do
+      expect(subject).to normalize(:hexcode).from("").to("")
+      expect(subject).to normalize(:hexcode).from(" ").to("")
+      expect(subject).to normalize(:hexcode).from("11").to("11")
+      expect(subject).to normalize(:hexcode).from("purple").to("purple")
+      expect(subject).to normalize(:hexcode).from("green ").to("green")
+    end
+
+    it "normalizes short hexcodes", :aggregate_failures do
+      expect(subject).to normalize(:hexcode).from(" ccc").to("#CCCCCC")
+      expect(subject).to normalize(:hexcode).from("333 ").to("#333333")
+      expect(subject).to normalize(:hexcode).from("#ddd").to("#DDDDDD")
+    end
+
+    it "normalizes full hexcodes", :aggregate_failures do
+      expect(subject).to normalize(:hexcode).from(" 800080").to("#800080")
+      expect(subject).to normalize(:hexcode).from("228b22 ").to("#228B22")
+      expect(subject).to normalize(:hexcode).from("#00CED1").to("#00CED1")
+    end
+  end
+
   describe "#setables" do
     it "returns an Array of instances" do
       expect(described_class.setables).to be_a(Array)

--- a/spec/models/design_color_spec.rb
+++ b/spec/models/design_color_spec.rb
@@ -45,7 +45,37 @@ RSpec.describe DesignColor do
     end
   end
 
-  describe "#get_hexcode" do
+  describe "validations" do
+    it "validates variable is present and unique" do
+      expect(subject).to validate_presence_of(:variable)
+      expect(subject).to validate_uniqueness_of(:variable)
+    end
+
+    it "validates hexcode is present" do
+      expect(subject).to validate_presence_of(:hexcode)
+    end
+
+    it "does not allow malformed hexcodes" do
+      expect(subject).not_to allow_values(
+        "1",
+        "#1",
+        "#1111111",
+        "#HHHHHH"
+      ).for(:hexcode)
+    end
+
+    it "allows valid hexcodes" do
+      expect(subject).to allow_values(
+        "111111",
+        "#111111",
+        "#ABC123",
+        "#111",
+        "111"
+      ).for(:hexcode)
+    end
+  end
+
+  describe "#hexcode" do
     it "returns hexcode if present" do
       primary_color
       expect(primary_color.hexcode).to eq("#3493B3")
@@ -54,40 +84,6 @@ RSpec.describe DesignColor do
     it "returns nil hexcode if hexcode not present" do
       expect(described_class.new(variable: "primary-button-color").hexcode)
         .to be_nil
-    end
-  end
-
-  describe "validations" do
-    context "a color_variable already exists" do
-      let(:design_color) do
-        described_class.new variable: "foo", hexcode: "#AB1234"
-      end
-
-      before do
-        design_color.save
-      end
-
-      it "fails validation for another design_color with same name" do
-        second_color_variable = described_class.new variable: "foo", hexcode: "#888888"
-        expect(second_color_variable).not_to be_valid
-      end
-    end
-
-    context "the hexcode's validation" do
-      it "fails validations" do
-        expect(described_class.new(variable: "foo", hexcode: "1")).not_to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "#1")).not_to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "#1111111")).not_to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "#HHHHHH")).not_to be_valid
-      end
-
-      it "passes validations" do
-        expect(described_class.new(variable: "foo", hexcode: "111111")).to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "#111111")).to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "#ABC123")).to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "#111")).to be_valid
-        expect(described_class.new(variable: "foo", hexcode: "111")).to be_valid
-      end
     end
   end
 

--- a/spec/models/design_color_spec.rb
+++ b/spec/models/design_color_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DesignColor do
   describe "validations" do
     context "a color_variable already exists" do
       let(:design_color) do
-        DesignColor.new variable: "foo", hexcode: "#AB1234"
+        described_class.new variable: "foo", hexcode: "#AB1234"
       end
 
       before do
@@ -46,32 +46,32 @@ RSpec.describe DesignColor do
       end
 
       it "fails validation for another design_color with same name" do
-        second_color_variable = DesignColor.new variable: "foo", hexcode: "#888888"
-        expect(second_color_variable.valid?).to be_falsey
+        second_color_variable = described_class.new variable: "foo", hexcode: "#888888"
+        expect(second_color_variable).not_to be_valid
       end
     end
 
     context "the hexcode's validation" do
       it "fails validations" do
-        expect(DesignColor.new(variable: "foo", hexcode: "1").valid?).to be_falsey
-        expect(DesignColor.new(variable: "foo", hexcode: "#1").valid?).to be_falsey
-        expect(DesignColor.new(variable: "foo", hexcode: "#1111111").valid?).to be_falsey
-        expect(DesignColor.new(variable: "foo", hexcode: "#HHHHHH").valid?).to be_falsey
+        expect(described_class.new(variable: "foo", hexcode: "1")).not_to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "#1")).not_to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "#1111111")).not_to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "#HHHHHH")).not_to be_valid
       end
 
       it "passes validations" do
-        expect(DesignColor.new(variable: "foo", hexcode: "111111").valid?).to be_truthy
-        expect(DesignColor.new(variable: "foo", hexcode: "#111111").valid?).to be_truthy
-        expect(DesignColor.new(variable: "foo", hexcode: "#ABC123").valid?).to be_truthy
-        expect(DesignColor.new(variable: "foo", hexcode: "#111").valid?).to be_truthy
-        expect(DesignColor.new(variable: "foo", hexcode: "111").valid?).to be_truthy
+        expect(described_class.new(variable: "foo", hexcode: "111111")).to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "#111111")).to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "#ABC123")).to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "#111")).to be_valid
+        expect(described_class.new(variable: "foo", hexcode: "111")).to be_valid
       end
     end
   end
 
   describe "#create" do
     context "no CustomStyle.current exists yet" do
-      subject { DesignColor.new variable: "foo", hexcode: "#111111" }
+      subject { described_class.new variable: "foo", hexcode: "#111111" }
 
       it "creates a CustomStyle.current" do
         expect(CustomStyle.current).to be_nil

--- a/spec/seeders/env_data/custom_design_seeder_spec.rb
+++ b/spec/seeders/env_data/custom_design_seeder_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe EnvData::CustomDesignSeeder, :webmock do
     it "uses those variables" do
       reset(:seed_design)
 
-      expect { seeder.seed! }.to raise_error /Hex code is invalid/
+      expect { seeder.seed! }.to raise_error /Hex code is not a valid 6-digit hexadecimal color code./
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/66557

# What are you trying to accomplish?

Fixes a 500 Error that users might encounter when attempting to create a new Color.

This PR ensures the `HexColor#rgb_colors` method and dependent methods such as `#darken` do not blow up if hexcode value is invalid (which can occur if the record is unpersisted or fails validation). **Missing/invalid R, G, B component values will now be handled as zero.**

## Screenshots

<img width="1221" height="327" alt="Screenshot 2025-08-18 at 16 31 03" src="https://github.com/user-attachments/assets/94d22c75-9a77-4f07-b65b-6a3076131bed" />
<img width="1200" height="318" alt="Screenshot 2025-08-18 at 16 30 29" src="https://github.com/user-attachments/assets/1cf2920d-a6a8-45d1-b9c9-01838f7f7aff" />


# What approach did you choose and why?

This PR also:

- adds basic feature spec coverage.
- fixes a broken HTML label (missing `for` attribute) (also needed for Capybara `fill_in` method to work).
- Improves the hexcode format validation message.
- Minor improvements to hexcode normalization (ignores values that do not look like hexcodes).
- DRYs up model validations and their specs.
- make `#icon_for_color` skip render if the hexcode is invalid (avoids rendering `<span class="color--preview " style="background-color: #INVALID;border-color: #80008050"> </span>`)

What this PR doesn't do:

- Primerize the Color Administration forms _(I considered it, since validation errors are not displayed properly (inline), but not really in scope)._

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
