### PR TITLE
create workflow for CLA checking

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,41 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read # this can be 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'contributor-license-agreement/signatures/version1.json'
+          path-to-document: 'https://www.openproject.org/legal/contributor-license-agreement' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          allowlist: dependabot
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          remote-organization-name: opf
+          remote-repository-name: legal
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [opened,closed,synchronize]
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -90,9 +90,9 @@ This code of conduct is adapted from the [Contributor Covenant](https://www.cont
 
 ## OpenProject Contributor License Agreement (CLA)
 
-If you want to contribute to OpenProject, please make sure to accept our Contributor License Agreement first. The contributor license agreement documents the rights granted by contributors to OpenProject.
+If you want to contribute to OpenProject, please make sure to accept our Contributor License Agreement. The contributor license agreement documents the rights granted by contributors to OpenProject.
 
-[Read and accept the Contributor License Agreement here.](https://www.openproject.org/legal/contributor-license-agreement/)
+A GitHub action will enforce the [CLA](https://www.openproject.org/legal/contributor-license-agreement/) has been read and accepted by every new contributor. You will only be asked once, the document is short, and signing is easy.
 
 ## Additional resources
 

--- a/docs/development/code-review-guidelines/README.md
+++ b/docs/development/code-review-guidelines/README.md
@@ -117,7 +117,7 @@ If there are breaking changes (e.g., to permissions, code relevant for developer
 
 ## Other
 
-- For external contributions: Check whether the author has signed a [Contributor License Agreement](../#openproject-contributor-license-agreement-cla) and kindly ask for it if not.
+- For external contributions: Check whether the author has signed a [Contributor License Agreement](../#openproject-contributor-license-agreement-cla) and kindly ask for it if not. There is a GitHub workflow ensuring the contributor signed the current CLA. If the action is green, consider this point done.
 
 - Copyright notice: When new files are added, make sure they contain the OpenProject copyright notice (copy from any file in OpenProject).
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/53520

# What are you trying to accomplish?

Add a [contributor-assistent](https://github.com/contributor-assistant/github-action?tab=readme-ov-file) workflow to the repo which will require all contributors to have signed the current CLA for their PRs to turn green.

The CLA is in a private repo (`legal`) so the signatures will be stored there as well.

### TODO

* [ ] Remove form from website: https://www.openproject.org/legal/contributor-license-agreement as that will no longer be necessary.
* [x] Update documents about requirement to sign CLA
* [ ] Add employees to `allowlist`
