### PR TITLE
[#67381] Older meetings show series backlog as 'untitled section'  

### DIFF
--- a/modules/meeting/app/components/meeting_sections/backlogs/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/header_component.html.erb
@@ -7,7 +7,7 @@
             box: @box, collapsed: @collapsed
           )
         ) do |header|
-          header.with_title(font_weight: :bold) { title }
+          header.with_title(font_weight: :bold) { @backlog.title }
           header.with_description { description }
           header.with_count(count: @backlog.agenda_items.count)
         end

--- a/modules/meeting/app/components/meeting_sections/backlogs/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/header_component.rb
@@ -55,14 +55,6 @@ module MeetingSections
       @current_meeting.in_progress?
     end
 
-    def title
-      if @meeting.recurring?
-        I18n.t(:label_series_backlog)
-      else
-        I18n.t(:label_agenda_backlog)
-      end
-    end
-
     def description
       if @meeting.recurring?
         I18n.t(:text_series_backlog)

--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -78,8 +78,9 @@ class Meeting::AddToSection < ApplicationForm
   end
 
   def option_title(item)
-    return I18n.t("meeting_section.untitled_title") if item.title.blank?
+    # Keep order (Bug #67381)
     return I18n.t("label_series_backlog") if item.backlog? && meeting.recurring?
+    return I18n.t("meeting_section.untitled_title") if item.title.blank? && !item.backlog?
 
     item.title
   end

--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -78,8 +78,6 @@ class Meeting::AddToSection < ApplicationForm
   end
 
   def option_title(item)
-    # Keep order (Bug #67381)
-    return I18n.t("label_series_backlog") if item.backlog? && meeting.recurring?
     return I18n.t("meeting_section.untitled_title") if item.title.blank? && !item.backlog?
 
     item.title

--- a/modules/meeting/app/models/meeting_section.rb
+++ b/modules/meeting/app/models/meeting_section.rb
@@ -42,6 +42,12 @@ class MeetingSection < ApplicationRecord
 
   scope :backlog, -> { where(backlog: true) }
 
+  def title
+    return super unless backlog?
+
+    meeting.recurring? ? I18n.t(:label_series_backlog) : I18n.t(:label_agenda_backlog)
+  end
+
   def untitled?
     title.blank?
   end

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -514,9 +514,27 @@ RSpec.describe "Open the Meetings tab",
             check_section_auto_selection(meeting_with_sections, "Agenda backlog")
           end
 
-          it "automatically selects the last section for recurring meeting occurrences" do
+          it "automatically selects the last section for recurring meeting occurrences that is not the series backlog" do
             last_section = recurring_meeting_occurrence.sections.last.title
             check_section_auto_selection(recurring_meeting_occurrence, last_section)
+          end
+
+          it "always has the series backlog as a manually selectable option" do
+            work_package_page.visit!
+            switch_to_meetings_tab
+
+            meetings_tab.open_add_to_meeting_dialog
+
+            fill_in("meeting_agenda_item_meeting_id", with: recurring_meeting_occurrence.title)
+            page.find(".ng-option-marked", text: recurring_meeting_occurrence.title)
+            page.find(".ng-option-marked").click
+
+            wait_for_network_idle
+
+            section_field = find_field("meeting_agenda_item_meeting_section_id")
+            section_field.click
+
+            expect(page).to have_css(".ng-option", text: "Series backlog")
           end
 
           it "shows no preselection when no sections exist for recurring meeting occurrences" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67381

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
The bug was caused because meetings created via the `Meetings::CreateService` have their backlog titled 'Agenda backlog', but those created via the initial migration are blank. Instead on depending on one or the other, the title is now determined at the model level when the section is a backlog and used directly

 This also keeps that logic in one place only and removes potential duplication from the backlog header component

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
