### PR TITLE
Bug/65740 error when exporting wp table grouped by project phase

### DIFF
--- a/app/models/project/phase.rb
+++ b/app/models/project/phase.rb
@@ -111,4 +111,6 @@ class Project::Phase < ApplicationRecord
   def following_phases
     @following_phases ||= project.available_phases.select { it.position > position }
   end
+
+  def to_s; name end
 end

--- a/app/models/queries/project_phase_definitions/database_queries.rb
+++ b/app/models/queries/project_phase_definitions/database_queries.rb
@@ -46,13 +46,15 @@ module Queries::ProjectPhaseDefinitions
         LEFT OUTER JOIN (
           SELECT
             ph.id,
+            ppd.position,
             ph.project_id,
-            ph.definition_id AS active_phase_definition_id
+            ph.definition_id AS project_phase_definition_id
           FROM project_phases ph
+          LEFT OUTER JOIN project_phase_definitions ppd ON ppd.id = ph.definition_id
           WHERE ph.project_id IN (#{projects_with_view_phases_permissions.to_sql})
           AND ph.active = true
         ) AS active_phases
-        ON active_phases.active_phase_definition_id = work_packages.project_phase_definition_id
+        ON active_phases.project_phase_definition_id = work_packages.project_phase_definition_id
           AND active_phases.project_id = work_packages.project_id
       SQL
     end

--- a/app/models/queries/work_packages/filter/project_phase_filter.rb
+++ b/app/models/queries/work_packages/filter/project_phase_filter.rb
@@ -62,7 +62,7 @@ class Queries::WorkPackages::Filter::ProjectPhaseFilter < Queries::WorkPackages:
   end
 
   def where
-    operator_strategy.sql_for_field(values, :active_phases, :active_phase_definition_id)
+    operator_strategy.sql_for_field(values, :active_phases, :project_phase_definition_id)
   end
 
   private

--- a/app/models/queries/work_packages/selects/project_phase_select.rb
+++ b/app/models/queries/work_packages/selects/project_phase_select.rb
@@ -33,7 +33,6 @@ class Queries::WorkPackages::Selects::ProjectPhaseSelect < Queries::WorkPackages
 
   def initialize
     super(:project_phase,
-          association: :project_phase_definition,
           group_by_column_name: :project_phase_definition,
           sortable: sortable_statement,
           groupable: group_by_statement,
@@ -43,11 +42,11 @@ class Queries::WorkPackages::Selects::ProjectPhaseSelect < Queries::WorkPackages
   end
 
   def groupable_select
-    "#{group_by_statement} as project_phase_definition_id"
+    group_by_statement
   end
 
   def group_by_statement
-    active_phase_null_case(true_case: "NULL", false_case: "project_phase_definitions.id")
+    "active_phases.project_phase_definition_id"
   end
 
   def order_for_count
@@ -67,7 +66,7 @@ class Queries::WorkPackages::Selects::ProjectPhaseSelect < Queries::WorkPackages
     # We use the join alias from the group by join statement to ensure that work packages with an *inactive* project
     # phase are treated like work packages *without* a project phase. In the result list, they will belong to the
     # same group: without an active project phase.
-    active_phase_null_case(true_case: "-1", false_case: "project_phase_definitions.position")
+    active_phase_null_case(true_case: "-1", false_case: "active_phases.position")
   end
 
   def self.instances(context = nil)

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe "work package export", :js, :selenium do
   end
 
   before do
+    login_as(current_user)
+
     service_instance = instance_double(WorkPackages::Exports::ScheduleService)
     allow(WorkPackages::Exports::ScheduleService)
       .to receive(:new)
@@ -92,8 +94,6 @@ RSpec.describe "work package export", :js, :selenium do
 
     query.column_names = query_columns
     query.save!
-
-    login_as(current_user)
   end
 
   RSpec::Matchers.define :has_mandatory_params do |expected|
@@ -422,6 +422,37 @@ RSpec.describe "work package export", :js, :selenium do
         expect(page).to have_text(I18n.t("export.dialog.columns.input_caption_required"))
         click_on I18n.t("export.dialog.submit")
         expect(page).to have_button(I18n.t("export.dialog.submit")) # form not submitted, button is still there
+      end
+
+      context "when exporting grouped by project phase column (regression #65740)" do
+        let!(:project_phase_with_gates) do
+          create(:project_phase,
+                 :with_gated_definition,
+                 project: project,
+                 start_date: Date.new(2024, 12, 1),
+                 finish_date: Date.new(2024, 12, 13))
+        end
+        let!(:project_phase) do
+          create(:project_phase,
+                 project:,
+                 start_date: Date.new(2024, 12, 1),
+                 finish_date: Date.new(2024, 12, 13))
+        end
+
+        let(:query) { create(:query, user: current_user, project:, group_by: "project_phase", name: "My custom query title") }
+        let(:export_type) { I18n.t("export.dialog.format.options.pdf.label") }
+        let(:export_sub_type) { I18n.t("export.dialog.pdf.export_type.options.table.label") }
+        let(:expected_params) { default_expected_params.merge({ pdf_export_type: "table", groupBy: "project_phase" }) }
+        let(:expected_columns) { %w[ID Subject Type Status Assignee Priority ProjectPhase] }
+
+        before do
+          wp1.update!(project_phase_definition_id: project_phase_with_gates.definition_id)
+          wp2.update!(project_phase_definition_id: project_phase.definition_id)
+        end
+
+        it "exports a pdf table" do
+          export!
+        end
       end
     end
 

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_spec.rb
@@ -33,6 +33,7 @@ require "spec_helper"
 RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
   include Redmine::I18n
   include PDFExportSpecUtils
+
   shared_let(:type_standard) { create(:type_standard) }
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:list_custom_field) do
@@ -217,6 +218,43 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
           *work_package_columns(work_package_child),
           "1/1", export_date_formatted, query.name
         ].join(" ")
+      end
+
+      context "when grouped by project phase column (regression #65740)" do
+        let(:user) { create(:admin) }
+        let!(:project_phase_with_gates) do
+          create(:project_phase, :with_gated_definition, project:)
+        end
+        let!(:project_phase) do
+          create(:project_phase, project:)
+        end
+        let(:query_attributes) { { group_by: "project_phase" } }
+        let(:column_names) { %w[id subject project_phase] }
+
+        before do
+          work_package_parent.update!(project_phase_definition_id: project_phase_with_gates.definition.id)
+          work_package_child.update!(project_phase_definition_id: project_phase.definition.id)
+        end
+
+        it "contains correct data" do
+          expected_pdf_strings = [
+            query.name,
+
+            project_phase_with_gates.name,
+            *column_titles - ["Project phase"],
+            work_package_parent.id.to_s,
+            work_package_parent.subject,
+
+            project_phase.name,
+            *column_titles - ["Project phase"],
+            work_package_child.id.to_s,
+            work_package_child.subject,
+
+            "1/1", export_date_formatted, query.name
+          ]
+
+          expect(pdf_strings).to eq(expected_pdf_strings.join(" "))
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65740

# What are you trying to accomplish?
The PDF export breaks since the query generated by our `project_phase_select` uses an alias for a sub select. The export and other modules such as costs generate a query that surrounds the original query. The surrounding query expects a certain structure and does not work with generated aliases.

Solution: simplify the generated SQL statement to not use aliases where possible.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
