### PR TITLE
Set `created` and `last_mofified` and sequence for meetings to properly detect changes

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -54,6 +54,11 @@ module Meetings
       calendar.event do |e|
         e.dtstart = ical_datetime(meeting.start_time)
         e.dtend = ical_datetime(meeting.end_time)
+
+        e.created = meeting.created_at.utc
+        e.last_modified = meeting.updated_at.utc
+        e.sequence = meeting.lock_version
+
         e.url = url_helpers.meeting_url(meeting)
         e.summary = meeting.title
         e.description = meeting.title
@@ -76,6 +81,10 @@ module Meetings
         e.summary = recurring_meeting.title
         e.description = recurring_meeting.title
         e.organizer = ical_organizer
+
+        e.created = recurring_meeting.template.created_at.utc
+        e.last_modified = recurring_meeting.template.updated_at.utc
+        e.sequence = recurring_meeting.template.lock_version
 
         e.rrule = recurring_meeting.schedule.rrules.first.to_ical # We currently only have one recurrence rule
         e.dtstart = ical_datetime(recurring_meeting.template.start_time)
@@ -108,12 +117,15 @@ module Meetings
         e.description = recurring_meeting.title
         e.organizer = ical_organizer
 
+        e.created = meeting.created_at.utc
+        e.last_modified = meeting.updated_at.utc
+        e.sequence = meeting.lock_version
+
         e.recurrence_id = ical_datetime(scheduled_meeting.start_time)
         e.dtstart = ical_datetime(meeting.start_time)
         e.dtend = ical_datetime(meeting.end_time)
         e.url = url_helpers.project_meeting_url(meeting.project, meeting)
         e.location = meeting.location.presence
-        e.sequence = meeting.lock_version
 
         add_attendees(event: e, meeting: meeting)
         e.status = if scheduled_meeting.cancelled?

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -83,7 +83,7 @@ module Meetings
         e.organizer = ical_organizer
 
         e.created = recurring_meeting.template.created_at.utc
-        e.last_modified = recurring_meeting.template.updated_at.utc
+        e.last_modified = [recurring_meeting.template.updated_at, recurring_meeting.updated_at].max.utc
         e.sequence = recurring_meeting.template.lock_version
 
         e.rrule = recurring_meeting.schedule.rrules.first.to_ical # We currently only have one recurrence rule

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe Meetings::IcalendarBuilder,
         expect(current_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
         expect(current_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
       end
+
+      it "sets created and last_modified timestamps correctly" do
+        builder.add_single_meeting_event(meeting:)
+        builder.update_calendar_status(cancelled: false)
+
+        event = parsed_calendar.events.first
+        expect(event.created.to_time).to be_within(1.second).of(meeting.created_at.utc)
+        expect(event.last_modified.to_time).to be_within(1.second).of(meeting.updated_at.utc)
+      end
     end
 
     context "when current user has accepted all invitations" do
@@ -235,6 +244,30 @@ RSpec.describe Meetings::IcalendarBuilder,
           expect(other_user_override.ical_params["rsvp"]).to eq(["FALSE"])
         end
       end
+
+      it "sets created and last_modified timestamps correctly for recurring series" do
+        builder.add_series_event(recurring_meeting:)
+
+        master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+        # Check master event timestamps
+        expect(master.created.to_time).to be_within(1.second).of(recurring_meeting.template.created_at.utc)
+        expect(master.last_modified.to_time).to be_within(1.second).of(recurring_meeting.template.updated_at.utc)
+
+        # Check override event timestamps
+        overrides.each do |override_event|
+          # Find the corresponding scheduled meeting for this override
+          scheduled_meeting = [second_occurrence, third_occurence].find do |sm|
+            sm.meeting && override_event.recurrence_id.to_time.utc.to_i == sm.start_time.utc.to_i
+          end
+
+          if scheduled_meeting&.meeting
+            expect(override_event.created.to_time).to be_within(1.second).of(scheduled_meeting.meeting.created_at.utc)
+            expect(override_event.last_modified.to_time).to be_within(1.second).of(scheduled_meeting.meeting.updated_at.utc)
+          end
+        end
+      end
     end
 
     context "when current user has accepted all invitations" do
@@ -267,6 +300,30 @@ RSpec.describe Meetings::IcalendarBuilder,
             expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
             expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
             expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+          end
+        end
+      end
+
+      it "sets created and last_modified timestamps correctly for recurring series when accepted" do
+        builder.add_series_event(recurring_meeting:)
+
+        master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+        # Check master event timestamps
+        expect(master.created.to_time).to be_within(1.second).of(recurring_meeting.template.created_at.utc)
+        expect(master.last_modified.to_time).to be_within(1.second).of(recurring_meeting.template.updated_at.utc)
+
+        # Check override event timestamps
+        overrides.each do |override_event|
+          # Find the corresponding scheduled meeting for this override
+          scheduled_meeting = [second_occurrence, third_occurence].find do |sm|
+            sm.meeting && override_event.recurrence_id.to_time.utc.to_i == sm.start_time.utc.to_i
+          end
+
+          if scheduled_meeting&.meeting
+            expect(override_event.created.to_time).to be_within(1.second).of(scheduled_meeting.meeting.created_at.utc)
+            expect(override_event.last_modified.to_time).to be_within(1.second).of(scheduled_meeting.meeting.updated_at.utc)
           end
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/67231

# What are you trying to accomplish?
- Set [CREATED]() and [LAST-MODIFIED]() dates in the iCalendar feed so that clients can properly detect changes to events
- Also set `SEQUENCE` to the lock version for all meeting items

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
