### PR TITLE
[#67400] Migrate Chronic Duration functions to TypeScript

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -218,6 +218,5 @@ export default defineConfig([
   globalIgnores([
     '**/.eslintrc.js',
     '**/vendor',
-    'src/app/shared/helpers/chronic_duration.js',
   ]),
 ]);

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -31,6 +31,7 @@ import moment from 'moment';
 
 import { ConfigurationResource } from 'core-app/features/hal/resources/configuration-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { type DurationFormat } from 'core-app/shared/helpers/chronic_duration';
 
 @Injectable({ providedIn: 'root' })
 export class ConfigurationService {
@@ -103,7 +104,7 @@ export class ConfigurationService {
     return this.systemPreference('dateFormat');
   }
 
-  public durationFormat():string {
+  public durationFormat():DurationFormat {
     return this.systemPreference('durationFormat');
   }
 

--- a/frontend/src/app/shared/helpers/chronic_duration.js
+++ b/frontend/src/app/shared/helpers/chronic_duration.js
@@ -35,7 +35,6 @@
  * lib/chronic_duration.rb.
  */
 
-/* eslint-disable */
 export class DurationParseError extends Error {
 }
 
@@ -165,10 +164,10 @@ function calculateFromWords(string, opts) {
 // Parse 3:41:59 and return 3 hours 41 minutes 59 seconds
 function filterByType(string, opts) {
   const chronoUnitsList = DURATION_UNITS_LIST.filter(function (value) {
-    if (value === "weeks") { return false }
-    if (opts.ignoreSecondsWhenColonSeperated && value === "seconds") { return false }
+    if (value === 'weeks') { return false; }
+    if (opts.ignoreSecondsWhenColonSeperated && value === 'seconds') { return false; }
 
-    return true
+    return true;
   });
 
   if (
@@ -347,7 +346,6 @@ export function outputChronicDuration(seconds, opts = {}) {
       break;
     case 'long':
       dividers = {
-        /* eslint-disable @gitlab/require-i18n-strings */
         years: ' year',
         months: ' month',
         weeks: ' week',
@@ -355,7 +353,6 @@ export function outputChronicDuration(seconds, opts = {}) {
         hours: ' hour',
         minutes: ' minute',
         seconds: ' second',
-        /* eslint-enable @gitlab/require-i18n-strings */
         pluralize: true,
       };
       break;
@@ -365,20 +362,20 @@ export function outputChronicDuration(seconds, opts = {}) {
         keepZero: true,
       };
 
-      units.days += units.weeks * daysPerWeek
-      units.weeks = 0
-      units.days += units.months * daysPerMonth
-      units.months = 0
-      units.days += Math.floor(units.years * SECONDS_PER_YEAR / 3600 / 24)
-      units.years = 0
+      units.days += units.weeks * daysPerWeek;
+      units.weeks = 0;
+      units.days += units.months * daysPerMonth;
+      units.months = 0;
+      units.days += Math.floor(units.years * SECONDS_PER_YEAR / 3600 / 24);
+      units.years = 0;
       if (units.days > 0) {
         dividers.days = 'd';
       }
 
-      units.hours += (((units.minutes * 60) + units.seconds) / 3600.0)
+      units.hours += (((units.minutes * 60) + units.seconds) / 3600.0);
       units.hours = parseFloat(Math.round(units.hours * 100)) / 100;
 
-      break
+      break;
     case 'hours_only':
       dividers = {
         hours: 'h',
@@ -387,7 +384,7 @@ export function outputChronicDuration(seconds, opts = {}) {
 
       units.hours = parseFloat(Math.round(units.hours * 100)) / 100;
 
-      break
+      break;
     case 'chrono':
       dividers = {
         years: ':',
@@ -431,7 +428,6 @@ export function outputChronicDuration(seconds, opts = {}) {
       break;
     default:
       dividers = {
-        /* eslint-disable @gitlab/require-i18n-strings */
         years: ' yr',
         months: ' mo',
         weeks: ' wk',
@@ -439,7 +435,6 @@ export function outputChronicDuration(seconds, opts = {}) {
         hours: ' hr',
         minutes: ' min',
         seconds: ' sec',
-        /* eslint-enable @gitlab/require-i18n-strings */
         pluralize: true,
       };
       break;

--- a/frontend/src/app/shared/helpers/chronic_duration.spec.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.spec.ts
@@ -40,6 +40,7 @@ import {
   parseChronicDuration,
   outputChronicDuration,
   DurationParseError,
+  type DurationFormat,
 } from './chronic_duration';
 
 
@@ -273,18 +274,19 @@ describe('outputChronicDuration', () => {
       hours_only: '12960h',
       chrono: '18:00:00:00:00',
     },
-  };
+  } as const;
 
   Object.entries(EXEMPLARS).forEach(([k, v]) => {
     const kf = parseFloat(k);
-    Object.entries(v).forEach(([key, val]) => {
+    (Object.keys(v) as DurationFormat[]).forEach((key) => {
+      const val = v[key];
       it(`properly outputs a duration of ${kf} seconds as ${val} using the ${key} format option`, () => {
         expect(outputChronicDuration(kf, { format: key })).toBe(val);
       });
     });
   });
 
-  const KEEP_ZERO_EXEMPLARS = {
+  const KEEP_ZERO_EXEMPLARS:Record<string, Partial<Record<DurationFormat, string|null>>> = {
     true: {
       micro: '0s',
       short: '0s',
@@ -303,7 +305,8 @@ describe('outputChronicDuration', () => {
 
   Object.entries(KEEP_ZERO_EXEMPLARS).forEach(([k, v]) => {
     const kb = Boolean(k);
-    Object.entries(v).forEach(([key, val]) => {
+    (Object.keys(v) as Partial<DurationFormat>[]).forEach((key) => {
+      const val = v[key] ?? null;
       it(`should properly output a duration of 0 seconds as ${val} using the ${key} format option, if the .keepZero option is ${kb}`, () => {
         expect(outputChronicDuration(0, { format: key, keepZero: kb })).toBe(val);
       });
@@ -387,11 +390,11 @@ describe('outputChronicDuration', () => {
 
   Object.entries(EXEMPLARS).forEach(([seconds, formatSpec]) => {
     const secondsF = parseFloat(seconds);
-    Object.keys(formatSpec).forEach((format) => {
+    (Object.keys(formatSpec) as DurationFormat[]).forEach((format) => {
       if (format === 'days_and_hours' || format === 'hours_only') return;
 
       it(`outputs a duration for ${seconds} that parses back to the same thing when using the ${format} format`, () => {
-        expect(parseChronicDuration(outputChronicDuration(secondsF, { format }))).toBe(secondsF);
+        expect(parseChronicDuration(outputChronicDuration(secondsF, { format })!)).toBe(secondsF);
       });
     });
   });

--- a/frontend/src/app/shared/helpers/chronic_duration.spec.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.spec.ts
@@ -161,9 +161,9 @@ describe('parseChronicDuration', () => {
     });
   });
 
-  describe('with .ignoreSecondsWhenColonSeperated param', () => {
+  describe('with .ignoreSecondsWhenColonSeparated param', () => {
     it('parses 8:15 to 8 hours 15 minutes when seconds are ignored', () => {
-      expect(parseChronicDuration('8:15', { ignoreSecondsWhenColonSeperated: true })).toBe(8 * 3600 + 15 * 60);
+      expect(parseChronicDuration('8:15', { ignoreSecondsWhenColonSeparated: true })).toBe(8 * 3600 + 15 * 60);
     });
 
     it('parses 8:15 to 8 minutes 15 seconds when seconds are not ignored', () => {

--- a/frontend/src/app/shared/helpers/chronic_duration.spec.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.spec.ts
@@ -382,9 +382,9 @@ describe('outputChronicDuration', () => {
     ).toBe('6 months 1 day 1 hour');
   });
 
-  it('returns hours only if hoursOnly option specified, rounded to nearest hour', () => {
+  it('returns hours only if hoursOnly option specified', () => {
     expect(outputChronicDuration(60 * 60 * 24 * 3 + 60 * 60 * 3, { hoursOnly: true })).toBe('75h');
-    expect(outputChronicDuration(4 * 3600 + 60 + 1, { hoursOnly: true })).toBe('4h');
+    expect(outputChronicDuration(4 * 3600 + 45 * 60, { hoursOnly: true })).toBe('4h 45m');
     expect(outputChronicDuration(5 * 3600, { hoursOnly: true })).toBe('5h');
   });
 

--- a/frontend/src/app/shared/helpers/chronic_duration.spec.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.spec.ts
@@ -382,6 +382,12 @@ describe('outputChronicDuration', () => {
     ).toBe('6 months 1 day 1 hour');
   });
 
+  it('returns hours only if hoursOnly option specified, rounded to nearest hour', () => {
+    expect(outputChronicDuration(60 * 60 * 24 * 3 + 60 * 60 * 3, { hoursOnly: true })).toBe('75h');
+    expect(outputChronicDuration(4 * 3600 + 60 + 1, { hoursOnly: true })).toBe('4h');
+    expect(outputChronicDuration(5 * 3600, { hoursOnly: true })).toBe('5h');
+  });
+
   describe('when the format is not specified', () => {
     it('uses the default format', () => {
       expect(outputChronicDuration(2 * 3600 + 20 * 60)).toBe('2 hrs 20 mins');

--- a/frontend/src/app/shared/helpers/chronic_duration.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.ts
@@ -120,8 +120,8 @@ function durationUnitsSecondsMultiplier(unit:string, opts:ChronicDurationOptions
     return 0;
   }
 
-  const hoursPerDay = opts.hoursPerDay || HOURS_PER_DAY;
-  const daysPerMonth = opts.daysPerMonth || DAYS_PER_MONTH;
+  const hoursPerDay = opts.hoursPerDay ?? HOURS_PER_DAY;
+  const daysPerMonth = opts.daysPerMonth ?? DAYS_PER_MONTH;
   const daysPerWeek = Math.trunc(daysPerMonth / FULL_WEEKS_PER_MONTH);
 
   switch (unit) {
@@ -174,7 +174,7 @@ function calculateFromWords(string:string, opts:ChronicDurationOptions):number {
         lastExplicitUnit = unit;
       } else {
         // No explicit unit and no previous unit, fall back to default
-        unit = opts.defaultUnit || 'seconds';
+        unit = opts.defaultUnit ?? 'seconds';
       }
 
       val += convertToNumber(v) * durationUnitsSecondsMultiplier(unit, opts);
@@ -292,8 +292,8 @@ export function outputChronicDuration(seconds:number, opts:ChronicDurationOption
     seconds,
   };
 
-  const hoursPerDay = opts.hoursPerDay || HOURS_PER_DAY;
-  const daysPerMonth = opts.daysPerMonth || DAYS_PER_MONTH;
+  const hoursPerDay = opts.hoursPerDay ?? HOURS_PER_DAY;
+  const daysPerMonth = opts.daysPerMonth ?? DAYS_PER_MONTH;
   const daysPerWeek = Math.trunc(daysPerMonth / FULL_WEEKS_PER_MONTH);
 
   const decimalPlaces =
@@ -343,8 +343,8 @@ export function outputChronicDuration(seconds:number, opts:ChronicDurationOption
     }
   }
 
-  let joiner = opts.joiner || ' ';
-  let process:((str:string) => string)|null = null;
+  let joiner = opts.joiner ?? ' ';
+  let process:((_str:string) => string)|null = null;
 
   let dividers:Dividers;
   switch (opts.format) {

--- a/frontend/src/app/shared/helpers/chronic_duration.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.ts
@@ -48,9 +48,27 @@ const HOURS_PER_DAY = 24;
 const DAYS_PER_MONTH = 30;
 
 const FLOAT_MATCHER = /[0-9]*\.?[0-9]+/g;
-const DURATION_UNITS_LIST = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'];
+const DURATION_UNITS_LIST = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'] as const;
+export type DurationUnit = typeof DURATION_UNITS_LIST[number];
+export type DurationFormat = 'micro'|'short'|'long'|'days_and_hours'|'hours_only'|'chrono'|'default';
 
-const MAPPINGS = {
+export interface ChronicDurationOptions {
+  hoursPerDay?:number;
+  daysPerMonth?:number;
+  defaultUnit?:DurationUnit;
+  raiseExceptions?:boolean;
+  ignoreSecondsWhenColonSeperated?:boolean;
+  keepZero?:boolean;
+  format?:DurationFormat;
+  joiner?:string;
+  limitToHours?:boolean;
+  weeks?:boolean;
+  units?:number;
+}
+
+type Dividers = Partial<Record<DurationUnit, string>> & { pluralize?:boolean; keepZero?:boolean};
+
+const MAPPINGS:Record<string, DurationUnit> = {
   seconds: 'seconds',
   second: 'seconds',
   secs: 'seconds',
@@ -88,13 +106,17 @@ const MAPPINGS = {
 
 const JOIN_WORDS = ['and', 'with', 'plus'];
 
-function convertToNumber(string) {
+function convertToNumber(string:string):number {
   const f = parseFloat(string);
   return f % 1 > 0 ? f : parseInt(string, 10);
 }
 
-function durationUnitsSecondsMultiplier(unit, opts) {
-  if (!DURATION_UNITS_LIST.includes(unit)) {
+function isDurationUnit(unit:string):unit is DurationUnit {
+  return (DURATION_UNITS_LIST as readonly string[]).includes(unit);
+}
+
+function durationUnitsSecondsMultiplier(unit:string, opts:ChronicDurationOptions):number {
+  if (!isDurationUnit(unit)) {
     return 0;
   }
 
@@ -122,9 +144,9 @@ function durationUnitsSecondsMultiplier(unit, opts) {
   }
 }
 
-function calculateFromWords(string, opts) {
+function calculateFromWords(string:string, opts:ChronicDurationOptions):number {
   let val = 0;
-  let lastExplicitUnit = null;
+  let lastExplicitUnit:DurationUnit|null = null;
   const words = string.split(' ');
 
   words.forEach((v, k) => {
@@ -132,10 +154,10 @@ function calculateFromWords(string, opts) {
       return;
     }
     if (v.search(FLOAT_MATCHER) >= 0) {
-      const nextWord = words[parseInt(k, 10) + 1];
-      let unit;
+      const nextWord = words[k + 1];
+      let unit:DurationUnit;
 
-      if (nextWord && DURATION_UNITS_LIST.includes(nextWord)) {
+      if (nextWord && isDurationUnit(nextWord)) {
         // Next word is a valid unit, use it and remember as last explicit unit
         unit = nextWord;
         lastExplicitUnit = nextWord;
@@ -162,7 +184,7 @@ function calculateFromWords(string, opts) {
 }
 
 // Parse 3:41:59 and return 3 hours 41 minutes 59 seconds
-function filterByType(string, opts) {
+function filterByType(string:string, opts:ChronicDurationOptions):string {
   const chronoUnitsList = DURATION_UNITS_LIST.filter(function (value) {
     if (value === 'weeks') { return false; }
     if (opts.ignoreSecondsWhenColonSeperated && value === 'seconds') { return false; }
@@ -175,7 +197,7 @@ function filterByType(string, opts) {
       .replace(/ +/g, '')
       .search(RegExp(`${FLOAT_MATCHER.source}(:${FLOAT_MATCHER.source})+`, 'g')) >= 0
   ) {
-    const res = [];
+    const res:string[] = [];
     string
       .replace(/ +/g, '')
       .split(':')
@@ -193,8 +215,8 @@ function filterByType(string, opts) {
 
 // Get rid of unknown words and map found
 // words to defined time units
-function filterThroughWhiteList(string, opts) {
-  const res = [];
+function filterThroughWhiteList(string:string, opts:ChronicDurationOptions):string {
+  const res:(string|number)[] = [];
   string.split(' ').forEach((word) => {
     if (word === '') {
       return;
@@ -213,13 +235,13 @@ function filterThroughWhiteList(string, opts) {
     }
   });
   // add '1' at front if string starts with something recognizable but not with a number, like 'day' or 'minute 30sec'
-  if (res.length > 0 && MAPPINGS[res[0]]) {
+  if (res.length > 0 && typeof res[0] === 'string' && MAPPINGS[res[0]]) {
     res.splice(0, 0, 1);
   }
   return res.join(' ');
 }
 
-function cleanup(string, opts) {
+function cleanup(string:string, opts:ChronicDurationOptions):string {
   let res = string.toLowerCase();
   res = filterByType(res, opts);
   res = res
@@ -229,7 +251,12 @@ function cleanup(string, opts) {
   return filterThroughWhiteList(res, opts);
 }
 
-function humanizeTimeUnit(number, unit, pluralize, keepZero) {
+function humanizeTimeUnit(
+  number:string,
+  unit:string|undefined,
+  pluralize?:boolean,
+  keepZero?:boolean
+):string|null {
   if (number === '0' && !keepZero) {
     return null;
   }
@@ -247,15 +274,15 @@ function humanizeTimeUnit(number, unit, pluralize, keepZero) {
 // Given a string representation of elapsed time,
 // return an integer (or float, if fractions of a
 // second are input)
-export function parseChronicDuration(string, opts = {}) {
+export function parseChronicDuration(string:string, opts:ChronicDurationOptions = {}):number|null {
   const result = calculateFromWords(cleanup(string, opts), opts);
   return !opts.keepZero && result === 0 ? null : result;
 }
 
 // Given an integer and an optional format,
 // returns a formatted string representing elapsed time
-export function outputChronicDuration(seconds, opts = {}) {
-  const units = {
+export function outputChronicDuration(seconds:number, opts:ChronicDurationOptions = {}):string|null {
+  const units:Record<DurationUnit, number> = {
     years: 0,
     months: 0,
     weeks: 0,
@@ -317,9 +344,9 @@ export function outputChronicDuration(seconds, opts = {}) {
   }
 
   let joiner = opts.joiner || ' ';
-  let process = null;
+  let process:((str:string) => string)|null = null;
 
-  let dividers;
+  let dividers:Dividers;
   switch (opts.format) {
     case 'micro':
       dividers = {
@@ -373,7 +400,7 @@ export function outputChronicDuration(seconds, opts = {}) {
       }
 
       units.hours += (((units.minutes * 60) + units.seconds) / 3600.0);
-      units.hours = parseFloat(Math.round(units.hours * 100)) / 100;
+      units.hours = parseFloat(Math.round(units.hours * 100) / 100 + '');
 
       break;
     case 'hours_only':
@@ -382,7 +409,7 @@ export function outputChronicDuration(seconds, opts = {}) {
         keepZero: true,
       };
 
-      units.hours = parseFloat(Math.round(units.hours * 100)) / 100;
+      units.hours = parseFloat(Math.round(units.hours * 100) / 100 + '');
 
       break;
     case 'chrono':
@@ -402,7 +429,7 @@ export function outputChronicDuration(seconds, opts = {}) {
         // Get rid of lead off zero
         // Get rid of trailing:
         const divider = ':';
-        const processed = [];
+        const processed:string[] = [];
         str.split(divider).forEach((n) => {
           if (n === '') {
             return;
@@ -411,8 +438,8 @@ export function outputChronicDuration(seconds, opts = {}) {
           if (n.search('\\.') >= 0) {
             processed.push(
               parseFloat(n)
-                .toFixed(decimalPlaces)
-                .padStart(3 + decimalPlaces, '0'),
+                .toFixed(decimalPlaces ?? 0)
+                .padStart(3 + (decimalPlaces ?? 0), '0'),
             );
           } else {
             processed.push(n.padStart(2, '0'));
@@ -440,19 +467,17 @@ export function outputChronicDuration(seconds, opts = {}) {
       break;
   }
 
-  let result = [];
-  ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'].forEach((t) => {
+  let result:string[] = [];
+  [...DURATION_UNITS_LIST].reverse().forEach((t) => {
     if (t === 'weeks' && !opts.weeks) {
       return;
     }
     let num = units[t];
     if (t === 'seconds' && num % 0 !== 0) {
-      num = num.toFixed(decimalPlaces);
-    } else {
-      num = num.toString();
+      num = parseFloat(num.toFixed(decimalPlaces ?? 0));
     }
     const keepZero = !dividers.keepZero && t === 'seconds' ? opts.keepZero : dividers.keepZero;
-    const humanized = humanizeTimeUnit(num, dividers[t], dividers.pluralize, keepZero);
+    const humanized = humanizeTimeUnit(num.toString(), dividers[t], dividers.pluralize, keepZero);
     if (humanized !== null) {
       result.push(humanized);
     }
@@ -462,11 +487,11 @@ export function outputChronicDuration(seconds, opts = {}) {
     result = result.slice(0, opts.units);
   }
 
-  result = result.join(joiner);
+  let resultStr = result.join(joiner);
 
   if (process) {
-    result = process(result);
+    resultStr = process(resultStr);
   }
 
-  return result.length === 0 ? null : result;
+  return resultStr.length === 0 ? null : resultStr;
 }

--- a/frontend/src/app/shared/helpers/chronic_duration.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.ts
@@ -64,6 +64,7 @@ export interface ChronicDurationOptions {
   limitToHours?:boolean;
   weeks?:boolean;
   units?:number;
+  hoursOnly?:boolean;
 }
 
 type Dividers = Partial<Record<DurationUnit, string>> & { pluralize?:boolean; keepZero?:boolean};
@@ -282,6 +283,11 @@ export function parseChronicDuration(string:string, opts:ChronicDurationOptions 
 // Given an integer and an optional format,
 // returns a formatted string representing elapsed time
 export function outputChronicDuration(seconds:number, opts:ChronicDurationOptions = {}):string|null {
+  if (opts.hoursOnly) {
+    const hours = Math.round(seconds / 3600);
+    return `${hours}h`;
+  }
+
   const units:Record<DurationUnit, number> = {
     years: 0,
     months: 0,

--- a/frontend/src/app/shared/helpers/chronic_duration.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.ts
@@ -284,7 +284,12 @@ export function parseChronicDuration(string:string, opts:ChronicDurationOptions 
 // returns a formatted string representing elapsed time
 export function outputChronicDuration(seconds:number, opts:ChronicDurationOptions = {}):string|null {
   if (opts.hoursOnly) {
-    const hours = Math.round(seconds / 3600);
+    const decimalHours = seconds / 3600;
+    const hours = Math.floor(decimalHours);
+    if (decimalHours % 1 !== 0) {
+      const minutes = Math.round((decimalHours % 1) * 60);
+      return `${hours}h ${minutes}m`;
+    }
     return `${hours}h`;
   }
 

--- a/frontend/src/app/shared/helpers/chronic_duration.ts
+++ b/frontend/src/app/shared/helpers/chronic_duration.ts
@@ -57,7 +57,7 @@ export interface ChronicDurationOptions {
   daysPerMonth?:number;
   defaultUnit?:DurationUnit;
   raiseExceptions?:boolean;
-  ignoreSecondsWhenColonSeperated?:boolean;
+  ignoreSecondsWhenColonSeparated?:boolean;
   keepZero?:boolean;
   format?:DurationFormat;
   joiner?:string;
@@ -187,7 +187,7 @@ function calculateFromWords(string:string, opts:ChronicDurationOptions):number {
 function filterByType(string:string, opts:ChronicDurationOptions):string {
   const chronoUnitsList = DURATION_UNITS_LIST.filter(function (value) {
     if (value === 'weeks') { return false; }
-    if (opts.ignoreSecondsWhenColonSeperated && value === 'seconds') { return false; }
+    if (opts.ignoreSecondsWhenColonSeparated && value === 'seconds') { return false; }
 
     return true;
   });

--- a/frontend/src/stimulus/helpers/chronic-duration-helper.ts
+++ b/frontend/src/stimulus/helpers/chronic-duration-helper.ts
@@ -40,7 +40,7 @@ export function durationStringToSeconds(value:string):number {
     return parseChronicDuration(normalizedValue, {
       defaultUnit: 'hours',
       ignoreSecondsWhenColonSeparated: true,
-    }) || 0;
+    }) ?? 0;
   }
 
 export function formattedHour(seconds:number):string {
@@ -48,5 +48,5 @@ export function formattedHour(seconds:number):string {
     return '';
   }
 
-return outputChronicDuration(seconds, { format: 'hours_only' }) ?? '';
+  return outputChronicDuration(seconds, { format: 'hours_only' }) ?? '';
 }

--- a/frontend/src/stimulus/helpers/chronic-duration-helper.ts
+++ b/frontend/src/stimulus/helpers/chronic-duration-helper.ts
@@ -39,7 +39,7 @@ export function durationStringToSeconds(value:string):number {
 
     return parseChronicDuration(normalizedValue, {
       defaultUnit: 'hours',
-      ignoreSecondsWhenColonSeperated: true,
+      ignoreSecondsWhenColonSeparated: true,
     }) || 0;
   }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/67400

# What are you trying to accomplish?

Migrates Chronic Duration functions to TypeScript
Also brings our fork in sync with latest upstream changes, manually applying the following patches:

- [Respect global time tracking hours-only setting in work item issues view](https://gitlab.com/gitlab-org/gitlab/-/commit/b280fdfc997402b110083c9d414023b13ae4a29d)
- [Prevent rounding of hours for time trackin](https://gitlab.com/gitlab-org/gitlab/-/commit/e939fe1c4247071eceaa55ce4ee77143f11e5566)

# What approach did you choose and why?


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
