### PR TITLE
[66995] Menu item is not correctly highlighted in Meeting "Attended"

### DIFF
--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -111,11 +111,14 @@ module Meetings
 
       [
         menu_item(title: I18n.t(:label_invitations),
-                  query_params: { filters: invitation_filter, sort: "start_time" }),
+                  query_params: { filters: invitation_filter, sort: "start_time" },
+                  selected: params[:filters].to_s.include?("invited_user_id")),
         menu_item(title: I18n.t(:label_attended),
-                  query_params: { filters: attendee_filter, upcoming: false }),
+                  query_params: { filters: attendee_filter, upcoming: false },
+                  selected: params[:filters].to_s.include?("attended_user_id")),
         menu_item(title: I18n.t(:label_created_by_me),
-                  query_params: { filters: author_filter })
+                  query_params: { filters: author_filter },
+                  selected: params[:filters].to_s.include?("author_id"))
       ]
     end
 

--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -107,18 +107,10 @@ module Meetings
     end
 
     def involvement_sidebar_menu_items
-      invitation_filter = [{ invited_user_id: { operator: "=", values: [User.current.id.to_s] } }].to_json
-
       [
-        menu_item(title: I18n.t(:label_invitations),
-                  query_params: { filters: invitation_filter, sort: "start_time" },
-                  selected: params[:filters].to_s.include?("invited_user_id")),
-        menu_item(title: I18n.t(:label_attended),
-                  query_params: { filters: attendee_filter, upcoming: false },
-                  selected: params[:filters].to_s.include?("attended_user_id")),
-        menu_item(title: I18n.t(:label_created_by_me),
-                  query_params: { filters: author_filter },
-                  selected: params[:filters].to_s.include?("author_id"))
+        invitations_menu_item,
+        attended_menu_item,
+        created_by_me_menu_item
       ]
     end
 
@@ -161,6 +153,33 @@ module Meetings
       href_meeting_id = href.split("/").last.to_i
 
       current_recurring_meeting_id == href_meeting_id
+    end
+
+    private
+
+    def invitations_menu_item
+      invitation_filter = [{ invited_user_id: { operator: "=", values: [User.current.id.to_s] } }].to_json
+      menu_item(
+        title: I18n.t(:label_invitations),
+        query_params: { filters: invitation_filter, sort: "start_time" },
+        selected: params[:filters].to_s.include?("invited_user_id")
+      )
+    end
+
+    def attended_menu_item
+      menu_item(
+        title: I18n.t(:label_attended),
+        query_params: { filters: attendee_filter, upcoming: false },
+        selected: params[:filters].to_s.include?("attended_user_id")
+      )
+    end
+
+    def created_by_me_menu_item
+      menu_item(
+        title: I18n.t(:label_created_by_me),
+        query_params: { filters: author_filter },
+        selected: params[:filters].to_s.include?("author_id")
+      )
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66995

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
This bug happens from time to time for other menu items as well in this section. Menu item selection now checks only for the presence of the relevant filter key (e.g. `attended_user_id`, `invited_user_id`, `author_id`) instead of full filter equality. This fixes issues with the menu rendering too early or too late under Turbo and ensures the correct item is marked as selected.
