### PR TITLE
Move `Project.workspace_type` validation from contract to model

### DIFF
--- a/app/contracts/projects/create_contract.rb
+++ b/app/contracts/projects/create_contract.rb
@@ -30,9 +30,9 @@
 
 module Projects
   class CreateContract < BaseContract
-    attribute :workspace_type do
-      validate_workspace_type_included
-    end
+    # TODO: differentiate on allowed types based on permissions.
+    # Permissions will need to be added: project, program, portfolio.
+    attribute :workspace_type
 
     include AdminWritableTimestamps
 
@@ -49,12 +49,6 @@ module Projects
     end
 
     protected
-
-    def validate_workspace_type_included
-      # TODO: differentiate on allowed types based on permissions.
-      # Permissions will need to be added: project, program, portfolio.
-      errors.add(:workspace_type, :blank) if model.workspace_type.nil?
-    end
 
     def collect_available_custom_field_attributes
       model.all_visible_custom_fields.map(&:attribute_name)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -52,7 +52,7 @@ class Project < ApplicationRecord
     project: "project",
     program: "program",
     portfolio: "portfolio"
-  }
+  }, validate: true
 
   has_many :members, -> {
     # TODO: check whether this should

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1146,6 +1146,7 @@ en:
         types: "Types"
         versions: "Versions"
         work_packages: "Work Packages"
+        workspace_type: "Workspace type"
       project_custom_field:
         is_required: "Required for all projects"
         custom_field_section: Section

--- a/spec/contracts/projects/create_contract_spec.rb
+++ b/spec/contracts/projects/create_contract_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Projects::CreateContract do
     context "if workspace_type is nil" do
       let(:project_workspace_type) { nil }
 
-      it_behaves_like "contract is invalid", workspace_type: %i(blank)
+      it_behaves_like "contract is invalid", workspace_type: %i[inclusion]
     end
 
     context "if workspace type is 'project'" do
@@ -100,6 +100,12 @@ RSpec.describe Projects::CreateContract do
       let(:project_workspace_type) { "portfolio" }
 
       it_behaves_like "contract is valid"
+    end
+
+    context "if workspace type is 'invalid type'" do
+      let(:project_workspace_type) { "invalid type" }
+
+      it_behaves_like "contract is invalid", workspace_type: %i[inclusion]
     end
 
     describe "permissions" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -32,6 +32,7 @@ require "spec_helper"
 
 RSpec.describe Project do
   include BecomeMember
+
   shared_let(:admin) { create(:admin) }
 
   let(:active) { true }
@@ -182,6 +183,18 @@ RSpec.describe Project do
 
         expect(project.name).to eql("A new name")
       end
+    end
+  end
+
+  describe "workspace_type" do
+    it "is set to nil by default, to force having errors when it has not been set" do
+      # Would it make sense to have "project" as default value?
+      project = described_class.new
+      expect(project.workspace_type).to be_nil
+    end
+
+    it "must be one of the allowed values: #{described_class.workspace_types.keys}" do
+      expect(project).to validate_inclusion_of(:workspace_type).in_array(%w[project program portfolio])
     end
   end
 


### PR DESCRIPTION
# Ticket

no ticket

# What are you trying to accomplish?

Avoid having a valid `Project` that can't be saved because of non-null db constraints on `workspace_type` field.
Initially that PR set a default value of `"project"` on that field in addition to the validations, but this has finally been reverted after discussing it. The aim of keeping it to `nil` by default is to have a validation error if that field is ever forgotten to be set.

## Screenshots

Before:

<img width="1917" height="426" alt="image" src="https://github.com/user-attachments/assets/a10a77f0-fc68-49a9-8d8c-51360e7e40ae" />

After:

<img width="899" height="296" alt="image" src="https://github.com/user-attachments/assets/744070f1-8d3d-4b75-9883-3523ddb034bc" />

# What approach did you choose and why?

- Do no set a default value "project" for field `workspace_type`. Keep `nil` as default value.
- Add `validate: true` on the `workspace_type` enum. This adds an inclusion validator which disallows blank values.
- Remove presence validation from `Projects::CreateContract` as it's now replaced by the inclusion validator.
- Add a proper i18n key for attribute `workspace_type`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
