### PR TITLE
[65606] Inform users on screen-readers that links will open in a new tab

### DIFF
--- a/app/views/admin/info.html.erb
+++ b/app/views/admin/info.html.erb
@@ -76,6 +76,7 @@ See COPYRIGHT and LICENSE files for more details.
                        ::OpenProject::Static::Links.url_for(:security_badge_documentation),
                        title: t(:label_what_is_this),
                        class: "security-badge--help-icon icon-context icon-help1",
+                       aria: { label: t(:label_what_is_this), describedby: "open-blank-target-link-description" },
                        target: "_blank"
     component.with_attribute(key: "", value: content)
   end

--- a/app/views/homescreen/blocks/_administration.html.erb
+++ b/app/views/homescreen/blocks/_administration.html.erb
@@ -54,6 +54,7 @@
                 ::OpenProject::Static::Links.url_for(:security_badge_documentation),
                 title: t(:label_what_is_this),
                 class: "security-badge--help-icon icon-context icon-help1",
+                aria: { label: t(:label_what_is_this), describedby: "open-blank-target-link-description" },
                 target: "_blank", rel: "noopener" %>
   <% end if display_security_badge_graphic? %>
 </div>

--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -63,7 +63,7 @@
               }
             ),
             {
-              aria: { label: t("homescreen.links.newsletter"), describedby: "open-blank-target-link-description"  },
+              aria: { label: t("homescreen.links.newsletter"), describedby: "open-blank-target-link-description" },
               target: "_blank",
               title: t("homescreen.links.newsletter"),
               rel: "noopener"

--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -25,7 +25,7 @@
               }
             ),
             {
-              aria: { label: t("label_openproject_website") },
+              aria: { label: t("label_openproject_website"), describedby: "open-blank-target-link-description"  },
               target: "_blank",
               title: t("label_openproject_website"),
               rel: "noopener"
@@ -44,7 +44,7 @@
               }
             ),
             {
-              aria: { label: t("homescreen.links.security_alerts") },
+              aria: { label: t("homescreen.links.security_alerts"), describedby: "open-blank-target-link-description"  },
               target: "_blank",
               title: t("homescreen.links.security_alerts"),
               rel: "noopener"
@@ -63,7 +63,7 @@
               }
             ),
             {
-              aria: { label: t("homescreen.links.newsletter") },
+              aria: { label: t("homescreen.links.newsletter"), describedby: "open-blank-target-link-description"  },
               target: "_blank",
               title: t("homescreen.links.newsletter"),
               rel: "noopener"

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -58,7 +58,8 @@ See COPYRIGHT and LICENSE files for more details.
       <%= link_to url,
                   class: "homescreen--links--item",
                   target: "_blank",
-                  aria_label: title do %>
+                  title: title,
+                  aria: { label: title, describedby: "open-blank-target-link-description" } do %>
         <%= op_icon(link[:icon]) %>
         <%= title %>
       <% end %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -53,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
         <strong><%= t(:noscript_heading) %></strong>
       </span>
       <%= t(:noscript_description) %>
-      <a href="http://www.enable-javascript.com/" target="_blank"><%= t(:noscript_learn_more) %></a>
+      <a href="http://www.enable-javascript.com/" target="_blank" aria-describedby="open-blank-target-link-description"><%= t(:noscript_learn_more) %></a>
     </p>
   </div>
 </noscript>
@@ -63,6 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div id="polite" aria-live="polite" aria-atomic="true" class="sr-only"></div>
   <div id="assertive" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 </live-region>
+<span id="open-blank-target-link-description" class="sr-only"><%= I18n.t("open_link_in_a_new_tab") %></span>
 <opce-spot-drop-modal-portal></opce-spot-drop-modal-portal>
 <% main_menu = render_main_menu(local_assigns.fetch(:menu_name, nil), @project) %>
 <% side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank? %>

--- a/app/views/warning_bar/_unsupported_browser.html.erb
+++ b/app/views/warning_bar/_unsupported_browser.html.erb
@@ -6,7 +6,7 @@
     <%= t("unsupported_browser.message") %>
 
     <a href="https://www.openproject.org/open-source/download/systemrequirements/"
-       target="_blank">
+       target="_blank" aria-describedby="open-blank-target-link-description">
       <%= t("unsupported_browser.update_message") %>
     </a>
   </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,7 +523,7 @@ en:
       life_cycle:
         header:
           title: "Project life cycle"
-          description_html: 'The active project phases define this project''s life cycle and are defined in the <a href=%{admin_settings_url} target="_blank">administration settings</a>. Enabled phases will be displayed in your <a href=%{overview_url} target="_blank">project overview</a>.'
+          description_html: 'The active project phases define this project''s life cycle and are defined in the <a href=%{admin_settings_url} target="_blank" aria-describedby="open-blank-target-link-description">administration settings</a>. Enabled phases will be displayed in your <a href=%{overview_url} target="_blank" aria-describedby="open-blank-target-link-description">project overview</a>.'
         non_defined: "No phases are currently defined."
         section_header: "Phases"
         step:
@@ -534,8 +534,8 @@ en:
         header:
           title: "Project attributes"
           description_html:
-            'These project attributes will be displayed in your <a href=%{overview_url} target="_blank">project overview page</a> under their respective sections. You can enable or disable individual attributes.
-            Project attributes and sections are defined in the <a href=%{admin_settings_url} target="_blank">administration settings</a> by the administrator of the instance. '
+            'These project attributes will be displayed in your <a href=%{overview_url} target="_blank" aria-describedby="open-blank-target-link-description">project overview page</a> under their respective sections. You can enable or disable individual attributes.
+            Project attributes and sections are defined in the <a href=%{admin_settings_url} target="_blank" aria-describedby="open-blank-target-link-description">administration settings</a> by the administrator of the instance. '
         filter:
           label: "Search project attribute"
         actions:
@@ -2393,10 +2393,10 @@ en:
         Please, check your inbox and follow the steps to start your 14-day free trial.
       domain_caption: The token will be valid for your currently configured host name.
       receive_newsletter_html: >
-        I want to receive the OpenProject <a target="_blank" href="https://www.openproject.org/newsletter/">newsletter</a>.
+        I want to receive the OpenProject <a target="_blank" aria-describedby="open-blank-target-link-description" href="https://www.openproject.org/newsletter/">newsletter</a>.
       consent_html: >
-        I agree with the <a target="_blank" href="https://www.openproject.org/terms-of-service/">terms of service</a>
-        and the <a target="_blank" href="https://www.openproject.org/data-privacy-and-security/">privacy policy</a>.
+        I agree with the <a target="_blank" aria-describedby="open-blank-target-link-description" href="https://www.openproject.org/terms-of-service/">terms of service</a>
+        and the <a target="_blank" aria-describedby="open-blank-target-link-description" href="https://www.openproject.org/data-privacy-and-security/">privacy policy</a>.
 
   email_calendar_updates:
     state:
@@ -2423,7 +2423,7 @@ en:
   error_can_not_delete_in_use_archived_undisclosed: "There are also work packages in archived projects. You need to ask an administrator to perform the deletion to see which projects are affected."
   error_can_not_delete_in_use_archived_work_packages: "There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the attribute of the respective work packages: %{archived_projects_urls}"
   error_can_not_delete_type:
-    explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" href="%{url}">this view</a>.'
+    explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" aria-describedby="open-blank-target-link-description" href="%{url}">this view</a>.'
   error_can_not_delete_standard_type: "Standard types cannot be deleted."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."
@@ -2732,13 +2732,13 @@ en:
           From now on, activity related to file links (files stored in external storages) will appear here in the
           Activity tab. The following represent activity concerning links that already existed:
         progress_calculation_adjusted_from_disabled_mode: >-
-          Progress calculation automatically <a href="%{href}" target="_blank">set to work-based mode and adjusted with version update</a>.
+          Progress calculation automatically <a href="%{href}" target="_blank" aria-describedby="open-blank-target-link-description">set to work-based mode and adjusted with version update</a>.
         progress_calculation_adjusted: >-
-          Progress calculation automatically <a href="%{href}" target="_blank">adjusted with version update</a>.
+          Progress calculation automatically <a href="%{href}" target="_blank" aria-describedby="open-blank-target-link-description">adjusted with version update</a>.
         scheduling_mode_adjusted: >-
           Scheduling mode automatically adjusted with version update.
         totals_removed_from_childless_work_packages: >-
-          Work and progress totals automatically removed for non-parent work packages with <a href="%{href}" target="_blank">version update</a>.
+          Work and progress totals automatically removed for non-parent work packages with <a href="%{href}" target="_blank" aria-describedby="open-blank-target-link-description">version update</a>.
           This is a maintenance task and can be safely ignored.
       total_percent_complete_mode_changed_to_work_weighted_average: >-
         Child work packages without Work are ignored.
@@ -3771,7 +3771,7 @@ en:
   notice_unsuccessful_update_with_reason: "Update failed: %{reason}"
   notice_successful_update_custom_fields_added_to_project: |
     Successful update. The custom fields of the activated types are automatically activated
-    on the work package form. <a href="%{url}" target="_blank">See more</a>.
+    on the work package form. <a href="%{url}" target="_blank" aria-describedby="open-blank-target-link-description">See more</a>.
   notice_to_many_principals_to_display: "There are too many results.\nNarrow down the search by typing in the name of the new member (or group)."
   notice_user_missing_authentication_method: User has yet to choose a password or another way to sign in.
   notice_user_invitation_resent: An invitation has been sent to %{email}.
@@ -4122,7 +4122,7 @@ en:
   setting_apiv3_cors_origins_text_html: >
     If CORS is enabled, these are the origins that are allowed to access OpenProject API.
     <br/>
-    Please check the <a href="%{origin_link}" target="_blank">Documentation on the Origin header</a> on how to specify the expected values.
+    Please check the <a href="%{origin_link}" target="_blank" aria-describedby="open-blank-target-link-description">Documentation on the Origin header</a> on how to specify the expected values.
   setting_apiv3_write_readonly_attributes: "Write access to read-only attributes"
   setting_apiv3_write_readonly_attributes_instructions_html: >
     If enabled, the API will allow administrators to write static read-only attributes during creation,
@@ -4145,7 +4145,7 @@ en:
   setting_apiv3_docs_enabled: "Enable docs page"
   setting_apiv3_docs_enabled_instructions_html: >
     If the docs page is enabled you can get an interactive view of the APIv3 documentation under
-    <a href="%{link}" target="_blank">%{link}</a>.
+    <a href="%{link}" target="_blank" aria-describedby="open-blank-target-link-description">%{link}</a>.
   setting_attachment_whitelist: "Attachment upload whitelist"
   setting_email_delivery_method: "Email delivery method"
   setting_emails_salutation: "Address user in emails with"
@@ -4392,7 +4392,7 @@ en:
       first_week_of_year_text_html: >
         Select the date of January that is contained in the first week of the year.
         This value together with first day of the week determines the total number of weeks in a year.
-        For more information, please see our <a href="%{link}" target="_blank">documentation</a> on this topic.
+        For more information, please see our <a href="%{link}" target="_blank" aria-describedby="open-blank-target-link-description">documentation</a> on this topic.
     experimental:
       save_confirmation: Caution! Risk of data loss! Only activate experimental features if you do not mind breaking your OpenProject installation and losing all of its data.
       warning_toast: Feature flags are settings that activate features that are still under development. They shall only be used for testing purposes. They shall never be activated on OpenProject installations holding important data. These features will very likely corrupt your data. Use them at your own risk.
@@ -4406,7 +4406,7 @@ en:
         type: "Entire row by Type"
         priority: "Entire row by Priority"
     icalendar:
-      enable_subscriptions_text_html: Allows users with the necessary permissions to subscribe to OpenProject calendars and access work package information via an external calendar client. <strong>Note:</strong> Please read about <a href="%{link}" target="_blank">iCalendar subscriptions</a> to understand potential security risks before enabling this.
+      enable_subscriptions_text_html: Allows users with the necessary permissions to subscribe to OpenProject calendars and access work package information via an external calendar client. <strong>Note:</strong> Please read about <a href="%{link}" target="_blank" aria-describedby="open-blank-target-link-description">iCalendar subscriptions</a> to understand potential security risks before enabling this.
     language_name_being_default: "%{language_name} (default)"
     notifications:
       events_explanation: "Governs for which event an email is sent out. Work packages are excluded from this list as the notifications for them can be configured specifically for every user."
@@ -4486,6 +4486,7 @@ en:
   text_access_token_hint: "Access tokens allow you to grant external applications access to resources in OpenProject."
   text_analyze: "Further analyze: %{subject}"
   text_are_you_sure: "Are you sure?"
+  open_link_in_a_new_tab: "Open link in a new tab"
   text_are_you_sure_continue: "Are you sure you want to continue?"
   text_are_you_sure_with_children: "Delete work package and all child work packages?"
   text_are_you_sure_with_project_custom_fields: "Deleting this attribute will also delete its values in all projects. Are you sure you want to do this?"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -334,7 +334,7 @@ en:
       warning: "Please don't share this URL with other users. Anyone with this link will be able to view work package details without an account or password."
       token_name_label: "Where will you be using this?"
       token_name_placeholder: 'Type a name, e.g. "Phone"'
-      token_name_description_text: 'If you subscribe to this calendar from multiple devices, this name will help you distinguish between them in your <a href="my/access_token", target="_blank">access tokens</a> list.'
+      token_name_description_text: 'If you subscribe to this calendar from multiple devices, this name will help you distinguish between them in your <a href="my/access_token", target="_blank" aria-describedby="open-blank-target-link-description">access tokens</a> list.'
       copy_url_label: "Copy URL"
       ical_generation_error_text: "An error occured while generating the calendar URL."
       success_message: 'The URL "%{name}" was successfully copied to your clipboard. Paste it in your calendar client to complete the subscription.'
@@ -625,7 +625,7 @@ en:
       reminders:
         note: "Note: “%{note}”"
       settings:
-        change_notification_settings: 'You can modify your <a target="_blank" href="%{url}">notification settings</a> to ensure you never miss an important update.'
+        change_notification_settings: 'You can modify your <a target="_blank" aria-describedby="open-blank-target-link-description" href="%{url}">notification settings</a> to ensure you never miss an important update.'
         title: "Notification settings"
         notify_me: "Notify me"
         reminders:
@@ -1238,7 +1238,7 @@ en:
           title_no_ee: "Placeholder user (Enterprise edition only add-on)"
           description: "Has no access to the project and no emails are sent out."
           description_no_ee: 'Has no access to the project and no emails are sent out.
-            <br>Check out the <a href="%{eeHref}" target="_blank">Enterprise edition</a>'
+            <br>Check out the <a href="%{eeHref}" target="_blank" aria-describedby="open-blank-target-link-description">Enterprise edition</a>'
 
       principal:
         label:
@@ -1263,7 +1263,7 @@ en:
           This is the role that the user will receive when they join your project. The role defines which actions they are allowed to take and which information they are allowed to see.
           <a
           href="https://www.openproject.org/docs/system-admin-guide/users-permissions/roles-permissions/#roles-and-permissions"
-          target="_blank">
+          target="_blank" aria-describedby="open-blank-target-link-description">
           Learn more about roles and permissions.
           </a>
         required: "Please select a role"

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.html
@@ -4,6 +4,7 @@
     [class.spot-list--item-action_disabled]="attachment.status === 'quarantined'"
     [href]="attachment._links.originOpen?.href || attachment._links.staticDownloadLocation.href"
     target="_blank"
+    aria-describedby="open-blank-target-link-description"
     (dragstart)="setDragData($event)"
   >
     <div

--- a/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.html
+++ b/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.html
@@ -21,6 +21,7 @@
       }"
       [href]="fileLink._links.staticOriginOpen.href"
       target="_blank"
+      aria-describedby="open-blank-target-link-description"
     >
       <div
         class="spot-list--item-title op-file-list--item-title"

--- a/lookbook/docs/patterns/accessibility/19-blank-target-link.md.erb
+++ b/lookbook/docs/patterns/accessibility/19-blank-target-link.md.erb
@@ -1,0 +1,59 @@
+# Accessibility for Links that Open in a New Tab
+
+Links that open in a new browser tab or window (`target="_blank"`) can be confusing for users, especially for those using assistive technologies. To ensure accessibility, we need to provide clear context so that all users understand that the link will open in a new tab.
+
+## Why `_blank` Links Need Accessible Hints
+
+- Users may lose track of their current page if a link opens in a new tab unexpectedly.
+- Screen reader users may not be aware of the new tab unless it is explicitly communicated.
+- Providing a description improves usability and ensures compliance with WCAG guidelines.
+
+---
+
+## Recommended Attributes
+
+To make `_blank` links accessible, we rely on:
+
+- **`aria-describedby`**: Points to a hidden element describing the new tab behavior.
+- **`aria-label`** *(optional)*: Can include context about the link and new tab behavior.
+- **`title`** *(optional)*: Provides a tooltip for sighted users.
+
+---
+
+## Hidden Description in `base.html`
+
+We include a single hidden element in `base.html` so that all `_blank` links can reference it:
+
+```erb
+<span id="open-blank-target-link-description" class="sr-only">
+  <%= I18n.t("open_link_in_a_new_tab") %>
+</span>
+```
+
+- Using a **single, centralized hidden element** ensures consistency across the application.
+- The element uses a **translation key** (`open_link_in_a_new_tab`) for multilingual support.
+- The `sr-only` class visually hides the element but keeps it accessible to screen readers.
+
+---
+
+## Example HTML Implementation
+
+```html
+<a href="https://www.openproject.org/docs/user-guide/"
+   target="_blank"
+   aria-describedby="open-blank-target-link-description"
+   aria-label="User guides">
+  User guides
+</a>
+```
+
+- The `aria-describedby` points to the hidden description in `base.html`.
+- The `aria-label` can provide a more explicit announcement for screen readers.
+- The `title` provides a tooltip for sighted users.
+- Screen readers announce the link text and the hidden description automatically.
+
+## Notes
+
+- Always indicate links opening in a new tab to assistive technology users.
+- Prefer `aria-describedby` and `aria-label` over relying solely on `title`.
+- Centralizing the hidden description in `base.html` ensures consistency and reduces duplication.

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -453,7 +453,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       href = OpenProject::Static::Links.url_for(:blog_article_progress_changes)
       expect(cause).to render_html_variant(
         "<strong>OpenProject system update:</strong> Progress calculation automatically " \
-        "<a href=\"#{href}\" target=\"_blank\" aria-describedby=\"open-blank-target-link-description\">set to work-based mode and adjusted with version update</a>."
+        "<a href=\"#{href}\" target=\"_blank\" " \
+        "aria-describedby=\"open-blank-target-link-description\">" \
+        "set to work-based mode and adjusted with version update</a>."
       )
     end
 
@@ -477,7 +479,9 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       href = OpenProject::Static::Links.url_for(:blog_article_progress_changes)
       expect(cause).to render_html_variant(
         "<strong>OpenProject system update:</strong> Progress calculation automatically " \
-        "<a href=\"#{href}\" target=\"_blank\" aria-describedby=\"open-blank-target-link-description\">adjusted with version update</a>."
+        "<a href=\"#{href}\" target=\"_blank\" " \
+        "aria-describedby=\"open-blank-target-link-description\">" \
+        "adjusted with version update</a>."
       )
     end
 

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       href = OpenProject::Static::Links.url_for(:blog_article_progress_changes)
       expect(cause).to render_html_variant(
         "<strong>OpenProject system update:</strong> Progress calculation automatically " \
-        "<a href=\"#{href}\" target=\"_blank\">set to work-based mode and adjusted with version update</a>."
+        "<a href=\"#{href}\" target=\"_blank\" aria-describedby=\"open-blank-target-link-description\">set to work-based mode and adjusted with version update</a>."
       )
     end
 
@@ -477,7 +477,7 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       href = OpenProject::Static::Links.url_for(:blog_article_progress_changes)
       expect(cause).to render_html_variant(
         "<strong>OpenProject system update:</strong> Progress calculation automatically " \
-        "<a href=\"#{href}\" target=\"_blank\">adjusted with version update</a>."
+        "<a href=\"#{href}\" target=\"_blank\" aria-describedby=\"open-blank-target-link-description\">adjusted with version update</a>."
       )
     end
 
@@ -513,7 +513,7 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
       expect(cause).to render_html_variant(
         "<strong>OpenProject system update:</strong> Work and progress totals " \
         "automatically removed for non-parent work packages with " \
-        "<a href=\"#{href}\" target=\"_blank\">version update</a>. " \
+        "<a href=\"#{href}\" target=\"_blank\" aria-describedby=\"open-blank-target-link-description\">version update</a>. " \
         "This is a maintenance task and can be safely ignored."
       )
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65606

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add aria-describedby for the link that has blank target
