### PR TITLE
code maintenance/66397 Remove duplicate theme setting fn calls

### DIFF
--- a/frontend/src/app/core/setup/globals/theme-utils.ts
+++ b/frontend/src/app/core/setup/globals/theme-utils.ts
@@ -30,7 +30,7 @@
 
 export type OpColorMode = 'light' | 'dark';
 
-export type OpTheme = OpColorMode | `${OpColorMode}_high_contrast`;
+export type OpTheme = OpColorMode | `${OpColorMode}_high_contrast` | 'sync_with_os';
 
 export class ThemeUtils {
   public applySystemThemeImmediately():void {

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -69,14 +69,6 @@ export default class AutoThemeSwitcher extends Controller {
     this.applySystemTheme();
   }
 
-  isLightMode():void {
-    window.OpenProject.theme.applyThemeToBody('light');
-  }
-
-  notLightMode():void {
-    window.OpenProject.theme.applyThemeToBody('dark');
-  }
-
   private applySystemTheme():void {
     window.OpenProject.theme.applySystemThemeImmediately();
     this.updateOpLogoContrast();

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -30,9 +30,7 @@
 
 import { Controller } from '@hotwired/stimulus';
 import { useMatchMedia } from 'stimulus-use';
-import { type OpTheme } from 'core-app/core/setup/globals/theme-utils';
-
-type OpThemeMode = OpTheme | 'sync_with_os';
+import { OpTheme } from 'core-app/core/setup/globals/theme-utils';
 
 export default class AutoThemeSwitcher extends Controller {
   static values = {
@@ -42,7 +40,7 @@ export default class AutoThemeSwitcher extends Controller {
   static targets = ['desktopLogo', 'mobileLogo'];
   static classes = ['desktopLightHighContrastLogo', 'mobileWhiteLogo'];
 
-  declare readonly modeValue:OpThemeMode;
+  declare readonly modeValue:OpTheme;
   declare readonly desktopLogoTarget:HTMLLinkElement;
   declare readonly mobileLogoTarget:HTMLLinkElement;
   declare readonly desktopLightHighContrastLogoClass:string;


### PR DESCRIPTION
`useMatchMedia` calls the change functions and then calls the is/not setters. The later is a duplicate and unnecessary in our context.

See: https://github.com/stimulus-use/stimulus-use/blob/19a9bbfebfa5ed4e35e66387271e35b9b564c566/src/use-match-media/use-match-media.ts#L60

Follows #19942