### PR TITLE
[#66467] Remove buttons from project dropdown

### DIFF
--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.html
@@ -96,7 +96,9 @@
         </ng-template>
       </ng-container>
 
-      <div class="spot-action-bar">
+      <div
+        *ngIf="!portfolioModelsEnabled"
+        class="spot-action-bar">
         <div class="spot-action-bar--right">
           <a
             class="button spot-action-bar--action"

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -64,6 +64,8 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
 
   public textFieldFocused = false;
 
+  public portfolioModelsEnabled = this.configuration.activeFeatureFlags.includes('portfolioModels');
+
   public canCreateNewProjects$ = this.currentUserService.hasCapabilities$('projects/create', 'global');
 
   public projects$ = combineLatest([

--- a/spec/features/global_roles/global_create_project_spec.rb
+++ b/spec/features/global_roles/global_create_project_spec.rb
@@ -103,4 +103,32 @@ RSpec.describe "Global role: Global Create project",
       projects_page.expect_no_project_create_button
     end
   end
+
+  describe "portfolio_models feature flag" do
+    context "when enabled", with_flag: { portfolio_models: true } do
+      let(:projects_menu) { Components::Projects::TopMenu.new }
+
+      current_user { admin }
+
+      it "does not show the button for project creation and list" do
+        projects_page.visit!
+        projects_menu.toggle!
+        projects_menu.expect_no_project_create_button
+        projects_menu.expect_no_project_list_button
+      end
+    end
+
+    describe "when disabled", with_flag: { portfolio_models: false } do
+      let(:projects_menu) { Components::Projects::TopMenu.new }
+
+      current_user { admin }
+
+      it "shows the button for project creation and list" do
+        projects_page.visit!
+        projects_menu.toggle!
+        projects_menu.expect_project_create_button
+        projects_menu.expect_project_list_button
+      end
+    end
+  end
 end

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -127,6 +127,22 @@ module Components
         end
       end
 
+      def expect_project_create_button
+        expect(page).to have_css(".spot-action-bar--action.-primary", text: "Project")
+      end
+
+      def expect_no_project_create_button
+        expect(page).to have_no_css(".spot-action-bar--action.-primary", text: "Project")
+      end
+
+      def expect_project_list_button
+        expect(page).to have_css(".spot-action-bar--action", text: "Project lists")
+      end
+
+      def expect_no_project_list_button
+        expect(page).to have_no_css(".spot-action-bar--action.-primary", text: "Project lists")
+      end
+
       def autocompleter_item_selector
         '[data-test-selector="op-header-project-select--item"]'
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66467

# What are you trying to accomplish?
Hide the project dropdown create and list buttons when the portfolio models feature is enabled.

# What approach did you choose and why?
Hide it in angular.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
