### PR TITLE
Ensure token_name is unique per token class, and has a proper error message

### DIFF
--- a/app/contracts/api_tokens/create_contract.rb
+++ b/app/contracts/api_tokens/create_contract.rb
@@ -32,7 +32,7 @@ module APITokens
   class CreateContract < BaseContract
     attribute :token_name
 
-    validates :token_name, presence: { message: proc { I18n.t("my.access_token.errors.token_name_blank") } }
+    validates :token_name, presence: true
     validate :token_name_is_unique, unless: :token_name_is_blank?
 
     private
@@ -42,8 +42,8 @@ module APITokens
     end
 
     def token_name_is_unique
-      if Token::API.where(user: model.user).any? { |t| t.token_name == model.token_name }
-        errors.add(:token_name, :taken, message: I18n.t("my.access_token.errors.token_name_in_use"))
+      if model.class.where(user: model.user).any? { |t| t.token_name == model.token_name }
+        errors.add(:token_name, :in_use)
       end
     end
   end

--- a/app/models/token/api.rb
+++ b/app/models/token/api.rb
@@ -29,13 +29,6 @@
 #++
 
 module Token
-  class API < HashedToken
-    store_attribute :data, :token_name, :string
-
-    private
-
-    def single_value?
-      false
-    end
+  class API < Named
   end
 end

--- a/app/models/token/named.rb
+++ b/app/models/token/named.rb
@@ -28,46 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
+module Token
+  class Named < HashedToken
+    store_attribute :data, :token_name, :string
 
-RSpec.describe APITokens::CreateContract do
-  let(:current_user) { create(:admin) }
-  let(:token_name) { "my token name" }
-  let(:token) { build_stubbed(:api_token, token_name:, user: current_user) }
+    protected
 
-  subject(:contract) { described_class.new(token, current_user) }
-
-  def expect_valid(valid, symbols = {})
-    expect(contract.validate).to eq(valid)
-
-    symbols.each do |key, arr|
-      expect(contract.errors.symbols_for(key)).to match_array arr
-    end
-  end
-
-  describe "validation" do
-    context "when token_name is set" do
-      it "is valid" do
-        expect_valid(true)
-      end
-    end
-
-    context "if the token_name is nil" do
-      let(:token_name) { nil }
-
-      it "is invalid" do
-        expect_valid(false, token_name: %i(blank))
-      end
-    end
-
-    context "if the token_name is taken for current user" do
-      before do
-        create(:api_token, token_name:, user: current_user)
-      end
-
-      it "is invalid" do
-        expect_valid(false, token_name: %i(in_use))
-      end
+    def single_value?
+      false
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -637,9 +637,6 @@ en:
         token/api:
           title: "The API token has been generated"
           warning: "This is the only time you will see this token. Make sure to copy it now."
-      errors:
-        token_name_blank: "Please provide an API token name"
-        token_name_in_use: "This API token name is already in use, please select a different one"
       failed_to_reset_token: "Failed to reset access token: %{error}"
       failed_to_create_token: "Failed to create access token: %{error}"
       failed_to_revoke_token: "Failed to revoke access token: %{error}"
@@ -1221,6 +1218,8 @@ en:
         is_readonly: "Work package read-only"
         excluded_from_totals: "Exclude from calculation of totals in hierarchy"
         default_done_ratio: "% Complete"
+      token/named:
+        token_name: "Token name"
       token/ical:
         calendar: "Calendar"
         ical_token_query_assignment: "Query assignment"
@@ -1704,9 +1703,11 @@ en:
         version:
           undeletable_archived_projects: "The version cannot be deleted as it has work packages attached to it."
           undeletable_work_packages_attached: "The version cannot be deleted as it has work packages attached to it."
-        token/api:
+        token/named:
           attributes:
             token_name:
+              blank: "Please provide a token name"
+              in_use: "This token name is already in use, please select a different one"
               format: "%{message}"
       template:
         body: "Please check the following fields:"

--- a/modules/meeting/app/models/token/ical_meeting.rb
+++ b/modules/meeting/app/models/token/ical_meeting.rb
@@ -29,11 +29,9 @@
 #++
 
 module Token
-  class ICalMeeting < HashedToken
+  class ICalMeeting < Token::Named
     include OpenProject::StaticRouting::UrlHelpers
     include ActionView::Helpers::UrlHelper
-
-    store_attribute :data, :token_name, :string
 
     def display_value
       if plain_value.present?
@@ -44,10 +42,6 @@ module Token
     end
 
     private
-
-    def single_value?
-      false
-    end
 
     def url_helpers
       @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new


### PR DESCRIPTION
https://community.openproject.org/work_packages/67227

The token_name was only defined for the API token, which meeting token
doesn't inherit from.

Token::Named wouldn't necessarily need to be inherited from, but only
that way will AR look up the ancestors for attribute and error names.