### PR TITLE
[67203] Update the look and feel of the 'Project status' widget in Project overview

### DIFF
--- a/modules/overviews/app/components/overviews/widgets/project_status_component.html.erb
+++ b/modules/overviews/app/components/overviews/widgets/project_status_component.html.erb
@@ -36,23 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
         end
 
         flex.with_row do
-          if edit_enabled?
-            settings_primer_form_with(
-              model: project,
-              url: project_widgets_project_status_path(project),
-              method: :patch,
-              data: { turbo: true }
-            ) do |f|
-              render(
-                Primer::Forms::FormList.new(
-                  Projects::Settings::StatusForm.new(f, hide_label: true),
-                  Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_status_description"))
-                )
-              )
-            end
-          else
-            format_text(project, :status_explanation)
-          end
+          format_text(project, :status_explanation)
         end
       end
     end

--- a/modules/overviews/app/components/overviews/widgets/project_status_component.rb
+++ b/modules/overviews/app/components/overviews/widgets/project_status_component.rb
@@ -39,12 +39,6 @@ module Overviews
       def title
         Project.human_attribute_name(:status_code)
       end
-
-      private
-
-      def edit_enabled?
-        current_user.allowed_in_project?(:edit_project, project)
-      end
     end
   end
 end

--- a/modules/overviews/spec/components/overviews/widgets/project_status_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/widgets/project_status_component_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe Overviews::Widgets::ProjectStatusComponent, type: :component do
   end
 
   context "when user is not allowed to edit" do
+    it "renders renders a disabled status button" do
+      expect(rendered_component).to have_button "Not set", disabled: true
+    end
+
     it "renders status description as formatted text" do
       expect(rendered_component).to have_css "p"
       expect(rendered_component).to have_css "strong", text: "This project is in jeopardy!"
@@ -68,18 +72,13 @@ RSpec.describe Overviews::Widgets::ProjectStatusComponent, type: :component do
       end
     end
 
-    it "renders form" do
-      expect(rendered_component).to have_element :form, method: :post,
-                                                        action: project_widgets_project_status_path(project)
+    it "renders renders an editable status button" do
+      expect(rendered_component).to have_button "Not set", disabled: false
     end
 
-    it "renders hidden method field" do
-      expect(rendered_component).to have_field "_method", type: :hidden, with: "patch"
-    end
-
-    it "renders text area field" do
-      expect(rendered_component).to have_element "opce-ckeditor-augmented-textarea",
-                                                 "data-test-selector": "augmented-text-area-status_explanation"
+    it "renders status description as formatted text" do
+      expect(rendered_component).to have_css "p"
+      expect(rendered_component).to have_css "strong", text: "This project is in jeopardy!"
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67203

# What are you trying to accomplish?
Within the project status widget:
* The status itself remains editable
* The status description changes to read-only

## Screenshots

<img width="757" height="323" alt="Bildschirmfoto 2025-10-01 um 14 25 04" src="https://github.com/user-attachments/assets/1cfcedce-11d2-4ecf-ab2c-8c61f68e2ea7" />

