### PR TITLE
[66939] Failed update re-rendered the entire component

### DIFF
--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -91,7 +91,10 @@ module Admin
               end,
               lambda do |validation_result|
                 add_errors_to_edit_form(validation_result)
-                render action: :edit
+                update_via_turbo_stream(
+                  component: ItemComponent.new(item: @active_item, show_edit_form: true)
+                )
+                respond_with_turbo_streams
               end
             )
         end

--- a/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_controller.rb
@@ -77,6 +77,7 @@ module Admin
             )
         end
 
+        # rubocop:disable Metrics/AbcSize
         def update
           input = item_input
           item_service
@@ -86,18 +87,15 @@ module Admin
                          short: input[:short],
                          score: input[:score])
             .either(
-              lambda do |_|
-                redirect_to(custom_field_item_path(@custom_field, @active_item.parent), status: :see_other)
-              end,
+              ->(*) { redirect_to(custom_field_item_path(@custom_field, @active_item.parent), status: :see_other) },
               lambda do |validation_result|
                 add_errors_to_edit_form(validation_result)
-                update_via_turbo_stream(
-                  component: ItemComponent.new(item: @active_item, show_edit_form: true)
-                )
+                update_via_turbo_stream(component: ItemComponent.new(item: @active_item, show_edit_form: true))
                 respond_with_turbo_streams
               end
             )
         end
+        # rubocop:enable Metrics/AbcSize
 
         def move
           item_service

--- a/spec/controllers/admin/custom_fields/hierarchy/items_controller_spec.rb
+++ b/spec/controllers/admin/custom_fields/hierarchy/items_controller_spec.rb
@@ -132,10 +132,16 @@ RSpec.describe Admin::CustomFields::Hierarchy::ItemsController, with_ee: [:custo
     end
 
     context "when validation fails" do
-      it "renders the new page" do
-        post :update, params: { custom_field_id: custom_field.id, id: luke.id, label: nil }
-        expect(response).to be_successful
-        expect(response).to render_template "edit"
+      before do
+        allow(controller).to receive(:respond_with_turbo_streams).and_call_original
+        allow(controller).to receive(:add_errors_to_edit_form).and_call_original
+      end
+
+      it "renders the errors on the page" do
+        post :update, params: { custom_field_id: custom_field.id, id: luke.id, label: nil, format: :turbo_stream }
+
+        expect(controller).to have_received(:respond_with_turbo_streams).once
+        expect(controller).to have_received(:add_errors_to_edit_form).once
       end
     end
   end


### PR DESCRIPTION
Related Work Package: [OP#66939](https://community.openproject.org/projects/document-workflows-stream/work_packages/66939/activity)

This bug was introduced when we added the tree view updating process. We were rendering the edit action, but the turbo frame affected was the one wrapping the entire component leading to the issue.

Now we issue a stream update for that. Not ideal, but works as a quick fix.