### PR TITLE
Adjust some OpenTelemetry configuration

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -53,9 +53,11 @@ Rails.application.configure do
 
       c.resource = OpenTelemetry::SDK::Resources::Resource.create(
         {
-          "deployment.environment" => Rails.env,
-          "service.namespace" => "openproject",
-          "service.instance.id" => Socket.gethostname
+          OpenTelemetry::SemConv::Incubating::DEPLOYMENT::DEPLOYMENT_ENVIRONMENT => Rails.env,
+          OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_INSTANCE_ID => SecureRandom.uuid,
+          OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_NAME => OpenProject::OpenTelemetry.process_type,
+          OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_NAMESPACE => "openproject",
+          OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_VERSION => OpenProject::VERSION.to_s
         }.transform_values(&:to_s)
       )
 

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
       c.resource = OpenTelemetry::SDK::Resources::Resource.create(
         {
           OpenTelemetry::SemConv::Incubating::DEPLOYMENT::DEPLOYMENT_ENVIRONMENT => Rails.env,
+          OpenTelemetry::SemConv::Incubating::HOST::HOST_NAME => Socket.gethostname,
           OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_INSTANCE_ID => SecureRandom.uuid,
           OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_NAME => OpenProject::OpenTelemetry.process_type,
           OpenTelemetry::SemConv::Incubating::SERVICE::SERVICE_NAMESPACE => "openproject",

--- a/lib_static/open_project/opentelemetry.rb
+++ b/lib_static/open_project/opentelemetry.rb
@@ -121,5 +121,24 @@ module OpenProject
         span.set_attribute(key.to_s, value.to_s)
       end
     end
+
+    # Determine process type
+    def process_type # rubocop:disable Metrics/PerceivedComplexity
+      if defined?(Rails::Server)
+        "web"
+      elsif defined?(Rails::Console)
+        "console"
+      elsif defined?(Rails::Runner)
+        "runner"
+      elsif defined?(Rails::Generators)
+        "generator"
+      elsif defined?(Rake) && Rake.application.top_level_tasks.any?
+        "rake"
+      elsif defined?(GoodJob::CLI) && GoodJob::CLI.within_exec?
+        "worker"
+      else
+        "unknown"
+      end
+    end
   end
 end


### PR DESCRIPTION
- Use constants for semantic names. As a bonus it gives documentation about the metric.
- Use a random UUID for the service name. It has to be unique for a given service name and namespace.
- Use process type as service name.
- Add service version.
- Use "[host.name](https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-semantic_conventions/v1.36.0/OpenTelemetry/SemConv/Incubating/HOST.html)" to store hostname in attributes instead of "[service.instance.id](https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-semantic_conventions/v1.36.0/OpenTelemetry/SemConv/Incubating/SERVICE.html)"

Do not set anything regarding the environment (edge / stage / prod) or shard name as these will be available as k8s labels anyway.
