### PR TITLE
support existing storied queries and clients by allowing favored filter

### DIFF
--- a/app/components/projects/projects_filters_component.rb
+++ b/app/components/projects/projects_filters_component.rb
@@ -62,6 +62,12 @@ class Projects::ProjectsFiltersComponent < Filter::FilterComponent
       Queries::Projects::Filters::TypeFilter
     ]
 
-    allowlist.any? { |clazz| filter.is_a? clazz }
+    # FavoritedFilter used to be called favored. The filter should not break for stored queries. Therefore,
+    # the filter is instantiated twice, once for "favorited", once for "favored".
+    # At the same time, the "Favorite" filter should not be displayed twice in the filter list.
+    # Removing it here has the drawback of a stored "favored" filter not showing up in the component.
+    # This is accepted.
+
+    allowlist.any? { |clazz| filter.is_a? clazz } && filter.name != :favored
   end
 end

--- a/app/models/queries/projects/filters/favorited_filter.rb
+++ b/app/models/queries/projects/filters/favorited_filter.rb
@@ -32,7 +32,20 @@ class Queries::Projects::Filters::FavoritedFilter < Queries::Projects::Filters::
   include Queries::Filters::Shared::BooleanFilter
 
   def self.key
-    :favorited
+    # The filter used to be called favored.
+    # To support:
+    # * Stored queries
+    # * API clients
+    # having that filter, the old key is also supported.
+    /favorited|favored/
+  end
+
+  def self.all_for(context = nil)
+    # Override superclass method to support the old name of the filter (see above).
+    [
+      create!(name: :favorited, context:),
+      create!(name: :favored, context:)
+    ]
   end
 
   def human_name


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/67313

# What are you trying to accomplish?

#20224 renames "favored" to "favorited" throughout the application. This is also carried out for the filter formerly named "FavoredFilter" which creates the problems that:
* a query with a "favored" filter will become invalid
* an API client using the "favored" filter will have an error message about a non existing filter returned.

To work around both issues, the old key for the filter is supported again.

Unfortunately, the filter will not be shown in the list of active filters as otherwise a "Favorite" filter would be displayed twice in the list to "Add filter":
<img width="982" height="328" alt="image" src="https://github.com/user-attachments/assets/ddb62fc5-ccfb-40d5-86fe-44da0b119b78" />

There is no easy fix for this which is why this behaviour is accepted.
