### PR TITLE
attempt to fix flickering spec - use expectation instead of all

### DIFF
--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -275,14 +275,12 @@ RSpec.describe "edit work package", :js do
         completer = wp_page.edit_field field_name
         completer.activate!
 
-        options = visible_user_auto_completer_options
-
         expected_options = [
           { name: manager.name, email: nil },  # Manager's email should not be visible
           { name: dev.name, email: dev.mail }  # Developer's email should be visible
         ]
 
-        expect(options).to eq(expected_options)
+        expect_visible_user_auto_completer_options(expected_options)
       end
     end
 
@@ -290,8 +288,6 @@ RSpec.describe "edit work package", :js do
       it "does show you the email of other users" do
         completer = wp_page.edit_field field_name
         completer.activate!
-
-        options = visible_user_auto_completer_options
 
         expected_options = [
           # With the right permissions, you can see other users email address
@@ -302,7 +298,7 @@ RSpec.describe "edit work package", :js do
             email: dev.mail }
         ]
 
-        expect(options).to eq(expected_options)
+        expect_visible_user_auto_completer_options(expected_options)
       end
     end
 

--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -159,31 +159,33 @@ module Components::Autocompleter
       expect(element).to have_css(".ng-value .ng-value-label", text: value, wait: 10)
     end
 
-    # Finds the currently visible, expanded user auto completer and returns its dropdown menu options.
+    # Checks for the currently visible, expanded user auto completer to contain the provided options.
     # A user always has a name, but their email is only visible in certain circumstances, so that value
     # might be nil.
     #
-    # The options are returned as an Array of Hashes, like this example with two users:
+    # The expected options are to be provided as an Array of Hashes, like this example with two users:
     #
     #   [
     #     { name: "Bob", email: nil },
     #     { name: "Alice", email: "alice@example.com" }
     #   ]
     #
-    # The order of elements in the Array is equal to the visible order on the website.
-    def visible_user_auto_completer_options
-      find(".ng-dropdown-panel [role='listbox']").all(".ng-option[role='option']").filter_map do |opt|
-        name = opt.find(".op-user-autocompleter--name", wait: 0).text
-        email =
-          if opt.has_css?(".op-autocompleter__option-principal-email", wait: 0)
-            opt.find(".op-autocompleter__option-principal-email", wait: 0).text
+    # The order the elements are provided in is also expected.
+    def expect_visible_user_auto_completer_options(expected)
+      within(".ng-dropdown-panel [role='listbox']") do
+        expected.each_with_index do |option, index|
+          expect(page)
+            .to have_css(".ng-option[role='option']:nth-child(#{index + 1}) .op-user-autocompleter--name",
+                         text: option[:name])
+          if option[:email]
+            expect(page)
+              .to have_css(".ng-option[role='option']:nth-child(#{index + 1}) .op-autocompleter__option-principal-email",
+                           text: option[:email])
+          else
+            expect(page)
+              .to have_no_css(".ng-option[role='option']:nth-child(#{index + 1}) .op-autocompleter__option-principal-email")
           end
-
-        { name:, email: }
-      rescue Capybara::ElementNotFound
-        # In rare cases, the auto completer result body includes additional elements that do not contain all of the
-        # expected information. For example in the share modal. We will omit these entries.
-        nil
+        end
       end
     end
   end

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -109,10 +109,8 @@ module Components
         within(selected_filter) do
           find('[data-filter-autocomplete="true"]').click
         end
-        wait_for_network_idle if using_cuprite?
-        options = visible_user_auto_completer_options
 
-        expect(options).to eq(expected_options)
+        expect_visible_user_auto_completer_options(expected_options)
       end
 
       def apply_operator(name, human_operator)


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Fix the flickering specs related to user autocompletion. Those probably stem from using all, which will not wait, instead of using expectations which will wait for the elements to exist.
