### PR TITLE
Fix nesting in EE::BannerComponent stylesheet

### DIFF
--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -121,7 +121,7 @@ $op-enterprise-banner-fixed-height-large: 320px
 
   &--close-icon
     .Button-visual
-    color: var(--enterprise-upsell-color)
+      color: var(--enterprise-upsell-color)
 
     &_hovering
       position: absolute


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Fixes nesting of `color` property in the `EnterpriseEdition::BannerComponent` stylesheet. Should fix the following warning in the console:

    ▲ [WARNING] This selector doesn't have any properties and won't be rendered. [plugin angular-sass]

        ../app/components/enterprise_edition/banner_component.sass:123:4:
          123 │     .Button-visual
              ╵     ^


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
