### PR TITLE
[67602] Primerized login dropdown does not autofocus on input fields

### DIFF
--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="form--field -required">
         <%= styled_label_tag "username-pulldown", User.human_attribute_name(:login) %>
         <div class="form--field-container">
-          <%= styled_text_field_tag "username", nil, id: "username-pulldown", tabindex: 1, autocapitalize: "none" %>
+          <%= styled_text_field_tag "username", nil, id: "username-pulldown", autocapitalize: "none" %>
         </div>
         <div class="form--field-extra-actions">
           <% if Setting::Autologin.enabled? %>
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="form--field -required">
         <%= styled_label_tag "password-pulldown", User.human_attribute_name(:password) %>
         <div class="form--field-container">
-          <%= styled_password_field_tag "password", nil, id: "password-pulldown", tabindex: 1 %>
+          <%= styled_password_field_tag "password", nil, id: "password-pulldown" %>
         </div>
         <div class="form--field-extra-actions">
           <% if Setting.lost_password? %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67602

# What are you trying to accomplish?
Remove tabindex and use natural tab flow
