### PR TITLE
[#65403] Primerize Account Settings > Language & Region

### DIFF
--- a/app/components/my/locale_component.html.erb
+++ b/app/components/my/locale_component.html.erb
@@ -30,7 +30,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   settings_primer_form_with(
     model:,
-    url: { action: "update_settings" }
+    url: { action: "update_settings" },
+    data: { turbo: false }
   ) do |f|
     render My::LocaleForm.new(f)
   end

--- a/app/components/my/locale_component.html.erb
+++ b/app/components/my/locale_component.html.erb
@@ -27,16 +27,11 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title(t(:label_my_account), t(:label_setting_plural)) %>
-
 <%=
-  render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t(:label_setting_plural) }
-    header.with_breadcrumbs(
-      [{ href: my_account_path, text: t(:label_my_account) },
-       t(:label_setting_plural)]
-    )
+  settings_primer_form_with(
+    model:,
+    url: { action: "update_settings" }
+  ) do |f|
+    render My::LocaleForm.new(f)
   end
 %>
-
-<%= render My::LocaleComponent.new(@user) %>

--- a/app/components/my/locale_component.rb
+++ b/app/components/my/locale_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module My
+  class LocaleComponent < ApplicationComponent
+    include ApplicationHelper
+
+    alias_method :user, :model
+  end
+end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -43,7 +43,7 @@ class MyController < ApplicationController
 
   no_authorization_required! :account,
                              :update_account,
-                             :settings,
+                             :locale,
                              :interface,
                              :update_settings,
                              :password,
@@ -52,7 +52,7 @@ class MyController < ApplicationController
                              :reminders
 
   menu_item :account, only: [:account]
-  menu_item :settings, only: [:settings]
+  menu_item :locale, only: [:locale]
   menu_item :interface, only: [:interface]
   menu_item :password, only: [:password]
   menu_item :notifications, only: [:notifications]
@@ -64,7 +64,7 @@ class MyController < ApplicationController
     write_settings
   end
 
-  def settings; end
+  def locale; end
 
   def update_settings
     write_settings

--- a/app/forms/my/locale_form.rb
+++ b/app/forms/my/locale_form.rb
@@ -60,6 +60,6 @@ class My::LocaleForm < ApplicationForm
   def available_languages
     @available_languages ||= valid_languages
       .map { translate_language(it) }
-      .sort_by(&:last)
+      .sort_by(&:first)
   end
 end

--- a/app/forms/my/locale_form.rb
+++ b/app/forms/my/locale_form.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class My::LocaleForm < ApplicationForm
+  include ApplicationHelper
+
+  form do |f|
+    f.select_list(
+      name: :language,
+      label: attribute_name(:language),
+      required: true,
+      include_blank: include_auto? ? I18n.t(:label_auto_option) : false,
+      input_width: :medium
+    ) do |list|
+      available_languages.each do |label, value|
+        list.option(label:, value:, lang: value)
+      end
+    end
+
+    f.fields_for(:pref, model.pref, nested: false) do |builder|
+      ::My::TimeZoneForm.new(builder)
+    end
+
+    f.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
+  end
+
+  private
+
+  def include_auto?
+    valid_languages.to_set == all_languages.to_set
+  end
+
+  def available_languages
+    @available_languages ||= valid_languages
+      .map { translate_language(it) }
+      .sort_by(&:last)
+  end
+end

--- a/app/forms/my/time_zone_form.rb
+++ b/app/forms/my/time_zone_form.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class My::TimeZoneForm < ApplicationForm
+  form do |f|
+    f.select_list(
+      name: :time_zone,
+      label: attribute_name(:time_zone),
+      required: true,
+      include_blank: false,
+      input_width: :large
+    ) do |list|
+      available_time_zones.each do |label, value|
+        list.option(label:, value:)
+      end
+    end
+  end
+
+  private
+
+  def available_time_zones
+    @available_time_zones ||= UserPreferences::UpdateContract
+      .assignable_time_zones
+      .group_by { it.tzinfo.canonical_zone }
+      .map { |canonical_zone, included_zones| build_time_zone_entry(canonical_zone, included_zones) }
+  end
+
+  def build_time_zone_entry(canonical_zone, zones)
+    zone_names = zones.map(&:name).join(", ")
+    offset = ActiveSupport::TimeZone.seconds_to_utc_offset(canonical_zone.base_utc_offset)
+
+    ["(UTC#{offset}) #{zone_names}", canonical_zone.identifier]
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -272,16 +272,14 @@ module ApplicationHelper
   end
 
   def lang_options_for_select(blank = true)
-    auto =
-      if blank && (valid_languages - all_languages) == (all_languages - valid_languages)
-        [["(auto)", ""]]
-      else
-        []
-      end
+    options = valid_languages.map { |lang| [*translate_language(lang), { lang: }] }
+    options.sort_by!(&:second)
 
-    mapped_languages = valid_languages.map { |lang| translate_language(lang) }
+    if blank && valid_languages.to_set == all_languages.to_set
+      options.unshift(["(auto)", ""])
+    end
 
-    auto + mapped_languages.sort_by(&:last)
+    options
   end
 
   def all_lang_options_for_select

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -276,7 +276,7 @@ module ApplicationHelper
     options.sort_by!(&:second)
 
     if blank && valid_languages.to_set == all_languages.to_set
-      options.unshift(["(auto)", ""])
+      options.unshift([I18n.t(:label_auto_option), ""])
     end
 
     options

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -273,7 +273,7 @@ module ApplicationHelper
 
   def lang_options_for_select(blank = true)
     options = valid_languages.map { |lang| [*translate_language(lang), { lang: }] }
-    options.sort_by!(&:second)
+    options.sort_by!(&:first)
 
     if blank && valid_languages.to_set == all_languages.to_set
       options.unshift([I18n.t(:label_auto_option), ""])
@@ -285,7 +285,7 @@ module ApplicationHelper
   def all_lang_options_for_select
     all_languages
       .map { |lang| translate_language(lang) }
-      .sort_by(&:last)
+      .sort_by(&:first)
   end
 
   def theme_options_for_select

--- a/app/views/my/locale.html.erb
+++ b/app/views/my/locale.html.erb
@@ -27,14 +27,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% html_title(t(:label_my_account), t(:label_setting_plural)) %>
+<% html_title(t(:label_my_account), t(:label_locale)) %>
 
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t(:label_setting_plural) }
+    header.with_title { t(:label_locale) }
     header.with_breadcrumbs(
       [{ href: my_account_path, text: t(:label_my_account) },
-       t(:label_setting_plural)]
+       t(:label_locale)]
     )
   end
 %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -229,10 +229,10 @@ Redmine::MenuManager.map :my_menu do |menu|
             { controller: "/my", action: "account" },
             caption: :label_profile,
             icon: "person-fill"
-  menu.push :settings,
-            { controller: "/my", action: "settings" },
-            caption: :label_setting_plural,
-            icon: "gear"
+  menu.push :locale,
+            { controller: "/my", action: "locale" },
+            caption: :label_locale,
+            icon: "globe"
   menu.push :interface,
             { controller: "/my", action: "interface" },
             caption: :label_interface,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3079,6 +3079,7 @@ en:
   label_journal_diff: "Description Comparison"
   label_language: "Language"
   label_languages: "Languages"
+  label_locale: "Language and Region"
   label_jump_to_a_project: "Jump to a project..."
   label_keyword_plural: "Keywords"
   label_language_based: "Based on user's language"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2830,6 +2830,7 @@ en:
   label_api_access_key: "API access key"
   label_api_access_key_created_on: "API access key created %{value} ago"
   label_api_access_key_type: "API"
+  label_auto_option: "(auto)"
   label_ical_access_key_type: "iCalendar"
   label_ical_access_key_description: 'iCalendar token "%{token_name}" for "%{calendar_name}" in "%{project_name}"'
   label_ical_access_key_not_present: "iCalendar token(s) not present."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -905,7 +905,7 @@ Rails.application.routes.draw do
     post "/my/change_password", action: "change_password"
 
     get "/my/account", action: "account"
-    get "/my/settings", action: "settings"
+    get "/my/locale", action: "locale"
     get "/my/interface", action: "interface"
     get "/my/notifications", action: "notifications"
     get "/my/reminders", action: "reminders"

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -106,7 +106,7 @@ class MeetingsController < ApplicationController
       text = I18n.t(:notice_successful_create)
       unless User.current.pref.time_zone?
         link = I18n.t(:notice_timezone_missing, zone: formatted_time_zone_offset)
-        text += " #{view_context.link_to(link, { controller: '/my', action: :settings, anchor: 'pref_time_zone' },
+        text += " #{view_context.link_to(link, { controller: '/my', action: :locale, anchor: 'pref_time_zone' },
                                          class: 'link_to_profile')}"
       end
       flash[:notice] = text.html_safe # rubocop:disable Rails/OutputSafety

--- a/spec/components/my/locale_component_spec.rb
+++ b/spec/components/my/locale_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe My::LocaleComponent, type: :component do
 
   subject(:rendered_component) do
     with_controller_class(MyController) do
-      with_request_url("/my/settings") do
+      with_request_url("/my/locale") do
         render_component(user)
       end
     end

--- a/spec/components/my/locale_component_spec.rb
+++ b/spec/components/my/locale_component_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe My::LocaleComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:user) { build_stubbed(:user) }
+
+  subject(:rendered_component) do
+    with_controller_class(MyController) do
+      with_request_url("/my/settings") do
+        render_component(user)
+      end
+    end
+  end
+
+  it "renders form" do
+    expect(rendered_component).to have_element :form, action: my_settings_path
+  end
+end

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -156,6 +156,17 @@ RSpec.describe MyController do
     end
   end
 
+  describe "locale" do
+    it "renders the locale template" do
+      as_logged_in_user user do
+        get :locale
+      end
+
+      expect(response).to be_successful
+      expect(response).to render_template "locale"
+    end
+  end
+
   describe "settings" do
     describe "PATCH" do
       let(:language) { "en" }

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -66,14 +66,15 @@ RSpec.describe "my", :js do
   end
 
   shared_examples "common tests for normal and LDAP user" do
-    describe "settings" do
+    describe "Language and Region" do
       before do
-        visit my_settings_path
+        visit my_locale_path
       end
 
       context "with a default time zone", with_settings: { user_default_timezone: "Asia/Tokyo" } do
         it "override user time zone" do
           expect(user.pref.time_zone).to eq "Asia/Tokyo"
+          expect(page).to have_heading "Language and Region"
 
           expect(page).to have_select "Time zone", selected: "(UTC+09:00) Tokyo"
           select "(UTC+01:00) Paris", from: "Time zone"
@@ -88,6 +89,7 @@ RSpec.describe "my", :js do
 
       it "updates user language" do
         expect(user.language).to eq "en"
+        expect(page).to have_heading "Language and Region"
 
         expect(page).to have_select "Language", selected: "English"
         select "Español", from: "Language"
@@ -101,6 +103,7 @@ RSpec.describe "my", :js do
 
       it "updates user language with change visible on navigating to other settings (regression #66951)" do
         expect(user.language).to eq "en"
+        expect(page).to have_heading "Language and Region"
 
         expect(page).to have_select "Language", selected: "English"
         select "Português do brasil", from: "Language"

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -67,20 +67,36 @@ RSpec.describe "my", :js do
 
   shared_examples "common tests for normal and LDAP user" do
     describe "settings" do
-      context "with a default time zone", with_settings: { user_default_timezone: "Asia/Tokyo" } do
-        it "can override a time zone" do
-          expect(user.pref.time_zone).to eq "Asia/Tokyo"
-          visit my_settings_path
+      before do
+        visit my_settings_path
+      end
 
-          expect(page).to have_select "pref_time_zone", selected: "(UTC+09:00) Tokyo"
-          select "(UTC+01:00) Paris", from: "pref_time_zone"
+      context "with a default time zone", with_settings: { user_default_timezone: "Asia/Tokyo" } do
+        it "override user time zone" do
+          expect(user.pref.time_zone).to eq "Asia/Tokyo"
+
+          expect(page).to have_select "Time zone", selected: "(UTC+09:00) Tokyo"
+          select "(UTC+01:00) Paris", from: "Time zone"
           click_on "Save"
 
-          expect(page).to have_select "pref_time_zone", selected: "(UTC+01:00) Paris"
-          wait_for_network_idle
-          user.reload
+          expect_and_dismiss_flash type: :success, message: "Account was successfully updated."
+
+          expect(page).to have_select "Time zone", selected: "(UTC+01:00) Paris"
           expect(user.pref.time_zone).to eq "Europe/Paris"
         end
+      end
+
+      it "updates user language" do
+        expect(user.language).to eq "en"
+
+        expect(page).to have_select "Language", selected: "English"
+        select "Español", from: "Language"
+        click_on "Save"
+
+        expect_and_dismiss_flash type: :success, message: "Cuenta se actualizó correctamente."
+
+        expect(page).to have_select "Idioma", selected: "Español"
+        expect(user.language).to eq "es"
       end
     end
   end

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -98,6 +98,25 @@ RSpec.describe "my", :js do
         expect(page).to have_select "Idioma", selected: "Español"
         expect(user.language).to eq "es"
       end
+
+      it "updates user language with change visible on navigating to other settings (regression #66951)" do
+        expect(user.language).to eq "en"
+
+        expect(page).to have_select "Language", selected: "English"
+        select "Português do brasil", from: "Language"
+        click_on "Save"
+
+        expect_and_dismiss_flash type: :success, message: "Conta foi atualizada com sucesso."
+
+        expect(page).to have_select "Idioma", selected: "Português do brasil"
+
+        within "#main-menu" do
+          click_on "Configurações de notificação"
+        end
+
+        expect(page).to have_heading "Configurações de notificação"
+        expect(page).to have_heading "Alertas de data"
+      end
     end
   end
 

--- a/spec/forms/my/locale_form_spec.rb
+++ b/spec/forms/my/locale_form_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe My::LocaleForm, type: :forms do
   before do
     allow(Redmine::I18n)
       .to receive(:all_languages)
-      .and_return %w[en de es ja zh-CN]
+      .and_return %w[en de es ja nl zh-CN]
   end
 
   include_context "with rendered form"
@@ -49,8 +49,16 @@ RSpec.describe My::LocaleForm, type: :forms do
         expect(select).to have_element :option, value: "de", text: "Deutsch", lang: "de"
         expect(select).to have_element :option, value: "es", text: "Español", lang: "es"
         expect(select).to have_element :option, value: "ja", text: "日本語", lang: "ja"
+        expect(select).to have_element :option, value: "nl", text: "Nederlands", lang: "nl"
         expect(select).to have_element :option, value: "zh-CN", text: "简体中文", lang: "zh-CN"
       end
+    end
+
+    it "renders options sorted by CLDR name" do
+      options_text = page.find(:select, "Language").all("option").map(&:text) # Capy :options filter ignores order
+      expect(options_text).to eq [
+        "(auto)", "Deutsch", "English", "Español", "Nederlands", "日本語", "简体中文"
+      ]
     end
 
     it "renders options for available languages, if set", with_settings: { available_languages: %w[en es ja] } do
@@ -61,7 +69,7 @@ RSpec.describe My::LocaleForm, type: :forms do
       ]
     end
 
-    it "renders auto option if all languages available", with_settings: { available_languages: %w[en de es ja zh-CN] } do
+    it "renders auto option if all languages available", with_settings: { available_languages: %w[en de es ja nl zh-CN] } do
       expect(page).to have_select "Language", with_options: ["(auto)"]
     end
 

--- a/spec/forms/my/locale_form_spec.rb
+++ b/spec/forms/my/locale_form_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "spec_helper"
+
+RSpec.describe My::LocaleForm, type: :forms do
+  before do
+    allow(Redmine::I18n)
+      .to receive(:all_languages)
+      .and_return %w[en de es ja zh-CN]
+  end
+
+  include_context "with rendered form"
+
+  let(:model) { build_stubbed(:user, language:) }
+  let(:language) { nil }
+
+  describe "'Language' select list" do
+    it "renders select list" do
+      expect(page).to have_select "Language", required: true do |select|
+        expect(select).to have_element :option, value: "en", text: "English", lang: "en"
+        expect(select).to have_element :option, value: "de", text: "Deutsch", lang: "de"
+        expect(select).to have_element :option, value: "es", text: "Español", lang: "es"
+        expect(select).to have_element :option, value: "ja", text: "日本語", lang: "ja"
+        expect(select).to have_element :option, value: "zh-CN", text: "简体中文", lang: "zh-CN"
+      end
+    end
+
+    it "renders options for available languages, if set", with_settings: { available_languages: %w[en es ja] } do
+      expect(page).to have_select "Language", options: [
+        "English",
+        "Español",
+        "日本語"
+      ]
+    end
+
+    it "renders auto option if all languages available", with_settings: { available_languages: %w[en de es ja zh-CN] } do
+      expect(page).to have_select "Language", with_options: ["(auto)"]
+    end
+
+    context "with no language set" do
+      it "renders no selected option" do
+        expect(page).to have_select "Language", selected: nil
+      end
+    end
+
+    context "with language set to 'es'" do
+      let(:language) { "es" }
+
+      it "renders selected option" do
+        expect(page).to have_select "Language", selected: "Español"
+      end
+    end
+  end
+
+  it "renders 'Time zone' select list" do
+    expect(page).to have_select "Time zone", required: true
+  end
+
+  it "renders submit button" do
+    expect(page).to have_button "Save", class: "Button--primary"
+  end
+end

--- a/spec/forms/my/time_zone_form_spec.rb
+++ b/spec/forms/my/time_zone_form_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "spec_helper"
+
+RSpec.describe My::TimeZoneForm, type: :forms do
+  include_context "with rendered form"
+
+  let(:model) { build_stubbed(:user_preference) }
+
+  it "renders select list" do
+    expect(page).to have_select "Time zone", required: true do |select|
+      expect(select).to have_element :option, value: "America/Los_Angeles", text: "(UTC-08:00) Pacific Time (US & Canada)"
+      expect(select).to have_element :option, value: "Europe/Berlin", text: "(UTC+01:00) Berlin, Copenhagen, Stockholm"
+      expect(select).to have_element :option, value: "Asia/Shanghai", text: "(UTC+08:00) Beijing, Chongqing"
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -193,7 +193,54 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe ".all_lang_options_for_select" do
+  describe "#lang_options_for_select" do
+    before do
+      allow(Redmine::I18n)
+        .to receive(:all_languages)
+        .and_return %w[en de es ja zh-CN]
+    end
+
+    context "with all available languages" do
+      it "returns options for all languages" do
+        expect(lang_options_for_select).to eq [
+          ["(auto)", ""],
+          ["Deutsch", "de", { lang: "de" }],
+          ["English", "en", { lang: "en" }],
+          ["Español", "es", { lang: "es" }],
+          ["日本語", "ja", { lang: "ja" }],
+          ["简体中文", "zh-CN", { lang: "zh-CN" }]
+        ]
+      end
+    end
+
+    context "with some available languages", with_settings: { available_languages: %w[en es ja] } do
+      it "returns options for available languages" do
+        expect(lang_options_for_select).to eq [
+          ["English", "en", { lang: "en" }],
+          ["Español", "es", { lang: "es" }],
+          ["日本語", "ja", { lang: "ja" }]
+        ]
+      end
+    end
+
+    context "when blank is true (default)" do
+      it "returns auto option if all languages available" do
+        expect(lang_options_for_select).to start_with ["(auto)", ""]
+      end
+
+      it "does not return auto option if some languages available", with_settings: { available_languages: %w[en] } do
+        expect(lang_options_for_select).not_to start_with ["(auto)", ""]
+      end
+    end
+
+    context "when blank is false" do
+      it "does not return auto option" do
+        expect(lang_options_for_select(false)).not_to start_with ["(auto)", ""]
+      end
+    end
+  end
+
+  describe "#all_lang_options_for_select" do
     it 'has all languages translated ("English" should appear only once)' do
       impostor_locales =
         all_lang_options_for_select

--- a/spec/lib/redmine/menu_manager_spec.rb
+++ b/spec/lib/redmine/menu_manager_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Redmine::MenuManager do
     context "for the my_menu" do
       it "includes the expected items" do
         expect(described_class.items(:my_menu).map(&:name))
-          .to include(:account, :settings, :password, :access_tokens, :notifications, :reminders, :delete_account)
+          .to include(:account, :locale, :password, :access_tokens, :notifications, :reminders, :delete_account)
       end
     end
 

--- a/spec/routing/my_spec.rb
+++ b/spec/routing/my_spec.rb
@@ -39,12 +39,8 @@ RSpec.describe "my routes" do
     expect(patch("/my/account")).to route_to("my#update_account")
   end
 
-  it "/my/settings GET routes to my#settings" do
-    expect(get("/my/settings")).to route_to("my#settings")
-  end
-
-  it "/my/settings PATCH routes to my#update_account" do
-    expect(patch("/my/settings")).to route_to("my#update_settings")
+  it "/my/locale GET routes to my#locale" do
+    expect(get("/my/locale")).to route_to("my#locale")
   end
 
   it "/my/interface GET routes to my#interface" do
@@ -62,6 +58,10 @@ RSpec.describe "my routes" do
   it "/my/deletion_info GET routes to users#deletion_info" do
     expect(get("/my/deletion_info")).to route_to(controller: "users",
                                                  action: "deletion_info")
+  end
+
+  it "/my/settings PATCH routes to my#update_account" do
+    expect(patch("/my/settings")).to route_to("my#update_settings")
   end
 
   context "for access tokens controller" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65403
https://community.openproject.org/wp/66951

# What are you trying to accomplish?

Renames the **My Account > Settings** page to **My account > Language & Region**.

Primerizes the design, introducing `My::LocaleComponent`, accompanying forms, along with basic spec coverage.

Also includes:
- fix for [OP #66951](https://community.openproject.org/wp/66951) by disabling Turbo in Language & Region form.
- applies `lang` attribute to individual Language options, with the goal of improving screenreader and browser translation tool support.
- localization improvements.

## Screenshots

<img width="1472" height="540" alt="Screenshot 2025-08-27 at 15 03 10" src="https://github.com/user-attachments/assets/eb04167a-93b6-4579-934f-d48da87e4342" />

<img width="1470" height="540" alt="Screenshot 2025-08-27 at 15 03 29" src="https://github.com/user-attachments/assets/1967eec7-e55e-4917-bdbe-b4353d4ad128" />

# What approach did you choose and why?


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
