### PR TITLE
Introduce DSL to build item groups

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -72,31 +72,30 @@ module Admin
         end
 
         def menu_items(menu) # rubocop:disable Metrics/AbcSize
-          edit_action_item(menu)
-          menu.with_divider
-          add_above_action_item(menu)
-          add_below_action_item(menu)
-          add_sub_item_action_item(menu)
+          with_item_group(menu) { edit_action_item(menu) }
+
+          with_item_group(menu) do
+            add_above_action_item(menu)
+            add_below_action_item(menu)
+            add_sub_item_action_item(menu)
+          end
 
           if OpenProject::FeatureDecisions.change_hierarchy_item_parent_active?
-            menu.with_divider
-            change_parent_item(menu)
+            with_item_group(menu) { change_parent_item(menu) }
           end
 
-          unless first_item? && last_item?
-            menu.with_divider
-          end
-          unless first_item?
-            move_to_top_action_item(menu)
-            move_up_action_item(menu)
-          end
-          unless last_item?
-            move_down_action_item(menu)
-            move_to_bottom_action_item(menu)
+          with_item_group(menu) do
+            unless first_item?
+              move_to_top_action_item(menu)
+              move_up_action_item(menu)
+            end
+            unless last_item?
+              move_down_action_item(menu)
+              move_to_bottom_action_item(menu)
+            end
           end
 
-          menu.with_divider
-          deletion_action_item(menu)
+          with_item_group(menu) { deletion_action_item(menu) }
         end
 
         private

--- a/app/components/op_primer/component_helpers.rb
+++ b/app/components/op_primer/component_helpers.rb
@@ -61,5 +61,32 @@ module OpPrimer
         render(row, &)
       end
     end
+
+    # Intended to help in building action menus with different sections, separated by dividers. Wrap all items that
+    # should go into the same section into a with_item_group block. Dividers are only rendered if needed (no empty sections).
+    #
+    # @example
+    #   def render_action_menu(menu)
+    #     with_item_group { menu.with_item(label: "Item alone in section") }
+    #     with_item_group do
+    #       menu.with_item(label: "hidden section") if false
+    #     end
+    #     with_item_group do
+    #       menu.with_item(label: "first in section")
+    #       menu.with_item(label: "last in section")
+    #     end
+    #   end
+    def with_item_group(menu)
+      pending_divider = menu.items.any? && menu.items.last[:type] != :divider
+      if pending_divider
+        menu.with_divider
+      end
+
+      size_before = menu.items.size
+      yield
+
+      # undo insertion of divider, if no items were added in this section
+      menu.items.pop if menu.items.size == size_before
+    end
   end
 end

--- a/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
@@ -30,6 +30,7 @@
 
 module Redmine::MenuManager::TopMenu::QuickAddMenu
   include OpenProject::StaticRouting::UrlHelpers
+  include OpPrimer::ComponentHelpers
 
   def render_quick_add_menu
     return unless show_quick_add_menu?
@@ -52,11 +53,8 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
         render(Primer::Beta::Octicon.new(icon: "triangle-down", aria: { label: I18n.t("menus.quick_add.label") }))
       end
 
-      add_first_level_items(menu)
-      if first_level_menu_items_for(:quick_add_menu, @project).present? && work_package_quick_add_items.present?
-        menu.with_divider
-      end
-      add_second_level_items(menu)
+      with_item_group(menu) { add_first_level_items(menu) }
+      with_item_group(menu) { add_second_level_items(menu) }
     end
   end
 

--- a/modules/costs/app/components/my/time_tracking/time_entry_row.rb
+++ b/modules/costs/app/components/my/time_tracking/time_entry_row.rb
@@ -45,16 +45,15 @@ module My
         render(Primer::Alpha::ActionMenu.new) do |menu|
           menu.with_show_button(icon: "kebab-horizontal", "aria-label": t("label_more"), scheme: :invisible)
 
-          if time_entry.ongoing?
-            stop_timer_action_button(menu)
-          else
-            edit_action_button(menu)
+          with_item_group(menu) do
+            if time_entry.ongoing?
+              stop_timer_action_button(menu)
+            else
+              edit_action_button(menu)
+            end
           end
 
-          if can_delete_time_entry?
-            menu.with_divider
-            delete_action_button(menu)
-          end
+          with_item_group(menu) { delete_action_button(menu) } if can_delete_time_entry?
         end
       end
 

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -65,33 +65,25 @@
             test_selector: "op-meeting-agenda-actions"
           )
 
-          edit_action_item(menu)
-          if !in_backlog?
-            copy_action_item(menu)
+          with_item_group(menu) do
+            edit_action_item(menu)
+            copy_action_item(menu) unless in_backlog?
           end
 
-          menu.with_divider if note_or_outcome_action_added? && editable?
-
-          add_note_action_item(menu) if add_note_action?
-          add_outcome_action_item(menu) if add_outcome_action?
-
-          unless first? && last?
-            menu.with_divider if editable?
-            move_actions(menu)
+          with_item_group(menu) do
+            add_note_action_item(menu) if add_note_action?
+            add_outcome_action_item(menu) if add_outcome_action?
           end
 
-          menu.with_divider if move_to_different_section_or_meeting_action_added?
+          with_item_group(menu) { move_actions(menu) } unless first? && last?
 
-          if !in_template? || in_backlog?
+          with_item_group(menu) do
             move_to_current_meeting_action_item(menu) if in_backlog?
-            move_to_backlog_action_item(menu) if !in_backlog?
-          end
-          if move_to_next_meeting_enabled?
-            move_to_next_meeting_action_item(menu)
+            move_to_backlog_action_item(menu) if !in_template? && !in_backlog?
+            move_to_next_meeting_action_item(menu) if move_to_next_meeting_enabled?
           end
 
-          menu.with_divider if editable?
-          delete_action_item(menu)
+          with_item_group(menu) { delete_action_item(menu) }
         end
       end
 

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -247,16 +247,6 @@ module MeetingAgendaItems
       @meeting.templated?
     end
 
-    def note_or_outcome_action_added?
-      (@meeting_agenda_item.editable? && @meeting_agenda_item.notes.blank?) || add_outcome_action?
-    end
-
-    def move_to_different_section_or_meeting_action_added?
-      return false unless editable?
-
-      !in_template? || in_backlog? || move_to_next_meeting_enabled?
-    end
-
     def editable?
       @editable ||= @meeting_agenda_item.editable? && can_manage_agendas?
     end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/show_notes_component.html.erb
@@ -22,10 +22,14 @@
               ml: 2,
               test_selector: "op-meeting-outcome-actions"
             )
-            edit_action_item(menu)
-            copy_action_item(menu)
-            menu.with_divider if edit_enabled?
-            delete_action_item(menu)
+            with_item_group(menu) do
+              edit_action_item(menu)
+              copy_action_item(menu)
+            end
+
+            with_item_group(menu) do
+              delete_action_item(menu)
+            end
           end
         end
       end

--- a/modules/meeting/app/components/meeting_sections/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/header_component.html.erb
@@ -26,16 +26,16 @@
           if editable?
             render(Primer::Alpha::ActionMenu.new(data: { test_selector: "meeting-section-action-menu" })) do |menu|
               menu.with_show_button(icon: "kebab-horizontal", "aria-label": t("settings.project_attributes.label_section_actions"), scheme: :invisible)
-              edit_action_item(menu)
-              menu.with_divider
-              add_agenda_item_action(menu)
-              add_work_package_action(menu)
-              unless first? && last?
-                menu.with_divider
-                move_actions(menu)
+
+              with_item_group(menu) { edit_action_item(menu) }
+
+              with_item_group(menu) do
+                add_agenda_item_action(menu)
+                add_work_package_action(menu)
               end
-              menu.with_divider
-              delete_action_item(menu)
+
+              with_item_group(menu) { move_actions(menu) } unless first? && last?
+              with_item_group(menu) { delete_action_item(menu) }
             end
           end
         end


### PR DESCRIPTION
Existing code around menu handling is sometimes hard to read, because the divider is rendered based on conditions surrounding the elements before or after it.
    
The new helper ensures that divided groups are reasonably visible in code, while taking away the need to special-case conditionals.

# Ticket
* https://community.openproject.org/wp/67513

# Checklist

* [x] proof-of-concept on one action menu
* [x] ask for feedback
* [ ] convert further action menus ([good example here](https://github.com/opf/openproject/blob/fa650bc05bc76ce4fc169ff4dd400e0cf77b0359/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb#L60-L94))