### PR TITLE
[67610] Individual home/overview of widgets for each level (project, program, portfolio)

### DIFF
--- a/modules/overviews/app/components/overviews/overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/overview_grid_component.html.erb
@@ -33,6 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
     grid.with_widget(Overviews::Widgets::ProjectStatusComponent, @project)
     grid.with_widget(Overviews::Widgets::SubitemsComponent, @project)
     grid.with_widget(Overviews::Widgets::MembersComponent, @project)
-    grid.with_widget(Overviews::Widgets::NewsComponent, @project)
+    if show_news_widget?
+      grid.with_widget(Overviews::Widgets::NewsComponent, @project)
+    end
   end
 %>

--- a/modules/overviews/app/components/overviews/overview_grid_component.rb
+++ b/modules/overviews/app/components/overviews/overview_grid_component.rb
@@ -38,5 +38,9 @@ module Overviews
 
       @project = project
     end
+
+    def show_news_widget?
+      @project.workspace_type == "project"
+    end
   end
 end

--- a/modules/overviews/app/components/overviews/widgets/news_component.rb
+++ b/modules/overviews/app/components/overviews/widgets/news_component.rb
@@ -54,6 +54,10 @@ module Overviews
       def title
         Project.human_attribute_name(:news)
       end
+
+      def render?
+        project.nil? || project.module_enabled?("news")
+      end
     end
   end
 end

--- a/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
@@ -26,12 +26,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+
 <%=
-  if @project.project?
-    render(Overviews::Workspaces::ProjectOverviewGridComponent.new(project: @project))
-  elsif @project.program?
-    render(Overviews::Workspaces::ProgramOverviewGridComponent.new(program: @project))
-  elsif @project.portfolio?
-    render(Overviews::Workspaces::PortfolioOverviewGridComponent.new(portfolio: @project))
+  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
+    grid.with_widget(Overviews::Widgets::DescriptionComponent, @portfolio)
+    grid.with_widget(Overviews::Widgets::ProjectStatusComponent, @portfolio)
+    grid.with_widget(Overviews::Widgets::SubitemsComponent, @portfolio)
+    grid.with_widget(Overviews::Widgets::MembersComponent, @portfolio)
   end
 %>

--- a/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.rb
+++ b/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.rb
@@ -29,14 +29,20 @@
 #++
 
 module Overviews
-  class OverviewGridComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
+  module Workspaces
+    class PortfolioOverviewGridComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpPrimer::ComponentHelpers
 
-    def initialize(project:)
-      super
+      def initialize(portfolio:)
+        super
 
-      @project = project
+        @portfolio = portfolio
+      end
+
+      def render?
+        @portfolio.portfolio?
+      end
     end
   end
 end

--- a/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.html.erb
@@ -26,12 +26,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+
 <%=
-  if @project.project?
-    render(Overviews::Workspaces::ProjectOverviewGridComponent.new(project: @project))
-  elsif @project.program?
-    render(Overviews::Workspaces::ProgramOverviewGridComponent.new(program: @project))
-  elsif @project.portfolio?
-    render(Overviews::Workspaces::PortfolioOverviewGridComponent.new(portfolio: @project))
+  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
+    grid.with_widget(Overviews::Widgets::DescriptionComponent, @program)
+    grid.with_widget(Overviews::Widgets::ProjectStatusComponent, @program)
+    grid.with_widget(Overviews::Widgets::SubitemsComponent, @program)
+    grid.with_widget(Overviews::Widgets::MembersComponent, @program)
   end
 %>

--- a/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.rb
+++ b/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.rb
@@ -29,14 +29,20 @@
 #++
 
 module Overviews
-  class OverviewGridComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
+  module Workspaces
+    class ProgramOverviewGridComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpPrimer::ComponentHelpers
 
-    def initialize(project:)
-      super
+      def initialize(program:)
+        super
 
-      @project = project
+        @program = program
+      end
+
+      def render?
+        @program.program?
+      end
     end
   end
 end

--- a/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.html.erb
@@ -26,12 +26,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
+
 <%=
-  if @project.project?
-    render(Overviews::Workspaces::ProjectOverviewGridComponent.new(project: @project))
-  elsif @project.program?
-    render(Overviews::Workspaces::ProgramOverviewGridComponent.new(program: @project))
-  elsif @project.portfolio?
-    render(Overviews::Workspaces::PortfolioOverviewGridComponent.new(portfolio: @project))
+  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
+    grid.with_widget(Overviews::Widgets::DescriptionComponent, @project)
+    grid.with_widget(Overviews::Widgets::ProjectStatusComponent, @project)
+    grid.with_widget(Overviews::Widgets::SubitemsComponent, @project)
+    grid.with_widget(Overviews::Widgets::MembersComponent, @project)
+    grid.with_widget(Overviews::Widgets::NewsComponent, @project)
   end
 %>

--- a/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.rb
+++ b/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.rb
@@ -29,14 +29,20 @@
 #++
 
 module Overviews
-  class OverviewGridComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpPrimer::ComponentHelpers
+  module Workspaces
+    class ProjectOverviewGridComponent < ApplicationComponent
+      include ApplicationHelper
+      include OpPrimer::ComponentHelpers
 
-    def initialize(project:)
-      super
+      def initialize(project:)
+        super
 
-      @project = project
+        @project = project
+      end
+
+      def render?
+        @project.project?
+      end
     end
   end
 end

--- a/modules/overviews/spec/components/overviews/widgets/news_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/widgets/news_component_spec.rb
@@ -95,4 +95,13 @@ RSpec.describe Overviews::Widgets::NewsComponent, type: :component do
       end
     end
   end
+
+  context "with project without news module enabled" do
+    let(:project) { create(:project, enabled_module_names: [:wiki]) }
+
+    it "does not render" do
+      expect(rendered_component).not_to have_primer_text "Nothing new to report.", color: "subtle"
+      expect(rendered_component).not_to have_list "News"
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67610

# What are you trying to accomplish?
* Do not render the news widget, if the module is not active
* Create different overviews depending on the workspace

## Screenshots
**Project**
<img width="1796" height="885" alt="Bildschirmfoto 2025-10-01 um 08 43 35" src="https://github.com/user-attachments/assets/1f678d37-ce9f-479e-8543-93beb5d85389" />


**Portfolio**
<img width="1805" height="737" alt="Bildschirmfoto 2025-10-01 um 08 43 15" src="https://github.com/user-attachments/assets/6bce5310-be2d-49fe-b474-01e4e25ffd18" />


