### PR TITLE
Bug/67521 it is possible to change custom field format by providing different format to update action

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -49,6 +49,8 @@ class CustomField < ApplicationRecord
           dependent: :destroy,
           inverse_of: "custom_field"
 
+  attr_readonly :field_format
+
   scope :hierarchy_root_and_children, -> { includes(hierarchy_root: { children: :children }) }
   scope :required, -> { where(is_required: true) }
 

--- a/app/services/custom_fields/update_service.rb
+++ b/app/services/custom_fields/update_service.rb
@@ -40,6 +40,10 @@ module CustomFields
 
     private
 
+    def set_attributes_params(params)
+      super.except(:field_format)
+    end
+
     def recalculate_values
       return unless recalculate_values?
 

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   class="form--section"
   id="custom_field_form">
 
-  <%= f.hidden_field :field_format %>
+  <%= f.hidden_field :field_format if @custom_field.new_record? %>
 
   <div class="form--field -required" id="custom_field_name_attributes">
     <%= f.text_field :name,

--- a/modules/reporting/spec/models/cost_query/filter_spec.rb
+++ b/modules/reporting/spec/models/cost_query/filter_spec.rb
@@ -389,13 +389,6 @@ RSpec.describe CostQuery, :reporting_query_helper do
         clear_cache
       end
 
-      def update_work_package_custom_field(name, options)
-        fld = WorkPackageCustomField.find_by(name:)
-        options.each_pair { |k, v| fld.send(:"#{k}=", v) }
-        fld.save!
-        clear_cache
-      end
-
       include OpenProject::Reporting::SpecHelper::CustomFieldFilterHelper
 
       it "creates classes for custom fields that get added after starting the server" do
@@ -414,25 +407,9 @@ RSpec.describe CostQuery, :reporting_query_helper do
         custom_field2.save
 
         clear_cache
-        ao = filter_class_name_string(custom_field2).constantize.available_operators.map(&:name)
-        CostQuery::Operator.null_operators.each do |o|
-          expect(ao).to include o.name
-        end
-      end
 
-      it "updates the available values on change" do
-        custom_field2.save
-
-        update_work_package_custom_field("Database", field_format: "string")
-        ao = filter_class_name_string(custom_field2).constantize.available_operators.map(&:name)
-        CostQuery::Operator.string_operators.each do |o|
-          expect(ao).to include o.name
-        end
-        update_work_package_custom_field("Database", field_format: "int")
-        ao = filter_class_name_string(custom_field2).constantize.available_operators.map(&:name)
-        CostQuery::Operator.integer_operators.each do |o|
-          expect(ao).to include o.name
-        end
+        expect(filter_class_name_string(custom_field2).constantize.available_operators.map(&:name))
+          .to include(*CostQuery::Operator.null_operators.map(&:name))
       end
 
       it "includes custom fields classes in CustomFieldEntries.all" do

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -45,8 +45,9 @@ RSpec.describe CustomFieldFormBuilder do
   describe "#custom_field" do
     let(:options) { { class: "custom-class" } }
 
+    let(:field_format) { "bool" }
     let(:custom_field) do
-      build_stubbed(:custom_field)
+      build_stubbed(:custom_field, field_format:)
     end
     let(:custom_value) do
       build_stubbed(:custom_value, customized: resource, custom_field:)
@@ -95,9 +96,7 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     context "for a date custom field" do
-      before do
-        custom_field.field_format = "date"
-      end
+      let(:field_format) { "date" }
 
       it_behaves_like "wrapped in container", "field-container" do
         let(:container_count) { 2 }
@@ -118,9 +117,7 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     context "for a text custom field" do
-      before do
-        custom_field.field_format = "text"
-      end
+      let(:field_format) { "text" }
 
       it_behaves_like "wrapped in container", "text-area-container" do
         let(:container_count) { 2 }
@@ -140,9 +137,7 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     context "for a string custom field" do
-      before do
-        custom_field.field_format = "string"
-      end
+      let(:field_format) { "string" }
 
       it_behaves_like "wrapped in container", "text-field-container" do
         let(:container_count) { 2 }
@@ -153,15 +148,14 @@ RSpec.describe CustomFieldFormBuilder do
           <input class="custom-class form--text-field"
                  id="user#{custom_field.id}"
                  name="user[#{custom_field.id}]"
-                 type="text" />
+                 type="text"
+                 value="" />
         }).at_path("input")
       end
     end
 
     context "for an int custom field" do
-      before do
-        custom_field.field_format = "int"
-      end
+      let(:field_format) { "int" }
 
       it_behaves_like "wrapped in container", "text-field-container" do
         let(:container_count) { 2 }
@@ -178,9 +172,7 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     context "for a float custom field" do
-      before do
-        custom_field.field_format = "float"
-      end
+      let(:field_format) { "float" }
 
       it_behaves_like "wrapped in container", "text-field-container" do
         let(:container_count) { 2 }
@@ -256,6 +248,8 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     context "for a user custom field" do
+      let(:field_format) { "user" }
+
       let(:project) { build_stubbed(:project) }
       let(:user1) { build_stubbed(:user) }
       let(:user2) { build_stubbed(:user) }
@@ -263,8 +257,6 @@ RSpec.describe CustomFieldFormBuilder do
       let(:resource) { project }
 
       before do
-        custom_field.field_format = "user"
-
         without_partial_double_verification do
           allow(project)
             .to receive(custom_field.attribute_getter)
@@ -320,6 +312,8 @@ RSpec.describe CustomFieldFormBuilder do
     end
 
     context "for a version custom field" do
+      let(:field_format) { "version" }
+
       let(:project) { build_stubbed(:project) }
       let(:version1) { build_stubbed(:version) }
       let(:version2) { build_stubbed(:version) }
@@ -327,8 +321,6 @@ RSpec.describe CustomFieldFormBuilder do
       let(:resource) { project }
 
       before do
-        custom_field.field_format = "version"
-
         without_partial_double_verification do
           allow(project)
             .to receive(custom_field.attribute_getter)

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe CustomField do
   let(:field)  { build(:custom_field) }
   let(:field2) { build(:custom_field) }
 
+  it { is_expected.to have_readonly_attribute(:field_format) }
+
   describe "#name" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(256) }

--- a/spec/models/work_package/work_package_acts_as_customizable_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_customizable_spec.rb
@@ -191,10 +191,7 @@ RSpec.describe WorkPackage, "acts_as_customizable" do
     end
 
     context "with a default value" do
-      before do
-        custom_field.update! default_value: "foobar"
-        model_instance.custom_values.destroy_all
-      end
+      let(:custom_field) { create(:string_wp_custom_field, default_value: "foobar") }
 
       it "returns no changes" do
         expect(model_instance.custom_field_changes).to be_empty
@@ -202,10 +199,7 @@ RSpec.describe WorkPackage, "acts_as_customizable" do
     end
 
     context "with a bool custom_field having a default value" do
-      before do
-        custom_field.update! field_format: "bool", default_value: "0"
-        model_instance.custom_values.destroy_all
-      end
+      let(:custom_field) { create(:boolean_wp_custom_field, default_value: "0") }
 
       it "returns no changes" do
         expect(model_instance.custom_field_changes).to be_empty

--- a/spec/services/custom_fields/update_service_spec.rb
+++ b/spec/services/custom_fields/update_service_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe CustomFields::UpdateService, type: :model do
       allow(contract_class).to receive(:new).with(custom_field, user, options: {}).and_return(contract_instance)
     end
 
+    describe "field_format attribute" do
+      context "when trying to change it" do
+        let!(:custom_field) { create(:boolean_wp_custom_field) }
+        let(:attributes) { { field_format: "text" } }
+
+        it "is ignored" do
+          expect(subject).to be_success
+
+          expect(custom_field.reload).to have_attributes(field_format: "bool")
+        end
+      end
+    end
+
     describe "calculated value custom field", with_flag: { calculated_value_project_attribute: true } do
       shared_let(:project1) { create(:project) }
       shared_let(:project2) { create(:project) }

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -159,15 +159,8 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
       end
 
       context "required custom field in the target project" do
+        let(:custom_field) { create(:work_package_custom_field, field_format: "text", is_required: true, is_for_all: false) }
         let(:target_custom_fields) { [custom_field] }
-
-        before do
-          custom_field.update(
-            field_format: "text",
-            is_required: true,
-            is_for_all: false
-          )
-        end
 
         it "does not copy the work package" do
           expect(service_result).to be_failure


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67521

# What are you trying to accomplish?
Prevent changing exiting custom field format

# What approach did you choose and why?
Mark attribute readonly, ignore in service and don't add as hidden input to the form for saved custom field

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
