### PR TITLE
Preload user attachments before creating avatar_url list.

### DIFF
--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -51,7 +51,7 @@ module Primer
           super()
           @input = input
           @value = value
-          @users = User.active.map do |user|
+          @users = User.active.preload(:attachments).map do |user|
             {
               id: user.id,
               username: user.name,


### PR DESCRIPTION
To avoid n+1 attachment queries.
Problem exists on `documents/new` and `documents/:id/edit` when document category is Experimental and BlockNoteJS editor is enabled.

