### PR TITLE
include spec for blocknote editor

### DIFF
--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -39,6 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
       block_note_hocuspocus_url_value: hocuspocus_url,
       block_note_hocuspocus_access_token_value: hocuspocus_access_token,
       block_note_document_id_value: document_id,
+      test_selector: "blocknote-document-description"
     }
   ) do
 %>

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "BlockNote editor rendering", :js do
+  let(:admin) { create(:admin) }
+  let(:project) { create(:project) }
+  let(:category) { create(:document_category, name: "Experimental", project:) }
+  let(:document) { create(:document, category:) }
+
+  before do
+    login_as(admin)
+  end
+
+  it "renders the blocknote editor when editting a document", with_flag: { block_note_editor: true } do
+    visit edit_document_path(document)
+
+    expect(page).to have_field("Category", required: true)
+    expect(page).to have_field("Title", required: true)
+
+    expect(page).to have_test_selector("blocknote-document-description")
+    expect(page).to have_css(".block-note-editor-container")
+
+    description_field = page.find_test_selector("blocknote-document-description")
+    description_field.click
+    description_field.send_keys("Additional text")
+
+    click_on("Save")
+
+    visit edit_document_path(document)
+
+    expect(page).to have_test_selector("blocknote-document-description", text: "Additional text")
+  end
+end

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "BlockNote editor rendering", :js do
   let(:admin) { create(:admin) }


### PR DESCRIPTION
This is a follow up to https://github.com/opf/openproject/pull/20184

# What are you trying to accomplish?
The idea is to have a spec to validate that blocknote opens up correctly. Should allow for easier validation when there are version upgrades or other changes that affect the editor.

I'm testing in the context of documents, for it's the only place it is being used still.