### PR TITLE
Use different contract to end meeting series

### DIFF
--- a/modules/meeting/app/contracts/recurring_meetings/end_series_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/end_series_contract.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module RecurringMeetings
+  class EndSeriesContract < BaseContract
+    include Redmine::I18n
+
+    validate :user_allowed_to_edit
+    validate :meeting_ended
+
+    def user_allowed_to_edit
+      unless user.allowed_in_project?(:edit_meetings, model.project)
+        errors.add :base, :error_unauthorized
+      end
+    end
+
+    def meeting_ended
+      return if model.end_date == Time.zone.today
+
+      errors.add :end_date, :invalid
+    end
+  end
+end

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -137,7 +137,7 @@ class RecurringMeetingsController < ApplicationController
 
   def end_series
     call = ::RecurringMeetings::UpdateService
-      .new(model: @recurring_meeting, user: current_user)
+      .new(model: @recurring_meeting, user: current_user, contract_class: RecurringMeetings::EndSeriesContract)
       .call(end_after: "specific_date", end_date: Time.zone.today)
 
     if call.success?

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_end_series_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_end_series_spec.rb
@@ -162,6 +162,33 @@ RSpec.describe "Recurring meetings complete template",
     end
   end
 
+  context "when there is a scheduled instance for today and tomorrow" do
+    let!(:today) do
+      create :scheduled_meeting,
+             :persisted,
+             recurring_meeting:,
+             start_time: DateTime.parse("2024-12-05T10:00:00Z")
+    end
+    let!(:tomorrow) do
+      create :scheduled_meeting,
+             :persisted,
+             recurring_meeting:,
+             start_time: DateTime.parse("2024-12-06T10:00:00Z")
+    end
+
+    subject do
+      Timecop.freeze("2024-12-05T09:59:00Z".to_datetime) { request }
+    end
+
+    it "does delete this occurrence" do
+      expect { subject }.to change(recurring_meeting.scheduled_meetings, :count).by(-2)
+      expect(response).to be_redirect
+
+      recurring_meeting.reload
+      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-05")
+    end
+  end
+
   context "when next occurrence is present" do
     let!(:schedule) do
       create :scheduled_meeting,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66483

# What are you trying to accomplish?
In the regular update service, we try to provide cover for all open occurrences and complain if they are not handled. Instead, provide a separate end meeting series contract, that ensures we validate the relevant information only
