### PR TITLE
Wait for reference value to change after saving

### DIFF
--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Meetings CRUD",
         within_window(first_window) do
           item = MeetingAgendaItem.find_by(title: "Update toast test item")
 
-          show_page.edit_agenda_item(item) do
+          show_page.edit_agenda_item(item, wait_for_reference_update: true) do
             fill_in "Title", with: "Updated title"
           end
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -442,15 +442,18 @@ module Pages::Meetings
       end
     end
 
-    def edit_agenda_item(item, save: true, &)
+    def edit_agenda_item(item, save: true, wait_for_reference_update: false, &)
       select_action item, "Edit"
       expect_item_edit_form(item)
+      reference_value = meeting_reference_value
       page.within("#meeting-agenda-items-form-component-#{item.id}") do
         yield
         if save
           click_save_and_wait_for_agenda_item_update
         end
       end
+
+      wait_for_reference_changed(reference_value) if save && wait_for_reference_update
     end
 
     def expect_item_edit_form(item, visible: true)
@@ -703,6 +706,17 @@ module Pages::Meetings
       input = page.find_by_id("meeting_start_time_hour")
       page.execute_script("arguments[0].value = arguments[1]", input.native, time)
       page.execute_script("arguments[0].dispatchEvent(new Event('input'))", input.native)
+    end
+
+    def meeting_reference_value
+      page_header = page.find("#meetings-header-component page-header")
+      page_header["data-reference-value"]
+    end
+
+    def wait_for_reference_changed(old_reference_value)
+      expect(page).to have_css("#meetings-header-component page-header") do |element|
+        element["data-reference-value"] != old_reference_value
+      end
     end
   end
 end


### PR DESCRIPTION
The meeting flash spec is flickering due to a timing issue. We are already waiting for the agenda item lock version to increase, but not for the header to be updated from a turbo stream after that happens. This PR hopes to fix this