### PR TITLE
[#66996] Hide deleted users from everywhere.

### DIFF
--- a/app/controllers/scim_v2/groups_controller.rb
+++ b/app/controllers/scim_v2/groups_controller.rb
@@ -122,7 +122,6 @@ module ScimV2
         .left_joins(:users, :user_auth_provider_links)
         .includes(:users, :user_auth_provider_links)
         .not_builtin
-        .where.not(status: Group.statuses[:deleted])
     end
 
     private

--- a/app/controllers/scim_v2/users_controller.rb
+++ b/app/controllers/scim_v2/users_controller.rb
@@ -107,7 +107,6 @@ module ScimV2
         .left_joins(:groups, :user_auth_provider_links)
         .includes(:groups, :user_auth_provider_links)
         .not_builtin
-        .where.not(status: User.statuses[:deleted])
     end
   end
 end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -30,6 +30,7 @@
 
 class Principal < ApplicationRecord
   include ::Scopes::Scoped
+  default_scope -> { where.not(status: Principal.statuses[:deleted]) }
 
   # Account statuses
   # Disables enum scopes to include not_builtin (cf. Principals::Scopes::Status)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -989,7 +989,7 @@ en:
   account:
     delete: "Delete account"
     delete_confirmation: "Are you sure you want to delete the account?"
-    deletion_pending: "Account has been locked and was scheduled for deletion. Note that this process takes place in the background. It might take a few moments until the user is fully deleted."
+    deletion_pending: "Account has been scheduled for deletion. Note that this process takes place in the background. It might take a few moments until the user is fully deleted."
     deletion_info:
       data_consequences:
         other: 'Of the data the user created (e.g. email, preferences, work packages, wiki entries) as much as possible will be deleted. Note however, that data like work packages and wiki entries can not be deleted without impeding the work of the other users. Such data is hence reassigned to an account called "Deleted user". As the data of every deleted account is reassigned to this account it will not be possible to distinguish the data the user created from the data of another deleted account.'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -473,26 +473,22 @@ RSpec.describe UsersController do
     end
 
     it "to be success" do
-      expect(response)
-        .to have_http_status(:ok)
+      expect(response).to have_http_status(:ok)
     end
 
     it "renders the index" do
-      expect(response)
-        .to have_rendered("index")
+      expect(response).to have_rendered("index")
     end
 
     it "assigns users" do
-      expect(assigns(:users))
-        .to contain_exactly(user, admin)
+      expect(assigns(:users)).to contain_exactly(user, admin)
     end
 
     context "with a name filter" do
       let(:params) { { name: user.firstname } }
 
       it "assigns users" do
-        expect(assigns(:users))
-          .to contain_exactly(user)
+        expect(assigns(:users)).to contain_exactly(user)
       end
     end
 
@@ -504,8 +500,15 @@ RSpec.describe UsersController do
       end
 
       it "assigns users" do
-        expect(assigns(:users))
-          .to contain_exactly(user)
+        expect(assigns(:users)).to contain_exactly(user)
+      end
+    end
+
+    context "with a user scheduled for deletion present" do
+      let!(:deleted_user) { create(:user_marked_for_deletion) }
+
+      it "does not include this user to the users list" do
+        expect(assigns(:users)).to contain_exactly(user, admin)
       end
     end
   end

--- a/spec/features/users/delete_spec.rb
+++ b/spec/features/users/delete_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe "user deletion:", :js do
 
       dialog.confirm_flow_with user_password
 
-      expect(page).to have_content "Account has been locked and was scheduled for deletion"
+      expect(page).to have_content("Account has been scheduled for deletion. " \
+                                   "Note that this process takes place in the background. " \
+                                   "It might take a few moments until the user is fully deleted.")
       expect(page).to have_current_path "/login"
     end
 
@@ -115,7 +117,9 @@ RSpec.describe "user deletion:", :js do
 
       dialog.confirm_flow_with user_password, should_fail: false
 
-      expect(page).to have_content "Account has been locked and was scheduled for deletion"
+      expect(page).to have_content("Account has been scheduled for deletion. " \
+                                   "Note that this process takes place in the background. " \
+                                   "It might take a few moments until the user is fully deleted.")
       expect(page).to have_current_path "/users"
     end
 
@@ -133,7 +137,9 @@ RSpec.describe "user deletion:", :js do
 
       dialog.confirm_flow_with user_password, with_keyboard: true, should_fail: false
 
-      expect(page).to have_content "Account has been locked and was scheduled for deletion"
+      expect(page).to have_content("Account has been scheduled for deletion. " \
+                                   "Note that this process takes place in the background. " \
+                                   "It might take a few moments until the user is fully deleted.")
       expect(page).to have_current_path "/users"
     end
 

--- a/spec/models/queries/placeholder_users/placeholder_user_query_spec.rb
+++ b/spec/models/queries/placeholder_users/placeholder_user_query_spec.rb
@@ -154,8 +154,9 @@ RSpec.describe Queries::PlaceholderUsers::PlaceholderUserQuery do
 
     describe "#results" do
       it "is the same as handwriting the query" do
-        expected = "SELECT \"users\".\"id\", \"users\".\"login\", \"users\".\"firstname\", \"users\".\"lastname\", \"users\".\"mail\", \"users\".\"admin\", \"users\".\"status\", \"users\".\"last_login_on\", \"users\".\"language\", \"users\".\"ldap_auth_source_id\", \"users\".\"created_at\", \"users\".\"updated_at\", \"users\".\"type\", \"users\".\"first_login\", \"users\".\"force_password_change\", \"users\".\"failed_login_count\", \"users\".\"last_failed_login_on\", \"users\".\"consented_at\", \"users\".\"webauthn_id\" FROM \"users\" WHERE \"users\".\"type\" = 'PlaceholderUser' ORDER BY \"users\".\"lastname\" DESC, \"users\".\"id\" DESC"
-
+        # rubocop:disable Layout/LineLength
+        expected = "SELECT \"users\".\"id\", \"users\".\"login\", \"users\".\"firstname\", \"users\".\"lastname\", \"users\".\"mail\", \"users\".\"admin\", \"users\".\"status\", \"users\".\"last_login_on\", \"users\".\"language\", \"users\".\"ldap_auth_source_id\", \"users\".\"created_at\", \"users\".\"updated_at\", \"users\".\"type\", \"users\".\"first_login\", \"users\".\"force_password_change\", \"users\".\"failed_login_count\", \"users\".\"last_failed_login_on\", \"users\".\"consented_at\", \"users\".\"webauthn_id\" FROM \"users\" WHERE \"users\".\"type\" = 'PlaceholderUser' AND \"users\".\"status\" != 5 ORDER BY \"users\".\"lastname\" DESC, \"users\".\"id\" DESC"
+        # rubocop:enable Layout/LineLength
         expect(instance.results.to_sql).to eql expected
       end
     end

--- a/spec/workers/principals/delete_job_integration_spec.rb
+++ b/spec/workers/principals/delete_job_integration_spec.rb
@@ -65,27 +65,24 @@ RSpec.describe Principals::DeleteJob, type: :model do
 
       before do
         work_package
+        principal.update_column(:status, User.statuses[:deleted])
         job
       end
 
       it "resets assigned to to the deleted user" do
-        expect(work_package.reload.assigned_to)
-          .to eql(deleted_user)
+        expect(work_package.reload.assigned_to).to eql(deleted_user)
       end
 
       it "resets assigned to in all journals to the deleted user" do
-        expect(Journal::WorkPackageJournal.pluck(:assigned_to_id))
-          .to eql([deleted_user.id])
+        expect(Journal::WorkPackageJournal.pluck(:assigned_to_id)).to eql([deleted_user.id])
       end
 
       it "resets responsible to to the deleted user" do
-        expect(work_package.reload.responsible)
-          .to eql(deleted_user)
+        expect(work_package.reload.responsible).to eql(deleted_user)
       end
 
       it "resets responsible to in all journals to the deleted user" do
-        expect(Journal::WorkPackageJournal.pluck(:responsible_id))
-          .to eql([deleted_user.id])
+        expect(Journal::WorkPackageJournal.pluck(:responsible_id)).to eql([deleted_user.id])
       end
     end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->
https://community.openproject.org/work_packages/66996

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Hide users marked for deletion from everywhere.


# What approach did you choose and why?
I used ActiveRecord `default_scope` feature because it seems to be the most convenient way...

# Merge checklist

- [x] Added/updated tests
