### PR TITLE
[67048] Missing padding left on widget header when user doesn't have permission to edit widget title

### DIFF
--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -62,7 +62,7 @@ $grid--widget-padding: 20px 20px 20px 20px
     &.-column
       width: $grid--gap-width
 
-  .op-widget-box--header
+  .op-widget-box--header:has(.grid--area-drag-handle)
     display: flex
     padding-left: 0
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67048

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Remove padding left on the title only when we have the draggable icon
