### PR TITLE
Split docker workflow into release and scheduled

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,53 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag to release. Note that this happens by default on the tag push. Only run this action when something went wrong!"
+        required: false
+
+jobs:
+  compute-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.compute.outputs.tags }}
+      branch: ${{ steps.compute.outputs.branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+      - name: Compute tags and branch
+        id: compute
+        run: |
+          if [[ ${{ github.event_name }} == 'push' ]]; then
+            # Tag push: v14.1.0
+            TAG_REF="${GITHUB_REF#refs/tags/}"
+            BRANCH_REF="$GITHUB_REF"
+          elif [[ ${{ github.event_name }} == 'workflow_dispatch' && -n "${{ inputs.tag }}" ]]; then
+            # Manual dispatch with tag
+            TAG_REF="${{ inputs.tag }}"
+            BRANCH_REF="${{ inputs.tag }}"
+          else
+            # Fallback to dev
+            TAG_REF="dev"
+            BRANCH_REF="dev"
+          fi
+
+          echo "branch=$BRANCH_REF" >> "$GITHUB_OUTPUT"
+
+          # Use Ruby script to generate tags
+          TAGS=$(./script/gh/docker-tags.rb --semver "$TAG_REF")
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: compute-tags
+    uses: ./.github/workflows/docker.yml
+    with:
+      branch: ${{ needs.compute-tags.outputs.branch }}
+      tags: ${{ needs.compute-tags.outputs.tags }}
+    secrets: inherit

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,4 +1,4 @@
-name: Docker Release
+name: Docker / Tagged builds
 
 on:
   push:
@@ -11,10 +11,10 @@ on:
         required: false
 
 jobs:
-  compute-tags:
+  compute-inputs:
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.compute.outputs.tags }}
+      tag: ${{ steps.compute.outputs.tag }}
       branch: ${{ steps.compute.outputs.branch }}
     steps:
       - name: Checkout
@@ -25,7 +25,7 @@ jobs:
         id: compute
         run: |
           if [[ ${{ github.event_name }} == 'push' ]]; then
-            # Tag push: v14.1.0
+            # Tag push e.g. refs/tags/v16.3.0 => v16.3.0
             TAG_REF="${GITHUB_REF#refs/tags/}"
             BRANCH_REF="$GITHUB_REF"
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' && -n "${{ inputs.tag }}" ]]; then
@@ -39,15 +39,33 @@ jobs:
           fi
 
           echo "branch=$BRANCH_REF" >> "$GITHUB_OUTPUT"
-
-          # Use Ruby script to generate tags
-          TAGS=$(./script/gh/docker-tags.rb --semver "$TAG_REF")
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG_REF" >> "$GITHUB_OUTPUT"
 
   build:
-    needs: compute-tags
+    needs: compute-inputs
     uses: ./.github/workflows/docker.yml
     with:
-      branch: ${{ needs.compute-tags.outputs.branch }}
-      tags: ${{ needs.compute-tags.outputs.tags }}
+      branch: ${{ needs.compute-inputs.outputs.branch }}
+      tag: ${{ needs.compute-inputs.outputs.tag }}
     secrets: inherit
+
+  trigger_helm_release:
+    if: ${{ github.repository == 'opf/openproject' }}
+    needs: [compute-inputs, build]
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Helm charts release
+        env:
+          TOKEN: ${{ secrets.OPENPROJECT_CI_TOKEN }}
+          REPOSITORY: opf/helm-charts
+          WORKFLOW_ID: core_release.yml
+        run: |
+          # FIXME: re-enable once workflows are confirmed to be doing the right thing
+          echo "Would have triggered helm charts release with tag: ${{ needs.compute-inputs.outputs.tag }}"
+          exit 0
+          curl -i --fail-with-body -H"authorization: Bearer $TOKEN" \
+            -XPOST -H"Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$REPOSITORY/actions/workflows/$WORKFLOW_ID/dispatches \
+            -d '{"ref": "main", "inputs": { "tag" : "${{ needs.compute-inputs.outputs.tag }}" }}'

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -13,8 +13,8 @@ jobs:
         include:
           - branch: dev
             tag: "dev"
-          - branch: release/16.3
-            tag: "16.3-pre"
+          - branch: release/16.4
+            tag: "16.4-rc,16-rc,rc"
     uses: ./.github/workflows/docker.yml
     with:
       branch: ${{ matrix.branch }}

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -1,4 +1,4 @@
-name: Docker Scheduled Builds
+name: Docker / Scheduled builds
 
 on:
   # build dev and release branches daily
@@ -12,13 +12,11 @@ jobs:
       matrix:
         include:
           - branch: dev
-            tags: "dev"
-          - branch: release/16.2
-            tags: "16.2-pre"
-          - branch: release/16.1
-            tags: "16.1-pre"
+            tag: "dev"
+          - branch: release/16.3
+            tag: "16.3-pre"
     uses: ./.github/workflows/docker.yml
     with:
       branch: ${{ matrix.branch }}
-      tags: ${{ matrix.tags }}
+      tag: ${{ matrix.tag }}
     secrets: inherit

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -1,0 +1,24 @@
+name: Docker Scheduled Builds
+
+on:
+  # build dev and release branches daily
+  schedule:
+    - cron: "20 2 * * *" # Daily at 02:20
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - branch: dev
+            tags: "dev"
+          - branch: release/16.2
+            tags: "16.2-pre"
+          - branch: release/16.1
+            tags: "16.1-pre"
+    uses: ./.github/workflows/docker.yml
+    with:
+      branch: ${{ matrix.branch }}
+      tags: ${{ matrix.tags }}
+    secrets: inherit

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -7,14 +7,22 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate matrix
+        id: set-matrix
+        run: |
+          matrix=$(ruby script/gh/docker-tags.rb --matrix)
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   build:
+    needs: generate-matrix
     strategy:
-      matrix:
-        include:
-          - branch: dev
-            tag: "dev"
-          - branch: release/16.4
-            tag: "16.4-rc"
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/docker.yml
     with:
       branch: ${{ matrix.branch }}

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -14,7 +14,7 @@ jobs:
           - branch: dev
             tag: "dev"
           - branch: release/16.4
-            tag: "16.4-rc,16-rc,rc"
+            tag: "16.4-rc"
     uses: ./.github/workflows/docker.yml
     with:
       branch: ${{ matrix.branch }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,15 @@
-name: Docker Build (Reusable)
+name: Docker
+run-name: Build docker image from branch ${{ inputs.branch }} with tag ${{ inputs.tag }}
 
 on:
   workflow_call:
     inputs:
       branch:
-        description: "The branch to checkout and build"
+        description: "The branch or tag to checkout and build"
         required: true
         type: string
-      tags:
-        description: "Comma-separated list of docker tags to use (e.g., 'dev' or '14.1.0,14.1,14')"
+      tag:
+        description: "The main docker tag to use (e.g., 'dev' or '16.3.0')"
         required: true
         type: string
 
@@ -30,15 +31,8 @@ jobs:
       - name: Set version outputs and convert tags
         id: extract_version
         run: |
-          # Use Ruby script to format tags and get version
-          FORMATTED_TAGS=$(./script/gh/docker-tags.rb --tags "${{ inputs.tags }}" --format)
-          VERSION=$(./script/gh/docker-tags.rb --tags "${{ inputs.tags }}" --version)
-          
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "checkout_ref=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
-          echo "formatted_tags<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$FORMATTED_TAGS" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "version=$(./script/gh/docker-tags.rb "${{ inputs.tag }}" --version)" >> "$GITHUB_OUTPUT"
+          echo "docker_tags=$(./script/gh/docker-tags.rb "${{ inputs.tag }}" --format-for-docker)" >> "$GITHUB_OUTPUT"
       - name: Cache NPM
         uses: runs-on/cache@v4
         with:
@@ -78,18 +72,13 @@ jobs:
           include-hidden-files: true
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
-      checkout_ref: ${{ steps.extract_version.outputs.checkout_ref }}
-      formatted_tags: ${{ steps.extract_version.outputs.formatted_tags }}
+      docker_tags: ${{ steps.extract_version.outputs.docker_tags }}
   build:
+    if: github.repository == 'opf/openproject'
     needs:
       - setup
-    if: github.repository == 'opf/openproject'
     runs-on:
-      labels:
-        - runs-on
-        - ssh=false
-        - run-id=${{ github.run_id }}
-        - ${{ matrix.runner }}
+      labels: "runs-on=${{ github.run_id }}/ssh=false/${{ matrix.runner }}"
     strategy:
       matrix:
         include:
@@ -162,7 +151,7 @@ jobs:
             org.opencontainers.image.documentation=https://www.openproject.org/docs/installation-and-operations/installation/
             org.opencontainers.image.vendor=OpenProject GmbH
           tags: |
-            ${{ needs.setup.outputs.formatted_tags }}
+            ${{ needs.setup.outputs.docker_tags }}
           images: |
             ${{ env.REGISTRY_IMAGE }}
       - name: Restore vendor/bundle
@@ -298,7 +287,7 @@ jobs:
             latest=false
             suffix=${{ steps.set_suffix.outputs.suffix }}
           tags: |
-            ${{ needs.setup.outputs.formatted_tags }}
+            ${{ needs.setup.outputs.docker_tags }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -320,20 +309,3 @@ jobs:
     with:
       subject: "Docker build failed"
       body: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  trigger_helm_release:
-    needs: [setup, build, merge]
-    permissions:
-      contents: none
-    if: ${{ github.repository == 'opf/openproject' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Helm charts release
-        env:
-          TOKEN: ${{ secrets.OPENPROJECT_CI_TOKEN }}
-          REPOSITORY: opf/helm-charts
-          WORKFLOW_ID: core_release.yml
-        run: |
-          curl -i --fail-with-body -H"authorization: Bearer $TOKEN" \
-            -XPOST -H"Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/$REPOSITORY/actions/workflows/$WORKFLOW_ID/dispatches \
-            -d '{"ref": "main", "inputs": { "tag" : "${{ needs.setup.outputs.version }}" }}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,65 +1,44 @@
-name: Docker
+name: Docker Build (Reusable)
 
 on:
-  # build dev daily
-  schedule:
-    - cron: "20 2 * * *" # Daily at 02:20
-
-  push:
-    tags:
-      - v*
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      tag:
-        description: "The tag to release. Note that this happens by default on the tag push. Only run this action when something went wrong!"
-        required: false
+      branch:
+        description: "The branch to checkout and build"
+        required: true
+        type: string
+      tags:
+        description: "Comma-separated list of docker tags to use (e.g., 'dev' or '14.1.0,14.1,14')"
+        required: true
+        type: string
 
 permissions:
   contents: read # to fetch code (actions/checkout)
 
 env:
-  REGISTRY_IMAGE: openproject/openproject
+  # FIXME: change back to openproject/openproject once workflows are confirmed to be doing the right thing
+  REGISTRY_IMAGE: openproject/openproject-test
 
 jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version
-        id: extract_version
-        run: |
-          if [[ ${{ github.event_name }} == 'push' ]]; then
-            TAG_REF=${GITHUB_REF#refs/tags/}
-            CHECKOUT_REF=$GITHUB_REF
-          elif [[ ${{ github.event_name }} == 'schedule' ]]; then
-            TAG_REF=dev
-            CHECKOUT_REF=refs/heads/dev
-          elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
-            TAG_REF=${{ inputs.tag }}
-            CHECKOUT_REF=${{ inputs.tag }}
-
-            if [ -z "$TAG_REF" ]; then
-              TAG_REF=dev
-              CHECKOUT_REF=dev
-            fi
-          else
-            echo "Unsupported event"
-            exit 1
-          fi
-
-          if [ -z "$TAG_REF" ] || [ -z "$CHECKOUT_REF" ]; then
-            echo "No TAG_REF or CHECKOUT_REF set. Aborting"
-            exit 1
-          fi
-
-          VERSION=${TAG_REF#v}
-          echo "Version: $VERSION"
-          echo "Checkout REF: $CHECKOUT_REF"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.extract_version.outputs.checkout_ref }}
+          ref: ${{ inputs.branch }}
+      - name: Set version outputs and convert tags
+        id: extract_version
+        run: |
+          # Use Ruby script to format tags and get version
+          FORMATTED_TAGS=$(./script/gh/docker-tags.rb --tags "${{ inputs.tags }}" --format)
+          VERSION=$(./script/gh/docker-tags.rb --tags "${{ inputs.tags }}" --version)
+          
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
+          echo "formatted_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FORMATTED_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Cache NPM
         uses: runs-on/cache@v4
         with:
@@ -100,6 +79,7 @@ jobs:
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
       checkout_ref: ${{ steps.extract_version.outputs.checkout_ref }}
+      formatted_tags: ${{ steps.extract_version.outputs.formatted_tags }}
   build:
     needs:
       - setup
@@ -137,7 +117,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.setup.outputs.checkout_ref }}
+          ref: ${{ inputs.branch }}
       - name: Prepare docker files
         run: |
           cp ./docker/prod/Dockerfile ./Dockerfile
@@ -157,8 +137,8 @@ jobs:
           echo '!/config/frontend_assets.manifest.json' >> .dockerignore
       - name: Add build information
         run: |
-          echo "${{ needs.setup.outputs.checkout_ref }}" > PRODUCT_VERSION
-          echo "https://github.com/opf/openproject/commits/${{ needs.setup.outputs.checkout_ref }}" > PRODUCT_URL
+          echo "${{ inputs.branch }}" > PRODUCT_VERSION
+          echo "https://github.com/opf/openproject/commits/${{ inputs.branch }}" > PRODUCT_URL
           date -u +"%Y-%m-%dT%H:%M:%SZ" > RELEASE_DATE
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -182,7 +162,7 @@ jobs:
             org.opencontainers.image.documentation=https://www.openproject.org/docs/installation-and-operations/installation/
             org.opencontainers.image.vendor=OpenProject GmbH
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.setup.outputs.version }}
+            ${{ needs.setup.outputs.formatted_tags }}
           images: |
             ${{ env.REGISTRY_IMAGE }}
       - name: Restore vendor/bundle
@@ -318,10 +298,7 @@ jobs:
             latest=false
             suffix=${{ steps.set_suffix.outputs.suffix }}
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.setup.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.setup.outputs.version }}
-            type=semver,pattern={{major}},value=${{ needs.setup.outputs.version }}
-            type=raw,value=dev,priority=200,enable={{is_default_branch}}
+            ${{ needs.setup.outputs.formatted_tags }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'optparse'
+require "optparse"
 
 class DockerTagsGenerator
   def initialize(tags_input)
@@ -17,21 +17,11 @@ class DockerTagsGenerator
     parse_tags(@tags_input).first
   end
 
-  private
-
-  def parse_tags(input)
-    input.split(',').map(&:strip).reject(&:empty?)
-  end
-
-  def format_for_docker_metadata(tags)
-    tags.map { |tag| "type=raw,value=#{tag}" }.join("\n")
-  end
-
   def self.generate_semver_tags(tag_ref)
     return [tag_ref] unless tag_ref.match?(/^v(\d+\.\d+\.\d+.*)$/)
 
-    version = tag_ref.sub(/^v/, '')
-    parts = version.split('.')
+    version = tag_ref.sub(/^v/, "")
+    parts = version.split(".")
     major = parts[0]
     minor = "#{major}.#{parts[1]}" if parts[1]
 
@@ -40,30 +30,55 @@ class DockerTagsGenerator
     tags << major
     tags.uniq
   end
+
+  private
+
+  def parse_tags(input)
+    input.split(",").map(&:strip).reject(&:empty?)
+  end
+
+  def format_for_docker_metadata(tags)
+    tags.map { |tag| "type=raw,value=#{tag}" }.join("\n")
+  end
+end
+
+def handle_semver_option(options)
+  tags = DockerTagsGenerator.generate_semver_tags(options[:semver])
+  if options[:format]
+    generator = DockerTagsGenerator.new(tags.join(","))
+    puts generator.generate_formatted_tags
+  else
+    puts tags.join(",")
+  end
+end
+
+def handle_tags_option(options)
+  generator = DockerTagsGenerator.new(options[:tags])
+  if options[:format]
+    puts generator.generate_formatted_tags
+  elsif options[:version]
+    puts generator.generate_version
+  else
+    puts options[:tags]
+  end
 end
 
 def main
   options = {}
-  
   OptionParser.new do |opts|
     opts.banner = "Usage: #{$0} [options]"
-    
     opts.on("--tags TAGS", "Comma-separated list of tags") do |tags|
       options[:tags] = tags
     end
-    
     opts.on("--semver TAG_REF", "Generate semver tags from tag reference") do |tag_ref|
       options[:semver] = tag_ref
     end
-    
     opts.on("--format", "Output formatted tags for docker metadata") do
       options[:format] = true
     end
-    
     opts.on("--version", "Output first tag as version") do
       options[:version] = true
     end
-    
     opts.on("-h", "--help", "Prints this help") do
       puts opts
       exit
@@ -71,30 +86,13 @@ def main
   end.parse!
 
   if options[:semver]
-    # Generate semver tags
-    tags = DockerTagsGenerator.generate_semver_tags(options[:semver])
-    if options[:format]
-      generator = DockerTagsGenerator.new(tags.join(','))
-      puts generator.generate_formatted_tags
-    else
-      puts tags.join(',')
-    end
+    handle_semver_option(options)
   elsif options[:tags]
-    # Use provided tags
-    generator = DockerTagsGenerator.new(options[:tags])
-    if options[:format]
-      puts generator.generate_formatted_tags
-    elsif options[:version]
-      puts generator.generate_version
-    else
-      puts options[:tags]
-    end
+    handle_tags_option(options)
   else
     puts "Error: Must specify either --tags or --semver"
     exit 1
   end
 end
 
-if __FILE__ == $0
-  main
-end
+main if __FILE__ == $0

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -63,6 +63,7 @@ def handle_tags_option(options)
   end
 end
 
+# rubocop:disable Metrics/AbcSize
 def main
   options = {}
   OptionParser.new do |opts|

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -5,6 +5,36 @@ require "optparse"
 require "net/http"
 require "json"
 
+def latest_release_major_minor
+  uri = URI("https://api.github.com/repos/opf/openproject/releases/latest")
+  res = Net::HTTP.get_response(uri)
+  if res.is_a?(Net::HTTPSuccess)
+    tag_name = JSON.parse(res.body)["tag_name"]
+    tag_name[/^v?(\d+\.\d+)/, 1]
+  end
+rescue StandardError
+  puts "Error getting latest release major: #{$!}"
+  nil
+end
+
+def generate_matrix
+  latest_version = latest_release_major_minor
+  return nil unless latest_version
+
+  {
+    "include" => [
+      {
+        "branch" => "dev",
+        "tag" => "dev"
+      },
+      {
+        "branch" => "release/#{latest_version}",
+        "tag" => "#{latest_version}-rc"
+      }
+    ]
+  }
+end
+
 class Tag
   def initialize(tag)
     @tag = tag
@@ -22,30 +52,18 @@ class Tag
     @tag.sub(/^v/, "").sub(/-rc$/, "")
   end
 
-  def latest_release_major_minor
-    uri = URI("https://api.github.com/repos/opf/openproject/releases/latest")
-    res = Net::HTTP.get_response(uri)
-    if res.is_a?(Net::HTTPSuccess)
-      tag_name = JSON.parse(res.body)["tag_name"]
-      tag_name[/^v?(\d+\.\d+)/, 1]
-    end
-  rescue
-    puts "Error getting latest release major: #{$!}"
-    nil
-  end
-
   def to_semver_docker_tags
     if semver?
       [
         "type=semver,pattern={{version}},value=#{version}",
         "type=semver,pattern={{major}}.{{minor}},value=#{version}",
-        "type=semver,pattern={{major}},value=#{version}",
+        "type=semver,pattern={{major}},value=#{version}"
       ]
     elsif rc?
       latest_major_minor = latest_release_major_minor
       tags = [
         "type=raw,value=#{major}.#{minor}-rc",
-        "type=raw,value=#{major}-rc",
+        "type=raw,value=#{major}-rc"
       ]
       if latest_major_minor && latest_major_minor == [major, minor].join(".")
         tags << [
@@ -57,7 +75,7 @@ class Tag
       ["type=raw,value=#{version}"]
     end
   end
-  
+
   def major
     return unless semver? || rc?
 
@@ -71,9 +89,7 @@ class Tag
   end
 end
 
-
-# rubocop:disable Metrics/AbcSize
-def main
+def main # rubocop:disable Metrics/AbcSize
   options = {}
   OptionParser.new do |opts|
     opts.banner = "Usage: #{$0} [TAG] [options]"
@@ -83,20 +99,33 @@ def main
     opts.on("--version", "Output first tag as version") do
       options[:version] = true
     end
+    opts.on("--matrix", "Generate matrix for GitHub Actions workflow") do
+      options[:matrix] = true
+    end
     opts.on("-h", "--help", "Prints this help") do
       puts opts
       exit
     end
   end.parse!
 
-  tag = Tag.new(ARGV.first)
-  if options[:version]
-    puts tag.version
-  elsif options[:format_for_docker]
-    puts tag.to_semver_docker_tags.join("\n")
+  if options[:matrix]
+    matrix = generate_matrix
+    if matrix
+      puts JSON.pretty_generate(matrix)
+    else
+      puts "Error: Could not generate matrix"
+      exit 1
+    end
   else
-    puts "Error: Must specify either --version or --format-for-docker"
-    exit 1
+    tag = Tag.new(ARGV.first)
+    if options[:version]
+      puts tag.version
+    elsif options[:format_for_docker]
+      puts tag.to_semver_docker_tags.join("\n")
+    else
+      puts "Error: Must specify either --version, --format-for-docker, or --matrix"
+      exit 1
+    end
   end
 end
 

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+class DockerTagsGenerator
+  def initialize(tags_input)
+    @tags_input = tags_input.strip
+  end
+
+  def generate_formatted_tags
+    tags = parse_tags(@tags_input)
+    format_for_docker_metadata(tags)
+  end
+
+  def generate_version
+    parse_tags(@tags_input).first
+  end
+
+  private
+
+  def parse_tags(input)
+    input.split(',').map(&:strip).reject(&:empty?)
+  end
+
+  def format_for_docker_metadata(tags)
+    tags.map { |tag| "type=raw,value=#{tag}" }.join("\n")
+  end
+
+  def self.generate_semver_tags(tag_ref)
+    return [tag_ref] unless tag_ref.match?(/^v(\d+\.\d+\.\d+.*)$/)
+
+    version = tag_ref.sub(/^v/, '')
+    parts = version.split('.')
+    major = parts[0]
+    minor = "#{major}.#{parts[1]}" if parts[1]
+
+    tags = [version]
+    tags << minor if minor
+    tags << major
+    tags.uniq
+  end
+end
+
+def main
+  options = {}
+  
+  OptionParser.new do |opts|
+    opts.banner = "Usage: #{$0} [options]"
+    
+    opts.on("--tags TAGS", "Comma-separated list of tags") do |tags|
+      options[:tags] = tags
+    end
+    
+    opts.on("--semver TAG_REF", "Generate semver tags from tag reference") do |tag_ref|
+      options[:semver] = tag_ref
+    end
+    
+    opts.on("--format", "Output formatted tags for docker metadata") do
+      options[:format] = true
+    end
+    
+    opts.on("--version", "Output first tag as version") do
+      options[:version] = true
+    end
+    
+    opts.on("-h", "--help", "Prints this help") do
+      puts opts
+      exit
+    end
+  end.parse!
+
+  if options[:semver]
+    # Generate semver tags
+    tags = DockerTagsGenerator.generate_semver_tags(options[:semver])
+    if options[:format]
+      generator = DockerTagsGenerator.new(tags.join(','))
+      puts generator.generate_formatted_tags
+    else
+      puts tags.join(',')
+    end
+  elsif options[:tags]
+    # Use provided tags
+    generator = DockerTagsGenerator.new(options[:tags])
+    if options[:format]
+      puts generator.generate_formatted_tags
+    elsif options[:version]
+      puts generator.generate_version
+    else
+      puts options[:tags]
+    end
+  else
+    puts "Error: Must specify either --tags or --semver"
+    exit 1
+  end
+end
+
+if __FILE__ == $0
+  main
+end

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -3,79 +3,52 @@
 
 require "optparse"
 
-class DockerTagsGenerator
-  def initialize(tags_input)
-    @tags_input = tags_input.strip
+class Tag
+  def initialize(tag)
+    @tag = tag
   end
 
-  def generate_formatted_tags
-    tags = parse_tags(@tags_input)
-    format_for_docker_metadata(tags)
+  def semver?
+    @tag.match?(/^v(\d+\.\d+\.\d+.*)$/)
   end
 
-  def generate_version
-    parse_tags(@tags_input).first
+  def version
+    @tag.sub(/^v/, "")
   end
 
-  def self.generate_semver_tags(tag_ref)
-    return [tag_ref] unless tag_ref.match?(/^v(\d+\.\d+\.\d+.*)$/)
+  def to_semver_docker_tags
+    if semver?
+      [
+        "type=semver,pattern={{version}},value=#{version}",
+        "type=semver,pattern={{major}}.{{minor}},value=#{version}",
+        "type=semver,pattern={{major}},value=#{version}",
+      ]
+    else
+      ["type=raw,value=#{version}"]
+    end
+  end
+  
+  def major
+    return unless semver?
 
-    version = tag_ref.sub(/^v/, "")
-    parts = version.split(".")
-    major = parts[0]
-    minor = "#{major}.#{parts[1]}" if parts[1]
-
-    tags = [version]
-    tags << minor if minor
-    tags << major
-    tags.uniq
+    version.split(".")[0]
   end
 
-  private
+  def minor
+    return unless semver?
 
-  def parse_tags(input)
-    input.split(",").map(&:strip).reject(&:empty?)
-  end
-
-  def format_for_docker_metadata(tags)
-    tags.map { |tag| "type=raw,value=#{tag}" }.join("\n")
-  end
-end
-
-def handle_semver_option(options)
-  tags = DockerTagsGenerator.generate_semver_tags(options[:semver])
-  if options[:format]
-    generator = DockerTagsGenerator.new(tags.join(","))
-    puts generator.generate_formatted_tags
-  else
-    puts tags.join(",")
+    version.split(".")[1]
   end
 end
 
-def handle_tags_option(options)
-  generator = DockerTagsGenerator.new(options[:tags])
-  if options[:format]
-    puts generator.generate_formatted_tags
-  elsif options[:version]
-    puts generator.generate_version
-  else
-    puts options[:tags]
-  end
-end
 
 # rubocop:disable Metrics/AbcSize
 def main
   options = {}
   OptionParser.new do |opts|
-    opts.banner = "Usage: #{$0} [options]"
-    opts.on("--tags TAGS", "Comma-separated list of tags") do |tags|
-      options[:tags] = tags
-    end
-    opts.on("--semver TAG_REF", "Generate semver tags from tag reference") do |tag_ref|
-      options[:semver] = tag_ref
-    end
-    opts.on("--format", "Output formatted tags for docker metadata") do
-      options[:format] = true
+    opts.banner = "Usage: #{$0} [TAG] [options]"
+    opts.on("--format-for-docker", "Output formatted tags for docker metadata") do
+      options[:format_for_docker] = true
     end
     opts.on("--version", "Output first tag as version") do
       options[:version] = true
@@ -86,12 +59,13 @@ def main
     end
   end.parse!
 
-  if options[:semver]
-    handle_semver_option(options)
-  elsif options[:tags]
-    handle_tags_option(options)
+  tag = Tag.new(ARGV.first)
+  if options[:version]
+    puts tag.version
+  elsif options[:format_for_docker]
+    puts tag.to_semver_docker_tags.join("\n")
   else
-    puts "Error: Must specify either --tags or --semver"
+    puts "Error: Must specify either --version or --format-for-docker"
     exit 1
   end
 end

--- a/script/gh/docker-tags.rb
+++ b/script/gh/docker-tags.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "optparse"
+require "net/http"
+require "json"
 
 class Tag
   def initialize(tag)
@@ -12,8 +14,24 @@ class Tag
     @tag.match?(/^v(\d+\.\d+\.\d+.*)$/)
   end
 
+  def rc?
+    @tag.match?(/-rc$/)
+  end
+
   def version
-    @tag.sub(/^v/, "")
+    @tag.sub(/^v/, "").sub(/-rc$/, "")
+  end
+
+  def latest_release_major_minor
+    uri = URI("https://api.github.com/repos/opf/openproject/releases/latest")
+    res = Net::HTTP.get_response(uri)
+    if res.is_a?(Net::HTTPSuccess)
+      tag_name = JSON.parse(res.body)["tag_name"]
+      tag_name[/^v?(\d+\.\d+)/, 1]
+    end
+  rescue
+    puts "Error getting latest release major: #{$!}"
+    nil
   end
 
   def to_semver_docker_tags
@@ -23,19 +41,31 @@ class Tag
         "type=semver,pattern={{major}}.{{minor}},value=#{version}",
         "type=semver,pattern={{major}},value=#{version}",
       ]
+    elsif rc?
+      latest_major_minor = latest_release_major_minor
+      tags = [
+        "type=raw,value=#{major}.#{minor}-rc",
+        "type=raw,value=#{major}-rc",
+      ]
+      if latest_major_minor && latest_major_minor == [major, minor].join(".")
+        tags << [
+          "type=raw,value=rc"
+        ]
+      end
+      tags
     else
       ["type=raw,value=#{version}"]
     end
   end
   
   def major
-    return unless semver?
+    return unless semver? || rc?
 
     version.split(".")[0]
   end
 
   def minor
-    return unless semver?
+    return unless semver? || rc?
 
     version.split(".")[1]
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/openproject/work_packages/67165/activity

Goal is to have daily builds for latest on specific branches (docker-scheduled.yml):
- dev => tagged `dev`
- release/16.3 => tagged `16.3-pre`

While pushed tags are still tagged according to the previous behaviour (docker-release.yml):
- v16.3.1 => tagged `16.3.1`, `16.3`, `16`

Both parent workflows trigger a reusable workflow (docker.yml), which only deals with builds, test, and pushes. Tag and branch are given as input.

Helm chart workflow dispatch is now only triggered for builds involving a git tag (invalid tags caused the workflow to be skipped downstream, but better to not launch anything at all).