### PR TITLE
Fix loading of video tag in Firefox

### DIFF
--- a/app/components/enterprise_trials/welcome_dialog_component.html.erb
+++ b/app/components/enterprise_trials/welcome_dialog_component.html.erb
@@ -17,17 +17,26 @@
         end
         flex.with_row(mt: 2) do
           content_tag :div, class: "onboarding--video" do
-            render(Primer::BaseComponent.new(
-              my: 2,
-              tag: :video,
-              frameborder: "0",
-              height: "430",
-              width: "100%",
-              autoplay: "autoplay",
-              controls: true,
-              src: OpenProject::Static::Links.url_for(:enterprise_welcome_video),
-              allowfullscreen: true
-            ))
+            render(
+              Primer::BaseComponent.new(
+                my: 2,
+                tag: :video,
+                height: "430",
+                width: "100%",
+                controls: true,
+                preload: "none",
+                allowfullscreen: true,
+                data: { "media-dialog-target": "video" }
+              )
+            ) do
+              render(
+                Primer::BaseComponent.new(
+                  tag: :source,
+                  src: OpenProject::Static::Links.url_for(:enterprise_welcome_video),
+                  type: "video/mp4"
+                )
+              )
+            end
           end
         end
       end

--- a/app/components/onboarding/video_dialog_component.html.erb
+++ b/app/components/onboarding/video_dialog_component.html.erb
@@ -6,6 +6,7 @@
         controller: "media-dialog"
       },
       title:,
+      classes: "Overlay--size-large-portrait",
       size: :xlarge
     )
   ) do |dialog|

--- a/app/components/onboarding/video_dialog_component.html.erb
+++ b/app/components/onboarding/video_dialog_component.html.erb
@@ -21,15 +21,22 @@
               Primer::BaseComponent.new(
                 my: 2,
                 tag: :video,
-                frameborder: "0",
                 height: "430",
                 width: "100%",
-                autoplay: "autoplay",
                 controls: true,
-                src: video_src,
-                allowfullscreen: true
+                preload: "none",
+                allowfullscreen: true,
+                data: { "media-dialog-target": "video" }
               )
-            )
+            ) do
+              render(
+                Primer::BaseComponent.new(
+                  tag: :source,
+                  src: video_src,
+                  type: "video/mp4"
+                )
+              )
+            end
           end
         )
       end

--- a/frontend/src/stimulus/controllers/dynamic/media-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/media-dialog.controller.ts
@@ -31,13 +31,27 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class MediaDialogController extends Controller<HTMLDialogElement> {
+  static targets = ['video'];
+
+  declare readonly videoTarget:HTMLVideoElement;
+
+  videoTargetConnected(target:HTMLVideoElement) {
+    // Wait for next frame to ensure dialog is fully rendered
+    requestAnimationFrame(() => {
+      // Add error handling for Firefox codec issues
+      target.addEventListener('error', (event) => {
+        console.error('Video failed to load in dialog context:', event);
+      });
+
+      // Force reload the video source to work around Firefox dialog issues
+      target.load();
+    });
+  }
+
   connect() {
     // Remove the video element on close to prevent background play
     this.element.addEventListener('close', () => {
-      this
-        .element
-        .querySelectorAll('iframe,video,embed')
-        .forEach(el => el.remove());
+      this.element.querySelectorAll('video').forEach(el => el.remove());
     });
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/media-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/media-dialog.controller.ts
@@ -43,6 +43,9 @@ export default class MediaDialogController extends Controller<HTMLDialogElement>
         console.error('Video failed to load in dialog context:', event);
       });
 
+      // Try setting autoplay now
+      target.autoplay = true;
+
       // Force reload the video source to work around Firefox dialog issues
       target.load();
     });


### PR DESCRIPTION
The video tag fails to load when within a dialog, so we try to forcefully load it on open. This seems to work in Firefox, Safari,  and Chrome

# Ticket
https://community.openproject.org/work_packages/67176