### PR TITLE
[#67313] Fix wording: Change "Favored" to "Favorited" (FOLLOW UP)

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -29,8 +29,22 @@
 #++
 
 class Favorite < ApplicationRecord
+  # @!attribute [rw] favorited_id
+  #   @return [Number]
+  # @!attribute [rw] favored_id
+  #   @deprecated use {favorited_id} instead.
+  #   @return [Number]
+  alias_attribute :favorited_id, :favored_id
+
+  # @!attribute [rw] favorited_type
+  #   @return [String]
+  # @!attribute [rw] favored_type
+  #   @deprecated use {favorited_type} instead.
+  #   @return [String]
+  alias_attribute :favorited_type, :favored_type
+
   belongs_to :user
-  belongs_to :favorited, polymorphic: true
+  belongs_to :favorited, polymorphic: true, foreign_key: :favored_id, foreign_type: :favored_type
 
   validates :favorited_id, uniqueness: { scope: %i[favorited_type user_id], message: :already_favorited }
 end

--- a/db/migrate/20250908151957_rename_favorites_favored_to_favorited.rb
+++ b/db/migrate/20250908151957_rename_favorites_favored_to_favorited.rb
@@ -28,6 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+# WARNING: FIXME: "BURN 🔥 AFTER MIGRATING"
+#   This migration file should be deleted before 16.5 is released.
 class RenameFavoritesFavoredToFavorited < ActiveRecord::Migration[8.0]
   def change
     rename_column :favorites, :favored_id, :favorited_id

--- a/db/migrate/20250916153905_rename_favorites_favorited_to_favored.rb
+++ b/db/migrate/20250916153905_rename_favorites_favorited_to_favored.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class RenameFavoritesFavoritedToFavored < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :favorites, :favorited_id, :favored_id
+    rename_column :favorites, :favorited_type, :favored_type
+  end
+end

--- a/db/migrate/20250916153905_rename_favorites_favorited_to_favored.rb
+++ b/db/migrate/20250916153905_rename_favorites_favorited_to_favored.rb
@@ -28,6 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+# WARNING: FIXME: "BURN 🔥 AFTER MIGRATING"
+#   This migration file should be deleted before 16.5 is released.
 class RenameFavoritesFavoritedToFavored < ActiveRecord::Migration[8.0]
   def change
     rename_column :favorites, :favorited_id, :favored_id

--- a/lib_static/open_project/acts/favoritable.rb
+++ b/lib_static/open_project/acts/favoritable.rb
@@ -51,7 +51,11 @@ module OpenProject
           class_eval do
             prepend InstanceMethods
 
-            has_many :favorites, as: :favorited, dependent: :delete_all, validate: false
+            has_many :favorites, as: :favorited,
+                                 foreign_key: :favored_id,
+                                 foreign_type: :favored_type,
+                                 dependent: :delete_all,
+                                 validate: false
             has_many :favoriting_users, through: :favorites, source: :user, validate: false
 
             scope :favorited_by, ->(user_id) {

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe Favorite do
 
   subject(:favorite) { create(:favorite, user:, favorited:) }
 
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+
+    it {
+      expect(subject).to belong_to(:favorited)
+        .with_foreign_key(:favored_id)
+        .with_foreign_type(:favored_type)
+    }
+  end
+
   describe "validations" do
     before do
       favorite

--- a/spec/support/shared/acts_as_favoritable.rb
+++ b/spec/support/shared/acts_as_favoritable.rb
@@ -41,9 +41,10 @@ RSpec.shared_examples_for "acts_as_favoritable included" do
       .with_foreign_key(:favored_id)
       .with_foreign_type(:favored_type)
       .dependent(:delete_all)
+      .validate(false)
   }
 
-  it { is_expected.to have_many(:favoriting_users).through(:favorites) }
+  it { is_expected.to have_many(:favoriting_users).through(:favorites).validate(false) }
 
   describe ".favorited_by" do
     it "returns instance for favoriting user" do

--- a/spec/support/shared/acts_as_favoritable.rb
+++ b/spec/support/shared/acts_as_favoritable.rb
@@ -36,7 +36,13 @@ RSpec.shared_examples_for "acts_as_favoritable included" do
     Favorite.create(user: favoriting_user, favorited: instance)
   end
 
-  it { is_expected.to have_many(:favorites).dependent(:delete_all) }
+  it {
+    expect(subject).to have_many(:favorites)
+      .with_foreign_key(:favored_id)
+      .with_foreign_type(:favored_type)
+      .dependent(:delete_all)
+  }
+
   it { is_expected.to have_many(:favoriting_users).through(:favorites) }
 
   describe ".favorited_by" do


### PR DESCRIPTION
**⚠️ Follow up to #20224**

# Ticket

https://community.openproject.org/wp/67313

# What are you trying to accomplish?

1. **Reverses the recent rename of `favorites.favored_*` columns to `favorited_`** The migration in #20224 was made without sufficient consultation and didn't adhere to best practice for renaming production database columns.
2. Aliases (and soft-deprecates) `favored_type` and `favored_id` attributes.
3. Configures associations on `Favorite` and `Favorited` to use the original column names.

This "undo" migration is ephemeral - the goal is to allow developers and those living on the "edge" back to get their schema back to the state it was before #20224 was merged. It is anticipated that these migrations will then be deleted (see #20328).

_There may eventually be a follow-up to the follow-up to the follow-up - to rename the columns safely. However, this is not time-sensitive._

# Proposed approach

1. Merge this PR into `dev`.
4. Developers + pre-release users run migrations locally within a deadline well before next release cut-off.
5. A [follow up PR](https://github.com/opf/openproject/pull/20328) will then remove the following migrations:

```
20250908151957_rename_favorites_favored_to_favorited.rb
20250916153905_rename_favorites_favorited_to_favored.rb
```


# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
