### PR TITLE
[65355] Meeting series menu header is not reflected in the breadcrumb

### DIFF
--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.html.erb
@@ -6,7 +6,7 @@
     render(Primer::OpenProject::PageHeader.new) do |header|
       header.with_title { page_title }
       header.with_description { page_description }
-      header.with_breadcrumbs(breadcrumb_items)
+      header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: :normal)
 
       header.with_action_menu(
         menu_arguments: { anchor_align: :end },

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
@@ -100,7 +100,7 @@ module RecurringMeetings
         ({ href: project_overview_path(@project.id), text: @project.name } if @project.present?),
         { href: @project.present? ? project_meetings_path(@project.id) : meetings_path,
           text: I18n.t(:label_meeting_plural) },
-        page_title(true)
+        helpers.nested_breadcrumb_element(I18n.t(:label_meeting_series), @meeting.title)
       ].compact
     end
   end

--- a/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/show_page_header_component.rb
@@ -78,17 +78,13 @@ module RecurringMeetings
       I18n.t(:label_recurring_meeting)
     end
 
-    def page_title(breadcrumb = nil)
-      @meeting.present? ? meeting_series_title(breadcrumb).to_s : I18n.t(:label_recurring_meeting_plural)
+    def page_title
+      @meeting.present? ? meeting_series_title.to_s : I18n.t(:label_recurring_meeting_plural)
     end
 
-    def meeting_series_title(breadcrumb)
+    def meeting_series_title
       concat @meeting.title
-      if breadcrumb
-        concat render(Primer::Beta::Text.new) { " (#{I18n.t(:label_meeting_series)})" }
-      else
-        concat render(Primer::Beta::Text.new(color: :muted)) { " (#{I18n.t(:label_meeting_series)})" }
-      end
+      concat render(Primer::Beta::Text.new(color: :muted)) { " (#{I18n.t(:label_meeting_series)})" }
     end
 
     def page_description


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65355

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show nested breadcrumb in recurring meetings correctly

## Screenshots
Before:
<img width="858" height="351" alt="Screenshot 2025-08-28 at 13 06 49" src="https://github.com/user-attachments/assets/4d6f9454-13a8-41ee-bc35-66f107485056" />

After:
<img width="911" height="405" alt="Screenshot 2025-08-28 at 13 06 23" src="https://github.com/user-attachments/assets/7f88efcc-6e3f-4b4b-beca-9663be1dbd13" />

