### PR TITLE
[#67649] ignore scored list cfs for custom actions

### DIFF
--- a/app/models/work_package_custom_field.rb
+++ b/app/models/work_package_custom_field.rb
@@ -61,7 +61,7 @@ class WorkPackageCustomField < CustomField
   }
 
   scope :usable_as_custom_action, -> {
-    where.not(field_format: %w[hierarchy])
+    where.not(field_format: %w[hierarchy scored_list])
          .order(:name)
   }
 


### PR DESCRIPTION
# Ticket
[#67649](https://community.openproject.org/work_packages/67649)

# What are you trying to accomplish?
- use same approach as for cfs of type hierarchy and ignore those for custom actions
- this can be fixed, once we have a primer ready selector for hierarchical lists