### PR TITLE
Fix have enterprise banner plan check

### DIFF
--- a/modules/openid_connect/spec/features/administration/oidc_custom_crud_spec.rb
+++ b/modules/openid_connect/spec/features/administration/oidc_custom_crud_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "OIDC administration CRUD",
   context "without EE", without_ee: %i[sso_auth_providers] do
     it "renders the upsell page" do
       visit "/admin/openid_connect/providers"
-      expect(page).to have_enterprise_banner(:premium)
+      expect(page).to have_enterprise_banner(:professional)
     end
   end
 end

--- a/modules/team_planner/spec/features/team_planner_upsell_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_upsell_spec.rb
@@ -43,18 +43,18 @@ RSpec.describe "Team planner index",
   it "shows an upsell banner" do
     visit team_planners_path
 
-    expect(page).to have_enterprise_banner(:premium)
+    expect(page).to have_enterprise_banner(:basic)
 
     visit project_team_planners_path(project)
 
-    expect(page).to have_enterprise_banner(:premium)
+    expect(page).to have_enterprise_banner(:basic)
 
     visit new_project_team_planners_path(project)
 
-    expect(page).to have_enterprise_banner(:premium)
+    expect(page).to have_enterprise_banner(:basic)
 
     visit project_team_planner_path(project, id: "new")
 
-    expect(page).to have_enterprise_banner(:premium)
+    expect(page).to have_enterprise_banner(:basic)
   end
 end

--- a/spec/support/matchers/has_enterprise_banner.rb
+++ b/spec/support/matchers/has_enterprise_banner.rb
@@ -28,16 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-RSpec::Matchers.define :have_enterprise_banner do |**args|
+RSpec::Matchers.define :have_enterprise_banner do |plan, **args|
   include TestSelectorFinders
 
   match do |page|
-    if args[:plan]
-      expected_text = I18n.t("ee.upsell.plan_text_html", plan: args[:plan].capitalize)
-      page.find(test_selector("op-enterprise-banner"), **args, text: expected_text)
-    else
-      page.find(test_selector("op-enterprise-banner"), **args)
+    if plan
+      plan_name = I18n.t("ee.upsell.plan_name", plan: plan.capitalize)
+      expected_text = I18n.t("ee.upsell.plan_text_html", plan_name:)
+      args[:text] = expected_text
     end
+
+    page.find(test_selector("op-enterprise-banner"), **args)
   end
 
   match_when_negated do |page|


### PR DESCRIPTION
# Ticket
Discovered during https://community.openproject.org/wp/64529

# What are you trying to accomplish?
`plan` was never checked, as it was expected to be a keyword argument, but positional is used everywhere

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
