### PR TITLE
[65507] Plan name in enterprise banners has insufficient color contrast

### DIFF
--- a/app/components/enterprise_edition/plan_for_feature.rb
+++ b/app/components/enterprise_edition/plan_for_feature.rb
@@ -81,7 +81,7 @@ module EnterpriseEdition
     end
 
     def plan_text
-      plan_name = render(Primer::Beta::Text.new(font_weight: :bold, classes: "upsell-colored")) do
+      plan_name = render(Primer::Beta::Text.new(font_weight: :bold, classes: "upsell-colored-text")) do
         I18n.t("ee.upsell.plan_name", plan: plan.capitalize)
       end
 

--- a/app/components/enterprise_edition/trial_teaser_component.rb
+++ b/app/components/enterprise_edition/trial_teaser_component.rb
@@ -69,7 +69,7 @@ module EnterpriseEdition
     end
 
     def plan_name
-      render(Primer::Beta::Text.new(font_weight: :bold, classes: "upsell-colored")) do
+      render(Primer::Beta::Text.new(font_weight: :bold, classes: "upsell-colored-text")) do
         I18n.t("ee.upsell.plan_name", plan: token.plan.capitalize)
       end
     end

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -91,6 +91,7 @@
       --ck-color-button-on-disabled-background: var(--button-default-bgColor-disabled);
       --ck-color-labeled-field-label-background: var(--overlay-bgColor);
       --ck-color-input-disabled-background: var(--bgColor-disabled);
+      --enterprise-upsell-text-color: var(--enterprise-upsell-color);
   }
 
   [data-dark-theme=dark_high_contrast] {

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -40,6 +40,9 @@
 .upsell-colored
   color: var(--enterprise-upsell-color) !important
 
+.upsell-colored-text
+  color: var(--enterprise-upsell-text-color) !important
+
 .upsell-colored-background
   background: var(--enterprise-upsell-color) !important
   color: white !important

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -133,5 +133,6 @@
   --full-view-split-right-width: 550px;
   --gantt-split-width: 50%;
   --enterprise-upsell-color: #FB8F44;
+  --enterprise-upsell-text-color: #CE4C00;
   --enterprise-upsell-border-color: #fb8f4466;
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65507

# What are you trying to accomplish?
Increase contrast of upsell coloured text

## Screenshots
<img width="837" height="188" alt="Bildschirmfoto 2025-09-30 um 10 27 13" src="https://github.com/user-attachments/assets/532611ef-e1ae-4bd7-9614-c5b7d6bd8b7c" />
