### PR TITLE
Fix subheader button margin on mobile

### DIFF
--- a/frontend/src/global_styles/content/_grid_mobile.sass
+++ b/frontend/src/global_styles/content/_grid_mobile.sass
@@ -9,3 +9,7 @@
     &.-widgeted
       grid-column: 1/2 !important
       grid-row: unset !important
+
+  .grid-mx
+    margin-left: 0
+    margin-right: 0


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Removes the subheader margin on mobile - so that the "+ Widget" button aligns correctly with the right of the content.

## Screenshots

| Before | After |
|--------|--------|
| <img width="750" height="1334" alt="localhost_5000_projects_footer_jump=home(iPhone SE) (1)" src="https://github.com/user-attachments/assets/d3e33fa2-3a68-4ec0-8fa3-c7b7f78b7e45" /> | <img width="750" height="1334" alt="localhost_5000_projects_footer_jump=home(iPhone SE)" src="https://github.com/user-attachments/assets/40c5f022-2d88-4d0a-991b-d2b762ec0b18" /> | 


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
