### PR TITLE
Add a name filter to versions

### DIFF
--- a/app/models/queries/versions/filters/name_filter.rb
+++ b/app/models/queries/versions/filters/name_filter.rb
@@ -28,11 +28,40 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Versions
-  ::Queries::Register.register(VersionQuery) do
-    filter Filters::SharingFilter
-    filter Filters::NameFilter
+class Queries::Versions::Filters::NameFilter < Queries::Versions::Filters::VersionFilter
+  def type
+    :string
+  end
 
-    order Orders::DefaultOrder
+  def where
+    case operator
+    when "="
+      ["LOWER(versions.name) IN (?)", sql_value]
+    when "!"
+      ["LOWER(versions.name) NOT IN (?)", sql_value]
+    when "~", "**"
+      ["LOWER(versions.name) LIKE ?", "%#{sql_value}%"]
+    when "!~"
+      ["LOWER(versions.name) NOT LIKE ?", "%#{sql_value}%"]
+    end
+  end
+
+  def human_name
+    I18n.t(:label_name)
+  end
+
+  def self.key
+    :name
+  end
+
+  private
+
+  def sql_value
+    case operator
+    when "=", "!"
+      values.map { |val| self.class.connection.quote_string(val.downcase) }.join(",")
+    when "**", "~", "!~"
+      values.first.downcase
+    end
   end
 end

--- a/docs/api/apiv3/paths/versions.yml
+++ b/docs/api/apiv3/paths/versions.yml
@@ -8,6 +8,7 @@ get:
         Currently supported filters are:
 
         + sharing: filters versions by how they are shared within the server (*none*, *descendants*, *hierarchy*, *tree*, *system*).
+        + name: filters versions by their name.
       example: '[{ "sharing": { "operator": "*", "values": ["system"] }" }]'
       in: query
       name: filters

--- a/spec/models/queries/versions/filters/name_filter_spec.rb
+++ b/spec/models/queries/versions/filters/name_filter_spec.rb
@@ -28,11 +28,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Versions
-  ::Queries::Register.register(VersionQuery) do
-    filter Filters::SharingFilter
-    filter Filters::NameFilter
+require "spec_helper"
 
-    order Orders::DefaultOrder
+RSpec.describe Queries::Versions::Filters::NameFilter do
+  include_context "filter tests"
+  let(:values) { ["A name"] }
+  let(:model) { Version }
+
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :name }
+    let(:human_name) { "Name" }
+    let(:type) { :string }
+    let(:model) { Version }
+
+    describe "#allowed_values" do
+      it "is nil" do
+        expect(instance.allowed_values).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
So far, we did not have a name filter on versions. That prevents us from easily finding the version we're trying to release in the release helpers