### PR TITLE
Bug/67706 limit number precision when displaying calculated values

### DIFF
--- a/app/models/custom_value/calculated_value_strategy.rb
+++ b/app/models/custom_value/calculated_value_strategy.rb
@@ -38,7 +38,15 @@ class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
   end
 
   def formatted_value
-    integer_value? ? value.to_s : number_with_delimiter(value.to_s)
+    return "" if value.blank?
+
+    if integer_value?
+      number_with_delimiter(value.to_i)
+    else
+      number_with_delimiter(
+        number_with_precision(value.to_f, precision: 3, strip_insignificant_zeros: true)
+      )
+    end
   end
 
   def validate_type_of_value

--- a/app/models/custom_value/calculated_value_strategy.rb
+++ b/app/models/custom_value/calculated_value_strategy.rb
@@ -59,6 +59,9 @@ class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
   private
 
   def integer_value?
-    value && value =~ /\A\d+\z/
+    # Use Epsilon comparison to determine whether the number, even if it is a float, should be
+    # considered an integer. E.g., a value of 42.000000000000000002 will be treated like an
+    # integer for our formatting purposes.
+    value && (value.to_f - value.to_i).abs < 1e-9
   end
 end

--- a/app/models/custom_value/calculated_value_strategy.rb
+++ b/app/models/custom_value/calculated_value_strategy.rb
@@ -43,9 +43,18 @@ class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
     if integer_value?
       number_with_delimiter(value.to_i)
     else
-      number_with_delimiter(
-        number_with_precision(value.to_f, precision: 3, strip_insignificant_zeros: true)
-      )
+      formatted = number_with_precision(value.to_f,
+                                        precision: 3,
+                                        strip_insignificant_zeros: true,
+                                        delimiter: I18n.t("number.format.delimiter"),
+                                        separator: I18n.t("number.format.separator"))
+
+      # Ensure at least one decimal place for floats
+      if formatted.exclude?(I18n.t("number.format.separator"))
+        "#{formatted}#{I18n.t('number.format.separator')}0"
+      else
+        formatted
+      end
     end
   end
 
@@ -59,9 +68,6 @@ class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
   private
 
   def integer_value?
-    # Use Epsilon comparison to determine whether the number, even if it is a float, should be
-    # considered an integer. E.g., a value of 42.000000000000000002 will be treated like an
-    # integer for our formatting purposes.
-    value && (value.to_f - value.to_i).abs < 1e-9
+    value =~ /\A[-+]?\d+\z/
   end
 end

--- a/app/models/custom_value/calculated_value_strategy.rb
+++ b/app/models/custom_value/calculated_value_strategy.rb
@@ -43,15 +43,17 @@ class CustomValue::CalculatedValueStrategy < CustomValue::FormatStrategy
     if integer_value?
       number_with_delimiter(value.to_i)
     else
+      delimiter = I18n.t("number.format.delimiter")
+      separator = I18n.t("number.format.separator")
       formatted = number_with_precision(value.to_f,
                                         precision: 3,
                                         strip_insignificant_zeros: true,
-                                        delimiter: I18n.t("number.format.delimiter"),
-                                        separator: I18n.t("number.format.separator"))
+                                        delimiter:,
+                                        separator:)
 
       # Ensure at least one decimal place for floats
-      if formatted.exclude?(I18n.t("number.format.separator"))
-        "#{formatted}#{I18n.t('number.format.separator')}0"
+      if formatted.exclude?(separator)
+        "#{formatted}#{separator}0"
       else
         formatted
       end

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -38,6 +38,8 @@ class CustomValue::FloatStrategy < CustomValue::FormatStrategy
   end
 
   def formatted_value
+    return "" if value.blank?
+
     number_with_delimiter(value.to_s)
   end
 

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -29,10 +29,16 @@
 #++
 
 class CustomValue::IntStrategy < CustomValue::FormatStrategy
+  include ActionView::Helpers::NumberHelper
+
   def typed_value
-    if value.present?
-      value.to_i
-    end
+    value.to_i if value.present?
+  end
+
+  def formatted_value
+    return "" if value.blank?
+
+    number_with_delimiter(value.to_s)
   end
 
   def validate_type_of_value

--- a/spec/models/custom_value/calculated_value_strategy_spec.rb
+++ b/spec/models/custom_value/calculated_value_strategy_spec.rb
@@ -66,15 +66,15 @@ RSpec.describe CustomValue::CalculatedValueStrategy do
     subject { instance.formatted_value }
 
     context "when value is a float string" do
-      let(:value) { "3.14" }
+      let(:value) { "32400.14" }
 
-      it "is the float string" do
-        expect(subject).to eql value
+      it "is the float string with delimiters" do
+        expect(subject).to eql "32,400.14"
       end
 
-      it "is localized" do
+      it "is localized with delimiters" do
         I18n.with_locale(:de) do
-          expect(subject).to eql "3,14"
+          expect(subject).to eql "32.400,14"
         end
       end
     end
@@ -82,16 +82,38 @@ RSpec.describe CustomValue::CalculatedValueStrategy do
     context "when value is a float string with many zeroed decimals" do
       let(:value) { "3.0000000000000000000000000000009" }
 
-      it "is considered an integer" do
-        expect(subject).to eql "3"
+      it "is formatted as a float with a minimum precision" do
+        expect(subject).to eql "3.0"
+      end
+    end
+
+    context "when value is a float string with some zeroed decimals" do
+      let(:value) { "3.000" }
+
+      it "is formatted as a float with a minimum precision" do
+        expect(subject).to eql "3.0"
+      end
+    end
+
+    context "when value is a float string with digits after the decimal point" do
+      let(:value) { "42.87391" }
+
+      it "is formatted as a float with a precision of 3 while rounding decimal places" do
+        expect(subject).to eql "42.874"
       end
     end
 
     context "when value is an int string" do
-      let(:value) { "42" }
+      let(:value) { "42312" }
 
-      it "is the int string" do
-        expect(subject).to eql value
+      it "is the int string with delimiters" do
+        expect(subject).to eql "42,312"
+      end
+
+      it "is localized with delimiters" do
+        I18n.with_locale(:de) do
+          expect(subject).to eql "42.312"
+        end
       end
     end
 

--- a/spec/models/custom_value/calculated_value_strategy_spec.rb
+++ b/spec/models/custom_value/calculated_value_strategy_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe CustomValue::CalculatedValueStrategy do
       end
     end
 
+    context "when value is a float string with many zeroed decimals" do
+      let(:value) { "3.0000000000000000000000000000009" }
+
+      it "is considered an integer" do
+        expect(subject).to eql "3"
+      end
+    end
+
     context "when value is an int string" do
       let(:value) { "42" }
 

--- a/spec/models/custom_value/int_strategy_spec.rb
+++ b/spec/models/custom_value/int_strategy_spec.rb
@@ -37,8 +37,14 @@ RSpec.describe CustomValue::IntStrategy do
   describe "#typed_value" do
     subject { instance.typed_value }
 
+    context "when value is an int string" do
+      let(:value) { "12" }
+
+      it { is_expected.to be(12) }
+    end
+
     context "when value is a float string" do
-      let(:value) { "10" }
+      let(:value) { "10.0" }
 
       it { is_expected.to be(10) }
     end
@@ -62,19 +68,31 @@ RSpec.describe CustomValue::IntStrategy do
     context "when value is an int string" do
       let(:value) { "10" }
 
-      it { is_expected.to be(10) }
+      it { is_expected.to eql("10") }
+    end
+
+    context "when value is a big integer" do
+      let(:value) { "10432501" }
+
+      it { is_expected.to eql("10,432,501") }
+
+      it "is localized" do
+        I18n.with_locale(:de) do
+          expect(subject).to eql "10.432.501"
+        end
+      end
     end
 
     context "when value is blank" do
       let(:value) { "" }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to be("") }
     end
 
     context "when value is nil" do
       let(:value) { nil }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to be("") }
     end
   end
 

--- a/spec/models/custom_value/int_strategy_spec.rb
+++ b/spec/models/custom_value/int_strategy_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CustomValue::IntStrategy do
   end
 
   describe "#formatted_value" do
-    subject { instance.typed_value }
+    subject { instance.formatted_value }
 
     context "when value is an int string" do
       let(:value) { "10" }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67706

Note: this PR intentionally targets 16.5 as the feature is available – albeit hidden behind a feature flag – there.

# What are you trying to accomplish?
Render floats with delimiters _and_ precision. For now, chose a precision of 3 which seems to be a good compromise between detail and comfort.

~~Also improved the detection that decides whether a calculated value is a float or an int value. In the past, it did not detect a value like `1.0` to be an integer - but I think it _should_.~~ We talked about this in our team weekly and decided to always show a float value as a float, even if it means that all numbers after the decimal point are a zero. We will, however, remove all but one zero in such a case.

Also noticed that integer custom field formatting have not been inconsistent delimiters for a long time. Fixed that to be more consistent. While at it, I noticed that the specs for integers were off. Fixed.

## Screenshots
<img width="283" height="596" alt="image" src="https://github.com/user-attachments/assets/becf7184-7708-4219-9dff-9e0b0a6d8ed3" />

<img width="1052" height="732" alt="image" src="https://github.com/user-attachments/assets/0490d474-b1e6-400b-ab3a-15b40b65c68e" />


# What approach did you choose and why?


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
