### PR TITLE
Link sessions and autologin tokens

### DIFF
--- a/app/components/users/sessions/row_component.rb
+++ b/app/components/users/sessions/row_component.rb
@@ -69,7 +69,7 @@ module Users
           expires = record.expires_on || (record.created_at + Setting.autologin.days)
           render(OpPrimer::RelativeTimeComponent.new(datetime: user_time_zone(expires), prefix: I18n.t(:label_on)))
         else
-          I18n.t("users.sessions.unknown")
+          I18n.t("users.sessions.browser_session")
         end
       end
 

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -82,14 +82,11 @@ module Accounts::CurrentUser
     return unless Setting::Autologin.enabled?
 
     autologin_cookie_name = OpenProject::Configuration["autologin_cookie_name"]
-    autologin_token = cookies[autologin_cookie_name]
-    return unless autologin_token
-
-    user = User.try_to_autologin(autologin_token)
-
-    if user
-      login_user(user)
-      user
+    token = Token::AutoLogin.find_valid_token cookies[autologin_cookie_name]
+    if token.present?
+      session[:autologin_token_id] = token.id
+      login_user(token.user)
+      token.user
     else
       cookies.delete(autologin_cookie_name)
       nil

--- a/app/controllers/my/auto_login_tokens_controller.rb
+++ b/app/controllers/my/auto_login_tokens_controller.rb
@@ -41,6 +41,11 @@ module My
     def destroy
       @token.destroy
 
+      # Destroy all linked sessions to it
+      linked_sessions = Sessions::AutologinSessionLink.where(token_id: @token.id)
+      Sessions::UserSession.where(id: linked_sessions.select(:session_id)).delete_all
+      linked_sessions.delete_all
+
       flash[:notice] = I18n.t(:notice_successful_delete)
       redirect_to my_sessions_path
     end

--- a/app/controllers/my/auto_login_tokens_controller.rb
+++ b/app/controllers/my/auto_login_tokens_controller.rb
@@ -41,11 +41,6 @@ module My
     def destroy
       @token.destroy
 
-      # Destroy all linked sessions to it
-      linked_sessions = Sessions::AutologinSessionLink.where(token_id: @token.id)
-      Sessions::UserSession.where(id: linked_sessions.select(:session_id)).delete_all
-      linked_sessions.delete_all
-
       flash[:notice] = I18n.t(:notice_successful_delete)
       redirect_to my_sessions_path
     end

--- a/app/controllers/my/sessions_controller.rb
+++ b/app/controllers/my/sessions_controller.rb
@@ -50,8 +50,8 @@ module My
 
       @unmapped_sessions = ::Sessions::UserSession
         .for_user(current_user)
+        .not_autologged
         .order(updated_at: :desc)
-        .where.not(id: ::Sessions::AutologinSessionLink.where(token_id: @autologin_tokens.select(:id)).select(:session_id))
 
       token = cookies[OpenProject::Configuration["autologin_cookie_name"]]
       if token

--- a/app/controllers/my/sessions_controller.rb
+++ b/app/controllers/my/sessions_controller.rb
@@ -44,13 +44,14 @@ module My
     menu_item :sessions
 
     def index
-      @sessions = ::Sessions::UserSession
-        .for_user(current_user)
-        .order(updated_at: :desc)
-
       @autologin_tokens = ::Token::AutoLogin
         .for_user(current_user)
         .order(expires_on: :asc)
+
+      @unmapped_sessions = ::Sessions::UserSession
+        .for_user(current_user)
+        .order(updated_at: :desc)
+        .where.not(id: ::Sessions::AutologinSessionLink.where(token_id: @autologin_tokens.select(:id)).select(:session_id))
 
       token = cookies[OpenProject::Configuration["autologin_cookie_name"]]
       if token

--- a/app/models/sessions/autologin_session_link.rb
+++ b/app/models/sessions/autologin_session_link.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Sessions
+  class AutologinSessionLink < ApplicationRecord
+    belongs_to :token, class_name: "Token::AutoLogin"
+    belongs_to :session, class_name: "Sessions::UserSession"
+  end
+end

--- a/app/models/sessions/autologin_session_link.rb
+++ b/app/models/sessions/autologin_session_link.rb
@@ -32,5 +32,17 @@ module Sessions
   class AutologinSessionLink < ApplicationRecord
     belongs_to :token, class_name: "Token::AutoLogin"
     belongs_to :session, class_name: "Sessions::UserSession"
+
+    before_destroy :delete_sessions
+
+    private
+
+    ##
+    # When the session link is destroyed (because the autologin token got destroyed),
+    # linked sessions should be destroyed. As the sessions table is unlogged for performance reasons,
+    # we cannot use a foreign key on_delete constraint but have to do it manually here.
+    def delete_sessions
+      Sessions::UserSession.where(id: session_id).delete_all
+    end
   end
 end

--- a/app/models/sessions/user_session.rb
+++ b/app/models/sessions/user_session.rb
@@ -47,6 +47,14 @@ module Sessions
       where(user_id: nil)
     end
 
+    scope :autologged, -> do
+      where(id: ::Sessions::AutologinSessionLink.select(:session_id))
+    end
+
+    scope :not_autologged, -> do
+      where.not(id: ::Sessions::AutologinSessionLink.select(:session_id))
+    end
+
     ##
     # Mark all records as readonly so they cannot
     # modify the database

--- a/app/models/token/auto_login.rb
+++ b/app/models/token/auto_login.rb
@@ -32,8 +32,11 @@ module Token
   class AutoLogin < HashedToken
     include ExpirableToken
 
-    has_many :autologin_session_links, class_name: "Sessions::AutologinSessionLink", foreign_key: "token_id",
-                                       dependent: :delete_all
+    has_many :autologin_session_links,
+             class_name: "Sessions::AutologinSessionLink",
+             foreign_key: "token_id",
+             dependent: :destroy,
+             inverse_of: :token
 
     ##
     # Set validity time for autologin tokens

--- a/app/models/token/auto_login.rb
+++ b/app/models/token/auto_login.rb
@@ -30,6 +30,35 @@
 
 module Token
   class AutoLogin < HashedToken
+    include ExpirableToken
+
+    has_many :autologin_session_links, class_name: "Sessions::AutologinSessionLink", foreign_key: "token_id",
+                                       dependent: :delete_all
+
+    ##
+    # Set validity time for autologin tokens
+    def self.validity_time
+      Setting.autologin.days
+    end
+
+    ##
+    # Find a valid autologin token from the given value.
+    # Validates the token by checking its expiration date and the user status.
+    #
+    # @param key [String] The plaintext token value
+    # @return [Token::AutoLogin, nil] The valid token or nil if not
+    def self.find_valid_token(key)
+      return if key.blank?
+
+      token = find_by_plaintext_value(key)
+
+      return if token.nil?
+      return if token.expired?
+      return unless token.user&.active?
+
+      token
+    end
+
     protected
 
     ##

--- a/app/models/token/base.rb
+++ b/app/models/token/base.rb
@@ -51,8 +51,8 @@ module Token
     self.table_name = "tokens"
     serialize :data, coder: ::Serializers::IndifferentHashSerializer
 
-    # Hashed tokens belong to a user and are unique per type
-    belongs_to :user
+    # Tokens belong to a user and are unique per type
+    belongs_to :user, optional: false
 
     # Create a plain and hashed value when creating a new token
     after_initialize :initialize_values

--- a/app/models/token/expirable_token.rb
+++ b/app/models/token/expirable_token.rb
@@ -57,6 +57,8 @@ module Token
       # Remove outdated token
       after_save :delete_expired_tokens
 
+      delegate :validity_time, to: :class
+
       def valid_plaintext?(input)
         return false if expired?
 
@@ -64,22 +66,18 @@ module Token
       end
 
       def expired?
-        expires_on.nil? || Time.now > expires_on
-      end
-
-      def validity_time
-        self.class.validity_time
+        expires_on.nil? || expires_on.past?
       end
 
       ##
       # Set the expiration column
       def set_expiration_time
-        self.expires_on = Time.now + validity_time
+        self.expires_on = validity_time.from_now
       end
 
       # Delete all expired tokens
       def delete_expired_tokens
-        self.class.where(["expires_on < ?", Time.now]).delete_all
+        self.class.expired.delete_all
       end
     end
 
@@ -87,7 +85,13 @@ module Token
       ##
       # Return a scope of active tokens
       def not_expired
-        where(["expires_on > ?", Time.now])
+        where(expires_on: Time.current..)
+      end
+
+      ##
+      # Return a scope of active tokens
+      def expired
+        where(expires_on: ...Time.current)
       end
     end
   end

--- a/app/models/token/hashed_token.rb
+++ b/app/models/token/hashed_token.rb
@@ -91,7 +91,7 @@ module Token
     private
 
     def initialize_values
-      if new_record? && !value.present?
+      if new_record? && value.blank?
         @plain_value = self.class.generate_token_value
         self.value = hash_function(@plain_value)
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -275,15 +275,6 @@ class User < Principal
     user
   end
 
-  # Returns the user who matches the given autologin +key+ or nil
-  def self.try_to_autologin(key)
-    token = Token::AutoLogin.find_by_plaintext_value(key) # rubocop:disable Rails/DynamicFindBy
-    # Make sure there's only 1 token that matches the key
-    if token && (token.created_at > Setting.autologin.to_i.day.ago) && token.user&.active?
-      token.user
-    end
-  end
-
   # Columns required for formatting the user's name.
   def self.columns_for_name(formatter = nil)
     case formatter || Setting.user_format

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -63,7 +63,7 @@ module Users
       return unless Setting::Autologin.enabled?
 
       # generate a key and set cookie if autologin
-      token = Token::AutoLogin.create(user:, data: token_session_information)
+      token = Token::AutoLogin.create!(user:, data: token_session_information)
       cookie_options = {
         value: token.plain_value,
         # The autologin expiry is checked on validating the token
@@ -81,7 +81,7 @@ module Users
 
     def assign_autologin_session(token_id)
       session_id = ::Sessions::UserSession.where(session_id: session.id.private_id).pick(:id)
-      ::Sessions::AutologinSessionLink.create(token_id:, session_id:)
+      ::Sessions::AutologinSessionLink.create!(token_id:, session_id:)
     end
 
     def successful_login

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -136,7 +136,11 @@ module Users
     end
 
     def retained_session_values
-      controller.session.to_h.slice *(default_retained_keys + omniauth_provider_keys)
+      controller
+        .session
+        .to_h
+        .with_indifferent_access
+        .slice *(default_retained_keys + omniauth_provider_keys)
     end
 
     def omniauth_provider_keys

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -44,12 +44,14 @@ module Users
 
     def call!
       autologin_requested = session.delete(:autologin_requested)
+      autologin_token_id = session.delete(:autologin_token_id)
       retain_session_values do
         reset_session!
 
         User.current = user
 
         set_autologin_cookie if autologin_requested
+        assign_autologin_session(autologin_token_id) if autologin_token_id.present?
       end
 
       successful_login
@@ -61,18 +63,25 @@ module Users
       return unless Setting::Autologin.enabled?
 
       # generate a key and set cookie if autologin
-      expires_on =  Setting.autologin.days.from_now.beginning_of_day
-      token = Token::AutoLogin.create(user:, data: session_identification, expires_on:)
+      token = Token::AutoLogin.create(user:, data: token_session_information)
       cookie_options = {
         value: token.plain_value,
         # The autologin expiry is checked on validating the token
         # but still expire the cookie to avoid unnecessary retries
-        expires: expires_on,
+        expires: token.expires_on,
         path: OpenProject::Configuration["autologin_cookie_path"],
         secure: OpenProject::Configuration.https?,
         httponly: true
       }
       cookies[OpenProject::Configuration["autologin_cookie_name"]] = cookie_options
+
+      # Tie the current session to this autologin token already
+      assign_autologin_session(token.id)
+    end
+
+    def assign_autologin_session(token_id)
+      session_id = ::Sessions::UserSession.where(session_id: session.id.private_id).pick(:id)
+      ::Sessions::AutologinSessionLink.create(token_id:, session_id:)
     end
 
     def successful_login
@@ -122,6 +131,10 @@ module Users
       }
     end
 
+    def token_session_information
+      session_identification.merge(session_id: session.id)
+    end
+
     def retained_session_values
       controller.session.to_h.slice *(default_retained_keys + omniauth_provider_keys)
     end
@@ -137,7 +150,7 @@ module Users
     end
 
     def default_retained_keys
-      %w[omniauth_provider user_from_auth_header]
+      %w[omniauth_provider user_from_auth_header autologin_token_id]
     end
 
     ##

--- a/app/views/my/sessions/index.html.erb
+++ b/app/views/my/sessions/index.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <%= render ::Users::Sessions::TableComponent.new(
-      rows: @autologin_tokens + @unmapped_sessions,
+      rows: @unmapped_sessions + @autologin_tokens,
       current_session: session,
       current_token: @current_token
     ) %>

--- a/app/views/my/sessions/index.html.erb
+++ b/app/views/my/sessions/index.html.erb
@@ -39,16 +39,8 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<%# Collect a “fingerprint” of each token: user_id + platform + browser %>
-<% token_fingerprints = @autologin_tokens.map { |t| [t.user_id, t.data["platform"], t.data["browser"]] } %>
-
-<%# Reject sessions that match any token fingerprint %>
-<% rows = @sessions.reject do |s|
-     token_fingerprints.include?([s.user_id, s.data["platform"], s.data["browser"]])
-   end + @autologin_tokens %>
-
 <%= render ::Users::Sessions::TableComponent.new(
-      rows: rows,
+      rows: @autologin_tokens + @unmapped_sessions,
       current_session: session,
       current_token: @current_token
     ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,6 +674,7 @@ en:
       unknown_browser: "unknown browser"
       unknown_os: "unknown operating system"
       unknown: "(unknown)"
+      browser_session: "(Browser session)"
       current: "Current (this device)"
       title: "Session management"
       instructions: "You are logged in to your account through the following devices. Revoke sessions that you do not recognise or from devices you do not control."

--- a/db/migrate/20250923142124_add_autologin_session_link.rb
+++ b/db/migrate/20250923142124_add_autologin_session_link.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAutologinSessionLink < ActiveRecord::Migration[8.0]
+  def change
+    create_table :autologin_session_links do |t|
+      t.belongs_to :token, null: false, index: true, foreign_key: { on_delete: :cascade }
+      t.belongs_to :session, index: true, null: false # cascade deletion not possible for unlogged sessions table
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/features/my/sessions_management_spec.rb
+++ b/spec/features/my/sessions_management_spec.rb
@@ -32,6 +32,7 @@ require "spec_helper"
 
 RSpec.describe "My account session management", :js, :selenium do
   include Redmine::I18n
+
   let(:user) { create(:user) }
 
   let(:old_session_time) { 5.days.ago }
@@ -50,6 +51,20 @@ RSpec.describe "My account session management", :js, :selenium do
            expires_on: 4.days.from_now)
   end
 
+  let!(:linked_sql_session) do
+    create(:user_session,
+           user:,
+           data: { browser: "Firefox", browser_version: "142", platform: "macOS", updated_at: 2.days.ago })
+  end
+
+  let!(:linked_session) do
+    Sessions::UserSession.find_by(session_id: linked_sql_session.session_id)
+  end
+
+  let!(:autologin_session_link) do
+    Sessions::AutologinSessionLink.create(token: autologin_token, session: linked_session)
+  end
+
   before do
     login_as(user)
     Sessions::UserSession.where(id: user_session.id).update_all(updated_at: 5.days.ago)
@@ -59,7 +74,7 @@ RSpec.describe "My account session management", :js, :selenium do
 
   it "can list and terminate sessions and remembered devices" do
     page.within_test_selector("Users::Sessions::TableComponent") do
-      # Current session + old session + remembered device
+      # Current session + old session + remembered device (linked session is aggregated with token)
       expect(page).to have_css(".session-row", count: 3)
 
       trs = page.all(".session-row")
@@ -70,13 +85,13 @@ RSpec.describe "My account session management", :js, :selenium do
       expect(trs[0]).to have_text("unknown operating system")
       expect(trs[0]).to have_no_test_selector("session-revoke-button")
 
-      # Old session
+      # Old session (unmapped session)
       expect(trs[1]).to have_text("Mozilla Firefox (Version 12.3)")
       expect(trs[1]).to have_text("Linux")
       expect(trs[1]).to have_text format_time(old_session_time)
       expect(trs[1]).to have_test_selector("session-revoke-button")
 
-      # Remembered device (token)
+      # Remembered device (token with aggregated linked session)
       expect(trs[2]).to have_text("Firefox (Version 142)")
       expect(trs[2]).to have_text("macOS")
       expect(trs[2]).to have_text(format_time(autologin_token.created_at))
@@ -92,7 +107,7 @@ RSpec.describe "My account session management", :js, :selenium do
 
     page.within_test_selector("Users::Sessions::TableComponent") do
       trs = page.all(".session-row")
-      # Revoke the remembered device
+      # Revoke the remembered device (this will also delete the linked session)
       within trs[1] do
         find_test_selector("session-revoke-button").click
       end
@@ -105,8 +120,9 @@ RSpec.describe "My account session management", :js, :selenium do
       expect(page).to have_css(".session-row", count: 1)
     end
 
-    # Both old session and token are gone
+    # Both old session, token, and linked session are gone
     expect { user_session.reload }.to raise_error(ActiveRecord::RecordNotFound)
     expect { autologin_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { linked_session.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 end

--- a/spec/models/token/auto_login_spec.rb
+++ b/spec/models/token/auto_login_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe Token::AutoLogin do
+  let(:user) { create(:user) }
+
+  before do
+    # Enable autologin for tests
+    allow(Setting).to receive(:autologin).and_return(30)
+  end
+
+  describe "inheritance and behavior" do
+    it "inherits from HashedToken" do
+      expect(described_class.superclass).to eq(Token::HashedToken)
+    end
+
+    it "includes ExpirableToken" do
+      expect(described_class.included_modules).to include(Token::ExpirableToken)
+    end
+
+    it "allows multiple values" do
+      token = described_class.new(user:)
+      expect(token.send(:single_value?)).to be false
+    end
+  end
+
+  describe "creation" do
+    it "creates a valid autologin token" do
+      token = described_class.create(user:)
+
+      expect(token).to be_valid
+      expect(token.user).to eq(user)
+      expect(token.value).to be_present
+      expect(token.plain_value).to be_present
+    end
+
+    it "generates a unique token value" do
+      token1 = described_class.create(user:)
+      token2 = described_class.create(user:)
+
+      expect(token1.value).not_to eq(token2.value)
+      expect(token1.plain_value).not_to eq(token2.plain_value)
+    end
+
+    it "sets expiration based on autologin setting" do
+      allow(Setting).to receive(:autologin).and_return(30)
+
+      token = described_class.create(user:)
+
+      expect(token.expires_on).to be_within(1.second).of(30.days.from_now)
+    end
+
+    it "can store browser and platform data" do
+      data = { browser: "Firefox", browser_version: "142", platform: "macOS" }
+      token = described_class.create(user:, data:)
+
+      expect(token.data[:browser]).to eq("Firefox")
+      expect(token.data[:browser_version]).to eq("142")
+      expect(token.data[:platform]).to eq("macOS")
+    end
+  end
+
+  describe "validation" do
+    it "requires a user" do
+      token = described_class.new
+
+      expect(token).not_to be_valid
+      expect(token.errors[:user]).to include("must exist")
+    end
+
+    it "validates token value uniqueness" do
+      token1 = described_class.create(user:)
+      token2 = described_class.new(user:, value: token1.value)
+
+      expect(token2).not_to be_valid
+      expect(token2.errors[:value]).to include("has already been taken.")
+    end
+  end
+
+  describe ".find_valid_token" do
+    let(:token) { described_class.create(user:) }
+
+    it "finds a valid token with correct plaintext value" do
+      found_token = described_class.find_valid_token(token.plain_value)
+      expect(found_token).to eq(token)
+    end
+
+    it "returns nil for blank key" do
+      expect(described_class.find_valid_token("")).to be_nil
+      expect(described_class.find_valid_token(nil)).to be_nil
+    end
+
+    it "returns nil for non-existent token" do
+      expect(described_class.find_valid_token("nonexistent")).to be_nil
+    end
+
+    it "returns nil for expired token" do
+      token.update!(expires_on: 1.day.ago)
+      expect(described_class.find_valid_token(token.plain_value)).to be_nil
+    end
+
+    it "returns nil for inactive user" do
+      user.update!(status: User.statuses[:locked])
+      expect(described_class.find_valid_token(token.plain_value)).to be_nil
+    end
+
+    it "returns nil for deleted user" do
+      # Create a new user and token for this test
+      test_user = create(:user)
+      test_token = described_class.create(user: test_user)
+
+      # Delete the token first, then the user
+      test_token.destroy
+      test_user.destroy
+
+      # The token should no longer exist
+      expect(described_class.find_valid_token(test_token.plain_value)).to be_nil
+    end
+  end
+
+  describe "expiration" do
+    it "is not expired when created" do
+      token = described_class.create(user:)
+      expect(token.expired?).to be false
+    end
+
+    it "is expired when expires_on is in the past" do
+      token = described_class.create(user:)
+      token.update!(expires_on: 1.day.ago)
+      expect(token.expired?).to be true
+    end
+
+    it "uses validity_time for expiration calculation" do
+      allow(described_class).to receive(:validity_time).and_return(7.days)
+      token = described_class.create(user:)
+
+      expect(token.expires_on).to be_within(1.second).of(7.days.from_now)
+    end
+  end
+
+  describe "associations" do
+    it "belongs to a user" do
+      token = described_class.create(user:)
+      expect(token.user).to eq(user)
+    end
+
+    it "can have multiple autologin session links" do
+      token = described_class.create(user:)
+
+      # Create SqlBypass sessions first
+      sql_session1 = create(:user_session, user:)
+      sql_session2 = create(:user_session, user:)
+
+      # Get the corresponding UserSession records
+      session1 = Sessions::UserSession.find_by(session_id: sql_session1.session_id)
+      session2 = Sessions::UserSession.find_by(session_id: sql_session2.session_id)
+
+      link1 = Sessions::AutologinSessionLink.create(token:, session: session1)
+      link2 = Sessions::AutologinSessionLink.create(token:, session: session2)
+
+      expect(token.autologin_session_links).to include(link1, link2)
+    end
+  end
+
+  describe "deletion behavior" do
+    it "deletes associated session links when token is destroyed" do
+      token = described_class.create(user:)
+
+      # Create SqlBypass session first
+      sql_session = create(:user_session, user:)
+
+      # Get the corresponding UserSession record
+      session = Sessions::UserSession.find_by(session_id: sql_session.session_id)
+      link = Sessions::AutologinSessionLink.create(token:, session:)
+
+      expect { token.destroy }.to change(Sessions::AutologinSessionLink, :count).by(-1)
+      expect { link.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/models/token/base_token_spec.rb
+++ b/spec/models/token/base_token_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Token::Base do
 
   it "create_should_remove_existing_tokenses" do
     subject.save!
-    t2 = Token::AutoLogin.create(user:)
+    t2 = described_class.create(user:)
     expect(subject.value).not_to eq(t2.value)
-    expect(Token::AutoLogin.exists?(subject.id)).to be false
-    expect(Token::AutoLogin.exists?(t2.id)).to be true
+    expect(described_class.exists?(subject.id)).to be false
+    expect(described_class.exists?(t2.id)).to be true
   end
 end

--- a/spec/requests/my/auto_login_tokens_spec.rb
+++ b/spec/requests/my/auto_login_tokens_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe "My::AutoLoginTokensController",
+               :skip_csrf,
+               type: :rails_request,
+               with_settings: { autologin: 7 } do
+  let(:user) { create(:user) }
+
+  before do
+    login_as(user)
+  end
+
+  describe "DELETE /my/auto_login_tokens/:id" do
+    let!(:autologin_token) do
+      create(:autologin_token,
+             user:,
+             data: { browser: "Firefox", browser_version: "142", platform: "macOS" })
+    end
+
+    let!(:linked_sql_session1) do
+      create(:user_session,
+             user:,
+             data: { browser: "Firefox", browser_version: "142", platform: "macOS" })
+    end
+
+    let!(:linked_sql_session2) do
+      create(:user_session,
+             user:,
+             data: { browser: "Firefox", browser_version: "142", platform: "macOS" })
+    end
+
+    let!(:unlinked_sql_session) do
+      create(:user_session,
+             user:,
+             data: { browser: "Chrome", browser_version: "120", platform: "Windows" })
+    end
+
+    let!(:linked_session1) do
+      Sessions::UserSession.find_by(session_id: linked_sql_session1.session_id)
+    end
+
+    let!(:linked_session2) do
+      Sessions::UserSession.find_by(session_id: linked_sql_session2.session_id)
+    end
+
+    let!(:unlinked_session) do
+      Sessions::UserSession.find_by(session_id: unlinked_sql_session.session_id)
+    end
+
+    let!(:autologin_session_link1) do
+      Sessions::AutologinSessionLink.create(token: autologin_token, session: linked_session1)
+    end
+
+    let!(:autologin_session_link2) do
+      Sessions::AutologinSessionLink.create(token: autologin_token, session: linked_session2)
+    end
+
+    let!(:other_token) { create(:autologin_token, user:) }
+    let!(:other_sql_session) { create(:user_session, user:) }
+    let!(:other_session) { Sessions::UserSession.find_by(session_id: other_sql_session.session_id) }
+    let!(:other_link) { Sessions::AutologinSessionLink.create(token: other_token, session: other_session) }
+
+    let!(:other_user) { create(:user) }
+    let!(:other_user_token) { create(:autologin_token, user: other_user) }
+
+    it "deletes the autologin token and all linked sessions" do
+      delete "/my/auto_login_tokens/#{autologin_token.id}"
+
+      # the subject token is deleted
+      expect { autologin_token.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      # linked sessions are deleted
+      expect { linked_session1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { linked_session2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      # session links are deleted
+      expect { autologin_session_link1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { autologin_session_link2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      # unlinked session remains
+      expect(unlinked_session.reload).to be_present
+
+      # other token and its linked session remain
+      expect(other_token.reload).to be_present
+      expect(other_session.reload).to be_present
+      expect(other_link.reload).to be_present
+    end
+
+    it "prevents deletion of tokens belonging to other users" do
+      expect do
+        delete "/my/auto_login_tokens/#{other_user_token.id}"
+      end.not_to change(Token::AutoLogin, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "handles non-existent token gracefully" do
+      expect do
+        delete "/my/auto_login_tokens/99999"
+      end.not_to change(Token::AutoLogin, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when token has no linked sessions" do
+      let!(:autologin_token_without_sessions) do
+        create(:autologin_token, user:)
+      end
+
+      it "deletes only the token" do
+        delete "/my/auto_login_tokens/#{autologin_token_without_sessions.id}"
+
+        expect { autologin_token_without_sessions.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+        expect { autologin_token.reload }.not_to raise_error
+        expect { linked_session1.reload }.not_to raise_error
+        expect { linked_session2.reload }.not_to raise_error
+
+        expect(response).to redirect_to(my_sessions_path)
+        expect(flash[:notice]).to eq(I18n.t(:notice_successful_delete))
+      end
+    end
+  end
+end

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -33,7 +33,8 @@ require "spec_helper"
 RSpec.describe Users::LoginService, type: :model do
   shared_let(:input_user) { create(:user) }
   let(:request) { {} }
-  let(:session) { {} }
+  let(:session) { ActionController::TestSession.new }
+  let!(:user_session) { create(:user_session, session_id: session.id.private_id) }
   let(:browser) do
     instance_double(Browser::Safari,
                     name: "Safari",
@@ -175,11 +176,12 @@ RSpec.describe Users::LoginService, type: :model do
         tokens = Token::AutoLogin.where(user: input_user)
         expect(tokens.count).to eq 1
         expect(tokens.first.user_id).to eq input_user.id
+        expect(tokens.first.expires_on).to be_within(1.minute).of(1.day.from_now)
 
         autologin_cookie = cookies[OpenProject::Configuration["autologin_cookie_name"]]
         expect(autologin_cookie).to be_present
         expect(autologin_cookie[:value]).to be_present
-        expect(autologin_cookie[:expires]).to eq (Time.zone.today + 1.day).beginning_of_day
+        expect(autologin_cookie[:expires]).to be_within(1.minute).of(1.day.from_now)
         expect(autologin_cookie[:path]).to eq "/"
         expect(autologin_cookie[:httponly]).to be true
         expect(autologin_cookie[:secure]).to eq Setting.https?

--- a/spec/services/users/logout_service_spec.rb
+++ b/spec/services/users/logout_service_spec.rb
@@ -105,11 +105,48 @@ RSpec.describe Users::LogoutService, type: :model do
         expect(Sessions::UserSession.for_user(user).count).to eq(2)
       end
 
-      describe "autologin cookie" do
+      describe "autologin cookie", with_settings: { autologin: 7 } do
         let!(:token) { create(:autologin_token, user:) }
+
+        let!(:linked_sql_session1) do
+          create(:user_session,
+                 user:,
+                 data: { browser: "Firefox", browser_version: "142", platform: "macOS" })
+        end
+
+        let!(:linked_sql_session2) do
+          create(:user_session,
+                 user:,
+                 data: { browser: "Firefox", browser_version: "142", platform: "macOS" })
+        end
+
+        let!(:other_linked_sql_session) do
+          create(:user_session,
+                 user:,
+                 data: { browser: "Firefox", browser_version: "142", platform: "macOS" })
+        end
+
+        let!(:linked_session1) do
+          Sessions::UserSession.find_by(session_id: linked_sql_session1.session_id)
+        end
+
+        let!(:linked_session2) do
+          Sessions::UserSession.find_by(session_id: linked_sql_session2.session_id)
+        end
+
+        let!(:other_session) do
+          Sessions::UserSession.find_by(session_id: other_linked_sql_session.session_id)
+        end
+
         let!(:other_token) { create(:autologin_token, user:) }
 
-        it "removes the matching autologin cookie and token" do
+        before do
+          Sessions::AutologinSessionLink.create(token:, session: linked_session1)
+          Sessions::AutologinSessionLink.create(token:, session: linked_session2)
+          Sessions::AutologinSessionLink.create(token: other_token, session: other_session)
+        end
+
+        it "removes only the matching autologin cookie and token, with associated sessions" do
           cookies[OpenProject::Configuration.autologin_cookie_name] = token.plain_value
 
           subject
@@ -117,6 +154,12 @@ RSpec.describe Users::LogoutService, type: :model do
           expect(cookies[OpenProject::Configuration.autologin_cookie_name]).to be_nil
           expect { token.reload }.to raise_error(ActiveRecord::RecordNotFound)
           expect(Token::AutoLogin.where(user_id: user.id).all).to contain_exactly other_token
+
+          expect { linked_session1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { linked_session2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+          expect { other_token.reload }.not_to raise_error
+          expect { other_session.reload }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
This PR implements an AutoLoginSessionLink model that links autologin tokens to user sessions, allowing for proper session management in the UI, as users expect to kill these sessions together, and not see duplicates.

Summary of changes:

- When logging in and requesting an autologin token, the newly created session is tied to this token through the `Sessions::AutologinSessionLink` model
- Whenever you restore a session through an existing autologin token, this session will also be linked.
- The My account > Session management has been updated to list only autologin tokens (their connected sessions are hidden), and sessions that are not mapped to an autologin token.
- Deleting an autologin token will also delete all connected sessions.

https://community.openproject.org/wp/65412

Replaces https://github.com/opf/openproject/pull/20401

