### PR TITLE
Better OpenTelemetry logging

### DIFF
--- a/config/initializers/grape_logging.rb
+++ b/config/initializers/grape_logging.rb
@@ -31,12 +31,17 @@
 Rails.application.configure do
   config.after_initialize do
     ActiveSupport::Notifications.subscribe("openproject_grape_logger") do |_, _, _, _, payload|
-      time = payload[:time]
+      # Have attributes somewhat in the same order as lograge does with
+      # processed controller action to ease later grok parsing.
+      # See `Lograge::LogSubscribers::ActionController#initial_data`
       attributes = {
-        duration: time[:total],
-        db: time[:db],
-        view: time[:view]
-      }.merge(payload.except(:time))
+        method: payload[:method],
+        path: payload[:path],
+        duration: payload[:time][:total],
+        db: payload[:time][:db],
+        view: payload[:time][:view],
+        **payload.except(:method, :path, :time)
+      }
 
       extended = OpenProject::Logging.extend_payload!(attributes, {})
       Rails.logger.info OpenProject::Logging.formatter.call(extended)

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -40,7 +40,8 @@ module API
 
     insert_before Grape::Middleware::Error,
                   ::GrapeLogging::Middleware::RequestLogger,
-                  { instrumentation_key: "openproject_grape_logger" }
+                  { instrumentation_key: "openproject_grape_logger",
+                    include: [API::Utilities::Loggers::EndpointName.new] }
 
     content_type :json, "application/json; charset=utf-8"
 

--- a/lib/api/utilities/loggers/endpoint_name.rb
+++ b/lib/api/utilities/loggers/endpoint_name.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module Utilities
+    module Loggers
+      class EndpointName < GrapeLogging::Loggers::Base
+        def parameters(request, _response)
+          name = endpoint_name(request.env["api.endpoint"])
+          name ? { endpoint_name: name } : {}
+        end
+
+        private
+
+        def endpoint_name(endpoint)
+          endpoint&.options && endpoint.options[:for].to_s
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our grok pattern is something like this in SigNoz:
`...%{SPACE}\[%{DATA:namespace}\]%{SPACE}method=%{WORD:http_method}...`

The parsing works for logs generated by lograge which look like this:

```
I, [2025-09-22T13:31:21.045328 https://github.com/opf/openproject/pull/47]  INFO -- :
[51a28da6-d112-45d9-b5fd-ba2f2c86fbba] [trace_id=2f2ce94953e0b1188c47eabfdd4d5b08]
[span_id=1aa8769d2ed98fc6] [public] method=GET path=/health_checks/default format=*/*
controller=OkComputer::OkComputerController action=show status=200 allocations=860
duration=2.47 view=0.15 db=0.00 user=3 domain= namespace=public shard=
```

But fails to parse for logs generated by grape logging, which look like this:
```
I, [2025-09-22T12:15:22.139783 https://github.com/opf/openproject/pull/55]  INFO -- :
[6878233d-b216-4f6e-a039-6f67f2c99684] [trace_id=af9a3f2a8d129f5603522c9a9e0e7599]
[span_id=1f43864c812ab072] [instance_1450094160_7477212_4176] duration=8384.68 db=1008.17
view=7376.51 status=200 method=GET path=/api/v3/queries/3687 params={\"pageSize\" => \"100\"}
host=qa.openproject-edge.com request_id=6878233d-b216-4f6e-a039-6f67f2c99684 user=344
domain=qa.openproject-edge.com namespace=instance_1450094160_7477212_4176 shard=
```

The parsing fails because `duration` is the field after `namespace`, and our pattern expects `method` instead.

This PR reorders the fields in the grape logging logs so that `method` and `path` appear first, as in lograge logs for controller actions.

It also adds the API endpoint class name to the grape logs, which should make it easier to find related code when needed.