### PR TITLE
[66504] WP number is visually truncated on time log entries table

### DIFF
--- a/app/components/work_packages/info_line_component.html.erb
+++ b/app/components/work_packages/info_line_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  flex_layout do |flex|
+  flex_layout(flex_wrap: :wrap) do |flex|
     flex.with_column(mr: 2) do
       render(WorkPackages::HighlightedTypeComponent.new(work_package: @work_package, font_size: :small))
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66504

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Make the container of info line component flex-wrap

## Screenshots
Before:

<img width="652" height="266" alt="Screenshot 2025-08-25 at 16 26 12" src="https://github.com/user-attachments/assets/efb475c3-badc-4501-bb06-3d715e2d5216" />

After:
<img width="654" height="263" alt="Screenshot 2025-08-25 at 16 25 39" src="https://github.com/user-attachments/assets/fae1a394-4699-49ff-9e4f-29ad4044d13d" />
