### PR TITLE
[#67161] disable ampf check for completeness of sharepoint storages

### DIFF
--- a/modules/storages/app/models/storages/sharepoint_storage.rb
+++ b/modules/storages/app/models/storages/sharepoint_storage.rb
@@ -94,7 +94,8 @@ module Storages
         storage_oauth_client_configured: oauth_client.present?,
         storage_redirect_uri_configured: oauth_client&.persisted?,
         storage_tenant_drive_configured: tenant_id.present?,
-        access_management_configured: !automatic_management_unspecified?,
+        # FIXME: Reenable the check once AMPF is configurable
+        # access_management_configured: !automatic_management_unspecified?,
         name_configured: name.present?
       }
     end


### PR DESCRIPTION
# Ticket
[#67161](https://community.openproject.org/work_packages/67161)

# What are you trying to accomplish?
- ampf configuration no longer needed for a sharepoint storage completeness (temporarily)

### Hint

- This is needed to make the sharepoint integration testable while still being behind a feature flag.
