### PR TITLE
[#65606] Apply description to links with blank target

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -303,7 +303,7 @@ module ApplicationHelper
 
   def body_data_attributes(local_assigns)
     {
-      controller: "application auto-theme-switcher hover-card-trigger beforeunload",
+      controller: "application auto-theme-switcher hover-card-trigger beforeunload external-links",
       relative_url_root: root_path,
       overflowing_identifier: ".__overflowing_body",
       rendered_at: Time.zone.now.iso8601,

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -63,6 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div id="polite" aria-live="polite" aria-atomic="true" class="sr-only"></div>
   <div id="assertive" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 </live-region>
+<span id="open-blank-target-link-description" class="sr-only"><%= I18n.t("open_link_in_a_new_tab") %></span>
 <opce-spot-drop-modal-portal></opce-spot-drop-modal-portal>
 <% main_menu = render_main_menu(local_assigns.fetch(:menu_name, nil), @project) %>
 <% side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4505,6 +4505,7 @@ en:
   text_access_token_hint: "Access tokens allow you to grant external applications access to resources in OpenProject."
   text_analyze: "Further analyze: %{subject}"
   text_are_you_sure: "Are you sure?"
+  open_link_in_a_new_tab: "Open link in a new tab"
   text_are_you_sure_continue: "Are you sure you want to continue?"
   text_are_you_sure_with_children: "Delete work package and all child work packages?"
   text_are_you_sure_with_project_custom_fields: "Deleting this attribute will also delete its values in all projects. Are you sure you want to do this?"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,5 @@
+import frontendConfig from './frontend/eslint.config.mjs';
+
+export default [
+  ...frontendConfig
+];

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -59,7 +59,7 @@ export default defineConfig([
       ],
 
       // Sometimes we need to shush the TypeScript compiler
-      'no-unused-vars': ['error', { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
+      'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
 
       // Allow short circuit evaluations

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text-modal.service.spec.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text-modal.service.spec.ts
@@ -4,6 +4,7 @@ import { AttributeHelpTextModalService } from './attribute-help-text-modal.servi
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { ToastService } from '../toaster/toast.service';
+import { MutationHelper } from 'core-stimulus/helpers/mutation-helper';
 
 describe('AttributeHelpTextModalService', () => {
   let fetchSpy:jasmine.Spy<Window['fetch']>;
@@ -152,36 +153,27 @@ describe('AttributeHelpTextModalService', () => {
   });
 });
 
-function waitForNativeElement<T extends Element>(selector:string):Promise<T> {
-  let element = document.querySelector<T>(selector);
+function waitForNativeElement<E extends Element>(selector:string):Promise<E> {
+  const element = document.querySelector<E>(selector);
   if (element) {
     return Promise.resolve(element);
   }
 
-  return new Promise<T>((resolve) => {
-    const observer = new MutationObserver(() => {
-      element = document.querySelector<T>(selector);
-      if (element) {
-        observer.disconnect();
-        resolve(element);
-      }
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
-  });
+  return MutationHelper.observeOnce(document, selector);
 }
 
-function waitForElementMutation<T extends Element>(
-  element:T,
-  predicate:(mutation:MutationRecord) => boolean = () => true,
-):Promise<MutationRecord> {
-  return new Promise((resolve) => {
-    const observer = new MutationObserver((mutationList) => {
-      const record = mutationList.find(predicate);
-      if (record) {
-        observer.disconnect();
-        resolve(record);
-      }
-    });
-    observer.observe(element, { childList: true, subtree: true, characterData: true });
+function waitForElementMutation(element:Element):Promise<MutationRecord> {
+  return new Promise<MutationRecord>((resolve) => {
+    const helper = new MutationHelper(
+      element,
+      {
+        onAnyRecord: (record) => {
+          helper.disconnect();
+          resolve(record);
+        }
+      },
+      { observerInit: { childList: true, subtree: true, characterData: true } }
+    );
+    helper.observe();
   });
 }

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -1,0 +1,76 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ApplicationController } from 'stimulus-use';
+import { useMutation } from 'stimulus-use';
+
+const BLANK_LINK_QUERY = 'a[target="_blank"]';
+const BLANK_LINK_DESCRIPTION_ID = 'open-blank-target-link-description';
+
+const isElement = (node:Node):node is Element => node.nodeType === Node.ELEMENT_NODE;
+const isBlankLink = (elem:Element):elem is HTMLAnchorElement => elem.matches(BLANK_LINK_QUERY);
+
+export default class ExternalLinksController extends ApplicationController {
+  connect() {
+    useMutation(this, { attributes: true, childList: true, subtree: true, attributeFilter: ['target'] });
+
+    // initial pass
+    document.querySelectorAll(BLANK_LINK_QUERY).forEach(applyLinkDescription);
+  }
+
+  mutate(mutations:MutationRecord[]) {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (isElement(node)) {
+          // added element itself is a blank link
+          if (isBlankLink(node)) {
+            applyLinkDescription(node);
+          }
+          // added sub-trees
+          node.querySelectorAll(BLANK_LINK_QUERY).forEach(applyLinkDescription);
+        }
+      });
+
+      // attribute changes
+      if (
+        mutation.type === 'attributes' &&
+        mutation.attributeName === 'target' &&
+        isElement(mutation.target) &&
+        isBlankLink(mutation.target)
+      ) {
+        applyLinkDescription(mutation.target);
+      }
+    });
+  }
+}
+
+function applyLinkDescription(link:HTMLAnchorElement) {
+  if (!link.hasAttribute('aria-describedby')) {
+    link.setAttribute('aria-describedby', BLANK_LINK_DESCRIPTION_ID);
+  }
+}

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -32,6 +32,16 @@ import { MutationHelper } from 'core-stimulus/helpers/mutation-helper';
 const BLANK_LINK_QUERY = 'a[target="_blank"]';
 const BLANK_LINK_DESCRIPTION_ID = 'open-blank-target-link-description';
 
+/**
+ * Observes all external links and sets their ARIA `describedby` attribute to
+ * {BLANK_LINK_DESCRIPTION_ID} - this element should exist in the DOM and
+ * provide localized text content along the lines of "Open link in a new tab".
+ *
+ * The goal is to make users of Assistive Technology aware that they may have to
+ * switch tabs on clicking a link.
+ *
+ * We consider links with a `target` attribute set to "_blank" as "external".
+ */
 export default class ExternalLinksController extends Controller<HTMLBodyElement> {
   private helper = MutationHelper.forAttributes(
     this.element,

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -26,46 +26,26 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ApplicationController } from 'stimulus-use';
-import { useMutation } from 'stimulus-use';
+import { Controller } from '@hotwired/stimulus';
+import { MutationHelper } from 'core-stimulus/helpers/mutation-helper';
 
 const BLANK_LINK_QUERY = 'a[target="_blank"]';
 const BLANK_LINK_DESCRIPTION_ID = 'open-blank-target-link-description';
 
-const isElement = (node:Node):node is Element => node.nodeType === Node.ELEMENT_NODE;
-const isBlankLink = (elem:Element):elem is HTMLAnchorElement => elem.matches(BLANK_LINK_QUERY);
+export default class ExternalLinksController extends Controller<HTMLBodyElement> {
+  private helper = MutationHelper.forAttributes(
+    this.element,
+    BLANK_LINK_QUERY,
+    applyLinkDescription,
+    { attributeFilter: ['target'], debounceMs: 50 }
+  );
 
-export default class ExternalLinksController extends ApplicationController {
   connect() {
-    useMutation(this, { attributes: true, childList: true, subtree: true, attributeFilter: ['target'] });
-
-    // initial pass
-    document.querySelectorAll(BLANK_LINK_QUERY).forEach(applyLinkDescription);
+    this.helper.observe();
   }
 
-  mutate(mutations:MutationRecord[]) {
-    mutations.forEach((mutation) => {
-      mutation.addedNodes.forEach((node) => {
-        if (isElement(node)) {
-          // added element itself is a blank link
-          if (isBlankLink(node)) {
-            applyLinkDescription(node);
-          }
-          // added sub-trees
-          node.querySelectorAll(BLANK_LINK_QUERY).forEach(applyLinkDescription);
-        }
-      });
-
-      // attribute changes
-      if (
-        mutation.type === 'attributes' &&
-        mutation.attributeName === 'target' &&
-        isElement(mutation.target) &&
-        isBlankLink(mutation.target)
-      ) {
-        applyLinkDescription(mutation.target);
-      }
-    });
+  disconnect() {
+    this.helper.disconnect();
   }
 }
 

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -60,7 +60,10 @@ export default class ExternalLinksController extends Controller<HTMLBodyElement>
 }
 
 function applyLinkDescription(link:HTMLAnchorElement) {
-  if (!link.hasAttribute('aria-describedby')) {
+  const existingValue = link.getAttribute('aria-describedby');
+  if (!existingValue) {
     link.setAttribute('aria-describedby', BLANK_LINK_DESCRIPTION_ID);
+  } else if (!existingValue.split(/\s+/).includes(BLANK_LINK_DESCRIPTION_ID)) {
+    link.setAttribute('aria-describedby', existingValue + ' ' + BLANK_LINK_DESCRIPTION_ID);
   }
 }

--- a/frontend/src/stimulus/helpers/mutation-helper.ts
+++ b/frontend/src/stimulus/helpers/mutation-helper.ts
@@ -1,0 +1,355 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+export interface MutationCallbacks<E> {
+  /** Called for every raw MutationRecord (useful for advanced cases) */
+  onAnyRecord?:(record:MutationRecord) => void;
+
+  /** Called for each *matching* element added to the DOM */
+  onAdded?:(el:E) => void;
+
+  /** Called for each *matching* element removed from the DOM */
+  onRemoved?:(el:E) => void;
+
+  /** Called for attribute changes on *matching* elements */
+  onAttributeChange?:(el:Element, attrName:string, oldValue:string|null) => void;
+
+  /** Called for text/characterData changes */
+  onTextChange?:(node:CharacterData, oldValue:string|null) => void;
+};
+
+export interface MutationHelperOptions {
+  /**
+   * Only elements that match this selector will trigger onAdded/onRemoved/onAttributeChange.
+   * If omitted, all elements are considered matches.
+   */
+  selector?:string;
+
+  /**
+   * Limit attribute callbacks to these names (e.g. ['hidden','aria-expanded']).
+   * If omitted, all attributes will trigger callbacks.
+   */
+  attributeFilter?:string[];
+
+  /**
+   * Observer init flags. Reasonable defaults applied if omitted.
+   * Defaults:
+   *   childList: true, subtree: true, attributes: true, attributeOldValue: true
+   */
+  observerInit?:MutationObserverInit;
+
+  /**
+   * Debounce/coalesce callback execution (ms). Helpful when many mutations fire at once.
+   * Set 0 to process synchronously (default 0).
+   */
+  debounceMs?:number;
+
+  /**
+   * Run a one-time scan on init and fire attribute callbacks for existing matches.
+   */
+  runInitial?:boolean;
+
+  /**
+   * When matching elements are added, fire attribute callbacks for attributes already present.
+   * (default: true)
+   */
+  attributeOnAdded?:boolean;
+}
+
+/**
+ * A tiny MutationObserver helper.
+ *
+ * Features:
+ * - Callbacks for added/removed nodes, attribute changes, and text changes.
+ * - Filter elements by CSS selector.
+ * - Attribute name filtering.
+ * - Debounce/coalesce bursts of mutations.
+ * - Utility static helpers for common patterns (observeAdded, observeRemoved, observeOnce).
+ */
+export class MutationHelper<E extends Element> {
+  private observer:MutationObserver;
+  private root:Node;
+  private selector?:string;
+  private attributeFilter?:Set<string>;
+  private cbs:MutationCallbacks<E>;
+  private debounceMs:number;
+  private queuedRecords:MutationRecord[] = [];
+  private timer:number|null = null;
+  private runInitial:boolean;
+  private attributeOnAdded:boolean;
+  private init:MutationObserverInit;
+
+  constructor(root:Node, callbacks:MutationCallbacks<E>, opts:MutationHelperOptions = {}) {
+    this.root = root;
+    this.cbs = callbacks;
+    this.selector = opts.selector;
+    this.attributeFilter = opts.attributeFilter ? new Set(opts.attributeFilter.map(n => n.toLowerCase())) : undefined;
+    this.debounceMs = opts.debounceMs ?? 0;
+    this.runInitial = !!opts.runInitial;
+    this.attributeOnAdded = opts.attributeOnAdded ?? true;
+    this.init = {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeOldValue: true,
+      characterData: false,
+      ...opts.observerInit,
+    };
+
+    // If user asked for attributeFilter but forgot to enable attributes, enable them.
+    if (this.attributeFilter && !this.init.attributes) {
+      this.init.attributes = true;
+    }
+
+    this.observer = new MutationObserver((records) => {
+      if (this.debounceMs > 0) {
+        this.queuedRecords.push(...records);
+        this.timer ??= window.setTimeout(() => {
+          const batch = this.queuedRecords.splice(0);
+          this.timer = null;
+          this.process(batch);
+        }, this.debounceMs);
+      } else {
+        this.process(records);
+      }
+    });
+  }
+
+  /** Start observing. */
+  observe():void {
+    this.observer.observe(this.root, this.init);
+
+    if (this.runInitial && this.cbs.onAttributeChange) {
+      this.primeAttributes(this.cbs.onAttributeChange);
+    }
+  }
+
+  /** Stop observing. Idempotent. */
+  disconnect():void {
+    if (this.timer != null) {
+      window.clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.queuedRecords.length = 0;
+    this.observer.disconnect();
+  }
+
+  /** Flush pending records synchronously. */
+  flush():void {
+    const pending = this.observer.takeRecords();
+    if (pending.length) this.process(pending);
+  }
+
+  private primeAttributes(cb:(el:Element, attrName:string, oldValue:string|null) => void) {
+    const elements = this.selector
+      ? (this.root as ParentNode).querySelectorAll(this.selector)
+      : (this.root as ParentNode).querySelectorAll('*');
+    const attrFilter = this.attributeFilter;
+
+    elements.forEach((el) => {
+      const names = attrFilter
+        ? [...attrFilter].filter((n) => el.hasAttribute(n))
+        : el.getAttributeNames();
+      for (const name of names) cb(el, name, null);
+    });
+  }
+
+  private process(records:MutationRecord[]):void {
+    if (!records.length) return;
+
+    const { onAnyRecord, onAdded, onRemoved, onAttributeChange, onTextChange } = this.cbs;
+    for (const rec of records) {
+      onAnyRecord?.(rec);
+
+      switch (rec.type) {
+        case 'childList': {
+          if (onAdded && rec.addedNodes.length) {
+            for (const node of rec.addedNodes) {
+              this.forEachMatchingElement(node, onAdded);
+            }
+          }
+          if (onRemoved && rec.removedNodes.length) {
+            for (const node of rec.removedNodes) {
+              this.forEachMatchingElement(node, onRemoved);
+            }
+          }
+          // NEW: if elements are added and already have the attribute(s), fire attribute callback
+          if (onAttributeChange && this.attributeOnAdded && rec.addedNodes.length) {
+            for (const node of rec.addedNodes) {
+              this.forEachMatchingElement(node, (el) => {
+                const names = this.attributeFilter
+                  ? [...this.attributeFilter].filter((n) => el.hasAttribute(n))
+                  : el.getAttributeNames(); // if not filtered, report all present attrs
+                for (const name of names) {
+                  onAttributeChange(el, name, null);
+                }
+              });
+            }
+          }
+          break;
+        }
+
+        case 'attributes': {
+          if (!onAttributeChange) break;
+          const target = rec.target;
+          if (isElement(target) && this.matchesFilter(target)) {
+            const attrName = rec.attributeName ?? '';
+            if (!this.attributeFilter || this.attributeFilter.has(attrName.toLowerCase())) {
+              onAttributeChange(target, attrName, (rec).oldValue ?? null);
+            }
+          }
+          break;
+        }
+
+        case 'characterData': {
+          if (!onTextChange) break;
+          const target = rec.target;
+          if (isCharacterData(target)) {
+            onTextChange(target, rec.oldValue ?? null);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  /** True if the element matches the configured selector (or no selector configured). */
+  private matchesFilter(el:Element):boolean {
+    if (!this.selector) return true;
+
+    return el.matches(this.selector);
+  }
+
+  /** Walk the node (and its subtree) and invoke cb for each matching Element. */
+  private forEachMatchingElement(node:Node, cb:(el:Element) => void):void {
+    if (isElement(node) && this.matchesFilter(node)) cb(node);
+
+    // If it's a DocumentFragment (e.g., from template or range), search inside it.
+    const root = node.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? (node as DocumentFragment) : null;
+    const ctx:ParentNode|null = (isElement(node) ? (node) : root) ?? null;
+
+    if (ctx) {
+      // If we have a selector, querySelectorAll is fast; otherwise walk children as Elements.
+      if (this.selector) {
+        ctx.querySelectorAll(this.selector).forEach(cb);
+      } else {
+        // No selector: visit element descendants
+        const treeWalker = document.createTreeWalker(ctx, NodeFilter.SHOW_ELEMENT);
+        let current:Node|null = treeWalker.currentNode;
+        if (isElement(current)) cb(current);
+        while ((current = treeWalker.nextNode())) {
+          if (isElement(current)) cb(current);
+        }
+      }
+    }
+  }
+
+  // ---------- Convenience static helpers ----------
+
+  /**
+   * Constructs a `MutationHelper` that observes elements added under `root` matching `selector`,
+   * calling `cb` once per element.
+   */
+  static forAdded<E extends Element>(
+    root:Node,
+    selector:string,
+    cb:(el:E) => void,
+    opts:Omit<MutationHelperOptions, 'selector'> = {}
+  ) {
+    return new MutationHelper<E>(root, { onAdded: cb }, { selector, ...opts });
+  }
+
+  /**
+   * Constructs a `MutationHelper` that observes elements removed under `root` matching `selector`,
+   * calling `cb` once per element.
+   */
+  static forRemoved<E extends Element>(
+    root:Node,
+    selector:string,
+    cb:(el:E) => void,
+    opts:Omit<MutationHelperOptions, 'selector'> = {}
+  ) {
+    return new MutationHelper<E>(root, { onRemoved: cb }, { selector, ...opts });
+  }
+
+  /**
+   * Constructs a `MutationHelper` that observes attribute changes for matching elements.
+   */
+  static forAttributes(
+    root:Node,
+    selector:string,
+    cb:(el:Element, attrName:string, oldValue:string|null) => void,
+    opts:Omit<MutationHelperOptions, 'selector'> & { attributeFilter?:string[]; runInitial?:boolean } = {}
+  ) {
+    return new MutationHelper(
+      root,
+      { onAttributeChange: cb },
+      {
+        selector,
+        attributeFilter: opts.attributeFilter,
+        debounceMs: opts.debounceMs,
+        attributeOnAdded: opts.attributeOnAdded ?? true,
+        runInitial: opts.runInitial ?? true, // default true for convenience
+        observerInit: {
+          attributes: true,
+          attributeOldValue: true,
+          subtree: true,
+          childList: true, // important: see elements as they are added
+          ...(opts.observerInit ?? {}),
+        },
+      }
+    );
+  }
+
+  /**
+   * Resolve with the first element added that matches `selector`, then auto-disconnect.
+   */
+  static observeOnce<E extends Element>(root:Node, selector?:string, opts:Omit<MutationHelperOptions, 'selector'> = {}):Promise<E> {
+    return new Promise<E>((resolve) => {
+      const helper = new MutationHelper<E>(
+        root,
+        {
+          onAdded: (el) => {
+            helper.disconnect();
+            resolve(el);
+          },
+        },
+        { selector, ...opts }
+      );
+      helper.observe();
+    });
+  }
+}
+
+// ---------- Type guards ----------
+function isElement(node:Node|null|undefined):node is Element {
+  return !!node && node.nodeType === Node.ELEMENT_NODE;
+}
+function isCharacterData(node:Node|null|undefined):node is CharacterData {
+  return !!node && (node.nodeType === Node.TEXT_NODE || node.nodeType === Node.CDATA_SECTION_NODE);
+}

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -30,6 +30,7 @@ import AutoThemeSwitcher from './controllers/auto-theme-switcher.controller';
 import { OpenProjectStimulusApplication } from 'core-stimulus/openproject-stimulus-application';
 import { Application } from '@hotwired/stimulus';
 import { BeforeunloadController } from './controllers/beforeunload.controller';
+import ExternalLinksController from './controllers/external-links.controller';
 
 declare global {
   interface Window {
@@ -65,6 +66,7 @@ OpenProjectStimulusApplication.preregister('work-packages--activities-tab--stems
 OpenProjectStimulusApplication.preregister('work-packages--activities-tab--editor', EditorController);
 OpenProjectStimulusApplication.preregister('beforeunload', BeforeunloadController);
 OpenProjectStimulusApplication.preregister('auto-theme-switcher', AutoThemeSwitcher);
+OpenProjectStimulusApplication.preregister('external-links', ExternalLinksController);
 
 const instance = OpenProjectStimulusApplication.start();
 window.Stimulus = instance;

--- a/spec/features/a11y/external_links_spec.rb
+++ b/spec/features/a11y/external_links_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "External links", :js do
+  let(:user) { create(:user) }
+
+  before do
+    login_as user
+  end
+
+  it "sets ARIA describedby on external links" do
+    visit "/"
+
+    expect(page).to have_link target: "_blank", described_by: "Open link in a new tab"
+    expect(page.all(:link, target: "_blank")).to all match_selector(:link, described_by: "Open link in a new tab")
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65606 

# What are you trying to accomplish?

Uses a `ExternalLinksController` Stimulus controller to set `aria-describedby` on all links with `target="blank"`. Uses a `MutationObserver` to ensure links that are added to the DOM dynamically (e.g. via Turbo Drive) are also updated.

# What approach did you choose and why?

Explained in my comment below: https://github.com/opf/openproject/pull/20282#issuecomment-3304422827

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
