### PR TITLE
[66937] The sidebar background in Dark mode is darker than the main page background

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -48,7 +48,7 @@
     --button--background-hover-color: var(--button-default-bgColor-hover);
     --button--background-color: var(--button-default-bgColor-rest);
     --header-border-bottom-width: 1px;
-    --header-bg-color: var(--page-header-bgColor);
+    --header-bg-color: var(--bgColor-inset);
     --header-item-font-color: var(--fgColor-default);
     --header-item-font-hover-color: var(--fgColor-default);
     --header-border-bottom-color: var(--borderColor-muted) !important;
@@ -58,7 +58,7 @@
     --main-menu-border-width: 1px;
     --main-menu-font-color: var(--fgColor-default);
     --main-menu-selected-font-color: var(--fgColor-default);
-    --main-menu-bg-color: var(--page-header-bgColor);
+    --main-menu-bg-color: var(--body-background);
   }
 
   /* For accessibility themes we are also overriding the header and the sidebar */
@@ -82,7 +82,6 @@
       --primary-button-color: var(--primary-button-color--dark-mode);
       --button--primary-background-disabled-color: var(--primary-button-color--major1);
       --button--primary-border-disabled-color: var(--primary-button-color--major1);
-      --main-menu-bg-color: var(--overlay-bgColor);
       --type-form-conf-attribute--background: var(--overlay-bgColor);
       --select-arrow-bg-color-url: url("data:image/svg+xml;utf8,<svg fill='white' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
       --ck-color-mention-text: var(--display-red-fgColor);

--- a/lookbook/docs/patterns/16-colors.md.erb
+++ b/lookbook/docs/patterns/16-colors.md.erb
@@ -150,6 +150,6 @@ However, we enforce the header and the main menu colors to use Primer css variab
 --primary-button-color: var(--primary-button-color--dark-mode);
 
 --main-menu-bg-color: var(--overlay-bgColor);
---header-bg-color: var(--page-header-bgColor);
+--header-bg-color: var(--bgColor-inset);
 ...
 ```


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66937

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

- [x] Change sidebar background colour to var(--body-background)
- [x] Change top navigation bar background colour to the equivalent of --bgColor-inset
