### PR TITLE
[#60585] PDF Gantt export potentially exports huge date ranges

### DIFF
--- a/app/models/exports/pdf/components/gantt/gantt_builder.rb
+++ b/app/models/exports/pdf/components/gantt/gantt_builder.rb
@@ -29,8 +29,11 @@
 #++
 
 module Exports::PDF::Components::Gantt
+  class InvalidDateRangeError < StandardError; end
+
   class GanttBuilder
     include Redmine::I18n
+
     BAR_CELL_PADDING = 5.to_f
     TEXT_CELL_PADDING_H = 3.to_f
     TEXT_CELL_PADDING_V = 1.to_f
@@ -39,6 +42,7 @@ module Exports::PDF::Components::Gantt
     DEFAULT_TEXT_COLUMN_DIVIDER = 4
     TEXT_COLUMN_MAX_WIDTH = 250.to_f
     LINE_STEP = 5.to_f
+    MAX_YEAR_RANGE = 10
 
     def initialize(pdf, title, column_width)
       @pdf = pdf
@@ -843,6 +847,11 @@ module Exports::PDF::Components::Gantt
     # @return [Array<Date>]
     def collect_column_dates(work_packages)
       wp_dates = collect_work_packages_dates(work_packages)
+      years = ((wp_dates.last - wp_dates.first) / 365).floor
+      if years > MAX_YEAR_RANGE
+        raise InvalidDateRangeError, I18n.t(:error_pdf_date_range_too_long, years: MAX_YEAR_RANGE)
+      end
+
       build_column_dates_range(wp_dates.first..wp_dates.last)
     end
 

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -87,6 +87,8 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
     success(file)
   rescue Prawn::Errors::CannotFit
     error(I18n.t(:error_pdf_export_too_many_columns))
+  rescue Exports::PDF::Components::Gantt::InvalidDateRangeError => e
+    error(e.message)
   rescue StandardError => e
     Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
     error(I18n.t(:error_pdf_failed_to_export, error: e.message))

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -83,8 +83,15 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
   end
 
   def export!
-    file = render_work_packages query.results.work_packages
-    success(file)
+    handle_export_errors do
+      success(render_work_packages(query.results.work_packages))
+    end
+  end
+
+  private
+
+  def handle_export_errors
+    yield
   rescue Prawn::Errors::CannotFit
     error(I18n.t(:error_pdf_export_too_many_columns))
   rescue Exports::PDF::Components::Gantt::InvalidDateRangeError => e
@@ -93,8 +100,6 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
     Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
     error(I18n.t(:error_pdf_failed_to_export, error: e.message))
   end
-
-  private
 
   def setup_page!
     self.pdf = get_pdf

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2463,6 +2463,7 @@ en:
   error_invalid_selected_value: "Invalid selected value."
   error_journal_attribute_not_present: "Journal does not contain attribute %{attribute}."
   error_pdf_export_too_many_columns: "Too many columns selected for the PDF export. Please reduce the number of columns."
+  error_pdf_date_range_too_long: "The selected work package date range exceeds the allowable limit for PDF export. Please condense the range to a maximum of %{years} years."
   error_pdf_failed_to_export: "The PDF export could not be saved: %{error}"
   error_token_authenticity: "Unable to verify Cross-Site Request Forgery token. Did you try to submit data on multiple browsers or tabs? Please close all tabs and try again."
   error_reminder_not_found: "The reminder was not found or was already notified about."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2463,7 +2463,7 @@ en:
   error_invalid_selected_value: "Invalid selected value."
   error_journal_attribute_not_present: "Journal does not contain attribute %{attribute}."
   error_pdf_export_too_many_columns: "Too many columns selected for the PDF export. Please reduce the number of columns."
-  error_pdf_date_range_too_long: "The selected work package date range exceeds the allowable limit for PDF export. Please condense the range to a maximum of %{years} years."
+  error_pdf_date_range_too_long: "The selected work package date range exceeds the allowable PDF export limit. Please condense the range to a maximum of %{years} years."
   error_pdf_failed_to_export: "The PDF export could not be saved: %{error}"
   error_token_authenticity: "Unable to verify Cross-Site Request Forgery token. Did you try to submit data on multiple browsers or tabs? Please close all tabs and try again."
   error_reminder_not_found: "The reminder was not found or was already notified about."

--- a/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_list_to_pdf_gantt_spec.rb
@@ -58,6 +58,7 @@ end
 RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
   include Redmine::I18n
   include PDFExportSpecUtils
+
   let!(:status_new) { create(:status, name: "New", is_default: true) }
   let(:type_standard) { create(:type_standard, name: "Standard", color: create(:color, hexcode: "#FFFF00")) }
   let(:type_bug) { create(:type_bug, name: "Bug", color: create(:color, hexcode: "#00FFFF")) }
@@ -104,6 +105,9 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
   let(:work_package_task_due) do
     Date.new(2024, 4, 21)
   end
+  let(:work_package_task_due_too_long) do
+    work_package_task_due + (Exports::PDF::Components::Gantt::GanttBuilder::MAX_YEAR_RANGE + 1).years
+  end
   let(:work_package_milestone_start) do
     nil
   end
@@ -127,6 +131,15 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
            subject: "Work package 2",
            start_date: work_package_milestone_start,
            due_date: work_package_milestone_due)
+  end
+  let(:work_package_task_far_future) do
+    create(:work_package,
+           project:,
+           status: status_new,
+           type: type_standard,
+           subject: "Work package 3",
+           start_date: work_package_task_start,
+           due_date: work_package_task_due_too_long)
   end
   let(:filler_work_packages) do
     Array.new(50) do
@@ -388,6 +401,20 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageListToPdf do
         [:fill_path_with_nonzero]
       ]
       expect(include_calls?(task, pdf[:calls])).to be true
+    end
+  end
+
+  describe "with a request for a PDF gantt with too long date range" do
+    let(:work_packages) { [work_package_task_far_future] }
+
+    it "raises as the date range is too long" do
+      expect { export_pdf }.to raise_error(
+        Exports::ExportError,
+        I18n.t(
+          :error_pdf_date_range_too_long,
+          years: Exports::PDF::Components::Gantt::GanttBuilder::MAX_YEAR_RANGE
+        )
+      )
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/60585

# What are you trying to achieve?

Avoid crashing background workers when generating a Gantt chart with ridiculously long time spans.

# What approach did you choose and why?

Only allow a range of 10 years of in the Gantt chart export

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
