### PR TITLE
[67721] New Assignee icon in Team planner invisible in dark mode

### DIFF
--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -48,6 +48,7 @@ $view-select-dropdown-width: 8rem
 
   &--add-existing-icon
     margin-right: var(--base-size-4)
+    fill: var(--body-font-color)
 
   .fc-scrollgrid
     border-top: none !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67721

# What are you trying to accomplish?
Adapt colour to make it visible in dark mode as well

## Screenshots

<img width="152" height="83" alt="Bildschirmfoto 2025-09-29 um 08 44 28" src="https://github.com/user-attachments/assets/0cea31d5-eeee-4cb2-b5a6-eb34af1d82f8" />
