### PR TITLE
Tell Dependabot to ignore Octicons

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@openproject/octicons"
       - dependency-name: "@openproject/primer-view-components"
   - package-ecosystem: "bundler"
     directory: "/"
@@ -38,6 +39,8 @@ updates:
         patterns:
           - "aws-*"
     ignore:
+      - dependency_name: "openproject-octicons"
+      - dependency-name: "openproject-octicons_helper"
       - dependency-name: "openproject-primer_view_components"
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Configures Dependabot to ignore both npm and gem Octicon updates.


# What approach did you choose and why?

Unfortunately, the previous attempt at configuring multi-ecosystem groups (see #20157 / [41f6a30](https://github.com/opf/openproject/pull/20157/commits/41f6a305cb7a7a99971dbcaa3cbc02ce3c62c573) / [06395be](https://github.com/opf/openproject/pull/20157/commits/06395be01a0c4e29be3e765f5942d183ab3208d1)) didn't work as expected. So for now, manually updating Octicon dependencies is the best strategy to ensure npm and gem versions are kept in sync.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

