### PR TITLE
Add capabilities/actions for users own time entries

### DIFF
--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -41,14 +41,15 @@ module Costs
                    permissible_on: :project
         permission :view_own_time_entries,
                    {},
-                   permissible_on: %i[work_package project]
+                   permissible_on: %i[work_package project],
+                   contract_actions: { time_entries: %i[read_own] }
 
         permission :log_own_time,
                    {},
                    permissible_on: %i[work_package project],
                    require: :loggedin,
-                   dependencies: :view_own_time_entries
-
+                   dependencies: :view_own_time_entries,
+                   contract_actions: { time_entries: %i[create_own] }
         permission :log_time,
                    {},
                    permissible_on: :project,
@@ -58,8 +59,8 @@ module Costs
         permission :edit_own_time_entries,
                    {},
                    permissible_on: %i[work_package project],
-                   require: :loggedin
-
+                   require: :loggedin,
+                   contract_actions: { time_entries: %i[edit_own destroy_own] }
         permission :edit_time_entries,
                    {},
                    permissible_on: :project,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67456

# What are you trying to accomplish?

Add the actions and capabilities for the permissions of `view_own_time_entries`, `log_own_time` and `edit_own_time_entries` to allow the Mobile App detecting whether or not these actions are supported in the current context.

The following actions/capabilities were created:

* `log_own_time` permission: `time_entries/create_own`
* `view_own_time_entries` permission: `time_entries/read_own`
* `edit_own_time_entries` permission:
  * `time_entries/edit_own`
  * `time_entries/destroy_own`

## Examples

### Actions

Example action for logging time for the current user:

```json5
      {
        "id": "time_entries/create_own",
        "_type": "Action",
        "_links": {
          "self": {
            "href": "/api/v3/actions/time_entries/create_own"
          }
        }
      }
```

### Capabilities

Example capability for the above action in the context of a user and project:

```json
{
  "id": "time_entries/create_own/p6-15",
  "_type": "Capability",
  "_links": {
    "self": {
      "href": "/api/v3/capabilities/time_entries/create_own/p6-15"
    },
    "action": {
      "href": "/api/v3/actions/time_entries/create_own"
    },
    "context": {
      "href": "/api/v3/projects/6",
      "title": "[dev] Empty"
    },
    "principal": {
      "href": "/api/v3/users/15",
      "title": "OpenProject Admin"
    }
  }
}
```

# Out of scope

Considering permissions that are not intended for individual users, but for managers (view other users time, etc.).

# Caveats

I could not find existing specs or explicit documentation for other capabilities/actions of our API. As the other capabilities are untested and this addition is small, I kept it that way.
