### PR TITLE
[#62712] highlight the relevant target element when the user gets to a page via a deep link

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component.sass
@@ -19,3 +19,12 @@
     &--journal-notes-body__internal-comment
         border-color: var(--display-brown-borderColor-emphasis)
 
+    & .--anchor-highlighted
+        border: 2px solid var(--borderColor-accent-emphasis)
+        border-radius: var(--borderRadius-medium) // if the element doesn't have a border yet, it should still look good / the same as our Boxes
+        // Box headers may have their own border (e.g. internal comments) which needs to be removed.
+        & .Box-header
+            margin: 0
+            border-top: none
+            border-left: none
+            border-right: none

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -60,15 +60,16 @@ export default class AutoScrollingController extends BaseController {
     // in case of a setAnchor click, we can go for a direct scroll approach
     const scrollableContainer = this.scrollableContainer;
     const activityElement = this.getActivityAnchorElement(anchorName, activityId);
+    const locationHash = `#${anchorName}-${activityId}`;
 
     if (scrollableContainer && activityElement) {
+      this.brieflyHighlightAndResetUrl(activityElement, locationHash);
       scrollableContainer.scrollTo({
         top: activityElement.offsetTop - 90,
         behavior: 'smooth',
       });
     }
-
-    window.location.hash = `#${anchorName}-${activityId}`;
+    window.location.hash = locationHash;
   }
 
   performAutoScrollingOnStreamsUpdate(journalsContainerAtBottom = false) {
@@ -123,24 +124,25 @@ export default class AutoScrollingController extends BaseController {
     const activityIdMatch = window.location.hash.match(anchorTypeRegex); // Ex. [ "#comment-80", "comment", "80" ]
 
     if (activityIdMatch && activityIdMatch.length === 3) {
-      this.scrollToActivity(activityIdMatch[1] as AnchorType, activityIdMatch[2]);
+      const activityElement = this.getActivityAnchorElement(activityIdMatch[1] as AnchorType, activityIdMatch[2]);
+      this.brieflyHighlightAndResetUrl(activityElement, window.location.hash);
+      this.scrollToActivity(activityElement);
     } else if (this.indexOutlet.sortingAscending && (!this.isMobile() || this.isWithinNotificationCenter())) {
       this.scrollToBottom();
     }
   }
 
-  private scrollToActivity(activityAnchorName:AnchorType, activityId:string) {
+  private scrollToActivity(activityElement:HTMLElement|null) {
     const maxAttempts = 20; // wait max 20 seconds for the activity to be rendered
-    this.tryScroll(activityAnchorName, activityId, 0, maxAttempts);
+    this.tryScroll(activityElement, 0, maxAttempts);
   }
 
   private scrollToBottom() {
     this.tryScrollToBottom(0, 20, 'auto');
   }
 
-  private tryScroll(activityAnchorName:AnchorType, activityId:string, attempts:number, maxAttempts:number) {
+  private tryScroll(activityElement:HTMLElement|null, attempts:number, maxAttempts:number) {
     const scrollableContainer = this.scrollableContainer;
-    const activityElement = this.getActivityAnchorElement(activityAnchorName, activityId);
     const topPadding = 70;
 
     if (activityElement && scrollableContainer) {
@@ -194,6 +196,19 @@ export default class AutoScrollingController extends BaseController {
       subtree: true,
       attributes: true,
     });
+  }
+
+  private brieflyHighlightAndResetUrl(activityElement:HTMLElement|null, locationHash:string) {
+    if (activityElement) {
+      activityElement.classList.add('--anchor-highlighted');
+      setTimeout(() => {
+        document.addEventListener('click', () => {
+          activityElement.classList.remove('--anchor-highlighted');
+          const newLocation = window.location.href.replace(locationHash, '');
+          window.history.replaceState(null, 'Remove anchor', newLocation);
+        }, {once: true});
+      });
+    }
   }
 
   private getActivityAnchorElement(activityAnchorName:AnchorType, activityId:string):HTMLElement | null {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -71,7 +71,7 @@ export default class AutoScrollingController extends BaseController {
     window.location.hash = `#${anchorName}-${activityId}`;
   }
 
-  performAutoScrollingOnStreamsUpdate(journalsContainerAtBottom:boolean = false) {
+  performAutoScrollingOnStreamsUpdate(journalsContainerAtBottom = false) {
     if (this.indexOutlet.sortingAscending && journalsContainerAtBottom) {
       // scroll to (new) bottom if sorting is ascending and journals container was already at bottom before a new activity was added
       if (this.isMobile()) {
@@ -92,7 +92,7 @@ export default class AutoScrollingController extends BaseController {
     }
   }
 
-  scrollInputContainerIntoView(timeout:number = 0, behavior:ScrollBehavior = 'smooth') {
+  scrollInputContainerIntoView(timeout = 0, behavior:ScrollBehavior = 'smooth') {
     const inputContainer = this.inputContainer;
     setTimeout(() => {
       if (inputContainer) {
@@ -104,7 +104,7 @@ export default class AutoScrollingController extends BaseController {
     }, timeout);
   }
 
-  scrollJournalContainer(toBottom:boolean, smooth:boolean = false) {
+  scrollJournalContainer(toBottom:boolean, smooth = false) {
     const scrollableContainer = this.scrollableContainer;
     if (scrollableContainer) {
       if (smooth) {
@@ -154,16 +154,20 @@ export default class AutoScrollingController extends BaseController {
         scrollableContainer.scrollTop = relativeTop - topPadding;
       }, 50);
     } else if (attempts < maxAttempts) {
-      setTimeout(() => this.tryScroll(activityAnchorName, activityId, attempts + 1, maxAttempts), 1000);
+      setTimeout(() => {
+        this.tryScroll(activityElement, attempts + 1, maxAttempts);
+      }, 1000);
     }
   }
 
-  private tryScrollToBottom(attempts:number = 0, maxAttempts:number = 20, behavior:ScrollBehavior = 'smooth') {
+  private tryScrollToBottom(attempts = 0, maxAttempts = 20, behavior:ScrollBehavior = 'smooth') {
     const scrollableContainer = this.scrollableContainer;
 
     if (!scrollableContainer) {
       if (attempts < maxAttempts) {
-        setTimeout(() => this.tryScrollToBottom(attempts + 1, maxAttempts), 1000);
+        setTimeout(() => {
+          this.tryScrollToBottom(attempts + 1, maxAttempts);
+        }, 1000);
       }
       return;
     }

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -274,6 +274,17 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
 
         activity_tab.expect_journal_notes(text: "First comment by admin")
       end
+
+      it "highlights the comment specified in the URL until the user clicks anywhere" do
+        visit project_work_package_path(project, work_package.id, "activity", anchor: "activity-2")
+        wp_page.wait_for_activity_tab
+
+        highlighted_comment = page.find(".--anchor-highlighted")
+        expect(highlighted_comment).to have_content("First comment by admin")
+        # click anything (without triggering navigation or something else)
+        page.find(:xpath, "//*[text()='First comment by admin']").click
+        expect(page).to have_no_css(".--anchor-highlighted")
+      end
     end
   end
 
@@ -1042,11 +1053,19 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             wp_page.wait_for_activity_tab
           end
 
-          it "scrolls to the comment specified in the URL" do
+          it "scrolls to the activity specified in the URL" do
             wait_for_auto_scrolling_to_finish
             activity_tab.expect_journal_container_at_position(50) # would be at the bottom if no anchor would be provided
 
             activity_tab.expect_activity_anchor_link(text: format_time(comment_1.updated_at))
+          end
+
+          it "highlights the activity specified in the URL until the user clicks anywhere" do
+            highlighted_comment = page.find(".--anchor-highlighted")
+            expect(highlighted_comment).to have_content("created this on")
+            # click anything (without triggering navigation or something else)
+            page.find(:xpath, "//*[text()='created this on']").click
+            expect(page).to have_no_css(".--anchor-highlighted")
           end
         end
 
@@ -1065,6 +1084,14 @@ RSpec.describe "Work package activity", :js, :with_cuprite do
             activity_tab.filter_journals(:only_changes)
 
             activity_tab.expect_activity_anchor_link(text: format_time(comment_1.updated_at))
+          end
+
+          it "highlights the comment specified in the URL until the user clicks anywhere" do
+            highlighted_comment = page.find(".Box.--anchor-highlighted")
+            expect(highlighted_comment).to have_content("Comment 1")
+            # click anything (without triggering navigation or something else)
+            page.find(:xpath, "//*[text()='Comment 1']").click
+            expect(page).to have_no_css(".Box.--anchor-highlighted")
           end
         end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/62712

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When a user opens a link to a work package with an anchor to an comment or activity, this comment or activity should be highlighted until the user clicks anywhere in the page.

## Screenshots
<img width="964" height="316" alt="Screenshot from 2025-09-01 13-03-26" src="https://github.com/user-attachments/assets/07946c96-a46c-4853-becc-b0b3a7dd126a" />
<img width="961" height="139" alt="Screenshot from 2025-09-01 13-03-36" src="https://github.com/user-attachments/assets/d094ef80-2ae7-420a-8a19-ab7ec6f75ad6" />
<img width="952" height="291" alt="Screenshot from 2025-09-01 13-51-13" src="https://github.com/user-attachments/assets/ed53dc00-b151-4b13-9836-94df31a559de" />
<img width="961" height="304" alt="Screenshot from 2025-09-01 13-12-18" src="https://github.com/user-attachments/assets/a4df38df-2abb-488d-8475-1c9eac497e07" />

# What approach did you choose and why?
We first considered using an CSS-only approach, but this isn't as straight-forward as it looks, because comments are loaded after the rest of the work package page. The CSS-only approach only worked when the site was already loaded or the element to highlight was in the initial page. We considered adding workarounds but decided against that since all ideas we had would be quite unexpected and probably lead to other problems in the long run. So using anchors and HTML IDs did not work. Since the scrolling was already done via javascript, I enhanced this to also highlight.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc) => not applicable
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
