### PR TITLE
Construct Valid origin_ids for Sharepoint File Links

### DIFF
--- a/frontend/src/app/core/upload/upload.service.ts
+++ b/frontend/src/app/core/upload/upload.service.ts
@@ -31,6 +31,7 @@ import { HttpEvent } from '@angular/common/http';
 
 export interface IUploadFile {
   file:File;
+  location?:string;
   overwrite?:boolean;
 }
 

--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -393,7 +393,7 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
           const link = this.uploadResourceLink(storage, data.file.name, data.location);
           return this.storageFilesResourceService.uploadLink(link);
         }),
-        switchMap((link) => this.uploadAndNotify(link, data.file, data.overwrite)),
+        switchMap((link) => this.uploadAndNotify(link, data.file, data.location, data.overwrite)),
         catchError((error) => {
           isUploadError = true;
           return throwError(error);
@@ -471,9 +471,9 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
     }
   }
 
-  private uploadAndNotify(link:IUploadLink, file:File, overwrite:boolean|null):Observable<IStorageFileUploadResponse> {
+  private uploadAndNotify(link:IUploadLink, file:File, location:string|null, overwrite:boolean|null):Observable<IStorageFileUploadResponse> {
     const { href } = link._links.destination;
-    const uploadFiles:IUploadFile[] = [{ file, overwrite: overwrite ?? undefined }];
+    const uploadFiles:IUploadFile[] = [{ file, location: location ?? undefined, overwrite: overwrite ?? undefined }];
     const observable = this.uploadService.upload<IStorageFileUploadResponse>(href, uploadFiles)[0];
     this.toastService.addUpload(this.text.toast.uploadingLabel, [[file, observable]]);
 

--- a/frontend/src/app/shared/components/storages/upload/sharepoint-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/sharepoint-upload.strategy.ts
@@ -54,7 +54,7 @@ export class SharepointUploadStrategy implements IUploadStrategy {
 
   private uploadSingle<T>(href:string, uploadFile:IUploadFile):Observable<HttpEvent<T>> {
     const contentRangeHeader = `bytes 0-${uploadFile.file.size - 1}/${uploadFile.file.size}`;
-
+    const driveId = (uploadFile.location ?? '').split(':')[0];
     return this.http.request<SharepointFileUploadResponse>(
       'put',
       href,
@@ -72,7 +72,7 @@ export class SharepointUploadStrategy implements IUploadStrategy {
       share(),
       map((event) =>
         convertHttpEvent(event, (responseBody) => ({
-          id: `${ uploadFile.location }:${ responseBody.id }`,
+          id: `${ driveId }:${ responseBody.id }`,
           name: responseBody.name,
           size: responseBody.size,
           mimeType: responseBody.file.mimeType,

--- a/frontend/src/app/shared/components/storages/upload/sharepoint-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/sharepoint-upload.strategy.ts
@@ -27,58 +27,56 @@
 //++
 
 import { Observable } from 'rxjs';
-import { ID } from '@datorama/akita';
-import { Injectable } from '@angular/core';
+import { map, share } from 'rxjs/operators';
 import { HttpClient, HttpEvent } from '@angular/common/http';
 
-import { IUploadFile, OpUploadService } from 'core-app/core/upload/upload.service';
+import { IUploadFile } from 'core-app/core/upload/upload.service';
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
 import { IUploadStrategy } from 'core-app/shared/components/storages/upload/upload-strategy';
-import { NextcloudUploadStrategy } from 'core-app/shared/components/storages/upload/nextcloud-upload.strategy';
-import { nextcloud, oneDrive, sharepoint } from 'core-app/shared/components/storages/storages-constants.const';
-import { OneDriveUploadStrategy } from 'core-app/shared/components/storages/upload/one-drive-upload.strategy';
-import { SharepointUploadStrategy } from 'core-app/shared/components/storages/upload/sharepoint-upload.strategy';
+import convertHttpEvent from 'core-app/core/upload/convert-http-event';
 
-export interface IStorageFileUploadResponse {
-  id:ID;
+export interface SharepointFileUploadResponse {
+  id:string;
   name:string;
-  mimeType:string;
+  file:{ mimeType:string };
   size:number;
 }
 
-@Injectable()
-export class StorageUploadService extends OpUploadService {
-  private uploadStrategy:IUploadStrategy;
+export class SharepointUploadStrategy implements IUploadStrategy {
+  constructor(private readonly http:HttpClient) { }
 
-  constructor(
-    private readonly http:HttpClient,
-  ) {
-    super();
-  }
-
-  public upload<T>(
+  public execute<T>(
     href:string,
     uploadFiles:IUploadFile[],
   ):Observable<HttpEvent<T>>[] {
-    if (!this.uploadStrategy) {
-      throw new Error('missing strategy');
-    }
-
-    return this.uploadStrategy.execute(href, uploadFiles);
+    return uploadFiles.map((file) => this.uploadSingle(href, file));
   }
 
-  public setUploadStrategy(storageType:string):void {
-    switch (storageType) {
-      case nextcloud:
-        this.uploadStrategy = new NextcloudUploadStrategy(this.http);
-        break;
-      case oneDrive:
-        this.uploadStrategy = new OneDriveUploadStrategy(this.http);
-        break;
-      case sharepoint:
-        this.uploadStrategy = new SharepointUploadStrategy(this.http);
-        break;
-      default:
-        throw new Error('unknown storage type');
-    }
+  private uploadSingle<T>(href:string, uploadFile:IUploadFile):Observable<HttpEvent<T>> {
+    const contentRangeHeader = `bytes 0-${uploadFile.file.size - 1}/${uploadFile.file.size}`;
+
+    return this.http.request<SharepointFileUploadResponse>(
+      'put',
+      href,
+      {
+        body: uploadFile.file,
+        headers: {
+          [EXTERNAL_REQUEST_HEADER]: 'true',
+          'Content-Range': contentRangeHeader,
+        },
+        observe: 'events',
+        reportProgress: true,
+        responseType: 'json',
+      },
+    ).pipe(
+      share(),
+      map((event) =>
+        convertHttpEvent(event, (responseBody) => ({
+          id: `${ uploadFile.location }:${ responseBody.id }`,
+          name: responseBody.name,
+          size: responseBody.size,
+          mimeType: responseBody.file.mimeType,
+        } as T))),
+    );
   }
 }

--- a/frontend/src/app/shared/components/storages/upload/sharepoint-upload.strategy.ts
+++ b/frontend/src/app/shared/components/storages/upload/sharepoint-upload.strategy.ts
@@ -43,6 +43,7 @@ export interface SharepointFileUploadResponse {
 }
 
 export class SharepointUploadStrategy implements IUploadStrategy {
+  // eslint-disable-next-line no-unused-vars
   constructor(private readonly http:HttpClient) { }
 
   public execute<T>(


### PR DESCRIPTION
SharePoint uses a compound ID rather than simple item id for file links. This PR implements a full blown strategy for SharePoint uploads that handle this case.

[OP#67557](https://community.openproject.org/work_packages/67557)
[OP#67245](https://community.openproject.org/work_packages/67245)
[OP#67515](https://community.openproject.org/work_packages/67515)

