### PR TITLE
Bump rails to 8.0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "activemodel-serializers-xml", "~> 1.0.1"
 gem "activerecord-import", "~> 2.2.0"
 gem "activerecord-session_store", "~> 2.2.0"
 gem "ox"
-gem "rails", "~> 8.0.1"
+gem "rails", "~> 8.0.2", ">= 8.0.2.1"
 gem "responders", "~> 3.0"
 
 gem "ffi", "~> 1.15"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1479,7 +1479,7 @@ DEPENDENCIES
   rack-test (~> 2.2.0)
   rack-timeout (~> 0.7.0)
   rack_session_access
-  rails (~> 8.0.1)
+  rails (~> 8.0.2, >= 8.0.2.1)
   rails-controller-testing (~> 1.0.2)
   rails-i18n (~> 8.0.0)
   rbtrace


### PR DESCRIPTION
https://rubyonrails.org/2025/8/13/Rails-Versions-8-0-2-1-7-2-2-2-and-7-1-5-2-have-been-released