### PR TITLE
Use separate service to properly end meeting with occurrences

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -136,15 +136,11 @@ class RecurringMeetingsController < ApplicationController
   end
 
   def end_series
-    call = ::RecurringMeetings::UpdateService
-      .new(model: @recurring_meeting, user: current_user, contract_class: RecurringMeetings::EndSeriesContract)
-      .call(end_after: "specific_date", end_date: Time.zone.today)
+    call = ::RecurringMeetings::EndService
+      .new(@recurring_meeting, current_user:)
+      .call
 
-    if call.success?
-      @recurring_meeting.scheduled_meetings.upcoming.destroy_all
-    else
-      flash[:error] = call.message
-    end
+    call.apply_flash_message!(flash)
     redirect_to action: :show
   end
 

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -305,10 +305,6 @@ class RecurringMeeting < ApplicationRecord
   def end_date_constraints
     return if end_date.nil?
 
-    if end_date < Date.current
-      errors.add(:end_date, :after_today)
-    end
-
     if parsed_start_date.present? && end_date < parsed_start_date
       errors.add(:end_date, :after, date: format_date(parsed_start_date))
     end

--- a/modules/meeting/app/services/recurring_meetings/end_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/end_service.rb
@@ -29,22 +29,45 @@
 #++
 
 module RecurringMeetings
-  class EndSeriesContract < BaseContract
-    include Redmine::I18n
+  class EndService < ::BaseServices::BaseCallable
+    attr_reader :recurring_meeting, :current_user
 
-    validate :user_allowed_to_edit
-    validate :meeting_ended
+    def initialize(recurring_meeting, current_user:)
+      super()
 
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:edit_meetings, model.project)
-        errors.add :base, :error_unauthorized
-      end
+      @recurring_meeting = recurring_meeting
+      @current_user = current_user
     end
 
-    def meeting_ended
-      return if model.end_date == Time.zone.yesterday
+    def call
+      # When we want the meeting to have ended today,
+      # yesterday remains the last possible occurrence, so we set end_date = yesterday.
+      # We do not want any occurrences today to remain.
+      result = ::RecurringMeetings::UpdateService
+        .new(model: recurring_meeting, user: current_user, contract_class: RecurringMeetings::EndSeriesContract)
+        .call(end_after: "specific_date", end_date: Time.zone.yesterday)
 
-      errors.add :end_date, :invalid
+      result.on_success do
+        remove_scheduled_meetings
+        remove_future_occurrences
+      end
+
+      result
+    end
+
+    private
+
+    ##
+    # Remove any upcoming scheduled meetings (e.g., those that are instantiated or cancelled)
+    def remove_scheduled_meetings
+      recurring_meeting.scheduled_meetings.upcoming.destroy_all
+    end
+
+    ##
+    # Remove all actual future occurrences of the meeting that remained.
+    # We do not use the DeleteService as that would send out notifications
+    def remove_future_occurrences
+      recurring_meeting.scheduled_instances.destroy_all
     end
   end
 end

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -17,15 +17,6 @@ RSpec.describe RecurringMeeting,
         expect(subject.errors[:end_date]).to include("must be after #{subject.start_date}.")
       end
     end
-
-    context "with end_date in the past" do
-      let(:end_date) { Date.yesterday }
-
-      it "is invalid" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:end_date]).to include("must be in the future.")
-      end
-    end
   end
 
   describe "intervals" do

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_end_series_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_end_series_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Recurring meetings complete template",
     create :recurring_meeting,
            project:,
            author: user,
-           start_time: DateTime.parse("2024-12-05T10:00:00Z"),
+           start_time: DateTime.parse("2024-12-03T10:00:00Z"),
            frequency: "daily"
   end
 
@@ -90,13 +90,13 @@ RSpec.describe "Recurring meetings complete template",
     end
 
     subject do
-      Timecop.freeze("2024-12-04T10:00:00Z".to_datetime) { request }
+      Timecop.freeze("2024-12-03T10:00:00Z".to_datetime) { request }
     end
 
     it "returns an error" do
       expect { subject }.not_to change { recurring_meeting.reload.updated_at }
       expect(response).to be_redirect
-      expect(flash[:error]).to include "End date must be after 2024-12-05."
+      expect(flash[:error]).to include "End date must be after 2024-12-03."
     end
   end
 
@@ -113,7 +113,7 @@ RSpec.describe "Recurring meetings complete template",
       expect(response).to be_redirect
 
       recurring_meeting.reload
-      expect(recurring_meeting.end_date).to eq Date.parse("2025-01-29")
+      expect(recurring_meeting.end_date).to eq Date.parse("2025-01-28")
 
       expect(recurring_meeting.scheduled_meetings.count).to eq(1)
       first = recurring_meeting.scheduled_meetings.first
@@ -137,7 +137,7 @@ RSpec.describe "Recurring meetings complete template",
       expect(response).to be_redirect
 
       recurring_meeting.reload
-      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-05")
+      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-04")
       expect(recurring_meeting.scheduled_meetings.count).to eq(1)
     end
   end
@@ -158,7 +158,7 @@ RSpec.describe "Recurring meetings complete template",
       expect(response).to be_redirect
 
       recurring_meeting.reload
-      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-05")
+      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-04")
     end
   end
 
@@ -185,7 +185,7 @@ RSpec.describe "Recurring meetings complete template",
       expect(response).to be_redirect
 
       recurring_meeting.reload
-      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-05")
+      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-04")
     end
   end
 
@@ -205,7 +205,7 @@ RSpec.describe "Recurring meetings complete template",
       expect(response).to be_redirect
 
       recurring_meeting.reload
-      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-05")
+      expect(recurring_meeting.end_date).to eq Date.parse("2024-12-04")
       expect(recurring_meeting.scheduled_meetings.count).to eq(0)
       expect { schedule.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end

--- a/modules/meeting/spec/services/recurring_meetings/end_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/end_service_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe RecurringMeetings::EndService, type: :model do
+  shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
+  shared_let(:user) do
+    create(:user, member_with_permissions: { project => %i[view_meetings edit_meetings] })
+  end
+
+  let(:recurring_meeting) do
+    create(:recurring_meeting,
+           project:,
+           start_time: Time.zone.tomorrow + 10.hours,
+           frequency: "daily",
+           interval: 1,
+           end_after: "specific_date",
+           end_date: 1.month.from_now)
+  end
+
+  let(:service) { described_class.new(recurring_meeting, current_user: user) }
+
+  describe "#call" do
+    context "when the service is successful" do
+      let(:update_service_instance) { instance_double(RecurringMeetings::UpdateService) }
+
+      before do
+        allow(RecurringMeetings::UpdateService)
+          .to receive(:new)
+                .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+                .and_return(update_service_instance)
+        allow(update_service_instance)
+          .to receive(:call)
+                .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+                .and_return(ServiceResult.success)
+      end
+
+      it "returns a successful result" do
+        result = service.call
+
+        expect(result).to be_success
+      end
+
+      it "calls the UpdateService with correct parameters" do
+        service.call
+
+        expect(RecurringMeetings::UpdateService)
+          .to have_received(:new)
+                .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+        expect(update_service_instance)
+          .to have_received(:call)
+                .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+      end
+    end
+
+    context "when the UpdateService fails" do
+      let(:error_result) { ServiceResult.failure(errors: { base: ["Some error"] }) }
+      let(:update_service_instance) { instance_double(RecurringMeetings::UpdateService) }
+
+      before do
+        allow(RecurringMeetings::UpdateService)
+          .to receive(:new)
+                .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+                .and_return(update_service_instance)
+        allow(update_service_instance)
+          .to receive(:call)
+                .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+                .and_return(error_result)
+      end
+
+      it "returns the failed result" do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.errors[:base]).to include("Some error")
+      end
+
+      it "does not remove scheduled meetings or occurrences" do
+        allow(recurring_meeting).to receive(:scheduled_meetings)
+        allow(recurring_meeting).to receive(:scheduled_instances)
+
+        service.call
+
+        expect(recurring_meeting).not_to have_received(:scheduled_meetings)
+        expect(recurring_meeting).not_to have_received(:scheduled_instances)
+      end
+    end
+  end
+
+  describe "scheduled meetings removal" do
+    let!(:upcoming_scheduled_meeting) do
+      create(:scheduled_meeting,
+             :persisted,
+             recurring_meeting:,
+             start_time: Time.zone.tomorrow + 1.day + 10.hours)
+    end
+
+    let!(:cancelled_scheduled_meeting) do
+      create(:scheduled_meeting,
+             :cancelled,
+             recurring_meeting:,
+             start_time: Time.zone.tomorrow + 2.days + 10.hours)
+    end
+
+    let!(:past_scheduled_meeting) do
+      create(:scheduled_meeting,
+             recurring_meeting:,
+             start_time: Time.zone.yesterday + 10.hours)
+    end
+
+    let(:update_service_instance) { instance_double(RecurringMeetings::UpdateService) }
+
+    before do
+      allow(RecurringMeetings::UpdateService)
+        .to receive(:new)
+        .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+        .and_return(update_service_instance)
+      allow(update_service_instance)
+        .to receive(:call)
+        .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+        .and_return(ServiceResult.success)
+    end
+
+    it "removes upcoming scheduled meetings" do
+      expect { service.call }
+        .to change { recurring_meeting.scheduled_meetings.upcoming.count }
+        .from(2).to(0)
+    end
+
+    it "does not remove past scheduled meetings" do
+      expect { service.call }
+        .not_to change { recurring_meeting.scheduled_meetings.past.count }
+    end
+
+    it "removes both persisted and cancelled upcoming meetings" do
+      service.call
+
+      expect { upcoming_scheduled_meeting.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { cancelled_scheduled_meeting.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { past_scheduled_meeting.reload }.not_to raise_error
+    end
+  end
+
+  describe "future occurrences removal" do
+    let!(:future_occurrence) do
+      create(:scheduled_meeting,
+             :persisted,
+             recurring_meeting:,
+             start_time: Time.zone.tomorrow + 1.day + 10.hours)
+    end
+
+    let!(:past_occurrence) do
+      create(:scheduled_meeting,
+             recurring_meeting:,
+             start_time: Time.zone.yesterday + 10.hours)
+    end
+
+    let(:update_service_instance) { instance_double(RecurringMeetings::UpdateService) }
+
+    before do
+      allow(RecurringMeetings::UpdateService)
+        .to receive(:new)
+              .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+              .and_return(update_service_instance)
+      allow(update_service_instance)
+        .to receive(:call)
+              .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+              .and_return(ServiceResult.success)
+    end
+
+    it "removes upcoming scheduled instances only" do
+      expect { service.call }
+        .to change { recurring_meeting.scheduled_instances.count }
+              .from(1).to(0)
+    end
+
+    it "removes future occurrences but not past ones" do
+      service.call
+
+      expect { future_occurrence.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { past_occurrence.reload }.not_to raise_error
+    end
+  end
+
+  describe "time zone handling" do
+    let(:recurring_meeting) do
+      create(:recurring_meeting,
+             project:,
+             start_time: Time.zone.tomorrow + 10.hours,
+             time_zone: "America/New_York",
+             frequency: "daily",
+             interval: 1,
+             end_after: "specific_date",
+             end_date: 1.month.from_now)
+    end
+
+    let(:update_service_instance) { instance_double(RecurringMeetings::UpdateService) }
+
+    before do
+      allow(RecurringMeetings::UpdateService)
+        .to receive(:new)
+              .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+              .and_return(update_service_instance)
+      allow(update_service_instance)
+        .to receive(:call)
+              .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+              .and_return(ServiceResult.success)
+    end
+
+    it "uses Time.zone.yesterday for end_date regardless of meeting timezone" do
+      service.call
+
+      expect(RecurringMeetings::UpdateService)
+        .to have_received(:new)
+              .with(model: recurring_meeting, user: user, contract_class: RecurringMeetings::EndSeriesContract)
+      expect(update_service_instance)
+        .to have_received(:call)
+              .with(end_after: "specific_date", end_date: Time.zone.yesterday)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/67297

- [x] Use separate service to delete all future occurrences and schedules
- [x] Remove constraint on end_date >= today, as long as it's > start_date
- [x] When ending the meeting, set the end_date to yesterday of the calling user, so that for their today, the meeting has ended already.