### PR TITLE
[#67064] PDF/XLS export of new budget columns in project list export

### DIFF
--- a/modules/budgets/app/models/projects/exports/formatters/budget_currency_attribute.rb
+++ b/modules/budgets/app/models/projects/exports/formatters/budget_currency_attribute.rb
@@ -30,7 +30,6 @@
 
 module Projects::Exports::Formatters
   class BudgetCurrencyAttribute < ::Exports::Formatters::Default
-
     def self.apply?(attribute, _export_format)
       budget_mapping.key? attribute.to_sym
     end
@@ -44,7 +43,7 @@ module Projects::Exports::Formatters
     end
 
     def format(project, **)
-      return unless project.module_enabled?("budgets")
+      return unless project.module_enabled?("budgets") && User.current.allowed_in_project?(:view_budgets, project)
 
       project_budgets = ::Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets.new(project)
       budgets_attribute = BudgetCurrencyAttribute.budget_mapping.fetch(attribute.to_sym)
@@ -58,4 +57,3 @@ module Projects::Exports::Formatters
     end
   end
 end
-

--- a/modules/budgets/app/models/projects/exports/formatters/budget_currency_attribute.rb
+++ b/modules/budgets/app/models/projects/exports/formatters/budget_currency_attribute.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Exports::Formatters
+  class BudgetCurrencyAttribute < ::Exports::Formatters::Default
+
+    def self.apply?(attribute, _export_format)
+      budget_mapping.key? attribute.to_sym
+    end
+
+    def self.budget_mapping
+      {
+        budget_available: :total_available,
+        budget_spent: :total_spent,
+        budget_planned: :total_planned
+      }
+    end
+
+    def format(project, **)
+      return unless project.module_enabled?("budgets")
+
+      project_budgets = ::Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets.new(project)
+      budgets_attribute = BudgetCurrencyAttribute.budget_mapping.fetch(attribute.to_sym)
+      return unless project_budgets && budgets_attribute
+
+      budget_format(project_budgets.public_send(budgets_attribute))
+    end
+
+    def budget_format(value)
+      number_to_currency(value, precision: 0)
+    end
+  end
+end
+

--- a/modules/budgets/app/models/projects/exports/formatters/budget_spent_ratio.rb
+++ b/modules/budgets/app/models/projects/exports/formatters/budget_spent_ratio.rb
@@ -30,16 +30,15 @@
 
 module Projects::Exports::Formatters
   class BudgetSpentRatio < ::Exports::Formatters::Default
-    def self.apply?(attribute, export_format)
+    def self.apply?(attribute, _export_format)
       attribute.to_sym == :budget_spent_ratio
     end
 
     def format(project, **)
-      return unless project.module_enabled?("budgets")
+      return unless project.module_enabled?("budgets") && User.current.allowed_in_project?(:view_budgets, project)
 
       project_budgets = ::Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets.new(project)
       number_to_percentage(project_budgets.total_ratio, precision: 0) if project_budgets
     end
   end
 end
-

--- a/modules/budgets/app/models/projects/exports/formatters/budget_spent_ratio.rb
+++ b/modules/budgets/app/models/projects/exports/formatters/budget_spent_ratio.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Exports::Formatters
+  class BudgetSpentRatio < ::Exports::Formatters::Default
+    def self.apply?(attribute, export_format)
+      attribute.to_sym == :budget_spent_ratio
+    end
+
+    def format(project, **)
+      return unless project.module_enabled?("budgets")
+
+      project_budgets = ::Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets.new(project)
+      number_to_percentage(project_budgets.total_ratio, precision: 0) if project_budgets
+    end
+  end
+end
+

--- a/modules/budgets/lib/budgets/engine.rb
+++ b/modules/budgets/lib/budgets/engine.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 module Budgets
   class Engine < ::Rails::Engine
     include OpenProject::Plugins::ActsAsOpEngine
@@ -54,6 +82,11 @@ module Budgets
     end
 
     config.to_prepare do
+      ::Exports::Register.register do
+        formatter Project, Projects::Exports::Formatters::BudgetCurrencyAttribute
+        formatter Project, Projects::Exports::Formatters::BudgetSpentRatio
+      end
+
       OpenProject::ProjectLatestActivity.register on: "Budget"
 
       # Add to the budget to the costs group

--- a/modules/budgets/spec/models/projects/exports/formatters/budget_currency_attribute_spec.rb
+++ b/modules/budgets/spec/models/projects/exports/formatters/budget_currency_attribute_spec.rb
@@ -30,32 +30,65 @@
 
 require "rails_helper"
 
-RSpec.describe "Projects budget formatters" do
+RSpec.describe Projects::Exports::Formatters::BudgetCurrencyAttribute do
   let(:project) { create(:project) }
   let(:project_budgets_double) { instance_double(Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets) }
   let(:budgets_patch_class) { Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets }
+  let(:user_with_permission) { create(:user, member_with_permissions: { project => [:view_budgets] }) }
+  let(:user_without_permission) { create(:user) }
 
   before do
     allow(budgets_patch_class).to receive(:new).with(project).and_return(project_budgets_double)
   end
 
-  describe Projects::Exports::Formatters::BudgetCurrencyAttribute do
-    describe ".apply?" do
-      it "returns true for supported budget attributes" do
-        expect(described_class.apply?(:budget_available, :csv)).to be true
-        expect(described_class.apply?(:budget_spent, :csv)).to be true
-        expect(described_class.apply?(:budget_planned, :csv)).to be true
-        expect(described_class.apply?(:budget_available, :pdf)).to be true
-        expect(described_class.apply?(:budget_spent, :pdf)).to be true
-        expect(described_class.apply?(:budget_planned, :pdf)).to be true
+  describe ".apply?" do
+    it "returns true for supported budget attributes" do
+      expect(described_class.apply?(:budget_available, :csv)).to be true
+      expect(described_class.apply?(:budget_spent, :csv)).to be true
+      expect(described_class.apply?(:budget_planned, :csv)).to be true
+      expect(described_class.apply?(:budget_available, :pdf)).to be true
+      expect(described_class.apply?(:budget_spent, :pdf)).to be true
+      expect(described_class.apply?(:budget_planned, :pdf)).to be true
+    end
+
+    it "returns false for unsupported attributes" do
+      expect(described_class.apply?(:budget_spent_ratio, :csv)).to be false
+    end
+  end
+
+  describe "#format" do
+    it "returns nil when the an attribute is not available" do
+      allow(project_budgets_double).to receive(:total_available).and_return(42.7)
+      instance = described_class.new(:budget_available)
+
+      expect(instance.format(project)).to be_nil
+    end
+
+    it "returns nil when ProjectBudgets is not available" do
+      allow(budgets_patch_class).to receive(:new).with(project).and_return(nil)
+      instance = described_class.new(:budget_spent_ratio)
+
+      expect(instance.format(project)).to be_nil
+    end
+
+    context "with user without permission" do
+      before do
+        User.current = user_without_permission
       end
 
-      it "returns false for unsupported attributes" do
-        expect(described_class.apply?(:budget_spent_ratio, :csv)).to be false
+      it "returns nil" do
+        allow(project_budgets_double).to receive(:total_available).and_return(42.7)
+        instance = described_class.new(:budget_available)
+
+        expect(instance.format(project)).to be_nil
       end
     end
 
-    describe "#format" do
+    context "with user with permission" do
+      before do
+        User.current = user_with_permission
+      end
+
       it "formats the budget available" do
         allow(project_budgets_double).to receive(:total_available).and_return(42.7)
         instance = described_class.new(:budget_available)
@@ -75,43 +108,6 @@ RSpec.describe "Projects budget formatters" do
         instance = described_class.new(:budget_planned)
 
         expect(instance.format(project)).to eq("43 EUR")
-      end
-    end
-  end
-
-  describe Projects::Exports::Formatters::BudgetSpentRatio do
-    describe ".apply?" do
-      it "returns true for :budget_spent_ratio" do
-        expect(described_class.apply?(:budget_spent_ratio, :csv)).to be true
-        expect(described_class.apply?(:budget_spent_ratio, :pdf)).to be true
-      end
-
-      it "returns false for other attributes" do
-        expect(described_class.apply?(:budget_spent, :pdf)).to be false
-        expect(described_class.apply?(:budget_planned, :unknown)).to be false
-      end
-    end
-
-    describe "#format" do
-      it "formats the spent ratio percentage" do
-        allow(project_budgets_double).to receive(:total_ratio).and_return(42.7)
-        instance = described_class.new(:budget_spent_ratio)
-
-        expect(instance.format(project)).to eq("43%")
-      end
-
-      it "returns nil when the spent ratio is not available" do
-        allow(project_budgets_double).to receive(:total_ratio).and_return(nil)
-        instance = described_class.new(:budget_spent_ratio)
-
-        expect(instance.format(project)).to be_nil
-      end
-
-      it "returns nil when ProjectBudgets is not available" do
-        allow(budgets_patch_class).to receive(:new).with(project).and_return(nil)
-        instance = described_class.new(:budget_spent_ratio)
-
-        expect(instance.format(project)).to be_nil
       end
     end
   end

--- a/modules/budgets/spec/models/projects/exports/formatters/budget_formatters_spec.rb
+++ b/modules/budgets/spec/models/projects/exports/formatters/budget_formatters_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "Projects budget formatters" do
+  let(:project) { create(:project) }
+  let(:project_budgets_double) { instance_double(Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets) }
+  let(:budgets_patch_class) { Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets }
+
+  before do
+    allow(budgets_patch_class).to receive(:new).with(project).and_return(project_budgets_double)
+  end
+
+  describe Projects::Exports::Formatters::BudgetCurrencyAttribute do
+    describe ".apply?" do
+      it "returns true for supported budget attributes" do
+        expect(described_class.apply?(:budget_available, :csv)).to be true
+        expect(described_class.apply?(:budget_spent, :csv)).to be true
+        expect(described_class.apply?(:budget_planned, :csv)).to be true
+        expect(described_class.apply?(:budget_available, :pdf)).to be true
+        expect(described_class.apply?(:budget_spent, :pdf)).to be true
+        expect(described_class.apply?(:budget_planned, :pdf)).to be true
+      end
+
+      it "returns false for unsupported attributes" do
+        expect(described_class.apply?(:budget_spent_ratio, :csv)).to be false
+      end
+    end
+
+    describe "#format" do
+      it "formats the budget available" do
+        allow(project_budgets_double).to receive(:total_available).and_return(42.7)
+        instance = described_class.new(:budget_available)
+
+        expect(instance.format(project)).to eq("43 EUR")
+      end
+
+      it "formats the budget spent" do
+        allow(project_budgets_double).to receive(:total_spent).and_return(42.7)
+        instance = described_class.new(:budget_spent)
+
+        expect(instance.format(project)).to eq("43 EUR")
+      end
+
+      it "formats the budget planned" do
+        allow(project_budgets_double).to receive(:total_planned).and_return(42.7)
+        instance = described_class.new(:budget_planned)
+
+        expect(instance.format(project)).to eq("43 EUR")
+      end
+    end
+  end
+
+  describe Projects::Exports::Formatters::BudgetSpentRatio do
+    describe ".apply?" do
+      it "returns true for :budget_spent_ratio" do
+        expect(described_class.apply?(:budget_spent_ratio, :csv)).to be true
+        expect(described_class.apply?(:budget_spent_ratio, :pdf)).to be true
+      end
+
+      it "returns false for other attributes" do
+        expect(described_class.apply?(:budget_spent, :pdf)).to be false
+        expect(described_class.apply?(:budget_planned, :unknown)).to be false
+      end
+    end
+
+    describe "#format" do
+      it "formats the spent ratio percentage" do
+        allow(project_budgets_double).to receive(:total_ratio).and_return(42.7)
+        instance = described_class.new(:budget_spent_ratio)
+
+        expect(instance.format(project)).to eq("43%")
+      end
+
+      it "returns nil when the spent ratio is not available" do
+        allow(project_budgets_double).to receive(:total_ratio).and_return(nil)
+        instance = described_class.new(:budget_spent_ratio)
+
+        expect(instance.format(project)).to be_nil
+      end
+
+      it "returns nil when ProjectBudgets is not available" do
+        allow(budgets_patch_class).to receive(:new).with(project).and_return(nil)
+        instance = described_class.new(:budget_spent_ratio)
+
+        expect(instance.format(project)).to be_nil
+      end
+    end
+  end
+end

--- a/modules/budgets/spec/models/projects/exports/formatters/budget_spent_ratio_spec.rb
+++ b/modules/budgets/spec/models/projects/exports/formatters/budget_spent_ratio_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Exports::Formatters::BudgetSpentRatio do
+  let(:project) { create(:project) }
+  let(:project_budgets_double) { instance_double(Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets) }
+  let(:budgets_patch_class) { Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets }
+  let(:user_with_permission) { create(:user, member_with_permissions: { project => [:view_budgets] }) }
+  let(:user_without_permission) { create(:user) }
+
+  before do
+    allow(budgets_patch_class).to receive(:new).with(project).and_return(project_budgets_double)
+  end
+
+  describe ".apply?" do
+    it "returns true for :budget_spent_ratio" do
+      expect(described_class.apply?(:budget_spent_ratio, :csv)).to be true
+      expect(described_class.apply?(:budget_spent_ratio, :pdf)).to be true
+    end
+
+    it "returns false for other attributes" do
+      expect(described_class.apply?(:budget_spent, :pdf)).to be false
+      expect(described_class.apply?(:budget_planned, :unknown)).to be false
+    end
+  end
+
+  describe "#format" do
+    it "returns nil when the spent ratio is not available" do
+      allow(project_budgets_double).to receive(:total_ratio).and_return(nil)
+      instance = described_class.new(:budget_spent_ratio)
+
+      expect(instance.format(project)).to be_nil
+    end
+
+    it "returns nil when ProjectBudgets is not available" do
+      allow(budgets_patch_class).to receive(:new).with(project).and_return(nil)
+      instance = described_class.new(:budget_spent_ratio)
+
+      expect(instance.format(project)).to be_nil
+    end
+
+    context "with user without permission" do
+      before do
+        User.current = user_without_permission
+      end
+
+      it "returns nil" do
+        allow(project_budgets_double).to receive(:total_ratio).and_return(42.7)
+        instance = described_class.new(:budget_spent_ratio)
+
+        expect(instance.format(project)).to be_nil
+      end
+    end
+
+    context "with user with permission" do
+      before do
+        User.current = user_with_permission
+      end
+
+      it "formats the spent ratio percentage" do
+        allow(project_budgets_double).to receive(:total_ratio).and_return(42.7)
+        instance = described_class.new(:budget_spent_ratio)
+
+        expect(instance.format(project)).to eq("43%")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/67064

# What are you trying to achieve?

Export of columns
budget_available, budget_spent, budget_planned, budget_spent_ratio

if 

* columns are selected in the project list

* module `budgets` is enabled in a project and

* the user has access the permissions to view budget information.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
