### PR TITLE
Better output when linking frontend modules

### DIFF
--- a/frontend/ci-plugins-generator.js
+++ b/frontend/ci-plugins-generator.js
@@ -1,27 +1,27 @@
 const path = require('node:path');
 const fs = require('node:fs');
-const _ = require("lodash");
+const _ = require('lodash');
 
 const LINKED_PLUGINS_MODULE_TEMPLATE = (plugins) => {
   const importableName = (name) => _.upperFirst(_.camelCase(name));
-  const frontendPlugins = plugins.map(([name, _]) => [name, importableName(name)]);
+  const frontendPlugins = plugins.map(([name]) => [name, importableName(name)]);
 
   return `
 import {NgModule} from "@angular/core";
 ${
   frontendPlugins
-    .map(([actualName, moduleName]) => 
+    .map(([actualName, moduleName]) =>
       `import {PluginModule as ${moduleName}} from './linked/${actualName}/main';`
     )
-    .join("\n")
+    .join('\n')
 }
 
 @NgModule({
     imports: [
         ${
           frontendPlugins
-            .map(([_, moduleName]) => moduleName)
-            .join(`,\n${" ".repeat(8)}`)
+            .map(([, moduleName]) => moduleName)
+            .join(`,\n${' '.repeat(8)}`)
         }
     ],
 })
@@ -29,18 +29,18 @@ export class LinkedPluginsModule { }
   `;
 };
 
-const railsRout = path.join(__dirname, "..");
+const railsRout = path.join(__dirname, '..');
 const pluginDir = path.join(railsRout, 'modules');
 const targetDir = path.join(railsRout, 'frontend/src/app/features/plugins/linked');
 
 const plugins = new Map([
-  ["budgets", path.join(pluginDir, "budgets")],
-  ["costs", path.join(pluginDir, "costs")],
-  ["openproject-avatars", path.join(pluginDir, "avatars")],
-  ["openproject-documents", path.join(pluginDir, "documents")],
-  ["openproject-github_integration", path.join(pluginDir, "github_integration")],
-  ["openproject-gitlab_integration", path.join(pluginDir, "gitlab_integration")],
-  ["openproject-meeting", path.join(pluginDir, "meeting")]
+  ['budgets', path.join(pluginDir, 'budgets')],
+  ['costs', path.join(pluginDir, 'costs')],
+  ['openproject-avatars', path.join(pluginDir, 'avatars')],
+  ['openproject-documents', path.join(pluginDir, 'documents')],
+  ['openproject-github_integration', path.join(pluginDir, 'github_integration')],
+  ['openproject-gitlab_integration', path.join(pluginDir, 'gitlab_integration')],
+  ['openproject-meeting', path.join(pluginDir, 'meeting')]
 ]);
 
 console.log(`Cleaning linked target directory ${targetDir}`);
@@ -48,20 +48,20 @@ fs.rmSync(targetDir, { recursive: true, force: true });
 fs.mkdirSync(targetDir);
 
 plugins.forEach((pluginPath, name) => {
-  const linkTarget = path.join(pluginPath, "frontend", "module");
+  const linkTarget = path.join(pluginPath, 'frontend', 'module');
   const linkPath = path.join(targetDir, name);
 
-  console.log(`Linking frontend of OpenProject plugin ${name} to ${linkPath}.`)
+  console.log(`Linking frontend of OpenProject plugin ${name} to ${linkPath}.`);
   fs.symlinkSync(linkTarget, linkPath);
 });
 
-const allFrontendPlugins = Array.from(plugins).filter(([_, pluginPath]) => {
-  const frontendEntry = path.join(pluginPath, "frontend", "module", "main.ts");
+const allFrontendPlugins = Array.from(plugins).filter(([, pluginPath]) => {
+  const frontendEntry = path.join(pluginPath, 'frontend', 'module', 'main.ts');
   return fs.existsSync(frontendEntry);
 });
 
 function generatePluginModule(plugins) {
-  const fileRegister = path.join(railsRout, "frontend/src/app/features/plugins/linked-plugins.module.ts");
+  const fileRegister = path.join(railsRout, 'frontend/src/app/features/plugins/linked-plugins.module.ts');
   console.log(`Regenerating frontend plugin registry ${fileRegister}.`);
 
   const result = LINKED_PLUGINS_MODULE_TEMPLATE(plugins);

--- a/frontend/ci-plugins-generator.js
+++ b/frontend/ci-plugins-generator.js
@@ -29,9 +29,9 @@ export class LinkedPluginsModule { }
   `;
 };
 
-const railsRout = path.join(__dirname, '..');
-const pluginDir = path.join(railsRout, 'modules');
-const targetDir = path.join(railsRout, 'frontend/src/app/features/plugins/linked');
+const railsRoot = path.join(__dirname, '..');
+const pluginDir = path.join(railsRoot, 'modules');
+const targetDir = path.join(railsRoot, 'frontend/src/app/features/plugins/linked');
 
 const plugins = new Map([
   ['budgets', path.join(pluginDir, 'budgets')],
@@ -51,7 +51,7 @@ plugins.forEach((pluginPath, name) => {
   const linkTarget = path.join(pluginPath, 'frontend', 'module');
   const linkPath = path.join(targetDir, name);
 
-  console.log(`Linking frontend of OpenProject plugin ${name} to ${linkPath}.`);
+  console.log(`Linking frontend of OpenProject plugin ${name} (${linkPath} -> ${linkTarget}).`);
   fs.symlinkSync(linkTarget, linkPath);
 });
 
@@ -61,7 +61,7 @@ const allFrontendPlugins = Array.from(plugins).filter(([, pluginPath]) => {
 });
 
 function generatePluginModule(plugins) {
-  const fileRegister = path.join(railsRout, 'frontend/src/app/features/plugins/linked-plugins.module.ts');
+  const fileRegister = path.join(railsRoot, 'frontend/src/app/features/plugins/linked-plugins.module.ts');
   console.log(`Regenerating frontend plugin registry ${fileRegister}.`);
 
   const result = LINKED_PLUGINS_MODULE_TEMPLATE(plugins);

--- a/lib/open_project/plugins/frontend_linking/generator.rb
+++ b/lib/open_project/plugins/frontend_linking/generator.rb
@@ -105,7 +105,7 @@ module ::OpenProject::Plugins
           source = File.join(path, "frontend", "module")
           target = File.join(target_dir, name)
 
-          puts "Linking frontend of OpenProject plugin #{name} to #{target}."
+          puts "Linking frontend of OpenProject plugin #{name} (#{target} -> #{source})."
           FileUtils.ln_sf(source, target)
         end
       end

--- a/lib/open_project/plugins/frontend_linking/generator.rb
+++ b/lib/open_project/plugins/frontend_linking/generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,6 +31,7 @@
 require "bundler"
 require "fileutils"
 
+# rubocop:disable Rails/Output
 module ::OpenProject::Plugins
   module FrontendLinking
     class Generator
@@ -58,25 +61,14 @@ module ::OpenProject::Plugins
       # Register plugins with an Angular frontend to the CLI build.
       # For that, search all gems with the group :opf_plugins
       def regenerate_angular_links
-        all_frontend_plugins.tap do |plugins|
-          target_dir = Rails.root.join("frontend/src/app/features/plugins/linked")
-          puts "Cleaning linked target directory #{target_dir}"
+        remove_all_frontend_plugins_links
+        create_frontend_plugins_links(all_frontend_plugins)
+        generate_plugin_module(all_angular_frontend_plugins)
+        generate_plugin_sass(all_plugins_with_global_styles)
+      end
 
-          # Removing the current linked directory and recreate
-          FileUtils.remove_dir(target_dir, force: true)
-          FileUtils.mkdir_p(target_dir)
-
-          plugins.each do |name, path|
-            source = File.join(path, "frontend", "module")
-            target = File.join(target_dir, name)
-
-            puts "Linking frontend of OpenProject plugin #{name} to #{target}."
-            FileUtils.ln_sf(source, target)
-          end
-
-          generate_plugin_module(all_angular_frontend_plugins)
-          generate_plugin_sass(all_plugins_with_global_styles)
-        end
+      def target_dir
+        Rails.root.join("frontend/src/app/features/plugins/linked")
       end
 
       def all_frontend_plugins
@@ -96,7 +88,25 @@ module ::OpenProject::Plugins
       def all_plugins_with_global_styles
         openproject_plugins.select do |_, path|
           style_file = File.join(path, "frontend", "module", "global_styles.*")
-          !Dir.glob(style_file).empty?
+          Dir.glob(style_file).any?
+        end
+      end
+
+      def remove_all_frontend_plugins_links
+        puts "Cleaning linked target directory #{target_dir}"
+
+        # Removing the current linked directory and recreate
+        FileUtils.remove_dir(target_dir, force: true)
+        FileUtils.mkdir_p(target_dir)
+      end
+
+      def create_frontend_plugins_links(plugins)
+        plugins.each do |name, path|
+          source = File.join(path, "frontend", "module")
+          target = File.join(target_dir, name)
+
+          puts "Linking frontend of OpenProject plugin #{name} to #{target}."
+          FileUtils.ln_sf(source, target)
         end
       end
 
@@ -137,10 +147,11 @@ module ::OpenProject::Plugins
 
         gems.dependencies
           .each_with_object({}) do |dep, l|
-          l[dep.name] = dep if (bundler_groups & dep.groups).any?
+          l[dep.name] = dep if bundler_groups.intersect?(dep.groups)
         end
           .compact
       end
     end
   end
 end
+# rubocop:enable Rails/Output

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_proje
 
       current_user { user }
 
-      it_behaves_like "invalid formula", "contains custom fields that are not allowed: int, float."
+      it_behaves_like "invalid formula", /contains custom fields that are not allowed: (int, float|float, int)./
     end
   end
 end


### PR DESCRIPTION
# Ticket

No ticket

# What are you trying to accomplish?

Have a more precise output of linked files when the plugin frontend modules are linked: both source and destination of the link.

## Screenshots

Before
```
Cleaning linked target directory /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked
Linking frontend of OpenProject plugin budgets to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/budgets.
Linking frontend of OpenProject plugin costs to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/costs.
Linking frontend of OpenProject plugin openproject-avatars to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-avatars.
Linking frontend of OpenProject plugin openproject-documents to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-documents.
Linking frontend of OpenProject plugin openproject-github_integration to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-github_integration.
Linking frontend of OpenProject plugin openproject-gitlab_integration to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-gitlab_integration.
Linking frontend of OpenProject plugin openproject-meeting to /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-meeting.
Regenerating frontend plugin registry /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked-plugins.module.ts.
Regenerating frontend plugin sass /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked-plugins.styles.sass.
```

After
```
Cleaning linked target directory /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked
Linking frontend of OpenProject plugin budgets (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/budgets -> /Users/cbliard/code/opf/openproject/dev/modules/budgets/frontend/module).
Linking frontend of OpenProject plugin costs (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/costs -> /Users/cbliard/code/opf/openproject/dev/modules/costs/frontend/module).
Linking frontend of OpenProject plugin openproject-avatars (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-avatars -> /Users/cbliard/code/opf/openproject/dev/modules/avatars/frontend/module).
Linking frontend of OpenProject plugin openproject-documents (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-documents -> /Users/cbliard/code/opf/openproject/dev/modules/documents/frontend/module).
Linking frontend of OpenProject plugin openproject-github_integration (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-github_integration -> /Users/cbliard/code/opf/openproject/dev/modules/github_integration/frontend/module).
Linking frontend of OpenProject plugin openproject-gitlab_integration (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-gitlab_integration -> /Users/cbliard/code/opf/openproject/dev/modules/gitlab_integration/frontend/module).
Linking frontend of OpenProject plugin openproject-meeting (/Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked/openproject-meeting -> /Users/cbliard/code/opf/openproject/dev/modules/meeting/frontend/module).
Regenerating frontend plugin registry /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked-plugins.module.ts.
Regenerating frontend plugin sass /Users/cbliard/code/opf/openproject/dev/frontend/src/app/features/plugins/linked-plugins.styles.sass.
```

# What approach did you choose and why?

Fix linting errors first, then implement the new behavior.
Also fixed a typo.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
