### PR TITLE
[65417] WP items in bulk delete modal are misaligned

### DIFF
--- a/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
+++ b/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
@@ -21,9 +21,11 @@
           </p>
           <ul>
             @for (child of singleWorkPackageChildren; track child) {
-              <li>
-                #<span [textContent]="child.id"></span>
-                <span [textContent]="child.subject || ''"></span>
+              <li class="spot-list--item">
+                <div class="spot-list--item-title">
+                  #<span [textContent]="child.id"></span>
+                  <span [textContent]="child.subject || ''"></span>
+                </div>
               </li>
             }
           </ul>
@@ -40,15 +42,14 @@
       </p>
       <ul>
         @for (wp of workPackages; track wp) {
-          <li>
-            #<span [textContent]="wp.id"></span>
-            &ngsp;
-            <span [textContent]="wp.subject"></span>
-            @if (children(wp).length > 0) {
-              <strong>
+          <li class="spot-list--item">
+            <div class="spot-list--item-title">
+              #<span [textContent]="wp.id"></span>
+              <span [textContent]="wp.subject"></span>
+              <strong *ngIf="children(wp).length > 0">
                 (+ {{ text.childCount(wp) }})
               </strong>
-            }
+            </div>
           </li>
         }
       </ul>

--- a/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
+++ b/frontend/src/app/shared/components/modals/wp-destroy-modal/wp-destroy.modal.html
@@ -46,9 +46,9 @@
             <div class="spot-list--item-title">
               #<span [textContent]="wp.id"></span>
               <span [textContent]="wp.subject"></span>
-              <strong *ngIf="children(wp).length > 0">
-                (+ {{ text.childCount(wp) }})
-              </strong>
+              @if (children(wp).length > 0) {
+                <strong>(+ {{ text.childCount(wp) }})</strong>
+              }
             </div>
           </li>
         }

--- a/spec/support/components/work_packages/destroy_modal.rb
+++ b/spec/support/components/work_packages/destroy_modal.rb
@@ -48,7 +48,7 @@ module Components
             expect(page).to have_css(".danger-zone--warning",
                                      text: "Are you sure you want to delete the following work packages?")
             wps.each do |wp|
-              expect(page).to have_css("li", text: "##{wp.id} #{wp.subject}")
+              expect(page).to have_css("li", text: "##{wp.id}#{wp.subject}")
             end
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65417

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Align WPs in wp bulk destroy modal 

## Screenshots
<img width="676" height="283" alt="Screenshot 2025-09-17 at 12 54 40" src="https://github.com/user-attachments/assets/1944efcf-65ba-4f74-ba91-2c0968a5642e" />
