### PR TITLE
Bug/66471 enable calculation of admin only calculated values on change of non admin only field values by non admins fix

### DIFF
--- a/app/services/projects/concerns/set_calculated_custom_field_values.rb
+++ b/app/services/projects/concerns/set_calculated_custom_field_values.rb
@@ -63,7 +63,9 @@ module Projects::Concerns
       # admin_only check.
       affected_cfs = model.available_custom_fields.unscope(where: :admin_only).affected_calculated_fields(changed_cf_ids)
 
-      model.calculate_custom_fields(affected_cfs)
+      model.change_by_system do
+        model.calculate_custom_fields(affected_cfs)
+      end
     end
   end
 end

--- a/spec/support/pages/projects/show.rb
+++ b/spec/support/pages/projects/show.rb
@@ -76,6 +76,10 @@ module Pages
         within("[data-test-selector='project-custom-field-#{custom_field.id}']", &)
       end
 
+      def expect_no_custom_field(custom_field)
+        expect(page).to have_no_css("[data-test-selector='project-custom-field-#{custom_field.id}']")
+      end
+
       def open_edit_dialog_for_section(section)
         within_project_attributes_sidebar do
           scroll_to_element(page.find("[data-test-selector='project-custom-field-section-#{section.id}']"))


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66471 depends on https://community.openproject.org/work_packages/66738

# What are you trying to accomplish?
Fix non admin user not being able to change custom fields used in calculation of admin only calculated values

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
