### PR TITLE
remove strategy not applicable for the limited values of types

### DIFF
--- a/app/models/queries/projects/filters/type_filter.rb
+++ b/app/models/queries/projects/filters/type_filter.rb
@@ -48,14 +48,4 @@ class Queries::Projects::Filters::TypeFilter < Queries::Projects::Filters::Base
   def self.key
     :type_id
   end
-
-  private
-
-  def type_strategy
-    # Instead of getting the IDs of all the projects a user is allowed
-    # to see we only check that the value is an integer. Non valid ids
-    # will then simply create an empty result but will not cause any
-    # harm.
-    @type_strategy ||= ::Queries::Filters::Strategies::IntegerList.new(self)
-  end
 end


### PR DESCRIPTION
# Ticket

N/A - drive by fix

# What are you trying to accomplish?

The comment suggests (because it is referencing the ids of projects), that the code was simply copied. The number of types should be manageable to check against so we can actually check whether the provided value is the id of a type.