### PR TITLE
[67530] Icons are misaligned on WP list baseline view

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.html
@@ -65,6 +65,7 @@
         }
         @if (baselineIncompatible) {
           <span
+            class="generic-table--sort-header--error-indicator"
             [attr.title]="text.baselineIncompatible"
             >
             <svg alert-icon size="small"></svg>

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -323,6 +323,9 @@ thead.-sticky th
   &_centered
     justify-content: center
 
+  &--error-indicator
+    margin-left: var(--base-size-8)
+
   & > a
     flex: 1 1
     width: 100%

--- a/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
@@ -30,6 +30,9 @@
   &--column-cell
     padding-right: 0
 
+    i
+      display: flex
+
   &--icon-added
     color: #5F42E0
     fill: #5F42E0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67530

# What are you trying to accomplish?
Align icon in baseline column

## Screenshots

<img width="276" height="65" alt="Bildschirmfoto 2025-09-23 um 09 22 19" src="https://github.com/user-attachments/assets/c098a53a-b6d6-4301-bf52-fdb1ab8fa826" />
<img width="203" height="88" alt="Bildschirmfoto 2025-09-23 um 09 28 21" src="https://github.com/user-attachments/assets/8fc0ebf5-e475-45ac-8a96-fca759aa9ec4" />
