### PR TITLE
[#67256] handle old provider data where group_regexes are nil

### DIFF
--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -109,6 +109,11 @@ module OpenIDConnect
       end
     end
 
+    def group_regexes
+      # handle legacy data, where group regexes where `nil`.
+      super || []
+    end
+
     def google?
       oidc_provider == "google"
     end


### PR DESCRIPTION
# Ticket
[#67256](https://community.openproject.org/work_packages/67256)

# What are you trying to accomplish?
- handle old provider data where group_regexes are nil

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
- fall back to `[]` on the attribute getter

### Hint
- much interested in @NobodysNightmare opinion here, if this is the right fix