### PR TITLE
[67535] Increase spacing for Baseline button in WP toolbar

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.html
@@ -13,7 +13,7 @@
     data-test-selector="baseline-button"
   >
     <svg op-baseline-icon size="small"/>
-    {{ text.toggle_title }}
+    <span class="button--text">{{ text.toggle_title }}</span>
     <svg triangle-down-icon size="small"/>
   </button>
   <op-baseline [visible]="opened"

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -135,7 +135,7 @@ $nm-color-success-background: #d8fdd1
       font-size: 14px
 
     .button--text
-      margin-left: 0.2em
+      margin: 0 4px
 
     .badge
       vertical-align: 1px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67535


# What are you trying to accomplish?
Increase spacing of toolbar button


