### PR TITLE
Fix flaky meeting spec partially

### DIFF
--- a/modules/meeting/spec/features/meeting_backlogs_spec.rb
+++ b/modules/meeting/spec/features/meeting_backlogs_spec.rb
@@ -179,7 +179,6 @@ RSpec.describe "Meeting Backlogs", :js do
         # edit item
         show_page.edit_agenda_item(item) do
           fill_in "Title", with: "Updated title"
-          click_on "Save"
         end
         show_page.expect_backlog collapsed: false
 
@@ -326,7 +325,6 @@ RSpec.describe "Meeting Backlogs", :js do
         # edit item
         first_occurrence_page.edit_agenda_item(item) do
           fill_in "Title", with: "Updated title"
-          click_on "Save"
         end
         first_occurrence_page.expect_series_backlog collapsed: false
 
@@ -355,7 +353,6 @@ RSpec.describe "Meeting Backlogs", :js do
         item = first_occurrence.agenda_items.first
         first_occurrence_page.edit_agenda_item(item) do
           fill_in "Title", with: "Meeting 1 item"
-          click_on "Save"
         end
 
         first_occurrence_page.select_action(item, I18n.t(:label_agenda_item_move_to_backlog))
@@ -371,7 +368,6 @@ RSpec.describe "Meeting Backlogs", :js do
         other_meeting_item = next_occurrence.agenda_items.first
         next_occurrence_page.edit_agenda_item(other_meeting_item) do
           fill_in "Title", with: "Meeting 2 item"
-          click_on "Save"
         end
 
         next_occurrence_page.select_action(other_meeting_item, I18n.t(:label_agenda_item_move_to_backlog))
@@ -396,7 +392,6 @@ RSpec.describe "Meeting Backlogs", :js do
         # update moved item to check if component is updated correctly
         first_occurrence_page.edit_agenda_item(other_meeting_item) do
           fill_in "Title", with: "Meeting 2 item, now updated"
-          click_on "Save"
         end
         first_occurrence_page.expect_agenda_item(title: "Meeting 2 item, now updated")
 

--- a/modules/meeting/spec/features/meetings_autofocus_spec.rb
+++ b/modules/meeting/spec/features/meetings_autofocus_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe "Meetings autofocus", :js do
       show_page.expect_focused_input("form_#{item.id}_meeting_agenda_item_title")
 
       fill_in "Title", with: "Updated title"
-      click_on "Save"
     end
     show_page.expect_agenda_item title: "Updated title"
 
@@ -146,7 +145,7 @@ RSpec.describe "Meetings autofocus", :js do
     expect(wp_item).to be_present
 
     # edit wp item
-    show_page.edit_agenda_item(wp_item) do
+    show_page.edit_agenda_item(wp_item, save: false) do
       show_page.expect_focused_input("form_#{wp_item.id}_meeting_agenda_item_work_package_id")
       click_on "Cancel"
     end
@@ -208,7 +207,6 @@ RSpec.describe "Meetings autofocus", :js do
       show_page.expect_focused_input("form_#{item.id}_meeting_agenda_item_title")
 
       fill_in "Title", with: "Updated title"
-      click_on "Save"
     end
     show_page.expect_agenda_item title: "Updated title"
 
@@ -259,7 +257,7 @@ RSpec.describe "Meetings autofocus", :js do
     expect(wp_item).to be_present
 
     # edit wp item
-    show_page.edit_agenda_item(wp_item) do
+    show_page.edit_agenda_item(wp_item, save: false) do
       show_page.expect_focused_input("form_#{wp_item.id}_meeting_agenda_item_work_package_id")
       click_on "Cancel"
     end
@@ -302,7 +300,6 @@ RSpec.describe "Meetings autofocus", :js do
       show_page.expect_focused_input("form_#{item.id}_meeting_agenda_item_title")
 
       fill_in "Title", with: "Updated title"
-      click_on "Save"
     end
     show_page.expect_agenda_item title: "Updated title"
 
@@ -329,7 +326,7 @@ RSpec.describe "Meetings autofocus", :js do
     expect(wp_item).to be_present
 
     # edit wp item
-    show_page.edit_agenda_item(wp_item) do
+    show_page.edit_agenda_item(wp_item, save: false) do
       show_page.expect_focused_input("form_#{wp_item.id}_meeting_agenda_item_work_package_id")
       click_on "Cancel"
     end

--- a/modules/meeting/spec/features/meetings_edit_agenda_spec.rb
+++ b/modules/meeting/spec/features/meetings_edit_agenda_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe "Meetings edit agenda", :js do
 
     second_item = MeetingAgendaItem.find_by(title: "Agenda Item #2")
 
-    show_page.edit_agenda_item(first_item) do
+    show_page.edit_agenda_item(first_item, save: false) do
       expect(show_page).to have_selector :rich_text, "Notes", text: "Preliminary notes ✅"
     end
 
-    show_page.edit_agenda_item(second_item) do
+    show_page.edit_agenda_item(second_item, save: false) do
       expect(show_page).to have_selector :rich_text, "Notes", text: "More notes..."
     end
   end

--- a/modules/meeting/spec/features/structured_meetings/history_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/history_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe "history",
     show_page.edit_agenda_item(item) do
       fill_in "Title", with: "Updated title"
       fill_in "Duration", with: "5"
-      click_on "Save"
     end
 
     # dynamically wait for the item to be updated successfully
@@ -239,7 +238,6 @@ RSpec.describe "history",
       select_autocomplete(find_test_selector("op-agenda-items-wp-autocomplete"),
                           query: "Changed task",
                           results_selector: "body")
-      click_link_or_button "Save"
     end
 
     show_page.expect_agenda_item title: "Changed task"

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe "Meetings CRUD",
     # Can update
     show_page.edit_agenda_item(item) do
       fill_in "Title", with: "Updated title"
-      click_on "Save"
     end
 
     show_page.expect_no_agenda_item title: "My agenda item"
@@ -138,7 +137,7 @@ RSpec.describe "Meetings CRUD",
     show_page.assert_agenda_order! "First", "Updated title", "Second"
 
     # Can edit and cancel with escape
-    show_page.edit_agenda_item(first) do
+    show_page.edit_agenda_item(first, save: false) do
       find_field("Title").send_keys :escape
     end
     show_page.expect_item_edit_form(first, visible: false)
@@ -159,16 +158,16 @@ RSpec.describe "Meetings CRUD",
     expect(wp_item).to be_present
 
     # Can edit and validate a work package item
-    show_page.edit_agenda_item(wp_item) do
+    show_page.edit_agenda_item(wp_item, save: false) do
       show_page.clear_item_edit_work_package_title
-      click_on "Save"
+      click_on "Save" # triggers an error
     end
 
     show_page.expect_item_edit_field_error(wp_item, "Work package can't be blank.")
     show_page.cancel_edit_form(wp_item)
 
     # Keeping the editing state of an agenda item while modifying other items
-    show_page.edit_agenda_item(second) do
+    show_page.edit_agenda_item(second, save: false) do
       fill_in "Title", with: "Second edited"
     end
 
@@ -185,7 +184,6 @@ RSpec.describe "Meetings CRUD",
 
     show_page.edit_agenda_item(my_item) do
       fill_in "Title", with: "My agenda item edited"
-      click_on "Save"
     end
 
     show_page.remove_agenda_item my_item
@@ -275,12 +273,12 @@ RSpec.describe "Meetings CRUD",
     show_page.expect_agenda_item title: "My agenda item"
     item = MeetingAgendaItem.find_by!(title: "My agenda item")
 
-    show_page.edit_agenda_item(item) do
+    show_page.edit_agenda_item(item, save: false) do
       # Side effect: update the item
       item.update!(title: "Updated title")
 
       fill_in "Title", with: "My agenda item edited"
-      click_on "Save"
+      click_on "Save" # triggers an error
     end
 
     expect(page).to have_css(".flash", text: I18n.t("activerecord.errors.messages.error_conflict"))
@@ -489,7 +487,6 @@ RSpec.describe "Meetings CRUD",
 
         show_page.edit_agenda_item(item_in_second_section) do
           fill_in "Duration", with: "15"
-          click_on "Save"
         end
 
         # duration gets updated

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe "Meetings CRUD",
 
           show_page.edit_agenda_item(item) do
             fill_in "Title", with: "Updated title"
-            show_page.click_save_and_wait_for_agenda_item_update
           end
 
           # Expect no notification in window1
@@ -284,8 +283,6 @@ RSpec.describe "Meetings CRUD",
             item = MeetingAgendaItem.find_by(title: "Backlog agenda item")
             next_occurrence_page.edit_agenda_item(item) do
               fill_in "Title", with: "Edited title"
-              click_on "Save"
-              sleep 0.5 # wait for save to apply
             end
 
             next_occurrence_page.trigger_change_poll

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Meetings CRUD",
 
           show_page.edit_agenda_item(item) do
             fill_in "Title", with: "Updated title"
-            click_on "Save"
+            show_page.click_save_and_wait_for_agenda_item_update
           end
 
           # Expect no notification in window1
@@ -285,6 +285,7 @@ RSpec.describe "Meetings CRUD",
             next_occurrence_page.edit_agenda_item(item) do
               fill_in "Title", with: "Edited title"
               click_on "Save"
+              sleep 0.5 # wait for save to apply
             end
 
             next_occurrence_page.trigger_change_poll

--- a/modules/meeting/spec/features/structured_meetings/update_flash_shared_examples.rb
+++ b/modules/meeting/spec/features/structured_meetings/update_flash_shared_examples.rb
@@ -51,8 +51,6 @@ RSpec.shared_examples "no flash appears when interacting with backlog in multipl
       item = MeetingAgendaItem.find_by(title: "Backlog agenda item")
       show_page.edit_agenda_item(item) do
         fill_in "Title", with: "Edited title"
-        click_on "Save"
-        sleep 1 # cannot use `show_page.click_save_and_wait_for_agenda_item_update` because of `travel_to`
       end
 
       show_page.trigger_change_poll

--- a/modules/meeting/spec/features/structured_meetings/update_flash_shared_examples.rb
+++ b/modules/meeting/spec/features/structured_meetings/update_flash_shared_examples.rb
@@ -52,6 +52,7 @@ RSpec.shared_examples "no flash appears when interacting with backlog in multipl
       show_page.edit_agenda_item(item) do
         fill_in "Title", with: "Edited title"
         click_on "Save"
+        sleep 1 # cannot use `show_page.click_save_and_wait_for_agenda_item_update` because of `travel_to`
       end
 
       show_page.trigger_change_poll

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -384,6 +384,8 @@ module Pages::Meetings
       end
     end
 
+    # Clicks "Save" button and waits until the number of agenda items in the database has
+    # changed.
     def click_save_and_wait_for_agenda_item_creation
       initial_db_items_count = MeetingAgendaItem.count
       click_on("Save")
@@ -396,13 +398,14 @@ module Pages::Meetings
       MeetingAgendaItem.maximum(:id)
     end
 
-    # warning: does not work when using `travel_to` because time is stopped.
+    # Clicks "Save" button and waits until some agenda items have a different
+    # `lock_version` value in the database.
     def click_save_and_wait_for_agenda_item_update
-      initial_db_items_updated_at = MeetingAgendaItem.order(:id).pluck(:updated_at)
+      initial_db_items_versions = MeetingAgendaItem.order(:id).pluck(:lock_version)
       click_on("Save")
 
       # wait for db save
-      wait_for { MeetingAgendaItem.order(:id).pluck(:updated_at) }.not_to eq(initial_db_items_updated_at)
+      wait_for { MeetingAgendaItem.order(:id).pluck(:lock_version) }.not_to eq(initial_db_items_versions)
     end
 
     def select_backlog_action(action)
@@ -439,10 +442,15 @@ module Pages::Meetings
       end
     end
 
-    def edit_agenda_item(item, &)
+    def edit_agenda_item(item, save: true, &)
       select_action item, "Edit"
       expect_item_edit_form(item)
-      page.within("#meeting-agenda-items-form-component-#{item.id}", &)
+      page.within("#meeting-agenda-items-form-component-#{item.id}") do
+        yield
+        if save
+          click_save_and_wait_for_agenda_item_update
+        end
+      end
     end
 
     def expect_item_edit_form(item, visible: true)

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -33,6 +33,7 @@ require_relative "base"
 module Pages::Meetings
   class Show < Base
     include ::Components::Autocompleter::NgSelectAutocompleteHelpers
+
     attr_accessor :meeting
 
     def initialize(meeting)
@@ -116,10 +117,12 @@ module Pages::Meetings
         click_on type.model_name.human
       end
 
+      created_id = nil
       in_agenda_form do
         yield
-        click_on("Save") if save
+        created_id = click_save_and_wait_for_agenda_item_creation if save
       end
+      expect(page).to have_css("#meeting-agenda-items-item-component-#{created_id}") if created_id
     end
 
     def expect_modal(...)
@@ -134,10 +137,12 @@ module Pages::Meetings
       select_section_action(section, "Add #{type.model_name.human.downcase}")
 
       within("#meeting-sections-show-component-#{section.id}") do
+        created_id = nil
         in_agenda_form do
           yield
-          click_on("Save") if save
+          created_id = click_save_and_wait_for_agenda_item_creation if save
         end
+        expect(page).to have_css("#meeting-agenda-items-item-component-#{created_id}") if created_id
       end
     end
 
@@ -370,11 +375,34 @@ module Pages::Meetings
       select_backlog_action("Add #{type.model_name.human.downcase}")
 
       within("#meeting-sections-backlogs-container-component") do
+        created_id = nil
         in_agenda_form do
           yield
-          click_on("Save")
+          created_id = click_save_and_wait_for_agenda_item_creation
         end
+        expect(page).to have_css("#meeting-agenda-items-item-component-#{created_id}")
       end
+    end
+
+    def click_save_and_wait_for_agenda_item_creation
+      initial_db_items_count = MeetingAgendaItem.count
+      click_on("Save")
+
+      # wait for db save
+      wait_for { MeetingAgendaItem.count }.not_to eq(initial_db_items_count)
+
+      # return created item id so that caller can wait for it (can't do it here
+      # because of being "in_agenda_form" scope)
+      MeetingAgendaItem.maximum(:id)
+    end
+
+    # warning: does not work when using `travel_to` because time is stopped.
+    def click_save_and_wait_for_agenda_item_update
+      initial_db_items_updated_at = MeetingAgendaItem.order(:id).pluck(:updated_at)
+      click_on("Save")
+
+      # wait for db save
+      wait_for { MeetingAgendaItem.order(:id).pluck(:updated_at) }.not_to eq(initial_db_items_updated_at)
     end
 
     def select_backlog_action(action)


### PR DESCRIPTION
failing spec: `modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb`

When run locally, it does not wait enough after saving an agenda item and it sometimes creates synchronizations issues such as:

- click on the menu icon of an agenda item too early, then the items are updated by the turbo response and the menu is closed, so it fails to find the ".Overlay" element. It is retried so it's not that big of a problem, but it's not ideal as it waits for nothing.

- save an agenda item on a browser window, then switch to another tab and expect the update notification to be displayed. Well sometimes it's not saved yet, so the notification is not displayed, and the test fails.

- A variant of the previous one: save an agenda item on a browser window, then switch to another tab and reload the page. Sometimes the save is not finished yet, so the page reloads but the agenda item is not there yet.

The fix is to wait for the save to complete. Either by waiting for the record to be created or updated, and then for the element to be displayed. Or also by just sleeping 1 second because I could not find a better synchronization mechanism.

Note that this still not fixes the flakiness where the `travel_to` seems to not be effective anymore when the recurring meeting is created. See run https://github.com/opf/openproject/actions/runs/17466279904/job/49602727897 for instance.
