### PR TITLE
[67702] Change working days pop-up: position of icons is off on the buttons

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/action-bar.sass
+++ b/frontend/src/app/spot/styles/sass/components/action-bar.sass
@@ -6,6 +6,10 @@
   a.button
     text-decoration: none
 
+  &--action
+    .octicon
+      margin-right: var(--base-size-8)
+
   &_transparent
     background-color: unset
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67702
https://community.openproject.org/wp/67711

# What are you trying to accomplish?
Increase spacing for octicons in actionBar buttons.

## Screenshots
<img width="707" height="376" alt="Bildschirmfoto 2025-09-25 um 14 10 42" src="https://github.com/user-attachments/assets/12b3a0e0-02c6-4032-a017-6a52893d659b" />


# What approach did you choose and why?
Since this is a spot component, I chose the minimal approach and selected the svg directly in the Sass file instead of using a class which would need to be applied in all places.

