### PR TITLE
[chore] harden request uri of sharepoint files query

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/base.rb
@@ -57,6 +57,10 @@ module Storages
             host_uri.path&.split("/")&.last
           end
 
+          def site_path
+            UrlBuilder.path(host_uri.path)
+          end
+
           def host_uri
             URI(@storage.host)
           end

--- a/modules/storages/app/common/storages/adapters/providers/share_point/queries/internal/lists_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/share_point/queries/internal/lists_query.rb
@@ -83,8 +83,9 @@ module Storages
               end
 
               def request_uri
-                storage_host = URI(@storage.host)
-                URI.join(base_uri.origin, "/v1.0/sites/#{storage_host.host}:#{storage_host.path}:/lists").to_s
+                endpoint_uri = UrlBuilder.url(base_uri, "/v1.0/sites", host_uri.host)
+
+                "#{endpoint_uri}:#{site_path}:/lists"
               end
 
               def build_collection(files)


### PR DESCRIPTION
# What are you trying to accomplish?
- allow using the file picker on sharepoint storages with a host url having a trailing `/`

[OP#66615](https://community.openproject.org/projects/document-workflows-stream/work_packages/66615/activity)
