### PR TITLE
Bug/67198 all meetings from calendar link show as not accepted but user cannot react to them

### DIFF
--- a/modules/meeting/app/models/scheduled_meeting.rb
+++ b/modules/meeting/app/models/scheduled_meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,7 +29,7 @@
 #++
 
 class ScheduledMeeting < ApplicationRecord
-  belongs_to :meeting
+  belongs_to :meeting, inverse_of: :scheduled_meeting
   belongs_to :recurring_meeting
 
   scope :upcoming, -> { where(start_time: Time.current..) }
@@ -40,8 +41,8 @@ class ScheduledMeeting < ApplicationRecord
   scope :cancelled, -> { where(cancelled: true) }
   scope :not_cancelled, -> { where(cancelled: false) }
 
-  validates_uniqueness_of :meeting, allow_nil: true
-  validates_presence_of :start_time
+  validates :meeting, uniqueness: { allow_nil: true }
+  validates :start_time, presence: true
 
   def previous_occurrence
     recurring_meeting.previous_occurrence(from_time: start_time)

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -46,7 +46,7 @@ module AllMeetings
         end
 
         calendar.preload_for_recurring_meetings(recurring_meetings: recurring_meetings)
-        calendar.mark_current_user_having_accepted_all_invitations!
+        calendar.treat_participations_from_user_as_accepted!
 
         recurring_meetings.each do |recurring_meeting|
           calendar.add_series_event(recurring_meeting:, cancelled: false)

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -46,6 +46,7 @@ module AllMeetings
         end
 
         calendar.preload_for_recurring_meetings(recurring_meetings: recurring_meetings)
+        calendar.mark_current_user_having_accepted_all_invitations!
 
         recurring_meetings.each do |recurring_meeting|
           calendar.add_series_event(recurring_meeting:, cancelled: false)

--- a/modules/meeting/app/services/meetings/ical_service.rb
+++ b/modules/meeting/app/services/meetings/ical_service.rb
@@ -40,7 +40,7 @@ module Meetings
 
     def call(cancelled: false)
       User.execute_as(user) do
-        calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default)
+        calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default, user: user)
         calendar.add_single_meeting_event(meeting:, cancelled:)
         calendar.update_calendar_status(cancelled:)
 

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -32,10 +32,10 @@ require "icalendar/tzinfo"
 
 module Meetings
   class IcalendarBuilder
-    attr_reader :timezone, :calendar, :all_times, :tzid, :current_user
+    attr_reader :timezone, :calendar, :all_times, :tzid, :calendar_generated_for_user
 
     def initialize(timezone:, user: User.current)
-      @current_user = user
+      @calendar_generated_for_user = user
       @timezone = timezone
       @tzid = timezone.tzinfo.canonical_identifier
       @calendar = build_icalendar
@@ -46,7 +46,7 @@ module Meetings
       @action_needed_from_user_as_attendee = true
     end
 
-    def mark_current_user_having_accepted_all_invitations!
+    def treat_participations_from_user_as_accepted!
       @action_needed_from_user_as_attendee = false
     end
 
@@ -189,7 +189,7 @@ module Meetings
     end
 
     def attendee_participation_status(user)
-      if current_user == user && @action_needed_from_user_as_attendee
+      if calendar_generated_for_user == user && @action_needed_from_user_as_attendee
         "NEEDS-ACTION"
       else
         "ACCEPTED" # until we handle RSVPs properly, we assume participants have accepted
@@ -197,7 +197,7 @@ module Meetings
     end
 
     def attendee_rsvp_needed?(user)
-      current_user == user && @action_needed_from_user_as_attendee
+      calendar_generated_for_user == user && @action_needed_from_user_as_attendee
     end
 
     def ical_datetime(time)

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -32,9 +32,10 @@ require "icalendar/tzinfo"
 
 module Meetings
   class IcalendarBuilder
-    attr_reader :timezone, :calendar, :all_times, :tzid
+    attr_reader :timezone, :calendar, :all_times, :tzid, :current_user
 
-    def initialize(timezone:)
+    def initialize(timezone:, user: User.current)
+      @current_user = user
       @timezone = timezone
       @tzid = timezone.tzinfo.canonical_identifier
       @calendar = build_icalendar
@@ -42,6 +43,11 @@ module Meetings
       @excluded_dates_cache = {}
       @instantiated_occurrences_cache = {}
       @series_cache_loaded = false
+      @action_needed_from_user_as_attendee = true
+    end
+
+    def mark_current_user_having_accepted_all_invitations!
+      @action_needed_from_user_as_attendee = false
     end
 
     def add_single_meeting_event(meeting:, cancelled: false) # rubocop:disable Metrics/AbcSize
@@ -171,8 +177,8 @@ module Meetings
           {
             "CN" => user.name,
             "EMAIL" => user.mail,
-            "PARTSTAT" => "ACCEPTED", # until we handle RSVPs properly, we assume participants have accepted
-            "RSVP" => "TRUE",
+            "PARTSTAT" => attendee_participation_status(user),
+            "RSVP" => attendee_rsvp_needed?(user) ? "TRUE" : "FALSE",
             "CUTYPE" => "INDIVIDUAL",
             "ROLE" => "REQ-PARTICIPANT"
           }
@@ -180,6 +186,18 @@ module Meetings
 
         event.append_attendee(address)
       end
+    end
+
+    def attendee_participation_status(user)
+      if current_user == user && @action_needed_from_user_as_attendee
+        "NEEDS-ACTION"
+      else
+        "ACCEPTED" # until we handle RSVPs properly, we assume participants have accepted
+      end
+    end
+
+    def attendee_rsvp_needed?(user)
+      current_user == user && @action_needed_from_user_as_attendee
     end
 
     def ical_datetime(time)

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -171,7 +171,7 @@ module Meetings
           {
             "CN" => user.name,
             "EMAIL" => user.mail,
-            "PARTSTAT" => "NEEDS-ACTION",
+            "PARTSTAT" => "ACCEPTED", # until we handle RSVPs properly, we assume participants have accepted
             "RSVP" => "TRUE",
             "CUTYPE" => "INDIVIDUAL",
             "ROLE" => "REQ-PARTICIPANT"

--- a/modules/meeting/app/services/recurring_meetings/ical_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/ical_service.rb
@@ -42,7 +42,7 @@ module RecurringMeetings
 
     def generate_series(cancelled: false) # rubocop:disable Metrics/AbcSize
       User.execute_as(user) do
-        calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default)
+        calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default, user: user)
         calendar.add_series_event(recurring_meeting: series, cancelled:)
 
         calendar.update_calendar_status(cancelled:)

--- a/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/init_occurrence_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/factories/meeting_participant_factory.rb
+++ b/modules/meeting/spec/factories/meeting_participant_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Meetings::IcalendarBuilder,
 
     context "when current user has accepted all invitations" do
       subject(:builder) do
-        described_class.new(timezone:, user: meeting.author).tap(&:mark_current_user_having_accepted_all_invitations!)
+        described_class.new(timezone:, user: meeting.author).tap(&:treat_participations_from_user_as_accepted!)
       end
 
       let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
@@ -121,7 +121,7 @@ RSpec.describe Meetings::IcalendarBuilder,
 
       context "when current user has accepted all invitations" do
         subject(:builder) do
-          described_class.new(timezone:, user: user1).tap(&:mark_current_user_having_accepted_all_invitations!)
+          described_class.new(timezone:, user: user1).tap(&:treat_participations_from_user_as_accepted!)
         end
 
         let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
@@ -239,7 +239,7 @@ RSpec.describe Meetings::IcalendarBuilder,
 
     context "when current user has accepted all invitations" do
       subject(:builder) do
-        described_class.new(timezone:, user: user1).tap(&:mark_current_user_having_accepted_all_invitations!)
+        described_class.new(timezone:, user: user1).tap(&:treat_participations_from_user_as_accepted!)
       end
 
       let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -31,6 +31,54 @@ RSpec.describe Meetings::IcalendarBuilder,
       expect(parsed_calendar.ip_method).to eq("REQUEST")
     end
 
+    it "sets PARTSTAT to ACCEPTED for all attendees" do
+      builder.add_single_meeting_event(meeting:)
+      builder.update_calendar_status(cancelled: false)
+
+      event = parsed_calendar.events.first
+      expect(event.attendee).not_to be_empty
+
+      event.attendee.each do |attendee|
+        expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+        expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
+        expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+        expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+      end
+    end
+
+    context "with multiple participants" do
+      let(:user1) { create(:user, firstname: "John", lastname: "Doe", mail: "john@example.com") }
+      let(:user2) { create(:user, firstname: "Jane", lastname: "Smith", mail: "jane@example.com") }
+      let(:meeting_with_participants) do
+        meeting = create(:meeting, start_time: Time.zone.parse("2025-08-30 10:00"))
+        create(:meeting_participant, meeting:, user: user1)
+        create(:meeting_participant, meeting:, user: user2)
+        meeting
+      end
+
+      it "sets PARTSTAT to ACCEPTED for all multiple attendees" do
+        builder.add_single_meeting_event(meeting: meeting_with_participants)
+        builder.update_calendar_status(cancelled: false)
+
+        event = parsed_calendar.events.first
+        expect(event.attendee.count).to eq(2)
+
+        # Find attendees by email
+        john_attendee = event.attendee.find { |a| a.to_s.include?("john@example.com") }
+        jane_attendee = event.attendee.find { |a| a.to_s.include?("jane@example.com") }
+
+        expect(john_attendee).to be_present
+        expect(jane_attendee).to be_present
+
+        [john_attendee, jane_attendee].each do |attendee|
+          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+          expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
+          expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+          expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+        end
+      end
+    end
+
     it "sets status CANCELLED when cancelled" do
       builder.add_single_meeting_event(meeting:, cancelled: true)
       builder.update_calendar_status(cancelled: true)
@@ -41,15 +89,23 @@ RSpec.describe Meetings::IcalendarBuilder,
   end
 
   context "with recurring meeting series" do
+    let(:project) { create(:project) }
+    let(:user1) { create(:user, firstname: "John", lastname: "Doe", member_with_permissions: { project => [:view_meetings] }) }
+    let(:user2) { create(:user, firstname: "John", lastname: "Doe", member_with_permissions: { project => [:view_meetings] }) }
+
     let(:recurring_meeting) do
       create(:recurring_meeting,
              start_time: Time.zone.parse("2025-08-25 09:00"),
              iterations: 10,
+             project: project,
              end_after: :iterations,
-             time_zone: timezone.tzinfo.name)
+             time_zone: timezone.tzinfo.name).tap do |recurring_meeting|
+        create(:meeting_participant, :invitee, meeting: recurring_meeting.template, user: user1)
+        create(:meeting_participant, :invitee, meeting: recurring_meeting.template, user: user2)
+      end
     end
 
-    let!(:cancelled_schedule) do
+    let!(:second_occurrence) do
       # Cancel second occurrence
       create(:scheduled_meeting,
              :cancelled,
@@ -57,27 +113,23 @@ RSpec.describe Meetings::IcalendarBuilder,
              start_time: recurring_meeting.start_time + 1.week)
     end
 
-    let!(:instantiated_schedule) do
+    let!(:third_occurence) do
       # Third occurrence instantiated and moved by +10 minutes
       base_start = recurring_meeting.start_time + 2.weeks
       create(:scheduled_meeting,
              recurring_meeting:,
              start_time: base_start)
 
-      # Create with meeting that has different start time
-      scheduled = ScheduledMeeting.create!(
-        recurring_meeting:,
-        start_time: base_start,
-        cancelled: false
-      )
+      result = RecurringMeetings::InitOccurrenceService
+          .new(user: User.system, recurring_meeting:)
+          .call(start_time: base_start)
 
-      meeting = create(:meeting,
-                       recurring_meeting:,
-                       start_time: base_start + 10.minutes,
-                       project: recurring_meeting.project)
+      meeting = result.result
 
-      scheduled.update!(meeting:)
-      scheduled
+      # Reschedule meeting to be 10 minutes later. It should still have the correct recurrence
+      meeting.update(start_time: base_start + 10.minutes)
+
+      meeting.scheduled_meeting
     end
 
     it "adds master event with RRULE and EXDATE plus override events" do
@@ -95,15 +147,42 @@ RSpec.describe Meetings::IcalendarBuilder,
 
       # EXDATE contains cancelled schedule start (original scheduled time, not moved time)
       exdates = Array(master.exdate).flat_map { |ex| Array(ex) }.map(&:value)
-      expect(exdates).to include(cancelled_schedule.start_time.in_time_zone(timezone))
+      expect(exdates).to include(second_occurrence.start_time.in_time_zone(timezone))
       # One override for instantiated schedule
       expect(overrides.size).to eq(1)
       ov = overrides.first
-      expect(ov.recurrence_id.value).to eq(instantiated_schedule.start_time.in_time_zone(timezone))
+      expect(ov.recurrence_id.value).to eq(third_occurence.start_time.in_time_zone(timezone))
       # Override start reflects moved meeting start time (+10m)
-      expect(ov.dtstart.to_time.min).to eq(instantiated_schedule.meeting.start_time.min)
-      expect(ov.dtstart.to_time.min).not_to eq(instantiated_schedule.start_time.min)
-      expect(ov.sequence.to_i).to eq(instantiated_schedule.meeting.lock_version)
+      expect(ov.dtstart.to_time.min).to eq(third_occurence.meeting.start_time.min)
+      expect(ov.dtstart.to_time.min).not_to eq(third_occurence.start_time.min)
+      expect(ov.sequence.to_i).to eq(third_occurence.meeting.lock_version)
+    end
+
+    it "sets PARTSTAT to ACCEPTED for all attendees in recurring meeting series" do
+      builder.add_series_event(recurring_meeting:)
+
+      master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+      overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+      # Check master event attendees
+      expect(master.attendee).not_to be_empty
+      master.attendee.each do |attendee|
+        expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+        expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
+        expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+        expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+      end
+
+      # Check override event attendees
+      overrides.each do |override_event|
+        expect(override_event.attendee).not_to be_empty
+        override_event.attendee.each do |attendee|
+          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+          expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
+          expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+          expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+        end
+      end
     end
   end
 

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -4,45 +4,75 @@ require "rails_helper"
 
 RSpec.describe Meetings::IcalendarBuilder,
                with_settings: { mail_from: "openproject@example.org", app_title: "OpenProject Testing" } do
-  subject(:builder) { described_class.new(timezone:) }
-
-  let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
-
   let(:timezone) { ActiveSupport::TimeZone["Europe/Berlin"] }
 
   context "with a single meeting" do
     let(:meeting) { create(:meeting, :author_participates, start_time: Time.zone.parse("2025-08-30 10:00")) }
 
-    it "adds basic event data" do
-      builder.add_single_meeting_event(meeting:)
-      builder.update_calendar_status(cancelled: false)
+    context "when current user needs to take action" do
+      subject(:builder) { described_class.new(timezone:, user: meeting.author) }
 
-      event = parsed_calendar.events.first
-      expect(event.summary).to include(meeting.title)
-      expect(event.description).to include(I18n.t(:label_meeting))
-      expect(event.uid).to eq(meeting.uid)
-      # Organizer
-      expect(event.organizer.to_s).to include("mailto:openproject@example.org")
-      # Attendees (author participates)
-      expect(event.attendee.first.to_s).to include("mailto:#{meeting.author.mail}")
-      # Timezone parameter
-      expect(event.dtstart.ical_params["tzid"]).to eq([timezone.tzinfo.canonical_identifier])
-      # Method defaults to REQUEST when not cancelled
-      expect(parsed_calendar.ip_method).to eq("REQUEST")
+      let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+      it "sets PARTSTAT to NEEDS-ACTION and RSVP to TRUE for current user" do
+        builder.add_single_meeting_event(meeting:)
+        builder.update_calendar_status(cancelled: false)
+
+        event = parsed_calendar.events.first
+        expect(event.attendee).not_to be_empty
+
+        # Find the current user's attendee entry
+        current_user_attendee = event.attendee.find { |a| a.to_s.include?(meeting.author.mail) }
+        expect(current_user_attendee).to be_present
+        expect(current_user_attendee.ical_params["partstat"]).to eq(["NEEDS-ACTION"])
+        expect(current_user_attendee.ical_params["rsvp"]).to eq(["TRUE"])
+        expect(current_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+        expect(current_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+      end
     end
 
-    it "sets PARTSTAT to ACCEPTED for all attendees" do
-      builder.add_single_meeting_event(meeting:)
-      builder.update_calendar_status(cancelled: false)
+    context "when current user has accepted all invitations" do
+      subject(:builder) do
+        described_class.new(timezone:, user: meeting.author).tap(&:mark_current_user_having_accepted_all_invitations!)
+      end
 
-      event = parsed_calendar.events.first
-      expect(event.attendee).not_to be_empty
+      let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
 
-      event.attendee.each do |attendee|
-        expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-        expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
-        expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
-        expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+      it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all attendees" do
+        builder.add_single_meeting_event(meeting:)
+        builder.update_calendar_status(cancelled: false)
+
+        event = parsed_calendar.events.first
+        expect(event.attendee).not_to be_empty
+
+        event.attendee.each do |attendee|
+          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+          expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+          expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+        end
+      end
+    end
+
+    context "when current user is not a participant" do
+      let(:other_user) { create(:user) }
+      let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+      subject(:builder) { described_class.new(timezone:, user: other_user) }
+
+      it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all attendees" do
+        builder.add_single_meeting_event(meeting:)
+        builder.update_calendar_status(cancelled: false)
+
+        event = parsed_calendar.events.first
+        expect(event.attendee).not_to be_empty
+
+        event.attendee.each do |attendee|
+          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+          expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+          expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+        end
       end
     end
 
@@ -56,35 +86,68 @@ RSpec.describe Meetings::IcalendarBuilder,
         meeting
       end
 
-      it "sets PARTSTAT to ACCEPTED for all multiple attendees" do
-        builder.add_single_meeting_event(meeting: meeting_with_participants)
-        builder.update_calendar_status(cancelled: false)
+      context "when current user needs to take action" do
+        subject(:builder) { described_class.new(timezone:, user: user1) }
 
-        event = parsed_calendar.events.first
-        expect(event.attendee.count).to eq(2)
+        let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
 
-        # Find attendees by email
-        john_attendee = event.attendee.find { |a| a.to_s.include?("john@example.com") }
-        jane_attendee = event.attendee.find { |a| a.to_s.include?("jane@example.com") }
+        it "sets PARTSTAT to NEEDS-ACTION and RSVP to TRUE for current user, ACCEPTED and FALSE for others" do
+          builder.add_single_meeting_event(meeting: meeting_with_participants)
+          builder.update_calendar_status(cancelled: false)
 
-        expect(john_attendee).to be_present
-        expect(jane_attendee).to be_present
+          event = parsed_calendar.events.first
+          expect(event.attendee.count).to eq(2)
 
-        [john_attendee, jane_attendee].each do |attendee|
-          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
-          expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
-          expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+          # Find attendees by email
+          john_attendee = event.attendee.find { |a| a.to_s.include?("john@example.com") }
+          jane_attendee = event.attendee.find { |a| a.to_s.include?("jane@example.com") }
+
+          expect(john_attendee).to be_present
+          expect(jane_attendee).to be_present
+
+          # John is the current user, so he should have NEEDS-ACTION and RSVP=TRUE
+          expect(john_attendee.ical_params["partstat"]).to eq(["NEEDS-ACTION"])
+          expect(john_attendee.ical_params["rsvp"]).to eq(["TRUE"])
+          expect(john_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+          expect(john_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+
+          # Jane is not the current user, so she should have ACCEPTED and RSVP=FALSE
+          expect(jane_attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+          expect(jane_attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(jane_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+          expect(jane_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
         end
       end
-    end
 
-    it "sets status CANCELLED when cancelled" do
-      builder.add_single_meeting_event(meeting:, cancelled: true)
-      builder.update_calendar_status(cancelled: true)
-      event = parsed_calendar.events.first
-      expect(event.status).to eq("CANCELLED")
-      expect(parsed_calendar.ip_method).to eq("CANCEL")
+      context "when current user has accepted all invitations" do
+        subject(:builder) do
+          described_class.new(timezone:, user: user1).tap(&:mark_current_user_having_accepted_all_invitations!)
+        end
+
+        let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+        it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all multiple attendees" do
+          builder.add_single_meeting_event(meeting: meeting_with_participants)
+          builder.update_calendar_status(cancelled: false)
+
+          event = parsed_calendar.events.first
+          expect(event.attendee.count).to eq(2)
+
+          # Find attendees by email
+          john_attendee = event.attendee.find { |a| a.to_s.include?("john@example.com") }
+          jane_attendee = event.attendee.find { |a| a.to_s.include?("jane@example.com") }
+
+          expect(john_attendee).to be_present
+          expect(jane_attendee).to be_present
+
+          [john_attendee, jane_attendee].each do |attendee|
+            expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+            expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+            expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+            expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+          end
+        end
+      end
     end
   end
 
@@ -132,55 +195,79 @@ RSpec.describe Meetings::IcalendarBuilder,
       meeting.scheduled_meeting
     end
 
-    it "adds master event with RRULE and EXDATE plus override events" do
-      builder.add_series_event(recurring_meeting:)
+    context "when current user needs to take action" do
+      subject(:builder) { described_class.new(timezone:, user: user1) }
 
-      master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
-      overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+      let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
 
-      expect(master).to be_present
-      expect(master.uid).to eq(recurring_meeting.uid)
+      it "sets PARTSTAT to NEEDS-ACTION and RSVP to TRUE for current user in recurring meeting series" do
+        builder.add_series_event(recurring_meeting:)
 
-      rrule = master.rrule.first
-      expect(rrule.frequency).to eq("WEEKLY")
-      expect(rrule.count).to eq(10)
+        master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
 
-      # EXDATE contains cancelled schedule start (original scheduled time, not moved time)
-      exdates = Array(master.exdate).flat_map { |ex| Array(ex) }.map(&:value)
-      expect(exdates).to include(second_occurrence.start_time.in_time_zone(timezone))
-      # One override for instantiated schedule
-      expect(overrides.size).to eq(1)
-      ov = overrides.first
-      expect(ov.recurrence_id.value).to eq(third_occurence.start_time.in_time_zone(timezone))
-      # Override start reflects moved meeting start time (+10m)
-      expect(ov.dtstart.to_time.min).to eq(third_occurence.meeting.start_time.min)
-      expect(ov.dtstart.to_time.min).not_to eq(third_occurence.start_time.min)
-      expect(ov.sequence.to_i).to eq(third_occurence.meeting.lock_version)
+        # Check master event attendees
+        expect(master.attendee).not_to be_empty
+        current_user_attendee = master.attendee.find { |a| a.to_s.include?(user1.mail) }
+        other_user_attendee = master.attendee.find { |a| a.to_s.include?(user2.mail) }
+
+        # Current user should have NEEDS-ACTION and RSVP=TRUE
+        expect(current_user_attendee.ical_params["partstat"]).to eq(["NEEDS-ACTION"])
+        expect(current_user_attendee.ical_params["rsvp"]).to eq(["TRUE"])
+        expect(current_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+        expect(current_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+
+        # Other user should have ACCEPTED and RSVP=FALSE
+        expect(other_user_attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+        expect(other_user_attendee.ical_params["rsvp"]).to eq(["FALSE"])
+        expect(other_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+        expect(other_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+
+        # Check override event attendees
+        overrides.each do |override_event|
+          expect(override_event.attendee).not_to be_empty
+          current_user_override = override_event.attendee.find { |a| a.to_s.include?(user1.mail) }
+          other_user_override = override_event.attendee.find { |a| a.to_s.include?(user2.mail) }
+
+          expect(current_user_override.ical_params["partstat"]).to eq(["NEEDS-ACTION"])
+          expect(current_user_override.ical_params["rsvp"]).to eq(["TRUE"])
+          expect(other_user_override.ical_params["partstat"]).to eq(["ACCEPTED"])
+          expect(other_user_override.ical_params["rsvp"]).to eq(["FALSE"])
+        end
+      end
     end
 
-    it "sets PARTSTAT to ACCEPTED for all attendees in recurring meeting series" do
-      builder.add_series_event(recurring_meeting:)
-
-      master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
-      overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
-
-      # Check master event attendees
-      expect(master.attendee).not_to be_empty
-      master.attendee.each do |attendee|
-        expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-        expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
-        expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
-        expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+    context "when current user has accepted all invitations" do
+      subject(:builder) do
+        described_class.new(timezone:, user: user1).tap(&:mark_current_user_having_accepted_all_invitations!)
       end
 
-      # Check override event attendees
-      overrides.each do |override_event|
-        expect(override_event.attendee).not_to be_empty
-        override_event.attendee.each do |attendee|
+      let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+      it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all attendees in recurring meeting series" do
+        builder.add_series_event(recurring_meeting:)
+
+        master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+        # Check master event attendees
+        expect(master.attendee).not_to be_empty
+        master.attendee.each do |attendee|
           expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(attendee.ical_params["rsvp"]).to eq(["TRUE"])
+          expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
           expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
           expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+        end
+
+        # Check override event attendees
+        overrides.each do |override_event|
+          expect(override_event.attendee).not_to be_empty
+          override_event.attendee.each do |attendee|
+            expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
+            expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+            expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+            expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+          end
         end
       end
     end
@@ -188,6 +275,9 @@ RSpec.describe Meetings::IcalendarBuilder,
 
   context "for timezone component" do
     let(:meeting) { create(:meeting, start_time: Time.zone.parse("2025-10-01 10:00")) }
+    let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+    subject(:builder) { described_class.new(timezone:) }
 
     it "includes a VTIMEZONE with TZID" do
       builder.add_single_meeting_event(meeting:)
@@ -198,6 +288,10 @@ RSpec.describe Meetings::IcalendarBuilder,
   end
 
   context "for timezone transitions across multiple years" do
+    subject(:builder) { described_class.new(timezone:) }
+
+    let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
     # We pick dates spread over multiple DST changes
     let!(:meetings) do
       [

--- a/modules/meeting/spec/services/recurring_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/ical_service_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe RecurringMeetings::ICalService, type: :model do # rubocop:disable
       expect(series_ical).to include("SUMMARY:Weekly")
       expect(series_ical).to include("CN=OpenProject:mailto:openproject@example.net")
       expect(series_ical).to include("ATTENDEE;CN=Bob Barker;EMAIL=bob@example.com;PARTSTAT=NEEDS-ACTION;RSVP=TRU")
-      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com;PARTSTAT=NEEDS-ACTION;RSVP=TRUE")
+      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com;PARTSTAT=ACCEPTED;RSVP=FALSE")
       expect(series_ical).to include("RRULE:FREQ=WEEKLY;UNTIL=20251202T000000Z")
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe RecurringMeetings::ICalService, type: :model do # rubocop:disable
       expect(series_ical).to include("LOCATION:https://example.com/meet/important-meeting")
       expect(series_ical).to include("SUMMARY:Weekly")
       expect(series_ical).to include("ATTENDEE;CN=Bob Barker;EMAIL=bob@example.com;PARTSTAT=NEEDS-ACTION;RSVP=TRU")
-      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com;PARTSTAT=NEEDS-ACTION;RSVP=TRUE")
+      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com;PARTSTAT=ACCEPTED;RSVP=FALSE")
       expect(series_ical).to include("RRULE:FREQ=WEEKLY")
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/67198

# What are you trying to accomplish?
Until we properly handle RSVP Status in our application, set all participants to be accepted when rendering the full calendar feed.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
