### PR TITLE
Avoid logging slow SQL for tenant creation

### DIFF
--- a/config/initializers/log_slow_sql_queries.rb
+++ b/config/initializers/log_slow_sql_queries.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
       # Skip transaction that may be blocked
       next if data[:sql].match?(/BEGIN|COMMIT/)
 
+      # Skip tenant creation (load dump)
+      next if data[:sql][..120].include?("Dumped by pg_dump")
+
       # Skip smaller durations
       duration = ((finish - start) * 1000).round(4)
       next if duration <= slow_sql_threshold


### PR DESCRIPTION
It logs the sql dump that is used to create tenants. It takes only 2.7 secs but it's enough to get it being logged.