### PR TITLE
Do not add multiple timezones when calling `to_ical` multiple times

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -158,6 +158,7 @@ module Meetings
     end
 
     def to_ical
+      calendar.timezones.clear
       calendar.add_timezone(build_single_vtimezone)
       calendar.to_ical
     end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -392,5 +392,12 @@ RSpec.describe Meetings::IcalendarBuilder,
       expect(standard_count).to eq(4)
       expect(daylight_count).to eq(4)
     end
+
+    it "does not add the timezone multiple times when `to_ical` is called multiple times" do
+      meetings.each { |m| builder.add_single_meeting_event(meeting: m) }
+      builder.to_ical
+      builder.to_ical
+      expect(parsed_calendar.timezones.size).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
# Ticket
Maybe related to https://community.openproject.org/projects/openproject/work_packages/67330/activity

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
