### PR TITLE
[#62712] Adapt wording to be consistent with work packages

### DIFF
--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -220,7 +220,7 @@ en:
       agenda_items: "Copy agenda items"
       agenda_text: "Copy the agenda of the old meeting"
       participants: "Copy list of participants"
-      to_clipboard: "Copy to clipboard"
+      to_clipboard: "Copy link to clipboard"
     email:
       send_emails: "Email participants"
       send_invitation_emails: >

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe "Meetings CRUD",
     expect(page).to have_test_selector("op-meeting-agenda-actions", count: 3)
 
     show_page.open_menu(second) do
-      expect(page).to have_css(".ActionListItem-label", text: "Copy to clipboard")
+      expect(page).to have_css(".ActionListItem-label", text: "Copy link to clipboard")
       expect(page).to have_css(".ActionListItem-label", count: 1)
     end
   end


### PR DESCRIPTION
# Ticket
Side quest during https://community.openproject.org/work_packages/62712

# What are you trying to accomplish?
Make it more clear for users what happens when they click on this button and align with the wording that is used in other places, e.g. work package comments

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
