### PR TITLE
[#66624] Fix contrast in widget graphs

### DIFF
--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -1,9 +1,12 @@
 import { Component, Input, SimpleChanges } from '@angular/core';
 import { WorkPackageTableConfiguration } from 'core-app/features/work-packages/components/wp-table/wp-table-configuration';
-import { ChartOptions, Plugin } from 'chart.js';
+import { ChartOptions } from 'chart.js';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { GroupObject } from 'core-app/features/hal/resources/wp-collection-resource';
-import DataLabelsPlugin from 'chartjs-plugin-datalabels';
+import { CommonModule } from '@angular/common';
+import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+import PrimerColorsPlugin from './../plugin.primer-colors';
 
 export interface WorkPackageEmbeddedGraphDataset {
   label:string;
@@ -20,7 +23,14 @@ interface ChartDataSet {
   selector: 'op-wp-embedded-graph',
   templateUrl: './wp-embedded-graph.html',
   styleUrls: ['./wp-embedded-graph.component.sass'],
-  standalone: false,
+  standalone: true,
+  imports: [
+    CommonModule,
+    BaseChartDirective
+  ],
+  providers: [
+    provideCharts(withDefaultRegisterables(ChartDataLabels, PrimerColorsPlugin)),
+  ]
 })
 export class WorkPackageEmbeddedGraphComponent {
   @Input() public datasets:WorkPackageEmbeddedGraphDataset[];
@@ -38,8 +48,6 @@ export class WorkPackageEmbeddedGraphComponent {
   public chartLabels:string[] = [];
 
   public chartData:ChartDataSet[] = [];
-
-  public chartPlugins:Plugin[] = [DataLabelsPlugin];
 
   public internalChartOptions:ChartOptions;
 

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, SimpleChanges } from '@angular/core';
+import { Component, Input, SimpleChanges, OnChanges } from '@angular/core';
 import { WorkPackageTableConfiguration } from 'core-app/features/work-packages/components/wp-table/wp-table-configuration';
 import { ChartOptions } from 'chart.js';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -32,7 +32,7 @@ interface ChartDataSet {
     provideCharts(withDefaultRegisterables(ChartDataLabels, PrimerColorsPlugin)),
   ]
 })
-export class WorkPackageEmbeddedGraphComponent {
+export class WorkPackageEmbeddedGraphComponent implements OnChanges {
   @Input() public datasets:WorkPackageEmbeddedGraphDataset[];
 
   @Input() public chartOptions:ChartOptions;
@@ -79,10 +79,10 @@ export class WorkPackageEmbeddedGraphComponent {
     }, [])) as string[];
 
     const labelCountMaps = this.datasets.map((dataset) => {
-      const countMap = (dataset.groups || []).reduce((hash, group) => ({
+      const countMap = (dataset.groups || []).reduce<any>((hash, group) => ({
         ...hash,
         [group.value]: group.count,
-      }), {} as any);
+      }), {});
 
       return {
         label: dataset.label,
@@ -206,11 +206,11 @@ export class WorkPackageEmbeddedGraphComponent {
   private setHeight() {
     if (this.chartType === 'horizontalBar' && this.datasets && this.datasets[0]) {
       const labels:string[] = [];
-      this.datasets.forEach((d) => d.groups!.forEach((g) => {
+      this.datasets.forEach((d) => { d.groups!.forEach((g) => {
         if (!labels.includes(g.value)) {
           labels.push(g.value);
         }
-      }));
+      }); });
       let height = labels.length * 40;
 
       if (this.datasets.length > 1) {

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -6,7 +6,7 @@ import { GroupObject } from 'core-app/features/hal/resources/wp-collection-resou
 import { CommonModule } from '@angular/common';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
-import PrimerColorsPlugin from './../plugin.primer-colors';
+import PrimerColorsPlugin, { getCSSVariable } from './../plugin.primer-colors';
 
 export interface WorkPackageEmbeddedGraphDataset {
   label:string;
@@ -110,12 +110,10 @@ export class WorkPackageEmbeddedGraphComponent implements OnChanges {
     const bodyFontColor= getComputedStyle(document.body).getPropertyValue('--body-font-color');
     const gridLineColor= getComputedStyle(document.body).getPropertyValue('--borderColor-muted');
     const backdropColor= getComputedStyle(document.body).getPropertyValue('--overlay-backdrop-bgColor');
+    const onEmphasisColor = getComputedStyle(document.body).getPropertyValue('--fgColor-onEmphasis');
 
-    const defaults:ChartOptions = {
-      color: bodyFontColor,
-      responsive: true,
-      maintainAspectRatio: false,
-      indexAxis: this.chartType === 'horizontalBar' ? 'y' : 'x',
+
+    const barChartOptions = {
       scales: {
         r: {
           angleLines: {
@@ -157,22 +155,35 @@ export class WorkPackageEmbeddedGraphComponent implements OnChanges {
           border: {
             color: this.isBarChart() ? bodyFontColor : 'transparent',
           },
-        },
-      },
+        }
+      }
+    }
+
+    const defaults:ChartOptions = {
+      color: bodyFontColor,
+      responsive: true,
+      maintainAspectRatio: false,
+      indexAxis: this.chartType === 'horizontalBar' ? 'y' : 'x',
       plugins: {
         legend: {
           // Only display legends if more than one dataset is provided.
           display: this.datasets.length > 1,
+          labels: {
+            font: {
+              family: "Times New Roman, serif", // getCSSVariable("--fontStack-sansSerif")
+              //size: 14
+            }
+          }
         },
-        datalabels: {
-          anchor: 'center',
-          align: this.chartType === 'bar' ? 'top' : 'center',
-          color: bodyFontColor,
-          font: {
-            weight: 'bold',
-            size: 14,
-          },
-        },
+        // datalabels: {
+        //   anchor: 'center',
+        //   align: this.chartType === 'bar' ? 'top' : 'center',
+        //   color: onEmphasisColor,
+        //   font: {
+        //     weight: 'bold',
+        //     size: 14,
+        //   },
+        // },
       },
     };
 

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -6,7 +6,7 @@ import { GroupObject } from 'core-app/features/hal/resources/wp-collection-resou
 import { CommonModule } from '@angular/common';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
-import PrimerColorsPlugin, { getCSSVariable } from './../plugin.primer-colors';
+import PrimerColorsPlugin from './../plugin.primer-colors';
 
 export interface WorkPackageEmbeddedGraphDataset {
   label:string;
@@ -110,10 +110,12 @@ export class WorkPackageEmbeddedGraphComponent implements OnChanges {
     const bodyFontColor= getComputedStyle(document.body).getPropertyValue('--body-font-color');
     const gridLineColor= getComputedStyle(document.body).getPropertyValue('--borderColor-muted');
     const backdropColor= getComputedStyle(document.body).getPropertyValue('--overlay-backdrop-bgColor');
-    const onEmphasisColor = getComputedStyle(document.body).getPropertyValue('--fgColor-onEmphasis');
 
-
-    const barChartOptions = {
+    const defaults:ChartOptions = {
+      color: bodyFontColor,
+      responsive: true,
+      maintainAspectRatio: false,
+      indexAxis: this.chartType === 'horizontalBar' ? 'y' : 'x',
       scales: {
         r: {
           angleLines: {
@@ -155,35 +157,22 @@ export class WorkPackageEmbeddedGraphComponent implements OnChanges {
           border: {
             color: this.isBarChart() ? bodyFontColor : 'transparent',
           },
-        }
-      }
-    }
-
-    const defaults:ChartOptions = {
-      color: bodyFontColor,
-      responsive: true,
-      maintainAspectRatio: false,
-      indexAxis: this.chartType === 'horizontalBar' ? 'y' : 'x',
+        },
+      },
       plugins: {
         legend: {
           // Only display legends if more than one dataset is provided.
           display: this.datasets.length > 1,
-          labels: {
-            font: {
-              family: "Times New Roman, serif", // getCSSVariable("--fontStack-sansSerif")
-              //size: 14
-            }
-          }
         },
-        // datalabels: {
-        //   anchor: 'center',
-        //   align: this.chartType === 'bar' ? 'top' : 'center',
-        //   color: onEmphasisColor,
-        //   font: {
-        //     weight: 'bold',
-        //     size: 14,
-        //   },
-        // },
+        datalabels: {
+          anchor: 'center',
+          align: this.chartType === 'bar' ? 'top' : 'center',
+          color: bodyFontColor,
+          font: {
+            weight: 'bold',
+            size: 14,
+          },
+        },
       },
     };
 

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.html
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.html
@@ -3,7 +3,6 @@
     <canvas baseChart
       [datasets]="chartData"
       [labels]="chartLabels"
-      [plugins]="chartPlugins"
       [type]="mappedChartType"
       [options]="internalChartOptions"
       >

--- a/frontend/src/app/shared/components/work-package-graphs/openproject-work-package-graphs.module.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/openproject-work-package-graphs.module.ts
@@ -38,9 +38,6 @@ import { WpGraphConfigurationSettingsTabInnerComponent } from 'core-app/shared/c
 import { WorkPackageEmbeddedGraphComponent } from 'core-app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component';
 import { WorkPackageOverviewGraphComponent } from 'core-app/shared/components/work-package-graphs/overview/wp-overview-graph.component';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
-import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
-import ChartDataLabels from 'chartjs-plugin-datalabels';
-import PrimerColorsPlugin from './plugin.primer-colors';
 
 @NgModule({
   imports: [
@@ -50,8 +47,10 @@ import PrimerColorsPlugin from './plugin.primer-colors';
 
     OpenprojectWorkPackagesModule,
 
-    BaseChartDirective,
     OpenprojectTabsModule,
+
+    // Embedded graphs
+    WorkPackageEmbeddedGraphComponent,
   ],
   declarations: [
     // Modals
@@ -61,11 +60,8 @@ import PrimerColorsPlugin from './plugin.primer-colors';
     WpGraphConfigurationSettingsTabComponent,
     WpGraphConfigurationSettingsTabInnerComponent,
 
-    // Embedded graphs
-    WorkPackageEmbeddedGraphComponent,
     // Work package graphs on version page
     WorkPackageOverviewGraphComponent,
-
   ],
   exports: [
     // Modals
@@ -74,9 +70,6 @@ import PrimerColorsPlugin from './plugin.primer-colors';
     // Embedded graphs
     WorkPackageEmbeddedGraphComponent,
     WorkPackageOverviewGraphComponent,
-  ],
-  providers: [
-    provideCharts(withDefaultRegisterables(ChartDataLabels, PrimerColorsPlugin)),
-  ],
+  ]
 })
 export class OpenprojectWorkPackageGraphsModule {} // eslint-disable-line @typescript-eslint/no-extraneous-class

--- a/frontend/src/app/shared/components/work-package-graphs/openproject-work-package-graphs.module.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/openproject-work-package-graphs.module.ts
@@ -40,6 +40,7 @@ import { WorkPackageOverviewGraphComponent } from 'core-app/shared/components/wo
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
+import PrimerColorsPlugin from './plugin.primer-colors';
 
 @NgModule({
   imports: [
@@ -75,7 +76,7 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
     WorkPackageOverviewGraphComponent,
   ],
   providers: [
-    provideCharts(withDefaultRegisterables(ChartDataLabels)),
+    provideCharts(withDefaultRegisterables(ChartDataLabels, PrimerColorsPlugin)),
   ],
 })
 export class OpenprojectWorkPackageGraphsModule {} // eslint-disable-line @typescript-eslint/no-extraneous-class

--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -48,14 +48,14 @@ const PRIMER_COLORS = [
   'green',  // (contrasts strongly with orange)
   'purple', // (cool, distinct)
   'red',    // (strong, but not first to avoid clash with orange)
-  'plum',   // (cooler purple, contrasts with teal)
+  'yellow', // (bright highlight, works better later)
   'blue',   // (strong primary)
   'pink',   // (vivid, contrasts with blue)
   'pine',   // (deep green, darker balance)
   'auburn', // (earthy tone)
   'brown',  // (neutral balance)
+  'cyan',   // (slight highlight between neutral colours)
   'gray',   // (neutral, mid-series filler)
-  'yellow', // (bright highlight, works better later)
   'lemon',  // (darker yellow, less eye-catching)
   'olive',  // (subdued green, background tone)
   'lime',   // (subdued green, good closing color)
@@ -66,10 +66,10 @@ function getCSSVariable(variable:string) {
 }
 
 const EMPHASIS_COLORS = PRIMER_COLORS
-  .map((color) => getCSSVariable(`--data-${color}-color-emphasis`));
+  .map((color) => getCSSVariable(`--display-${color}-scale-4`));
 
 const MUTED_COLORS = PRIMER_COLORS
-  .map((color) => getCSSVariable(`--data-${color}-color-muted`));
+  .map((color) => getCSSVariable(`--display-${color}-scale-1`));
 
 function getEmphasisColor(i:number) {
   return EMPHASIS_COLORS[i % EMPHASIS_COLORS.length];

--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -61,7 +61,7 @@ const PRIMER_COLORS = [
   'lime',   // (subdued green, good closing color)
 ];
 
-export function getCSSVariable(variable:string) {
+function getCSSVariable(variable:string) {
   return getComputedStyle(document.body).getPropertyValue(variable).trim();
 }
 

--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -1,0 +1,141 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+// Based on https://github.com/chartjs/Chart.js/blob/master/src/plugins/plugin.colors.ts
+
+import {
+  BarController,
+  Chart,
+  ChartDataset,
+  ChartType,
+  DoughnutController,
+  Plugin,
+  PolarAreaController
+} from 'chart.js';
+
+export interface PrimerColorsPluginOptions {
+  enabled?:boolean;
+}
+
+const PRIMER_COLORS = [
+  'teal',   // (fresh contrast)
+  'orange', // (bold, warm → most eye-catching → first)
+  'green',  // (contrasts strongly with orange)
+  'purple', // (cool, distinct)
+  'red',    // (strong, but not first to avoid clash with orange)
+  'plum',   // (cooler purple, contrasts with teal)
+  'blue',   // (strong primary)
+  'pink',   // (vivid, contrasts with blue)
+  'pine',   // (deep green, darker balance)
+  'auburn', // (earthy tone)
+  'brown',  // (neutral balance)
+  'gray',   // (neutral, mid-series filler)
+  'yellow', // (bright highlight, works better later)
+  'lemon',  // (darker yellow, less eye-catching)
+  'olive',  // (subdued green, background tone)
+  'lime',   // (subdued green, good closing color)
+];
+
+function getCSSVariable(variable:string) {
+  return getComputedStyle(document.body).getPropertyValue(variable).trim();
+}
+
+const EMPHASIS_COLORS = PRIMER_COLORS
+  .map((color) => getCSSVariable(`--data-${color}-color-emphasis`));
+
+const MUTED_COLORS = PRIMER_COLORS
+  .map((color) => getCSSVariable(`--data-${color}-color-muted`));
+
+function getEmphasisColor(i:number) {
+  return EMPHASIS_COLORS[i % EMPHASIS_COLORS.length];
+}
+
+function getMutedColor(i:number) {
+  return MUTED_COLORS[i % MUTED_COLORS.length];
+}
+
+function colorizeDefaultDataset(dataset:ChartDataset, i:number) {
+  dataset.borderColor = getEmphasisColor(i);
+  dataset.backgroundColor = getMutedColor(i);
+
+  return ++i;
+}
+
+function colorizeBarDataset(dataset:ChartDataset, i:number) {
+  dataset.backgroundColor = dataset.data.map(() => getEmphasisColor(i++));
+
+  return i;
+}
+
+function colorizeDoughnutDataset(dataset:ChartDataset, i:number) {
+  dataset.backgroundColor = dataset.data.map(() => getEmphasisColor(i++));
+
+  return i;
+}
+
+function colorizePolarAreaDataset(dataset:ChartDataset, i:number) {
+  dataset.backgroundColor = dataset.data.map(() => getMutedColor(i++));
+
+  return i;
+}
+
+function getColorizer(chart:Chart) {
+  let i = 0;
+
+  return (dataset:ChartDataset, datasetIndex:number) => {
+    const controller = chart.getDatasetMeta(datasetIndex).controller;
+
+    if (controller instanceof DoughnutController) {
+      i = colorizeDoughnutDataset(dataset, i);
+    } else if (controller instanceof PolarAreaController) {
+      i = colorizePolarAreaDataset(dataset, i);
+    } else if (controller instanceof BarController) {
+      i = colorizeBarDataset(dataset, i);
+    } else {
+      i = colorizeDefaultDataset(dataset, i);
+    }
+  };
+}
+
+const plugin:Plugin<ChartType, PrimerColorsPluginOptions> = {
+  id: 'primer-colors',
+  defaults: { enabled: true },
+
+  beforeLayout(chart, _args, options) {
+    if (!options.enabled) {
+      return;
+    }
+
+    const { data: { datasets } } = chart.config;
+    const colorizer = getColorizer(chart);
+
+    datasets.forEach(colorizer);
+  },
+};
+
+export default plugin;

--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -61,7 +61,7 @@ const PRIMER_COLORS = [
   'lime',   // (subdued green, good closing color)
 ];
 
-function getCSSVariable(variable:string) {
+export function getCSSVariable(variable:string) {
   return getComputedStyle(document.body).getPropertyValue(variable).trim();
 }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/66624

# What are you trying to accomplish?

Fixes contrast in widget graphs by using [Primer's data visualization colors](https://primer.style/product/primitives/color/#data-visualization).

## Screenshots

Light

<img width="1398" height="634" alt="image" src="https://github.com/user-attachments/assets/cb916c9a-a2ac-42bc-a490-7f9edbadb448" />

Dark High-Contrast

<img width="1404" height="636" alt="image" src="https://github.com/user-attachments/assets/64f1bf03-f2f3-4041-9552-bdb9d1e939ba" />


# What approach did you choose and why?

Similar approach to #20173, except that:

- we use all Primer data visualization colors intead of just two.
- we apply colors to all charts, not just bar charts: to make graphs look good, we vary whether we colorize the background or borders, depending on type (this logic is mostly copied from Chart.js's built-in color plugin)
- the logic is encapsulated in a Chart.js plugin (so could eventually be extracted).

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
