### PR TITLE
[65132] Avoid eating characters when modifying duration in work package date picker

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/date-picker/preview.controller.ts
@@ -317,8 +317,12 @@ export default class PreviewController extends DialogPreviewController {
     this.updateFlatpickrCalendar();
   }
 
+  // Must be true for duration field to avoid modifying the value while the user
+  // is typing or pressing backspace.
+  // Must be false for start and finish date fields to allow value to be
+  // corrected if the date is invalid (non-working day for instance).
   ignoreActiveValueWhenMorphing():boolean {
-    return false;
+    return document.activeElement?.id === 'work_package_duration';
   }
 
   readInitialValues() {

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -66,6 +68,21 @@ RSpec.describe "Custom field filter in boards",
 
     wp.save
     wp
+  end
+
+  let!(:workflow_open_to_closed) do
+    create(:workflow,
+           type:,
+           role:,
+           old_status_id: open_status.id,
+           new_status_id: closed_status.id)
+  end
+  let!(:workflow_closed_to_open) do
+    create(:workflow,
+           type:,
+           role:,
+           old_status_id: closed_status.id,
+           new_status_id: open_status.id)
   end
 
   let(:filters) { Components::WorkPackages::Filters.new }

--- a/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Status action board",
     filters.expect_filter_by("Type", "is (OR)", [type_task.name, type_bug.name])
 
     # Wait a bit before saving the page to ensure both values are processed
-    sleep 2
+    board_page.wait_for_lists_reload
 
     board_page.expect_changed
     board_page.save
@@ -142,12 +142,8 @@ RSpec.describe "Status action board",
     board_page.card_for(task_wp).expect_type "Task"
     board_page.card_for(bug_wp).expect_type "Bug"
 
-    # Wait a bit before moving the items too fast
-    sleep 2
-
     # Move bug to open
     board_page.move_card_by_name("Closed bug item", from: "Closed", to: "Open")
-    board_page.wait_for_lists_reload
 
     board_page.expect_card("Closed", "Closed bug item", present: false)
     board_page.expect_card("Open", "Closed bug item", present: true)
@@ -155,8 +151,6 @@ RSpec.describe "Status action board",
     # Expect type unchanged
     board_page.card_for(task_wp).expect_type "Task"
     board_page.card_for(bug_wp).expect_type "Bug"
-
-    sleep 2
 
     task_wp.reload
     bug_wp.reload

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -175,6 +175,11 @@ module Pages
       target = page.find list_selector(to)
 
       drag_n_drop_element(from: source, to: target)
+      wait_for_lists_reload
+
+      # Wait a little more because the cards sorting order can still be changing
+      # after moving them
+      sleep 2
     end
 
     def move_card_by_name(text, from:, to:)
@@ -182,14 +187,20 @@ module Pages
       target = page.find list_selector(to)
 
       drag_n_drop_element(from: source, to: target)
+      wait_for_lists_reload
+
+      # Wait a little more because the cards sorting order can still be changing
+      # after moving them
+      sleep 2
     end
 
     def wait_for_lists_reload
       # wait for reload of lists to start and finish
       # Not sure if that's the most reliable way to do it, but there is nothing visible
       # about the PATCH request being sent and executed successfully after moving a card.
-      expect(page).to have_css(".op-loading-indicator", wait: 5)
-      expect(page).to have_no_css(".op-loading-indicator")
+      # Use has_css? to not fail if no loading indicator is present at all
+      has_css?(".op-loading-indicator", wait: 2)
+      expect(page).to have_no_css(".op-loading-indicator", wait: 5)
     end
 
     def add_list(option: nil, query: option)
@@ -217,8 +228,8 @@ module Pages
 
     def save
       page.find(".editable-toolbar-title--save").click
-      wait_for_lists_reload
       expect_and_dismiss_toaster message: "Successful update."
+      wait_for_lists_reload
     end
 
     def expect_changed

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -33,11 +33,7 @@ module Components::Autocompleter
     end
 
     def ng_click_autocompleter(target)
-      if using_cuprite?
-        target.click
-      else
-        page.execute_script("arguments[0].click();", target.native)
-      end
+      target.click
     end
 
     def ng_find_dropdown(element, results_selector: nil)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65132

# What are you trying to accomplish?

When typing characters in the work package date picker duration field, some key strokes get ignored and the value is not what has been typed.

## Screenshots

See original ticket to see a GIF demonstrating the issue

# What approach did you choose and why?

It's due to the morphing which morphes everything, including the values inside the active element.

Now the morphing is ignoring the active element if that active element is the work package duration field.

# Merge checklist

- [ ] Added/updated tests
  - Not added as I was not sure how to write some for it.
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
