### PR TITLE
Remove npm run build:fast after esbuild introduction

### DIFF
--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -101,7 +101,7 @@ backend_stuff() {
 }
 
 frontend_stuff() {
-	execute_quiet "OPENPROJECT_ANGULAR_BUILD=fast DATABASE_URL=nulldb://db time bin/rails openproject:plugins:register_frontend assets:precompile"
+	execute_quiet "DATABASE_URL=nulldb://db time bin/rails openproject:plugins:register_frontend assets:precompile"
 	execute_quiet "cp -rp config/frontend_assets.manifest.json public/assets/frontend_assets.manifest.json"
 }
 

--- a/docker/pullpreview/docker-compose.yml
+++ b/docker/pullpreview/docker-compose.yml
@@ -13,8 +13,6 @@ volumes:
 x-defaults: &defaults
   build:
     context: .
-    args:
-      OPENPROJECT_ANGULAR_BUILD: "fast"
   restart: unless-stopped
   env_file:
     - .env.pullpreview

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -181,7 +181,6 @@
   },
   "scripts": {
     "analyze": "ng build --configuration production --stats-json && webpack-bundle-analyzer -h 0.0.0.0 -p 9999 ../public/assets/frontend/stats.json",
-    "build:fast": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build --configuration production",
     "build": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --configuration production --named-chunks --source-map",
     "build:watch": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --watch --named-chunks",
     "ci:plugins:register_frontend": "node ci-plugins-generator.js",

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -62,14 +62,7 @@ namespace :assets do
 
     puts "Building angular frontend"
     Dir.chdir Rails.root.join("frontend") do
-      cmd =
-        if ENV["OPENPROJECT_ANGULAR_BUILD"] == "fast"
-          "npm run build:fast"
-        else
-          "npm run build"
-        end
-
-      sh(cmd) do |ok, res|
+      sh("npm run build") do |ok, res|
         raise "Failed to compile angular frontend: #{res.exitstatus}" if !ok
       end
     end


### PR DESCRIPTION
The fast build was introduced to avoid source maps, but now esbuild should be a lot faster in itself, so ideally we can avoid using a different build for CI, preventing errors caused by this change.