### PR TITLE
Show authentication provider create message

### DIFF
--- a/modules/auth_saml/app/components/saml/providers/sections/form_component.html.erb
+++ b/modules/auth_saml/app/components/saml/providers/sections/form_component.html.erb
@@ -33,7 +33,7 @@
             form,
             provider:,
             submit_button_options: { label: button_label },
-            cancel_button_options: { hidden: edit_mode }
+            cancel_button_options: { hidden: new_mode }
           )
         )
       end

--- a/modules/auth_saml/app/components/saml/providers/sections/form_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/form_component.rb
@@ -30,16 +30,16 @@
 #
 module Saml::Providers::Sections
   class FormComponent < SectionComponent
-    attr_reader :edit_state, :next_edit_state, :edit_mode
+    attr_reader :edit_state, :next_edit_state, :new_mode
 
     def initialize(provider, edit_state:, form_class:,
                    heading:, banner: nil, banner_scheme: :default,
-                   next_edit_state: nil, edit_mode: nil)
+                   next_edit_state: nil, new_mode: nil)
       super(provider)
 
       @edit_state = edit_state
       @next_edit_state = next_edit_state
-      @edit_mode = edit_mode
+      @new_mode = new_mode
       @form_class = form_class
       @heading = heading
       @banner = banner
@@ -48,9 +48,9 @@ module Saml::Providers::Sections
 
     def url
       if provider.new_record?
-        saml_providers_path(edit_state:, edit_mode:, next_edit_state:)
+        saml_providers_path(edit_state:, new_mode:, next_edit_state:)
       else
-        saml_provider_path(provider, edit_state:, edit_mode:, next_edit_state:)
+        saml_provider_path(provider, edit_state:, new_mode:, next_edit_state:)
       end
     end
 
@@ -63,7 +63,7 @@ module Saml::Providers::Sections
     end
 
     def button_label
-      if edit_mode
+      if new_mode
         I18n.t(:button_continue)
       else
         I18n.t(:button_update)

--- a/modules/auth_saml/app/components/saml/providers/sections/metadata_form_component.html.erb
+++ b/modules/auth_saml/app/components/saml/providers/sections/metadata_form_component.html.erb
@@ -2,14 +2,14 @@
   primer_form_with(
     model: provider,
     id: "saml-providers-edit-form",
-    url: import_metadata_saml_provider_path(provider, edit_mode:),
+    url: import_metadata_saml_provider_path(provider, new_mode:),
     data: {
       controller: "show-when-value-selected"
     },
     method: :post
   ) do |form|
     flex_layout do |flex|
-      if edit_mode
+      if new_mode
         flex.with_row do
           render(Primer::Beta::Text.new(tag: :p, mb: 4, font_size: :small)) do
             t("saml.providers.section_texts.metadata_form")
@@ -49,7 +49,7 @@
             form,
             provider:,
             submit_button_options: { label: button_label },
-            cancel_button_options: { hidden: edit_mode },
+            cancel_button_options: { hidden: new_mode },
             state: :metadata
           )
         )

--- a/modules/auth_saml/app/components/saml/providers/sections/metadata_form_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/metadata_form_component.rb
@@ -30,8 +30,8 @@
 #
 module Saml::Providers::Sections
   class MetadataFormComponent < FormComponent
-    def initialize(provider, edit_mode: nil)
-      super(provider, edit_state: :metadata, edit_mode:, form_class: nil, heading: nil)
+    def initialize(provider, new_mode: nil)
+      super(provider, edit_state: :metadata, new_mode:, form_class: nil, heading: nil)
     end
   end
 end

--- a/modules/auth_saml/app/components/saml/providers/sections/request_attributes_form_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/sections/request_attributes_form_component.rb
@@ -30,16 +30,16 @@
 #
 module Saml::Providers::Sections
   class RequestAttributesFormComponent < FormComponent
-    def initialize(provider, edit_mode: nil)
+    def initialize(provider, new_mode: nil)
       super(provider,
             edit_state: :requested_attributes,
-            edit_mode:,
+            new_mode:,
             form_class: Saml::Providers::RequestAttributesForm,
             heading: I18n.t("saml.instructions.requested_attributes"))
     end
 
     def button_label
-      if edit_mode
+      if new_mode
         I18n.t(:button_finish_setup)
       else
         I18n.t(:button_save)

--- a/modules/auth_saml/app/components/saml/providers/view_component.html.erb
+++ b/modules/auth_saml/app/components/saml/providers/view_component.html.erb
@@ -20,7 +20,7 @@
                 form_class: Saml::Providers::NameInputForm,
                 edit_state:,
                 next_edit_state: :metadata,
-                edit_mode:,
+                new_mode:,
                 heading: nil
               )
             )
@@ -46,7 +46,7 @@
             render(
               Saml::Providers::Sections::MetadataFormComponent.new(
                 provider,
-                edit_mode:
+                new_mode:
               )
             )
           else
@@ -76,7 +76,7 @@
                 form_class: Saml::Providers::ConfigurationForm,
                 edit_state:,
                 next_edit_state: :encryption,
-                edit_mode:,
+                new_mode:,
                 banner: provider.last_metadata_update ? t("saml.providers.section_texts.configuration_metadata") : nil,
                 banner_scheme: :default,
                 heading: nil
@@ -104,7 +104,7 @@
                 form_class: Saml::Providers::EncryptionForm,
                 edit_state:,
                 next_edit_state: :mapping,
-                edit_mode:,
+                new_mode:,
                 heading: t("saml.providers.section_texts.encryption_form")
               )
             )
@@ -133,7 +133,7 @@
                 form_class: Saml::Providers::MappingForm,
                 edit_state:,
                 next_edit_state: :requested_attributes,
-                edit_mode:,
+                new_mode:,
                 heading: t("saml.instructions.mapping")
               )
             )
@@ -156,7 +156,7 @@
             render(
               Saml::Providers::Sections::RequestAttributesFormComponent.new(
                 provider,
-                edit_mode:
+                new_mode:
               )
             )
           else

--- a/modules/auth_saml/app/components/saml/providers/view_component.rb
+++ b/modules/auth_saml/app/components/saml/providers/view_component.rb
@@ -33,7 +33,7 @@ module Saml::Providers
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    options :view_mode, :edit_state, :edit_mode
+    options :view_mode, :edit_state, :new_mode
 
     alias_method :provider, :model
   end

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -20,11 +20,7 @@ module Saml
     def edit
       respond_to do |format|
         format.turbo_stream do
-          component = Saml::Providers::ViewComponent.new(@provider,
-                                                         view_mode: :edit,
-                                                         new_mode: @new_mode,
-                                                         edit_state: @edit_state)
-          update_via_turbo_stream(component:)
+          update_view_component(view_mode: :edit, new_mode: @new_mode, edit_state: @edit_state)
           scroll_into_view_via_turbo_stream("saml-providers-edit-form", behavior: :instant)
           render turbo_stream: turbo_streams
         end
@@ -114,14 +110,7 @@ module Saml
 
       respond_to do |format|
         format.turbo_stream do
-          update_via_turbo_stream(
-            component: Saml::Providers::ViewComponent.new(
-              @provider,
-              new_mode: @new_mode,
-              edit_state: @next_edit_state,
-              view_mode: :show
-            )
-          )
+          update_view_component(new_mode: @new_mode, edit_state: @next_edit_state, view_mode: :show)
           render turbo_stream: turbo_streams
         end
         format.html do
@@ -135,6 +124,10 @@ module Saml
           end
         end
       end
+    end
+
+    def update_view_component(new_mode:, edit_state:, view_mode:)
+      update_via_turbo_stream(component: Saml::Providers::ViewComponent.new(@provider, new_mode:, edit_state:, view_mode:))
     end
 
     def check_ee

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -32,17 +32,7 @@ module Saml
       end
     end
 
-    def show
-      respond_to do |format|
-        format.turbo_stream do
-          component = Saml::Providers::ViewComponent.new(@provider,
-                                                         view_mode: :show)
-          update_via_turbo_stream(component:)
-          render turbo_stream: turbo_streams
-        end
-        format.html
-      end
-    end
+    def show; end
 
     def new
       @provider = ::Saml::Provider.new
@@ -117,6 +107,11 @@ module Saml
     private
 
     def successful_save_response
+      if @new_mode && !@next_edit_state
+        flash[:notice] = I18n.t("saml.providers.notice_created")
+        return redirect_to saml_provider_path(@provider)
+      end
+
       respond_to do |format|
         format.turbo_stream do
           update_via_turbo_stream(
@@ -130,7 +125,7 @@ module Saml
           render turbo_stream: turbo_streams
         end
         format.html do
-          if @new_mode && @next_edit_state
+          if @next_edit_state
             redirect_to edit_saml_provider_path(@provider,
                                                 anchor: "saml-providers-edit-form",
                                                 new_mode: @new_mode,

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -22,7 +22,7 @@ module Saml
         format.turbo_stream do
           component = Saml::Providers::ViewComponent.new(@provider,
                                                          view_mode: :edit,
-                                                         edit_mode: @edit_mode,
+                                                         new_mode: @new_mode,
                                                          edit_state: @edit_state)
           update_via_turbo_stream(component:)
           scroll_into_view_via_turbo_stream("saml-providers-edit-form", behavior: :instant)
@@ -53,10 +53,10 @@ module Saml
       @provider = call.result
 
       if call.success?
-        if @edit_mode || @provider.last_metadata_update.present?
+        if @new_mode || @provider.last_metadata_update.present?
           redirect_to edit_saml_provider_path(@provider,
                                               anchor: "saml-providers-edit-form",
-                                              edit_mode: @edit_mode,
+                                              new_mode: @new_mode,
                                               edit_state: :configuration)
         else
           redirect_to saml_provider_path(@provider)
@@ -90,7 +90,7 @@ module Saml
         .call(update_params)
 
       if call.success?
-        flash[:notice] = I18n.t(:notice_successful_update) unless @edit_mode
+        flash[:notice] = I18n.t(:notice_successful_update) unless @new_mode
         successful_save_response
       else
         @provider = call.result
@@ -122,7 +122,7 @@ module Saml
           update_via_turbo_stream(
             component: Saml::Providers::ViewComponent.new(
               @provider,
-              edit_mode: @edit_mode,
+              new_mode: @new_mode,
               edit_state: @next_edit_state,
               view_mode: :show
             )
@@ -130,10 +130,10 @@ module Saml
           render turbo_stream: turbo_streams
         end
         format.html do
-          if @edit_mode && @next_edit_state
+          if @new_mode && @next_edit_state
             redirect_to edit_saml_provider_path(@provider,
                                                 anchor: "saml-providers-edit-form",
-                                                edit_mode: true,
+                                                new_mode: @new_mode,
                                                 edit_state: @next_edit_state)
           else
             redirect_to saml_provider_path(@provider)
@@ -187,7 +187,7 @@ module Saml
 
     def set_edit_state
       @edit_state = params[:edit_state].to_sym if params.key?(:edit_state)
-      @edit_mode = ActiveRecord::Type::Boolean.new.cast(params[:edit_mode])
+      @new_mode = ActiveRecord::Type::Boolean.new.cast(params[:new_mode])
       @next_edit_state = params[:next_edit_state].to_sym if params.key?(:next_edit_state)
     end
   end

--- a/modules/auth_saml/app/views/saml/providers/edit.html.erb
+++ b/modules/auth_saml/app/views/saml/providers/edit.html.erb
@@ -26,7 +26,7 @@
       Saml::Providers::ViewComponent.new(
         @provider,
         view_mode: :edit,
-        edit_mode: @edit_mode,
+        new_mode: @new_mode,
         edit_state: @edit_state
       )
     ) %>

--- a/modules/auth_saml/app/views/saml/providers/new.html.erb
+++ b/modules/auth_saml/app/views/saml/providers/new.html.erb
@@ -20,4 +20,4 @@
   <% end %>
 <% end %>
 
-<%= render(Saml::Providers::ViewComponent.new(@provider, edit_mode: true, edit_state: :name)) %>
+<%= render(Saml::Providers::ViewComponent.new(@provider, new_mode: true, edit_state: :name)) %>

--- a/modules/auth_saml/config/locales/en.yml
+++ b/modules/auth_saml/config/locales/en.yml
@@ -54,15 +54,16 @@ en:
       label_edit: Edit SAML identity provider %{name}
       label_uid: Internal user id
       label_mapping: Mapping
-
       label_requested_attribute_for: "Requested attribute for: %{attribute}"
+
       no_results_table: No SAML identity providers have been defined yet.
+      notice_created: A new SAML identity provider was successfully created.
       plural: SAML identity providers
       singular: SAML identity provider
       requested_attributes: Requested attributes
       attribute_mapping: Attribute mapping
       attribute_mapping_text: >
-        The following fields control which attributes provided by the SAML identity provider 
+        The following fields control which attributes provided by the SAML identity provider
         are used to provide user attributes in OpenProject
       metadata:
         dialog: "This is the URL where the OpenProject SAML metadata is available. Optionally use it to configure your identity provider:"
@@ -71,7 +72,7 @@ en:
         description: Connect OpenProject to a SAML identity provider
       request_attributes:
         title: 'Requested attributes'
-        legend: > 
+        legend: >
           These attributes are added to the SAML XML metadata to signify to the identify provider which attributes OpenProject requires.
           You may still need to explicitly configure your identity provider to send these attributes. Please refer to your IdP's documentation.
         name: 'Requested attribute key'

--- a/modules/openid_connect/app/components/openid_connect/providers/sections/form_component.html.erb
+++ b/modules/openid_connect/app/components/openid_connect/providers/sections/form_component.html.erb
@@ -34,7 +34,7 @@
             form,
             provider:,
             submit_button_options: { label: button_label },
-            cancel_button_options: { hidden: edit_mode }
+            cancel_button_options: { hidden: new_mode }
           )
         )
       end

--- a/modules/openid_connect/app/components/openid_connect/providers/sections/form_component.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/sections/form_component.rb
@@ -30,7 +30,7 @@
 
 module OpenIDConnect::Providers::Sections
   class FormComponent < ::Saml::Providers::Sections::SectionComponent
-    attr_reader :edit_state, :next_edit_state, :edit_mode, :fetch_metadata
+    attr_reader :edit_state, :next_edit_state, :new_mode, :fetch_metadata
 
     delegate :form_data, to: :@form_class
 
@@ -41,13 +41,13 @@ module OpenIDConnect::Providers::Sections
                    banner: nil,
                    banner_scheme: :default,
                    next_edit_state: nil,
-                   edit_mode: nil,
+                   new_mode: nil,
                    fetch_metadata: false)
       super(provider)
 
       @edit_state = edit_state
       @next_edit_state = next_edit_state
-      @edit_mode = edit_mode
+      @new_mode = new_mode
       @form_class = form_class
       @heading = heading
       @banner = banner
@@ -64,8 +64,8 @@ module OpenIDConnect::Providers::Sections
     end
 
     def form_url_params
-      if edit_mode
-        { edit_state:, fetch_metadata:, edit_mode:, next_edit_state: }
+      if new_mode
+        { edit_state:, fetch_metadata:, new_mode:, next_edit_state: }
       else
         { edit_state:, fetch_metadata: }
       end
@@ -80,7 +80,7 @@ module OpenIDConnect::Providers::Sections
     end
 
     def button_label
-      return I18n.t(:button_save) unless edit_mode
+      return I18n.t(:button_save) unless new_mode
 
       if next_edit_state.nil?
         I18n.t(:button_finish_setup)

--- a/modules/openid_connect/app/components/openid_connect/providers/sections/metadata_form_component.html.erb
+++ b/modules/openid_connect/app/components/openid_connect/providers/sections/metadata_form_component.html.erb
@@ -11,7 +11,7 @@
     method: :put
   ) do |form|
     flex_layout do |flex|
-      unless edit_mode
+      unless new_mode
         flex.with_row do
           render(Primer::Alpha::Banner.new(mb: 2, scheme: :warning, icon: :alert)) do
             t("openid_connect.providers.section_texts.metadata_form_banner")
@@ -49,7 +49,7 @@
             form,
             provider:,
             submit_button_options: { label: button_label },
-            cancel_button_options: { hidden: edit_mode },
+            cancel_button_options: { hidden: new_mode },
             state: :metadata
           )
         )

--- a/modules/openid_connect/app/components/openid_connect/providers/view_component.html.erb
+++ b/modules/openid_connect/app/components/openid_connect/providers/view_component.html.erb
@@ -21,7 +21,7 @@
                                           form_class: OpenIDConnect::Providers::NameInputForm,
                                           edit_state:,
                                           next_edit_state: :client_details,
-                                          edit_mode:,
+                                          new_mode:,
                                           heading: nil,
                                           fetch_metadata: true
                                         )
@@ -44,7 +44,7 @@
                   provider,
                   form_class: OpenIDConnect::Providers::ClientDetailsForm,
                   edit_state:,
-                  edit_mode:,
+                  new_mode:,
                   heading: nil,
                   fetch_metadata: true
                 )
@@ -71,7 +71,7 @@
                                           form_class: OpenIDConnect::Providers::NameInputAndTenantForm,
                                           edit_state:,
                                           next_edit_state: :client_details,
-                                          edit_mode:,
+                                          new_mode:,
                                           heading: nil,
                                           fetch_metadata: true
                                         )
@@ -94,7 +94,7 @@
                   provider,
                   form_class: OpenIDConnect::Providers::ClientDetailsForm,
                   edit_state:,
-                  edit_mode:,
+                  new_mode:,
                   heading: nil,
                   fetch_metadata: true
                 )
@@ -122,7 +122,7 @@
                   form_class: OpenIDConnect::Providers::NameInputForm,
                   edit_state:,
                   next_edit_state: :metadata,
-                  edit_mode:,
+                  new_mode:,
                   heading: nil
                 )
               else
@@ -149,7 +149,7 @@
                   form_class: nil,
                   heading: nil,
                   edit_state:,
-                  edit_mode:,
+                  new_mode:,
                   next_edit_state: :metadata_details,
                   fetch_metadata: true
                 )
@@ -181,7 +181,7 @@
                   form_class: OpenIDConnect::Providers::MetadataDetailsForm,
                   edit_state:,
                   next_edit_state: :client_details,
-                  edit_mode:,
+                  new_mode:,
                   banner: provider.metadata_url.present? ? t("openid_connect.providers.section_texts.configuration_metadata") : nil,
                   banner_scheme: :default,
                   heading: nil
@@ -210,7 +210,7 @@
                   form_class: OpenIDConnect::Providers::ClientDetailsForm,
                   edit_state:,
                   next_edit_state: :attribute_mapping,
-                  edit_mode:,
+                  new_mode:,
                   heading: nil
                 )
               )
@@ -241,7 +241,7 @@
                   form_class: OpenIDConnect::Providers::AttributeMappingForm,
                   edit_state:,
                   next_edit_state: OpenProject::FeatureDecisions.oidc_group_sync_active? ? :group_mapping : :claims,
-                  edit_mode:,
+                  new_mode:,
                   heading: nil
                 )
               )
@@ -269,7 +269,7 @@
                     form_class: OpenIDConnect::Providers::GroupMappingForm,
                     edit_state:,
                     next_edit_state: :claims,
-                    edit_mode:,
+                    new_mode:,
                     heading: nil
                   )
                 )
@@ -294,7 +294,7 @@
                   provider,
                   form_class: OpenIDConnect::Providers::ClaimsForm,
                   edit_state:,
-                  edit_mode:,
+                  new_mode:,
                   heading: nil
                 )
               )

--- a/modules/openid_connect/app/components/openid_connect/providers/view_component.rb
+++ b/modules/openid_connect/app/components/openid_connect/providers/view_component.rb
@@ -34,7 +34,7 @@ module OpenIDConnect
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
-      options :view_mode, :edit_state, :edit_mode
+      options :view_mode, :edit_state, :new_mode
 
       alias_method :provider, :model
     end

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -79,11 +79,7 @@ module OpenIDConnect
     def edit
       respond_to do |format|
         format.turbo_stream do
-          component = OpenIDConnect::Providers::ViewComponent.new(@provider,
-                                                                  view_mode: :edit,
-                                                                  new_mode: @new_mode,
-                                                                  edit_state: @edit_state)
-          update_via_turbo_stream(component:)
+          update_view_component(view_mode: :edit, new_mode: @new_mode, edit_state: @edit_state)
           scroll_into_view_via_turbo_stream("openid-connect-providers-edit-form", behavior: :instant)
           render turbo_stream: turbo_streams
         end
@@ -152,14 +148,7 @@ module OpenIDConnect
 
       respond_to do |format|
         format.turbo_stream do
-          update_via_turbo_stream(
-            component: OpenIDConnect::Providers::ViewComponent.new(
-              @provider,
-              new_mode: @new_mode,
-              edit_state: @next_edit_state,
-              view_mode: :show
-            )
-          )
+          update_view_component(new_mode: @new_mode, edit_state: @next_edit_state, view_mode: :show)
           render turbo_stream: turbo_streams
         end
         format.html do
@@ -179,20 +168,19 @@ module OpenIDConnect
     def failed_save_response(action_to_render)
       respond_to do |format|
         format.turbo_stream do
-          update_via_turbo_stream(
-            component: OpenIDConnect::Providers::ViewComponent.new(
-              @provider,
-              new_mode: @new_mode,
-              edit_state: @edit_state,
-              view_mode: :show
-            )
-          )
+          update_view_component(new_mode: @new_mode, edit_state: @edit_state, view_mode: :show)
           render turbo_stream: turbo_streams
         end
         format.html do
           render action: action_to_render, status: :unprocessable_entity
         end
       end
+    end
+
+    def update_view_component(new_mode:, edit_state:, view_mode:)
+      update_via_turbo_stream(
+        component: OpenIDConnect::Providers::ViewComponent.new(@provider, new_mode:, edit_state:, view_mode:)
+      )
     end
 
     def set_edit_state

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -81,7 +81,7 @@ module OpenIDConnect
         format.turbo_stream do
           component = OpenIDConnect::Providers::ViewComponent.new(@provider,
                                                                   view_mode: :edit,
-                                                                  edit_mode: @edit_mode,
+                                                                  new_mode: @new_mode,
                                                                   edit_state: @edit_state)
           update_via_turbo_stream(component:)
           scroll_into_view_via_turbo_stream("openid-connect-providers-edit-form", behavior: :instant)
@@ -145,12 +145,17 @@ module OpenIDConnect
     end
 
     def successful_save_response
+      if @new_mode && !@next_edit_state
+        flash[:notice] = I18n.t("openid_connect.providers.notice_created")
+        return redirect_to openid_connect_provider_path(@provider)
+      end
+
       respond_to do |format|
         format.turbo_stream do
           update_via_turbo_stream(
             component: OpenIDConnect::Providers::ViewComponent.new(
               @provider,
-              edit_mode: @edit_mode,
+              new_mode: @new_mode,
               edit_state: @next_edit_state,
               view_mode: :show
             )
@@ -158,13 +163,13 @@ module OpenIDConnect
           render turbo_stream: turbo_streams
         end
         format.html do
-          flash[:notice] = I18n.t(:notice_successful_update) unless @edit_mode
-          if @edit_mode && @next_edit_state
+          if @next_edit_state
             redirect_to edit_openid_connect_provider_path(@provider,
                                                           anchor: "openid-connect-providers-edit-form",
-                                                          edit_mode: true,
+                                                          new_mode: @new_mode,
                                                           edit_state: @next_edit_state)
           else
+            flash[:notice] = I18n.t(:notice_successful_update) unless @new_mode
             redirect_to openid_connect_provider_path(@provider)
           end
         end
@@ -177,7 +182,7 @@ module OpenIDConnect
           update_via_turbo_stream(
             component: OpenIDConnect::Providers::ViewComponent.new(
               @provider,
-              edit_mode: @edit_mode,
+              new_mode: @new_mode,
               edit_state: @edit_state,
               view_mode: :show
             )
@@ -192,7 +197,7 @@ module OpenIDConnect
 
     def set_edit_state
       @edit_state = params[:edit_state].to_sym if params.key?(:edit_state)
-      @edit_mode = ActiveRecord::Type::Boolean.new.cast(params[:edit_mode])
+      @new_mode = ActiveRecord::Type::Boolean.new.cast(params[:new_mode])
       @next_edit_state = params[:next_edit_state].to_sym if params.key?(:next_edit_state)
     end
 

--- a/modules/openid_connect/app/views/openid_connect/providers/edit.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/edit.html.erb
@@ -34,7 +34,7 @@
         OpenIDConnect::Providers::ViewComponent.new(
           @provider,
           view_mode: :edit,
-          edit_mode: @edit_mode,
+          new_mode: @new_mode,
           edit_state: @edit_state
         )
       )

--- a/modules/openid_connect/app/views/openid_connect/providers/new.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/new.html.erb
@@ -12,4 +12,4 @@
   end
 %>
 
-<%= render(OpenIDConnect::Providers::ViewComponent.new(@provider, edit_mode: true, edit_state: :name)) %>
+<%= render(OpenIDConnect::Providers::ViewComponent.new(@provider, new_mode: true, edit_state: :name)) %>

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -133,6 +133,7 @@ en:
       label_configuration_details: Metadata
       label_client_details: Client details
       label_attribute_mapping: Attribute mapping
+      notice_created: A new OpenID provider was successfully created.
       client_details_description: Configuration details of OpenProject as an OIDC client
       no_results_table: No providers have been defined yet.
       plural: OpenID providers


### PR DESCRIPTION
So far we didn't redirect the user anywhere and they couldn't know
that they successfully created their provider. Now we redirect them
to the show view and display a success message.

As part of this change the "edit mode" was renamed to "new mode", because
it's exclusively set to true during initial provider creation, so it's rather
reflecting on being tied to the "new" user flow, than to any "edit" user flow.

Those changes were applied to both OpenID Connect providers and SAML providers.

# Ticket
https://community.openproject.org/wp/67257