### PR TITLE
Only show participated meetings in iCal feed

### DIFF
--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -115,9 +115,9 @@ class Meeting < ApplicationRecord
 
   accepts_nested_attributes_for :participants, allow_destroy: true
 
-  validates_presence_of :title, :project_id
+  validates :title, :project_id, presence: true
 
-  validates_numericality_of :duration, greater_than: 0
+  validates :duration, numericality: { greater_than: 0 }
 
   before_save :add_new_participants_as_watcher
 

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -85,6 +85,10 @@ class Meeting < ApplicationRecord
       .merge(Project.allowed_to(args.first || User.current, :view_meetings))
   }
 
+  scope :participated_by, ->(user) {
+    joins(:participants).where(meeting_participants: { user_id: user.id })
+  }
+
   acts_as_attachable(
     after_remove: :attachments_changed,
     order: "#{Attachment.table_name}.file",

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,6 +31,8 @@
 class MeetingParticipant < ApplicationRecord
   belongs_to :meeting
   belongs_to :user
+
+  validates :user, presence: true, uniqueness: { scope: :meeting_id }
 
   scope :invited, -> { where(invited: true) }
   scope :attended, -> { where(attended: true) }

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -32,8 +32,6 @@ class MeetingParticipant < ApplicationRecord
   belongs_to :meeting
   belongs_to :user
 
-  validates :user, presence: true, uniqueness: { scope: :meeting_id }
-
   scope :invited, -> { where(invited: true) }
   scope :attended, -> { where(attended: true) }
 

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -99,6 +99,10 @@ class RecurringMeeting < ApplicationRecord
       .merge(Project.allowed_to(args.first || User.current, :view_meetings))
   }
 
+  scope :participated_by, ->(user) {
+    left_outer_joins(template: :participants).where(participants: { user_id: user.id })
+  }
+
   # Virtual attributes that can be passed on to the template on save
   virtual_attribute :location do
     nil

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -40,18 +40,18 @@ class RecurringMeeting < ApplicationRecord
   belongs_to :project
   belongs_to :author, class_name: "User"
 
-  validates_presence_of :start_time, :title, :frequency, :end_after, :time_zone
-  validates_presence_of :end_date, if: -> { end_after_specific_date? }
-  validates_numericality_of :iterations,
-                            only_integer: true,
+  validates :start_time, :title, :frequency, :end_after, :time_zone, presence: true
+  validates :end_date, presence: { if: -> { end_after_specific_date? } }
+  validates :iterations,
+            numericality: { only_integer: true,
                             greater_than_or_equal_to: 1,
                             less_than_or_equal_to: MAX_ITERATIONS,
-                            if: -> { end_after_iterations? }
-  validates_numericality_of :interval,
-                            only_integer: true,
+                            if: -> { end_after_iterations? } }
+  validates :interval,
+            numericality: { only_integer: true,
                             greater_than_or_equal_to: 1,
                             less_than_or_equal_to: MAX_INTERVAL,
-                            if: -> { !frequency_working_days? }
+                            if: -> { !frequency_working_days? } }
 
   validate :end_date_constraints,
            if: -> { end_after_specific_date? }
@@ -61,8 +61,8 @@ class RecurringMeeting < ApplicationRecord
   # Unset any previously set schedule before running validations
   before_validation :unset_schedule
 
-  after_save :unset_schedule
   before_destroy :remove_jobs
+  after_save :unset_schedule
 
   enum :frequency,
        {

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -66,7 +66,7 @@ module AllMeetings
 
     def single_meetings
       @single_meetings ||= if include_historic
-                             Meeting.not_recurring.visible(user).articipated_by(user)
+                             Meeting.not_recurring.visible(user).participated_by(user)
                            else
                              Meeting.not_recurring.from_today.visible(user).participated_by(user)
                            end

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -61,14 +61,14 @@ module AllMeetings
     private
 
     def recurring_meetings
-      @recurring_meetings ||= RecurringMeeting.visible(user)
+      @recurring_meetings ||= RecurringMeeting.visible(user).participated_by(user)
     end
 
     def single_meetings
       @single_meetings ||= if include_historic
-                             Meeting.not_recurring.visible(user)
+                             Meeting.not_recurring.visible(user).articipated_by(user)
                            else
-                             Meeting.not_recurring.from_today.visible(user)
+                             Meeting.not_recurring.from_today.visible(user).participated_by(user)
                            end
     end
   end

--- a/modules/meeting/db/migrate/20250821092618_add_indices_to_meeting_participants.rb
+++ b/modules/meeting/db/migrate/20250821092618_add_indices_to_meeting_participants.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndicesToMeetingParticipants < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :meeting_participants, :meeting_id, algorithm: :concurrently
+    add_index :meeting_participants, :user_id, algorithm: :concurrently
+
+    add_index :meeting_participants, %i[meeting_id user_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/modules/meeting/db/migrate/20250821092618_add_indices_to_meeting_participants.rb
+++ b/modules/meeting/db/migrate/20250821092618_add_indices_to_meeting_participants.rb
@@ -6,7 +6,5 @@ class AddIndicesToMeetingParticipants < ActiveRecord::Migration[8.0]
   def change
     add_index :meeting_participants, :meeting_id, algorithm: :concurrently
     add_index :meeting_participants, :user_id, algorithm: :concurrently
-
-    add_index :meeting_participants, %i[meeting_id user_id], unique: true, algorithm: :concurrently
   end
 end

--- a/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
@@ -100,8 +100,18 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
 
     let!(:invisible_meeting) do
       create(:meeting,
-             author: user, # creatd by the user but in a project the user cannot see
-             project: create(:project, name: "Invisible Project"),
+             author: user,
+             project: create(:project, name: "Invisible Project"), # in a project the user cannot see
+             title: "Important meeting",
+             location: "https://example.com/meet/important-meeting",
+             start_time: relevant_time + 1.week,
+             duration: 1.0)
+    end
+
+    let!(:not_invited_meeting) do
+      create(:meeting,
+             author: user,
+             project:,
              title: "Important meeting",
              location: "https://example.com/meet/important-meeting",
              start_time: relevant_time + 1.week,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/66727/activity?query_id=5331

# What are you trying to accomplish?
- Add indices for meeting participation
- Add a new `participated_by` scope to only load meetings i am invited to
- Use that new scope in the all iCal export

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
