### PR TITLE
Use retry_block on activities spec

### DIFF
--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -389,16 +389,11 @@ module Components
       end
 
       def set_journal_sorting(sorting, default_filter: :all)
-        page.find_test_selector("op-wp-journals-sorting-menu").click
-
-        case sorting
-        when :asc
-          page.find_test_selector("op-wp-journals-sorting-asc").click
-        when :desc
-          page.find_test_selector("op-wp-journals-sorting-desc").click
+        retry_block do
+          page.find_test_selector("op-wp-journals-sorting-menu").click
+          page.find_test_selector("op-wp-journals-sorting-#{sorting}").click
+          expect(page).to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")
         end
-
-        wait_for { page }.to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")
       end
 
       def trigger_update_streams_poll


### PR DESCRIPTION
```
  2) Work package activity sorting sorts the activities based on the sorting preference
     Failure/Error: target.find(:test_id, value, **)

     Capybara::ElementNotFound:
       Unable to find visible test_id "op-wp-journals-sorting-desc"
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/finders.rb:312:in 'block in Capybara::Node::Finders#synced_resolve'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in 'Capybara::Node::Base#synchronize'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/finders.rb:301:in 'Capybara::Node::Finders#synced_resolve'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/finders.rb:60:in 'Capybara::Node::Finders#find'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:774:in 'Capybara::Session#find'
     # ./spec/support/finders/test_selector_finders.rb:39:in 'TestSelectorFinders#find_test_selector'
     # ./spec/support/components/work_packages/activities.rb:398:in 'Components::WorkPackages::Activities#set_journal_sorting'
     # ./spec/features/activities/work_package/activities_spec.rb:764:in 'block (3 levels) in <top (required)>'

Finished in 12 minutes 7 seconds (files took 32.85 seconds to load)
2793 examples, 2 failures, 16 pending, 2 errors occurred outside of examples
```
