### PR TITLE
[67618] Icons are misaligned on WP and meeting attachments

### DIFF
--- a/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
+++ b/frontend/src/global_styles/content/work_packages/shared/_file_list.sass
@@ -91,6 +91,7 @@
         text-decoration: none
 
   & &--item &--item-floating-actions
+    display: flex
     padding-right: 0
 
   //& &--item &--item-floating-actions


### PR DESCRIPTION
https://community.openproject.org/wp/67618
