### PR TITLE
Implementation/64528 recalculate when a factored in cf is deleted in the administration

### DIFF
--- a/app/contracts/custom_fields/delete_contract.rb
+++ b/app/contracts/custom_fields/delete_contract.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomFields
+  class DeleteContract < BaseContract
+    class ReferencedInOtherFieldsHtmlError
+      include Rails.application.routes.url_helpers
+      include ActionView::Helpers::OutputSafetyHelper
+      include ActionView::Helpers::TranslationHelper
+      include ActionView::Helpers::UrlHelper
+
+      def message(referenced, referencing)
+        links = referencing.map do |cf|
+          url = admin_settings_project_custom_field_path(cf)
+          link_to(cf.name, url)
+        end
+
+        t(
+          "activerecord.errors.models.custom_field.referenced_in_other_fields_html",
+          name: referenced.name,
+          links: to_sentence(links),
+          count: links.length
+        )
+      end
+    end
+
+    validate :not_referenced
+
+    def not_referenced
+      referencing = model.class.with_formula_referencing(model)
+      return if referencing.empty?
+
+      errors.add(
+        :base,
+        :referenced_in_other_fields,
+        message: ReferencedInOtherFieldsHtmlError.new.message(model, referencing)
+      )
+    end
+  end
+end

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -147,9 +147,15 @@ module Admin::Settings
     end
 
     def destroy
-      @custom_field.destroy
+      result = CustomFields::DeleteService.new(user: current_user, model: @custom_field).call
 
-      update_section_via_turbo_stream(project_custom_field_section: @custom_field.project_custom_field_section.reload)
+      if result.success?
+        update_section_via_turbo_stream(project_custom_field_section: @custom_field.project_custom_field_section.reload)
+      else
+        render_error_flash_message_via_turbo_stream(
+          message: join_flash_messages(result.errors)
+        )
+      end
 
       respond_with_turbo_streams
     end

--- a/app/controllers/admin/settings/project_custom_fields_controller.rb
+++ b/app/controllers/admin/settings/project_custom_fields_controller.rb
@@ -114,29 +114,33 @@ module Admin::Settings
     end
 
     def move
-      call = CustomFields::UpdateService.new(user: current_user, model: @custom_field).call(
+      result = CustomFields::UpdateService.new(user: current_user, model: @custom_field).call(
         move_to: params[:move_to]&.to_sym
       )
 
-      if call.success?
+      if result.success?
         update_sections_via_turbo_stream(project_custom_field_sections: @project_custom_field_sections)
       else
-        # TODO: handle error
+        render_error_flash_message_via_turbo_stream(
+          message: join_flash_messages(result.errors)
+        )
       end
 
       respond_with_turbo_streams
     end
 
     def drop
-      call = ::ProjectCustomFields::DropService.new(user: current_user, project_custom_field: @custom_field).call(
+      result = ::ProjectCustomFields::DropService.new(user: current_user, project_custom_field: @custom_field).call(
         target_id: params[:target_id],
         position: params[:position]
       )
 
-      if call.success?
-        drop_success_streams(call)
+      if result.success?
+        drop_success_streams(result)
       else
-        # TODO: handle error
+        render_error_flash_message_via_turbo_stream(
+          message: join_flash_messages(result.errors)
+        )
       end
 
       respond_with_turbo_streams

--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -44,6 +44,10 @@ module CustomField::CalculatedValue
   end
 
   class_methods do
+    def with_formula_referencing(id)
+      where("(formula -> 'referenced_custom_fields') @> ?", id)
+    end
+
     # Select custom fields of type calculated_value that are listed in
     # changed_cf_ids, or are referencing custom fields in changed_cf_ids either
     # directly or through other calculated fields

--- a/app/services/custom_fields/delete_service.rb
+++ b/app/services/custom_fields/delete_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomFields
+  class DeleteService < ::BaseServices::Delete
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1412,6 +1412,9 @@ en:
               minimum: "need to include at least one filter for principal, context or id with the '=' operator."
         custom_field:
           at_least_one_custom_option: "At least one option needs to be available."
+          referenced_in_other_fields_html:
+            one: "%{name} is used in project attribute calculation %{links}."
+            other: "%{name} is used in project attribute calculations: %{links}."
         custom_fields_project:
           attributes:
             project_ids:

--- a/spec/contracts/custom_fields/delete_contract_spec.rb
+++ b/spec/contracts/custom_fields/delete_contract_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe CustomFields::DeleteContract do
+  include_context "ModelContract shared context"
+
+  let(:cf) { build_stubbed(:project_custom_field) }
+  let(:contract) do
+    described_class.new(cf, current_user, options: {})
+  end
+
+  it_behaves_like "contract is valid for active admins and invalid for regular users"
+
+  describe "checks that field is not referenced" do
+    let(:current_user) { build_stubbed(:admin) }
+
+    before do
+      allow(ProjectCustomField).to receive(:with_formula_referencing).with(cf).and_return(referencing)
+    end
+
+    context "when the custom field is not referenced" do
+      let(:referencing) { [] }
+
+      include_examples "contract is valid"
+    end
+
+    context "when the custom field is referenced" do
+      let(:referencing) { [build_stubbed(:project_custom_field)] }
+
+      include_examples "contract is invalid", base: :referenced_in_other_fields
+    end
+  end
+end

--- a/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
+++ b/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
@@ -34,7 +34,7 @@ require_relative "shared_context"
 RSpec.describe "Create project custom fields in sections", :js do
   include_context "with seeded project custom fields"
 
-  let(:cf_index_page) { Pages::Admin::CustomFields::CustomFieldsProjects::Index.new }
+  let(:cf_index_page) { Pages::Admin::Settings::ProjectCustomFields::Index.new }
 
   context "with insufficient permissions" do
     it "is not accessible" do

--- a/spec/features/admin/custom_fields/projects/index_spec.rb
+++ b/spec/features/admin/custom_fields/projects/index_spec.rb
@@ -34,7 +34,7 @@ require_relative "shared_context"
 RSpec.describe "List project custom fields", :js do
   include_context "with seeded project custom fields"
 
-  let(:cf_index_page) { Pages::Admin::CustomFields::CustomFieldsProjects::Index.new }
+  let(:cf_index_page) { Pages::Admin::Settings::ProjectCustomFields::Index.new }
 
   context "with insufficient permissions" do
     it "is not accessible" do

--- a/spec/features/admin/custom_fields/projects/index_spec.rb
+++ b/spec/features/admin/custom_fields/projects/index_spec.rb
@@ -265,14 +265,70 @@ RSpec.describe "List project custom fields", :js do
         end
       end
 
-      it "allows to delete a custom field" do
-        within_project_custom_field_menu(boolean_project_custom_field) do
-          accept_confirm do
-            click_on("Delete")
+      describe "deleting custom fields" do
+        it "allows to delete a custom field" do
+          within_project_custom_field_menu(boolean_project_custom_field) do
+            accept_confirm do
+              click_on("Delete")
+            end
           end
+
+          expect(page).to have_no_css("[data-test-selector='project-custom-field-container-#{boolean_project_custom_field.id}']")
         end
 
-        expect(page).to have_no_css("[data-test-selector='project-custom-field-container-#{boolean_project_custom_field.id}']")
+        it "prevents deletion of custom field used in a calculated value custom fields" do
+          within_project_custom_field_menu(integer_project_custom_field) do
+            accept_confirm do
+              click_on("Delete")
+            end
+          end
+          page.within(find_flash_element(type: :error)) do
+            expect(page).to have_cf_admin_link(calculated_from_int_project_custom_field)
+            expect(page).to have_cf_admin_link(calculated_from_int_and_float_project_custom_field)
+          end
+          expect_and_dismiss_flash(
+            message: "Integer field is used in project attribute calculations: Calculated field using int and " \
+                     "Calculated field using int and float.",
+            type: :error
+          )
+          expect(page).to have_css("[data-test-selector='project-custom-field-container-#{integer_project_custom_field.id}']")
+
+          within_project_custom_field_menu(float_project_custom_field) do
+            accept_confirm do
+              click_on("Delete")
+            end
+          end
+          page.within(find_flash_element(type: :error)) do
+            expect(page).to have_cf_admin_link(calculated_from_int_and_float_project_custom_field)
+          end
+          expect_and_dismiss_flash(
+            message: "Float field is used in project attribute calculation Calculated field using int and float.",
+            type: :error
+          )
+          expect(page).to have_css("[data-test-selector='project-custom-field-container-#{float_project_custom_field.id}']")
+
+          # Can delete calculated value field
+          within_project_custom_field_menu(calculated_from_int_and_float_project_custom_field) do
+            accept_confirm do
+              click_on("Delete")
+            end
+          end
+          expect(page).to have_no_css(
+            "[data-test-selector='project-custom-field-container-#{calculated_from_int_and_float_project_custom_field.id}']"
+          )
+
+          # Can delete used custom field afterwards
+          within_project_custom_field_menu(float_project_custom_field) do
+            accept_confirm do
+              click_on("Delete")
+            end
+          end
+          expect(page).to have_no_css("[data-test-selector='project-custom-field-container-#{float_project_custom_field.id}']")
+        end
+
+        def have_cf_admin_link(custom_field)
+          have_link(custom_field.name, href: admin_settings_project_custom_field_path(custom_field))
+        end
       end
 
       it "redirects to the custom field edit page via menu item" do

--- a/spec/features/admin/custom_fields/projects/project_mappings_spec.rb
+++ b/spec/features/admin/custom_fields/projects/project_mappings_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Project Custom Field Mappings", :js do
     create(:project_custom_field_project_mapping, project_custom_field:, project: archived_project)
   end
 
-  let(:project_custom_field_mappings_page) { Pages::Admin::CustomFields::CustomFieldsProjects::ProjectMappings.new }
+  let(:project_custom_field_mappings_page) { Pages::Admin::Settings::ProjectCustomFields::ProjectMappings.new }
 
   context "with insufficient permissions" do
     it "is not accessible" do

--- a/spec/features/admin/custom_fields/projects/shared_context.rb
+++ b/spec/features/admin/custom_fields/projects/shared_context.rb
@@ -29,6 +29,8 @@
 #++
 
 RSpec.shared_context "with seeded project custom fields" do
+  using CustomFieldFormulaReferencing
+
   shared_let(:admin) { create(:admin) }
   shared_let(:non_admin) { create(:user) }
 
@@ -64,6 +66,26 @@ RSpec.shared_context "with seeded project custom fields" do
   let!(:text_project_custom_field) do
     create(:text_project_custom_field,  name: "Text field",
                                         project_custom_field_section: section_for_input_fields)
+  end
+
+  let!(:calculated_from_int_project_custom_field) do
+    create(
+      :calculated_value_project_custom_field,
+      :skip_validations,
+      name: "Calculated field using int",
+      formula: "#{integer_project_custom_field} * 2",
+      project_custom_field_section: section_for_input_fields
+    )
+  end
+
+  let!(:calculated_from_int_and_float_project_custom_field) do
+    create(
+      :calculated_value_project_custom_field,
+      :skip_validations,
+      name: "Calculated field using int and float",
+      formula: "#{float_project_custom_field} * #{integer_project_custom_field}",
+      project_custom_field_section: section_for_input_fields
+    )
   end
 
   let!(:list_project_custom_field) do

--- a/spec/models/acts_as_customizable/calculated_value_spec.rb
+++ b/spec/models/acts_as_customizable/calculated_value_spec.rb
@@ -31,6 +31,8 @@
 require "spec_helper"
 
 RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_value_project_attribute: true } do
+  using CustomFieldFormulaReferencing
+
   let(:model_class) do
     Class.new do
       include ActsAsCustomizable::CalculatedValue
@@ -46,8 +48,6 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_valu
     allow(instance).to receive(:custom_field_values).with(all: true).and_return(custom_field_values)
     allow(instance).to receive(:custom_field_values=)
   end
-
-  def ref(custom_field) = "{{cf_#{custom_field.id}}}"
 
   describe "#calculate_custom_fields" do
     context "when calling with empty array" do
@@ -143,8 +143,8 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_valu
       let(:cf_a) { build_stubbed(:integer_project_custom_field) }
       let(:cf_b) { build_stubbed(:integer_project_custom_field) }
 
-      let(:cf1) { build_stubbed(:calculated_value_project_custom_field, formula: "#{ref cf_a} + #{ref cf_b}") }
-      let(:cf2) { build_stubbed(:calculated_value_project_custom_field, formula: "#{ref cf_a} * #{ref cf_b}") }
+      let(:cf1) { build_stubbed(:calculated_value_project_custom_field, formula: "#{cf_a} + #{cf_b}") }
+      let(:cf2) { build_stubbed(:calculated_value_project_custom_field, formula: "#{cf_a} * #{cf_b}") }
 
       let(:custom_field_values) do
         {
@@ -168,7 +168,7 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_valu
     context "when calling with custom fields referencing other calculated fields" do
       let(:cf1) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 1") }
       let(:cf2) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 2") }
-      let(:cf3) { build_stubbed(:calculated_value_project_custom_field, formula: "#{ref cf1} * #{ref cf2}") }
+      let(:cf3) { build_stubbed(:calculated_value_project_custom_field, formula: "#{cf1} * #{cf2}") }
 
       let(:custom_field_values) do
         {
@@ -206,8 +206,8 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_valu
       let(:cf_missing) { build_stubbed(:integer_project_custom_field) }
       let(:cf_unavailable) { build_stubbed(:integer_project_custom_field) }
 
-      let(:cf_using_missing) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + #{ref cf_missing}") }
-      let(:cf_using_unavailable) { build_stubbed(:calculated_value_project_custom_field, formula: "2 + #{ref cf_unavailable}") }
+      let(:cf_using_missing) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + #{cf_missing}") }
+      let(:cf_using_unavailable) { build_stubbed(:calculated_value_project_custom_field, formula: "2 + #{cf_unavailable}") }
       let(:cf_other) { build_stubbed(:calculated_value_project_custom_field, formula: "1 + 2") }
 
       let(:custom_field_values) do
@@ -252,10 +252,10 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_valu
 
       before do
         {
-          cf1 => "#{ref cf_a} * #{ref cf2}",
-          cf2 => "#{ref cf_b} * #{ref cf3}",
-          cf3 => "#{ref cf1} * #{ref cf4}",
-          cf4 => "#{ref cf_c} * #{ref cf_d}"
+          cf1 => "#{cf_a} * #{cf2}",
+          cf2 => "#{cf_b} * #{cf3}",
+          cf3 => "#{cf1} * #{cf4}",
+          cf4 => "#{cf_c} * #{cf_d}"
         }.each do |cf, formula|
           cf.formula = formula
         end

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -31,17 +31,17 @@
 require "spec_helper"
 
 RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_project_attribute: true } do
-  subject(:custom_field) { create(:calculated_value_project_custom_field, formula: "1 + 1") }
+  using CustomFieldFormulaReferencing
 
-  def ref(custom_field) = "{{cf_#{custom_field.id}}}"
+  subject(:custom_field) { create(:calculated_value_project_custom_field, formula: "1 + 1") }
 
   describe ".with_formula_referencing", :aggregate_failures do
     shared_let(:cf_a) { create(:integer_project_custom_field, default_value: 1) }
     shared_let(:cf_b) { create(:integer_project_custom_field, default_value: 2) }
     shared_let(:cf_c) { create(:integer_project_custom_field, default_value: 3) }
 
-    shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} + #{ref cf_b}") }
-    shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_b} + #{ref cf1}") }
+    shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_a} + #{cf_b}") }
+    shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_b} + #{cf1}") }
 
     let(:scope) { CustomField }
 
@@ -70,10 +70,10 @@ RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_proje
       shared_let(:cf_b) { create(:integer_project_custom_field, default_value: 2) }
       shared_let(:cf_c) { create(:integer_project_custom_field, default_value: 3) }
       shared_let(:cf_d) { create(:integer_project_custom_field, default_value: 4) }
-      shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} * 2") }
-      shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} + #{ref cf_b}") }
-      shared_let(:cf3) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_b} * 2") }
-      shared_let(:cf4) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_c} * 2") }
+      shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_a} * 2") }
+      shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_a} + #{cf_b}") }
+      shared_let(:cf3) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_b} * 2") }
+      shared_let(:cf4) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_c} * 2") }
 
       it "returns an empty array if argument is empty" do
         expect(scope.affected_calculated_fields([])).to eq([])
@@ -141,9 +141,9 @@ RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_proje
       shared_let(:cf_c) { create(:integer_project_custom_field, default_value: 3) }
       shared_let(:cf_d) { create(:integer_project_custom_field, default_value: 4) }
 
-      shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf_a} + #{ref cf_b}") }
-      shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf1} * #{ref cf_c}") }
-      shared_let(:cf3) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{ref cf2} * #{ref cf_d}") }
+      shared_let(:cf1) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf_a} + #{cf_b}") }
+      shared_let(:cf2) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf1} * #{cf_c}") }
+      shared_let(:cf3) { create(:calculated_value_project_custom_field, :skip_validations, formula: "#{cf2} * #{cf_d}") }
 
       it "returns referencing fields when passing referenced constant field ids" do
         expect(scope.affected_calculated_fields([cf_a.id])).to contain_exactly(cf1, cf2, cf3)
@@ -193,9 +193,9 @@ RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_proje
 
       before do
         {
-          cf1 => "#{ref cf_a} + #{ref cf2}",
-          cf2 => "#{ref cf_b} + #{ref cf3}",
-          cf3 => "#{ref cf_c} + #{ref cf1}"
+          cf1 => "#{cf_a} + #{cf2}",
+          cf2 => "#{cf_b} + #{cf3}",
+          cf3 => "#{cf_c} + #{cf1}"
         }.each do |cf, formula|
           cf.formula = formula
           cf.save!(validate: false)

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           end
         end
 
-        def ref(custom_field) = "{{cf_#{custom_field.id}}}"
+        using CustomFieldFormulaReferencing
 
         context "when trying to explicitly set values of calculated custom fields" do
           let!(:cf_static) { create(:integer_project_custom_field, projects: [project]) }
@@ -355,12 +355,12 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           let!(:cf_calculated1) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_static} * 7")
+                   formula: "#{cf_static} * 7")
           end
           let!(:cf_calculated2) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_calculated1} * 11")
+                   formula: "#{cf_calculated1} * 11")
           end
 
           let(:call_attributes) do
@@ -391,12 +391,12 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           let!(:cf_calculated1) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_static} * 7")
+                   formula: "#{cf_static} * 7")
           end
           let!(:cf_calculated2) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_calculated1} * 11")
+                   formula: "#{cf_calculated1} * 11")
           end
 
           let(:call_attributes) do
@@ -428,15 +428,15 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           let!(:cf_c) { create(:integer_project_custom_field, projects: [project]) }
           let!(:cf_calculated1) do
             create(:calculated_value_project_custom_field, :skip_validations,
-                   projects: [project], formula: "#{ref cf_a} * 7")
+                   projects: [project], formula: "#{cf_a} * 7")
           end
           let!(:cf_calculated2) do
             create(:calculated_value_project_custom_field, :skip_validations,
-                   projects: [project], formula: "#{ref cf_b} * 11")
+                   projects: [project], formula: "#{cf_b} * 11")
           end
           let!(:cf_calculated3) do
             create(:calculated_value_project_custom_field, :skip_validations,
-                   projects: [project], formula: "#{ref cf_c} * 13")
+                   projects: [project], formula: "#{cf_c} * 13")
           end
 
           let(:call_attributes) do
@@ -474,16 +474,16 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           let!(:cf_calculated1) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_static} * 7")
+                   formula: "#{cf_static} * 7")
           end
           let!(:cf_calculated2) do
             create(:calculated_value_project_custom_field, :skip_validations,
-                   formula: "#{ref cf_calculated1} * 11")
+                   formula: "#{cf_calculated1} * 11")
           end
           let!(:cf_calculated3) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_calculated2} * 13")
+                   formula: "#{cf_calculated2} * 13")
           end
 
           let(:call_attributes) do
@@ -522,17 +522,17 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           let!(:cf_calculated1) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_static} * 7")
+                   formula: "#{cf_static} * 7")
           end
           let!(:cf_calculated2) do
             create(:calculated_value_project_custom_field, :skip_validations, :admin_only,
                    projects: [project],
-                   formula: "#{ref cf_calculated1} * 11")
+                   formula: "#{cf_calculated1} * 11")
           end
           let!(:cf_calculated3) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_calculated2} * 13")
+                   formula: "#{cf_calculated2} * 13")
           end
 
           let(:call_attributes) do
@@ -565,7 +565,7 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           let!(:cf_calculated) do
             create(:calculated_value_project_custom_field, :skip_validations,
                    projects: [project],
-                   formula: "#{ref cf_static} * #{ref cf_referenced}")
+                   formula: "#{cf_static} * #{cf_referenced}")
           end
 
           let(:call_attributes) do
@@ -632,7 +632,7 @@ RSpec.describe Projects::SetAttributesService, type: :model do
             let!(:cf_referenced) do
               create(:calculated_value_project_custom_field, :skip_validations, :admin_only,
                      projects: [project],
-                     formula: "21 * #{ref cf_referenced1}")
+                     formula: "21 * #{cf_referenced1}")
             end
 
             before do

--- a/spec/support/custom_field_formula_referencing.rb
+++ b/spec/support/custom_field_formula_referencing.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Allows cleaner building of calculated value formulas in specs:
+#
+#     using CustomFieldFormulaReferencing
+#
+#     create(:calculated_value_project_custom_field, formula: "#{cf_1} * #{cf_2} + #{cf_3}")
+module CustomFieldFormulaReferencing
+  refine CustomField do
+    def to_s
+      "{{cf_#{id}}}"
+    end
+  end
+end

--- a/spec/support/pages/admin/settings/project_custom_fields/index.rb
+++ b/spec/support/pages/admin/settings/project_custom_fields/index.rb
@@ -32,8 +32,8 @@ require "support/pages/custom_fields/index_page"
 
 module Pages
   module Admin
-    module CustomFields
-      module CustomFieldsProjects
+    module Settings
+      module ProjectCustomFields
         class Index < ::Pages::CustomFields::IndexPage
           def path
             "/admin/settings/project_custom_fields"

--- a/spec/support/pages/admin/settings/project_custom_fields/project_mappings.rb
+++ b/spec/support/pages/admin/settings/project_custom_fields/project_mappings.rb
@@ -32,8 +32,8 @@ require "support/pages/custom_fields/project_mappings"
 
 module Pages
   module Admin
-    module CustomFields
-      module CustomFieldsProjects
+    module Settings
+      module ProjectCustomFields
         class ProjectMappings < ::Pages::CustomFields::ProjectMappings
           def path(project_custom_field)
             "/admin/settings/project_custom_fields/#{project_custom_field.id}/project_mappings"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64528

# What are you trying to accomplish?
~Recalculate custom fields when referenced field is deleted in administration~ Disallow deleting custom fields referenced in calculated value custom fields

## Note
Is usage of `CustomFieldFormulaReferencing` clear or not?

## Screenshots
<img width="830" height="296" alt="image" src="https://github.com/user-attachments/assets/8fa5da74-bce6-4b54-8e1c-ce0cc545d3e0" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
