### PR TITLE
[#65315] Show a list of registered feature IDs in lookbook

### DIFF
--- a/lookbook/docs/components/enterprise-feature-list.md.erb
+++ b/lookbook/docs/components/enterprise-feature-list.md.erb
@@ -1,7 +1,6 @@
 Feature IDs are defined in the [openproject-token](https://github.com/opf/openproject-token) gem.
 They are used to associate features to plans.
 For develop usage see [this document](./enterprise).
-For usage in the docs see [below](#usage-in-the-docs).
 
 # List of feature IDs
 

--- a/lookbook/docs/components/enterprise-feature-list.md.erb
+++ b/lookbook/docs/components/enterprise-feature-list.md.erb
@@ -1,0 +1,51 @@
+Feature IDs are defined in the [openproject-token](https://github.com/opf/openproject-token) gem.
+They are used to associate features to plans.
+For develop usage see [this document](./enterprise).
+For usage in the docs see [below](#usage-in-the-docs).
+
+# List of feature IDs
+
+This is the lists of all currently registered feature IDs.
+
+<% OpenProject::Token::FEATURES_PER_PLAN.values.flatten.uniq.map(&:to_s).sort.each do |fid| %>
+## <%= I18n.t("ee.features.#{fid}", locale: 'en', default: fid.humanize) %>
+
+**Feature ID**<br>
+`<%= fid %>`
+
+<%
+  active_plans = OpenProject::Token::ACTIVE_PLAN_NAMES
+    .select{ |key| OpenProject::Token::FEATURES_PER_PLAN[key]&.include?(fid.to_sym) }
+  unless active_plans.empty?
+ %>
+
+**Active plans**<br>
+<%= active_plans.map{ |key| key.to_s.titleize }.join(", ") %>
+
+<% end %>
+<%
+  legacy_plans = OpenProject::Token::LEGACY_PLAN_NAMES
+    .select{ |key| OpenProject::Token::FEATURES_PER_PLAN[key]&.include?(fid.to_sym) }
+  unless legacy_plans.empty?
+%>
+
+**Legacy plans**<br>
+<%= legacy_plans.map{ |key| key.to_s.titleize }.join(", ") %>
+
+<% end %>
+<% end %>
+
+# Usage in the docs
+
+To render a feature information banner in the documentation on our [website](https://www.openproject.org/docs/), use the following syntax in the docs Markdown.
+
+```markdown
+[feature: feature_id ]
+```
+
+Example:
+
+```markdown
+[feature: custom_field_hierarchies ]
+```
+**Important**: Must be on an own line. Occurrences in headers, lists, quotes, tables, etc. are ignored.

--- a/lookbook/docs/components/enterprise.md.erb
+++ b/lookbook/docs/components/enterprise.md.erb
@@ -2,6 +2,8 @@ OpenProject provides multiple ways to render upsell components. These adapt auto
 
 This document describes the different components and how to use them.
 
+For a list of all currently used feature IDs, please see the [enterprise feature list](./enterprise-feature-list).
+
 # Requirements
 
 ## Token Gem


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/65315

Display a list of all registered feature IDs in the `openproject-token` gem.
with names and plans, to be used as a reference for doc authors.

# Merge checklist

- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
