### PR TITLE
Introduce `CollaborativeDocument` as a Delegated `Document` type

### DIFF
--- a/modules/documents/app/models/collaborative_document.rb
+++ b/modules/documents/app/models/collaborative_document.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CollaborativeDocument < ApplicationRecord
+  include Documentable
+
+  belongs_to :type
+  belongs_to :status
+  belongs_to :author, class_name: "User"
+  belongs_to :assigned_to, class_name: "Principal", optional: true
+  belongs_to :responsible, class_name: "Principal", optional: true
+end

--- a/modules/documents/app/models/concerns/documentable.rb
+++ b/modules/documents/app/models/concerns/documentable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Documentable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :document, as: :documentable, touch: true, dependent: :destroy
+  end
+end

--- a/modules/documents/app/models/document.rb
+++ b/modules/documents/app/models/document.rb
@@ -31,6 +31,11 @@
 class Document < ApplicationRecord
   belongs_to :project
   belongs_to :category, class_name: "DocumentCategory"
+
+  delegated_type :documentable,
+                 types: %w[CollaborativeDocument],
+                 dependent: :destroy
+
   acts_as_attachable delete_permission: :manage_documents,
                      add_permission: :manage_documents
 
@@ -46,8 +51,8 @@ class Document < ApplicationRecord
                      references: :projects,
                      date_column: "#{table_name}.created_at"
 
-  validates_presence_of :project, :title, :category
-  validates_length_of :title, maximum: 60
+  validates :project, :title, :category, presence: true
+  validates :title, length: { maximum: 60 }
 
   scope :visible, ->(user = User.current) {
     includes(:project)

--- a/modules/documents/db/migrate/20250819152511_add_documentable_to_documents.rb
+++ b/modules/documents/db/migrate/20250819152511_add_documentable_to_documents.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddDocumentableToDocuments < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :documents, :documentable, polymorphic: true, index: true
+  end
+end

--- a/modules/documents/db/migrate/20250819155002_create_collaborative_documents.rb
+++ b/modules/documents/db/migrate/20250819155002_create_collaborative_documents.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CreateCollaborativeDocuments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :collaborative_documents do |t|
+      t.text :content
+      t.references :author, foreign_key: { to_table: :users }, null: false
+      t.references :type, foreign_key: { to_table: :types }, null: false
+      t.references :assigned_to, foreign_key: { to_table: :users }
+      t.references :responsible, foreign_key: { to_table: :users }
+      t.references :status, foreign_key: true
+      t.date :due_date
+
+      t.timestamps
+    end
+  end
+end

--- a/modules/documents/spec/factories/collaborative_document_factory.rb
+++ b/modules/documents/spec/factories/collaborative_document_factory.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :collaborative_document do
+    content { "My Content" }
+    author factory: :user
+    assigned_to factory: :user
+    type factory: :type
+    status factory: :status
+
+    document factory: :document
+  end
+end

--- a/modules/documents/spec/models/collaborative_document_spec.rb
+++ b/modules/documents/spec/models/collaborative_document_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe CollaborativeDocument do
+  describe "Associations" do
+    it { is_expected.to have_one(:document).dependent(:destroy) }
+    it { is_expected.to belong_to(:type) }
+    it { is_expected.to belong_to(:status) }
+    it { is_expected.to belong_to(:author).class_name("User") }
+    it { is_expected.to belong_to(:assigned_to).class_name("Principal").optional }
+    it { is_expected.to belong_to(:responsible).class_name("Principal").optional }
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/wp/66597

`CollaborativeDocuments` are an extension of the existing "File Based" `Document`s. They have the following _additional_ properties:

  * Type
  * Status
  * Assignee
  * Responsible
  * Due Date

_See [Rails Delegated Types](https://api.rubyonrails.org/classes/ActiveRecord/DelegatedType.html)_