### PR TITLE
Rename color mode inquiry methods

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -142,7 +142,7 @@ module ColorsHelper
   end
 
   def set_generic_color_for(class_name:, color:)
-    mode_variables = User.current.pref.base_theme_dark? ? default_variables_dark : default_variables_light
+    mode_variables = User.current.pref.dark_color_mode? ? default_variables_dark : default_variables_light
 
     concat "#{class_name} { #{default_color_styles(color.hexcode)} #{mode_variables} }"
   end
@@ -150,7 +150,7 @@ module ColorsHelper
   def set_background_colors_for(class_name:, color:)
     concat "#{class_name} { #{default_color_styles(color.hexcode)} }"
 
-    if User.current.pref.base_theme_dark?
+    if User.current.pref.dark_color_mode?
       concat "#{class_name} { #{default_variables_dark} }"
       concat "#{class_name} { #{highlighted_background_dark} }"
     else
@@ -162,7 +162,7 @@ module ColorsHelper
   def set_foreground_colors_for(class_name:, color:)
     concat "#{class_name} { #{default_color_styles(color.hexcode)} }"
 
-    if User.current.pref.base_theme_dark?
+    if User.current.pref.dark_color_mode?
       concat "#{class_name} { #{default_variables_dark} }"
       concat "#{class_name} { #{highlighted_foreground_dark} }"
     else

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -145,8 +145,8 @@ class UserPreference < ApplicationRecord
     settings[:force_dark_theme_contrast] = to_boolean(value)
   end
 
-  COLOR_MODES.each do |base_theme_name|
-    define_method("base_theme_#{base_theme_name}?") { theme.split("_", 2)[0] == base_theme_name.to_s }
+  COLOR_MODES.each do |color_mode|
+    define_method("#{color_mode}_color_mode?") { theme.split("_", 2)[0] == color_mode.to_s }
   end
 
   THEMES.each do |theme_name|

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe UserPreference do
       it "defaults to light" do
         expect(subject.theme).to eq("light")
         expect(subject).to be_a_light_theme
-        expect(subject).to be_a_base_theme_light
+        expect(subject).to be_a_light_color_mode
       end
     end
 
@@ -263,7 +263,7 @@ RSpec.describe UserPreference do
       it "returns the dark theme" do
         expect(subject.theme).to eq("dark")
         expect(subject).to be_a_dark_theme
-        expect(subject).to be_a_base_theme_dark
+        expect(subject).to be_a_dark_color_mode
       end
     end
 
@@ -274,7 +274,7 @@ RSpec.describe UserPreference do
         expect(subject.theme).to eq("light")
         expect(subject).to be_a_light_theme
         expect(subject).to be_a_light_high_contrast_theme
-        expect(subject).to be_a_base_theme_light
+        expect(subject).to be_a_light_color_mode
         expect(subject.increase_theme_contrast?).to be true
       end
     end
@@ -286,7 +286,7 @@ RSpec.describe UserPreference do
         expect(subject.theme).to eq("dark")
         expect(subject).to be_a_dark_theme
         expect(subject).to be_a_dark_high_contrast_theme
-        expect(subject).to be_a_base_theme_dark
+        expect(subject).to be_a_dark_color_mode
         expect(subject.increase_theme_contrast?).to be true
       end
     end
@@ -298,7 +298,7 @@ RSpec.describe UserPreference do
         expect(subject.theme).to eq("light")
         expect(subject).to be_a_light_theme
         expect(subject).not_to be_a_light_high_contrast_theme
-        expect(subject).to be_a_base_theme_light
+        expect(subject).to be_a_light_color_mode
         expect(subject.increase_theme_contrast?).to be false
       end
     end
@@ -310,7 +310,7 @@ RSpec.describe UserPreference do
         expect(subject.theme).to eq("dark")
         expect(subject).to be_a_dark_theme
         expect(subject).not_to be_a_dark_high_contrast_theme
-        expect(subject).to be_a_base_theme_dark
+        expect(subject).to be_a_dark_color_mode
         expect(subject.increase_theme_contrast?).to be false
       end
     end


### PR DESCRIPTION
https://community.openproject.org/wp/66396

Replace `base_theme_{light|dark}?` with `{light|dark}_color_mode?` as the more consistent domain name.