### PR TITLE
Align toolbar buttons in WP split view

### DIFF
--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -150,7 +150,7 @@ a.button
   // This fix works for all browsers, except for Firefox on Windows (:cry:)
   &:has(> .octicon)
     body:not(.-browser-windows):not(.-browser-firefox) &
-      display: flex
+      display: inline-flex
       align-items: center
 
 .button--icon


### PR DESCRIPTION
# What are you trying to accomplish?
Switch to inline-flex to avoid unnessary line-breaks. This should also fix the failing `activity_notifications_spec.rb`

## Screenshots
**Before**
<img width="339" height="243" alt="Bildschirmfoto 2025-10-02 um 08 41 44" src="https://github.com/user-attachments/assets/062ce1b8-9ea8-41a1-8df7-a4a452661a13" />

**After**
<img width="274" height="105" alt="Bildschirmfoto 2025-10-02 um 08 41 27" src="https://github.com/user-attachments/assets/9414b8ee-5cdc-446a-800d-467c7775f3a7" />

