### PR TITLE
[#61940] Work package exports also show subprojects despite excluded

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
@@ -40,6 +40,7 @@ describe('UrlParamsHelper', () => {
     const params = {
       ids: [1, 2, 3],
       str: '@#$%',
+      importantOption: false
     };
     let queryString:string;
 
@@ -48,11 +49,15 @@ describe('UrlParamsHelper', () => {
     });
 
     it("concatenates propertys with '&'", () => {
-      expect(queryString.split('&').length).toEqual(4);
+      expect(queryString.split('&').length).toEqual(5);
     });
 
     it('escapes special characters', () => {
       expect(queryString.indexOf('@') === -1).toBeTruthy();
+    });
+
+    it('does not omit false', () => {
+      expect(queryString.includes('importantOption=false')).toBeTruthy();
     });
   });
 

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
@@ -113,7 +113,7 @@ export class UrlParamsHelperService {
 
     const parts:string[] = [];
     _.each(params, (value, key) => {
-      if (!value) {
+      if (value === undefined || value === null) {
         return;
       }
       if (!Array.isArray(value)) {

--- a/spec/support/components/project_include_component.rb
+++ b/spec/support/components/project_include_component.rb
@@ -55,6 +55,10 @@ module Components
       page.find("[data-qa-project-include-all-subprojects]").click
     end
 
+    def expect_include_all_subprojects_unchecked
+      expect(page.find("[data-qa-project-include-all-subprojects]")).not_to be_checked
+    end
+
     def toggle_checkbox(project_id)
       page.find("[data-qa-project-include-id='#{project_id}']").click
       clear_tooltips


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/61940

# What are you trying to achieve?

Work package exports also show subprojects despite being excluded, due to an unsaved query may have include_subprojects set to true via `Setting.display_subprojects_work_packages?` but the URL parameter `includeSubprojects` is omitted if set to false in the frontend.

# What approach did you choose and why?

Don't omit the parameter

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
