### PR TITLE
[#59359] redirect to edit path after creating a custom field

### DIFF
--- a/app/controllers/concerns/custom_fields/shared_actions.rb
+++ b/app/controllers/concerns/custom_fields/shared_actions.rb
@@ -55,9 +55,10 @@ module CustomFields
           .call(get_custom_field_params.merge(type: permitted_params.custom_field_type))
 
         if call.success?
+          custom_field = call.result
           flash[:notice] = t(:notice_successful_create)
-          call_hook(:controller_custom_fields_new_after_save, custom_field: call.result)
-          redirect_to index_path(call.result, tab: call.result.class.name)
+          call_hook(:controller_custom_fields_new_after_save, custom_field:)
+          redirect_to edit_path(custom_field, id: custom_field.id)
         else
           @custom_field = call.result || new_custom_field
           render action: :new, status: :unprocessable_entity
@@ -142,7 +143,7 @@ module CustomFields
 
         index = 0
 
-        params[:custom_field][:custom_options_attributes].each do |_id, attributes|
+        params[:custom_field][:custom_options_attributes].each_value do |attributes|
           attributes[:position] = (index = index + 1)
         end
       end

--- a/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
+++ b/spec/features/admin/custom_fields/projects/create_in_section_spec.rb
@@ -75,13 +75,12 @@ RSpec.describe "Create project custom fields in sections", :js do
 
         click_on("Save")
 
-        # redirects to the overview page
-        # the tab parameter is set as the redirect originates from the former custom field controller but does not have an effect
-        expect(page).to have_current_path(admin_settings_project_custom_fields_path(tab: "ProjectCustomField"))
-
-        expect(page).to have_text("New custom field")
+        expect(page).to have_text("Successful creation")
 
         latest_custom_field = ProjectCustomField.reorder(created_at: :asc).last
+
+        expect(page).to have_current_path(admin_settings_project_custom_field_path(latest_custom_field))
+        expect(page).to have_text("New custom field")
 
         expect(latest_custom_field.name).to eq("New custom field")
         expect(latest_custom_field.admin_only).to be(true)
@@ -96,11 +95,11 @@ RSpec.describe "Create project custom fields in sections", :js do
 
         click_on("Save")
 
-        # redirects to the overview page
-        # the tab parameter is set as the redirect originates from the former custom field controller but does not have an effect
-        expect(page).to have_current_path(admin_settings_project_custom_fields_path(tab: "ProjectCustomField"))
+        expect(page).to have_text("Successful creation")
 
         latest_custom_field = ProjectCustomField.reorder(created_at: :asc).last
+
+        expect(page).to have_current_path(admin_settings_project_custom_field_path(latest_custom_field))
 
         expect(latest_custom_field.name).to eq("New custom field")
         expect(latest_custom_field.project_custom_field_section).to eq(section_for_multi_select_fields)
@@ -157,11 +156,10 @@ RSpec.describe "Create project custom fields in sections", :js do
 
             click_on("Save")
 
-            # redirects to the overview page
-            # the tab parameter is set as the redirect originates from the
-            # former custom field controller but does not have an effect
-            expect(page).to have_current_path(admin_settings_project_custom_fields_path(tab: "ProjectCustomField"))
+            expect(page).to have_text("Successful creation")
 
+            created = ProjectCustomField.find_by_name("New calculated value custom field")
+            expect(page).to have_current_path(admin_settings_project_custom_field_path(created))
             expect(page).to have_text("New calculated value custom field")
           end
         end

--- a/spec/features/admin/custom_fields/shared_custom_field_expectations.rb
+++ b/spec/features/admin/custom_fields/shared_custom_field_expectations.rb
@@ -80,9 +80,6 @@ RSpec.shared_examples_for "list custom fields" do |type|
 
     expect(page).to have_text("Successful creation")
 
-    click_on "Operating System"
-    wait_for_reload
-
     expect(page).to have_field("custom_field_multi_value", checked: true)
 
     expect(page).to have_css(".custom-option-row", count: 3)

--- a/spec/features/admin/custom_fields/work_packages/hierarchy_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/hierarchy_spec.rb
@@ -49,21 +49,16 @@ RSpec.describe "work package custom fields of type hierarchy", :js do
     fill_in "Name", with: hierarchy_name
     click_on "Save"
 
-    new_custom_field_page.expect_and_dismiss_flash(message: "Successful creation.")
-
-    custom_field_index_page.expect_current_path("tab=WorkPackageCustomField")
-    expect(page).to have_list_item(hierarchy_name)
-
-    # endregion
-
-    # region Edit the details of the custom field
+    expect(page).to have_text("Successful creation.")
 
     CustomField.find_by(name: hierarchy_name).tap do |custom_field|
       hierarchy_page.add_custom_field_state(custom_field)
     end
-
-    click_on hierarchy_name
     hierarchy_page.expect_current_path
+
+    # endregion
+
+    # region Edit the details of the custom field
 
     expect(page).to have_test_selector("op-custom-fields--new-hierarchy-banner")
     expect(page).to have_css(".PageHeader-title", text: hierarchy_name)

--- a/spec/features/admin/custom_fields/work_packages/user_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/user_spec.rb
@@ -53,13 +53,10 @@ RSpec.describe "User custom fields edit", :js do
 
     new_cf_page.expect_and_dismiss_flash(message: "Successful creation.")
 
-    # Expect field to be created
-    index_cf_page.expect_current_path("tab=WorkPackageCustomField")
-    expect(page).to have_list_item("My User CF")
+    cf = CustomField.last
+    expect(page).to have_current_path(edit_custom_field_path(cf))
 
     # Edit again
-    click_on "My User CF"
-
     expect(page).to have_no_field("custom_field_custom_options_attributes_0_value")
     fill_in "Name", with: "My User CF (edited)"
 
@@ -68,8 +65,9 @@ RSpec.describe "User custom fields edit", :js do
     new_cf_page.expect_and_dismiss_flash(message: "Successful update.")
 
     # Expect field to be saved
+    cf.reload
+
     expect(page).to have_css(".PageHeader-title", text: "My User CF (edited)")
-    cf = CustomField.last
     expect(cf.name).to eq("My User CF (edited)")
   end
 end


### PR DESCRIPTION
# Ticket
[#59359](https://community.openproject.org/work_packages/59359)


# What are you trying to accomplish?
- after creating a custom field we want to land on the edit path, ready to assign projects, create items, or change details.
