### PR TITLE
[67733] Wrong warning message when revoking a browser session

### DIFF
--- a/app/components/users/sessions/row_component.rb
+++ b/app/components/users/sessions/row_component.rb
@@ -106,7 +106,7 @@ module Users
             "aria-label": I18n.t(:button_revoke),
             data: {
               method: :delete,
-              confirm: I18n.t(:text_are_you_sure),
+              confirm: I18n.t("users.sessions.deletion_warning"),
               disable_with: I18n.t(:label_loading)
             }
           )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -688,6 +688,7 @@ en:
       title: "Session management"
       instructions: "You are logged in to your account through the following devices. Revoke sessions that you do not recognise or from devices you do not control."
       may_not_delete_current: "You cannot delete your current session."
+      deletion_warning: "Are you sure you want to revoke this session? You will be logged out on this device."
     groups:
       member_in_these_groups: "This user is currently a member of the following groups:"
       no_results_title_text: This user is currently not a member in any group.


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67733

# What are you trying to accomplish?
Change warning message when deleting a session

