### PR TITLE
Shrink widget heights on project overview

### DIFF
--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -50,8 +50,8 @@ $widget-box--enumeration-width: 20px
     .widget-box--feature-list
       flex-grow: 2
 
-  &.-vertical
-    flex-flow: column wrap
+    &.-align-boxes-start
+      align-items: start
 
   .icon-context:before
     padding-right: 5px
@@ -67,7 +67,6 @@ $widget-box--enumeration-width: 20px
   .widget-box
     position: relative
     @include widget-box--style
-    min-height: 250px
     word-wrap: break-word
     overflow: hidden
 

--- a/modules/grids/app/components/grids/widget_grid_component.rb
+++ b/modules/grids/app/components/grids/widget_grid_component.rb
@@ -34,7 +34,7 @@ module Grids
       build_widget(widget_class, *widget_args, **system_arguments)
     }
 
-    def initialize(**system_arguments)
+    def initialize(align_boxes_start: false, **system_arguments)
       super()
 
       @system_arguments = system_arguments
@@ -42,7 +42,8 @@ module Grids
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
         "widget-boxes",
-        "-flex"
+        "-flex",
+        "-align-boxes-start" => align_boxes_start
       )
     end
 

--- a/modules/overviews/app/components/overviews/overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/overview_grid_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Grids::WidgetGridComponent.new) do |grid|
+  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
     grid.with_widget(Overviews::Widgets::DescriptionComponent, @project)
     grid.with_widget(Overviews::Widgets::ProjectStatusComponent, @project)
     grid.with_widget(Overviews::Widgets::SubitemsComponent, @project)


### PR DESCRIPTION
# What are you trying to accomplish?
According to the designs and after discussion with the product team, we decided that the widgets on the new overview page should not grow in height. On the homescreen however, the widget should grow and align as before.

## Screenshots
**After**
<img width="1805" height="848" alt="Bildschirmfoto 2025-09-25 um 08 44 06" src="https://github.com/user-attachments/assets/fc5fb7bf-5b95-473b-84e4-81cc6512ef32" />

**Before**
<img width="1807" height="816" alt="Bildschirmfoto 2025-09-25 um 08 44 26" src="https://github.com/user-attachments/assets/16afb526-e5a8-4c5b-bc8b-69bb81caab96" />
