### PR TITLE
Implementation/64530 extend project api to consider calculated values

### DIFF
--- a/docs/api/apiv3/tags/schemas.yml
+++ b/docs/api/apiv3/tags/schemas.yml
@@ -51,6 +51,7 @@ description: |-
   | minLength         | The value of the property must at least contain the specified amount of characters | Integer      | 0       |
   | maxLength         | The value of the property must at most contain the specified amount of characters  | Integer      | ∞       |
   | regularExpression | The value of the property must match the given regular expression (if not null)    | String       | null    |
+  | formula           | If present, contains a formula that is used to calculate the value of the property | String       | null    |
   | location          | If present, contains a reference to the location of the property in the JSON       | String       | null    |
   | description       | If present, contains a formattable, human readable description                     | Formattable  | null    |
   | deprecated        | If present, the client should consider the existence of the property deprecated    | Boolean      | false   |

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -69,6 +69,7 @@ module API
                     :max_length,
                     :regular_expression,
                     :options,
+                    :formula,
                     :location,
                     :description,
                     :deprecated
@@ -84,6 +85,7 @@ module API
       property :regular_expression, exec_context: :decorator
       property :deprecated, exec_context: :decorator
       property :options, exec_context: :decorator
+      property :formula, exec_context: :decorator, render_nil: false
 
       property :location, exec_context: :decorator
 

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -63,6 +63,7 @@ module API
                    max_length: nil,
                    regular_expression: nil,
                    options: {},
+                   formula: nil,
                    show_if: true,
                    description: nil,
                    deprecated: nil)
@@ -77,6 +78,7 @@ module API
                                    max_length,
                                    regular_expression,
                                    options,
+                                   formula,
                                    location,
                                    description,
                                    deprecated)
@@ -299,6 +301,7 @@ module API
                                  max_length,
                                  regular_expression,
                                  options,
+                                 formula,
                                  location,
                                  description,
                                  deprecated)
@@ -317,6 +320,7 @@ module API
         schema.max_length = max_length
         schema.regular_expression = regular_expression
         schema.options = options
+        schema.formula = formula
 
         schema
       end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -43,7 +43,8 @@ module API
           "version" => "Version",
           "list" => "CustomOption",
           "hierarchy" => "CustomField::Hierarchy::Item",
-          "scored_list" => "CustomField::Hierarchy::Item"
+          "scored_list" => "CustomField::Hierarchy::Item",
+          "calculated_value" => "CalculatedValue"
         }.freeze
 
         LINK_FORMATS = %w(list user version hierarchy).freeze
@@ -197,7 +198,8 @@ module API
                         min_length: cf_min_length(custom_field),
                         max_length: cf_max_length(custom_field),
                         regular_expression: cf_regexp(custom_field),
-                        options: cf_options(custom_field)
+                        options: cf_options(custom_field),
+                        formula: cf_formula(custom_field)
         end
 
         def inject_link_value(custom_field, config)
@@ -322,6 +324,12 @@ module API
 
         def cf_regexp(custom_field)
           custom_field.regexp.presence
+        end
+
+        def cf_formula(custom_field)
+          if custom_field.field_format_calculated_value?
+            custom_field.formula_string
+          end
         end
 
         def cf_options(custom_field)

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -35,23 +35,35 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
 
   subject(:generated) { representer.to_json }
 
+  let(:available_custom_fields) { [int_custom_field, version_custom_field] }
+  let(:all_available_custom_fields) { [int_custom_field, version_custom_field] }
   let(:project) do
     build_stubbed(:project,
                   :with_status,
                   parent: parent_project,
                   description: "some description").tap do |p|
-      allow(p).to receive_messages(available_custom_fields: [int_custom_field, version_custom_field],
-                                   all_available_custom_fields: [int_custom_field, version_custom_field],
+      allow(p).to receive_messages(available_custom_fields:,
+                                   all_available_custom_fields:,
                                    ancestors_from_root: ancestors)
 
-      allow(p)
-        .to receive(int_custom_field.attribute_getter)
-              .and_return(int_custom_value.value)
+      if available_custom_fields.include?(int_custom_field)
+        allow(p)
+          .to receive(int_custom_field.attribute_getter)
+                .and_return(int_custom_value.value)
+      end
 
-      allow(p)
-        .to receive(:custom_value_for)
-              .with(version_custom_field)
-              .and_return(version_custom_value)
+      if available_custom_fields.include?(version_custom_field)
+        allow(p)
+          .to receive(:custom_value_for)
+                .with(version_custom_field)
+                .and_return(version_custom_value)
+      end
+
+      if available_custom_fields.include?(calculated_value_custom_field)
+        allow(p)
+          .to receive(calculated_value_custom_field.attribute_getter)
+                .and_return(calculated_custom_value.value)
+      end
     end
   end
 
@@ -71,6 +83,14 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
         .to receive(:typed_value)
               .and_return(version)
     end
+  end
+  let(:calculated_value_custom_field) do
+    build_stubbed(:calculated_value_project_custom_field, :skip_validations, admin_only: false, formula: "21 + 3")
+  end
+  let(:calculated_custom_value) do
+    CustomValue.new(custom_field: calculated_value_custom_field,
+                    value: "24.0",
+                    customized: nil)
   end
   let(:permissions) { %i[view_project add_work_packages view_members] }
   let(:parent_project) do
@@ -185,6 +205,17 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
         it "has no property for the int custom field" do
           expect(subject).not_to have_json_path("customField#{int_custom_field.id}")
         end
+      end
+    end
+
+    describe "calculated value custom field" do
+      let(:available_custom_fields) { [calculated_value_custom_field] }
+      let(:all_available_custom_fields) { [calculated_value_custom_field] }
+      let(:cf_path) { "customField#{calculated_value_custom_field.id}" }
+
+      it "has a property for the calculated value custom field" do
+        expect(subject).to be_json_eql(calculated_custom_value.value.to_json)
+                             .at_path(cf_path)
       end
     end
   end

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -88,9 +88,7 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
     build_stubbed(:calculated_value_project_custom_field, :skip_validations, admin_only: false, formula: "21 + 3")
   end
   let(:calculated_custom_value) do
-    CustomValue.new(custom_field: calculated_value_custom_field,
-                    value: "24.0",
-                    customized: nil)
+    build(:custom_value, custom_field: calculated_value_custom_field, value: "24.0")
   end
   let(:permissions) { %i[view_project add_work_packages view_members] }
   let(:parent_project) do

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -55,25 +55,16 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
     end
 
     allow(contract)
-      .to receive(:available_custom_fields)
-      .and_return([custom_field])
-
-    allow(contract)
       .to receive(:assignable_values)
       .with(:status_code, current_user)
       .and_return(allowed_status)
 
     allow(contract)
-      .to receive(:model)
-      .and_return(model)
+      .to receive_messages(available_custom_fields: [custom_field], model: model)
+
 
     allow(model)
-      .to receive(:new_record?)
-      .and_return(new_record)
-
-    allow(model)
-      .to receive(:id)
-      .and_return(model_id)
+      .to receive_messages(new_record?: new_record, id: model_id)
 
     contract
   end

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
   let(:custom_field) do
     build_stubbed(:integer_project_custom_field)
   end
+  let(:calculated_value_cf) do
+    build_stubbed(:calculated_value_project_custom_field, formula: "23 + {{cf_#{custom_field.id}}}")
+  end
   let(:allowed_status) { ["some status"] }
   let(:contract) do
     contract = double("contract")
@@ -60,8 +63,7 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
       .and_return(allowed_status)
 
     allow(contract)
-      .to receive_messages(available_custom_fields: [custom_field], model: model)
-
+      .to receive_messages(available_custom_fields: [custom_field, calculated_value_cf], model: model)
 
     allow(model)
       .to receive_messages(new_record?: new_record, id: model_id)
@@ -84,7 +86,7 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
     end
   end
 
-  context "generation" do
+  describe "generation" do
     subject(:generated) { representer.to_json }
 
     describe "_type" do
@@ -294,6 +296,18 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
       it_behaves_like "has basic schema properties" do
         let(:type) { "Integer" }
         let(:name) { custom_field.name }
+        let(:required) { false }
+        let(:writable) { false }
+      end
+    end
+
+    describe "calculated value custom field" do
+      let(:path) { "customField#{calculated_value_cf.id}" }
+
+      it_behaves_like "has basic schema properties" do
+        let(:type) { "CalculatedValue" }
+        let(:name) { calculated_value_cf.name }
+        let(:formula) { "23 + {{cf_#{custom_field.id}}}" }
         let(:required) { false }
         let(:writable) { false }
       end

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -82,6 +82,16 @@ RSpec.shared_examples_for "has basic schema properties" do
       expect(subject).not_to have_json_path("#{path}/description")
     end
   end
+
+  it "indicates if it has a formula" do
+    if defined?(formula)
+      expect(subject)
+        .to be_json_eql(formula.to_json)
+              .at_path("#{path}/formula")
+    else
+      expect(subject).not_to have_json_path("#{path}/formula")
+    end
+  end
 end
 
 RSpec.shared_examples_for "indicates length requirements" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64530

# What are you trying to accomplish?

Offer a way to interact with calculated values using the API.

There were two possibilities of representing calculated values in the API:

1. As a separate resource that can (but is not required to) be embedded into a project representation. It has its own ID and API, offering ways to read and write it. This is done for custom fields such as Version or User, where you can also do a lot with the resources apart from enabling or disabling them.
2. As a property of projects. This is done for custom fields such as Integer, Float or Boolean.

After [multiple discussions and brainstorming](https://community.openproject.org/projects/development/meetings/6404), I went with the second approach. The main reason is that calculated values have a assigned custom value that is a constant - not an ID to relating to another model. The latter is required to properly build an API around it. We don't get that here, so we would have to either blow up the entire implementation by defining an actual model for calculated values - or we need to treat it like a pseudo-resource within the API. I didn't like either of these options. The only thing that sets calculated values apart from a float is that they contain a formula and may produce errors. This is not enough to justify the mention measures. Meaning:

* Calculated values behave a lot like project custom fields of type float:
  * They are returned as a floating point value if a value could be calculated.
  * If no value could be calculated, they are rendered as `nil`.
* Within the project schema, calculated values are represented with their own type, they will also include their formula.
* Following our past implementations, the feature flag is not checked when _reading_ calculated values. Within the API, there is no way to create calculated values, see the _caveats_ section. As a consequence, the feature flag plays no role in this PR.
  * Conditional read access will be a concern once the [Enterprise Token](https://community.openproject.org/wp/64529) is added.
* The current PR does not support error messages. This will be a concern of the upcoming [error handling work package](https://community.openproject.org/wp/66093).

## Caveats

* The project custom field support within our API is very basic. There is no way to edit project custom fields like admins can within the web UI. You cannot edit them, you cannot disable them per project. You can only enable them per project implicitly by assigning a value to them.
* Calculated values have no writable value - therefore you cannot enable them by assigning a value to them.
* Since project custom fields cannot be edited, there is no way to edit the formula of a calculated value via the API.

All of the above could be addressed by providing a proper project custom field API that offers mostly the same features as the Web UI. The current implementation aims to integrate calculated values into the current API structure as well as possible.

## Examples

Project schema response (excerpt):

```json
{
  "_type": "Schema",
  "_dependencies": [],
  "id": {
    "type": "Integer",
    "name": "ID",
    "required": true,
    "hasDefault": false,
    "writable": false,
    "options": {}
  },
  "name": {
    "type": "String",
    "name": "Name",
    "required": true,
    "hasDefault": false,
    "writable": true,
    "minLength": 1,
    "maxLength": 255,
    "options": {}
  },
  "_attributeGroups": [
    {
      "_type": "ProjectFormCustomFieldSection",
      "id": 4,
      "name": "Project attributes",
      "attributes": [
        "customField17",
        "customField20",
        "customField21"
      ]
    }
  ],
  "customField17": {
    "type": "Float",
    "name": "float value",
    "required": false,
    "hasDefault": false,
    "writable": true,
    "options": {
      "rtl": null
    }
  },
  "customField20": {
    "type": "CalculatedValue",
    "name": "calc val",
    "required": false,
    "hasDefault": false,
    "writable": true,
    "options": {
      "rtl": null
    },
    "formula": "{{cf_17}} * 2"
  },
  "customField21": {
    "type": "Version",
    "name": "version field",
    "required": false,
    "hasDefault": false,
    "writable": true,
    "location": "_links",
    "_links": {}
  },
  "_links": {
    "self": {
      "href": "/api/v3/projects/schema"
    }
  }
}
```

Project response (excerpt):

```json
{
  "_embedded": {
    "status": {
      "_type": "ProjectStatus",
      "id": "on_track",
      "name": "On track",
      "_links": {
        "self": {
          "href": "/api/v3/project_statuses/on_track",
          "title": "On track"
        }
      }
    },
    "customField21": {
      "_type": "Version",
      "id": 25,
      "name": "v1",
      "description": {
        "format": "plain",
        "raw": "v1 description",
        "html": "<p>v1 description</p>"
      },
      "startDate": "2025-09-01",
      "endDate": "2025-09-15",
      "status": "open",
      "sharing": "none",
      "createdAt": "2025-09-01T13:10:07.687Z",
      "updatedAt": "2025-09-01T13:10:07.687Z",
      "_links": {
        "self": {
          "href": "/api/v3/versions/25",
          "title": "v1"
        }
      }
    }
  },
  "_type": "Project",
  "id": 4,
  "identifier": "demo-project",
  "name": "Demo project",
  "customField17": 98.0,
  "customField20": 196,
  "_links": {
    "self": {
      "href": "/api/v3/projects/4",
      "title": "Demo project"
    },
    "customField21": {
      "title": "v1",
      "href": "/api/v3/versions/25"
    },
    "parent": {
      "href": null
    }
  }
}
```

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in API
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
