### PR TITLE
avoid loading confirm destroy form twice

### DIFF
--- a/modules/storages/app/components/storages/admin/edit_form_header_component.html.erb
+++ b/modules/storages/app/components/storages/admin/edit_form_header_component.html.erb
@@ -27,34 +27,30 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= primer_form_with(
-      model: @storage,
-      url: confirm_destroy_admin_settings_storage_path(@storage),
-      method: :get
-    ) do %>
-  <%=
-    render(Primer::OpenProject::PageHeader.new) do |header|
-      header.with_title(test_selector: "storage-new-page-header--title") do
-        render OpTurbo::FrameComponent.new(@storage, context: :edit_storage_header) do
-          label_storage_name_with_provider_label
-        end
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title(test_selector: "storage-new-page-header--title") do
+      render OpTurbo::FrameComponent.new(@storage, context: :edit_storage_header) do
+        label_storage_name_with_provider_label
       end
-
-      header.with_breadcrumbs(breadcrumbs_items)
-
-      header.with_action_button(
-        scheme: :danger,
-        mobile_icon: :trash,
-        mobile_label: I18n.t("button_delete"),
-        type: :submit,
-        aria: { label: I18n.t("storages.label_delete_storage") },
-        test_selector: "storage-delete-button"
-      ) do |button|
-        button.with_leading_visual_icon(icon: :trash)
-        I18n.t("button_delete")
-      end
-
-      helpers.render_tab_header_nav(header, tabs, test_selector: :storage_detail_header)
     end
-  %>
-<% end %>
+
+    header.with_breadcrumbs(breadcrumbs_items)
+
+    header.with_action_button(
+      scheme: :danger,
+      mobile_icon: :trash,
+      mobile_label: I18n.t("button_delete"),
+      aria: { label: I18n.t("storages.label_delete_storage") },
+      tag: :a,
+      href: confirm_destroy_admin_settings_storage_path(@storage),
+      data: { "turbo-frame": "_top" },
+      test_selector: "storage-delete-button"
+    ) do |button|
+      button.with_leading_visual_icon(icon: :trash)
+      I18n.t("button_delete")
+    end
+
+    helpers.render_tab_header_nav(header, tabs, test_selector: :storage_detail_header)
+  end
+%>

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -184,7 +184,6 @@ module Storages
                            .new(user: User.current, model: @storage)
                            .call
 
-        # rubocop:disable Rails/ActionControllerFlashBeforeRender
         service_result.on_failure do
           flash[:error] = service_result.errors.full_messages
         end
@@ -192,8 +191,6 @@ module Storages
         service_result.on_success do
           flash[:notice] = I18n.t(:notice_successful_delete)
         end
-        # rubocop:enable Rails/ActionControllerFlashBeforeRender
-
         redirect_to admin_settings_storages_path
       end
 

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -188,13 +188,16 @@ RSpec.describe("Activation of storages in projects",
 
     page.find(".icon.icon-delete").click
 
+    expect(page).to have_css(".form--section-title", text: "DELETE FILE STORAGE")
+
     # Approve Confirmation
     page.fill_in "delete_confirmation", with: storage.name
+    expect(page).to have_button("Delete", disabled: false)
     page.click_on("Delete")
 
     # List of ProjectStorages empty again
     expect(page).to have_current_path external_file_storages_project_settings_project_storages_path(project)
-    expect(page).to have_text(I18n.t("storages.no_results"))
+    expect(page).to have_content(I18n.t("storages.no_results"))
   end
 
   describe "automatic project folder mode" do


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Avoids having a submit button targeting the turbo frame using data-turbo-frame="top".

This avoid flickering in the browser. Hopefully, it also fixes flickering specs. 
