### PR TITLE
[#64356] Image not visible in PDF export

### DIFF
--- a/app/models/exports/pdf/common/attachments.rb
+++ b/app/models/exports/pdf/common/attachments.rb
@@ -89,13 +89,14 @@ module Exports::PDF::Common::Attachments
   def attachment_by_api_content_src(src)
     return nil if src.empty?
 
-    # we only accept absolute paths containing /attachments/:id/
-    # to prevent accessing hot-linked attachments from other hosts e.g. https://example.com/attachments/1/somefile.png
-    # we only accept sources like
-    # /api/v3/attachments/:id/content (our default api path)
-    # /attachments/:id/filename.ext (inserted by drag and drop from the files tab)
+    # we accept absolut linked images
+    # (but not hot-linked from elsewhere: https://example.com/another_api/attachments/1/somefile.png)
+    #
+    # #{api_url_helpers.root_path}api/v3/attachments/:id/content (our default api path)
+    # #{api_url_helpers.root_path}attachments/:id/filename.ext (e.g. inserted by drag and drop from the files tab)
+
     attachment_regex = %r{/attachments/(\d+)/}
-    return nil unless src.start_with?("/") && src.match?(attachment_regex)
+    return nil unless src.start_with?(api_url_helpers.root_path) && src.match?(attachment_regex)
 
     attachments_id = src.scan(attachment_regex).first.first
     attachment = Attachment.find_by(id: attachments_id.to_i)

--- a/app/models/exports/pdf/common/attachments.rb
+++ b/app/models/exports/pdf/common/attachments.rb
@@ -87,14 +87,17 @@ module Exports::PDF::Common::Attachments
   end
 
   def attachment_by_api_content_src(src)
-    attachment_regex = %r{/attachments/(\d+)/content}
-    return nil unless src&.match?(attachment_regex)
+    return nil if src.empty?
+
+    # we only accept absolute paths containing /attachments/:id/
+    # to prevent accessing hot-linked attachments from other hosts e.g. https://example.com/attachments/1/somefile.png
+    # we only accept sources like
+    # /api/v3/attachments/:id/content (our default api path)
+    # /attachments/:id/filename.ext (inserted by drag and drop from the files tab)
+    attachment_regex = %r{/attachments/(\d+)/}
+    return nil unless src.start_with?("/") && src.match?(attachment_regex)
 
     attachments_id = src.scan(attachment_regex).first.first
-
-    # return nil if the src is not an attachment url
-    return nil unless api_url_helpers.attachment_content(attachments_id) == src
-
     attachment = Attachment.find_by(id: attachments_id.to_i)
     return nil if attachment.nil?
     return nil unless attachment.visible?

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -33,6 +33,7 @@ require "spec_helper"
 RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   include Redmine::I18n
   include PDFExportSpecUtils
+
   let(:type) do
     create(:type_bug,
            custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool, cf_link])
@@ -148,6 +149,12 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
           <figcaption>Image Caption</figcaption>
          </figure>
       </p>
+      <figure class="op-uc-figure">
+         <div class="op-uc-figure--content">
+            <img class="op-uc-image" src="/attachments/#{image_attachment.id}/image.png" alt='"image redirect"'>
+         </div>
+         <figcaption>Image Redirect</figcaption>
+      </figure>
       <p><unknown-tag>Foo</unknown-tag></p>
       <img class="op-uc-image op-uc-image_inline" src="/api/v3/attachments/#{image_attachment_elsewhere.id}/content">
     DESCRIPTION
@@ -290,13 +297,14 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
           "Lorem", " ", "ipsum", " ", "dolor", " ", "sit", " ",
           "amet", ", consetetur sadipscing elitr.", " ", "@OpenProject Admin",
           "Image Caption",
-          "Foo",
           "1", export_date_formatted, project.name,
+          "Image Redirect",
+          "Foo",
           "2", export_date_formatted, project.name
         ].flatten.join(" ")
         expect(result).to eq(expected_result)
         expect(result).not_to include("DisabledCustomField")
-        expect(pdf[:images].length).to eq(3)
+        expect(pdf[:images].length).to eq(4)
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/64356

# What are you trying to achieve?

There are two valid images src for use in work package descriptions

`/api/v3/attachments/:id/content` (our default api path)

`/attachments/:id/filename.ext` (inserted by drag and drop from the files tab)

also support if OpenProject is served from a subdirectory, e.g. `/openproject/attachments/:id/filename.ext`

The PDF export is very strict and only supports the first.

# What approach did you choose and why?

Support both because both are valid.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
