### PR TITLE
Bug/66925 activity shows changes to admin only custom fields also to non admin users

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -32,6 +32,7 @@ class JournalsController < ApplicationController
   before_action :load_and_authorize_in_optional_project, only: [:index]
   before_action :find_journal,
                 :ensure_permitted,
+                :ensure_valid_for_diffing,
                 only: [:diff]
   authorization_checked! :diff
 
@@ -62,8 +63,6 @@ class JournalsController < ApplicationController
   end
 
   def diff
-    return render_404 unless valid_field_for_diffing?
-
     unless @journal.details[field_param] in [from, to]
       return render_400 message: I18n.t(:error_journal_attribute_not_present, attribute: field_param)
     end
@@ -103,14 +102,22 @@ class JournalsController < ApplicationController
     @field_param ||= params[:field].parameterize.underscore
   end
 
-  def valid_field_for_diffing?
+  def ensure_valid_for_diffing
     case field_param
     when "description",
          "status_explanation",
          /\Aagenda_items_\d+_notes\z/
-      true
+      # no additional checks
     when /\Acustom_fields_(?<id>\d+)\z/
-      ::CustomField.exists?(id: Regexp.last_match[:id], field_format: "text")
+      cf = CustomField.select(:field_format, :admin_only).find_by(id: Regexp.last_match[:id])
+
+      if cf.admin_only && !User.current.admin?
+        render_403
+      elsif cf.field_format != "text"
+        render_404
+      end
+    else
+      render_404
     end
   end
 

--- a/lib/open_project/journal_formatter/custom_field.rb
+++ b/lib/open_project/journal_formatter/custom_field.rb
@@ -35,6 +35,8 @@ class OpenProject::JournalFormatter::CustomField
   end
 
   def render(key, values, options = { html: true })
+    return if custom_field_for_key(key)&.admin_only && !User.current.admin?
+
     formatter_for_key(key).render(key, values, options)
   end
 

--- a/spec/controllers/journals_controller_spec.rb
+++ b/spec/controllers/journals_controller_spec.rb
@@ -76,80 +76,126 @@ RSpec.describe JournalsController do
       end
 
       describe "with a user not having the :view_work_package permission" do
-        before do
-          RolePermission.delete_all
-        end
+        let(:user) { build_stubbed(:user) }
 
         it { expect(response).to have_http_status(:forbidden) }
       end
     end
 
-    context "for work package text custom field" do
+    context "for work package custom field" do
       shared_let(:type) { project.types.first }
-
-      shared_let(:custom_field) do
-        create(:text_wp_custom_field).tap do |custom_field|
-          project.work_package_custom_fields << custom_field
-          type.custom_fields << custom_field
-        end
-      end
-
       shared_let(:work_package) do
         create(:work_package, type:,
                               author: user,
                               project:)
       end
+
+      let!(:custom_field) do
+        create(factory_name).tap do |custom_field|
+          project.work_package_custom_fields << custom_field
+          type.custom_fields << custom_field
+        end
+      end
+
       let(:params) { { id: work_package.last_journal.id.to_s, field: "custom_fields_#{custom_field.id}", format: "js" } }
 
       before do
         work_package.update custom_field_values: { custom_field.id => "foo" }
       end
 
-      describe "with a user having :view_work_package permission" do
-        it { expect(response).to have_http_status(:ok) }
+      context "with format text" do
+        let(:factory_name) { :text_wp_custom_field }
 
-        it "presents the diff correctly" do
-          expect(response.body.strip).to be_html_eql <<-HTML
-            <div class="text-diff">
-              <label class="sr-only">Begin of the insertion</label>
-              <ins class="diffmod">foo</ins>
-              <label class="sr-only">End of the insertion</label>
-            </div>
-          HTML
+        describe "with a user having :view_work_package permission" do
+          it { expect(response).to have_http_status(:ok) }
+
+          it "presents the diff correctly" do
+            expect(response.body.strip).to be_html_eql <<-HTML
+              <div class="text-diff">
+                <label class="sr-only">Begin of the insertion</label>
+                <ins class="diffmod">foo</ins>
+                <label class="sr-only">End of the insertion</label>
+              </div>
+            HTML
+          end
+        end
+
+        describe "with a user not having the :view_work_package permission" do
+          let(:user) { build_stubbed(:user) }
+
+          it { expect(response).to have_http_status(:forbidden) }
         end
       end
 
-      describe "with a user not having the :view_work_package permission" do
-        before do
-          RolePermission.delete_all
-        end
+      context "with format string" do
+        let(:factory_name) { :wp_custom_field }
 
-        it { expect(response).to have_http_status(:forbidden) }
+        it { expect(response).to have_http_status(:not_found) }
       end
     end
 
-    context "for work package string custom field" do
-      shared_let(:type) { project.types.first }
+    context "for project custom field" do
+      let(:params) { { id: project.last_journal.id.to_s, field: "custom_fields_#{custom_field.id}", format: "js" } }
 
-      shared_let(:custom_field) do
-        create(:wp_custom_field).tap do |custom_field|
-          project.work_package_custom_fields << custom_field
-          type.custom_fields << custom_field
+      before do
+        project.update custom_field_values: { custom_field.id => "foo" }
+      end
+
+      context "with format text" do
+        context "when visible to everyone" do
+          let!(:custom_field) { create(:text_project_custom_field, projects: [project]) }
+
+          describe "with a user being project member" do
+            it { expect(response).to have_http_status(:ok) }
+
+            it "presents the diff correctly" do
+              expect(response.body.strip).to be_html_eql <<-HTML
+                <div class="text-diff">
+                  <label class="sr-only">Begin of the insertion</label>
+                  <ins class="diffmod">foo</ins>
+                  <label class="sr-only">End of the insertion</label>
+                </div>
+              HTML
+            end
+          end
+
+          describe "with a user not being project member" do
+            let(:user) { build_stubbed(:user) }
+
+            it { expect(response).to have_http_status(:forbidden) }
+          end
+        end
+
+        context "when admin only" do
+          let!(:custom_field) { create(:text_project_custom_field, :admin_only, projects: [project]) }
+
+          describe "with a non admin user being a project member" do
+            it { expect(response).to have_http_status(:forbidden) }
+          end
+
+          describe "with an admin user" do
+            let(:user) { build_stubbed(:admin) }
+
+            it { expect(response).to have_http_status(:ok) }
+
+            it "presents the diff correctly" do
+              expect(response.body.strip).to be_html_eql <<-HTML
+                <div class="text-diff">
+                  <label class="sr-only">Begin of the insertion</label>
+                  <ins class="diffmod">foo</ins>
+                  <label class="sr-only">End of the insertion</label>
+                </div>
+              HTML
+            end
+          end
         end
       end
 
-      shared_let(:work_package) do
-        create(:work_package, type:,
-                              author: user,
-                              project:)
-      end
-      let(:params) { { id: work_package.last_journal.id.to_s, field: "custom_fields_#{custom_field.id}", format: "js" } }
+      context "with format string" do
+        let!(:custom_field) { create(:string_project_custom_field, projects: [project]) }
 
-      before do
-        work_package.update custom_field_values: { custom_field.id => "foo" }
+        it { expect(response).to have_http_status(:not_found) }
       end
-
-      it { expect(response).to have_http_status(:not_found) }
     end
 
     context "for project description" do
@@ -174,9 +220,7 @@ RSpec.describe JournalsController do
       end
 
       describe "with a user not being member of the project" do
-        before do
-          Member.delete_all
-        end
+        let(:user) { build_stubbed(:user) }
 
         it { expect(response).to have_http_status(:forbidden) }
       end
@@ -204,6 +248,7 @@ RSpec.describe JournalsController do
                               author: user,
                               project:)
       end
+
       let(:params) { { id: work_package.last_journal.id.to_s, field: :another_field, format: "js" } }
 
       it { expect(response).to have_http_status(:not_found) }
@@ -220,9 +265,7 @@ RSpec.describe JournalsController do
       end
 
       describe "even with a user having all permissions" do
-        before do
-          user.update(admin: true)
-        end
+        let(:user) { build_stubbed(:admin) }
 
         it { expect(response).to have_http_status(:forbidden) }
       end

--- a/spec/lib/open_project/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/open_project/journal_formatter/custom_field_spec.rb
@@ -33,11 +33,10 @@ require "spec_helper"
 RSpec.describe OpenProject::JournalFormatter::CustomField do
   include CustomFieldsHelper
   include ActionView::Helpers::TagHelper
-  # WARNING: the order of the modules is important to ensure that url_for of
+  # WARNING: the order of inclusion is important to ensure that url_for of
   # ActionController::UrlWriter is called and not the one of ActionView::Helpers::UrlHelper
+  include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
-
-  def url_helper = Rails.application.routes.url_helpers
 
   let(:instance) { described_class.new(journal) }
   let(:id) { 1 }
@@ -335,14 +334,14 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
     let(:custom_field) { build_stubbed(:text_wp_custom_field) }
 
     let(:path) do
-      url_helper.diff_journal_path(id: journal.id,
-                                   field: key.downcase)
+      diff_journal_path(id: journal.id,
+                        field: key.downcase)
     end
     let(:url) do
-      url_helper.diff_journal_url(id: journal.id,
-                                  field: key.downcase,
-                                  protocol: Setting.protocol,
-                                  host: Setting.host_name)
+      diff_journal_url(id: journal.id,
+                       field: key.downcase,
+                       protocol: Setting.protocol,
+                       host: Setting.host_name)
     end
     let(:link) { link_to(I18n.t(:label_details), path, class: "diff-details", target: "_top") }
     let(:full_url_link) { link_to(I18n.t(:label_details), url, class: "diff-details", target: "_top") }

--- a/spec/lib/open_project/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/open_project/journal_formatter/custom_field_spec.rb
@@ -184,6 +184,24 @@ RSpec.describe OpenProject::JournalFormatter::CustomField do
     end
   end
 
+  context "with admin only custom field" do
+    let(:values) { [nil, "1"] }
+
+    before { custom_field.admin_only = true }
+
+    context "as a non admin user" do
+      current_user { build_stubbed(:user) }
+
+      it { expect(rendered).to be_nil }
+    end
+
+    context "as an admin" do
+      current_user { build_stubbed(:admin) }
+
+      it { expect(rendered).to be_a(String) }
+    end
+  end
+
   context "for a multi-select custom field" do
     let(:custom_field) { build_stubbed(:user_wp_custom_field) }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66925

# What are you trying to accomplish?
Allow activity for admin only custom fields to be viewed only by admins.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
