### PR TITLE
[67470] Project overview click zone doesn't react to clicking + displays wrong cursor type

### DIFF
--- a/frontend/src/global_styles/content/_grid.sass
+++ b/frontend/src/global_styles/content/_grid.sass
@@ -137,8 +137,14 @@ $grid--widget-padding: 20px 20px 20px 20px
     background: linear-gradient(to bottom, rgba(var(--body-background), 0) 60%, rgba(var(--body-background), 1))
 
 .grid--widget-add
+  display: flex
+  height: 100%
+  width: 100%
+  justify-content: center
+  align-items: center
   padding: 15px
   color: var(--fgColor-muted)
+  cursor: pointer
 
   &.-gap
     opacity: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67470

# What are you trying to accomplish?
Increase clickable area of "add zones" on overview page

