### PR TITLE
[#62265] Advanced work package meeting selector  

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -96,8 +96,8 @@ module PaginationHelper
   ##
   # For "Show more" paginated links, we want to load an initial number of items (defaulting to 5)
   # unless a higher number is provided. These values do not correspond to the per_page_options
-  def show_more_limit_param(options = params, initial_limit: SHOW_MORE_DEFAULT_LIMIT)
-    limit = options[:limit].to_i
+  def show_more_limit_param(limit: nil, initial_limit: SHOW_MORE_DEFAULT_LIMIT)
+    limit = limit.to_i
     if limit.zero?
       initial_limit
     else
@@ -107,8 +107,8 @@ module PaginationHelper
 
   ##
   # Paginate an AR relation for the "show more" pagination functionality
-  def show_more_pagination(paginator, options = params)
-    paginator.paginate(page: 1, per_page: show_more_limit_param(options))
+  def show_more_pagination(paginator, limit: nil)
+    paginator.paginate(page: 1, per_page: show_more_limit_param(limit:))
   end
 
   private

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -124,6 +124,9 @@ import {
 import {
   UserAutocompleterComponent,
 } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
+import {
+  MeetingAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component';
 import { AttributeValueMacroComponent } from 'core-app/shared/components/fields/macros/attribute-value-macro.component';
 import { AttributeLabelMacroComponent } from 'core-app/shared/components/fields/macros/attribute-label-macro.component';
 import {
@@ -382,6 +385,7 @@ export class OpenProjectModule implements DoBootstrap {
     registerCustomElement('opce-project-autocompleter', ProjectAutocompleterComponent, { injector });
     registerCustomElement('opce-members-autocompleter', MembersAutocompleterComponent, { injector });
     registerCustomElement('opce-user-autocompleter', UserAutocompleterComponent, { injector });
+    registerCustomElement('opce-meeting-autocompleter', MeetingAutocompleterComponent, { injector });
     registerCustomElement('opce-time-entries-work-package-autocompleter', TimeEntriesWorkPackageAutocompleterComponent, { injector });
     registerCustomElement('opce-macro-attribute-value', AttributeValueMacroComponent, { injector });
     registerCustomElement('opce-macro-attribute-label', AttributeLabelMacroComponent, { injector });

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
@@ -1,5 +1,8 @@
 <ng-template #optionTemplate let-item>
-  <div>{{ item.name }}</div>
-  <div>ID: {{ item.id }}</div>
-  <div>time: {{ item.start_time }}</div>
+    <div>ID: {{ item.id }}</div>
+    <div>Name: {{ item.name }}</div>
+    <div>Project: {{ item.project }}</div>
+    <div>Time: {{ item.start_time }}</div>
+    <div>Date: {{ item.start_date }}</div>
+    <div *ngIf="item.frequency">Frequency: {{ item.frequency }}</div>
 </ng-template>

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
@@ -3,21 +3,21 @@
 </ng-template>
 
 <ng-template #optionTemplate let-item let-search="search">
-    <div class="op-autocompleter__meeting-option-grid">
-        <div class="op-autocompleter__field--name" [opSearchHighlight]="search">
+    <div class="op-meeting-autocompleter">
+        <div class="op-meeting-autocompleter--name" [opSearchHighlight]="search">
             {{ item.name }}
         </div>
-        <div class="op-autocompleter__field--date">
+        <div class="op-meeting-autocompleter--date">
             {{ item.start_date }}
         </div>
-        <div class="op-autocompleter__field--project-label">Project:</div>
+        <div class="op-meeting-autocompleter--project-label">Project:</div>
 
-        <div class="op-autocompleter__field--frequency" *ngIf="item.frequency">
+        <div class="op-meeting-autocompleter--frequency" *ngIf="item.frequency">
             {{ item.frequency }}
         </div>
-        <div class="op-autocompleter__field--time">
+        <div class="op-meeting-autocompleter--time">
             {{ item.start_time }}
         </div>
-        <div class="op-autocompleter__field--project">{{ item.project }}</div>
+        <div class="op-meeting-autocompleter--project">{{ item.project }}</div>
     </div>
 </ng-template>

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
@@ -1,8 +1,19 @@
-<ng-template #optionTemplate let-item>
-    <div>ID: {{ item.id }}</div>
-    <div>Name: {{ item.name }}</div>
-    <div>Project: {{ item.project }}</div>
-    <div>Time: {{ item.start_time }}</div>
-    <div>Date: {{ item.start_date }}</div>
-    <div *ngIf="item.frequency">Frequency: {{ item.frequency }}</div>
+<ng-template #optionTemplate let-item let-search="search">
+    <div class="op-autocompleter__meeting-option-grid">
+        <div class="op-autocompleter__field--name" [opSearchHighlight]="search">
+            {{ item.name }}
+        </div>
+        <div class="op-autocompleter__field--date">
+            {{ item.start_date }}
+        </div>
+        <div class="op-autocompleter__field--project-label">Project:</div>
+
+        <div class="op-autocompleter__field--frequency" *ngIf="item.frequency">
+            {{ item.frequency }}
+        </div>
+        <div class="op-autocompleter__field--time">
+            {{ item.start_time }}
+        </div>
+        <div class="op-autocompleter__field--project">{{ item.project }}</div>
+    </div>
 </ng-template>

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
@@ -1,4 +1,5 @@
 <ng-template #optionTemplate let-item>
-  <div>{{ item.label }}</div>
-  <div>ID: {{ item.value }}</div>
+  <div>{{ item.name }}</div>
+  <div>ID: {{ item.id }}</div>
+  <div>time: {{ item.start_time }}</div>
 </ng-template>

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
@@ -1,0 +1,4 @@
+<ng-template #optionTemplate let-item>
+  <div>{{ item.label }}</div>
+  <div>ID: {{ item.value }}</div>
+</ng-template>

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.html
@@ -1,3 +1,7 @@
+<ng-template #labelTemplate let-item>
+    {{ item.name }} - {{ item.start_date }} {{ item.start_time }} - {{ item.project }}
+</ng-template>
+
 <ng-template #optionTemplate let-item let-search="search">
     <div class="op-autocompleter__meeting-option-grid">
         <div class="op-autocompleter__field--name" [opSearchHighlight]="search">

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.sass
@@ -1,45 +1,44 @@
 @import '../../global_styles/openproject/variables'
 
-.op-autocompleter
-  &__meeting-option-grid
-    display: grid
-    grid-template-columns: 2fr 1fr 1fr
-    grid-template-rows: auto auto
-    column-gap: var(--stack-gap-condensed)
-    row-gap: calc(var(--stack-gap-condensed) / 2)
-    align-items: baseline
-    font-size: var(--font-size-small)
-
-  &__field--name
+.op-meeting-autocompleter
+  display: grid
+  grid-template-columns: 2fr 1fr 1fr
+  grid-template-rows: auto auto
+  column-gap: var(--stack-gap-condensed)
+  row-gap: calc(var(--stack-gap-condensed) / 2)
+  align-items: baseline
+  font-size: var(--font-size-small)
+  
+  &--name
     grid-row: 1
     grid-column: 1
     font-weight: 600
     overflow: hidden
     text-overflow: ellipsis
 
-  &__field--date
+  &--date
     grid-row: 1
     grid-column: 2
     color: var(--fgColor-muted)
 
-  &__field--project-label
+  &--project-label
     grid-row: 1
     grid-column: 3
     color: var(--fgColor-muted)
     text-align: left
 
-  &__field--frequency
+  &--frequency
     grid-row: 2
     grid-column: 1
     color: var(--fgColor-muted)
     font-size: var(--font-size-small)
 
-  &__field--time
+  &--time
     grid-row: 2
     grid-column: 2
     color: var(--fgColor-muted)
 
-  &__field--project
+  &--project
     grid-row: 2
     grid-column: 3
     font-weight: 600
@@ -48,20 +47,20 @@
     white-space: nowrap
 
   @media screen and (max-width: $breakpoint-sm)
-    &__option-grid
+    &
       grid-template-columns: 1fr
       grid-template-rows: auto
       row-gap: calc(var(--stack-gap-condensed) / 2)
 
-    &__field--project-label,
-    &__field--frequency
+    &--project-label,
+    &--frequency
       display: none
 
-    &__field--name,
-    &__field--date,
-    &__field--project-label,
-    &__field--frequency,
-    &__field--time,
-    &__field--project
+    &--name,
+    &--date,
+    &--project-label,
+    &--frequency,
+    &--time,
+    &--project
       grid-column: 1
       grid-row: auto

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.sass
@@ -1,0 +1,67 @@
+@import '../../global_styles/openproject/variables'
+
+.op-autocompleter
+  &__meeting-option-grid
+    display: grid
+    grid-template-columns: 2fr 1fr 1fr
+    grid-template-rows: auto auto
+    column-gap: var(--stack-gap-condensed)
+    row-gap: calc(var(--stack-gap-condensed) / 2)
+    align-items: baseline
+    font-size: var(--font-size-small)
+
+  &__field--name
+    grid-row: 1
+    grid-column: 1
+    font-weight: 600
+    overflow: hidden
+    text-overflow: ellipsis
+
+  &__field--date
+    grid-row: 1
+    grid-column: 2
+    color: var(--fgColor-muted)
+
+  &__field--project-label
+    grid-row: 1
+    grid-column: 3
+    color: var(--fgColor-muted)
+    text-align: left
+
+  &__field--frequency
+    grid-row: 2
+    grid-column: 1
+    color: var(--fgColor-muted)
+    font-size: var(--font-size-small)
+
+  &__field--time
+    grid-row: 2
+    grid-column: 2
+    color: var(--fgColor-muted)
+
+  &__field--project
+    grid-row: 2
+    grid-column: 3
+    font-weight: 600
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
+
+  @media screen and (max-width: $breakpoint-sm)
+    &__option-grid
+      grid-template-columns: 1fr
+      grid-template-rows: auto
+      row-gap: calc(var(--stack-gap-condensed) / 2)
+
+    &__field--project-label,
+    &__field--frequency
+      display: none
+
+    &__field--name,
+    &__field--date,
+    &__field--project-label,
+    &__field--frequency,
+    &__field--time,
+    &__field--project
+      grid-column: 1
+      grid-row: auto

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.ts
@@ -33,6 +33,7 @@ import {
 
 @Component({
   templateUrl: './meeting-autocompleter-template.component.html',
+  styleUrls: ['./meeting-autocompleter-template.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.ts
@@ -38,6 +38,6 @@ import {
   standalone: false,
 })
 export class MeetingAutocompleterTemplateComponent implements IAutocompleterTemplateComponent {
-  // @ViewChild('labelTemplate') labelTemplate?:TemplateRef<Element>;
+  @ViewChild('labelTemplate') labelTemplate?:TemplateRef<Element>;
   @ViewChild('optionTemplate') optionTemplate:TemplateRef<Element>;
 }

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component.ts
@@ -1,0 +1,42 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ChangeDetectionStrategy, Component, TemplateRef, ViewChild } from '@angular/core';
+import {
+  IAutocompleterTemplateComponent,
+} from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
+
+@Component({
+  templateUrl: './meeting-autocompleter-template.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class MeetingAutocompleterTemplateComponent implements IAutocompleterTemplateComponent {
+  // @ViewChild('labelTemplate') labelTemplate?:TemplateRef<Element>;
+  @ViewChild('optionTemplate') optionTemplate:TemplateRef<Element>;
+}

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.sass
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.sass
@@ -1,0 +1,20 @@
+@import '../../global_styles/openproject/variables'
+
+#add-work-package-to-meeting-dialog
+  .ng-dropdown-panel .ng-dropdown-panel-items
+    max-height: 320px !important
+
+    .ng-optgroup.ng-option-disabled
+      background-color: var(--bgColor-neutral-muted) !important
+
+      .ng-option-label
+        font-weight: normal
+        color: black
+
+    .ng-option.ng-option-child
+      padding-left: var(--base-size-16)
+      border-bottom: 1px solid var(--borderColor-default) !important
+
+    .ng-option.ng-option-marked
+      background-color: var(--bgColor-muted) !important
+

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.ts
@@ -40,7 +40,6 @@ export const meetingsAutocompleterSelector = 'op-meeting-autocompleter';
   templateUrl: '../op-autocompleter/op-autocompleter.component.html',
   styleUrls: ['./meeting-autocompleter.component.sass'],
   encapsulation: ViewEncapsulation.None,
-  selector: meetingsAutocompleterSelector,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.ts
@@ -29,29 +29,24 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  OnInit,
+  OnInit, HostBinding, ViewEncapsulation,
 } from '@angular/core';
-import { ID } from '@datorama/akita';
 import { OpAutocompleterComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
 import { MeetingAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component';
 
 export const meetingsAutocompleterSelector = 'op-meeting-autocompleter';
 
-export interface IMeetingAutocompleteItem {
-  id:ID;
-  name:string;
-  email?:string|null;
-  href:string|null;
-  avatar?:string|null;
-}
-
 @Component({
   templateUrl: '../op-autocompleter/op-autocompleter.component.html',
+  styleUrls: ['./meeting-autocompleter.component.sass'],
+  encapsulation: ViewEncapsulation.None,
   selector: meetingsAutocompleterSelector,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class MeetingAutocompleterComponent extends OpAutocompleterComponent<IMeetingAutocompleteItem> implements OnInit {
+export class MeetingAutocompleterComponent extends OpAutocompleterComponent implements OnInit {
+  @HostBinding('class.op-meeting-autocompleter') public className = true;
+
   ngOnInit():void {
     super.ngOnInit();
 

--- a/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component.ts
@@ -1,0 +1,60 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  Component,
+  ChangeDetectionStrategy,
+  OnInit,
+} from '@angular/core';
+import { ID } from '@datorama/akita';
+import { OpAutocompleterComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
+import { MeetingAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component';
+
+export const meetingsAutocompleterSelector = 'op-meeting-autocompleter';
+
+export interface IMeetingAutocompleteItem {
+  id:ID;
+  name:string;
+  email?:string|null;
+  href:string|null;
+  avatar?:string|null;
+}
+
+@Component({
+  templateUrl: '../op-autocompleter/op-autocompleter.component.html',
+  selector: meetingsAutocompleterSelector,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class MeetingAutocompleterComponent extends OpAutocompleterComponent<IMeetingAutocompleteItem> implements OnInit {
+  ngOnInit():void {
+    super.ngOnInit();
+
+    this.applyTemplates(MeetingAutocompleterTemplateComponent);
+  }
+}

--- a/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
+++ b/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
@@ -22,6 +22,9 @@ import {
   UserAutocompleterComponent,
 } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
 import {
+  MeetingAutocompleterComponent,
+} from 'core-app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter.component';
+import {
   ProjectAutocompleterComponent,
 } from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component';
 import {
@@ -47,6 +50,9 @@ import {
   UserAutocompleterTemplateComponent,
 } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component';
 import {
+  MeetingAutocompleterTemplateComponent,
+} from 'core-app/shared/components/autocompleter/meeting-autocompleter/meeting-autocompleter-template.component';
+import {
   ProjectAutocompleterTemplateComponent,
 } from 'core-app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component';
 import {
@@ -64,6 +70,8 @@ export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
   DraggableAutocompleteComponent,
   UserAutocompleterComponent,
   UserAutocompleterTemplateComponent,
+  MeetingAutocompleterTemplateComponent,
+  MeetingAutocompleterComponent,
   ProjectAutocompleterComponent,
   ProjectAutocompleterTemplateComponent,
   ProjectPhaseAutocompleterComponent,

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
@@ -4,7 +4,8 @@
       id: "add-work-package-to-meeting-form",
       model: @meeting_agenda_item,
       method: :post,
-      url: work_package_meeting_agenda_items_path(@work_package)
+      url: work_package_meeting_agenda_items_path(@work_package),
+      data: data_attributes
     ) do |f|
       flex_layout(mb: 3) do |flex|
         flex.with_row do
@@ -12,10 +13,16 @@
             render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @base_errors.join("\n") }
           end
         end
-        flex.with_row do
+        flex.with_row(mb: 3) do
+          render(Primer::Beta::Text.new) { I18n.t("text_add_work_package_to_meeting_form") }
+        end
+        flex.with_row(mb: 3) do
           render(MeetingAgendaItem::MeetingForm.new(f, wrapper_id: "add-work-package-to-meeting-dialog"))
         end
-        flex.with_row(mt: 3) do
+        flex.with_row(mb: 3) do
+          render(Meeting::AddToSection.new(f, wrapper_id: "add-work-package-to-meeting-dialog"))
+        end
+        flex.with_row do
           render(MeetingAgendaItem::Notes.new(f))
         end
       end

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.rb
@@ -40,5 +40,15 @@ module WorkPackageMeetingsTab
       @meeting_agenda_item = meeting_agenda_item || MeetingAgendaItem.new(work_package: @work_package)
       @base_errors = base_errors
     end
+
+    private
+
+    def data_attributes
+      {
+        controller: "refresh-on-form-changes",
+        "refresh-on-form-changes-target": "form",
+        "refresh-on-form-changes-turbo-stream-url-value": refresh_form_work_package_meeting_agenda_items_path(@work_package)
+      }
+    end
   end
 end

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -381,41 +381,13 @@ class MeetingsController < ApplicationController
 
     # We group meetings into individual groups, but only for upcoming meetings
     if params[:upcoming] == "false"
-      @meetings = show_more_pagination(@query.results)
+      @meetings = show_more_pagination(@query.results, limit: params[:limit])
     else
-      @grouped_meetings = group_meetings(@query.results)
+      service = ::GroupMeetingsService.new(@query.results, limit: params[:limit])
+      call = service.call
+
+      @grouped_meetings = call.result
     end
-  end
-
-  def group_meetings(all_meetings) # rubocop:disable Metrics/AbcSize
-    next_week = Time
-      .current
-      .next_occurring(OpenProject::Internationalization::Date.beginning_of_week)
-      .beginning_of_day
-    groups = Hash.new { |h, k| h[k] = [] }
-    groups[:later] = show_more_pagination(all_meetings
-                                            .where(start_time: next_week..)
-                                            .order(start_time: :asc))
-
-    all_meetings
-      .where(start_time: ...next_week)
-      .order(start_time: :asc)
-      .each do |meeting|
-      start_date = in_user_zone(meeting.start_time).to_date
-
-      group_key =
-        if start_date == Time.zone.today
-          :today
-        elsif start_date == Time.zone.tomorrow
-          :tomorrow
-        else
-          :this_week
-        end
-
-      groups[group_key] << meeting
-    end
-
-    groups
   end
 
   def build_meeting

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -26,7 +26,7 @@ class RecurringMeetingsController < ApplicationController
         RecurringMeeting.visible
       end
 
-    @recurring_meetings = show_more_pagination(results)
+    @recurring_meetings = show_more_pagination(results, limit: params[:limit])
 
     respond_to do |format|
       format.html do

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -69,7 +69,7 @@ class WorkPackageMeetingsTabController < ApplicationController
           work_package_id: @work_package.id,
           presenter_id: current_user.id,
           item_type: MeetingAgendaItem::ITEM_TYPES[:work_package],
-          meeting_section_id: backlog_id
+          meeting_section_id: params[:meeting_agenda_item][:meeting_section_id]
         )
       )
 
@@ -83,6 +83,30 @@ class WorkPackageMeetingsTabController < ApplicationController
       # show errors in form
       update_add_to_meeting_form_component_via_turbo_stream(meeting_agenda_item:, base_errors: call.errors[:base])
     end
+
+    respond_with_turbo_streams
+  end
+
+  def refresh_form
+    @meeting_agenda_item = MeetingAgendaItem.new(
+      meeting: Meeting.find(params[:meeting_agenda_item][:meeting_id]),
+      notes: params[:meeting_agenda_item][:notes]
+    )
+
+    call = MeetingAgendaItems::SetAttributesService.new(
+      user: current_user,
+      model: @meeting_agenda_item,
+      contract_class: EmptyContract
+    ).call
+
+    meeting_agenda_item = call.result
+
+    update_via_turbo_stream(
+      component: WorkPackageMeetingsTab::AddWorkPackageToMeetingFormComponent.new(
+        work_package: @work_package,
+        meeting_agenda_item: meeting_agenda_item
+      )
+    )
 
     respond_with_turbo_streams
   end

--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Meeting::AddToSection < ApplicationForm
+  form do |meeting_form|
+    meeting_form.autocompleter(
+      name: :meeting_section_id,
+      label: I18n.t("label_add_work_package_to_meeting_section_label"),
+      caption: I18n.t("label_section_selection_caption"),
+      input_width: :large,
+      autocomplete_options: {
+        decorated: true,
+        defaultData: false,
+        multiple: false,
+        focus_directly: false,
+        disabled: meeting.blank?,
+        placeholder: placeholder_text,
+        append_to: append_to_container
+      }
+    ) do |select|
+      items.each do |item|
+        select.option(
+          value: item.id,
+          label: option_title(item),
+          selected: preselected_option.present? && item.id == preselected_option[:id]
+        )
+      end
+    end
+  end
+
+  def initialize(wrapper_id: nil)
+    super()
+
+    @wrapper_id = wrapper_id
+  end
+
+  private
+
+  delegate :meeting, to: :model
+
+  def append_to_container
+    @wrapper_id.nil? ? "body" : "##{@wrapper_id}"
+  end
+
+  def items
+    items = []
+    items.concat(meeting.sections) unless meeting.blank? || any_non_backlog_sections?
+    items.push(meeting.backlog) if meeting.present?
+
+    items
+  end
+
+  def option_title(item)
+    return I18n.t("meeting_section.untitled_title") if item.title.blank?
+    return I18n.t("label_series_backlog") if item.backlog? && meeting.recurring?
+
+    item.title
+  end
+
+  def preselected_option
+    return if meeting.blank?
+
+    if meeting.recurring?
+      without_backlog = items.reject(&:backlog?)
+      item = without_backlog.last
+    else
+      item = meeting.backlog
+    end
+
+    item
+  end
+
+  def any_non_backlog_sections?
+    meeting.sections.none? || (meeting.sections.one? && meeting.sections.first.title.blank?)
+  end
+
+  def placeholder_text
+    I18n.t("placeholder_section_select_meeting_first") if meeting.blank?
+  end
+end

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -40,6 +40,7 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
       autocomplete_options: {
         component: "opce-meeting-autocompleter",
         items: meeting_options,
+        group_by: "group_label",
         # Do not try to load data from API (it will look for a "resource")
         defaultData: false,
         bindLabel: "name",
@@ -57,18 +58,13 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
   end
 
   def meeting_options
-    MeetingAgendaItems::CreateContract
+    meetings = MeetingAgendaItems::CreateContract
       .assignable_meetings(User.current)
       .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.zone.now)
       .order("meetings.start_time")
       .includes(:project)
-      .map do |meeting|
-      {
-        id: meeting.id,
-        name: meeting.title,
-        start_time: format_time(meeting.start_time)
-      }
-    end
+
+    GroupMeetingsService.new(meetings, as_options: true).call.result
   end
 
   def append_to_container

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -41,7 +41,7 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
         component: "opce-meeting-autocompleter",
         items: meeting_options,
         group_by: "group_label",
-        # Do not try to load data from API (it will look for a "resource")
+        focus_directly: true,
         defaultData: false,
         bindLabel: "name",
         bindValue: "id",

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -39,6 +39,7 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
       caption: I18n.t("label_meeting_selection_caption"),
       autocomplete_options: {
         component: "opce-meeting-autocompleter",
+        hiddenFieldAction: "change->refresh-on-form-changes#triggerTurboStream",
         items: meeting_options,
         group_by: "group_label",
         focus_directly: true,
@@ -46,16 +47,22 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
         bindLabel: "name",
         bindValue: "id",
         multiple: false,
-        append_to: append_to_container
+        append_to: append_to_container,
+        model: meeting_options.detect { |option| option[:id] == model.meeting_id },
+        inputValue: model.meeting_id,
+        virtualScroll: false
       }
     )
   end
 
   def initialize(disabled: false, wrapper_id: nil)
     super()
+
     @disabled = disabled
     @wrapper_id = wrapper_id
   end
+
+  private
 
   def meeting_options
     meetings = MeetingAgendaItems::CreateContract

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -39,32 +39,36 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
       caption: I18n.t("label_meeting_selection_caption"),
       autocomplete_options: {
         component: "opce-meeting-autocompleter",
+        items: meeting_options,
+        # Do not try to load data from API (it will look for a "resource")
+        defaultData: false,
+        bindLabel: "name",
+        bindValue: "id",
         multiple: false,
-        decorated: true,
         append_to: append_to_container
       }
-    ) do |select|
-      MeetingAgendaItems::CreateContract
-        .assignable_meetings(User.current)
-        .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.zone.now)
-        .order("meetings.start_time")
-        .includes(:project)
-        .each do |meeting|
-          select.option(
-            label: "#{meeting.project.name}: " \
-                   "#{meeting.title} " \
-                   "#{format_date(meeting.start_time)} " \
-                   "#{format_time(meeting.start_time, include_date: false)}",
-            value: meeting.id
-          )
-        end
-    end
+    )
   end
 
   def initialize(disabled: false, wrapper_id: nil)
     super()
     @disabled = disabled
     @wrapper_id = wrapper_id
+  end
+
+  def meeting_options
+    MeetingAgendaItems::CreateContract
+      .assignable_meetings(User.current)
+      .where("meetings.start_time + (interval '1 hour' * meetings.duration) >= ?", Time.zone.now)
+      .order("meetings.start_time")
+      .includes(:project)
+      .map do |meeting|
+      {
+        id: meeting.id,
+        name: meeting.title,
+        start_time: format_time(meeting.start_time)
+      }
+    end
   end
 
   def append_to_container

--- a/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/meeting_form.rb
@@ -38,6 +38,7 @@ class MeetingAgendaItem::MeetingForm < ApplicationForm
       label: I18n.t("label_meeting"),
       caption: I18n.t("label_meeting_selection_caption"),
       autocomplete_options: {
+        component: "opce-meeting-autocompleter",
         multiple: false,
         decorated: true,
         append_to: append_to_container

--- a/modules/meeting/app/services/group_meetings_service.rb
+++ b/modules/meeting/app/services/group_meetings_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class GroupMeetingsService
+  include Redmine::I18n
+  include PaginationHelper
+
+  def initialize(all_meetings, as_options: false, limit: nil)
+    @all_meetings = all_meetings
+    @as_options = as_options
+    @limit = @as_options ? @all_meetings.count : limit
+  end
+
+  def call
+    if @as_options
+      ServiceResult.success(result: build_options)
+    else
+      ServiceResult.success(result: group_meetings)
+    end
+  end
+
+  private
+
+  def group_meetings # rubocop:disable Metrics/AbcSize
+    next_week = Time
+                  .current
+                  .next_occurring(OpenProject::Internationalization::Date.beginning_of_week)
+                  .beginning_of_day
+    groups = Hash.new { |h, k| h[k] = [] }
+    groups[:later] = show_more_pagination(@all_meetings
+                                            .where(start_time: next_week..)
+                                            .order(start_time: :asc), limit: @limit)
+
+    @all_meetings
+      .where(start_time: ...next_week)
+      .order(start_time: :asc)
+      .each do |meeting|
+      start_date = in_user_zone(meeting.start_time).to_date
+
+      group_key =
+        if start_date == Time.zone.today
+          :today
+        elsif start_date == Time.zone.tomorrow
+          :tomorrow
+        else
+          :this_week
+        end
+
+      groups[group_key] << meeting
+    end
+
+    groups
+  end
+
+  # Flattens groups into autocompleter options
+  def build_options
+    group_meetings.flat_map do |key, meetings|
+      label = I18n.t("label_meeting_index_#{key}")
+
+      meetings.map do |meeting|
+        {
+          id: meeting.id,
+          name: meeting.title,
+          project: meeting.project.name,
+          start_time: format_time(meeting.start_time, include_date: false),
+          start_date: format_date(meeting.start_time),
+          group_label: label,
+          frequency: frequency(meeting)
+        }
+      end
+    end
+  end
+
+  def frequency(meeting)
+    meeting.recurring_meeting.human_frequency if meeting.recurring_meeting.present?
+  end
+end

--- a/modules/meeting/app/services/group_meetings_service.rb
+++ b/modules/meeting/app/services/group_meetings_service.rb
@@ -54,9 +54,6 @@ class GroupMeetingsService
                   .next_occurring(OpenProject::Internationalization::Date.beginning_of_week)
                   .beginning_of_day
     groups = Hash.new { |h, k| h[k] = [] }
-    groups[:later] = show_more_pagination(@all_meetings
-                                            .where(start_time: next_week..)
-                                            .order(start_time: :asc), limit: @limit)
 
     @all_meetings
       .where(start_time: ...next_week)
@@ -75,6 +72,11 @@ class GroupMeetingsService
 
       groups[group_key] << meeting
     end
+
+    # Order of groups here affects group ordering in autocompleter
+    groups[:later] = show_more_pagination(@all_meetings
+                                            .where(start_time: next_week..)
+                                            .order(start_time: :asc), limit: @limit)
 
     groups
   end

--- a/modules/meeting/app/services/group_meetings_service.rb
+++ b/modules/meeting/app/services/group_meetings_service.rb
@@ -81,7 +81,7 @@ class GroupMeetingsService
     groups
   end
 
-  # Flattens groups into autocompleter options
+  # Flatten groups into autocompleter options
   def build_options
     group_meetings.flat_map do |key, meetings|
       label = I18n.t("label_meeting_index_#{key}")

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -610,9 +610,13 @@ en:
   text_meeting_not_editable_anymore: "This meeting is not editable anymore."
   text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."
 
-  label_add_work_package_to_meeting_dialog_title: "Add work package to meeting"
+  label_add_work_package_to_meeting_dialog_title: "Select meeting"
+  label_add_work_package_to_meeting_section_label: "Add to section"
   label_add_work_package_to_meeting_dialog_button: "Add to meeting"
-  label_meeting_selection_caption: "It's only possible to add this work package to upcoming or ongoing open meetings."
+  label_meeting_selection_caption: "It is only possible to add this work package to an upcoming or an ongoing meeting."
+  label_section_selection_caption: "Choose a particular section of the agenda or add it to the backlog."
+  placeholder_section_select_meeting_first: "Meeting selection is required first"
+  text_add_work_package_to_meeting_form: "The work package will be added to the selected meeting or backlog as an agenda item."
 
   text_add_work_package_to_meeting_description: "A work package can be added to one or multiple meetings for discussion. Any notes concerning it are also visible here."
   text_agenda_item_no_notes: "No notes provided"

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       collection do
         get :dialog, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting_dialog
         post :create, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting
+        get :refresh_form, controller: "work_package_meetings_tab", action: :refresh_form
       end
     end
   end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -67,7 +67,7 @@ module OpenProject::Meeting
                                   details_dialog update_details toggle_notifications],
                      recurring_meetings: %i[edit cancel_edit update update_title details_dialog update_details
                                             notify end_series end_series_dialog],
-                     work_package_meetings_tab: %i[add_work_package_to_meeting_dialog add_work_package_to_meeting],
+                     work_package_meetings_tab: %i[add_work_package_to_meeting_dialog add_work_package_to_meeting refresh_form],
                      meeting_participants: %i[create destroy mark_all_attended toggle_attendance manage_participants_dialog]
                    },
                    permissible_on: :project,

--- a/modules/meeting/spec/factories/meeting_factory.rb
+++ b/modules/meeting/spec/factories/meeting_factory.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
       meeting.project = evaluator.project if evaluator.project
 
       # create backlog
-      create(:meeting_section, meeting:, backlog: true)
+      create(:meeting_section, meeting:, backlog: true, title: I18n.t(:label_agenda_backlog))
     end
 
     factory :meeting_template do |meeting|

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -478,6 +478,103 @@ RSpec.describe "Open the Meetings tab",
 
           expect(page.find(".op-meeting-agenda-item--presenter")).to have_text(user.name)
         end
+
+        context "when testing section selection behaviour" do
+          shared_let(:meeting_without_sections) { create(:meeting, project:, start_time: 1.hour.from_now) }
+          shared_let(:meeting_with_sections) do
+            create(:meeting, project:, start_time: 2.hours.from_now).tap do |meeting|
+              create(:meeting_section, meeting:, title: "Section 1")
+              create(:meeting_section, meeting:, title: "Section 2")
+            end
+          end
+          shared_let(:recurring_meeting) do
+            create(:recurring_meeting, project:)
+          end
+          shared_let(:empty_recurring_meeting_occurrence) do
+            create(:meeting,
+                   project:,
+                   recurring_meeting:,
+                   start_time: 3.hours.from_now)
+          end
+          shared_let(:recurring_meeting_occurrence) do
+            create(:meeting,
+                   project:,
+                   recurring_meeting:,
+                   start_time: 4.hours.from_now).tap do |meeting|
+              create(:meeting_section, meeting:, title: "Section 1")
+              create(:meeting_section, meeting:, title: "Section 2")
+            end
+          end
+
+          it "automatically selects the backlog for one-time meetings without sections" do
+            check_section_auto_selection(meeting_without_sections, "Agenda backlog")
+          end
+
+          it "automatically selects the backlog for one-time meetings with sections" do
+            check_section_auto_selection(meeting_with_sections, "Agenda backlog")
+          end
+
+          it "automatically selects the last section for recurring meeting occurrences" do
+            last_section = recurring_meeting_occurrence.sections.last.title
+            check_section_auto_selection(recurring_meeting_occurrence, last_section)
+          end
+
+          it "shows no preselection when no sections exist for recurring meeting occurrences" do
+            meeting = empty_recurring_meeting_occurrence
+
+            work_package_page.visit!
+            switch_to_meetings_tab
+
+            meetings_tab.open_add_to_meeting_dialog
+
+            fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
+            page.find(".ng-option-marked", text: meeting.title)
+            page.find(".ng-option-marked").click
+
+            wait_for_network_idle
+
+            section_field = find_field("meeting_agenda_item_meeting_section_id")
+            expect(section_field).not_to be_disabled
+
+            expect(page).to have_no_css(".ng-value-label")
+          end
+
+          it "updates section selection when switching between meetings" do
+            work_package_page.visit!
+            switch_to_meetings_tab
+
+            meetings_tab.open_add_to_meeting_dialog
+
+            retry_block do
+              fill_in("meeting_agenda_item_meeting_id", with: recurring_meeting_occurrence.title)
+              page.find(".ng-option-marked", text: recurring_meeting_occurrence.title)
+              page.find(".ng-option-marked").click
+
+              wait_for_network_idle
+
+              last_section = recurring_meeting_occurrence.sections.last
+              expect(page).to have_content(last_section.title)
+
+              fill_in("meeting_agenda_item_meeting_id", with: meeting_without_sections.title)
+              page.find(".ng-option-marked", text: meeting_without_sections.title)
+              page.find(".ng-option-marked").click
+
+              wait_for_network_idle
+
+              expect(page).to have_content("Agenda backlog")
+            end
+          end
+
+          it "shows section autocompleter as disabled when no meeting is selected" do
+            work_package_page.visit!
+            switch_to_meetings_tab
+
+            meetings_tab.open_add_to_meeting_dialog
+
+            page.find_field("meeting_agenda_item_meeting_section_id", disabled: true, visible: false)
+            expect(page).to have_content("Meeting selection is required first")
+          end
+        end
       end
     end
 
@@ -513,8 +610,28 @@ RSpec.describe "Open the Meetings tab",
     it_behaves_like "with a meetings tab"
   end
 
+  private
+
   def switch_to_meetings_tab
     work_package_page.switch_to_tab(tab: "meetings")
     meetings_tab.expect_tab_content_rendered # wait for the tab to be rendered
+  end
+
+  def check_section_auto_selection(meeting, expected_section)
+    work_package_page.visit!
+    switch_to_meetings_tab
+
+    meetings_tab.open_add_to_meeting_dialog
+
+    fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
+    page.find(".ng-option-marked", text: meeting.title)
+    page.find(".ng-option-marked").click
+
+    wait_for_network_idle
+
+    section_field = find_field("meeting_agenda_item_meeting_section_id")
+    expect(section_field).not_to be_disabled
+
+    expect(page).to have_css(".ng-value-label", text: expected_section)
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/62265

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add and use custom meeting autocompleter in the form
- Move grouping logic to GroupMeetingsService, so that everything is in one place for the meetings index page & the autocompleter
- Add 'Add to section' field to the form along with refresh logic to always update when a particular meeting is selected, using `refresh-on-form-changes`
- Add specs for all the automatic section selections

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
