### PR TITLE
Bug/58342 creating a project via template sends out mail notifications to all template users

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -45,15 +45,6 @@ class ApplicationMailer < ActionMailer::Base
   default from: Proc.new { Setting.mail_from }
 
   class << self
-    # Activates/deactivates email deliveries during +block+
-    def with_deliveries(temporary_state = true, &)
-      old_state = ActionMailer::Base.perform_deliveries
-      ActionMailer::Base.perform_deliveries = temporary_state
-      yield
-    ensure
-      ActionMailer::Base.perform_deliveries = old_state
-    end
-
     def host
       if OpenProject::Configuration.rails_relative_url_root.blank?
         Setting.host_name

--- a/app/models/setting/mail_settings.rb
+++ b/app/models/setting/mail_settings.rb
@@ -33,7 +33,6 @@ class Setting
     ##
     # Reload the currently configured mailer configuration
     def reload_mailer_settings!
-      ActionMailer::Base.perform_deliveries = true
       ActionMailer::Base.delivery_method = Setting.email_delivery_method if Setting.email_delivery_method
 
       case Setting.email_delivery_method

--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -61,11 +61,7 @@ module Projects::Copy
 
       attributes = member
                      .attributes.dup.except("id", "project_id", "created_at", "updated_at")
-                     .merge(role_ids:,
-                            project: target,
-                            # This is magic for now. The settings has been set before in the Projects::CopyService
-                            # It would be better if this was not sneaked in but rather passed in as a parameter.
-                            send_notifications: ActionMailer::Base.perform_deliveries)
+                     .merge(role_ids:, project: target)
 
       Members::CreateService
         .new(user: User.current, contract_class: EmptyContract)

--- a/app/services/projects/copy/wiki_dependent_service.rb
+++ b/app/services/projects/copy/wiki_dependent_service.rb
@@ -71,14 +71,9 @@ module Projects::Copy
     end
 
     def copy_wiki_page(source_page, new_parent_id)
-      # Relying on ActionMailer::Base.perform_deliveries is violating cohesion
-      # but the value is currently not otherwise provided
       service_call = WikiPages::CopyService
                      .new(user:, model: source_page, contract_class: WikiPages::CopyContract)
-                     .call(wiki: target.wiki,
-                           parent_id: new_parent_id,
-                           send_notifications: ActionMailer::Base.perform_deliveries,
-                           copy_attachments: copy_attachments?)
+                     .call(wiki: target.wiki, parent_id: new_parent_id, copy_attachments: copy_attachments?)
 
       if service_call.success?
         service_call.result

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -138,10 +138,7 @@ module Projects::Copy
         responsible_id: work_package_responsible_id(source_work_package),
         custom_field_values: custom_value_attributes(source_work_package, user_cf_ids),
         # We don't support copying budgets right now
-        budget_id: nil,
-
-        # We persist the setting in the job which will trigger a delayed job for potentially sending the journal notifications.
-        send_notifications: params.dig(:params, :send_notifications)
+        budget_id: nil
       }
     end
 

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -112,20 +112,16 @@ class CopyProjectJob < ApplicationJob
   # rubocop:disable Metrics/AbcSize
   # Most of the cost is from handling errors, we need to check what can be moved around / removed
   def create_project_copy(target_project_params, associations_to_copy, send_mails)
-    errors = []
+    service_result = copy_project(target_project_params, associations_to_copy, send_mails)
+    target_project = service_result.result
+    errors = service_result.errors.full_messages
 
-    ProjectMailer.with_deliveries(send_mails) do
-      service_result = copy_project(target_project_params, associations_to_copy, send_mails)
-      target_project = service_result.result
-      errors = service_result.errors.full_messages
-
-      # We assume the copying worked "successfully" if the project was saved
-      if target_project&.persisted?
-        return target_project, errors
-      else
-        logger.error("Copying project fails with validation errors: #{errors.join("\n")}")
-        return nil, errors
-      end
+    # We assume the copying worked "successfully" if the project was saved
+    if target_project&.persisted?
+      [target_project, errors]
+    else
+      logger.error("Copying project fails with validation errors: #{errors.join("\n")}")
+      [nil, errors]
     end
   rescue ActiveRecord::RecordNotFound => e
     logger.error("Entity missing: #{e.message} #{e.backtrace.join("\n")}")

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -69,40 +69,6 @@ RSpec.describe UserMailer do
     allow(Setting).to receive(:default_language).and_return("en")
   end
 
-  describe "#with_deliveries" do
-    context "with false" do
-      before do
-        described_class.with_deliveries(false) do
-          described_class.test_mail(recipient).deliver_now
-        end
-      end
-
-      it_behaves_like "mail is not sent"
-    end
-
-    context "with true" do
-      before do
-        described_class.with_deliveries(true) do
-          described_class.test_mail(recipient).deliver_now
-        end
-      end
-
-      it_behaves_like "mail is sent"
-    end
-
-    context "with true but user is locked" do
-      let(:recipient) { build_stubbed(:user, status: Principal.statuses[:locked]) }
-
-      before do
-        described_class.with_deliveries(true) do
-          described_class.test_mail(recipient).deliver_now
-        end
-      end
-
-      it_behaves_like "mail is not sent"
-    end
-  end
-
   describe "#test_mail" do
     let(:test_email) { "bob.bobbi@example.com" }
     let(:recipient) { build_stubbed(:user, firstname: "Bob", lastname: "Bobbi", mail: test_email) }

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -501,7 +501,7 @@ RSpec.describe Setting do
            smtp_timeout: 1234
          } do
         described_class.reload_mailer_settings!
-        expect(ActionMailer::Base).to have_received(:perform_deliveries=).with(true)
+        expect(ActionMailer::Base).not_to have_received(:perform_deliveries=).with(true)
         expect(ActionMailer::Base).to have_received(:delivery_method=).with(:smtp)
         expect(ActionMailer::Base.smtp_settings[:smtp_authentication]).to be_nil
         expect(ActionMailer::Base.smtp_settings).to eq(address: "smtp.example.com",
@@ -529,7 +529,7 @@ RSpec.describe Setting do
            smtp_ssl: 1
          } do
         described_class.reload_mailer_settings!
-        expect(ActionMailer::Base).to have_received(:perform_deliveries=).with(true)
+        expect(ActionMailer::Base).not_to have_received(:perform_deliveries=).with(true)
         expect(ActionMailer::Base).to have_received(:delivery_method=).with(:smtp)
         expect(ActionMailer::Base.smtp_settings[:smtp_authentication]).to be_nil
         expect(ActionMailer::Base.smtp_settings).to eq(address: "smtp.example.com",
@@ -556,7 +556,7 @@ RSpec.describe Setting do
            smtp_ssl: 0
          } do
         described_class.reload_mailer_settings!
-        expect(ActionMailer::Base).to have_received(:perform_deliveries=).with(true)
+        expect(ActionMailer::Base).not_to have_received(:perform_deliveries=).with(true)
         expect(ActionMailer::Base).to have_received(:delivery_method=).with(:smtp)
         expect(ActionMailer::Base.smtp_settings[:smtp_authentication]).to be_nil
         expect(ActionMailer::Base.smtp_settings).to eq(address: "smtp.example.com",
@@ -586,7 +586,7 @@ RSpec.describe Setting do
            smtp_ssl: 1
          } do
         described_class.reload_mailer_settings!
-        expect(ActionMailer::Base).to have_received(:perform_deliveries=).with(true)
+        expect(ActionMailer::Base).not_to have_received(:perform_deliveries=).with(true)
         expect(ActionMailer::Base).to have_received(:delivery_method=).with(:smtp)
         expect(ActionMailer::Base.smtp_settings[:smtp_authentication]).to be_nil
         expect(ActionMailer::Base.smtp_settings).to eq(address: "smtp.example.com",

--- a/spec/workers/copy_project_job_spec.rb
+++ b/spec/workers/copy_project_job_spec.rb
@@ -355,4 +355,46 @@ RSpec.describe CopyProjectJob, type: :model, with_good_job_batches: [CopyProject
       TABLE
     end
   end
+
+  # Bug #58342: combination of class attribute ActionMailer::Base.perform_deliveries that was not thread local, so was
+  # reset to true before every request and job run, and using it to override Journal::NotificationConfiguration.active?
+  # to decide to send notifications could cause notifications to be sent for adding as member despite selecting not to
+  # do it.
+  describe "sending notifications" do
+    shared_let(:project) { create(:project) }
+    shared_let(:admin) { create(:admin) }
+    shared_let(:user) { create(:user) }
+    shared_let(:roles) { [create(:project_role)] }
+    shared_let(:member) { create(:member, user:, project:, roles:) }
+
+    let(:params) { { name: "Copy", identifier: "copy" } }
+
+    def perform_the_job
+      batch = GoodJob::Batch.enqueue(user: admin, source_project: project) do
+        described_class.perform_later(target_project_params: params, associations_to_copy: [:members])
+      end
+      GoodJob.perform_inline
+      batch.reload
+
+      expect(batch).to be_succeeded
+    end
+
+    it "doesn't touch the perform_deliveries" do
+      allow(ActionMailer::Base).to receive(:perform_deliveries=)
+
+      perform_the_job
+
+      expect(ActionMailer::Base).not_to have_received(:perform_deliveries=)
+    end
+
+    it "calls Members::CreateService without send_notifications override" do
+      members_create_service = instance_double(Members::CreateService)
+      allow(Members::CreateService).to receive(:new).and_return(members_create_service)
+      allow(members_create_service).to receive(:call)
+
+      perform_the_job
+
+      expect(members_create_service).to have_received(:call).with(hash_excluding(:send_notifications))
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/58342

# What are you trying to accomplish?
Prevent notifications from being sent sometimes when project is copied with «Send email notifications during the project copy» is unchecked. Why was the bug happening:
* `ActionMailer::Base.perform_deliveries` was set around call to `Projects::CopyService` (using `with_deliveries`)
* in most cases `send_notifications` is used only by `BaseContracted` to set `Journal::NotificationConfiguration.active?`, for the duration of `perform` and attempts to provide `send_notifications` to wrapped service calls are ignored and logged
* this is not the case for `Members::CreateService`, as `send_notifications`, if set, is also used to override `Journal::NotificationConfiguration.active?` (`Members::Concerns::NotificationSender#send_notifications?`)
* `Members::CreateService` is called for every member from `Projects::Copy::MembersDependentService` and was receiving `send_notifications` explicitly set to `ActionMailer::Base.perform_deliveries`
* this was expected to not be a problem, as `ActionMailer::Base.perform_deliveries` was set around call to `Projects::CopyService` to the desired value
* but `perform_deliveries` is a class attribute, so not thread local and it was set to `true` before every request and job run (by `Setting::MailSettings#reload_mailer_settings!`), which was done to ensure email sending configuration is up to date if changed from admin
* so if any job was started after `perform_deliveries` was set around `Projects::CopyService` and before `Projects::Copy::MembersDependentService` finished, `perform_deliveries` was reset to `true` and `Members::CreateService` was called with `send_notifications: true` forcing it to send notifications (and `perform_deliveries = true` was allowing them to be sent)
* this also should have caused reverse effect if in the middle of a copy project job with «Send email notifications during the project copy» another one started with the preference unchecked forcing no notifications until any other job start reversed the effect, but it should have being rarer and much less obvious, as notifications were not sent when expected to instead of sent when not expected to

# What approach did you choose and why?
Stop dynamically setting `perform_deliveries` in the app (as it is a class variable, so not thread local and is reset on every request and job run) and remove explicitly setting `send_notifications` in all `Projects::CopyService` dependencies.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
