### PR TITLE
Use relations state to update Gantt rendering

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -120,10 +120,11 @@ export class WorkPackageTableTimelineRelations extends UntilDestroyedMixin imple
     // for all visible WorkPackage rows...
     combineLatest([
       this.querySpace.renderedWorkPackages.values$(),
+      this.wpRelations.observeAll(),
       this.wpTableTimeline.live$(),
     ])
       .pipe(
-        filter(([_, timeline]) => timeline.visible),
+        filter(([_render, _relations, timeline]) => timeline.visible),
         this.untilDestroyed(),
         map(([rendered, _]) => rendered),
       )


### PR DESCRIPTION
The relations state is not taken into consideration when the gantt redraws, so we should include its updates in the recalculation of the gantt chart.

https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/63437/activity