### PR TITLE
[#64885-FIXUP] Update Delete Project Danger Dialog copy

### DIFF
--- a/app/components/projects/delete_dialog_component.html.erb
+++ b/app/components/projects/delete_dialog_component.html.erb
@@ -32,6 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     Primer::OpenProject::DangerDialog.new(
       id:,
       title: t(:"project.destroy.title"),
+      size: :medium_portrait,
       form_arguments: {
         action: project_path(project),
         method: :delete,

--- a/app/components/projects/delete_dialog_component.html.erb
+++ b/app/components/projects/delete_dialog_component.html.erb
@@ -31,34 +31,41 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     Primer::OpenProject::DangerDialog.new(
       id:,
-      title: t(:"project.destroy.title", name: @project),
+      title: t(:"project.destroy.title"),
       form_arguments: {
-        action: project_path(@project),
+        action: project_path(project),
         method: :delete,
         data: { turbo: false }
       }
     )
   ) do |dialog|
     dialog.with_confirmation_message do |message|
-      message.with_heading(tag: :h2) { t(:"project.destroy.heading", name: @project) }
+      message.with_heading(tag: :h2) { t(:"project.destroy.heading") }
       message.with_description do
-        t("project.destroy.info")
+        t(
+          :"project.destroy.confirmation_message_for_subprojects_html",
+          name: project.name,
+          count: subprojects.size
+        )
       end
     end
-    dialog.with_confirmation_check_box_content(I18n.t(:text_permanent_delete_confirmation_checkbox_label))
-    dialog.with_additional_details(display: :block) do
-%>
-    <p><%= t("project.destroy.confirmation", identifier: @project.identifier) %></p>
-    <ul class="mb-3">
-      <li><%= t("project.destroy.project_delete_result_1") %></li>
-      <% if has_managed_project_folders? %>
-        <li><%= t("project.destroy.project_delete_result_2") %></li>
-      <% end %>
-    </ul>
-    <% if subproject_names.any? %>
-      <%= t("project.destroy.subprojects_confirmation", value: subproject_names.to_sentence) %>
-    <% end %>
-<%
+
+    if subprojects.any?
+      dialog.with_additional_details(display: :block) do
+        render(
+          Primer::Box.new(
+            mb: 3,
+            border: true,
+            border_radius: 2,
+            bg: :inset,
+            p: 3
+          )
+        ) do
+          render_subproject_list
+        end
+      end
     end
+
+    dialog.with_confirmation_check_box_content(I18n.t(:text_permanent_delete_confirmation_checkbox_label))
   end
 %>

--- a/app/components/projects/delete_dialog_component.rb
+++ b/app/components/projects/delete_dialog_component.rb
@@ -33,6 +33,8 @@ module Projects
     include ApplicationHelper
     include OpTurbo::Streamable
 
+    attr_reader :project
+
     def initialize(project:)
       super
 
@@ -43,10 +45,18 @@ module Projects
 
     def id = "delete-project-dialog"
 
-    def has_managed_project_folders? = @project.project_storages.any?(&:project_folder_automatic?)
+    def render_subproject_list(**options)
+      content_tag(:ul, options) do
+        safe_join(
+          subprojects.map do |subproject|
+            content_tag(:li, subproject.name)
+          end
+        )
+      end
+    end
 
-    def subproject_names
-      @project.descendants.map(&:to_s)
+    def subprojects
+      project.descendants
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3897,13 +3897,15 @@ en:
       one: "1 project"
       other: "%{count} projects"
     destroy:
-      confirmation: "If you continue, the project %{identifier} will be permanently destroyed. You will:"
-      project_delete_result_1: "Delete all related data."
-      project_delete_result_2: "Delete all managed project folders in the attached storages."
-      info: "Deleting the project is an irreversible action. Please proceed with caution."
-      subprojects_confirmation: "Its subproject(s): %{value} will also be deleted."
-      title: "Delete project %{name}"
-      heading: "Permanently delete project %{name}?"
+      title: "Delete project"
+      heading: "Permanently delete this project?"
+      confirmation_message_for_subprojects_html:
+        zero: >
+          You are about to permanently delete all data relating to project <strong>%{name}</strong>.
+        one: >
+          You are about to permanently delete all data relating to project <strong>%{name}</strong> and this subproject:
+        other: >
+          You are about to permanently delete all data relating to project <strong>%{name}</strong> and these subprojects:
     filters:
       project_phase: "Project phase: %{phase}"
       project_phase_any: "Project phase: Any"

--- a/spec/components/projects/delete_dialog_component_spec.rb
+++ b/spec/components/projects/delete_dialog_component_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe Projects::DeleteDialogComponent, type: :component do
 
   describe "with a project" do
     it "shows a heading" do
-      expect(subject).to have_text "Permanently delete project Top Secret Project?"
+      expect(subject).to have_text "Permanently delete this project?"
     end
 
     it "shows a simple info message" do
-      expect(subject).to have_text "Deleting the project is an irreversible action. Please proceed with caution."
+      expect(subject).to have_text "You are about to permanently delete all data relating to project Top Secret Project."
     end
   end
 end

--- a/spec/features/projects/destroy_spec.rb
+++ b/spec/features/projects/destroy_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe "Projects#destroy", :js do
   end
 
   it "destroys the project" do
-    expect(page).to have_modal "Delete project foo"
-    within_modal "Delete project foo" do
-      expect(page).to have_heading "Permanently delete project foo?"
+    expect(page).to have_modal "Delete project"
+    within_modal "Delete project" do
+      expect(page).to have_heading "Permanently delete this project?"
 
       expect(page).to have_unchecked_field "I understand that this deletion cannot be reversed"
 


### PR DESCRIPTION
# Ticket

Follow on for https://community.openproject.org/wp/64885

# What are you trying to accomplish?

Updates Danger Dialog text and formatting.

- Updates formatting of subprojects list.
- Removes storage deletion warning.
- Increases dialog size to medium portrait.

## Screenshots

| With no subprojects | With 1 subproject | With multiple subprojects |
|--------|--------|--------|
| <img width="502" height="334" alt="Screenshot 2025-08-28 at 12 18 52" src="https://github.com/user-attachments/assets/685c432d-c562-4d6c-bd2e-b96c6281757a" /> | <img width="503" height="390" alt="Screenshot 2025-08-28 at 12 19 11" src="https://github.com/user-attachments/assets/b4f4f334-c84f-4b0f-b053-bd83546533e6" /> | <img width="506" height="518" alt="Screenshot 2025-08-28 at 12 19 40" src="https://github.com/user-attachments/assets/1c0c7fa8-2c22-4064-ad49-6dbeb739bdf9" /> |

# What approach did you choose and why?


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
