### PR TITLE
[67178] Update Enterprise plan text in widget on application start page

### DIFF
--- a/app/components/enterprise_trials/banner_component.html.erb
+++ b/app/components/enterprise_trials/banner_component.html.erb
@@ -34,7 +34,7 @@
                   email: @trial_key.data[:email]
                 ) %>
           <% else %>
-            <%= t("ee.upsell.homescreen_description") %>
+            <%= link_translate("ee.upsell.homescreen_description", links: { enterprise_url: }) %>
           <% end %>
         </p>
         <p>

--- a/app/components/enterprise_trials/banner_component.rb
+++ b/app/components/enterprise_trials/banner_component.rb
@@ -40,5 +40,9 @@ module EnterpriseTrials
 
       super
     end
+
+    def enterprise_url
+      OpenProject::Static::Links.url_for(:enterprise_features, :feature_comparison)
+    end
   end
 end

--- a/app/views/homescreen/blocks/_upsell.html.erb
+++ b/app/views/homescreen/blocks/_upsell.html.erb
@@ -20,7 +20,10 @@
 
     <div class="widget-box--blocks--upsell-description">
       <p>
-        <%= t("ee.upsell.homescreen_description") %>
+        <%= link_translate(
+              "ee.upsell.homescreen_description",
+              links: { enterprise_url: OpenProject::Static::Links.url_for(:enterprise_features, :feature_comparison) }
+            ) %>
       </p>
       <p>
         <%= t("ee.upsell.homescreen_subline") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2303,8 +2303,7 @@ en:
         Already have a token? Add it using the button below to upgrade to the booked Enterprise plan.
       hide_banner: "Hide this banner"
       homescreen_description: >
-        Enterprise plans extend the Community edition of OpenProject you are currently using.
-        They include add-ons, additional features and professional support that enables organisations of all sizes to achieve great things together.
+        Enterprise plans extend the Community edition of OpenProject with additional [Enterprise add-ons](enterprise_url) and professional support, ideal for organizations running OpenProject in a mission-critical environment.
       homescreen_subline: By upgrading, you will also be supporting an open source project.
       baseline_comparison:
         description: Highlight changes made to this list since any point in the past.

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -58,6 +58,8 @@ enterprise_features:
     href: https://www.openproject.org/docs/system-admin-guide/projects/project-life-cycle/
   default:
     href: https://www.openproject.org/enterprise-edition
+  feature_comparison:
+    href: https://www.openproject.org/pricing/#features
   form_configuration:
     href: https://www.openproject.org/docs/system-admin-guide/manage-work-packages/work-package-types/#work-package-form-configuration-enterprise-add-on
   internal_comments:


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67178

# What are you trying to accomplish?
Update EE banner text and use `link_translate` helper

