### PR TITLE
[#66688] Last changes in formula when submitting by pressing Enter/Return inside formula are not saved

### DIFF
--- a/frontend/src/stimulus/controllers/pattern-input.controller.ts
+++ b/frontend/src/stimulus/controllers/pattern-input.controller.ts
@@ -97,6 +97,7 @@ export default class PatternInputController extends Controller {
   input_keydown(event:KeyboardEvent) {
     if (event.key === 'Enter') {
       event.preventDefault();
+      this.updateFormInputValue();
       this.formInputTarget.form?.requestSubmit();
       return;
     }

--- a/spec/features/admin/custom_fields/projects/calculated_value_spec.rb
+++ b/spec/features/admin/custom_fields/projects/calculated_value_spec.rb
@@ -122,6 +122,18 @@ RSpec.describe "Edit project custom field calculated value", :js, with_flag: { c
 
       expect(calculated_value.reload.formula_string).to eq(original_formula)
     end
+
+    it "allows submitting formula by pressing Enter/Return" do
+      formula = "2 + 2"
+
+      pattern_input = find(:xpath, "//input[@id='custom_field_formula']/parent::div//div[@contenteditable='true']")
+
+      pattern_input.set("#{formula}\n")
+
+      expect(page).to have_text("Successful update")
+
+      expect(calculated_value.reload.formula_string).to eq(formula)
+    end
   end
 
   context "without the feature flag", with_flag: { calculated_value_project_attribute: false } do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66688

# What are you trying to accomplish?
Fix not saving formula when submitting using Enter/Return

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
