### PR TITLE
[67710] Team planner: no spacing between the icon and the Assignee

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -333,7 +333,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   private personIcon = toDOMString(
     personIconData, // SVG data for the icon.
     'small',
-    { 'aria-hidden': 'true',},
+    { 'aria-hidden': 'true',
+      class: ' op-team-planner--add-existing-icon',},
   );
 
   private viewOptionDefaults = {

--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -46,6 +46,9 @@ $view-select-dropdown-width: 8rem
   &--add-existing-toggle, &--view-select-dropdown
     z-index: 6
 
+  &--add-existing-icon
+    margin-right: var(--base-size-4)
+
   .fc-scrollgrid
     border-top: none !important
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67710

# What are you trying to accomplish?
Add spacing to the right of person icon

## Screenshots
**After**
<img width="154" height="66" alt="Bildschirmfoto 2025-09-26 um 08 33 09" src="https://github.com/user-attachments/assets/783ce1b0-e02c-4ace-b8f9-5f62116a2ae6" />

**Before**
<img width="112" height="59" alt="Bildschirmfoto 2025-09-26 um 08 33 36" src="https://github.com/user-attachments/assets/427da4ec-f3b8-4c3d-9a0d-7e7a0c7e7938" />

