### PR TITLE
Be more lenient in the fields passed to the modal

### DIFF
--- a/app/components/work_packages/progress/base_modal_component.rb
+++ b/app/components/work_packages/progress/base_modal_component.rb
@@ -91,11 +91,7 @@ module WorkPackages
         # an element by default.
         return nil if field.nil?
 
-        field = FIELD_MAP[field.to_s]
-
-        return field if field.present?
-
-        raise ArgumentError, "The selected field is not one of #{FIELD_MAP.keys.join(', ')}."
+        FIELD_MAP[field.to_s].presence || :no_field
       end
     end
   end

--- a/spec/components/work_packages/progress/shared_modal_examples.rb
+++ b/spec/components/work_packages/progress/shared_modal_examples.rb
@@ -30,23 +30,11 @@
 
 RSpec.shared_examples_for "progress modal validations" do
   describe "validations" do
-    context "when focused_field is not an accepted value" do
-      it "raises an ArgumentError" do
+    context "when focused_field is not an accepted value (Regression #62075)" do
+      it "returns :no_field" do
         work_package = build(:work_package)
 
-        expect do
-          described_class.new(work_package, focused_field: :foo)
-        end.to raise_error(ArgumentError, /The selected field is not one of/)
-      end
-    end
-
-    context "when given another progress related not accepted by the component" do
-      it "raises an ArgumentError" do
-        work_package = build(:work_package)
-
-        expect do
-          described_class.new(work_package, focused_field: "jerry")
-        end.to raise_error(ArgumentError, /The selected field is not one of/)
+        expect(described_class.new(work_package, focused_field: "global-search--input").focused_field).to eq(:no_field)
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/62075/github

# What are you trying to accomplish?
When we do focus another input field on the page, the debounced preview logic kicks in and passes the fields name to the `frmaeSrc`. Since the search field is not whitelisted, we are throwing an argument error. This seems a bit strict. The new logic accepts all field values. The modal is closed immediately afterwards anyways and this cancels the loading.


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
