### PR TITLE
Fix flaky `date_editor_spec.rb` spec

### DIFF
--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe "Backlogs in backlog view", :js,
     check "Show versions folded"
 
     click_button "Update backlogs module"
+    expect_and_dismiss_flash(message: "Account was successfully updated.")
 
     backlogs_page.visit!
 

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -129,6 +129,13 @@ module Pages
 
     def ensure_page_loaded
       expect_angular_frontend_initialized
+
+      # wait for work packages page to be visible and have content in it
+      has_selector?(".work-packages-page--ui-view div")
+      # wait for content loader to disappear (in the activity tab)
+      has_no_selector?("content-loader", wait: 10)
+
+      nil
     end
 
     def disable_ajax_requests


### PR DESCRIPTION
failing spec: `spec/features/work_packages/details/date_editor_spec.rb:481`
failing job: https://github.com/opf/openproject/actions/runs/17148953008/job/48650666950?pr=20026

The spec does not wait long enough for the page to load. It tries to activate the combinedDate field, and this one has internal checks about its state to ensure it has really been clicked. So it's clicked, but the loading takes some time, so it tries again. But when it tries again, the display field has already been masked, so it can't be clicked a second time, and the spec fails. (See `#activate!` in `spec/support/edit_fields/edit_field.rb` for more details.)

When it's fast enough, the test passes, hence the flickering.

To fix it, we wait for the page to be fully loaded before clicking the date field. This way the activation of the field and the loading of the date picker is hopefully done faster.

To wait for loading, we wait for an element inside the main work package page component, and wait for the loader placeholders to go away in the activity tab.
