### PR TITLE
[#61438] Possible to create relations to work package for which user does not have permission to manage relations 

### DIFF
--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -78,8 +78,12 @@ module Relations
     def validate_user_allowed
       return if model.to_id.nil? || model.from_id.nil?
 
-      unless manage_relations?
-        errors.add :base, :error_unauthorized
+      unless from_manageable?
+        errors.add :from_id, :error_not_manageable
+      end
+
+      unless to_manageable?
+        errors.add :to_id, :error_not_manageable
       end
     end
 
@@ -99,8 +103,12 @@ module Relations
       ::WorkPackage.visible(user)
     end
 
-    def manage_relations?
+    def from_manageable?
       user.allowed_in_work_package?(:manage_work_package_relations, model.from)
+    end
+
+    def to_manageable?
+      user.allowed_in_work_package?(:manage_work_package_relations, model.to)
     end
   end
 end

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -36,9 +36,9 @@ module Relations
     attribute :from
     attribute :to
 
-    validate :validate_user_allowed
     validate :validate_from_exists
     validate :validate_to_exists
+    validate :validate_user_allowed
     validate :validate_nodes_relatable
     validate :validate_accepted_type
 
@@ -76,7 +76,8 @@ module Relations
     end
 
     def validate_user_allowed
-      return if model.to_id.nil? || model.from_id.nil?
+      # Only check if the work packages exist and are visible
+      return if skip_validation?
 
       unless from_manageable?
         errors.add :from_id, :error_not_manageable
@@ -109,6 +110,10 @@ module Relations
 
     def to_manageable?
       user.allowed_in_work_package?(:manage_work_package_relations, model.to)
+    end
+
+    def skip_validation?
+      model.to_id.nil? || model.from_id.nil? || errors[:from_id].any? || errors[:to_id].any?
     end
   end
 end

--- a/app/contracts/relations/delete_contract.rb
+++ b/app/contracts/relations/delete_contract.rb
@@ -31,5 +31,15 @@
 module Relations
   class DeleteContract < ::DeleteContract
     delete_permission -> { user.allowed_in_work_package?(:manage_work_package_relations, model.from) }
+
+    validate :validate_to_deletable
+
+    def validate_to_deletable
+      return unless user.allowed_in_work_package?(:manage_work_package_relations, model.from)
+
+      unless user.allowed_in_work_package?(:manage_work_package_relations, model.to)
+        errors.add :base, :error_not_deletable
+      end
+    end
   end
 end

--- a/app/contracts/relations/delete_contract.rb
+++ b/app/contracts/relations/delete_contract.rb
@@ -30,14 +30,14 @@
 
 module Relations
   class DeleteContract < ::DeleteContract
-    delete_permission -> { user.allowed_in_work_package?(:manage_work_package_relations, model.from) }
+    delete_permission -> {
+      user.allowed_in_work_package?(:manage_work_package_relations, model.from) &&
+        user.allowed_in_work_package?(:manage_work_package_relations, model.to)
+    }
 
-    validate :validate_to_deletable
-
-    def validate_to_deletable
-      return unless user.allowed_in_work_package?(:manage_work_package_relations, model.from)
-
-      unless user.allowed_in_work_package?(:manage_work_package_relations, model.to)
+    # Override method to add more specific error
+    def user_allowed
+      unless authorized?
         errors.add :base, :error_not_deletable
       end
     end

--- a/app/controllers/work_package_relations_controller.rb
+++ b/app/controllers/work_package_relations_controller.rb
@@ -30,6 +30,7 @@
 
 class WorkPackageRelationsController < ApplicationController
   include OpTurbo::ComponentStream
+  include OpTurbo::FlashStreamHelper
 
   before_action :set_work_package
   before_action :set_relation, only: %i[edit update]
@@ -48,10 +49,16 @@ class WorkPackageRelationsController < ApplicationController
   end
 
   def edit
-    respond_with_dialog(
-      WorkPackageRelationsTab::WorkPackageRelationDialogComponent
-        .new(work_package: @work_package, relation: @relation)
-    )
+    contract = Relations::UpdateContract.new(@relation, current_user)
+
+    if contract.valid?
+      respond_with_dialog(
+        WorkPackageRelationsTab::WorkPackageRelationDialogComponent
+          .new(work_package: @work_package, relation: @relation)
+      )
+    else
+      respond_with_flash_error(message: I18n.t(:"activerecord.errors.models.relation.attributes.base.error_not_editable"))
+    end
   end
 
   def create
@@ -97,7 +104,11 @@ class WorkPackageRelationsController < ApplicationController
         ServiceResult.success
       end
 
-    respond_with_relations_tab_update(service_result)
+    if service_result.failure?
+      respond_with_flash_error(message: service_result.message)
+    else
+      respond_with_relations_tab_update(service_result)
+    end
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1569,9 +1569,13 @@ en:
             circular_dependency: "The relationship creates a circle of relationships."
           attributes:
             to_id:
+              format: "The selected work package %{message}"
               error_readonly: "cannot be changed for existing relations."
+              error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
             from_id:
+              format: "The selected work package %{message}"
               error_readonly: "cannot be changed for existing relations."
+              error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
         repository:
           not_available: "SCM vendor is not available"
           not_whitelisted: "is not allowed by the configuration."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1568,12 +1568,17 @@ en:
           typed_dag:
             circular_dependency: "The relationship creates a circle of relationships."
           attributes:
+            base:
+              error_not_deletable: "This relation cannot be deleted because you do not have edit permissions for the selected work package."
+              error_not_editable: "This relation cannot be edited because you do not have edit permissions for the selected work package."
             to_id:
               format: "The selected work package %{message}"
+              error_not_found: "could not be found."
               error_readonly: "cannot be changed for existing relations."
               error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
             from_id:
               format: "The selected work package %{message}"
+              error_not_found: "could not be found."
               error_readonly: "cannot be changed for existing relations."
               error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
         repository:

--- a/spec/contracts/relations/delete_contract_spec.rb
+++ b/spec/contracts/relations/delete_contract_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe Relations::DeleteContract do
+  include_context "ModelContract shared context"
+
+  shared_let(:from_project) { create(:project) }
+  shared_let(:to_project) { create(:project) }
+  shared_let(:from_work_package) { create(:work_package, project: from_project) }
+  shared_let(:to_work_package) { create(:work_package, project: to_project) }
+  shared_let(:relation) { create(:relation, from: from_work_package, to: to_work_package) }
+
+  let(:contract) { described_class.new(relation, current_user) }
+
+  context "when user has permission to manage relations for both work packages" do
+    let(:current_user) do
+      create(:user,
+             member_with_permissions: {
+               from_project => %i[manage_work_package_relations],
+               to_project => %i[manage_work_package_relations]
+             })
+    end
+
+    it_behaves_like "contract is valid"
+  end
+
+  context "when user has permission for 'from' work package but not 'to' work package" do
+    let(:current_user) do
+      create(:user,
+             member_with_permissions: {
+               from_project => %i[manage_work_package_relations]
+             })
+    end
+
+    it_behaves_like "contract is invalid", base: :error_not_deletable
+  end
+
+  context "when user has permission for 'to' work package but not 'from' work package" do
+    let(:current_user) do
+      create(:user,
+             member_with_permissions: {
+               to_project => %i[manage_work_package_relations]
+             })
+    end
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+
+  context "when user has no permissions for either work package" do
+    let(:current_user) { create(:user) }
+
+    it_behaves_like "contract is invalid", base: :error_unauthorized
+  end
+
+  context "when user is an admin" do
+    let(:current_user) { create(:admin) }
+
+    it_behaves_like "contract is valid"
+  end
+
+  include_examples "contract reuses the model errors" do
+    let(:current_user) { create(:admin) }
+  end
+end

--- a/spec/contracts/relations/delete_contract_spec.rb
+++ b/spec/contracts/relations/delete_contract_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe Relations::DeleteContract do
              })
     end
 
-    it_behaves_like "contract is invalid", base: :error_unauthorized
+    it_behaves_like "contract is invalid", base: :error_not_deletable
   end
 
   context "when user has no permissions for either work package" do
     let(:current_user) { create(:user) }
 
-    it_behaves_like "contract is invalid", base: :error_unauthorized
+    it_behaves_like "contract is invalid", base: :error_not_deletable
   end
 
   context "when user is an admin" do

--- a/spec/contracts/relations/shared_contract_examples.rb
+++ b/spec/contracts/relations/shared_contract_examples.rb
@@ -99,6 +99,7 @@ RSpec.shared_examples_for "relation contract" do
   before do
     mock_permissions_for(current_user) do |mock|
       mock.allow_in_project *permissions, project: canonical_relation_from.project
+      mock.allow_in_project *permissions, project: canonical_relation_to.project
     end
   end
 
@@ -108,7 +109,17 @@ RSpec.shared_examples_for "relation contract" do
     context "when lacking the necessary permission" do
       let(:permissions) { [] }
 
-      it_behaves_like "contract is invalid", base: :error_unauthorized
+      it_behaves_like "contract is invalid", from_id: :error_not_manageable
+    end
+
+    context "when lacking the necessary permission for the to work package" do
+      before do
+        mock_permissions_for(current_user) do |mock|
+          mock.allow_in_project *permissions, project: canonical_relation_from.project
+        end
+      end
+
+      it_behaves_like "contract is invalid", to_id: :error_not_manageable
     end
 
     context "when the work package for from is not visible" do

--- a/spec/features/work_packages/details/relations/primerized_relations_spec.rb
+++ b/spec/features/work_packages/details/relations/primerized_relations_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe "Primerized work package relations tab",
 
       wait_for_network_idle
 
-      expect(page).to have_text "Related work package not found."
+      expect(page).to have_text "The selected work package could not be found."
 
       relations_tab.search_in_autocompleter(wp_blocks)
 

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
       it "lets the user know the attribute is read-only" do
         msg = JSON.parse(last_response.body)["message"]
 
-        expect(msg).to include "Related work package cannot be changed for existing relations."
+        expect(msg).to include "The selected work package cannot be changed for existing relations."
       end
     end
   end

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -338,8 +338,8 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     context "without manage_work_package_relations" do
       let(:permissions) { [:view_work_packages] }
 
-      it "is forbidden" do
-        expect(last_response).to have_http_status :forbidden
+      it "returns 422" do
+        expect(last_response).to have_http_status :unprocessable_entity
       end
     end
 
@@ -347,7 +347,7 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     # This one is expected to fail (422) because the `to` work package
     # is in another project for which the user does not have permission to
     # view work packages.
-    context "without manage_work_package_relations" do
+    context "without manage_work_package_relations for 'to' work package" do
       let!(:to) { create(:work_package) }
 
       it "returns 422" do

--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -401,8 +401,8 @@ RSpec.describe "API v3 Relation resource", content_type: :json do
     context "lacking the permission" do
       let(:permissions) { %i[view_work_packages] }
 
-      it "returns 403" do
-        expect(last_response).to have_http_status :forbidden
+      it "returns 422" do
+        expect(last_response).to have_http_status :unprocessable_entity
       end
 
       it "leaves the relation" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/61438

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add validations for the 'to' work package when adding/editing a relation
- Improve the validations for the 'from' work package when adding/editing a relation
   - These were simple 'could not be accessed' base errors before, that weren't very helpful, so I changed them to use the improved inline errors as well
- Add a validation for the 'to' work package when deleting a relation
- Add flash error banners for editing/deleting, because inline error messages weren't possible with no form open
   - For the edit case, this is done as soon as the button is pressed, for improved UX
   - Some related errors had to also be reworded to use the common base phrase "The selected work package..."

# Note
- I'm unsure about the API changes, and if those are okay as is or if they need to be documented/noted somewhere else too

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
