### PR TITLE
Retry downloads of bim dependencies in docker

### DIFF
--- a/docker/dev/backend/scripts/setup-bim
+++ b/docker/dev/backend/scripts/setup-bim
@@ -10,7 +10,7 @@
 apt-get install -y wget unzip
 
 # https://learn.microsoft.com/en-gb/dotnet/core/install/linux-debian#debian-12
-wget --quiet https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
+wget --no-verbose --tries 3 https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
 dpkg -i /tmp/packages-microsoft-prod.deb
 rm /tmp/packages-microsoft-prod.deb
 
@@ -24,16 +24,16 @@ cd $tmpdir
 npm install -g @xeokit/xeokit-gltf-to-xkt@1.3.1
 
 # Install COLLADA2GLTF
-wget --quiet https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
+wget --no-verbose --tries 3 https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
 unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 # IFCconvert
-wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+wget --no-verbose --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
 unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
-wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
+wget --no-verbose --tries 3 https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
 tar -zxvf xeokit-metadata-linux-x64.tar.gz
 chmod +x xeokit-metadata-linux-x64/xeokit-metadata
 cp -r xeokit-metadata-linux-x64/ "/usr/lib/xeokit-metadata"

--- a/docker/prod/setup/preinstall-common.sh
+++ b/docker/prod/setup/preinstall-common.sh
@@ -61,7 +61,7 @@ if [ ! "$BIM_SUPPORT" = "false" ]; then
 	apt-get install -y wget unzip
 
 	# https://learn.microsoft.com/en-gb/dotnet/core/install/linux-debian#debian-12
-	wget --quiet https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
+	wget --no-verbose --tries 3 https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb
 	dpkg -i /tmp/packages-microsoft-prod.deb
 	rm /tmp/packages-microsoft-prod.deb
 
@@ -75,16 +75,16 @@ if [ ! "$BIM_SUPPORT" = "false" ]; then
 	npm install -g @xeokit/xeokit-gltf-to-xkt@1.3.1
 
 	# Install COLLADA2GLTF
-	wget --quiet https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
+	wget --no-verbose --tries 3 https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
 	unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 	mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 	# IFCconvert
-	wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+	wget --no-verbose --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
 	unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
 	mv IfcConvert "/usr/local/bin/IfcConvert"
 
-	wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
+	wget --no-verbose --tries 3 https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
 	tar -zxvf xeokit-metadata-linux-x64.tar.gz
 	chmod +x xeokit-metadata-linux-x64/xeokit-metadata
 	cp -r xeokit-metadata-linux-x64/ "/usr/lib/xeokit-metadata"

--- a/modules/bim/bin/setup_dev.sh
+++ b/modules/bim/bin/setup_dev.sh
@@ -20,16 +20,16 @@ tmpdir=$(mktemp -d)
 cd $tmpdir
 
 # Install COLLADA2GLTF
-wget --quiet https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
+wget --quiet --tries 3 https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
 unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 # IFCconvert
-wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+wget --quiet --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
 unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
-wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
+wget --quiet --tries 3 https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
 tar -zxvf xeokit-metadata-linux-x64.tar.gz
 chmod +x xeokit-metadata-linux-x64/xeokit-metadata
 cp -rT xeokit-metadata-linux-x64 "/usr/lib/xeokit-metadata"

--- a/packaging/setup
+++ b/packaging/setup
@@ -19,7 +19,7 @@ find packaging/ -type f -print0 | xargs -0 sed -i "s|_APP_NAME_|${APP_NAME}|"
 mkdir -p vendor/bim
 pushd vendor/bim
 # These are referenced in /packaging/addons/openproject-edition/bin/preinstall
-wget --quiet https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
-wget --quiet https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
-wget --quiet https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
+wget --quiet --tries 3 https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/v2.1.5/COLLADA2GLTF-v2.1.5-linux.zip
+wget --quiet --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
+wget --quiet --tries 3 https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz
 popd


### PR DESCRIPTION
Download failed in some CI builds for some reason [1], while it worked for previous builds [2]. I would assume it's transient download errors.

Adding `--tries 3` to the wget commands to retry the downloads should fix the issue.

Also replaced `--quiet` with `--no-verbose` to be terser than default but still get error information when it fails.

[1] https://github.com/opf/openproject-flavours/actions/runs/17911001201 and https://github.com/opf/openproject-flavours/actions/runs/17910946720/job/50922134721
[2] https://github.com/opf/openproject-flavours/actions/runs/17910953231/job/50922155467
