### PR TITLE
Dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+
+multi-ecosystem-groups:
+  primer:
+    schedule:
+      interval: "daily"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -26,7 +32,16 @@ updates:
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "@openproject/primer-view-components"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    target-branch: "dev"
+    versioning-strategy: increase
+    patterns:
+      - "@openproject/primer-view-components"
+      - "@primer/*"
+    multi-ecosystem-group: "primer"
+
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -38,8 +53,15 @@ updates:
       aws-gems:
         patterns:
           - "aws-*"
-    ignore:
-      - dependency-name: "openproject-primer_view_components"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    target-branch: "dev"
+    versioning-strategy: increase
+    patterns:
+      - "openproject-primer_view_components"
+    multi-ecosystem-group: "primer"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,13 @@ updates:
           - '@blocknote/*'
       fullcalendar:
         patterns:
-          - '@fullcalendar*'
+          - '@fullcalendar/*'
       html-eslint:
         patterns:
           - '@html-eslint/*'
       appsignal:
         patterns:
-          - '@appsignal*'
+          - '@appsignal/*'
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       angular:
         patterns:
           - '@angular*'
+      blocknote:
+        patterns:
+          - '@blocknote/*'
       fullcalendar:
         patterns:
           - '@fullcalendar*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ multi-ecosystem-groups:
   primer:
     schedule:
       interval: "daily"
+  octicons:
+    schedule:
+      interval: "daily"
 
 updates:
   - package-ecosystem: "npm"
@@ -42,6 +45,14 @@ updates:
       - "@primer/*"
     multi-ecosystem-group: "primer"
 
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    target-branch: "dev"
+    versioning-strategy: increase
+    patterns:
+      - "@openproject/octicons-angular"
+    multi-ecosystem-group: "octicons"
+
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
@@ -61,6 +72,14 @@ updates:
     patterns:
       - "openproject-primer_view_components"
     multi-ecosystem-group: "primer"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    target-branch: "dev"
+    versioning-strategy: increase
+    patterns:
+      - "openproject-octicons*"
+    multi-ecosystem-group: "octicons"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       fullcalendar:
         patterns:
           - '@fullcalendar*'
+      html-eslint:
+        patterns:
+          - '@html-eslint/*'
       appsignal:
         patterns:
           - '@appsignal*'


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

- Improve how Dependabot groups npm dependencies (`@blocknote` and `@html-lint`)
- Defines [multi-ecosystem groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates) for Primer and Octicons - with the goal of keeping npm and gem depencies in lock step.
- This effectively reverts #19289 / a1fce843, which ignored Primer dependencies.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
