### PR TITLE
Console Error: Missing target element "mobileLogo" for "auto-theme-switcher" controller when user has a custom OP Logo

### DIFF
--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -45,6 +45,7 @@ export default class AutoThemeSwitcher extends Controller {
   declare readonly mobileLogoTarget:HTMLLinkElement;
   declare readonly desktopLightHighContrastLogoClass:string;
   declare readonly mobileWhiteLogoClass:string;
+  declare readonly hasMobileLogoTarget:boolean;
 
   connect() {
     if (this.modeValue !== 'sync_with_os') return;
@@ -74,7 +75,11 @@ export default class AutoThemeSwitcher extends Controller {
 
   private updateOpLogoContrast():void {
     const prefersSystemLightHighContrast = window.OpenProject.theme.prefersSystemLightHighContrast();
+
     this.desktopLogoTarget.classList.toggle(this.desktopLightHighContrastLogoClass, prefersSystemLightHighContrast);
-    this.mobileLogoTarget.classList.toggle(this.mobileWhiteLogoClass, !prefersSystemLightHighContrast);
+    // Custom logos are not supported on mobile
+    if (this.hasMobileLogoTarget) {
+      this.mobileLogoTarget.classList.toggle(this.mobileWhiteLogoClass, !prefersSystemLightHighContrast);
+    }
   }
 }


### PR DESCRIPTION
https://community.openproject.org/work_packages/67422

Custom logos are currently not supported on mobile. Safely update the logo contrast during theme switching.

https://github.com/opf/openproject/blob/8a4976382d26c8b86711841481c01c3fd8ff5829/lib/redmine/menu_manager/top_menu_helper.rb#L49

<img width="2331" height="1506" alt="Screenshot 2025-09-15 at 4 07 02 PM" src="https://github.com/user-attachments/assets/ee7a0884-0f78-44b1-b37c-cc5780d51d41" />
