### PR TITLE
Do not allow logging time for a group

### DIFF
--- a/modules/costs/app/components/time_entries/user_form.rb
+++ b/modules/costs/app/components/time_entries/user_form.rb
@@ -77,7 +77,7 @@ module TimeEntries
 
     def user_completer_filters
       filters = [
-        { name: "type", operator: "=", values: %w[User Group] },
+        { name: "type", operator: "=", values: %w[User] },
         { name: "status", operator: "=", values: [Principal.statuses[:active], Principal.statuses[:invited]] }
       ]
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-time-and-costs/work_packages/63517/github

# What are you trying to accomplish?
It does not make sense to have groups as a user for logging the time. This PR removes groups from the filter.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
