### PR TITLE
[#67060] Update 'More' menu of meetings with a 'Add to section' option  

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/meetings/add-params.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/add-params.controller.ts
@@ -34,14 +34,12 @@ import { appendCollapsedState } from '../../../helpers/collapsible-helper';
 
 export default class extends ApplicationController {
   private turboRequests:TurboRequestsService;
-  static targets = ['container'];
-
-  declare readonly containerTarget:HTMLElement;
 
   static metaNames = ['csrf-token'];
 
   declare readonly csrfToken:string;
 
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   async connect() {
     useMeta(this, { suffix: false });
     const context = await window.OpenProject.getPluginContext();
@@ -55,7 +53,6 @@ export default class extends ApplicationController {
     const url = new URL(target.dataset.href!, window.location.origin);
 
     appendCollapsedState(url.searchParams);
-    url.searchParams.append('current_meeting_id', this.containerTarget.dataset.meeting!);
 
     void this
       .turboRequests

--- a/frontend/src/stimulus/controllers/dynamic/meetings/add-params.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/add-params.controller.ts
@@ -46,11 +46,18 @@ export default class extends ApplicationController {
     this.turboRequests = context.services.turboRequests;
   }
 
-  interceptMoveTo(event:Event):void {
+  intercept(event:Event):void {
     event.preventDefault();
 
     const target = event.currentTarget as HTMLElement;
+
+    const confirmMessage = target.dataset.confirmMessage;
+    if (confirmMessage && !window.confirm(confirmMessage)) {
+      return;
+    }
+
     const url = new URL(target.dataset.href!, window.location.origin);
+    const method = target.dataset.method! || 'PUT';
 
     appendCollapsedState(url.searchParams);
 
@@ -59,7 +66,7 @@ export default class extends ApplicationController {
       .request(
         url.toString(),
         {
-          method: 'PUT',
+          method,
           headers: {
             'X-CSRF-Token': this.csrfToken,
             Accept: 'text/vnd.turbo-stream.html',

--- a/frontend/src/stimulus/controllers/dynamic/meetings/section-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/section-form.controller.ts
@@ -31,6 +31,7 @@
 import * as Turbo from '@hotwired/turbo';
 import { Controller } from '@hotwired/stimulus';
 import { useMeta } from 'stimulus-use';
+import { appendCollapsedState } from '../../../helpers/collapsible-helper';
 
 export default class extends Controller {
   static values = {
@@ -55,8 +56,11 @@ export default class extends Controller {
   }
 
   async cancel() {
-    const response = await fetch(this.cancelUrlValue, {
-      method: 'GET',
+    const url = new URL(this.cancelUrlValue, window.location.origin);
+    appendCollapsedState(url.searchParams);
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
       headers: {
         'X-CSRF-Token': this.csrfToken,
         Accept: 'text/vnd.turbo-stream.html',

--- a/modules/meeting/app/components/meeting_agenda_items/item_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -40,7 +41,8 @@ module MeetingAgendaItems
       state: :show,
       container: nil,
       display_notes_input: nil,
-      first_and_last: []
+      first_and_last: [],
+      current_occurrence: nil
     )
       super
 
@@ -49,6 +51,7 @@ module MeetingAgendaItems
       @display_notes_input = display_notes_input
       @container = container
       @first_and_last = first_and_last
+      @current_occurrence = current_occurrence
     end
 
     def wrapper_uniq_by
@@ -73,7 +76,8 @@ module MeetingAgendaItems
     def child_component_params
       {
         meeting_agenda_item: @meeting_agenda_item,
-        display_notes_input: (@display_notes_input if @state == :edit)
+        display_notes_input: (@display_notes_input if @state == :edit),
+        current_occurrence: @current_occurrence
       }.compact
     end
 
@@ -89,7 +93,8 @@ module MeetingAgendaItems
           id: @meeting_agenda_item.id,
           "draggable-id": @meeting_agenda_item.id,
           "draggable-type": "agenda-item",
-          "drop-url": drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item)
+          "drop-url": drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
+                                                    current_occurrence: @current_occurrence)
         }
       }
     end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/edit_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/edit_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,12 +33,13 @@ module MeetingAgendaItems
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting_agenda_item:, display_notes_input: nil)
+    def initialize(meeting_agenda_item:, display_notes_input: nil, current_occurrence: nil)
       super
 
       @meeting_agenda_item = meeting_agenda_item
       @type = @meeting_agenda_item.item_type.to_sym
       @display_notes_input = display_notes_input
+      @current_occurrence = current_occurrence
     end
 
     def call
@@ -47,8 +49,10 @@ module MeetingAgendaItems
                  meeting_section: @meeting_agenda_item.meeting_section,
                  meeting_agenda_item: @meeting_agenda_item,
                  method: :put,
-                 submit_path: meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item, format: :turbo_stream),
-                 cancel_path: cancel_edit_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item),
+                 submit_path: meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
+                                                       format: :turbo_stream, current_occurrence: @current_occurrence),
+                 cancel_path: cancel_edit_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
+                                                                   current_occurrence: @current_occurrence),
                  type: @type,
                  display_notes_input: @display_notes_input
                ))

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -76,22 +76,24 @@
           end
 
           with_item_group(menu) do
-            menu.with_sub_menu_item(label: "Move") do |submenu|
-              with_item_group(submenu) { move_actions(submenu) } unless first? && last?
+            if editable?
+              menu.with_sub_menu_item(label: "Move") do |submenu|
+                with_item_group(submenu) { move_actions(submenu) } unless first? && last?
 
-              with_item_group(submenu) do
-                if !in_template? || in_backlog?
-                  if in_backlog?
-                    move_to_current_meeting_action_item(submenu) if !visible_sections?
-                  else
-                    move_to_backlog_action_item(submenu)
+                with_item_group(submenu) do
+                  if !in_template? || in_backlog?
+                    if in_backlog?
+                      move_to_current_meeting_action_item(submenu) if !visible_sections?
+                    else
+                      move_to_backlog_action_item(submenu)
+                    end
+                    move_to_section_action_item(submenu) if visible_sections?
                   end
-                  move_to_section_action_item(submenu) if visible_sections?
                 end
-              end
 
-              with_item_group(submenu) do
-                move_to_next_meeting_action_item(submenu) if move_to_next_meeting_enabled?
+                with_item_group(submenu) do
+                  move_to_next_meeting_action_item(submenu) if move_to_next_meeting_enabled?
+                end
               end
             end
           end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -78,21 +78,24 @@
           with_item_group(menu) do
             if editable?
               menu.with_sub_menu_item(label: "Move") do |submenu|
-                with_item_group(submenu) { move_actions(submenu) } unless first? && last?
-
-                with_item_group(submenu) do
-                  if !in_template? || in_backlog?
-                    if in_backlog?
-                      move_to_current_meeting_action_item(submenu) if !visible_sections?
-                    else
-                      move_to_backlog_action_item(submenu)
-                    end
-                    move_to_section_action_item(submenu) if visible_sections?
-                  end
+                unless first? && last?
+                  move_actions(submenu)
                 end
 
-                with_item_group(submenu) do
-                  move_to_next_meeting_action_item(submenu) if move_to_next_meeting_enabled?
+                submenu.with_divider if move_to_different_section_or_meeting_action_added? && !(first? && last?)
+
+                if !in_template? || in_backlog?
+                  if in_backlog?
+                    move_to_current_meeting_action_item(submenu)
+                  else
+                    move_to_backlog_action_item(submenu)
+                  end
+                  move_to_section_action_item(submenu)
+                end
+
+                if move_to_next_meeting_enabled?
+                  submenu.with_divider
+                  move_to_next_meeting_action_item(submenu)
                 end
               end
             end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -75,12 +75,24 @@
             add_outcome_action_item(menu) if add_outcome_action?
           end
 
-          with_item_group(menu) { move_actions(menu) } unless first? && last?
-
           with_item_group(menu) do
-            move_to_current_meeting_action_item(menu) if in_backlog?
-            move_to_backlog_action_item(menu) if !in_template? && !in_backlog?
-            move_to_next_meeting_action_item(menu) if move_to_next_meeting_enabled?
+            menu.with_sub_menu_item(label: "Move") do |submenu|
+              with_item_group(submenu) { move_actions(submenu) } unless first? && last?
+
+              with_item_group(submenu) do
+                if !in_template? && !in_backlog?
+                  move_to_backlog_action_item(submenu)
+                end
+
+                move_to_section_action_item(submenu)
+              end
+
+              with_item_group(submenu) do
+                move_to_next_meeting_action_item(submenu) if move_to_next_meeting_enabled?
+              end
+
+              submenu.with_divider if move_to_different_section_or_meeting_action_added?
+            end
           end
 
           with_item_group(menu) { delete_action_item(menu) }

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -75,28 +75,24 @@
             add_outcome_action_item(menu) if add_outcome_action?
           end
 
-          with_item_group(menu) do
-            if editable?
-              menu.with_sub_menu_item(label: "Move") do |submenu|
-                unless first? && last?
-                  move_actions(submenu)
-                end
+          if editable?
+            with_item_group(menu) do
+              menu.with_sub_menu_item(label: I18n.t("label_agenda_item_move")) do |submenu|
+                submenu.with_leading_visual_icon(icon: :"op-arrow-in")
+                with_item_group(submenu) { move_actions(submenu) } unless first? && last?
 
-                submenu.with_divider if move_to_different_section_or_meeting_action_added? && !(first? && last?)
-
-                if !in_template? || in_backlog?
-                  if in_backlog?
-                    move_to_current_meeting_action_item(submenu)
-                  else
-                    move_to_backlog_action_item(submenu)
+                with_item_group(submenu) do
+                  if !in_template? || in_backlog?
+                    if in_backlog?
+                      move_to_current_meeting_action_item(submenu)
+                    else
+                      move_to_backlog_action_item(submenu)
+                    end
+                    move_to_section_action_item(submenu)
                   end
-                  move_to_section_action_item(submenu)
                 end
 
-                if move_to_next_meeting_enabled?
-                  submenu.with_divider
-                  move_to_next_meeting_action_item(submenu)
-                end
+                with_item_group(submenu) { move_to_next_meeting_action_item(submenu) }
               end
             end
           end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -84,14 +84,12 @@
                   move_to_backlog_action_item(submenu)
                 end
 
-                move_to_section_action_item(submenu)
+                move_to_section_action_item(submenu) if in_section?
               end
 
               with_item_group(submenu) do
                 move_to_next_meeting_action_item(submenu) if move_to_next_meeting_enabled?
               end
-
-              submenu.with_divider if move_to_different_section_or_meeting_action_added?
             end
           end
 

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -80,11 +80,14 @@
               with_item_group(submenu) { move_actions(submenu) } unless first? && last?
 
               with_item_group(submenu) do
-                if !in_template? && !in_backlog?
-                  move_to_backlog_action_item(submenu)
+                if !in_template? || in_backlog?
+                  if in_backlog?
+                    move_to_current_meeting_action_item(submenu) if !visible_sections?
+                  else
+                    move_to_backlog_action_item(submenu)
+                  end
+                  move_to_section_action_item(submenu) if visible_sections?
                 end
-
-                move_to_section_action_item(submenu) if in_section?
               end
 
               with_item_group(submenu) do

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -214,7 +214,12 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--add-params#interceptMoveTo",
-                       href: drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item, type: :to_backlog)
+                       href: drop_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         type: :to_backlog,
+                         current_occurrence: @current_occurrence
+                       )
                      } }) do |item|
         item.with_leading_visual_icon(icon: "discussion-outdated")
       end
@@ -222,12 +227,18 @@ module MeetingAgendaItems
 
     def move_to_current_meeting_action_item(menu)
       return unless editable?
+      return if many_sections?
 
       menu.with_item(label: I18n.t(:label_agenda_item_move_to_current_meeting),
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--add-params#interceptMoveTo",
-                       href: drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item, type: :to_current)
+                       href: drop_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         type: :to_current,
+                         current_occurrence: @current_occurrence
+                       )
                      } }) do |item|
         item.with_leading_visual_icon(icon: "cross-reference")
       end
@@ -235,17 +246,16 @@ module MeetingAgendaItems
 
     def move_to_section_action_item(menu)
       return unless editable?
+      return unless many_sections?
 
       menu.with_item(label: I18n.t(:label_agenda_item_move_to_section),
-                     tag: :button,
-                     content_arguments: {
-                       data: {
-                         action: "click->meetings--add-params#interceptMoveTo",
-                         href: move_to_section_dialog_meeting_agenda_item_path(
-                           @meeting_agenda_item.meeting,
-                           @meeting_agenda_item
-                         )
-                       }
+                     href: move_to_section_dialog_meeting_agenda_item_path(
+                       @meeting_agenda_item.meeting,
+                       @meeting_agenda_item,
+                       current_occurrence: @current_occurrence
+                     ),
+                     form_arguments: {
+                       method: :put, data: { "turbo-stream": true }
                      }) do |item|
         item.with_leading_visual_icon(icon: "op-move")
       end
@@ -273,6 +283,12 @@ module MeetingAgendaItems
       @meeting.templated?
     end
 
+    def move_to_different_section_or_meeting_action_added?
+      return false unless editable?
+
+      !in_template? || in_backlog? || move_to_next_meeting_enabled?
+    end
+
     def editable?
       @editable ||= @meeting_agenda_item.editable? && can_manage_agendas?
     end
@@ -281,10 +297,18 @@ module MeetingAgendaItems
       true
     end
 
-    def visible_sections?
-      return true if @meeting.templated?
+    # def visible_sections?
+    #   return true if @meeting.templated?
+    #
+    #   @meeting.sections.many?
+    # end
 
-      @meeting.sections.many? && @meeting.sections.first.title.blank?
+    def many_sections?
+      if @meeting_agenda_item.in_backlog? && @current_occurrence.present?
+        @current_occurrence.sections.many?
+      else
+        @meeting.sections.many?
+      end
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -249,14 +249,15 @@ module MeetingAgendaItems
       return unless many_sections?
 
       menu.with_item(label: I18n.t(:label_agenda_item_move_to_section),
-                     href: move_to_section_dialog_meeting_agenda_item_path(
-                       @meeting_agenda_item.meeting,
-                       @meeting_agenda_item,
-                       current_occurrence: @current_occurrence
-                     ),
-                     form_arguments: {
-                       method: :put, data: { "turbo-stream": true }
-                     }) do |item|
+                     tag: :button,
+                     content_arguments: { data: {
+                       action: "click->meetings--add-params#intercept",
+                       href: move_to_section_dialog_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         current_occurrence: @current_occurrence
+                       )
+                     } }) do |item|
         item.with_leading_visual_icon(icon: "op-move")
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -199,10 +199,10 @@ module MeetingAgendaItems
       end
     end
 
-    def move_to_section_action_item(menu)
+    def move_to_backlog_action_item(menu)
       return unless editable?
 
-      menu.with_item(label: "Move to section",
+      menu.with_item(label: I18n.t(:label_agenda_item_move_to_backlog),
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--add-params#interceptMoveTo",
@@ -225,16 +225,18 @@ module MeetingAgendaItems
       end
     end
 
-    def move_to_backlog_action_item(menu)
+    def move_to_section_action_item(menu)
       return unless editable?
 
-      menu.with_item(label: I18n.t(:label_agenda_item_move_to_backlog),
-                     tag: :button,
-                     content_arguments: { data: {
-                       action: "click->meetings--add-params#interceptMoveTo",
-                       href: drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item, type: :to_backlog)
-                     } }) do |item|
-        item.with_leading_visual_icon(icon: "discussion-outdated")
+      menu.with_item(label: I18n.t(:label_agenda_item_move_to_section),
+                     href: move_to_section_dialog_meeting_agenda_item_path(
+                       @meeting_agenda_item.meeting,
+                       @meeting_agenda_item
+                     ),
+                     content_arguments: {
+                       data: { controller: "async-dialog" }
+                     }) do |item|
+        item.with_leading_visual_icon(icon: "op-move")
       end
     end
 
@@ -262,6 +264,10 @@ module MeetingAgendaItems
 
     def editable?
       @editable ||= @meeting_agenda_item.editable? && can_manage_agendas?
+    end
+
+    def in_section?
+      true
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -213,7 +213,7 @@ module MeetingAgendaItems
       menu.with_item(label: I18n.t(:label_agenda_item_move_to_backlog),
                      tag: :button,
                      content_arguments: { data: {
-                       action: "click->meetings--add-params#interceptMoveTo",
+                       action: "click->meetings--add-params#intercept",
                        href: drop_meeting_agenda_item_path(
                          @meeting_agenda_item.meeting,
                          @meeting_agenda_item,
@@ -232,7 +232,7 @@ module MeetingAgendaItems
       menu.with_item(label: I18n.t(:label_agenda_item_move_to_current_meeting),
                      tag: :button,
                      content_arguments: { data: {
-                       action: "click->meetings--add-params#interceptMoveTo",
+                       action: "click->meetings--add-params#intercept",
                        href: drop_meeting_agenda_item_path(
                          @meeting_agenda_item.meeting,
                          @meeting_agenda_item,

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -36,13 +36,14 @@ module MeetingAgendaItems
     include OpPrimer::ComponentHelpers
     include Redmine::I18n
 
-    def initialize(meeting_agenda_item:, first_and_last: [])
+    def initialize(meeting_agenda_item:, first_and_last: [], current_occurrence: nil)
       super
 
       @meeting_agenda_item = meeting_agenda_item
       @meeting = meeting_agenda_item.meeting
       @series = @meeting.recurring_meeting
       @first_and_last = first_and_last
+      @current_occurrence = current_occurrence
     end
 
     def wrapper_uniq_by
@@ -101,7 +102,8 @@ module MeetingAgendaItems
       return unless editable?
 
       menu.with_item(label: t("label_edit"),
-                     href: edit_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item),
+                     href: edit_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
+                                                         current_occurrence: @current_occurrence),
                      content_arguments: {
                        data: { "turbo-stream": true }
                      }) do |item|
@@ -112,7 +114,7 @@ module MeetingAgendaItems
     def add_note_action_item(menu)
       menu.with_item(label: t("label_agenda_item_add_notes"),
                      href: edit_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
-                                                         display_notes_input: true),
+                                                         display_notes_input: true, current_occurrence: @current_occurrence),
                      content_arguments: {
                        data: { "turbo-stream": true }
                      }) do |item|
@@ -123,7 +125,8 @@ module MeetingAgendaItems
     def add_outcome_action_item(menu)
       menu.with_item(label: t("label_agenda_item_add_outcome"),
                      href: new_meeting_outcome_path(@meeting_agenda_item.meeting,
-                                                    meeting_agenda_item_id: @meeting_agenda_item&.id),
+                                                    meeting_agenda_item_id: @meeting_agenda_item&.id,
+                                                    current_occurrence: @current_occurrence),
                      content_arguments: {
                        data: { "turbo-stream": true }
                      }) do |item|
@@ -151,8 +154,8 @@ module MeetingAgendaItems
       menu.with_item(
         label: t(:label_agenda_item_move_to_next),
         href: move_to_next_dialog_meeting_agenda_item_path(@meeting_agenda_item.meeting,
-                                                    @meeting_agenda_item,
-                                                    datetime: next_date.iso8601),
+                                                           @meeting_agenda_item,
+                                                           datetime: next_date.iso8601),
         content_arguments: {
           data: { controller: "async-dialog" }
         }
@@ -176,7 +179,8 @@ module MeetingAgendaItems
       label = @meeting_agenda_item.work_package_id.present? ? wp_agenda_item_delete_label : t(:text_destroy)
       menu.with_item(label:,
                      scheme: :danger,
-                     href: meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item),
+                     href: meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
+                                                    current_occurrence: @current_occurrence),
                      form_arguments: {
                        method: :delete, data: { turbo_confirm: t(:text_are_you_sure), "turbo-stream": true }
                      }) do |item|
@@ -190,8 +194,12 @@ module MeetingAgendaItems
 
     def move_action_item(menu, move_to, label_text, icon)
       menu.with_item(label: label_text,
-                     href: move_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
-                                                         move_to:),
+                     href: move_meeting_agenda_item_path(
+                       @meeting_agenda_item.meeting,
+                       @meeting_agenda_item,
+                       move_to:,
+                       current_occurrence: @current_occurrence
+                     ),
                      form_arguments: {
                        method: :put, data: { "turbo-stream": true }
                      }) do |item|

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -199,10 +199,10 @@ module MeetingAgendaItems
       end
     end
 
-    def move_to_backlog_action_item(menu)
+    def move_to_section_action_item(menu)
       return unless editable?
 
-      menu.with_item(label: I18n.t(:label_agenda_item_move_to_backlog),
+      menu.with_item(label: "Move to section",
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--add-params#interceptMoveTo",
@@ -222,6 +222,19 @@ module MeetingAgendaItems
                        href: drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item, type: :to_current)
                      } }) do |item|
         item.with_leading_visual_icon(icon: "cross-reference")
+      end
+    end
+
+    def move_to_backlog_action_item(menu)
+      return unless editable?
+
+      menu.with_item(label: I18n.t(:label_agenda_item_move_to_backlog),
+                     tag: :button,
+                     content_arguments: { data: {
+                       action: "click->meetings--add-params#interceptMoveTo",
+                       href: drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item, type: :to_backlog)
+                     } }) do |item|
+        item.with_leading_visual_icon(icon: "discussion-outdated")
       end
     end
 

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -229,12 +229,15 @@ module MeetingAgendaItems
       return unless editable?
 
       menu.with_item(label: I18n.t(:label_agenda_item_move_to_section),
-                     href: move_to_section_dialog_meeting_agenda_item_path(
-                       @meeting_agenda_item.meeting,
-                       @meeting_agenda_item
-                     ),
+                     tag: :button,
                      content_arguments: {
-                       data: { controller: "async-dialog" }
+                       data: {
+                         action: "click->meetings--add-params#interceptMoveTo",
+                         href: move_to_section_dialog_meeting_agenda_item_path(
+                           @meeting_agenda_item.meeting,
+                           @meeting_agenda_item
+                         )
+                       }
                      }) do |item|
         item.with_leading_visual_icon(icon: "op-move")
       end
@@ -268,6 +271,12 @@ module MeetingAgendaItems
 
     def in_section?
       true
+    end
+
+    def visible_sections?
+      return true if @meeting.templated?
+
+      @meeting.sections.many? && @meeting.sections.first.title.blank?
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_next_meeting_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_next_meeting_dialog_component.html.erb
@@ -37,7 +37,8 @@ See COPYRIGHT and LICENSE files for more details.
         action: move_to_next_meeting_agenda_item_path(
           @agenda_item.meeting,
           @agenda_item,
-          datetime: @datetime
+          datetime: @datetime,
+          current_occurrence: @current_occurrence
         ),
         method: :post
       }

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
@@ -39,7 +39,8 @@ See COPYRIGHT and LICENSE files for more details.
       render(
         MeetingAgendaItems::MoveToSectionFormComponent.new(
           meeting: @meeting,
-          agenda_item: @agenda_item
+          agenda_item: @agenda_item,
+          collapsed: @collapsed
         )
       )
     end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
@@ -1,0 +1,69 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(
+    Primer::Alpha::Dialog.new(
+      title: "Move to section",
+      id: "move-to-section-dialog"
+    )
+  ) do |dialog|
+    dialog.with_header(variant: :large)
+    dialog.with_body do
+      render(
+        MeetingAgendaItems::MoveToSectionFormComponent.new(
+          agenda_item: @agenda_item
+        )
+      )
+    end
+    dialog.with_footer do
+      component_collection do |buttons|
+        buttons.with_component(
+          Primer::Beta::Button.new(
+            data: {
+              "close-dialog-id": "move-to-section-dialog"
+            }
+          )
+        ) do
+          t("button_cancel")
+        end
+        buttons.with_component(
+          Primer::Beta::Button.new(
+            scheme: :primary,
+            form: "move-to-section-form",
+            data: { turbo: true },
+            type: :submit
+          )
+        ) do
+          t("button_save")
+        end
+      end
+    end
+  end
+%>

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
@@ -38,6 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
     dialog.with_body do
       render(
         MeetingAgendaItems::MoveToSectionFormComponent.new(
+          meeting: @meeting,
           agenda_item: @agenda_item
         )
       )

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.html.erb
@@ -31,11 +31,12 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     Primer::Alpha::Dialog.new(
       title: "Move to section",
-      id: "move-to-section-dialog"
+      id: "move-to-section-dialog",
+      size: :large
     )
   ) do |dialog|
     dialog.with_header(variant: :large)
-    dialog.with_body do
+    dialog.with_body(classes: "Overlay-body_autocomplete_height") do
       render(
         MeetingAgendaItems::MoveToSectionFormComponent.new(
           meeting: @meeting,

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.rb
@@ -34,11 +34,12 @@ module MeetingAgendaItems
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting:, agenda_item:)
+    def initialize(meeting:, agenda_item:, collapsed:)
       super
 
       @meeting = meeting
       @agenda_item = agenda_item
+      @collapsed = collapsed
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module MeetingAgendaItems
+  class MoveToSectionDialogComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    def initialize(agenda_item:)
+      super
+
+      @agenda_item = agenda_item
+    end
+
+    private
+
+
+  end
+end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_dialog_component.rb
@@ -34,14 +34,11 @@ module MeetingAgendaItems
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(agenda_item:)
+    def initialize(meeting:, agenda_item:)
       super
 
+      @meeting = meeting
       @agenda_item = agenda_item
     end
-
-    private
-
-
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
@@ -35,7 +35,8 @@ See COPYRIGHT and LICENSE files for more details.
       method: :post,
       url: move_to_section_meeting_agenda_item_path(
         @agenda_item.meeting,
-        @agenda_item
+        @agenda_item,
+        collapsed: @collapsed
       )
     ) do |f|
       flex_layout(mb: 3) do |flex|

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
@@ -1,0 +1,53 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  component_wrapper do
+    primer_form_with(
+      id: "move-to-section-form",
+      model: @agenda_item,
+      method: :post,
+      url: move_to_section_meeting_agenda_item_path(
+        @agenda_item.meeting,
+        @agenda_item
+      )
+    ) do |f|
+      flex_layout(mb: 3) do |flex|
+        flex.with_row do
+          if @base_errors&.any?
+            render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @base_errors.join("\n") }
+          end
+        end
+        flex.with_row(mb: 3) do
+          render(Meeting::AddToSection.new(f, wrapper_id: "move-to-section-dialog"))
+        end
+      end
+    end
+  end
+%>

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
           end
         end
         flex.with_row(mb: 3) do
-          render(Meeting::AddToSection.new(f, wrapper_id: "move-to-section-dialog"))
+          render(Meeting::AddToSection.new(f, wrapper_id: "move-to-section-dialog", occurrence: @meeting))
         end
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.rb
@@ -34,11 +34,12 @@ module MeetingAgendaItems
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting:, agenda_item:)
+    def initialize(meeting:, agenda_item:, collapsed:)
       super
 
       @meeting = meeting
       @agenda_item = agenda_item
+      @collapsed = collapsed
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.rb
@@ -34,9 +34,10 @@ module MeetingAgendaItems
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(agenda_item:)
+    def initialize(meeting:, agenda_item:)
       super
 
+      @meeting = meeting
       @agenda_item = agenda_item
     end
   end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module MeetingAgendaItems
+  class MoveToSectionFormComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    def initialize(agenda_item:)
+      super
+
+      @agenda_item = agenda_item
+    end
+  end
+end

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
@@ -26,10 +26,12 @@
         component.with_item(
           label: t("activerecord.models.meeting_section"),
           tag: :a,
-          content_arguments: {
+          href: meeting_sections_path(@meeting),
+          content_arguments: { data: {
+            action: "click->meetings--add-params#intercept",
             href: meeting_sections_path(@meeting),
-            data: { "turbo-stream": true, "turbo-method": :post }
-          }
+            method: "POST"
+          } }
         )
       end
     end

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
@@ -10,7 +10,7 @@
         label: t("activerecord.models.meeting_agenda_item"),
         tag: :a,
         content_arguments: {
-          href: new_meeting_agenda_item_path(@meeting, type: "simple", meeting_section_id: @meeting_section&.id),
+          href: new_meeting_agenda_item_path(@meeting, type: "simple", meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
           data: { "turbo-stream": true }
         }
       )
@@ -18,7 +18,7 @@
         label: t("activerecord.models.work_package"),
         tag: :a,
         content_arguments: {
-          href: new_meeting_agenda_item_path(@meeting, type: "work_package", meeting_section_id: @meeting_section&.id),
+          href: new_meeting_agenda_item_path(@meeting, type: "work_package", meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
           data: { "turbo-stream": true }
         }
       )

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.rb
@@ -33,12 +33,13 @@ module MeetingAgendaItems
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting:, meeting_section: nil, disabled: false)
+    def initialize(meeting:, meeting_section: nil, disabled: false, current_occurrence: nil)
       super
 
       @meeting = meeting
       @meeting_section = meeting_section
       @disabled = @meeting.closed? || disabled
+      @current_occurrence = current_occurrence
     end
 
     private

--- a/modules/meeting/app/components/meeting_agenda_items/new_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_component.html.erb
@@ -9,8 +9,8 @@
               meeting_agenda_item: @meeting_agenda_item,
               meeting_section: @meeting_section,
               method: :post,
-              submit_path: meeting_agenda_items_path(@meeting, format: :turbo_stream),
-              cancel_path: cancel_new_meeting_agenda_items_path(@meeting, meeting_section_id: @meeting_section&.id),
+              submit_path: meeting_agenda_items_path(@meeting, format: :turbo_stream, current_occurrence: @current_occurrence),
+              cancel_path: cancel_new_meeting_agenda_items_path(@meeting, meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
               type: @type
             )
           )

--- a/modules/meeting/app/components/meeting_agenda_items/new_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_component.rb
@@ -33,7 +33,7 @@ module MeetingAgendaItems
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting:, meeting_section: nil, meeting_agenda_item: nil, hidden: true, type: :simple)
+    def initialize(meeting:, meeting_section: nil, meeting_agenda_item: nil, hidden: true, type: :simple, current_occurrence: nil)
       super
 
       @meeting = meeting
@@ -41,6 +41,7 @@ module MeetingAgendaItems
       @meeting_agenda_item = meeting_agenda_item || build_agenda_item
       @hidden = hidden
       @type = type
+      @current_occurrence = current_occurrence
     end
 
     private

--- a/modules/meeting/app/components/meeting_sections/backlogs/clear_backlog_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/clear_backlog_dialog_component.html.erb
@@ -5,7 +5,7 @@
       confirm_button_text: I18n.t(:label_backlog_clear_button),
       title: I18n.t(:label_backlog_clear),
       form_arguments: {
-        action: clear_backlog_meeting_sections_path(@meeting),
+        action: clear_backlog_meeting_sections_path(@meeting, current_occurrence: @current_occurrence),
         method: :post
       }
     )

--- a/modules/meeting/app/components/meeting_sections/backlogs/clear_backlog_dialog_component.rb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/clear_backlog_dialog_component.rb
@@ -33,10 +33,11 @@ module MeetingSections
     include ApplicationHelper
     include OpTurbo::Streamable
 
-    def initialize(meeting)
+    def initialize(meeting, current_occurrence:)
       super
 
       @meeting = meeting
+      @current_occurrence = current_occurrence
     end
 
     private

--- a/modules/meeting/app/components/meeting_sections/backlogs/container_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/container_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  component_wrapper(data: wrapper_data_attributes) do
+  component_wrapper do
     if show?
       flex_layout(mb: 3) do |flex|
         flex.with_row(mt: 3) do

--- a/modules/meeting/app/components/meeting_sections/backlogs/container_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/container_component.html.erb
@@ -11,7 +11,7 @@
             MeetingSections::ShowComponent.new(
               meeting_section: @backlog,
               collapsed: @collapsed,
-              current_meeting: @meeting
+              current_occurrence: @meeting
             )
           )
         end

--- a/modules/meeting/app/components/meeting_sections/backlogs/container_component.rb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/container_component.rb
@@ -47,12 +47,5 @@ module MeetingSections
     def show?
       !@meeting.closed? && !@meeting.template? && @backlog
     end
-
-    def wrapper_data_attributes
-      {
-        "meetings--add-params-target": "container",
-        meeting: @meeting.id
-      }
-    end
   end
 end

--- a/modules/meeting/app/components/meeting_sections/backlogs/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/header_component.rb
@@ -34,13 +34,13 @@ module MeetingSections
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(backlog:, collapsed:, current_meeting:, box: nil)
+    def initialize(backlog:, collapsed:, current_occurrence:, box: nil)
       super
 
       @backlog = backlog
       @meeting = backlog.meeting
       @box = box
-      @current_meeting = current_meeting
+      @current_occurrence = current_occurrence
 
       # When a specific collapsed state is needed, collapsed is passed in as either true or false
       # When the collapsed state needs to be determined based on meeting status, collapsed is nil and set via default
@@ -49,10 +49,10 @@ module MeetingSections
 
     private
 
-    def default_collapsed_state
+    def default_collapsed_state # rubocop:disable Naming/PredicateMethod
       # For a series backlog, the status of the current occurrence needs to be checked instead of the template
-      # For a one-time backlog, @meeting == @current_meeting
-      @current_meeting.in_progress?
+      # For a one-time backlog, @meeting == @current_occurrence
+      @current_occurrence.in_progress?
     end
 
     def description
@@ -70,7 +70,7 @@ module MeetingSections
     def clear_action_item(menu)
       menu.with_item(
         label: I18n.t(:label_backlog_clear),
-        href: clear_backlog_dialog_meeting_sections_path(@meeting),
+        href: clear_backlog_dialog_meeting_sections_path(@meeting, current_occurrence: @current_occurrence),
         scheme: :danger,
         tag: :a,
         content_arguments: {
@@ -84,7 +84,8 @@ module MeetingSections
     def add_agenda_item_action(menu)
       menu.with_item(
         label: t("label_agenda_item_add", count: 1),
-        href: new_meeting_agenda_item_path(@meeting, type: "simple", meeting_section_id: @backlog.id),
+        href: new_meeting_agenda_item_path(@meeting, type: "simple", meeting_section_id: @backlog.id,
+                                                     current_occurrence: @current_occurrence),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-backlog-add-agenda-item-from-menu" }
         }
@@ -96,7 +97,8 @@ module MeetingSections
     def add_work_package_action(menu)
       menu.with_item(
         label: t("label_agenda_item_work_package_add", count: 1),
-        href: new_meeting_agenda_item_path(@meeting, type: "work_package", meeting_section_id: @backlog.id),
+        href: new_meeting_agenda_item_path(@meeting, type: "work_package", meeting_section_id: @backlog.id,
+                                                     current_occurrence: @current_occurrence),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-backlog-add-work-package-from-menu" }
         }

--- a/modules/meeting/app/components/meeting_sections/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/header_component.html.erb
@@ -63,9 +63,12 @@
             render(
               Primer::Beta::Button.new(
                 scheme: :secondary,
-                tag: :a,
-                href: cancel_edit_meeting_section_path(@meeting_section.meeting, @meeting_section),
-                data: { "turbo-stream": true }
+                tag: :button,
+                data: {
+                  action: "click->meetings--add-params#intercept",
+                  href: cancel_edit_meeting_section_path(@meeting_section.meeting, @meeting_section),
+                  method: "POST"
+                }
               )
             ) do |_c|
               t("button_cancel")

--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -153,16 +153,15 @@ module MeetingSections
           t("text_are_you_sure")
         end
       menu.with_item(label: t("text_destroy"),
+                     tag: :button,
                      scheme: :danger,
-                     href: meeting_section_path(@meeting_section.meeting, @meeting_section),
-                     form_arguments: {
-                       method: :delete,
-                       data: {
-                         turbo_confirm: confirm_text,
-                         turbo_stream: true,
-                         test_selector: "meeting-section-delete"
-                       }
-                     }) do |item|
+                     content_arguments: { data: {
+                       action: "click->meetings--add-params#intercept",
+                       href: meeting_section_path(@meeting_section.meeting, @meeting_section),
+                       method: "DELETE",
+                       confirm_message: confirm_text,
+                       test_selector: "meeting-section-delete"
+                     } }) do |item|
         item.with_leading_visual_icon(icon: :trash)
       end
     end

--- a/modules/meeting/app/components/meeting_sections/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/show_component.html.erb
@@ -7,7 +7,7 @@
         end
       elsif render_backlog?
         component.with_header do
-          render(MeetingSections::Backlogs::HeaderComponent.new(backlog: @meeting_section, box: component, collapsed: @collapsed, current_meeting: @current_meeting))
+          render(MeetingSections::Backlogs::HeaderComponent.new(backlog: @meeting_section, box: component, collapsed: @collapsed, current_occurrence: @current_occurrence))
         end
       end
       if render_new_button_in_section?
@@ -17,7 +17,7 @@
               render(Primer::Beta::Text.new(color: :subtle)) { t("meeting_section.empty_text") }
             end
             empty_list_container.with_column do
-              render(MeetingAgendaItems::NewButtonComponent.new(meeting: @meeting, meeting_section: @meeting_section))
+              render(MeetingAgendaItems::NewButtonComponent.new(meeting: @meeting, meeting_section: @meeting_section, current_occurrence: @current_occurrence))
             end
           end
         end
@@ -28,13 +28,14 @@
             MeetingAgendaItems::ItemComponent.new(
               meeting_agenda_item: agenda_item,
               container: component,
-              first_and_last:
+              first_and_last:,
+              current_occurrence: @current_occurrence
             )
           )
         end
       end
       component.with_row(p: 0, border_top: 0, id: insert_target_modifier_id) do
-        render(MeetingAgendaItems::NewComponent.new(meeting: @meeting, meeting_section: @meeting_section, hidden: @form_hidden, type: @form_type))
+        render(MeetingAgendaItems::NewComponent.new(meeting: @meeting, meeting_section: @meeting_section, hidden: @form_hidden, type: @form_type, current_occurrence: @current_occurrence))
       end
     end
   end

--- a/modules/meeting/app/components/meeting_sections/show_component.rb
+++ b/modules/meeting/app/components/meeting_sections/show_component.rb
@@ -37,7 +37,7 @@ module MeetingSections
     with_collection_parameter :meeting_section
 
     def initialize(meeting_section:, first_and_last: [], form_hidden: true, form_type: :simple, insert_target_modified: true,
-                   force_wrapper: false, state: :show, collapsed: nil, current_meeting: nil)
+                   force_wrapper: false, state: :show, collapsed: nil, current_occurrence: nil)
       super
 
       @meeting = meeting_section.meeting
@@ -50,7 +50,7 @@ module MeetingSections
       @force_wrapper = force_wrapper
       @state = state
       @collapsed = collapsed
-      @current_meeting = current_meeting
+      @current_occurrence = current_occurrence
     end
 
     private

--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -95,25 +95,27 @@ module Meetings
         )
       end
 
-      def update_show_items_via_turbo_stream(meeting: @meeting)
+      def update_show_items_via_turbo_stream(meeting: @meeting, current_occurrence: nil)
         meeting.sections.each do |meeting_section|
-          update_show_items_of_section_via_turbo_stream(meeting_section:)
+          update_show_items_of_section_via_turbo_stream(meeting_section:, current_occurrence:)
         end
       end
 
-      def update_show_items_of_section_via_turbo_stream(meeting_section: @meeting_section)
+      def update_show_items_of_section_via_turbo_stream(current_occurrence:, meeting_section: @meeting_section)
         agenda_items = meeting_section.agenda_items.with_includes_to_render
         first_and_last = [agenda_items.first, agenda_items.last]
 
         agenda_items.each do |meeting_agenda_item|
           update_via_turbo_stream(
-            component: MeetingAgendaItems::ItemComponent::ShowComponent.new(meeting_agenda_item:, first_and_last:)
+            component: MeetingAgendaItems::ItemComponent::ShowComponent.new(meeting_agenda_item:, first_and_last:,
+                                                                            current_occurrence:)
           )
         end
       end
 
-      def update_new_component_via_turbo_stream(hidden: false, meeting_section: @meeting_section, meeting_agenda_item: nil,
-                                                meeting: @meeting, type: :simple)
+      def update_new_component_via_turbo_stream(hidden: false, meeting_section: @meeting_section,
+                                                meeting_agenda_item: nil, meeting: @meeting, type: :simple,
+                                                current_occurrence: nil)
         if meeting_section.nil? && meeting_agenda_item.nil?
           meeting_section = meeting.sections.last
         end
@@ -128,7 +130,8 @@ module Meetings
             meeting:,
             meeting_section:,
             meeting_agenda_item:,
-            type:
+            type:,
+            current_occurrence:
           )
         )
       end
@@ -145,12 +148,12 @@ module Meetings
         )
       end
 
-      def render_agenda_item_form_via_turbo_stream(collapsed:, meeting: @meeting, meeting_section: @meeting_section,
-                                                   type: :simple)
+      def render_agenda_item_form_via_turbo_stream(collapsed:, current_occurrence:, meeting: @meeting,
+                                                   meeting_section: @meeting_section, type: :simple)
         if meeting.sections.empty? && meeting_section != meeting.backlog
           render_agenda_item_form_for_empty_meeting_via_turbo_stream(type:)
         else
-          render_agenda_item_form_in_section_via_turbo_stream(meeting:, meeting_section:, type:, collapsed:)
+          render_agenda_item_form_in_section_via_turbo_stream(meeting:, meeting_section:, type:, collapsed:, current_occurrence:)
         end
 
         update_new_button_via_turbo_stream(disabled: true) unless meeting_section == meeting.backlog
@@ -164,18 +167,19 @@ module Meetings
         )
       end
 
-      def render_agenda_item_form_in_section_via_turbo_stream(collapsed:, meeting: @meeting, meeting_section: @meeting_section,
-                                                              type: :simple)
+      def render_agenda_item_form_in_section_via_turbo_stream(collapsed:, current_occurrence:, meeting: @meeting,
+                                                              meeting_section: @meeting_section, type: :simple)
         if meeting_section.nil?
           meeting_section = meeting.sections.last
         end
         if meeting_section.agenda_items.empty?
-          update_section_via_turbo_stream(meeting_section:, form_hidden: false, form_type: type, collapsed:)
+          update_section_via_turbo_stream(meeting_section:, form_hidden: false, form_type: type, collapsed:, current_occurrence:)
         else
           update_new_component_via_turbo_stream(
             hidden: false,
             meeting_section:,
-            type:
+            type:,
+            current_occurrence:
           )
         end
       end
@@ -204,27 +208,30 @@ module Meetings
         update_new_button_via_turbo_stream(disabled: false, meeting:) if form_hidden == true
       end
 
-      def update_item_via_turbo_stream(state: :show, meeting_agenda_item: @meeting_agenda_item, display_notes_input: nil)
+      def update_item_via_turbo_stream(current_occurrence:, state: :show, meeting_agenda_item: @meeting_agenda_item,
+                                       display_notes_input: nil)
         update_via_turbo_stream(
           component: MeetingAgendaItems::ItemComponent.new(
             state:,
             meeting_agenda_item:,
-            display_notes_input:
+            display_notes_input:,
+            current_occurrence:
           )
         )
-        update_show_items_via_turbo_stream
+        update_show_items_via_turbo_stream(current_occurrence:)
       end
 
-      def add_item_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item, clear_slate: false) # rubocop:disable Metrics/AbcSize
+      def add_item_via_turbo_stream(current_occurrence:, meeting_agenda_item: @meeting_agenda_item, clear_slate: false) # rubocop:disable Metrics/AbcSize
         if clear_slate
           update_list_via_turbo_stream(form_hidden: false, form_type: @agenda_item_type)
-        elsif meeting_agenda_item.meeting.agenda_items.count == 1 && meeting_agenda_item.meeting.sections.present?
+        elsif meeting_agenda_item.meeting.agenda_items.one? && meeting_agenda_item.meeting.sections.present?
           update_list_via_turbo_stream(form_hidden: true)
 
           update_new_component_via_turbo_stream(
             hidden: true,
             meeting_section: meeting_agenda_item.meeting_section,
-            type: @agenda_item_type
+            type: @agenda_item_type,
+            current_occurrence:
           )
         else
           update_section_header_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section)
@@ -232,7 +239,8 @@ module Meetings
           add_before_via_turbo_stream(
             component: MeetingAgendaItems::ItemComponent.new(
               state: :show,
-              meeting_agenda_item:
+              meeting_agenda_item:,
+              current_occurrence:
             ),
             target_component: MeetingSections::ShowComponent.new(
               meeting_section: @meeting_agenda_item.meeting_section
@@ -242,7 +250,8 @@ module Meetings
           update_new_component_via_turbo_stream(
             hidden: true,
             meeting_section: meeting_agenda_item.meeting_section,
-            type: @agenda_item_type
+            type: @agenda_item_type,
+            current_occurrence:
           )
 
           update_new_button_via_turbo_stream(disabled: false)
@@ -251,44 +260,45 @@ module Meetings
         end
       end
 
-      def remove_item_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item, clear_slate: false)
+      def remove_item_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item, clear_slate: false, current_occurrence: nil)
         if clear_slate
           update_list_via_turbo_stream
         else
-          update_show_items_of_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section)
+          update_show_items_of_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section, current_occurrence:)
           if meeting_agenda_item.meeting_section.agenda_items.empty?
             # Show the empty section state by updating the whole section if items are empty
-            update_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section)
+            update_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section, current_occurrence:)
           else
             remove_via_turbo_stream(
               component: MeetingAgendaItems::ItemComponent.new(
                 state: :show,
                 meeting_agenda_item:,
-                display_notes_input: nil
+                display_notes_input: nil,
+                current_occurrence:
               )
             )
           end
         end
       end
 
-      def move_item_within_section_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item)
-        move_item_via_turbo_stream(meeting_agenda_item:)
+      def move_item_within_section_via_turbo_stream(current_occurrence:, meeting_agenda_item: @meeting_agenda_item)
+        move_item_via_turbo_stream(meeting_agenda_item:, current_occurrence:)
 
         # Update the header for updated timestamp
         update_header_component_via_turbo_stream unless @meeting_agenda_item.meeting_section.backlog?
 
         # update the displayed time slots of all other items in the section
-        update_show_items_of_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section)
+        update_show_items_of_section_via_turbo_stream(meeting_section: meeting_agenda_item.meeting_section, current_occurrence:)
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
-      def move_item_to_other_section_via_turbo_stream(old_section:, current_section:, meeting_agenda_item: @meeting_agenda_item,
-                                                      collapsed: nil)
+      def move_item_to_other_section_via_turbo_stream(old_section:, current_section:, current_occurrence:,
+                                                      meeting_agenda_item: @meeting_agenda_item, collapsed: nil)
         # old_section.meeting and current_section.meeting are different when items are moved to/from a series backlog
         current_section_meeting = current_section.meeting
         old_section_meeting = old_section.meeting
 
-        move_item_via_turbo_stream(meeting_agenda_item:)
+        move_item_via_turbo_stream(meeting_agenda_item:, current_occurrence:)
 
         # update the old section
         if old_section.backlog?
@@ -305,14 +315,14 @@ module Meetings
               update_section_via_turbo_stream(meeting_section: old_section)
             end
           else
-            update_show_items_of_section_via_turbo_stream(meeting_section: old_section)
+            update_show_items_of_section_via_turbo_stream(meeting_section: old_section, current_occurrence:)
           end
         end
 
         # update the new section
         if current_section.backlog?
           update_backlog_via_turbo_stream(meeting: old_section_meeting, collapsed:)
-        elsif current_section_meeting.sections.count == 1 && current_section_meeting.agenda_items.count == 1
+        elsif current_section_meeting.sections.one? && current_section_meeting.agenda_items.one?
           # Special case when first item is being moved from backlog to empty meeting
           update_list_via_turbo_stream(meeting: current_section_meeting)
           update_header_component_via_turbo_stream(meeting: current_section_meeting)
@@ -320,19 +330,19 @@ module Meetings
           update_header_component_via_turbo_stream(meeting: current_section_meeting)
           update_section_header_via_turbo_stream(meeting_section: current_section)
 
-          if current_section.agenda_items.count == 1
+          if current_section.agenda_items.one?
             update_section_via_turbo_stream(meeting_section: current_section)
           else
-            update_show_items_of_section_via_turbo_stream(meeting_section: current_section)
+            update_show_items_of_section_via_turbo_stream(meeting_section: current_section, current_occurrence:)
           end
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
-      def move_item_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item)
+      def move_item_via_turbo_stream(current_occurrence:, meeting_agenda_item: @meeting_agenda_item)
         # Note: The `remove_component` and the `component` are pointing to the same
         # component, but we still need to instantiate them separately, otherwise re-adding
-        # of the item will render and empty component.
+        # of the item will render an empty component.
         remove_component = MeetingAgendaItems::ItemComponent.new(state: :show, meeting_agenda_item:)
         remove_via_turbo_stream(component: remove_component)
 
@@ -341,11 +351,13 @@ module Meetings
         target_component = if meeting_agenda_item.lower_item
                              MeetingAgendaItems::ItemComponent.new(
                                state: :show,
-                               meeting_agenda_item: meeting_agenda_item.lower_item
+                               meeting_agenda_item: meeting_agenda_item.lower_item,
+                               current_occurrence:
                              )
                            else
                              MeetingSections::ShowComponent.new(
-                               meeting_section: meeting_agenda_item.meeting_section
+                               meeting_section: meeting_agenda_item.meeting_section,
+                               current_occurrence:
                              )
                            end
 
@@ -385,7 +397,7 @@ module Meetings
       end
 
       def update_section_via_turbo_stream(meeting_section: @meeting_section, form_hidden: true, form_type: :simple,
-                                          force_wrapper: false, state: :show, collapsed: nil)
+                                          force_wrapper: false, state: :show, collapsed: nil, current_occurrence: nil)
         update_via_turbo_stream(
           component: MeetingSections::ShowComponent.new(
             meeting_section:,
@@ -393,7 +405,8 @@ module Meetings
             form_hidden:,
             force_wrapper:,
             state:,
-            collapsed:
+            collapsed:,
+            current_occurrence:
           )
         )
       end

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -184,38 +184,21 @@ class MeetingAgendaItemsController < ApplicationController
     respond_with_turbo_streams
   end
 
-  def drop # rubocop:disable Metrics/AbcSize
+  def drop
     current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     meeting_agenda_item_section = @meeting_agenda_item.meeting_section
 
     call = if @target_id.nil?
              ::MeetingAgendaItems::UpdateService
                .new(user: current_user, model: @meeting_agenda_item)
-               .call(meeting_id: params[:current_meeting_id], meeting_section: nil)
+               .call(meeting: current_occurrence, meeting_section: nil)
            else
              ::MeetingAgendaItems::DropService
                .new(user: current_user, meeting_agenda_item: @meeting_agenda_item)
                .call(target_id: @target_id, position: @position)
            end
 
-    if call.success?
-      old_section, current_section, section_changed = assign_drop_results(call, meeting_agenda_item_section)
-
-      if section_changed
-        move_item_to_other_section_via_turbo_stream(
-          old_section:,
-          current_section:,
-          collapsed: ActiveModel::Type::Boolean.new.cast(params[:collapsed]),
-          current_occurrence:
-        )
-      else
-        move_item_within_section_via_turbo_stream(current_occurrence:)
-      end
-    else
-      generic_call_failure_response(call)
-    end
-
-    respond_with_turbo_streams
+    handle_agenda_item_update_on_move(call, meeting_agenda_item_section, current_occurrence:)
   end
 
   def move
@@ -261,7 +244,8 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def move_to_section_dialog
-    meeting = params[:current_meeting_id].present? ? Meeting.find(params[:current_meeting_id]) : @meeting_agenda_item.meeting
+    meeting = params[:current_occurrence].present? ? Meeting.find(params[:current_occurrence]) : @meeting_agenda_item.meeting
+
     respond_with_dialog MeetingAgendaItems::MoveToSectionDialogComponent.new(
       agenda_item: @meeting_agenda_item,
       meeting:
@@ -276,23 +260,7 @@ class MeetingAgendaItemsController < ApplicationController
              .new(user: current_user, model: @meeting_agenda_item)
              .call(meeting_section:)
 
-    if call.success?
-      old_section, current_section, section_changed = assign_drop_results(call, meeting_agenda_item_section)
-
-      if section_changed
-        move_item_to_other_section_via_turbo_stream(
-          old_section:,
-          current_section:,
-          collapsed: ActiveModel::Type::Boolean.new.cast(params[:collapsed])
-        )
-      else
-        move_item_within_section_via_turbo_stream
-      end
-    else
-      generic_call_failure_response(call)
-    end
-
-    respond_with_turbo_streams
+    handle_agenda_item_update_on_move(call, meeting_agenda_item_section, current_occurrence: nil)
   end
 
   private
@@ -371,7 +339,7 @@ class MeetingAgendaItemsController < ApplicationController
   def assign_drop_params # rubocop:disable Metrics/AbcSize
     @target_id, @position =
       if params[:type] == "to_current"
-        meeting = Meeting.find_by(id: params[:current_meeting_id])
+        meeting = Meeting.find_by(id: params[:current_occurrence])
         section = meeting.sections.reorder(position: :desc).first
         [section&.id, section&.last_position]
       elsif params[:type] == "to_backlog"
@@ -393,5 +361,26 @@ class MeetingAgendaItemsController < ApplicationController
     end
 
     [old_section, current_section, section_changed]
+  end
+
+  def handle_agenda_item_update_on_move(call, meeting_agenda_item_section, current_occurrence:)
+    if call.success?
+      old_section, current_section, section_changed = assign_drop_results(call, meeting_agenda_item_section)
+
+      if section_changed
+        move_item_to_other_section_via_turbo_stream(
+          old_section:,
+          current_section:,
+          collapsed: ActiveModel::Type::Boolean.new.cast(params[:collapsed]),
+          current_occurrence:
+        )
+      else
+        move_item_within_section_via_turbo_stream(current_occurrence:)
+      end
+    else
+      generic_call_failure_response(call)
+    end
+
+    respond_with_turbo_streams
   end
 end

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -248,7 +248,8 @@ class MeetingAgendaItemsController < ApplicationController
 
     respond_with_dialog MeetingAgendaItems::MoveToSectionDialogComponent.new(
       agenda_item: @meeting_agenda_item,
-      meeting:
+      meeting:,
+      collapsed: params[:collapsed]
     )
   end
 

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -250,8 +250,10 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def move_to_section_dialog
+    meeting = params[:current_meeting_id].present? ? Meeting.find(params[:current_meeting_id]) : @meeting_agenda_item.meeting
     respond_with_dialog MeetingAgendaItems::MoveToSectionDialogComponent.new(
-      agenda_item: @meeting_agenda_item
+      agenda_item: @meeting_agenda_item,
+      meeting:
     )
   end
 

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -38,6 +38,8 @@ class MeetingAgendaItemsController < ApplicationController
   before_action :set_agenda_item_type, only: %i[new create]
   before_action :set_meeting_agenda_item,
                 except: %i[new cancel_new create]
+  before_action :set_current_occurrence,
+                only: %i[new cancel_new edit cancel_edit create update destroy drop move move_to_section_dialog]
   before_action :authorize
   before_action :check_recurring_meeting_param, only: %i[move_to_next_meeting]
   before_action :assign_drop_params, only: %i[drop]
@@ -53,33 +55,49 @@ class MeetingAgendaItemsController < ApplicationController
           collapsed = false
         end
       end
-      current_occurrence = Meeting.find_by(id: params[:current_occurrence])
-      render_agenda_item_form_via_turbo_stream(meeting_section:, collapsed:, type: @agenda_item_type, current_occurrence:)
+      render_agenda_item_form_via_turbo_stream(meeting_section:, collapsed:, type: @agenda_item_type,
+                                               current_occurrence: @current_occurrence)
     end
 
     respond_with_turbo_streams
   end
 
   def cancel_new
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     if params[:meeting_section_id].present?
       meeting_section = MeetingSection.find_by(id: params[:meeting_section_id])
       if meeting_section.agenda_items.empty?
         if meeting_section.backlog?
           collapsed = false
         end
-        update_section_via_turbo_stream(form_hidden: true, meeting_section:, collapsed:, current_occurrence:)
+        update_section_via_turbo_stream(form_hidden: true, meeting_section:, collapsed:, current_occurrence: @current_occurrence)
       end
     end
 
-    update_new_component_via_turbo_stream(hidden: true, meeting_section:, current_occurrence:)
+    update_new_component_via_turbo_stream(hidden: true, meeting_section:, current_occurrence: @current_occurrence)
     update_new_button_via_turbo_stream(disabled: false) unless meeting_section&.backlog?
 
     respond_with_turbo_streams
   end
 
+  def edit
+    if @meeting_agenda_item.editable?
+      update_item_via_turbo_stream(state: :edit, display_notes_input: params[:display_notes_input],
+                                   current_occurrence: @current_occurrence)
+    else
+      update_all_via_turbo_stream
+      render_error_flash_message_via_turbo_stream(message: t("text_meeting_not_editable_anymore"))
+    end
+
+    respond_with_turbo_streams
+  end
+
+  def cancel_edit
+    update_item_via_turbo_stream(state: :show, current_occurrence: @current_occurrence)
+
+    respond_with_turbo_streams
+  end
+
   def create # rubocop:disable Metrics/AbcSize
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     call = ::MeetingAgendaItems::CreateService
       .new(user: current_user)
       .call(
@@ -94,18 +112,18 @@ class MeetingAgendaItemsController < ApplicationController
     if call.success?
       if @meeting_agenda_item.meeting_section.backlog?
         update_section_via_turbo_stream(meeting_section: @meeting_agenda_item.meeting_section, collapsed: false,
-                                        current_occurrence:)
+                                        current_occurrence: @current_occurrence)
       else
         reset_meeting_from_agenda_item
         # enable continue editing
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
-        add_item_via_turbo_stream(clear_slate: false, current_occurrence:)
+        add_item_via_turbo_stream(clear_slate: false, current_occurrence: @current_occurrence)
       end
     else
       # show errors
       update_new_component_via_turbo_stream(
-        hidden: false, meeting_agenda_item: @meeting_agenda_item, type: @agenda_item_type, current_occurrence:
+        hidden: false, meeting_agenda_item: @meeting_agenda_item, type: @agenda_item_type, current_occurrence: @current_occurrence
       )
       render_base_error_in_flash_message_via_turbo_stream(call.errors)
     end
@@ -113,27 +131,7 @@ class MeetingAgendaItemsController < ApplicationController
     respond_with_turbo_streams
   end
 
-  def edit
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
-    if @meeting_agenda_item.editable?
-      update_item_via_turbo_stream(state: :edit, display_notes_input: params[:display_notes_input], current_occurrence:)
-    else
-      update_all_via_turbo_stream
-      render_error_flash_message_via_turbo_stream(message: t("text_meeting_not_editable_anymore"))
-    end
-
-    respond_with_turbo_streams
-  end
-
-  def cancel_edit
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
-    update_item_via_turbo_stream(state: :show, current_occurrence:)
-
-    respond_with_turbo_streams
-  end
-
   def update # rubocop:disable Metrics/AbcSize
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     call = ::MeetingAgendaItems::UpdateService
       .new(user: current_user, model: @meeting_agenda_item)
       .call(meeting_agenda_item_params)
@@ -144,11 +142,11 @@ class MeetingAgendaItemsController < ApplicationController
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
       end
-      update_item_via_turbo_stream(current_occurrence:)
+      update_item_via_turbo_stream(current_occurrence: @current_occurrence)
       update_section_header_via_turbo_stream(meeting_section: @meeting_agenda_item.meeting_section)
     else
       # show errors
-      update_item_via_turbo_stream(state: :edit, current_occurrence:)
+      update_item_via_turbo_stream(state: :edit, current_occurrence: @current_occurrence)
       render_base_error_in_flash_message_via_turbo_stream(call.errors)
     end
 
@@ -156,7 +154,6 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def destroy # rubocop:disable Metrics/AbcSize
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     section = @meeting_agenda_item.meeting_section
 
     call = ::MeetingAgendaItems::DeleteService
@@ -165,12 +162,12 @@ class MeetingAgendaItemsController < ApplicationController
 
     if call.success?
       if section.backlog?
-        update_section_via_turbo_stream(meeting_section: section, collapsed: false, current_occurrence:)
+        update_section_via_turbo_stream(meeting_section: section, collapsed: false, current_occurrence: @current_occurrence)
       else
         reset_meeting_from_agenda_item
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
-        remove_item_via_turbo_stream(clear_slate: @meeting.agenda_items.empty?, current_occurrence:)
+        remove_item_via_turbo_stream(clear_slate: @meeting.agenda_items.empty?, current_occurrence: @current_occurrence)
 
         # If section is deleted via an after_destroy/after_update action, it needs to be handled separately
         if MeetingSection.exists?(section.id) && section&.reload.present?
@@ -185,30 +182,28 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def drop
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     meeting_agenda_item_section = @meeting_agenda_item.meeting_section
 
     call = if @target_id.nil?
              ::MeetingAgendaItems::UpdateService
                .new(user: current_user, model: @meeting_agenda_item)
-               .call(meeting: current_occurrence, meeting_section: nil)
+               .call(meeting: @current_occurrence, meeting_section: nil)
            else
              ::MeetingAgendaItems::DropService
                .new(user: current_user, meeting_agenda_item: @meeting_agenda_item)
                .call(target_id: @target_id, position: @position)
            end
 
-    handle_agenda_item_update_on_move(call, meeting_agenda_item_section, current_occurrence:)
+    handle_agenda_item_update_on_move(call, meeting_agenda_item_section, current_occurrence: @current_occurrence)
   end
 
   def move
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     call = ::MeetingAgendaItems::UpdateService
       .new(user: current_user, model: @meeting_agenda_item)
       .call(move_to: params[:move_to]&.to_sym)
 
     if call.success?
-      move_item_within_section_via_turbo_stream(current_occurrence:)
+      move_item_within_section_via_turbo_stream(current_occurrence: @current_occurrence)
     else
       generic_call_failure_response(call)
     end
@@ -244,7 +239,7 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def move_to_section_dialog
-    meeting = params[:current_occurrence].present? ? Meeting.find(params[:current_occurrence]) : @meeting_agenda_item.meeting
+    meeting = @current_occurrence || @meeting_agenda_item.meeting
 
     respond_with_dialog MeetingAgendaItems::MoveToSectionDialogComponent.new(
       agenda_item: @meeting_agenda_item,
@@ -300,6 +295,10 @@ class MeetingAgendaItemsController < ApplicationController
     @meeting_agenda_item = MeetingAgendaItem.find(params[:id])
   end
 
+  def set_current_occurrence
+    @current_occurrence = Meeting.find_by(id: params[:current_occurrence])
+  end
+
   def meeting_agenda_item_params
     params
       .require(:meeting_agenda_item)
@@ -340,7 +339,7 @@ class MeetingAgendaItemsController < ApplicationController
   def assign_drop_params # rubocop:disable Metrics/AbcSize
     @target_id, @position =
       if params[:type] == "to_current"
-        meeting = Meeting.find_by(id: params[:current_occurrence])
+        meeting = @current_occurrence
         section = meeting.sections.reorder(position: :desc).first
         [section&.id, section&.last_position]
       elsif params[:type] == "to_backlog"

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -53,30 +53,33 @@ class MeetingAgendaItemsController < ApplicationController
           collapsed = false
         end
       end
-      render_agenda_item_form_via_turbo_stream(meeting_section:, collapsed:, type: @agenda_item_type)
+      current_occurrence = Meeting.find_by(id: params[:current_occurrence])
+      render_agenda_item_form_via_turbo_stream(meeting_section:, collapsed:, type: @agenda_item_type, current_occurrence:)
     end
 
     respond_with_turbo_streams
   end
 
   def cancel_new
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     if params[:meeting_section_id].present?
       meeting_section = MeetingSection.find_by(id: params[:meeting_section_id])
       if meeting_section.agenda_items.empty?
         if meeting_section.backlog?
           collapsed = false
         end
-        update_section_via_turbo_stream(form_hidden: true, meeting_section:, collapsed:)
+        update_section_via_turbo_stream(form_hidden: true, meeting_section:, collapsed:, current_occurrence:)
       end
     end
 
-    update_new_component_via_turbo_stream(hidden: true, meeting_section:)
+    update_new_component_via_turbo_stream(hidden: true, meeting_section:, current_occurrence:)
     update_new_button_via_turbo_stream(disabled: false) unless meeting_section&.backlog?
 
     respond_with_turbo_streams
   end
 
   def create # rubocop:disable Metrics/AbcSize
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     call = ::MeetingAgendaItems::CreateService
       .new(user: current_user)
       .call(
@@ -90,18 +93,19 @@ class MeetingAgendaItemsController < ApplicationController
 
     if call.success?
       if @meeting_agenda_item.meeting_section.backlog?
-        update_section_via_turbo_stream(meeting_section: @meeting_agenda_item.meeting_section, collapsed: false)
+        update_section_via_turbo_stream(meeting_section: @meeting_agenda_item.meeting_section, collapsed: false,
+                                        current_occurrence:)
       else
         reset_meeting_from_agenda_item
         # enable continue editing
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
-        add_item_via_turbo_stream(clear_slate: false)
+        add_item_via_turbo_stream(clear_slate: false, current_occurrence:)
       end
     else
       # show errors
       update_new_component_via_turbo_stream(
-        hidden: false, meeting_agenda_item: @meeting_agenda_item, type: @agenda_item_type
+        hidden: false, meeting_agenda_item: @meeting_agenda_item, type: @agenda_item_type, current_occurrence:
       )
       render_base_error_in_flash_message_via_turbo_stream(call.errors)
     end
@@ -110,8 +114,9 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def edit
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     if @meeting_agenda_item.editable?
-      update_item_via_turbo_stream(state: :edit, display_notes_input: params[:display_notes_input])
+      update_item_via_turbo_stream(state: :edit, display_notes_input: params[:display_notes_input], current_occurrence:)
     else
       update_all_via_turbo_stream
       render_error_flash_message_via_turbo_stream(message: t("text_meeting_not_editable_anymore"))
@@ -121,12 +126,14 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def cancel_edit
-    update_item_via_turbo_stream(state: :show)
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
+    update_item_via_turbo_stream(state: :show, current_occurrence:)
 
     respond_with_turbo_streams
   end
 
   def update # rubocop:disable Metrics/AbcSize
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     call = ::MeetingAgendaItems::UpdateService
       .new(user: current_user, model: @meeting_agenda_item)
       .call(meeting_agenda_item_params)
@@ -137,11 +144,11 @@ class MeetingAgendaItemsController < ApplicationController
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
       end
-      update_item_via_turbo_stream
+      update_item_via_turbo_stream(current_occurrence:)
       update_section_header_via_turbo_stream(meeting_section: @meeting_agenda_item.meeting_section)
     else
       # show errors
-      update_item_via_turbo_stream(state: :edit)
+      update_item_via_turbo_stream(state: :edit, current_occurrence:)
       render_base_error_in_flash_message_via_turbo_stream(call.errors)
     end
 
@@ -149,6 +156,7 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def destroy # rubocop:disable Metrics/AbcSize
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     section = @meeting_agenda_item.meeting_section
 
     call = ::MeetingAgendaItems::DeleteService
@@ -157,12 +165,12 @@ class MeetingAgendaItemsController < ApplicationController
 
     if call.success?
       if section.backlog?
-        update_section_via_turbo_stream(meeting_section: section, collapsed: false)
+        update_section_via_turbo_stream(meeting_section: section, collapsed: false, current_occurrence:)
       else
         reset_meeting_from_agenda_item
         update_header_component_via_turbo_stream
         update_sidebar_details_component_via_turbo_stream
-        remove_item_via_turbo_stream(clear_slate: @meeting.agenda_items.empty?)
+        remove_item_via_turbo_stream(clear_slate: @meeting.agenda_items.empty?, current_occurrence:)
 
         # If section is deleted via an after_destroy/after_update action, it needs to be handled separately
         if MeetingSection.exists?(section.id) && section&.reload.present?
@@ -177,6 +185,7 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def drop # rubocop:disable Metrics/AbcSize
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     meeting_agenda_item_section = @meeting_agenda_item.meeting_section
 
     call = if @target_id.nil?
@@ -196,10 +205,11 @@ class MeetingAgendaItemsController < ApplicationController
         move_item_to_other_section_via_turbo_stream(
           old_section:,
           current_section:,
-          collapsed: ActiveModel::Type::Boolean.new.cast(params[:collapsed])
+          collapsed: ActiveModel::Type::Boolean.new.cast(params[:collapsed]),
+          current_occurrence:
         )
       else
-        move_item_within_section_via_turbo_stream
+        move_item_within_section_via_turbo_stream(current_occurrence:)
       end
     else
       generic_call_failure_response(call)
@@ -209,12 +219,13 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def move
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     call = ::MeetingAgendaItems::UpdateService
       .new(user: current_user, model: @meeting_agenda_item)
       .call(move_to: params[:move_to]&.to_sym)
 
     if call.success?
-      move_item_within_section_via_turbo_stream
+      move_item_within_section_via_turbo_stream(current_occurrence:)
     else
       generic_call_failure_response(call)
     end

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -249,6 +249,39 @@ class MeetingAgendaItemsController < ApplicationController
     end
   end
 
+  def move_to_section_dialog
+    respond_with_dialog MeetingAgendaItems::MoveToSectionDialogComponent.new(
+      agenda_item: @meeting_agenda_item
+    )
+  end
+
+  def move_to_section
+    meeting_agenda_item_section = @meeting_agenda_item.meeting_section
+    meeting_section = MeetingSection.find_by(id: params[:meeting_agenda_item][:meeting_section_id])
+
+    call = ::MeetingAgendaItems::UpdateService
+             .new(user: current_user, model: @meeting_agenda_item)
+             .call(meeting_section:)
+
+    if call.success?
+      old_section, current_section, section_changed = assign_drop_results(call, meeting_agenda_item_section)
+
+      if section_changed
+        move_item_to_other_section_via_turbo_stream(
+          old_section:,
+          current_section:,
+          collapsed: ActiveModel::Type::Boolean.new.cast(params[:collapsed])
+        )
+      else
+        move_item_within_section_via_turbo_stream
+      end
+    else
+      generic_call_failure_response(call)
+    end
+
+    respond_with_turbo_streams
+  end
+
   private
 
   def init_next_meeting_occurrence

--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -35,6 +35,7 @@ class MeetingSectionsController < ApplicationController
   before_action :set_meeting
   before_action :set_meeting_section,
                 except: %i[create clear_backlog clear_backlog_dialog]
+  before_action :set_collapsed_state, only: %i[create cancel_edit destroy]
   before_action :authorize
 
   def create # rubocop:disable Metrics/AbcSize
@@ -54,6 +55,8 @@ class MeetingSectionsController < ApplicationController
       update_section_via_turbo_stream(force_wrapper: true, state: :edit)
       # update the section header of the previously last section in order to ensure the action menu move options are updated
       update_section_header_via_turbo_stream(meeting_section: @meeting.sections.last(2).first) if @meeting.sections.count > 1
+      # update backlog to ensure move actions match meeting content
+      update_backlog_via_turbo_stream(meeting: @meeting, collapsed: @collapsed)
       update_new_button_via_turbo_stream(disabled: true)
       update_header_component_via_turbo_stream
     else
@@ -82,6 +85,9 @@ class MeetingSectionsController < ApplicationController
       update_section_header_via_turbo_stream(state: :show)
       update_new_button_via_turbo_stream(disabled: false)
     end
+
+    # update backlog to ensure move actions match meeting content
+    update_backlog_via_turbo_stream(meeting: @meeting, collapsed: @collapsed)
 
     respond_with_turbo_streams
   end
@@ -119,6 +125,8 @@ class MeetingSectionsController < ApplicationController
       update_new_button_via_turbo_stream(disabled: false)
       # update all section headers in order to ensure the action menu move options are updated
       update_section_headers_via_turbo_stream
+      # update backlog to ensure move actions match meeting content
+      update_backlog_via_turbo_stream(meeting: @meeting, collapsed: @collapsed)
       update_header_component_via_turbo_stream
     else
       generic_call_failure_response(call)
@@ -212,6 +220,10 @@ class MeetingSectionsController < ApplicationController
 
   def set_meeting_section
     @meeting_section = MeetingSection.find(params[:id])
+  end
+
+  def set_collapsed_state
+    @collapsed = ActiveModel::Type::Boolean.new.cast(params[:collapsed])
   end
 
   def meeting_section_params

--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -171,6 +171,7 @@ class MeetingSectionsController < ApplicationController
   end
 
   def clear_backlog
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     errors = []
     meeting_section = @meeting.backlog
     @meeting.backlog.agenda_items.each do |item|
@@ -181,14 +182,15 @@ class MeetingSectionsController < ApplicationController
       errors << call.errors unless call.success?
     end
 
-    update_section_via_turbo_stream(collapsed: true, meeting_section:)
+    update_section_via_turbo_stream(collapsed: true, meeting_section:, current_occurrence: current_occurrence)
     render_error_flash_message_via_turbo_stream(message: t("text_backlog_clear_error")) if errors.any?
 
     respond_with_turbo_streams
   end
 
   def clear_backlog_dialog
-    respond_with_dialog MeetingSections::Backlogs::ClearBacklogDialogComponent.new(@meeting)
+    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
+    respond_with_dialog MeetingSections::Backlogs::ClearBacklogDialogComponent.new(@meeting, current_occurrence:)
   end
 
   private

--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -36,7 +37,19 @@ class MeetingSectionsController < ApplicationController
   before_action :set_meeting_section,
                 except: %i[create clear_backlog clear_backlog_dialog]
   before_action :set_collapsed_state, only: %i[create cancel_edit destroy]
+  before_action :set_current_occurrence, only: %i[clear_backlog clear_backlog_dialog]
   before_action :authorize
+
+  def edit
+    if @meeting_section.editable?
+      update_section_header_via_turbo_stream(state: :edit)
+    else
+      update_all_via_turbo_stream
+      render_error_flash_message_via_turbo_stream(message: t("text_meeting_not_editable_anymore"))
+    end
+
+    respond_with_turbo_streams
+  end
 
   def create # rubocop:disable Metrics/AbcSize
     call = ::MeetingSections::CreateService
@@ -61,17 +74,6 @@ class MeetingSectionsController < ApplicationController
       update_header_component_via_turbo_stream
     else
       render_base_error_in_flash_message_via_turbo_stream(call.errors)
-    end
-
-    respond_with_turbo_streams
-  end
-
-  def edit
-    if @meeting_section.editable?
-      update_section_header_via_turbo_stream(state: :edit)
-    else
-      update_all_via_turbo_stream
-      render_error_flash_message_via_turbo_stream(message: t("text_meeting_not_editable_anymore"))
     end
 
     respond_with_turbo_streams
@@ -179,7 +181,6 @@ class MeetingSectionsController < ApplicationController
   end
 
   def clear_backlog
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
     errors = []
     meeting_section = @meeting.backlog
     @meeting.backlog.agenda_items.each do |item|
@@ -190,15 +191,15 @@ class MeetingSectionsController < ApplicationController
       errors << call.errors unless call.success?
     end
 
-    update_section_via_turbo_stream(collapsed: true, meeting_section:, current_occurrence: current_occurrence)
+    update_section_via_turbo_stream(collapsed: true, meeting_section:, current_occurrence: @current_occurrence)
     render_error_flash_message_via_turbo_stream(message: t("text_backlog_clear_error")) if errors.any?
 
     respond_with_turbo_streams
   end
 
   def clear_backlog_dialog
-    current_occurrence = Meeting.find_by(id: params[:current_occurrence])
-    respond_with_dialog MeetingSections::Backlogs::ClearBacklogDialogComponent.new(@meeting, current_occurrence:)
+    respond_with_dialog MeetingSections::Backlogs::ClearBacklogDialogComponent.new(@meeting,
+                                                                                   current_occurrence: @current_occurrence)
   end
 
   private
@@ -220,6 +221,10 @@ class MeetingSectionsController < ApplicationController
 
   def set_meeting_section
     @meeting_section = MeetingSection.find(params[:id])
+  end
+
+  def set_current_occurrence
+    @current_occurrence = Meeting.find_by(id: params[:current_occurrence])
   end
 
   def set_collapsed_state

--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -34,7 +34,7 @@ class Meeting::AddToSection < ApplicationForm
       name: :meeting_section_id,
       label: I18n.t("label_add_work_package_to_meeting_section_label"),
       caption:,
-      input_width: :large,
+      input_width:,
       autocomplete_options: {
         decorated: true,
         defaultData: false,
@@ -70,9 +70,9 @@ class Meeting::AddToSection < ApplicationForm
     @wrapper_id.nil? ? "body" : "##{@wrapper_id}"
   end
 
-  def items
+  def items # rubocop:disable Metrics/AbcSize
     items = []
-    items.concat(meeting.sections) unless meeting.blank? || meeting.templated?
+    items.concat(meeting.sections) if meeting.present? && !meeting.templated?
     items.concat(@occurrence.sections) if @occurrence.present? && @occurrence != meeting
     items.push(meeting.backlog) if meeting.present?
 
@@ -108,5 +108,9 @@ class Meeting::AddToSection < ApplicationForm
 
   def caption
     I18n.t("label_section_selection_caption") if @occurrence.nil?
+  end
+
+  def input_width
+    @occurrence.present? ? nil : :large
   end
 end

--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -33,7 +33,7 @@ class Meeting::AddToSection < ApplicationForm
     meeting_form.autocompleter(
       name: :meeting_section_id,
       label: I18n.t("label_add_work_package_to_meeting_section_label"),
-      caption: I18n.t("label_section_selection_caption"),
+      caption:,
       input_width: :large,
       autocomplete_options: {
         decorated: true,
@@ -55,10 +55,11 @@ class Meeting::AddToSection < ApplicationForm
     end
   end
 
-  def initialize(wrapper_id: nil)
+  def initialize(wrapper_id: nil, occurrence: nil)
     super()
 
     @wrapper_id = wrapper_id
+    @occurrence = occurrence
   end
 
   private
@@ -71,7 +72,8 @@ class Meeting::AddToSection < ApplicationForm
 
   def items
     items = []
-    items.concat(meeting.sections) unless meeting.blank? || any_non_backlog_sections?
+    items.concat(meeting.sections) unless meeting.blank? || meeting.templated?
+    items.concat(@occurrence.sections) if @occurrence.present? && @occurrence != meeting
     items.push(meeting.backlog) if meeting.present?
 
     items
@@ -97,10 +99,14 @@ class Meeting::AddToSection < ApplicationForm
   end
 
   def any_non_backlog_sections?
-    meeting.sections.none? || (meeting.sections.one? && meeting.sections.first.title.blank?)
+    meeting.sections.none? || (meeting.sections.many? && meeting.sections.first.title.blank?)
   end
 
   def placeholder_text
     I18n.t("placeholder_section_select_meeting_first") if meeting.blank?
+  end
+
+  def caption
+    I18n.t("label_section_selection_caption") if @occurrence.nil?
   end
 end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -541,6 +541,7 @@ en:
   label_agenda_item_move_to_next: "Move to next meeting"
   label_agenda_item_move_to_backlog: "Move to backlog"
   label_agenda_item_move_to_current_meeting: "Move to current meeting"
+  label_agenda_item_move_to_section: "Move to section"
   label_agenda_item_move_to_top: "Move to top"
   label_agenda_item_move_to_bottom: "Move to bottom"
   label_agenda_item_move_up: "Move up"

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -123,7 +123,7 @@ Rails.application.routes.draw do
         get :clear_backlog_dialog
       end
       member do
-        get :cancel_edit
+        post :cancel_edit
         put :drop
         put :move
       end

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
         put :move
         get :move_to_next_dialog, action: :move_to_next_meeting_dialog
         post :move_to_next, action: :move_to_next_meeting
+        get :move_to_section_dialog
+        post :move_to_section
       end
     end
     resources :sections, controller: "meeting_sections" do

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -113,7 +113,7 @@ Rails.application.routes.draw do
         put :move
         get :move_to_next_dialog, action: :move_to_next_meeting_dialog
         post :move_to_next, action: :move_to_next_meeting
-        get :move_to_section_dialog
+        put :move_to_section_dialog
         post :move_to_section
       end
     end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -90,7 +90,8 @@ module OpenProject::Meeting
                    {
                      meetings: %i[change_state],
                      meeting_agenda_items: %i[new cancel_new create edit cancel_edit update destroy drop move
-                                              move_to_next_meeting move_to_next_meeting_dialog],
+                                              move_to_next_meeting move_to_next_meeting_dialog
+                                              move_to_section move_to_section_dialog],
                      meeting_sections: %i[new cancel_new create edit cancel_edit update destroy drop move
                                           clear_backlog clear_backlog_dialog]
                    },

--- a/modules/meeting/spec/features/move_to_section_spec.rb
+++ b/modules/meeting/spec/features/move_to_section_spec.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+require_relative "../support/pages/meetings/show"
+require_relative "../support/pages/recurring_meeting/show"
+
+RSpec.describe "Move agenda items to section", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  shared_let(:user) do
+    create :user,
+           member_with_permissions: { project => %i[view_meetings manage_agendas] }
+  end
+  shared_let(:reader) do
+    create :user,
+           member_with_permissions: { project => %i[view_meetings] }
+  end
+
+  let(:current_user) { user }
+
+  before do
+    login_as current_user
+  end
+
+  describe "for one-time meetings" do
+    shared_let(:meeting) do
+      create :meeting,
+             project:,
+             author: user,
+             state: :in_progress
+    end
+
+    let(:show_page) { Pages::Meetings::Show.new(meeting) }
+
+    context "when meeting has multiple sections" do
+      let!(:section1) { create(:meeting_section, meeting:, title: "Section 1") }
+      let!(:section2) { create(:meeting_section, meeting:, title: "Section 2") }
+      let!(:section3) { create(:meeting_section, meeting:, title: "Section 3") }
+      let!(:agenda_item) { create(:meeting_agenda_item, meeting:, meeting_section: section1, title: "Item to move") }
+
+      it "allows moving an item to another section" do
+        show_page.visit!
+        show_page.expect_agenda_item_in_section(title: "Item to move", section: section1)
+
+        show_page.select_action(agenda_item, I18n.t(:label_agenda_item_move_to_section))
+
+        expect(page).to have_css("#move-to-section-dialog")
+        expect(page).to have_text("Move to section")
+
+        within("#move-to-section-dialog") do
+          select_autocomplete page.find("opce-autocompleter"),
+                              query: "Section 2",
+                              select_text: "Section 2",
+                              results_selector: "#move-to-section-dialog"
+          click_button "Save"
+        end
+
+        show_page.expect_no_agenda_item_in_section(title: "Item to move", section: section1)
+        show_page.expect_agenda_item_in_section(title: "Item to move", section: section2)
+      end
+
+      it "preserves backlog collapsed state when moving items between sections" do
+        show_page.visit!
+
+        # Set state to opposite of default
+        show_page.click_on_backlog
+        show_page.expect_backlog collapsed: false
+
+        show_page.select_action(agenda_item, I18n.t(:label_agenda_item_move_to_section))
+
+        within("#move-to-section-dialog") do
+          select_autocomplete page.find("opce-autocompleter"),
+                              query: "Section 3",
+                              select_text: "Section 3",
+                              results_selector: "#move-to-section-dialog"
+          click_button "Save"
+        end
+
+        show_page.expect_backlog collapsed: false
+      end
+
+      it "allows moving items from backlog to a specific section" do
+        backlog_item = create(:meeting_agenda_item, meeting:, meeting_section: meeting.backlog, title: "Backlog item")
+
+        show_page.visit!
+        show_page.click_on_backlog
+        show_page.within_backlog do
+          show_page.expect_agenda_item(title: "Backlog item")
+        end
+
+        show_page.select_action(backlog_item, I18n.t(:label_agenda_item_move_to_section))
+
+        within("#move-to-section-dialog") do
+          select_autocomplete page.find("opce-autocompleter"),
+                              query: "Section 2",
+                              select_text: "Section 2",
+                              results_selector: "#move-to-section-dialog"
+          click_button "Save"
+        end
+
+        show_page.within_backlog do
+          show_page.expect_no_agenda_item(title: "Backlog item")
+        end
+        show_page.expect_agenda_item_in_section(title: "Backlog item", section: section2)
+      end
+
+      context "with view permission only" do
+        let(:current_user) { reader }
+
+        it "does not show the move to section option" do
+          show_page.visit!
+          show_page.expect_agenda_item(title: "Item to move")
+
+          show_page.open_menu(agenda_item) do
+            expect(page).to have_no_text("Move to section")
+          end
+        end
+      end
+    end
+
+    context "when meeting has only one section" do
+      let!(:section1) { create(:meeting_section, meeting:, title: "Only Section") }
+      let!(:agenda_item) { create(:meeting_agenda_item, meeting:, meeting_section: section1, title: "Item") }
+
+      it "shows 'Move to current meeting' instead of 'Move to section' for backlog items" do
+        backlog_item = create(:meeting_agenda_item, meeting:, meeting_section: meeting.backlog, title: "Backlog item")
+
+        show_page.visit!
+        show_page.click_on_backlog
+
+        show_page.open_menu(backlog_item) do
+          click_on "Move"
+          expect(page).to have_css(".ActionListItem-label", text: "Move to current meeting")
+          expect(page).to have_no_css(".ActionListItem-label", text: "Move to section")
+        end
+      end
+
+      it "does not show 'Move to section' for regular agenda items" do
+        show_page.visit!
+
+        show_page.open_menu(agenda_item) do
+          click_on "Move"
+          expect(page).to have_no_text("Move to section")
+        end
+      end
+    end
+
+    context "when meeting has no sections" do
+      let!(:agenda_item) { create(:meeting_agenda_item, meeting:, title: "Item") }
+
+      it "shows 'Move to current meeting' instead of 'Move to section' for backlog items" do
+        backlog_item = create(:meeting_agenda_item, meeting:, meeting_section: meeting.backlog, title: "Backlog item")
+
+        show_page.visit!
+        show_page.click_on_backlog
+
+        show_page.open_menu(backlog_item) do
+          click_on "Move"
+          expect(page).to have_css(".ActionListItem-label", text: "Move to current meeting")
+          expect(page).to have_no_css(".ActionListItem-label", text: "Move to section")
+        end
+      end
+
+      it "does not show 'Move to section' for regular agenda items" do
+        show_page.visit!
+
+        show_page.open_menu(agenda_item) do
+          click_on "Move"
+          expect(page).to have_no_text("Move to section")
+        end
+      end
+    end
+  end
+
+  describe "for recurring meetings" do
+    shared_let(:recurring_meeting) do
+      create :recurring_meeting,
+             :skip_validations,
+             project:,
+             start_time: "2024-12-31T13:30:00Z",
+             frequency: "daily",
+             end_after: "specific_date",
+             end_date: "2025-01-03",
+             author: user
+    end
+
+    let(:first_occurrence) { recurring_meeting.meetings.where(template: false).first }
+    let(:first_occurrence_page) { Pages::Meetings::Show.new(first_occurrence) }
+
+    before do
+      travel_to(Date.new(2024, 12, 30))
+
+      first_occurrence_time = recurring_meeting.first_occurrence.to_time
+      RecurringMeetings::InitNextOccurrenceJob.perform_now(recurring_meeting, first_occurrence_time)
+
+      first_occurrence.update(state: :in_progress)
+    end
+
+    context "when occurrence has multiple sections" do
+      let!(:section1) { create(:meeting_section, meeting: first_occurrence, title: "Occurrence section 1") }
+      let!(:section2) { create(:meeting_section, meeting: first_occurrence, title: "Occurrence section 2") }
+      let!(:agenda_item) do
+        create(:meeting_agenda_item, meeting: first_occurrence, meeting_section: section1, title: "Occurrence item")
+      end
+
+      it "allows moving items from series backlog to a specific section" do
+        backlog_item = create(:meeting_agenda_item,
+                              meeting: recurring_meeting.template,
+                              meeting_section: recurring_meeting.template.backlog,
+                              title: "Series backlog item")
+
+        first_occurrence_page.visit!
+        first_occurrence_page.click_on_backlog
+        first_occurrence_page.select_action(backlog_item, I18n.t(:label_agenda_item_move_to_section))
+
+        within("#move-to-section-dialog") do
+          select_autocomplete page.find("opce-autocompleter"),
+                              query: "Occurrence section 1",
+                              select_text: "Occurrence section 1",
+                              results_selector: "#move-to-section-dialog"
+          click_button "Save"
+        end
+
+        first_occurrence_page.within_backlog do
+          first_occurrence_page.expect_no_agenda_item(title: "Series backlog item")
+        end
+        first_occurrence_page.expect_agenda_item_in_section(title: "Series backlog item", section: section1)
+      end
+
+      it "allows moving items from section to series backlog preserving collapsed state" do
+        first_occurrence_page.visit!
+
+        first_occurrence_page.click_on_backlog
+        first_occurrence_page.expect_series_backlog collapsed: false
+
+        first_occurrence_page.select_action(agenda_item, I18n.t(:label_agenda_item_move_to_section))
+
+        within("#move-to-section-dialog") do
+          select_autocomplete page.find("opce-autocompleter"),
+                              query: "Series backlog",
+                              select_text: "Series backlog",
+                              results_selector: "#move-to-section-dialog"
+          click_button "Save"
+        end
+
+        first_occurrence_page.expect_series_backlog collapsed: false
+        first_occurrence_page.within_backlog do
+          first_occurrence_page.expect_agenda_item(title: "Occurrence item")
+        end
+        first_occurrence_page.expect_no_agenda_item_in_section(title: "Occurrence item", section: section1)
+      end
+
+      it "preserves backlog collapsed state when moving items between sections" do
+        first_occurrence_page.visit!
+
+        first_occurrence_page.click_on_backlog
+        first_occurrence_page.expect_series_backlog collapsed: false
+
+        first_occurrence_page.select_action(agenda_item, I18n.t(:label_agenda_item_move_to_section))
+
+        within("#move-to-section-dialog") do
+          select_autocomplete page.find("opce-autocompleter"),
+                              query: "Occurrence section 2",
+                              select_text: "Occurrence section 2",
+                              results_selector: "#move-to-section-dialog"
+          click_button "Save"
+        end
+
+        first_occurrence_page.expect_series_backlog collapsed: false
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "Meetings CRUD",
     expect(page).to have_css("#meeting-agenda-items-new-button-component")
     expect(page).to have_test_selector("op-meeting-agenda-actions", count: 3)
 
-    # other_use can view and copy links, but not edit
+    # other_use can view and copy links, but not edit or move
     login_as other_user
     show_page.visit!
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -369,8 +369,10 @@ module Pages::Meetings
 
     def expect_empty_backlog
       within_backlog do
-        expect(page).to have_text("Drag items here or create a new one")
-        expect(page).to have_button("Add")
+        retry_block do
+          expect(page).to have_text("Drag items here or create a new one")
+          expect(page).to have_button("Add")
+        end
       end
     end
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -225,6 +225,9 @@ module Pages::Meetings
 
     def select_action(item, action)
       open_menu(item) do
+        if action.downcase.include?("move")
+          click_on "Move"
+        end
         click_on action
       end
     end
@@ -644,6 +647,8 @@ module Pages::Meetings
 
     def expect_backlog_actions(item, series: false)
       open_menu(item) do
+        click_on "Move"
+
         expect(page).to have_css(".ActionListItem-label", text: "Edit")
         expect(page).to have_css(".ActionListItem-label", text: "Add notes")
         expect(page).to have_css(".ActionListItem-label", text: "Move to current meeting")
@@ -651,6 +656,7 @@ module Pages::Meetings
 
         expect(page).to have_no_css(".ActionListItem-label", text: "Move to backlog")
         expect(page).to have_no_css(".ActionListItem-label", text: "Add outcome")
+
         if series
           expect(page).to have_no_css(".ActionListItem-label", text: "Move to next meeting")
         end
@@ -663,8 +669,11 @@ module Pages::Meetings
 
     def expect_non_backlog_actions(item, series: false)
       open_menu(item) do
+        click_on "Move"
+
         expect(page).to have_css(".ActionListItem-label", text: "Move to backlog")
         expect(page).to have_no_css(".ActionListItem-label", text: "Move to current meeting")
+
         if series
           expect(page).to have_css(".ActionListItem-label", text: "Move to next meeting")
         end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -213,6 +213,12 @@ module Pages::Meetings
       expect(page).not_to have_test_selector("op-meeting-agenda-title", text: title)
     end
 
+    def expect_no_agenda_item_in_section(title:, section:)
+      within("#meeting-sections-show-component-#{section.id}") do
+        expect_no_agenda_item(title:)
+      end
+    end
+
     def expect_agenda_action_menu(item)
       expect(page)
         .to have_css("#meeting-agenda-items-item-component-#{item.id} #{test_selector('op-meeting-agenda-actions')}")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67060

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Reuse the section autocompleter from the work package meetings tab form in a new agenda item action, with minimal changes to work in both use cases
- Show the new 'Move to section' action conditionally depending on the number of sections in the agenda
- For series occurrences, this proved to be a problem as there was no way to keep the reference of the current occurrence from within the backlog
   - So, the earlier stimulus based approach of adding the current occurrence on click was changed in favour of always keeping and passing that along as a parameter
   - While I checked extensively, I'm not 100% about this and there still could be cases where the parameter is lost in the update component chain in particular cases
- Collapsed state needs to be checked and kept for more controller actions, as now the backlog needs to be reloaded whenever sections are added/removed to ensure the actions shown for each agenda item are correct
- The agenda item menu has been changed to use a new helper that handles the dividers automatically

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
