### PR TITLE
[#67722] hide segmented control and checkbox

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/change_item_parent_dialog_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/change_item_parent_dialog_component.html.erb
@@ -38,7 +38,11 @@ See COPYRIGHT and LICENSE files for more details.
     dialog.with_body do
       primer_form_with(**form_arguments) do |form|
         render(
-          Primer::OpenProject::FilterableTreeView.new(form_arguments: { builder: form, name: :new_parent })
+          Primer::OpenProject::FilterableTreeView.new(
+            form_arguments: { builder: form, name: :new_parent },
+            include_sub_items_check_box_arguments: { hidden: true },
+            filter_mode_control_arguments: { hidden: true }
+          )
         ) do |tree_view|
           add_sub_tree(tree_view, hierarchy_items)
         end


### PR DESCRIPTION
# Ticket
[#67722](https://community.openproject.org/work_packages/67722)


# What are you trying to accomplish?
- set segmented control to :none
- set include checkbox to hidden: true

# Hints

Two things are not yet appropriate in use:

- if both are hidden, a left margin remains before the search bar
  
<img width="790" height="576" alt="image" src="https://github.com/user-attachments/assets/754a13d1-9f78-4351-84aa-9392dbc6dd36" />

- if used in code, the IDE highlights the parameter of `filter_mode_control_arguments` for not being a hash

<img width="839" height="226" alt="image" src="https://github.com/user-attachments/assets/98ef1bfe-fe62-4d97-a7ca-60af865b6405" />
