### PR TITLE
Use ProjectEagerLoadingWrapper objects in polymorphic associations

### DIFF
--- a/lib/api/v3/projects/project_eager_loading_wrapper.rb
+++ b/lib/api/v3/projects/project_eager_loading_wrapper.rb
@@ -36,6 +36,14 @@ module API
         delegate :is_a?, to: :__getobj__
 
         class << self
+          # Class methods that are required by Rails when a Project is associated as a polymorphic object.
+          # E.g., when you call `CalculatedValueError.where(customized: this_wrapper)`
+          delegate :polymorphic_name,
+                   :has_query_constraints?,
+                   :composite_primary_key?,
+                   :primary_key,
+                   to: :Project
+
           def wrap(projects)
             if projects.present?
               custom_fields_by_project_id = custom_fields_from_projects

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -312,7 +312,7 @@ module API
             next unless custom_field.calculated_value?
             next unless available_custom_fields.include?(custom_field)
 
-            errors = custom_field.calculated_value_errors.where(customized_id: id, customized_type: "Project")
+            errors = custom_field.calculated_value_errors.where(customized: self)
             errors.map do |err|
               { code: err.error_code,
                 message: CalculatedValues::ErrorsHelper.calculated_value_error_msg(err) }

--- a/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
+++ b/spec/lib/api/v3/projects/project_eager_loading_wrapper_spec.rb
@@ -67,4 +67,28 @@ RSpec.describe API::V3::Projects::ProjectEagerLoadingWrapper do
       end
     end
   end
+
+  describe "delegations" do
+    shared_examples "delegates class method to Project" do |method_name|
+      it "delegates #{method_name} to Project" do
+        expect(described_class.public_send(method_name)).to eq(Project.public_send(method_name))
+      end
+    end
+
+    describe ".polymorphic_name" do
+      it_behaves_like "delegates class method to Project", :polymorphic_name
+    end
+
+    describe ".has_query_constraints?" do
+      it_behaves_like "delegates class method to Project", :has_query_constraints?
+    end
+
+    describe ".composite_primary_key?" do
+      it_behaves_like "delegates class method to Project", :composite_primary_key?
+    end
+
+    describe ".primary_key" do
+      it_behaves_like "delegates class method to Project", :primary_key
+    end
+  end
 end

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
         before do
           value_errors_double = double
           allow(value_errors_double).to receive(:where)
-                                          .with(customized_id: project.id, customized_type: "Project")
+                                          .with(customized: project)
                                           .and_return([calculated_value_error])
 
           allow(calculated_value_custom_field).to receive(:calculated_value_errors)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67708

# What are you trying to accomplish?

While working on Calculated Value error messages, I had to revert 7a2b2ece9557c8027b4edffeb2c99f59863be4cd since it was causing problems when called from certain contexts. E.g., the project overview sidebar spec produced errors:

`NoMethodError: undefined method 'polymophic_name' for ProjectEagerLoadingWrapper`

After investigation, I found out there were some delegations missing from the wrapper. It behaved different enough from a real Project that Rails could not build the correct ActiveRecord query... By providing them, we can go back to the more elegant execution of `customized: self` and make the wrapper more transparent.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
