### PR TITLE
Add localized links for links to docs

### DIFF
--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -47,11 +47,31 @@ module OpenProject
         end
 
         def url_for(*items)
-          links.dig(*items, :href)
+          href = links.dig(*items, :href)
+
+          if docs_url?(href)
+            with_locale_param(href)
+          else
+            href
+          end
         end
 
         def has?(name)
           @links.key? name
+        end
+
+        def docs_url?(url)
+          url.start_with?(docs_url)
+        end
+
+        def docs_url
+          links[:openproject_docs][:href]
+        end
+
+        def with_locale_param(href)
+          url = Addressable::URI.parse(href)
+          url.query_values = (url.query_values || {}).merge(go_to_locale: I18n.locale)
+          url.to_s
         end
 
         private

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -61,7 +61,7 @@ module OpenProject
         end
 
         def docs_url?(url)
-          url.start_with?(docs_url)
+          url&.start_with?(docs_url)
         end
 
         def docs_url

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -46,10 +46,10 @@ module OpenProject
           @links ||= static_links.merge(dynamic_links)
         end
 
-        def url_for(*items)
+        def url_for(*items, localize_url: true)
           href = links.dig(*items, :href)
 
-          if docs_url?(href)
+          if localize_url && docs_url?(href)
             with_locale_param(href)
           else
             href

--- a/lib/open_project_scimitar.rb
+++ b/lib/open_project_scimitar.rb
@@ -33,17 +33,20 @@ module OpenProjectScimitar
     Scimitar::AuthenticationScheme.new(
       type: "oauth2",
       name: "OAuth2",
-      description: OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_static_access_token_authentication_method)
+      description: OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_static_access_token_authentication_method,
+                                                      localize_url: false)
     ),
     Scimitar::AuthenticationScheme.new(
       type: "oauthbearertoken",
       name: "OAuth Bearer Token",
-      description: OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_oauth2_client_credentials_authentication_method)
+      description: OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_oauth2_client_credentials_authentication_method,
+                                                      localize_url: false)
     ),
     Scimitar::AuthenticationScheme.new(
       type: "oidcjwt",
       name: "OpenID Provider JWT",
-      description: OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_jwt_authetication_method)
+      description: OpenProject::Static::Links.url_for(:sysadmin_docs, :scim_jwt_authetication_method,
+                                                      localize_url: false)
     )
   ].freeze
 end

--- a/lib_static/redmine/i18n.rb
+++ b/lib_static/redmine/i18n.rb
@@ -111,10 +111,10 @@ module Redmine
     #
     # @param i18n_key [String] The I18n key to translate.
     # @param links [Hash] Link names mapped to URLs.
-    # @param external [Boolean] Whether the links should be opened as external links, i.e. in a new tab (default: false)
+    # @param external [Boolean] Whether the links should be opened as external links, i.e. in a new tab (default: true)
     # @param underline [Boolean] Whether to underline links inserted into the text (default: true)
-    def link_translate(i18n_key, links: {}, locale: ::I18n.locale, external: false, underline: true)
-      translation = ::I18n.t(i18n_key.to_s, locale:)
+    def link_translate(i18n_key, links: {}, external: true, underline: true) # rubocop:disable Metrics/AbcSize
+      translation = ::I18n.t(i18n_key.to_s)
       result = translation.scan(link_regex).inject(translation) do |t, matches|
         link, text, key = matches
         link_reference = links[key.to_sym]

--- a/spec/components/enterprise_edition/banner_component_spec.rb
+++ b/spec/components/enterprise_edition/banner_component_spec.rb
@@ -49,15 +49,9 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
       }.compact
     }
   end
-  let(:static_links) do
-    {
-      enterprise_features: {
-        some_enterprise_feature: {
-          href:
-        }
-      }
-    }
-  end
+
+  let(:enterprise_feature_link) { href }
+
   let(:translations) do
     {
       ee: {
@@ -82,8 +76,13 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
 
   before do
     allow(OpenProject::Static::Links)
-      .to receive(:links)
-            .and_return(static_links)
+      .to receive(:url_for)
+      .and_call_original
+
+    allow(OpenProject::Static::Links)
+      .to receive(:url_for)
+      .with(:enterprise_features, :some_enterprise_feature)
+      .and_return(enterprise_feature_link)
 
     allow(OpenProject::Token)
       .to receive(:lowest_plan_for)
@@ -248,16 +247,7 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
   end
 
   context "without a link key in the static_link file" do
-    let(:static_links) do
-      {
-        enterprise_features: {
-          default: {
-            href: "https://example.com"
-          },
-          some_enterprise_feature: {}
-        }
-      }
-    end
+    let(:enterprise_feature_link) { nil }
 
     it "uses the default" do
       render_component_in_mo
@@ -266,7 +256,8 @@ RSpec.describe EnterpriseEdition::BannerComponent, type: :component do
 
       expect(component).to have_text(expected_title)
       expect(component).to have_text(expected_description)
-      expect(component).to have_link("More information", href: "https://example.com")
+
+      expect(component).to have_link("More information", href: "https://www.openproject.org/enterprise-edition")
     end
   end
 

--- a/spec/lib/open_project/static/links_spec.rb
+++ b/spec/lib/open_project/static/links_spec.rb
@@ -27,7 +27,6 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
 require "spec_helper"
 
 RSpec.describe OpenProject::Static::Links do
@@ -35,9 +34,105 @@ RSpec.describe OpenProject::Static::Links do
     subject { described_class.url_for(*args) }
 
     let(:args) { %i[enterprise_features board_view] }
+    let(:locale_param) { "?go_to_locale=#{I18n.locale}" }
 
-    it "resolves the URL stored in the href" do
-      expect(subject).to eq("https://www.openproject.org/docs/user-guide/agile-boards/#action-boards-enterprise-add-on")
+    it "resolves the URL stored in the href with a locale" do
+      expect(subject)
+        .to eq("https://www.openproject.org/docs/user-guide/agile-boards/#{locale_param}#action-boards-enterprise-add-on")
+    end
+
+    context "with german locale" do
+      before do
+        I18n.locale = :de
+      end
+
+      it "resolves the URL stored in the href with a locale" do
+        expect(subject)
+          .to eq("https://www.openproject.org/docs/user-guide/agile-boards/#{locale_param}#action-boards-enterprise-add-on")
+      end
+    end
+
+    context "with docs URLs" do
+      let(:args) { %i[sysadmin_docs oidc] }
+
+      it "adds locale parameter to docs URLs" do
+        expect(subject)
+          .to eq("https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/#{locale_param}")
+      end
+    end
+
+    context "with non-docs URLs" do
+      let(:args) { %i[website] }
+
+      it "does not add locale parameter to non-docs URLs" do
+        expect(subject).to eq("https://www.openproject.org")
+        expect(subject).not_to include("go_to_locale=")
+      end
+    end
+  end
+
+  describe ".docs_url?" do
+    subject { described_class.docs_url?(url) }
+
+    context "with docs URLs" do
+      let(:url) { "https://www.openproject.org/docs/user-guide/agile-boards/" }
+
+      it "returns true for URLs that start with the docs base URL" do
+        expect(subject).to be true
+      end
+    end
+
+    context "with non-docs URLs" do
+      let(:url) { "https://www.openproject.org/enterprise-edition" }
+
+      it "returns false for URLs that do not start with the docs base URL" do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe ".with_locale_param" do
+    subject { described_class.with_locale_param(href) }
+
+    let(:href) { "https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/" }
+
+    before do
+      allow(I18n).to receive(:locale).and_return(:en)
+    end
+
+    it "adds go_to_locale parameter to the URL" do
+      expect(subject).to include("go_to_locale=en")
+    end
+
+    it "preserves the original URL structure" do
+      expect(subject).to start_with(href)
+    end
+
+    context "with URL that already has query parameters" do
+      let(:href) { "https://www.openproject.org/docs/user-guide/agile-boards/?section=boards" }
+
+      it "adds go_to_locale parameter while preserving existing parameters" do
+        expect(subject).to include("section=boards")
+        expect(subject).to include("go_to_locale=en")
+      end
+    end
+
+    context "with different locale" do
+      before do
+        allow(I18n).to receive(:locale).and_return(:de)
+      end
+
+      it "uses the current I18n locale" do
+        expect(subject).to include("go_to_locale=de")
+      end
+    end
+  end
+
+  describe ".docs_url" do
+    subject { described_class.docs_url }
+
+    it "returns the base docs URL" do
+      expect(subject).to eq("https://www.openproject.org/docs/")
     end
   end
 end

--- a/spec/lib/redmine/i18n_spec.rb
+++ b/spec/lib/redmine/i18n_spec.rb
@@ -186,7 +186,6 @@ module OpenProject
     end
 
     describe "link_translation" do
-      let(:locale) { :en }
       let(:urls) do
         { url_1: "http://openproject.com/foo", url_2: "/baz" }
       end
@@ -194,31 +193,17 @@ module OpenProject
       before do
         allow(::I18n)
           .to receive(:t)
-          .with("translation_with_a_link", locale: anything)
+          .with("translation_with_a_link")
           .and_return("There is a [link](url_1) in this translation! Maybe even [two](url_2)?")
       end
 
       it "allows to insert links into translations" do
-        translated = link_translate :translation_with_a_link, links: urls
+        translated = link_translate :translation_with_a_link, links: urls, external: false
 
         expect(translated).to eq(
           'There is a <a href="http://openproject.com/foo" data-view-component="true" class="Link Link--underline">link</a>' +
           ' in this translation! Maybe even <a href="/baz" data-view-component="true" class="Link Link--underline">two</a>?'
         )
-      end
-
-      context "with locale" do
-        let(:locale) { :de }
-
-        it "uses the passed locale" do
-          translated = link_translate(:translation_with_a_link, links: urls, locale:)
-
-          expect(translated).to eq(
-            'There is a <a href="http://openproject.com/foo" data-view-component="true" class="Link Link--underline">link</a>' +
-            ' in this translation! Maybe even <a href="/baz" data-view-component="true" class="Link Link--underline">two</a>?'
-          )
-          expect(I18n).to have_received(:t).with(anything, locale:)
-        end
       end
 
       context "when passing URLs as a list of symbols" do
@@ -233,7 +218,7 @@ module OpenProject
         end
 
         it "resolves the links from static links" do
-          translated = link_translate :translation_with_a_link, links: urls
+          translated = link_translate :translation_with_a_link, links: urls, external: false
 
           expect(translated).to eq(
             'There is a <a href="https://example.com/a-b" data-view-component="true" class="Link Link--underline">link</a>' +


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66253

@as-op introduced a link param for docs to quickly switch locales. This PR implements the core change to add this parameter to the core links for docs. We simply compare the URL to the static docs links to find pages which we can translate.

This currently only works for docs.

This PR also:

- Removes the `locale` parameter of link_translate which was introduced for an accessibility message in the past, but is unused by now
- Treats all links as external by default
