### PR TITLE
[67645] CTA on Project settings file storage page are too close to another

### DIFF
--- a/modules/storages/app/views/storages/project_settings/_storage_select_form.html.erb
+++ b/modules/storages/app/views/storages/project_settings/_storage_select_form.html.erb
@@ -44,15 +44,18 @@ See COPYRIGHT and LICENSE files for more details.
 
 <div class="form--field">
   <%=
-      render Primer::Beta::Button.new(scheme: :primary, type: :submit) do |button|
+      render Primer::Beta::Button.new(scheme: :primary, type: :submit, mr: 2) do |button|
         button.with_leading_visual_icon(icon: :check)
         submit_button_label
       end
   %>
   <%=
-      render Primer::Beta::Button.new(tag: :a, href: external_file_storages_project_settings_project_storages_path(@project)) do |button|
-        button.with_leading_visual_icon(icon: :x)
-        t(:button_cancel)
-      end
+    render Primer::Beta::Button.new(
+      tag: :a,
+      href: external_file_storages_project_settings_project_storages_path(@project)
+    ) do |button|
+      button.with_leading_visual_icon(icon: :x)
+      t(:button_cancel)
+    end
   %>
 </div>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67645

# What are you trying to accomplish?
Add space between buttons and swap position

## Screenshots
<img width="804" height="320" alt="Bildschirmfoto 2025-10-01 um 10 53 35" src="https://github.com/user-attachments/assets/a7d945cb-4e01-401a-8446-0e91badf6330" />

