### PR TITLE
[67045] Wrong capitalization of "Language and region" section under Account settings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3094,7 +3094,7 @@ en:
   label_journal_diff: "Description Comparison"
   label_language: "Language"
   label_languages: "Languages"
-  label_locale: "Language and Region"
+  label_locale: "Language and region"
   label_jump_to_a_project: "Jump to a project..."
   label_keyword_plural: "Keywords"
   label_language_based: "Based on user's language"

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "my", :js do
       context "with a default time zone", with_settings: { user_default_timezone: "Asia/Tokyo" } do
         it "override user time zone" do
           expect(user.pref.time_zone).to eq "Asia/Tokyo"
-          expect(page).to have_heading "Language and Region"
+          expect(page).to have_heading "Language and region"
 
           expect(page).to have_select "Time zone", selected: "(UTC+09:00) Tokyo"
           select "(UTC+01:00) Paris", from: "Time zone"
@@ -89,7 +89,7 @@ RSpec.describe "my", :js do
 
       it "updates user language" do
         expect(user.language).to eq "en"
-        expect(page).to have_heading "Language and Region"
+        expect(page).to have_heading "Language and region"
 
         expect(page).to have_select "Language", selected: "English"
         select "Español", from: "Language"
@@ -103,7 +103,7 @@ RSpec.describe "my", :js do
 
       it "updates user language with change visible on navigating to other settings (regression #66951)" do
         expect(user.language).to eq "en"
-        expect(page).to have_heading "Language and Region"
+        expect(page).to have_heading "Language and region"
 
         expect(page).to have_select "Language", selected: "English"
         select "Português do brasil", from: "Language"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67045
