### PR TITLE
Fix alignment of octicons in Buttons

### DIFF
--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -144,6 +144,15 @@ a.button
     display: inline-flex
     align-items: center
 
+  // This is very bad :(
+  // but as long as we have that mixture of old buttons with octicons inside we have to enforce the alignment
+  // Unfortunately, each browser/OS combination behaves differently
+  // This fix works for all browsers, except for Firefox on Windows (:cry:)
+  &:has(> .octicon)
+    body:not(.-browser-windows):not(.-browser-firefox) &
+      display: flex
+      align-items: center
+
 .button--icon
   @include icon-common
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67711
https://community.openproject.org/wp/67699

# What are you trying to accomplish?
Enforce flex on buttons with octicons inside for alignment. Unfortunately, we see a lot of different results of this depending on the OS / browser combination. This fix was the best I could find, here is an overview of the impact:

|  | Firefox | Chrome |
|---|---|---|
| Linux | ✅ (better) | ✅ (better) |
| Mac | ☑️ (no difference) | ☑️ (no difference) |
| Windows | ❌ (worse) | ✅ (better) |



