### PR TITLE
Fix updating OIDC provider via environment variables

### DIFF
--- a/modules/openid_connect/app/contracts/openid_connect/providers/base_contract.rb
+++ b/modules/openid_connect/app/contracts/openid_connect/providers/base_contract.rb
@@ -67,7 +67,7 @@ module OpenIDConnect
       end
 
       attribute :groups_claim
-      validates :groups_claim, presence: true
+      validates :groups_claim, presence: true, if: -> { model.sync_groups? }
 
       attribute :group_regexes
       validate :group_regexes_parseable

--- a/modules/openid_connect/app/services/openid_connect/configuration_mapper.rb
+++ b/modules/openid_connect/app/services/openid_connect/configuration_mapper.rb
@@ -65,7 +65,9 @@ module OpenIDConnect
         "mapping_email" => options.dig("attribute_map", "email"),
         "mapping_first_name" => options.dig("attribute_map", "first_name"),
         "mapping_last_name" => options.dig("attribute_map", "last_name"),
-        "mapping_admin" => options.dig("attribute_map", "admin")
+        "mapping_admin" => options.dig("attribute_map", "admin"),
+        "sync_groups" => options["sync_groups"] == "true",
+        "groups_claim" => options["groups_claim"]
       }.compact
     end
 

--- a/modules/openid_connect/spec/contracts/openid_connect/providers/create_contract_spec.rb
+++ b/modules/openid_connect/spec/contracts/openid_connect/providers/create_contract_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe OpenIDConnect::Providers::CreateContract do
     let(:current_user) { build_stubbed(:admin) }
 
     it_behaves_like "contract is valid"
+
+    context "when the groups_claim is empty" do
+      let(:provider) { build(:oidc_provider, groups_claim: "", sync_groups: true) }
+
+      it_behaves_like "contract is invalid", groups_claim: :blank
+
+      context "and when we don't want to synchronize groups" do
+        let(:provider) { build(:oidc_provider, groups_claim: "", sync_groups: false) }
+
+        it_behaves_like "contract is valid"
+      end
+    end
   end
 
   context "when non-admin" do

--- a/modules/openid_connect/spec/contracts/openid_connect/providers/update_contract_spec.rb
+++ b/modules/openid_connect/spec/contracts/openid_connect/providers/update_contract_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe OpenIDConnect::Providers::UpdateContract do
     let(:current_user) { build_stubbed(:admin) }
 
     it_behaves_like "contract is valid"
+
+    context "when the groups_claim is empty" do
+      let(:provider) { build_stubbed(:oidc_provider, groups_claim: "", sync_groups: true) }
+
+      it_behaves_like "contract is invalid", groups_claim: :blank
+
+      context "and when we don't want to synchronize groups" do
+        let(:provider) { build_stubbed(:oidc_provider, groups_claim: "", sync_groups: false) }
+
+        it_behaves_like "contract is valid"
+      end
+    end
   end
 
   context "when non-admin" do

--- a/modules/openid_connect/spec/services/openid_connect/configuration_mapper_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/configuration_mapper_spec.rb
@@ -175,6 +175,44 @@ RSpec.describe OpenIDConnect::ConfigurationMapper, type: :model do
     end
   end
 
+  describe "sync_groups" do
+    subject { result["sync_groups"] }
+
+    context "when 'false'" do
+      let(:configuration) { { sync_groups: "false" } }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when 'true'" do
+      let(:configuration) { { sync_groups: "true" } }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when not provided" do
+      let(:configuration) { {} }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe "groups_claim" do
+    subject { result["groups_claim"] }
+
+    context "when provided" do
+      let(:configuration) { { groups_claim: "foobar" } }
+
+      it { is_expected.to eq("foobar") }
+    end
+
+    context "when not provided" do
+      let(:configuration) { {} }
+
+      it { is_expected.to be_blank }
+    end
+  end
+
   %w[authorization_endpoint token_endpoint userinfo_endpoint end_session_endpoint jwks_uri].each do |key|
     describe "setting #{key}" do
       subject { result }


### PR DESCRIPTION
The main fix is to allow the claim to be empty when synchronization is disabled. Otherwise we might also have problems editing existing providers via the UI.

Additionally we now allow to perform basic configuration of group sync via environment variables, though passing an array of regular expressions is not yet supported.

# Ticket

https://community.openproject.org/wp/67438