### PR TITLE
Prevent destruction of angular frontend on the first load event

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -205,6 +205,7 @@ import {
   OpWpDatePickerInstanceComponent,
 } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component';
 import { OpInviteUserModalAugmentService } from 'core-app/features/invite-user-modal/invite-user-modal-augment.service';
+import { TurboLoadEvent } from '@hotwired/turbo';
 
 export function initializeServices(injector:Injector) {
   return () => {
@@ -362,8 +363,19 @@ export class OpenProjectModule implements DoBootstrap {
   ngDoBootstrap(appRef:ApplicationRef) {
     this.runBootstrap(appRef);
 
+    // Remember the initial page load
+    let initialHref:string|null = window.location.href;
+
     // Connect ui router to turbo drive
-    document.addEventListener('turbo:load', () => {
+    document.addEventListener('turbo:load', (evt:TurboLoadEvent) => {
+      // Skip a turbo:load event on the current URL
+      // as this might happen if bootstrap runs before turbo init
+      if (initialHref && evt.detail.url === initialHref) {
+        // Unset the href so that any following turbo:load fires
+        initialHref = null;
+        return;
+      }
+
       // Remove all previous references to components
       // This is mainly the bsae component
       appRef.components.slice().forEach((component) => {

--- a/frontend/src/app/features/plugins/plugin-context.ts
+++ b/frontend/src/app/features/plugins/plugin-context.ts
@@ -1,4 +1,4 @@
-import { Injector, NgZone } from '@angular/core';
+import { ApplicationRef, Injector, NgZone } from '@angular/core';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
@@ -87,6 +87,9 @@ export class OpenProjectPluginContext {
 
   // Angular zone reference
   @InjectField() public readonly zone:NgZone;
+
+  // Angular application reference
+  @InjectField() public readonly appRef:ApplicationRef;
 
   // Angular2 global injector reference
   constructor(public readonly injector:Injector) {

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -10,6 +10,7 @@ import { applyTurboNavigationPatch } from './turbo-navigation-patch';
 import { debugLog, whenDebugging } from 'core-app/shared/helpers/debug_output';
 import { TURBO_EVENTS } from './constants';
 import { StreamActions } from '@hotwired/turbo';
+import { addTurboAngularWrapper } from "core-turbo/turbo-angular-wrapper";
 
 Turbo.session.drive = true;
 Turbo.setProgressBarDelay(100);
@@ -33,6 +34,7 @@ registerDialogStreamAction();
 registerFlashStreamAction();
 registerLiveRegionStreamAction();
 registerInputCaptionStreamAction();
+addTurboAngularWrapper();
 
 StreamActions.reloadPage = function reloadPage() {
   window.location.reload();

--- a/frontend/src/turbo/turbo-angular-wrapper.ts
+++ b/frontend/src/turbo/turbo-angular-wrapper.ts
@@ -1,0 +1,31 @@
+import { skip } from 'rxjs/operators';
+import { fromEvent } from 'rxjs';
+import { runBootstrap } from 'core-app/app.module';
+import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+
+export function addTurboAngularWrapper() {
+  // When turbo:load fires, the angular application needs to be rebootstrapped.
+  // However, we don't want this to happen on the initial page load
+  fromEvent(document, 'turbo:load')
+    .pipe(
+      skip(1), // Skip the first turbo:load event
+    )
+    .subscribe(() => {
+      void window
+        .OpenProject
+        .getPluginContext()
+        .then((pluginContext:OpenProjectPluginContext) => {
+          const appRef = pluginContext.appRef;
+
+          // Remove all previous references to components
+          // This is mainly the base component
+          appRef.components.slice().forEach((component) => {
+            appRef.detachView(component.hostView);
+            component.destroy();
+          });
+
+          // Run bootstrap again to initialize the new application
+          runBootstrap(appRef);
+        });
+    });
+}


### PR DESCRIPTION
There is a timing issue where angular initializes before turbo fires the load event, causing the angular frontend to be destroyed again right away