### PR TITLE
bug/67608 Switching work package tabs does not persist "Internal comments"-checkbox

### DIFF
--- a/app/forms/work_packages/activities_tab/journals/internal_note_form.rb
+++ b/app/forms/work_packages/activities_tab/journals/internal_note_form.rb
@@ -36,7 +36,7 @@ module WorkPackages::ActivitiesTab::Journals
         checked: false,
         data: {
           "work-packages--activities-tab--internal-comment-target": "internalCheckbox",
-          action: "input->work-packages--activities-tab--internal-comment#toggleInternal"
+          action: "input->work-packages--activities-tab--internal-comment#updateInternalState"
         }
       )
     end

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
@@ -167,7 +167,7 @@ export default class InternalCommentController extends BaseController {
     try {
       localStorage.setItem(this.storageKey, JSON.stringify(isChecked));
     } catch (error) {
-      console.warn('Failed to persist internal comment state:', error);
+      window.ErrorReporter.captureException(error as Error);
     }
   }
 
@@ -192,7 +192,7 @@ export default class InternalCommentController extends BaseController {
         localStorage.removeItem(this.storageKey);
       }
     } catch (error) {
-      console.warn('Failed to restore internal comment state:', error);
+      window.ErrorReporter.captureException(error as Error);
     }
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
@@ -59,6 +59,11 @@ export default class InternalCommentController extends BaseController {
     this.restoreInternalState();
   }
 
+  disconnect():void {
+    super.disconnect();
+    this.rescueInternalState();
+  }
+
   onSubmitEnd(_event:CustomEvent):void {
     if (this.hasInternalCheckboxTarget) {
       this.toggleInternal();
@@ -161,6 +166,12 @@ export default class InternalCommentController extends BaseController {
     }
   }
 
+  private rescueInternalState():void {
+    if (!this.hasInternalCheckboxTarget) return;
+
+    this.persistInternalState(this.internalCheckboxTarget.checked);
+  }
+
   private restoreInternalState():void {
     if (!this.hasInternalCheckboxTarget) return;
 
@@ -170,6 +181,10 @@ export default class InternalCommentController extends BaseController {
         const isChecked = JSON.parse(storedState) as boolean;
         this.internalCheckboxTarget.checked = isChecked;
         this.setInternalStateWithoutPersistence(isChecked);
+        // Remove the stored state after restoration to ensure the internal comment state
+        // is only persisted temporarily (e.g., across a single navigation or reload).
+        // This prevents stale state from being applied unintentionally in future sessions.
+        localStorage.removeItem(this.storageKey);
       }
     } catch (error) {
       console.warn('Failed to restore internal comment state:', error);

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
@@ -65,14 +65,19 @@ export default class InternalCommentController extends BaseController {
   }
 
   onSubmitEnd(_event:CustomEvent):void {
-    if (this.hasInternalCheckboxTarget) {
-      this.toggleInternal();
-    }
+    this.updateInternalState({ persist: false });
   }
 
-  toggleInternal():void {
+  updateInternalState({ persist = true } = {}):void {
+    if (!this.hasInternalCheckboxTarget) return;
+
     const isChecked = this.internalCheckboxTarget.checked;
-    this.setInternalStateWithPersistence(isChecked);
+
+    if (persist) {
+      this.setInternalStateWithPersistence(isChecked);
+    } else {
+      this.setInternalStateWithoutPersistence(isChecked);
+    }
 
     if (isChecked) {
       void this.sanitizeInternalMentions();

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/internal-comment.controller.ts
@@ -54,6 +54,11 @@ export default class InternalCommentController extends BaseController {
 
   declare isInternalValue:boolean;
 
+  connect():void {
+    super.connect();
+    this.restoreInternalState();
+  }
+
   onSubmitEnd(_event:CustomEvent):void {
     if (this.hasInternalCheckboxTarget) {
       this.toggleInternal();
@@ -62,7 +67,7 @@ export default class InternalCommentController extends BaseController {
 
   toggleInternal():void {
     const isChecked = this.internalCheckboxTarget.checked;
-    this.setInternalState(isChecked);
+    this.setInternalStateWithPersistence(isChecked);
 
     if (isChecked) {
       void this.sanitizeInternalMentions();
@@ -83,17 +88,16 @@ export default class InternalCommentController extends BaseController {
           this.editorOutlet.focusEditor();
         } else {
           this.internalCheckboxTarget.checked = true;
-          this.setInternalState(this.internalCheckboxTarget.checked);
+          this.setInternalStateWithPersistence(this.internalCheckboxTarget.checked);
           this.editorOutlet.focusEditor();
         }
       }
     }
   }
 
-  private setInternalState(isChecked:boolean):void {
-    this.formContainerTarget.classList.toggle(this.highlightClass, isChecked);
-    this.toggleLearnMoreLink(isChecked);
-    this.isInternalValue = isChecked;
+  private setInternalStateWithPersistence(isChecked:boolean):void {
+    this.setInternalStateWithoutPersistence(isChecked);
+    this.persistInternalState(isChecked);
   }
 
   private toggleLearnMoreLink(isChecked:boolean):void {
@@ -107,7 +111,7 @@ export default class InternalCommentController extends BaseController {
       const editorData = this.ckEditorInstance.getData({ trim: false });
       if (editorData.length === 0) return;
 
-      const sanitizePath = `/work_packages/${this.indexOutlet.workPackageIdValue}/activities/sanitize_internal_mentions`;
+      const sanitizePath = `/work_packages/${this.workPackageId}/activities/sanitize_internal_mentions`;
 
       try {
         const response = await fetch(sanitizePath, {
@@ -149,7 +153,44 @@ export default class InternalCommentController extends BaseController {
     });
   }
 
+  private persistInternalState(isChecked:boolean):void {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(isChecked));
+    } catch (error) {
+      console.warn('Failed to persist internal comment state:', error);
+    }
+  }
+
+  private restoreInternalState():void {
+    if (!this.hasInternalCheckboxTarget) return;
+
+    try {
+      const storedState = localStorage.getItem(this.storageKey);
+      if (storedState !== null) {
+        const isChecked = JSON.parse(storedState) as boolean;
+        this.internalCheckboxTarget.checked = isChecked;
+        this.setInternalStateWithoutPersistence(isChecked);
+      }
+    } catch (error) {
+      console.warn('Failed to restore internal comment state:', error);
+    }
+  }
+
+  private setInternalStateWithoutPersistence(isChecked:boolean):void {
+    this.formContainerTarget.classList.toggle(this.highlightClass, isChecked);
+    this.toggleLearnMoreLink(isChecked);
+    this.isInternalValue = isChecked;
+  }
+
   private get ckEditorInstance() {
     return this.editorOutlet.ckEditorInstance;
+  }
+
+  private get storageKey():string {
+    return `work-package-${this.workPackageId}-internal-comment-state`;
+  }
+
+  private get workPackageId():string {
+    return String(this.indexOutlet.workPackageIdValue);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/quote-comment.controller.ts
@@ -83,7 +83,7 @@ export default class QuoteCommentController extends Controller {
   private setCommentRestriction(isInternal:boolean) {
     if (isInternal && !this.workPackagesActivitiesTabInternalCommentOutlet.internalCheckboxTarget.checked) {
       this.workPackagesActivitiesTabInternalCommentOutlet.internalCheckboxTarget.checked = isInternal;
-      this.workPackagesActivitiesTabInternalCommentOutlet.toggleInternal();
+      this.workPackagesActivitiesTabInternalCommentOutlet.updateInternalState();
     }
   }
 

--- a/spec/features/activities/work_package/internal_comments_spec.rb
+++ b/spec/features/activities/work_package/internal_comments_spec.rb
@@ -317,6 +317,66 @@ RSpec.describe "Work package internal comments",
     end
   end
 
+  describe "internal comment checkbox state persistence" do
+    current_user { project_admin }
+
+    let(:second_work_package) { create(:work_package, project:, author: admin) }
+    let(:second_wp_page) { Pages::FullWorkPackage.new(second_work_package, project) }
+
+    before do
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+    end
+
+    it "persists checkbox state when switching between work package tabs" do
+      activity_tab.open_new_comment_editor
+      activity_tab.check_internal_comment_checkbox
+      activity_tab.expect_internal_comment_checked
+
+      wp_page.switch_to_tab tab: "relations"
+      wp_page.switch_to_tab tab: "activity"
+      wp_page.wait_for_activity_tab
+
+      activity_tab.open_new_comment_editor
+      activity_tab.expect_internal_comment_checked
+    end
+
+    it "isolates checkbox state between different work packages" do
+      activity_tab.open_new_comment_editor
+      activity_tab.check_internal_comment_checkbox
+      activity_tab.expect_internal_comment_checked
+
+      second_wp_page.visit!
+      second_wp_page.wait_for_activity_tab
+
+      second_wp_activity_tab = Components::WorkPackages::Activities.new(second_work_package)
+      second_wp_activity_tab.open_new_comment_editor
+      second_wp_activity_tab.expect_internal_comment_unchecked
+
+      wp_page.visit!
+      wp_page.wait_for_activity_tab
+
+      activity_tab.open_new_comment_editor
+      activity_tab.expect_internal_comment_checked
+    end
+
+    it "handles localStorage errors gracefully" do
+      page.execute_script(<<~JS)
+        localStorage.setItem = function() {
+          throw new Error('Storage quota exceeded');
+        };
+      JS
+
+      activity_tab.open_new_comment_editor
+      activity_tab.check_internal_comment_checkbox
+      activity_tab.expect_internal_comment_checked
+
+      page.execute_script(<<~JS)
+        localStorage.setItem = Storage.prototype.setItem;
+      JS
+    end
+  end
+
   describe "making internal comments public" do
     current_user { project_admin }
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/67608

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

When navigating to different tabs, retain the status of the internal comment checkbox. This prevents users from inadvertently submitting an intended internal comment as a public one.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/e225022d-63ab-4014-88ae-976548c34fb5


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->


Added `localStorage` persistence to maintain internal comment checkbox state when users switch between work package tabs. The state is isolated per work package to prevent interference between different work packages.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
