### PR TITLE
[#67371] Use real open project URL for api calls with op-blocknote-extensions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -102,7 +102,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.0.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.5/op-blocknote-extensions-0.0.5.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.6/op-blocknote-extensions-0.0.6.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.1.0",
@@ -19886,9 +19886,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.5",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.5/op-blocknote-extensions-0.0.5.tgz",
-      "integrity": "sha512-C2dSyUdI1BsuC1OHAf+eEL7qMmwd9H9kCR7zcyoIphyCBZ/mBWS9zalHKOV4UE6n8mNV2NACraCy5Oor7wrnUg==",
+      "version": "0.0.6",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.6/op-blocknote-extensions-0.0.6.tgz",
+      "integrity": "sha512-QzweHJjZeOEdzvpHAPbIeHyTt8qhexdzOfqZmmR5+ml3v7eTl8+fcQTzSo/oKqcUdFNUHpyJVgo4QZeGONxdKg==",
       "dependencies": {
         "styled-components": "^6.1.19"
       },
@@ -40107,8 +40107,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.5/op-blocknote-extensions-0.0.5.tgz",
-      "integrity": "sha512-C2dSyUdI1BsuC1OHAf+eEL7qMmwd9H9kCR7zcyoIphyCBZ/mBWS9zalHKOV4UE6n8mNV2NACraCy5Oor7wrnUg==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.6/op-blocknote-extensions-0.0.6.tgz",
+      "integrity": "sha512-QzweHJjZeOEdzvpHAPbIeHyTt8qhexdzOfqZmmR5+ml3v7eTl8+fcQTzSo/oKqcUdFNUHpyJVgo4QZeGONxdKg==",
       "requires": {
         "styled-components": "^6.1.19"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.0.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.5/op-blocknote-extensions-0.0.5.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.6/op-blocknote-extensions-0.0.6.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.1.0",

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -31,7 +31,7 @@
 import { BlockNoteSchema, defaultBlockSpecs, filterSuggestionItems } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/mantine';
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
-import { getDefaultOpenProjectSlashMenuItems, openProjectWorkPackageBlockSpec } from 'op-blocknote-extensions';
+import { initOpenProjectApi, getDefaultOpenProjectSlashMenuItems, openProjectWorkPackageBlockSpec } from 'op-blocknote-extensions';
 import { useEffect, useState } from 'react';
 import { OpColorMode } from 'core-app/core/setup/globals/theme-utils';
 import { HocuspocusProvider } from '@hocuspocus/provider';
@@ -50,6 +50,7 @@ export interface OpBlockNoteContainerProps {
   users:User[];
   activeUser:User;
   documentId:string;
+  openProjectUrl:string;
 }
 
 const schema = BlockNoteSchema.create({
@@ -67,7 +68,10 @@ export default function OpBlockNoteContainer({ inputField,
                                                activeUser,
                                                hocuspocusUrl,
                                                hocuspocusAccessToken,
-                                               documentId }:OpBlockNoteContainerProps) {
+                                               documentId,
+                                               openProjectUrl }:OpBlockNoteContainerProps) {
+  initOpenProjectApi({ baseUrl: openProjectUrl});
+
   const [isLoading, setIsLoading] = useState(true);
 
   let collaboration:any;

--- a/frontend/src/stimulus/controllers/dynamic/block-note.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/block-note.controller.ts
@@ -47,6 +47,7 @@ export default class extends Controller {
     hocuspocusUrl: String,
     hocuspocusAccessToken: String,
     documentId: String,
+    openProjectUrl: String,
   };
 
   declare readonly blockNoteEditorTarget:HTMLElement;
@@ -57,6 +58,7 @@ export default class extends Controller {
   declare readonly hocuspocusUrlValue:string;
   declare readonly hocuspocusAccessTokenValue:string;
   declare readonly documentIdValue:string;
+  declare readonly openProjectUrlValue:string;
 
   connect() {
     const root = createRoot(this.blockNoteEditorTarget);
@@ -72,6 +74,7 @@ export default class extends Controller {
       hocuspocusUrl: this.hocuspocusUrlValue,
       hocuspocusAccessToken: this.hocuspocusAccessTokenValue,
       documentId: this.documentIdValue,
+      openProjectUrl: this.openProjectUrlValue,
     });
   }
 }

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -39,6 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
       block_note_hocuspocus_url_value: hocuspocus_url,
       block_note_hocuspocus_access_token_value: hocuspocus_access_token,
       block_note_document_id_value: document_id,
+      block_note_open_project_url_value: open_project_url,
       test_selector: "blocknote-document-description"
     }
   ) do

--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -42,6 +42,7 @@ module Primer
                     :active_user,
                     :hocuspocus_url,
                     :hocuspocus_access_token,
+                    :open_project_url,
                     :document_id
 
         delegate :name, to: :@input
@@ -65,6 +66,7 @@ module Primer
           @document_id = document_id
           @hocuspocus_url = Setting.collaborative_editing_hocuspocus_url
           @hocuspocus_access_token = ::CollaborativeEditing::DocumentAccessTokenGenerator.call(document_id, value)
+          @open_project_url = root_url
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/67371

# What are you trying to accomplish?
Make the op-blocknote-extensions plugin usable for real deployments where a pre-configured fallback URL will not work

