### PR TITLE
Ensure models don't leak between test through RequestStore, for example User.anonymous

### DIFF
--- a/spec/support/rspec_cleanup.rb
+++ b/spec/support/rspec_cleanup.rb
@@ -16,6 +16,11 @@ RSpec.configure do |config|
     RequestStore.clear!
   end
 
+  config.append_after(:all) do
+    # Ensure models don't leak between test through RequestStore if it is used in after(:all)
+    RequestStore.clear!
+  end
+
   # We don't want this to be reported on CI as it breaks the build
   unless ENV["CI"]
     config.append_after(:suite) do


### PR DESCRIPTION
Stumbled upon [test failure](https://github.com/opf/openproject/actions/runs/17582783029/attempts/1?pr=20243) that got bisected to:
```shell
rspec -fd './modules/storages/spec/requests/api/v3/projects/projects_storages_filter_spec.rb[1:1:1:2:1:2]' './spec/models/principals/scopes/ordered_by_name_spec.rb[1:1:1:1:1,1:1:1:1:2:1,1:1:2:1:1,1:1:2:1:2:1,1:1:3:1:1,1:1:3:1:2:1,1:1:4:1:1,1:1:4:1:2:1,1:1:5:1:1,1:1:5:1:2:1,1:1:6:1:1,1:1:6:1:2:1]' --seed 33618
```
Problem comes from `AnonymousUser` leaking from `after(:all)` by being cached in `RequestStore`.
This ensures that `RequestStore` is empty not only after each test, but also after each context.
