### PR TITLE
[#66641] Show project attributes in sections in the mobile app

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1116,6 +1116,7 @@ en:
         active_value:
           true: "unarchived"
           false: "archived"
+        attribute_groups: "Attribute Groups"
         description: "Description"
         enabled_modules: "Enabled modules"
         identifier: "Identifier"

--- a/docs/api/apiv3/components/schemas/projects_schema_model.yml
+++ b/docs/api/apiv3/components/schemas/projects_schema_model.yml
@@ -1,9 +1,111 @@
 # Schema: Projects_schemaModel
 ---
 type: object
+description: |-
+  A schema for a project. This schema defines the attributes of a project.
+
+properties:
+  _type:
+    type: string
+    enum: [Schema]
+    description: The type identifier for this resource
+  _dependencies:
+    type: array
+    description: Schema dependencies (currently empty for projects)
+  _attributeGroups:
+    type: array
+    items:
+      type: object
+      properties:
+        _type:
+          type: string
+          enum: [ProjectFormCustomFieldSection]
+          description: The type identifier for this resource
+        name:
+          type: string
+          description: The human-readable name of the custom field section
+        attributes:
+          type: array
+          items:
+            type: string
+          description: |-
+            Array of camelCase custom field attribute names belonging to this section.
+            Only includes custom fields visible to the current user.
+    description: |-
+      Defines the organizational structure of project custom fields into sections for UI rendering.
+
+      Each attribute group represents a project attribute section containing related project attributes.
+      The sections determine how project attributes are visually organized and grouped in forms.
+
+      **Key behaviors:**
+      - Admin-only project attributes appear only for users with admin privileges
+      - Empty sections (with no accessible project attributes) are omitted from the response
+      - The order reflects the configured section positioning in admin settings
+      - Each section contains only project attributes assigned to that specific section
+
+      **Example structure:**
+      ```json
+      [
+        {
+          "_type": "ProjectFormCustomFieldSection",
+          "name": "Project Details",
+          "attributes": ["customField1", "customField3"]
+        },
+        {
+          "_type": "ProjectFormCustomFieldSection",
+          "name": "Budget Information",
+          "attributes": ["customField2", "customField4"]
+        }
+      ]
+      ```
+  id:
+    $ref: './schema_property_model.yml'
+  name:
+    $ref: './schema_property_model.yml'
+  identifier:
+    $ref: './schema_property_model.yml'
+  description:
+    $ref: './schema_property_model.yml'
+  public:
+    $ref: './schema_property_model.yml'
+  active:
+    $ref: './schema_property_model.yml'
+  status:
+    $ref: './schema_property_model.yml'
+  statusExplanation:
+    $ref: './schema_property_model.yml'
+  parent:
+    $ref: './schema_property_model.yml'
+  createdAt:
+    $ref: './schema_property_model.yml'
+  updatedAt:
+    $ref: './schema_property_model.yml'
+  _links:
+    type: object
+    description: Links related to this resource
+    properties:
+      self:
+        type: object
+        properties:
+          href:
+            type: string
+            example: "/api/v3/projects/schema"
+
 example:
   _type: Schema
   _dependencies: []
+  _attributeGroups:
+  - _type: ProjectFormCustomFieldSection
+    name: Project Details
+    attributes:
+      customField30
+      customField34
+  - _type: ProjectFormCustomFieldSection
+    name: Budget Information
+    attributes:
+      customField31
+      customField32
+      customField35
   id:
     type: Integer
     name: ID

--- a/docs/api/apiv3/components/schemas/projects_schema_model.yml
+++ b/docs/api/apiv3/components/schemas/projects_schema_model.yml
@@ -21,6 +21,9 @@ properties:
           type: string
           enum: [ProjectFormCustomFieldSection]
           description: The type identifier for this resource
+        id:
+          type: integer
+          description: The unique identifier of the custom field section
         name:
           type: string
           description: The human-readable name of the custom field section

--- a/docs/api/apiv3/paths/projects_schema.yml
+++ b/docs/api/apiv3/paths/projects_schema.yml
@@ -9,6 +9,18 @@ get:
             response:
               value:
                 _dependencies: []
+                _attributeGroups:
+                - _type: ProjectFormCustomFieldSection
+                  name: Project Details
+                  attributes:
+                  - customField30
+                  - customField34
+                - _type: ProjectFormCustomFieldSection
+                  name: Budget Information
+                  attributes:
+                  - customField31
+                  - customField32
+                  - customField35
                 _links:
                   self:
                     href: "/api/v3/projects/schema"

--- a/docs/development/concepts/resource-schemas/README.md
+++ b/docs/development/concepts/resource-schemas/README.md
@@ -74,6 +74,9 @@ An exemplary schema response on the Community for the OpenProject project (`ID=1
 
 The work package schema also contains the reference to the attribute groups from the form configuration in the `_attributeGroups` property.
 
+The project schema also contains the reference the project attribute sections and their project attributes in the `_attributeGroups` property.
+
+
 ## Frontend usage
 
 The OpenProject frontend usually ensure that whenever you get access to a HAL resource, its associated schema (if there is any) is also loaded. This is done through the [`SchemaCacheService`](https://github.com/opf/openproject/blob/dev/frontend/src/app/core/schemas/schema-cache.service.ts). It will request the associated schema unless it has already been cached in the global states object to avoid loading a schema multiple times.

--- a/docs/development/concepts/resource-schemas/README.md
+++ b/docs/development/concepts/resource-schemas/README.md
@@ -72,10 +72,10 @@ This results in work package schemas being defined per project and type combinat
 
 An exemplary schema response on the Community for the OpenProject project (`ID=14`) and the Bug type (`ID=1`) is [community.openproject.org/api/v3/work_packages/schemas/14-1](https://community.openproject.org/api/v3/work_packages/schemas/14-1)
 
-The work package schema also contains the reference to the attribute groups from the form configuration in the `_attributeGroups` property.
+Work package and project schemas contain references to their respective attribute groups in the `_attributeGroups` property:
 
-The project schema also contains the reference the project attribute sections and their project attributes in the `_attributeGroups` property.
-
+- Work package schemas reference attribute groups from the form configuration
+- Project schemas reference project attribute sections and their project attributes
 
 ## Frontend usage
 

--- a/lib/api/v3/projects/schemas/project_custom_field_section_representer.rb
+++ b/lib/api/v3/projects/schemas/project_custom_field_section_representer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Projects
+      module Schemas
+        class ProjectCustomFieldSectionRepresenter < ::API::Decorators::Single
+          property :name,
+                   exec_context: :decorator
+
+          property :attributes,
+                   exec_context: :decorator
+
+          def _type
+            "ProjectFormCustomFieldSection"
+          end
+
+          delegate :name, to: :represented
+
+          def attributes
+            represented.custom_fields.map do |cf|
+              convert_property(cf.attribute_name)
+            end
+          end
+
+          def convert_property(attribute)
+            ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/projects/schemas/project_custom_field_section_representer.rb
+++ b/lib/api/v3/projects/schemas/project_custom_field_section_representer.rb
@@ -33,6 +33,9 @@ module API
     module Projects
       module Schemas
         class ProjectCustomFieldSectionRepresenter < ::API::Decorators::Single
+          property :id,
+                   exec_context: :decorator
+
           property :name,
                    exec_context: :decorator
 
@@ -43,7 +46,7 @@ module API
             "ProjectFormCustomFieldSection"
           end
 
-          delegate :name, to: :represented
+          delegate :id, :name, to: :represented
 
           def attributes
             represented.custom_fields.map do |cf|
@@ -51,8 +54,8 @@ module API
             end
           end
 
-          def convert_property(attribute)
-            ::API::Utilities::PropertyNameConverter.from_ar_name(attribute)
+          def convert_property(attribute_name)
+            ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
           end
         end
       end

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -107,8 +109,75 @@ module API
           schema :updated_at,
                  type: "DateTime"
 
-          def self.represented_class
-            ::Project
+          # Cannot be cached here due to custom field visibility checks on a user level.
+          # However caching is still applied further down in the `section_representation` method.
+          property :attribute_groups,
+                   name_source: ->(*) { I18n.t("activerecord.attributes.project.attribute_groups") },
+                   type: "[]String",
+                   as: "_attributeGroups",
+                   exec_context: :decorator,
+                   uncacheable: true
+
+          class << self
+            def represented_class
+              ::Project
+            end
+
+            def attribute_group(property)
+              lambda do
+                key = property.to_s
+                attribute_group_map key
+              end
+            end
+          end
+
+          def attribute_groups
+            project_custom_field_sections.map do |section|
+              section_representation(section)
+            end
+          end
+
+          ##
+          # Return a map of attribute => group name
+          def attribute_group_map(key)
+            return nil if project_custom_field_sections.empty?
+
+            @attribute_group_map ||= project_custom_field_sections.each_with_object({}) do |section, hash|
+              section.custom_fields.each do |cf|
+                hash[cf.attribute_name(:camel_case)] = section.name
+              end
+            end
+
+            @attribute_group_map[key]
+          end
+
+          private
+
+          def project_custom_field_sections
+            @project_custom_field_sections ||= ProjectCustomFieldSection
+                                                .joins(:custom_fields)
+                                                .includes(:custom_fields)
+                                                .merge(ProjectCustomField.visible(current_user))
+                                                .group(:id, "custom_fields.id")
+                                                .order(:position, :position_in_custom_field_section)
+          end
+
+          def section_representation(section)
+            OpenProject::Cache.fetch(*section_cache_key(section)) do
+              ::JSON::parse(::API::V3::Projects::Schemas::ProjectCustomFieldSectionRepresenter
+                              .new(section, current_user:, embed_links: true)
+                              .to_json)
+            end
+          end
+
+          def section_cache_key(section)
+            ["project_schema_custom_field_section",
+             section.id,
+             I18n.locale,
+             represented.model,
+             represented.model.available_custom_fields.sort_by(&:id)]
+              .flatten
+              .compact
           end
         end
       end

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -152,9 +152,7 @@ module API
              section.id,
              I18n.locale,
              represented.model,
-             represented.model.available_custom_fields.sort_by(&:id)]
-              .flatten
-              .compact
+             *represented.model.available_custom_fields.sort_by(&:id)]
           end
         end
       end

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -113,7 +113,6 @@ module API
           # However caching is still applied further down in the `section_representation` method.
           property :attribute_groups,
                    name_source: ->(*) { I18n.t("activerecord.attributes.project.attribute_groups") },
-                   type: "[]String",
                    as: "_attributeGroups",
                    exec_context: :decorator,
                    uncacheable: true
@@ -122,33 +121,12 @@ module API
             def represented_class
               ::Project
             end
-
-            def attribute_group(property)
-              lambda do
-                key = property.to_s
-                attribute_group_map key
-              end
-            end
           end
 
           def attribute_groups
             project_custom_field_sections.map do |section|
               section_representation(section)
             end
-          end
-
-          ##
-          # Return a map of attribute => group name
-          def attribute_group_map(key)
-            return nil if project_custom_field_sections.empty?
-
-            @attribute_group_map ||= project_custom_field_sections.each_with_object({}) do |section, hash|
-              section.custom_fields.each do |cf|
-                hash[cf.attribute_name(:camel_case)] = section.name
-              end
-            end
-
-            @attribute_group_map[key]
           end
 
           private
@@ -164,9 +142,8 @@ module API
 
           def section_representation(section)
             OpenProject::Cache.fetch(*section_cache_key(section)) do
-              ::JSON::parse(::API::V3::Projects::Schemas::ProjectCustomFieldSectionRepresenter
-                              .new(section, current_user:, embed_links: true)
-                              .to_json)
+              ::API::V3::Projects::Schemas::ProjectCustomFieldSectionRepresenter
+                .new(section, current_user:)
             end
           end
 

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -131,13 +131,16 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
           it "renders section attribute group elements of the schema" do
             expect(subject)
               .to be_json_eql(
-                {
-                  _type: "ProjectFormCustomFieldSection",
-                  name: "Common Project Attributes",
-                  attributes: ["customField#{user_custom_field.id}"]
-                }.to_json
+                [
+                  {
+                    _type: "ProjectFormCustomFieldSection",
+                    id: user_section.id,
+                    name: "Common Project Attributes",
+                    attributes: ["customField#{user_custom_field.id}"]
+                  }
+                ].to_json
               )
-              .at_path("_attributeGroups/0")
+              .at_path("_attributeGroups")
           end
         end
 
@@ -147,23 +150,22 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
           it "renders section attribute group elements of the schema" do
             expect(subject)
               .to be_json_eql(
-                {
-                  _type: "ProjectFormCustomFieldSection",
-                  name: "Common Project Attributes",
-                  attributes: ["customField#{user_custom_field.id}"]
-                }.to_json
+                [
+                  {
+                    _type: "ProjectFormCustomFieldSection",
+                    id: user_section.id,
+                    name: "Common Project Attributes",
+                    attributes: ["customField#{user_custom_field.id}"]
+                  },
+                  {
+                    _type: "ProjectFormCustomFieldSection",
+                    id: admin_section.id,
+                    name: "Admin Project Attributes",
+                    attributes: ["customField#{admin_custom_field.id}"]
+                  }
+                ].to_json
               )
-              .at_path("_attributeGroups/0")
-
-            expect(subject)
-              .to be_json_eql(
-                {
-                  _type: "ProjectFormCustomFieldSection",
-                  name: "Admin Project Attributes",
-                  attributes: ["customField#{admin_custom_field.id}"]
-                }.to_json
-              )
-              .at_path("_attributeGroups/1")
+              .at_path("_attributeGroups")
           end
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66641

# What are you trying to accomplish?
Display attributeGroups in the project schema API.

## Screenshots

<details><summary>API response</summary>
<p>

<img width="885" height="728" alt="image" src="https://github.com/user-attachments/assets/b750efb0-aa21-4f0e-a487-65cf35e95c92" />


</p>
</details> 

<details><summary>API docs</summary>
<p>

<img width="1231" height="737" alt="image" src="https://github.com/user-attachments/assets/8a82080a-d87e-4f66-825c-4eb87e80f6b4" />


</p>
</details> 

# What approach did you choose and why?
Create a `ProjectCustomFieldSectionRepresenter` and use it to display `attribute_groups` inside the `ProjectSchemaRepresenter`.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
