### PR TITLE
[#42761] No date formatting in XLS export of Cost Report

### DIFF
--- a/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
+++ b/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
@@ -41,7 +41,8 @@ class OpenProject::Reporting::CostEntryXlsTable < OpenProject::XlsExport::XlsVie
 
   def build_cost_rows
     sorted_results.each do |result|
-      spreadsheet.add_row(cost_row(result))
+      row = spreadsheet.add_row(cost_row(result))
+      row.set_format 0, date_format
     end
   end
 
@@ -73,7 +74,7 @@ class OpenProject::Reporting::CostEntryXlsTable < OpenProject::XlsExport::XlsVie
   end
 
   def cost_main_columns(result)
-    main_cols = [show_field(:spent_on, result.fields["spent_on"])]
+    main_cols = [result.fields["spent_on"].to_date]
     main_cols.concat cost_main_times_columns(result) if with_times_column?
     main_cols
   end

--- a/modules/xls_export/lib/open_project/xls_export/xls_views.rb
+++ b/modules/xls_export/lib/open_project/xls_export/xls_views.rb
@@ -69,6 +69,14 @@ class OpenProject::XlsExport::XlsViews
     "0.00"
   end
 
+  def date_format
+    @date_format ||= Spreadsheet::Format.new(
+      number_format: "yyyy-mm-dd",
+      horizontal_align: :left,
+      vertical_align: :top
+    )
+  end
+
   def project_representation(value)
     ar_presentation(Project, value, &:name)
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/42761

# What are you trying to achieve?

The dates were inserted as string, which Excel.exe and Numbers.app don't accept as dates.

# What approach did you choose and why?

In XLS there is no dedicated "date" format, but dates are stored as float with a formatter. We define such a formatter now and set the format to the cell.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major XLS readers (Excel, Numbers)
