### PR TITLE
fix dependabot name for CLA tool

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,7 +47,7 @@ jobs:
             cbliard,
             corinnaguenther,
             crohr,
-            dependabot,
+            dependabot[bot],
             dombesz,
             dominic-brauenlein,
             dsteiner,


### PR DESCRIPTION
Do not request CLA from dependabot ... He will probably never sign it :D