### PR TITLE
[#67159] Fix Delete action in Projects List menu

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -375,7 +375,7 @@ module Projects
           icon: :trash,
           label: I18n.t(:button_delete),
           href: confirm_destroy_project_path(project),
-          data: { turbo: false }
+          data: { turbo_stream: true }
         }
       end
     end

--- a/spec/components/projects/row_component_spec.rb
+++ b/spec/components/projects/row_component_spec.rb
@@ -31,20 +31,70 @@
 require "rails_helper"
 
 RSpec.describe Projects::RowComponent, type: :component do
-  describe "#name" do
+  include Rails.application.routes.url_helpers
+
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:project) { build_stubbed(:project, name: "My Project No. 1", identifier: "myproject_no_1") }
+  let(:table) do
+    instance_double(Projects::TableComponent, columns: [Queries::Projects::Selects::Default.new(:name)],
+                                              favored_project_ids: [])
+  end
+
+  let(:user) { build_stubbed(:user) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_component(row: [project, 0], table:)
+  end
+
+  describe "Project Name" do
     it "renders the project name as a link" do
-      project = build_stubbed(:project, name: "My Project No. 1", identifier: "myproject_no_1")
-
-      table = instance_double(Projects::TableComponent, columns: [Queries::Projects::Selects::Default.new(:name)],
-                                                        favored_project_ids: [])
-      component = described_class.new(row: [project, 0], table:)
-
-      render_inline(component)
-
-      expect(page).to have_css(
+      expect(rendered_component).to have_css(
         "a[data-turbo='false'][href='/projects/myproject_no_1']",
         text: "My Project No. 1"
       )
+    end
+  end
+
+  describe "Menu" do
+    context "when the user has no project edit permissions" do
+      it "renders a Primer ActionMenu (single variant)" do
+        expect(subject).to have_element "action-menu", "data-select-variant": "none"
+      end
+
+      it "renders menu items", :aggregate_failures do
+        expect(rendered_component).to have_menu do |menu|
+          expect(menu).to have_selector :menuitem, count: 1
+          expect(menu).to have_selector :menuitem, text: "Add to favorites"
+        end
+      end
+    end
+
+    context "when the user has project edit permissions" do
+      let(:user) { build_stubbed(:admin) }
+
+      it "renders a Primer ActionMenu (single variant)" do
+        expect(subject).to have_element "action-menu", "data-select-variant": "none"
+      end
+
+      it "renders menu items", :aggregate_failures do
+        expect(rendered_component).to have_menu do |menu|
+          expect(menu).to have_selector :menuitem, count: 7
+          expect(menu).to have_selector :menuitem, text: "New subproject"
+          expect(menu).to have_selector :menuitem, text: "Project settings"
+          expect(menu).to have_selector :menuitem, text: "Project activity"
+          expect(menu).to have_selector :menuitem, text: "Add to favorites"
+          expect(menu).to have_selector :menuitem, text: "Archive"
+          expect(menu).to have_selector :menuitem, text: "Copy"
+          expect(menu).to have_selector :menuitem, text: "Delete" do |link|
+            expect(link[:href]).to eq confirm_destroy_project_path(project)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/components/projects/row_component_spec.rb
+++ b/spec/components/projects/row_component_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Projects::RowComponent, type: :component do
           expect(menu).to have_selector :menuitem, text: "Copy"
           expect(menu).to have_selector :menuitem, text: "Delete" do |link|
             expect(link[:href]).to eq confirm_destroy_project_path(project)
+            expect(link[:"data-turbo-stream"]).to eq "true"
           end
         end
       end

--- a/spec/features/projects/destroy_spec.rb
+++ b/spec/features/projects/destroy_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Projects#destroy", :js do
 
       click_on "Delete permanently"
     end
-    expect(page).to have_no_modal "Delete project foo"
+    expect(page).to have_no_modal "Delete project"
 
     expect_flash type: :success, message: I18n.t("projects.delete.scheduled")
     expect(project.reload).to eq(project)

--- a/spec/features/projects/lists/table_spec.rb
+++ b/spec/features/projects/lists/table_spec.rb
@@ -272,6 +272,26 @@ RSpec.describe "Projects lists table display and actions", :js, with_settings: {
         expect(project).not_to be_favored_by(admin)
       end
 
+      specify "project can be deleted" do
+        login_as(admin)
+        visit projects_path
+
+        projects_page.activate_menu_of(project) do |menu|
+          expect(menu).to have_text("Delete")
+          click_link_or_button "Delete"
+        end
+
+        expect(page).to have_modal "Delete project"
+
+        within_modal "Delete project" do
+          expect(page).to have_heading "Permanently delete this project?"
+
+          # We test the actual deletion in spec/features/projects/destroy_spec.rb
+          click_on "Cancel"
+        end
+        expect(page).to have_no_modal "Delete project"
+      end
+
       specify "flash sortBy is being escaped" do
         login_as(admin)
         visit projects_path(sortBy: "[[\"><script src='/foobar.js'></script>\",\"\"]]")


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/67159

# What are you trying to accomplish?

Fixes the project deletion from the Projects List row menu. This should have been part of [OP # 64885](https://community.openproject.org/wp/64885) / opf/openproject#19684, but was overlooked.

Also adds basic examples to component specs and Projects List feature.

## Screenshots

<img width="260" height="276" alt="Screenshot 2025-09-01 at 15 42 17" src="https://github.com/user-attachments/assets/1513ac0b-4990-41ca-a128-16caeb764256" />

<img width="1011" height="415" alt="Screenshot 2025-09-01 at 15 42 23" src="https://github.com/user-attachments/assets/7faeba86-a844-4218-b37a-69b559763824" />




# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
