### PR TITLE
More fixes after SharePoint → Sharepoint

### DIFF
--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -149,11 +149,11 @@ storage_docs:
     href: https://portal.azure.com/
   one_drive_setup:
     href: https://www.openproject.org/docs/system-admin-guide/integrations/one-drive/
-  share_point_drive_id_guide:
+  sharepoint_drive_id_guide:
     href: https://www.openproject.org/docs/system-admin-guide/integrations/one-drive/drive-guide/
-  share_point_oauth_application:
+  sharepoint_oauth_application:
     href: https://portal.azure.com/
-  share_point_setup:
+  sharepoint_setup:
     href: https://www.openproject.org/docs/system-admin-guide/integrations/one-drive/
   troubleshooting:
     href: https://www.openproject.org/docs/user-guide/file-management/nextcloud-integration/#possible-errors-and-troubleshooting

--- a/modules/storages/app/components/storages/admin/forms/oauth_client_form_component.rb
+++ b/modules/storages/app/components/storages/admin/forms/oauth_client_form_component.rb
@@ -61,9 +61,9 @@ module Storages::Admin::Forms
       render(Primer::Beta::Link.new(href:, underline: true, target:)) { I18n.t("storages.instructions.one_drive.application_link_text") }
     end
 
-    def share_point_integration_link(target: "_blank")
-      href = ::OpenProject::Static::Links[:storage_docs][:share_point_oauth_application][:href]
-      render(Primer::Beta::Link.new(href:, underline: true, target:)) { I18n.t("storages.instructions.share_point.application_link_text") }
+    def sharepoint_integration_link(target: "_blank")
+      href = ::OpenProject::Static::Links[:storage_docs][:sharepoint_oauth_application][:href]
+      render(Primer::Beta::Link.new(href:, underline: true, target:)) { I18n.t("storages.instructions.sharepoint.application_link_text") }
     end
 
     def nextcloud_integration_link(target: "_blank")

--- a/modules/storages/app/controllers/storages/admin/access_management_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/access_management_controller.rb
@@ -31,7 +31,7 @@
 class Storages::Admin::AccessManagementController < ApplicationController
   include OpTurbo::ComponentStream
 
-  ALLOWED_STORAGES = %i[storages_one_drive_storage storages_share_point_storage].freeze
+  ALLOWED_STORAGES = %i[storages_one_drive_storage storages_sharepoint_storage].freeze
 
   layout "admin"
 

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -261,8 +261,8 @@ class Storages::Admin::StoragesController < ApplicationController
       :storages_nextcloud_storage
     elsif params.key?(:storages_one_drive_storage)
       :storages_one_drive_storage
-    elsif params.key?(:storages_share_point_storage)
-      :storages_share_point_storage
+    elsif params.key?(:storages_sharepoint_storage)
+      :storages_sharepoint_storage
     else
       :storages_storage
     end

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -240,7 +240,7 @@ en:
       storage_audience_blank: No audience has been configured.
       storage_audience_description: Exchanging tokens for audience "%{audience}".
       storage_audience_idp: Using access token obtained by identity provider during login, regardless of audience.
-      storage_oauth: Nextcloud OAuth
+      storage_oauth: Storage OAuth
       storage_provider: Storage provider
       token_exchange: Token Exchange
     health:

--- a/modules/storages/spec/features/storages/admin/create_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/create_storage_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Admin Create a new file storage",
         expect(page).not_to have_test_selector("label-openproject_oauth_application_configured-status")
 
         # OAuth client
-        wait_for { page }.to have_test_selector("storage-oauth-client-label", text: "Nextcloud OAuth")
+        wait_for { page }.to have_test_selector("storage-oauth-client-label", text: "Storage OAuth")
         expect(page).not_to have_test_selector("label-storage_oauth_client_configured-status")
         expect(page).to have_test_selector("storage-oauth-client-id-description",
                                            text: "Allow OpenProject to access Nextcloud data using OAuth.")

--- a/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
+++ b/modules/storages/spec/features/storages/admin/edit_storage_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Admin Edit File storage",
                                            text: "OAuth Client ID: #{oauth_application.uid}")
 
         # OAuth client
-        expect(page).to have_test_selector("storage-oauth-client-label", text: "Nextcloud OAuth")
+        expect(page).to have_test_selector("storage-oauth-client-label", text: "Storage OAuth")
         expect(page).to have_test_selector("label-storage_oauth_client_configured-status", text: "Completed")
         expect(page).to have_test_selector("storage-oauth-client-id-description",
                                            text: "OAuth Client ID: #{oauth_client.client_id}")


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Standardised all references from 'share_point' to 'sharepoint' across static links, controllers, and components for naming consistency. Also updated a label from 'Nextcloud OAuth' to 'Storage OAuth' in the English locale.

# Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
