### PR TITLE
Allow to add a docker-compose.override.yml to hocuspocus dev setup

### DIFF
--- a/docker/dev/hocuspocus/.gitignore
+++ b/docker/dev/hocuspocus/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.override.yml


### PR DESCRIPTION
# Ticket
 Side quest during https://community.openproject.org/wp/67371

# What are you trying to accomplish?
Add a docker-compose.override.yml to the hocuspocus dev setup which should not be checked in with git.
