### PR TITLE
[#64523] Allow 'Scored List' as formula format

### DIFF
--- a/app/models/custom_field/calculated_value.rb
+++ b/app/models/custom_field/calculated_value.rb
@@ -37,7 +37,7 @@ module CustomField::CalculatedValue
   MATH_OPERATORS_FOR_FORMULA = %w[+ - * / % ( )].freeze
 
   # Field formats that can be used within a formula.
-  FIELD_FORMATS_FOR_FORMULA = %w[int float calculated_value].freeze
+  FIELD_FORMATS_FOR_FORMULA = %w[int float calculated_value scored_list].freeze
 
   def self.calculator_instance
     Dentaku::Calculator.new(case_sensitive: true)

--- a/app/models/custom_value/ar_object_strategy.rb
+++ b/app/models/custom_value/ar_object_strategy.rb
@@ -30,22 +30,22 @@
 
 class CustomValue::ARObjectStrategy < CustomValue::FormatStrategy
   def typed_value
-    cached_typed_value
+    cached_ar_object
   end
 
   def formatted_value
-    typed_value.to_s
+    cached_ar_object.to_s
   end
 
   def parse_value(val)
     if val.is_a?(ar_class)
-      self.memoized_typed_value = val
+      @cached_ar_object = val
 
       val.id.to_s
-    elsif val.blank?
-      super(nil)
     else
-      super
+      @cached_ar_object = nil
+
+      val.presence
     end
   end
 
@@ -57,12 +57,13 @@ class CustomValue::ARObjectStrategy < CustomValue::FormatStrategy
 
   private
 
-  def cached_typed_value
-    return memoized_typed_value if memoized_typed_value
+  # This method is not inlined in typed_value to allow separate changes to typed_value and formatted_value
+  def cached_ar_object
+    return @cached_ar_object if @cached_ar_object
 
     if value.present?
       RequestStore.fetch(:"#{ar_class.name.underscore}_custom_value_#{value}") do
-        self.memoized_typed_value = ar_object(value)
+        @cached_ar_object = ar_object(value)
       end
     end
   end

--- a/app/models/custom_value/ar_object_strategy.rb
+++ b/app/models/custom_value/ar_object_strategy.rb
@@ -30,13 +30,7 @@
 
 class CustomValue::ARObjectStrategy < CustomValue::FormatStrategy
   def typed_value
-    return memoized_typed_value if memoized_typed_value
-
-    if value.present?
-      RequestStore.fetch(:"#{ar_class.name.underscore}_custom_value_#{value}") do
-        self.memoized_typed_value = ar_object(value)
-      end
-    end
+    cached_typed_value
   end
 
   def formatted_value
@@ -62,6 +56,16 @@ class CustomValue::ARObjectStrategy < CustomValue::FormatStrategy
   end
 
   private
+
+  def cached_typed_value
+    return memoized_typed_value if memoized_typed_value
+
+    if value.present?
+      RequestStore.fetch(:"#{ar_class.name.underscore}_custom_value_#{value}") do
+        self.memoized_typed_value = ar_object(value)
+      end
+    end
+  end
 
   def ar_class
     raise NotImplementedError

--- a/app/models/custom_value/ar_object_strategy.rb
+++ b/app/models/custom_value/ar_object_strategy.rb
@@ -71,7 +71,7 @@ class CustomValue::ARObjectStrategy < CustomValue::FormatStrategy
     raise NotImplementedError
   end
 
-  def ar_object(_value)
-    raise NotImplementedError
+  def ar_object(value)
+    ar_class.find_by(id: value)
   end
 end

--- a/app/models/custom_value/bool_strategy.rb
+++ b/app/models/custom_value/bool_strategy.rb
@@ -52,15 +52,13 @@ class CustomValue::BoolStrategy < CustomValue::FormatStrategy
   end
 
   def parse_value(val)
-    parsed_val = if !present?(val)
-                   nil
-                 elsif ActiveRecord::Type::Boolean::FALSE_VALUES.include?(val)
-                   OpenProject::Database::DB_VALUE_FALSE
-                 else
-                   OpenProject::Database::DB_VALUE_TRUE
-                 end
-
-    super(parsed_val)
+    if !present?(val)
+      nil
+    elsif ActiveRecord::Type::Boolean::FALSE_VALUES.include?(val)
+      OpenProject::Database::DB_VALUE_FALSE
+    else
+      OpenProject::Database::DB_VALUE_TRUE
+    end
   end
 
   def validate_type_of_value; end

--- a/app/models/custom_value/format_strategy.rb
+++ b/app/models/custom_value/format_strategy.rb
@@ -51,12 +51,8 @@ class CustomValue::FormatStrategy
     value.to_s
   end
 
-  # Parses the value to
-  # 1) have a unified representation for different inputs
-  # 2) memoize typed values (if the subclass decides to do so
+  # Parses the value to have a unified representation for different inputs
   def parse_value(val)
-    self.memoized_typed_value = nil
-
     val
   end
 
@@ -65,8 +61,4 @@ class CustomValue::FormatStrategy
   def validate_type_of_value
     raise "SubclassResponsibility"
   end
-
-  private
-
-  attr_accessor :memoized_typed_value
 end

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -30,7 +30,7 @@
 
 class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   def formatted_value
-    item = cached_typed_value
+    item = cached_ar_object
 
     if item
       item.to_s

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -30,13 +30,13 @@
 
 class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   def typed_value
-    item = cached_ar_object
+    item = cached_typed_value
 
     item.score.presence || item
   end
 
   def formatted_value
-    item = cached_ar_object
+    item = cached_typed_value
 
     if item.nil?
       "#{value} #{I18n.t(:label_not_found)}"
@@ -59,16 +59,6 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   end
 
   private
-
-  def cached_ar_object
-    return memoized_typed_value if memoized_typed_value
-
-    if value.present?
-      RequestStore.fetch(:"#{ar_class.name.underscore}_custom_value_#{value}") do
-        self.memoized_typed_value = ar_object(value)
-      end
-    end
-  end
 
   def ar_class
     CustomField::Hierarchy::Item

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -34,7 +34,7 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
 
     if item.nil?
       "#{value} #{I18n.t(:label_not_found)}"
-    elsif item.short.present?
+    elsif item.short?
       "#{item.label} (#{item.short})"
     else
       item.label

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -30,14 +30,13 @@
 
 class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   def typed_value
-    item = super
+    item = cached_ar_object
 
     item.score.presence || item
   end
 
   def formatted_value
-    # TODO: add caching for `ar_object`
-    item = ar_object(value)
+    item = cached_ar_object
 
     if item.nil?
       "#{value} #{I18n.t(:label_not_found)}"
@@ -62,6 +61,16 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   end
 
   private
+
+  def cached_ar_object
+    return memoized_typed_value if memoized_typed_value
+
+    if value.present?
+      RequestStore.fetch(:"#{ar_class.name.underscore}_custom_value_#{value}") do
+        self.memoized_typed_value = ar_object(value)
+      end
+    end
+  end
 
   def ar_class
     CustomField::Hierarchy::Item

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -32,18 +32,16 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   def formatted_value
     item = cached_typed_value
 
-    if item.nil?
-      "#{value} #{I18n.t(:label_not_found)}"
-    elsif item.short?
-      "#{item.label} (#{item.short})"
+    if item
+      item.to_s
     else
-      item.label
+      "#{value} #{I18n.t(:label_not_found)}"
     end
   end
 
   def validate_type_of_value
-    item = CustomField::Hierarchy::Item.find_by(id: value)
-    return :invalid if item.nil?
+    item = ar_object(value)
+    return :invalid unless item
 
     parent = custom_field.hierarchy_root
 

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -42,8 +42,6 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
       "#{value} #{I18n.t(:label_not_found)}"
     elsif item.short.present?
       "#{item.label} (#{item.short})"
-    elsif item.score.present?
-      "#{item.label} (#{item.score})"
     else
       item.label
     end

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -58,10 +58,6 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
     CustomField::Hierarchy::Item
   end
 
-  def ar_object(value)
-    CustomField::Hierarchy::Item.find_by(id: value.to_s)
-  end
-
   def persistence_service
     @persistence_service ||= CustomFields::Hierarchy::HierarchicalItemService.new
   end

--- a/app/models/custom_value/hierarchy_strategy.rb
+++ b/app/models/custom_value/hierarchy_strategy.rb
@@ -29,6 +29,27 @@
 #++
 
 class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
+  def typed_value
+    item = super
+
+    item.score.presence || item
+  end
+
+  def formatted_value
+    # TODO: add caching for `ar_object`
+    item = ar_object(value)
+
+    if item.nil?
+      "#{value} #{I18n.t(:label_not_found)}"
+    elsif item.short.present?
+      "#{item.label} (#{item.short})"
+    elsif item.score.present?
+      "#{item.label} (#{item.score})"
+    else
+      item.label
+    end
+  end
+
   def validate_type_of_value
     item = CustomField::Hierarchy::Item.find_by(id: value)
     return :invalid if item.nil?
@@ -47,14 +68,7 @@ class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
   end
 
   def ar_object(value)
-    item = CustomField::Hierarchy::Item.find_by(id: value.to_s)
-    if item.nil?
-      "#{value} #{I18n.t(:label_not_found)}"
-    elsif item.short.present?
-      "#{item.label} (#{item.short})"
-    else
-      item.label
-    end
+    CustomField::Hierarchy::Item.find_by(id: value.to_s)
   end
 
   def persistence_service

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -36,8 +36,7 @@ class CustomValue::ListStrategy < CustomValue::ARObjectStrategy
   end
 
   def typed_value
-    super_value = super
-    (super_value && super_value.to_s) || nil
+    super&.to_s
   end
 
   private

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -47,11 +47,10 @@ class CustomValue::ListStrategy < CustomValue::ARObjectStrategy
   end
 
   def ar_object(value)
-    option = CustomOption.find_by(id: value.to_s)
-    if option.nil?
-      "#{value} #{I18n.t(:label_not_found)}"
-    else
+    if (option = super)
       option.value
+    else
+      "#{value} #{I18n.t(:label_not_found)}"
     end
   end
 end

--- a/app/models/custom_value/scored_list_strategy.rb
+++ b/app/models/custom_value/scored_list_strategy.rb
@@ -30,6 +30,6 @@
 
 class CustomValue::ScoredListStrategy < CustomValue::HierarchyStrategy
   def typed_value
-    cached_typed_value&.score
+    cached_ar_object&.score
   end
 end

--- a/app/models/custom_value/scored_list_strategy.rb
+++ b/app/models/custom_value/scored_list_strategy.rb
@@ -28,41 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class CustomValue::HierarchyStrategy < CustomValue::ARObjectStrategy
-  def formatted_value
-    item = cached_typed_value
-
-    if item.nil?
-      "#{value} #{I18n.t(:label_not_found)}"
-    elsif item.short.present?
-      "#{item.label} (#{item.short})"
-    else
-      item.label
-    end
-  end
-
-  def validate_type_of_value
-    item = CustomField::Hierarchy::Item.find_by(id: value)
-    return :invalid if item.nil?
-
-    parent = custom_field.hierarchy_root
-
-    if persistence_service.descendant_of?(item:, parent:).failure?
-      :inclusion
-    end
-  end
-
-  private
-
-  def ar_class
-    CustomField::Hierarchy::Item
-  end
-
-  def ar_object(value)
-    CustomField::Hierarchy::Item.find_by(id: value.to_s)
-  end
-
-  def persistence_service
-    @persistence_service ||= CustomFields::Hierarchy::HierarchicalItemService.new
+class CustomValue::ScoredListStrategy < CustomValue::HierarchyStrategy
+  def typed_value
+    cached_typed_value&.score
   end
 end

--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -34,8 +34,4 @@ class CustomValue::UserStrategy < CustomValue::ARObjectStrategy
   def ar_class
     Principal
   end
-
-  def ar_object(value)
-    Principal.find_by(id: value)
-  end
 end

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -34,8 +34,4 @@ class CustomValue::VersionStrategy < CustomValue::ARObjectStrategy
   def ar_class
     Version
   end
-
-  def ar_object(value)
-    Version.find_by(id: value)
-  end
 end

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -98,7 +98,7 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      enabled: lambda do
                                                        OpenProject::FeatureDecisions.scored_list_custom_fields_active?
                                                      end,
-                                                     formatter: "CustomValue::HierarchyStrategy")
+                                                     formatter: "CustomValue::ScoredListStrategy")
 
   fields.register OpenProject::CustomFieldFormat.new("calculated_value",
                                                      label: :label_calculated_value,

--- a/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
+++ b/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
@@ -59,7 +59,7 @@ module API
             def link_value_getter_values(represented, custom_field)
               Array(represented.custom_value_for(custom_field)).flat_map do |custom_value|
                 if custom_value && custom_value.value.present?
-                  title = link_value_title(custom_value)
+                  title = link_value_title(custom_value, custom_field)
 
                   [{
                     title:,
@@ -96,9 +96,11 @@ module API
               API::V3::Principals::PrincipalType.for(custom_value.typed_value)
             end
 
-            def link_value_title(custom_value)
+            def link_value_title(custom_value, custom_field)
               if custom_value.typed_value.respond_to?(:name)
                 custom_value.typed_value.name
+              elsif custom_field.field_format.in?(%w[scored_list hierarchy])
+                custom_value.formatted_value
               else
                 custom_value.typed_value
               end

--- a/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
+++ b/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
@@ -99,7 +99,7 @@ module API
             def link_value_title(custom_value, custom_field)
               if custom_value.typed_value.respond_to?(:name)
                 custom_value.typed_value.name
-              elsif custom_field.field_format.in?(%w[scored_list hierarchy])
+              elsif custom_field.hierarchical_list?
                 custom_value.formatted_value
               else
                 custom_value.typed_value

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -40,7 +40,7 @@ module Redmine
           cattr_accessor :customizable_options
           self.customizable_options = options
 
-          # we are validating custom_values manually in :validate_custom_values
+          # We are validating custom_values manually in :validate_custom_values
           # N.B. the default for validate should be false, however specs seem to think differently
           has_many :custom_values, -> {
             includes(:custom_field)
@@ -131,7 +131,7 @@ module Redmine
         #
         # In some cases, the implementing class has a changing list of custom field values
         # depending on certain attributes. When those attributes are changed, the cache can
-        # be kept up to date by including them in the overriden custom_field_cache_key method.
+        # be kept up to date by including them in the overridden custom_field_cache_key method.
         #
         # i.e.: The work package custom field values are changing based on the project_id and type_id.
         # The only way to keep the cache updated is to include those ids in the cache key.
@@ -256,7 +256,7 @@ module Redmine
             next cfv_changes unless cfv.changed?
 
             # In order to construct a valid changes hash, we need to find the old value if it exists.
-            # Otherwise set it to nil.
+            # Otherwise, set it to nil.
             cfv_was = custom_value_was_for(cfv)
             value_was = cfv_was&.value
 
@@ -402,7 +402,7 @@ module Redmine
         end
 
         # Explicitly touch the customizable if
-        # there where only changes to custom_values (added or removed).
+        # there were only changes to custom_values (added or removed).
         # Particularly important for caching.
         def touch_customizable
           touch if !saved_changes? && custom_values.loaded? && (custom_values.any?(&:saved_changes?) || custom_value_destroyed)

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -221,14 +221,15 @@ FactoryBot.define do
         calculated_value
         date
         float
+        hierarchy multi_hierarchy
         integer
         link
-        list
+        list multi_list
         scored_list
         string
         text
-        user
-        version
+        user multi_user
+        version multi_version
       ].each do |trait|
         factory :"#{trait}_project_custom_field", traits: [trait]
       end
@@ -254,20 +255,17 @@ FactoryBot.define do
 
       %w[
         boolean
+        date
+        float
+        hierarchy multi_hierarchy
+        integer
+        link
+        list multi_list
+        scored_list
         string
         text
-        integer
-        float
-        date
-        list
-        multi_list
-        version
-        multi_version
-        user
-        multi_user
-        link
-        hierarchy
-        scored_list
+        user multi_user
+        version multi_version
       ].each do |trait|
         factory :"#{trait}_wp_custom_field", traits: [trait]
       end

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -204,7 +204,7 @@ FactoryBot.define do
         projects { [] }
       end
 
-      # enable the the custom_field for the given projects
+      # Enable the custom_field for the given projects
       after(:create) do |custom_field, evaluator|
         projects = Array(evaluator.projects)
         next if projects.blank?
@@ -217,16 +217,17 @@ FactoryBot.define do
       end
 
       factory :boolean_project_custom_field, traits: [:boolean]
+      factory :calculated_value_project_custom_field, traits: [:calculated_value]
+      factory :date_project_custom_field, traits: [:date]
+      factory :float_project_custom_field, traits: [:float]
+      factory :integer_project_custom_field, traits: [:integer]
+      factory :link_project_custom_field, traits: [:link]
+      factory :list_project_custom_field, traits: [:list]
+      factory :scored_list_project_custom_field, traits: [:scored_list]
       factory :string_project_custom_field, traits: [:string]
       factory :text_project_custom_field, traits: [:text]
-      factory :integer_project_custom_field, traits: [:integer]
-      factory :calculated_value_project_custom_field, traits: [:calculated_value]
-      factory :float_project_custom_field, traits: [:float]
-      factory :date_project_custom_field, traits: [:date]
-      factory :list_project_custom_field, traits: [:list]
-      factory :version_project_custom_field, traits: [:version]
       factory :user_project_custom_field, traits: [:user]
-      factory :link_project_custom_field, traits: [:link]
+      factory :version_project_custom_field, traits: [:version]
     end
 
     factory :user_custom_field, class: "UserCustomField"

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -216,18 +216,22 @@ FactoryBot.define do
         end
       end
 
-      factory :boolean_project_custom_field, traits: [:boolean]
-      factory :calculated_value_project_custom_field, traits: [:calculated_value]
-      factory :date_project_custom_field, traits: [:date]
-      factory :float_project_custom_field, traits: [:float]
-      factory :integer_project_custom_field, traits: [:integer]
-      factory :link_project_custom_field, traits: [:link]
-      factory :list_project_custom_field, traits: [:list]
-      factory :scored_list_project_custom_field, traits: [:scored_list]
-      factory :string_project_custom_field, traits: [:string]
-      factory :text_project_custom_field, traits: [:text]
-      factory :user_project_custom_field, traits: [:user]
-      factory :version_project_custom_field, traits: [:version]
+      %w[
+        boolean
+        calculated_value
+        date
+        float
+        integer
+        link
+        list
+        scored_list
+        string
+        text
+        user
+        version
+      ].each do |trait|
+        factory :"#{trait}_project_custom_field", traits: [trait]
+      end
     end
 
     factory :user_custom_field, class: "UserCustomField"
@@ -248,21 +252,25 @@ FactoryBot.define do
         end
       end
 
-      factory :boolean_wp_custom_field, traits: [:boolean]
-      factory :string_wp_custom_field, traits: [:string]
-      factory :text_wp_custom_field, traits: [:text]
-      factory :integer_wp_custom_field, traits: [:integer]
-      factory :float_wp_custom_field, traits: [:float]
-      factory :date_wp_custom_field, traits: [:date]
-      factory :list_wp_custom_field, traits: [:list]
-      factory :multi_list_wp_custom_field, traits: [:multi_list]
-      factory :version_wp_custom_field, traits: [:version]
-      factory :multi_version_wp_custom_field, traits: [:multi_version]
-      factory :user_wp_custom_field, traits: [:user]
-      factory :multi_user_wp_custom_field, traits: [:multi_user]
-      factory :link_wp_custom_field, traits: [:link]
-      factory :hierarchy_wp_custom_field, traits: [:hierarchy]
-      factory :scored_list_wp_custom_field, traits: [:scored_list]
+      %w[
+        boolean
+        string
+        text
+        integer
+        float
+        date
+        list
+        multi_list
+        version
+        multi_version
+        user
+        multi_user
+        link
+        hierarchy
+        scored_list
+      ].each do |trait|
+        factory :"#{trait}_wp_custom_field", traits: [trait]
+      end
     end
 
     factory :issue_custom_field, class: "WorkPackageCustomField" do

--- a/spec/features/admin/custom_fields/projects/calculated_value_spec.rb
+++ b/spec/features/admin/custom_fields/projects/calculated_value_spec.rb
@@ -31,8 +31,14 @@
 require "spec_helper"
 require_relative "shared_context"
 
-RSpec.describe "Edit project custom field calculated value", :js, with_flag: { calculated_value_project_attribute: true } do
+RSpec.describe "Edit project custom field calculated value", :js,
+               with_flag: { calculated_value_project_attribute: true } do
   include_context "with seeded project custom fields"
+
+  shared_let(:scored_list_project_custom_field) do
+    create(:scored_list_project_custom_field, :skip_validations, name: "Scored list field",
+                                                                 project_custom_field_section: section_for_select_fields)
+  end
 
   let(:calculated_value) { calculated_from_int_project_custom_field }
 
@@ -165,11 +171,23 @@ RSpec.describe "Edit project custom field calculated value", :js, with_flag: { c
             click_on(float_project_custom_field.name)
           end
 
+          # Input divide operator
+          pattern_input.send_keys(" / ")
+          expect(page).to have_no_css(".op-pattern-input--suggestions-dropdown .ActionListItem")
+
+          # Open suggestion list again
+          pattern_input.send_keys("/")
+          within ".op-pattern-input--suggestions-dropdown" do
+            expect(page).to have_css(".ActionListItem", text: scored_list_project_custom_field.name)
+            click_on(scored_list_project_custom_field.name)
+          end
+
           click_on("Save")
           wait_for_network_idle
 
           new_formula = calculated_value.reload.formula_string
-          expect(new_formula).to eq("#{integer_project_custom_field} * 2 + #{float_project_custom_field}")
+          expect(new_formula)
+            .to eq("#{integer_project_custom_field} * 2 + #{float_project_custom_field} / #{scored_list_project_custom_field}")
         end
       end
     end

--- a/spec/features/admin/custom_fields/projects/shared_context.rb
+++ b/spec/features/admin/custom_fields/projects/shared_context.rb
@@ -95,9 +95,9 @@ RSpec.shared_context "with seeded project custom fields" do
   end
 
   shared_let(:list_project_custom_field, refind: true) do
-    create(:list_project_custom_field,  name: "List field",
-                                        project_custom_field_section: section_for_select_fields,
-                                        possible_values: ["Option 1", "Option 2", "Option 3"])
+    create(:list_project_custom_field, name: "List field",
+                                       project_custom_field_section: section_for_select_fields,
+                                       possible_values: ["Option 1", "Option 2", "Option 3"])
   end
 
   shared_let(:version_project_custom_field, refind: true) do
@@ -106,27 +106,24 @@ RSpec.shared_context "with seeded project custom fields" do
   end
 
   shared_let(:user_project_custom_field, refind: true) do
-    create(:user_project_custom_field,  name: "User field",
-                                        project_custom_field_section: section_for_select_fields)
+    create(:user_project_custom_field, name: "User field",
+                                       project_custom_field_section: section_for_select_fields)
   end
 
   shared_let(:multi_list_project_custom_field, refind: true) do
-    create(:list_project_custom_field,  name: "Multi list field",
-                                        project_custom_field_section: section_for_multi_select_fields,
-                                        possible_values: ["Option 1", "Option 2", "Option 3"],
-                                        multi_value: true)
+    create(:multi_list_project_custom_field, name: "Multi list field",
+                                             project_custom_field_section: section_for_multi_select_fields,
+                                             possible_values: ["Option 1", "Option 2", "Option 3"])
   end
 
   shared_let(:multi_version_project_custom_field, refind: true) do
-    create(:version_project_custom_field, name: "Multi version field",
-                                          project_custom_field_section: section_for_multi_select_fields,
-                                          multi_value: true)
+    create(:multi_version_project_custom_field, name: "Multi version field",
+                                                project_custom_field_section: section_for_multi_select_fields)
   end
 
   shared_let(:multi_user_project_custom_field, refind: true) do
-    create(:user_project_custom_field, name: "Multi user field",
-                                       project_custom_field_section: section_for_multi_select_fields,
-                                       multi_value: true)
+    create(:multi_user_project_custom_field, name: "Multi user field",
+                                             project_custom_field_section: section_for_multi_select_fields)
   end
 
   let(:input_fields) do

--- a/spec/features/admin/custom_fields/projects/shared_context.rb
+++ b/spec/features/admin/custom_fields/projects/shared_context.rb
@@ -34,41 +34,47 @@ RSpec.shared_context "with seeded project custom fields" do
   shared_let(:admin) { create(:admin) }
   shared_let(:non_admin) { create(:user) }
 
-  shared_let(:section_for_input_fields) { create(:project_custom_field_section, name: "Input fields") }
-  shared_let(:section_for_select_fields) { create(:project_custom_field_section, name: "Select fields") }
-  shared_let(:section_for_multi_select_fields) { create(:project_custom_field_section, name: "Multi select fields") }
+  shared_let(:section_for_input_fields, refind: true) do
+    create(:project_custom_field_section, name: "Input fields")
+  end
+  shared_let(:section_for_select_fields, refind: true) do
+    create(:project_custom_field_section, name: "Select fields")
+  end
+  shared_let(:section_for_multi_select_fields, refind: true) do
+    create(:project_custom_field_section, name: "Multi select fields")
+  end
 
-  let!(:boolean_project_custom_field) do
+  shared_let(:boolean_project_custom_field, refind: true) do
     create(:boolean_project_custom_field, name: "Boolean field",
                                           project_custom_field_section: section_for_input_fields)
   end
 
-  let!(:string_project_custom_field) do
+  shared_let(:string_project_custom_field, refind: true) do
     create(:string_project_custom_field, name: "String field",
                                          project_custom_field_section: section_for_input_fields)
   end
 
-  let!(:integer_project_custom_field) do
+  shared_let(:integer_project_custom_field, refind: true) do
     create(:integer_project_custom_field, name: "Integer field",
                                           project_custom_field_section: section_for_input_fields)
   end
 
-  let!(:float_project_custom_field) do
+  shared_let(:float_project_custom_field, refind: true) do
     create(:float_project_custom_field, name: "Float field",
                                         project_custom_field_section: section_for_input_fields)
   end
 
-  let!(:date_project_custom_field) do
+  shared_let(:date_project_custom_field, refind: true) do
     create(:date_project_custom_field,  name: "Date field",
                                         project_custom_field_section: section_for_input_fields)
   end
 
-  let!(:text_project_custom_field) do
+  shared_let(:text_project_custom_field, refind: true) do
     create(:text_project_custom_field,  name: "Text field",
                                         project_custom_field_section: section_for_input_fields)
   end
 
-  let!(:calculated_from_int_project_custom_field) do
+  shared_let(:calculated_from_int_project_custom_field, refind: true) do
     create(
       :calculated_value_project_custom_field,
       :skip_validations,
@@ -78,7 +84,7 @@ RSpec.shared_context "with seeded project custom fields" do
     )
   end
 
-  let!(:calculated_from_int_and_float_project_custom_field) do
+  shared_let(:calculated_from_int_and_float_project_custom_field, refind: true) do
     create(
       :calculated_value_project_custom_field,
       :skip_validations,
@@ -88,42 +94,42 @@ RSpec.shared_context "with seeded project custom fields" do
     )
   end
 
-  let!(:list_project_custom_field) do
+  shared_let(:list_project_custom_field, refind: true) do
     create(:list_project_custom_field,  name: "List field",
                                         project_custom_field_section: section_for_select_fields,
                                         possible_values: ["Option 1", "Option 2", "Option 3"])
   end
 
-  let!(:version_project_custom_field) do
+  shared_let(:version_project_custom_field, refind: true) do
     create(:version_project_custom_field, name: "Version field",
                                           project_custom_field_section: section_for_select_fields)
   end
 
-  let!(:user_project_custom_field) do
+  shared_let(:user_project_custom_field, refind: true) do
     create(:user_project_custom_field,  name: "User field",
                                         project_custom_field_section: section_for_select_fields)
   end
 
-  let!(:multi_list_project_custom_field) do
+  shared_let(:multi_list_project_custom_field, refind: true) do
     create(:list_project_custom_field,  name: "Multi list field",
                                         project_custom_field_section: section_for_multi_select_fields,
                                         possible_values: ["Option 1", "Option 2", "Option 3"],
                                         multi_value: true)
   end
 
-  let!(:multi_version_project_custom_field) do
+  shared_let(:multi_version_project_custom_field, refind: true) do
     create(:version_project_custom_field, name: "Multi version field",
                                           project_custom_field_section: section_for_multi_select_fields,
                                           multi_value: true)
   end
 
-  let!(:multi_user_project_custom_field) do
+  shared_let(:multi_user_project_custom_field, refind: true) do
     create(:user_project_custom_field, name: "Multi user field",
                                        project_custom_field_section: section_for_multi_select_fields,
                                        multi_value: true)
   end
 
-  let!(:input_fields) do
+  let(:input_fields) do
     [
       boolean_project_custom_field,
       string_project_custom_field,
@@ -134,7 +140,7 @@ RSpec.shared_context "with seeded project custom fields" do
     ]
   end
 
-  let!(:select_fields) do
+  let(:select_fields) do
     [
       list_project_custom_field,
       version_project_custom_field,
@@ -142,7 +148,7 @@ RSpec.shared_context "with seeded project custom fields" do
     ]
   end
 
-  let!(:multi_select_fields) do
+  let(:multi_select_fields) do
     [
       multi_list_project_custom_field,
       multi_version_project_custom_field,

--- a/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
@@ -590,51 +590,6 @@ RSpec.describe "Show project custom fields on project overview page", :js do
             end
           end
         end
-
-        context "when one of the values is a scored list", with_flag: { scored_list_custom_fields: true } do
-          let!(:scored_list) do
-            field = create(:scored_list_project_custom_field,
-                           projects: [project],
-                           name: "Scored List",
-                           project_custom_field_section: section_for_input_fields,
-                           possible_values: %w[Ten])
-
-            item = create(:hierarchy_item, score: 10, label: "Ten")
-            create(:custom_value, :skip_validations, customized: project, custom_field: field, value: item.id.to_s)
-
-            field
-          end
-
-          let!(:calculated_from_scored_list) do
-            field = create(
-              :calculated_value_project_custom_field,
-              :skip_validations,
-              formula: "{{cf_#{scored_list.id}}} * 2",
-              projects: [project],
-              name: "Calculated field using scored list",
-              project_custom_field_section: section_for_input_fields
-            )
-
-            create(:custom_value, customized: project, custom_field: field, value: 10 * 2)
-
-            field
-          end
-
-          it "shows the correct value for the project custom field" do
-            overview_page.visit_page
-
-            overview_page.within_project_attributes_sidebar do
-              overview_page.within_custom_field_container(scored_list) do
-                expect(page).to have_text "Ten"
-              end
-
-              overview_page.within_custom_field_container(calculated_from_scored_list) do
-                expect(page).to have_text "Calculated field using scored list"
-                expect(page).to have_text "20"
-              end
-            end
-          end
-        end
       end
 
       describe "with an error present" do
@@ -901,6 +856,31 @@ RSpec.describe "Show project custom fields on project overview page", :js do
               expect(page).to have_text "User field"
               expect(page).to have_text I18n.t("placeholders.default")
             end
+          end
+        end
+      end
+    end
+
+    describe "with scored list CF", with_flag: { scored_list_custom_fields: true } do
+      let!(:scored_list) do
+        create(:scored_list_project_custom_field,
+               projects: [project],
+               name: "Scored List",
+               project_custom_field_section: section_for_input_fields,
+               possible_values: %w[Ten])
+      end
+      let!(:item) { create(:hierarchy_item, score: 10, label: "Ten") }
+
+      before do
+        create(:custom_value, :skip_validations, customized: project, custom_field: scored_list, value: item.id.to_s)
+      end
+
+      it "shows the correct value for the project custom field" do
+        overview_page.visit_page
+
+        overview_page.within_project_attributes_sidebar do
+          overview_page.within_custom_field_container(scored_list) do
+            expect(page).to have_text "Ten"
           end
         end
       end

--- a/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/sidebar_spec.rb
@@ -590,6 +590,51 @@ RSpec.describe "Show project custom fields on project overview page", :js do
             end
           end
         end
+
+        context "when one of the values is a scored list", with_flag: { scored_list_custom_fields: true } do
+          let!(:scored_list) do
+            field = create(:scored_list_project_custom_field,
+                           projects: [project],
+                           name: "Scored List",
+                           project_custom_field_section: section_for_input_fields,
+                           possible_values: %w[Ten])
+
+            item = create(:hierarchy_item, score: 10, label: "Ten")
+            create(:custom_value, :skip_validations, customized: project, custom_field: field, value: item.id.to_s)
+
+            field
+          end
+
+          let!(:calculated_from_scored_list) do
+            field = create(
+              :calculated_value_project_custom_field,
+              :skip_validations,
+              formula: "{{cf_#{scored_list.id}}} * 2",
+              projects: [project],
+              name: "Calculated field using scored list",
+              project_custom_field_section: section_for_input_fields
+            )
+
+            create(:custom_value, customized: project, custom_field: field, value: 10 * 2)
+
+            field
+          end
+
+          it "shows the correct value for the project custom field" do
+            overview_page.visit_page
+
+            overview_page.within_project_attributes_sidebar do
+              overview_page.within_custom_field_container(scored_list) do
+                expect(page).to have_text "Ten"
+              end
+
+              overview_page.within_custom_field_container(calculated_from_scored_list) do
+                expect(page).to have_text "Calculated field using scored list"
+                expect(page).to have_text "20"
+              end
+            end
+          end
+        end
       end
 
       describe "with an error present" do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -294,6 +294,47 @@ RSpec.describe API::V3::Utilities::CustomFieldInjector do
       end
     end
 
+    {
+      hierarchy: { with_ee: [:custom_field_hierarchies] },
+      scored_list: { with_flag: { scored_list_custom_fields: true } }
+    }.each do |format, tags|
+      describe "#{format} custom field", **tags do
+        let(:custom_field) do
+          create(
+            :"#{format}_wp_custom_field",
+            is_required: true
+          )
+        end
+
+        it_behaves_like "has basic schema properties" do
+          let(:path) { cf_path }
+          let(:type) { "CustomField::Hierarchy::Item" }
+          let(:name) { custom_field.name }
+          let(:required) { true }
+          let(:writable) { true }
+          let(:location) { "_links" }
+        end
+
+        context "with schema not writable" do
+          let(:schema_writable) { false }
+
+          it_behaves_like "has basic schema properties" do
+            let(:path) { cf_path }
+            let(:type) { "CustomField::Hierarchy::Item" }
+            let(:name) { custom_field.name }
+            let(:required) { true }
+            let(:writable) { false }
+            let(:location) { "_links" }
+          end
+        end
+
+        it_behaves_like "links to allowed values via collection link" do
+          let(:path) { cf_path }
+          let(:href) { api_v3_paths.custom_field_items(custom_field.id) }
+        end
+      end
+    end
+
     describe "user custom field on new project" do
       let(:schema) do
         instance_double(API::V3::WorkPackages::Schema::SpecificWorkPackageSchema,
@@ -464,6 +505,54 @@ RSpec.describe API::V3::Utilities::CustomFieldInjector do
           expect(subject)
             .to be_json_eql(typed_value.to_json)
             .at_path("_links/#{cf_path}/title")
+        end
+      end
+    end
+
+    %w[hierarchy scored_list].each do |format|
+      context "for #{format} custom field" do
+        let(:value) { build_stubbed(:hierarchy_item) }
+        let(:raw_value) { value.id.to_s }
+        let(:typed_value) { value }
+        let(:field_format) { format }
+        let(:formatted_value) { value.to_s }
+
+        before do
+          allow(custom_value).to receive_messages(formatted_value:)
+        end
+
+        it_behaves_like "has a titled link" do
+          let(:link) { cf_path }
+          let(:href) { api_v3_paths.custom_field_item(value.id) }
+          let(:title) { formatted_value }
+        end
+
+        context "when value is nil" do
+          let(:value) { nil }
+          let(:raw_value) { "" }
+          let(:typed_value) { "" }
+
+          it_behaves_like "has an empty link" do
+            let(:link) { cf_path }
+          end
+        end
+
+        context "when value is some invalid string" do
+          let(:value) { "some invalid string" }
+          let(:raw_value) { "some invalid string" }
+          let(:typed_value) { "some invalid string not found" }
+
+          it "has an empty href" do
+            expect(subject)
+              .to be_json_eql(nil.to_json)
+              .at_path("_links/#{cf_path}/href")
+          end
+
+          it "has the invalid value as title" do
+            expect(subject)
+              .to be_json_eql(formatted_value.to_json)
+              .at_path("_links/#{cf_path}/title")
+          end
         end
       end
     end

--- a/spec/models/acts_as_customizable/calculated_value_spec.rb
+++ b/spec/models/acts_as_customizable/calculated_value_spec.rb
@@ -30,7 +30,10 @@
 
 require "spec_helper"
 
-RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_value_project_attribute: true } do
+RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: {
+  calculated_value_project_attribute: true,
+  scored_list_custom_fields: true
+} do
   using CustomFieldFormulaReferencing
   include CalculatedValues::ErrorsHelper
 
@@ -379,6 +382,33 @@ RSpec.describe ActsAsCustomizable::CalculatedValue, with_flag: { calculated_valu
         instance.calculate_custom_fields([cf2, cf3, cf4])
         expect(instance).to have_received(:custom_field_values=)
           .with(cf2.id => 3 * 5 * 7 * 11, cf3.id => 5 * 7 * 11, cf4.id => 5 * 7).once
+      end
+    end
+
+    context "when using scored lists" do
+      let(:cf_list) { build_stubbed(:scored_list_project_custom_field) }
+      let(:cf1) { build_stubbed(:calculated_value_project_custom_field) }
+      let(:hierarchy_item) { create(:hierarchy_item, score: 7) }
+
+      let(:enabled_custom_field_ids) { [cf_list, cf1].map(&:id) }
+      let(:custom_field_values) do
+        {
+          cf_list => hierarchy_item.id
+        }.map { |custom_field, value| build_stubbed(:custom_value, custom_field:, value:) }
+      end
+
+      before do
+        {
+          cf1 => "#{cf_list} * 2"
+        }.each do |cf, formula|
+          cf.formula = formula
+        end
+      end
+
+      it "calculates values using the score of the selected entry" do
+        instance.calculate_custom_fields([cf1])
+        expect(instance).to have_received(:custom_field_values=)
+                              .with(cf1.id => 2 * 7).once
       end
     end
   end

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -30,7 +30,10 @@
 
 require "spec_helper"
 
-RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_project_attribute: true } do
+RSpec.describe CustomField::CalculatedValue, with_flag: {
+  calculated_value_project_attribute: true,
+  scored_list_custom_fields: true
+} do
   using CustomFieldFormulaReferencing
 
   subject(:custom_field) { create(:calculated_value_project_custom_field, formula: "1 + 1") }
@@ -216,13 +219,15 @@ RSpec.describe CustomField::CalculatedValue, with_flag: { calculated_value_proje
   describe "#usable_custom_field_references_for_formula" do
     let!(:int) { create(:project_custom_field, :integer, default_value: 4, is_for_all: true) }
     let!(:float) { create(:project_custom_field, :float, default_value: 5.5, is_for_all: true) }
+    let!(:scored_list) { create(:project_custom_field, :scored_list, is_for_all: true) }
     let!(:other_calculated_value) { create(:calculated_value_project_custom_field, formula: "2 + 2", is_for_all: true) }
 
     current_user { create(:admin) }
 
     context "with permission to see all custom fields" do
       it "returns custom fields with formats that can be used in formulas" do
-        expect(subject.usable_custom_field_references_for_formula).to contain_exactly(int, float, other_calculated_value)
+        expected = [int, float, other_calculated_value, scored_list]
+        expect(subject.usable_custom_field_references_for_formula).to match_array(expected)
       end
 
       it "excludes custom field formats that are not usable in formulas" do

--- a/spec/models/custom_value/hierarchy_strategy_spec.rb
+++ b/spec/models/custom_value/hierarchy_strategy_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CustomValue::HierarchyStrategy do
+  let(:instance) { described_class.new(custom_value) }
+  let(:custom_value) { instance_double(CustomValue, value:, custom_field:, customized:) }
+  let(:customized) { instance_double(Project) }
+  let(:custom_field) { build(:custom_field, hierarchy_root:) }
+  let(:hierarchy_item) { build_stubbed(:hierarchy_item) }
+  let(:hierarchy_root) { build_stubbed(:hierarchy_item) }
+
+  before do
+    allow(CustomField::Hierarchy::Item).to receive(:find_by)
+  end
+
+  describe "#parse_value/#typed_value" do
+    subject { instance }
+
+    context "with a hierarchy item" do
+      let(:value) { hierarchy_item }
+
+      it "returns the hierarchy item and sets it for later retrieval" do
+        expect(subject.parse_value(value)).to eql hierarchy_item.id.to_s
+
+        expect(subject.typed_value).to eql value
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+
+    context "with an id string" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      it "returns the string and has to later find the hierarchy item" do
+        allow(CustomField::Hierarchy::Item)
+          .to receive(:find_by)
+          .with(id: hierarchy_item.id.to_s)
+          .and_return(hierarchy_item)
+
+        expect(subject.parse_value(value)).to eql value
+
+        expect(subject.typed_value).to eql hierarchy_item
+      end
+    end
+
+    context "with an id string of missing item" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      it "returns the string and has to later find the hierarchy item" do
+        expect(subject.parse_value(value)).to eql value
+        expect(subject.typed_value).to be_nil
+      end
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it "is nil and does not look for the hierarchy_item" do
+        expect(subject.parse_value(value)).to be_nil
+
+        expect(subject.typed_value).to be_nil
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it "is nil and does not look for the hierarchy item" do
+        expect(subject.parse_value(value)).to be_nil
+
+        expect(subject.typed_value).to be_nil
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+  end
+
+  describe "#formatted_value" do
+    subject { instance.formatted_value }
+
+    context "with an id string" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      before do
+        hierarchy_item.label = "Foo Bar Baz"
+
+        allow(CustomField::Hierarchy::Item)
+          .to receive(:find_by)
+          .with(id: hierarchy_item.id.to_s)
+          .and_return(hierarchy_item)
+      end
+
+      it "is the hierarchy item label" do
+        expect(subject).to eql "Foo Bar Baz"
+      end
+
+      context "when item has short value" do
+        before do
+          hierarchy_item.short = "foo"
+        end
+
+        it "is the hierarchy item label and short" do
+          expect(subject).to eql "Foo Bar Baz (foo)"
+        end
+      end
+    end
+
+    context "with an id string of missing item" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      it "is the hierarchy item to_s (with db access)" do
+        expect(subject).to eql "#{hierarchy_item.id} not found"
+      end
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it "is blank and does not look for the hierarchy item" do
+        expect(subject).to eql " not found"
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it "is blank and does not look for the hierarchy item" do
+        expect(subject).to eql " not found"
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+  end
+
+  describe "#validate_type_of_value" do
+    subject { instance.validate_type_of_value }
+
+    let(:value) { hierarchy_item.id.to_s }
+
+    context "when value is an id of missing item" do
+      it "rejects" do
+        expect(subject).to be :invalid
+      end
+    end
+
+    context "when value is an id of existing item" do
+      before do
+        allow(CustomField::Hierarchy::Item)
+          .to receive(:find_by)
+          .with(id: hierarchy_item.id.to_s)
+          .and_return(hierarchy_item)
+
+        hierarchical_item_service = instance_double(CustomFields::Hierarchy::HierarchicalItemService)
+        service_result = (is_descendant ? Dry::Monads::Success : Dry::Monads::Failure).new(nil)
+
+        allow(CustomFields::Hierarchy::HierarchicalItemService)
+          .to receive(:new)
+          .and_return(hierarchical_item_service)
+
+        allow(hierarchical_item_service)
+          .to receive(:descendant_of?)
+          .with(item: hierarchy_item, parent: hierarchy_root)
+          .and_return(service_result)
+      end
+
+      context "when item is not a descendant of custom_field hierarchy root" do
+        let(:is_descendant) { false }
+
+        it "rejects" do
+          expect(subject).to be :inclusion
+        end
+      end
+
+      context "when item is a descendant of custom_field hierarchy root" do
+        let(:is_descendant) { true }
+
+        it "accepts" do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/models/custom_value/scored_list_strategy_spec.rb
+++ b/spec/models/custom_value/scored_list_strategy_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CustomValue::ScoredListStrategy do
+  let(:instance) { described_class.new(custom_value) }
+  let(:custom_value) { instance_double(CustomValue, value:, custom_field:, customized:) }
+  let(:customized) { instance_double(Project) }
+  let(:custom_field) { build(:custom_field, hierarchy_root:) }
+  let(:hierarchy_item) { build_stubbed(:hierarchy_item, score: 42) }
+  let(:hierarchy_root) { build_stubbed(:hierarchy_item) }
+
+  before do
+    allow(CustomField::Hierarchy::Item).to receive(:find_by)
+  end
+
+  describe "#parse_value/#typed_value" do
+    subject { instance }
+
+    context "with a hierarchy item" do
+      let(:value) { hierarchy_item }
+
+      it "returns the hierarchy item and sets it for later retrieval" do
+        expect(subject.parse_value(value)).to eql hierarchy_item.id.to_s
+
+        expect(subject.typed_value).to eq 42
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+
+      context "without score set" do
+        let(:hierarchy_item) { build_stubbed(:hierarchy_item) }
+
+        it "returns nil for typed value" do
+          expect(subject.parse_value(value)).to eql hierarchy_item.id.to_s
+
+          expect(subject.typed_value).to be_nil
+
+          expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+        end
+      end
+    end
+
+    context "with an id string" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      it "returns the string and has to later find the hierarchy item" do
+        allow(CustomField::Hierarchy::Item)
+          .to receive(:find_by)
+          .with(id: hierarchy_item.id.to_s)
+          .and_return(hierarchy_item)
+
+        expect(subject.parse_value(value)).to eql value
+
+        expect(subject.typed_value).to eq 42
+      end
+
+      context "without score set" do
+        let(:hierarchy_item) { build_stubbed(:hierarchy_item) }
+
+        it "returns nil for typed value" do
+          allow(CustomField::Hierarchy::Item)
+            .to receive(:find_by)
+            .with(id: hierarchy_item.id.to_s)
+            .and_return(hierarchy_item)
+
+          expect(subject.parse_value(value)).to eql value
+
+          expect(subject.typed_value).to be_nil
+        end
+      end
+    end
+
+    context "with an id string of missing item" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      it "returns the string and typed_value is nil (missing item)" do
+        expect(subject.parse_value(value)).to eql value
+        expect(subject.typed_value).to be_nil
+      end
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it "is nil and does not look for the hierarchy_item" do
+        expect(subject.parse_value(value)).to be_nil
+
+        expect(subject.typed_value).to be_nil
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it "is nil and does not look for the hierarchy item" do
+        expect(subject.parse_value(value)).to be_nil
+
+        expect(subject.typed_value).to be_nil
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+  end
+
+  describe "#formatted_value" do
+    subject { instance.formatted_value }
+
+    context "with an id string" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      before do
+        hierarchy_item.label = "Foo Bar Baz"
+
+        allow(CustomField::Hierarchy::Item)
+          .to receive(:find_by)
+          .with(id: hierarchy_item.id.to_s)
+          .and_return(hierarchy_item)
+      end
+
+      it "is the hierarchy item label" do
+        expect(subject).to eql "Foo Bar Baz"
+      end
+
+      context "when item has short value" do
+        before do
+          hierarchy_item.short = "foo"
+        end
+
+        it "is the hierarchy item label and short" do
+          expect(subject).to eql "Foo Bar Baz (foo)"
+        end
+      end
+    end
+
+    context "with an id string of missing item" do
+      let(:value) { hierarchy_item.id.to_s }
+
+      it "is the hierarchy item to_s (with db access)" do
+        expect(subject).to eql "#{hierarchy_item.id} not found"
+      end
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it "is blank and does not look for the hierarchy item" do
+        expect(subject).to eql " not found"
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it "is blank and does not look for the hierarchy item" do
+        expect(subject).to eql " not found"
+
+        expect(CustomField::Hierarchy::Item).not_to have_received(:find_by)
+      end
+    end
+  end
+
+  describe "#validate_type_of_value" do
+    subject { instance.validate_type_of_value }
+
+    let(:value) { hierarchy_item.id.to_s }
+
+    context "when value is an id of missing item" do
+      it "rejects" do
+        expect(subject).to be :invalid
+      end
+    end
+
+    context "when value is an id of existing item" do
+      before do
+        allow(CustomField::Hierarchy::Item)
+          .to receive(:find_by)
+          .with(id: hierarchy_item.id.to_s)
+          .and_return(hierarchy_item)
+
+        hierarchical_item_service = instance_double(CustomFields::Hierarchy::HierarchicalItemService)
+        service_result = (is_descendant ? Dry::Monads::Success : Dry::Monads::Failure).new(nil)
+
+        allow(CustomFields::Hierarchy::HierarchicalItemService)
+          .to receive(:new)
+          .and_return(hierarchical_item_service)
+
+        allow(hierarchical_item_service)
+          .to receive(:descendant_of?)
+          .with(item: hierarchy_item, parent: hierarchy_root)
+          .and_return(service_result)
+      end
+
+      context "when item is not a descendant of custom_field hierarchy root" do
+        let(:is_descendant) { false }
+
+        it "rejects" do
+          expect(subject).to be :inclusion
+        end
+      end
+
+      context "when item is a descendant of custom_field hierarchy root" do
+        let(:is_descendant) { true }
+
+        it "accepts" do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64523

- [x] Allow usage of ScoredList in formula
- [x] During calculation, make sure the selected value is used. To do so, adjust the Strategy used by the Custom Field.
  - [x] Since Hierarchies and Scored Lists share the same strategy: ensure that Hierarchies still behave well w.r.t. rendering and editing them.
  - [x] Ensure the API still works
- [x] Specs
- [x] Recalculate when enabling/disabling the field
- [x] Recalculate when another entry from the list is selected on the overview page

## Out of scope

Recalculating when a scored list is _modified_ in the administration. For example, when a score is changed. For that, there is another work package.

# Screenshots

https://github.com/user-attachments/assets/6ad5717c-01be-40b8-b0ce-dc52ccfa9188


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
