### PR TITLE
Add minio to dev setup to ease development of uploads against S3

### DIFF
--- a/docker/dev/minio/.gitignore
+++ b/docker/dev/minio/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.override.yml

--- a/docker/dev/minio/docker-compose.core-override.example.yml
+++ b/docker/dev/minio/docker-compose.core-override.example.yml
@@ -1,0 +1,17 @@
+# The following overrides should be copied to the core docker-compose.overrides.yml in the main directory.
+# Only use them if you DO NOT use the TLS setup.
+# If you use the TLS setup, ignore the following values and instead see
+# tls/docker-compose.core-override.example.yml for the minio TLS setup values.
+
+services:
+  backend:
+    environment:
+     OPENPROJECT_ATTACHMENTS__STORAGE: "fog"
+     OPENPROJECT_FOG_DIRECTORY: "openproject-uploads"
+     OPENPROJECT_FOG_CREDENTIALS_PROVIDER: "AWS" # Minio is S3 compliant, so we can use the AWS provider
+     OPENPROJECT_FOG_CREDENTIALS_ENDPOINT: "http://127.0.0.1:9000" # URI for your MinIO instance
+     OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: "minioadmin"
+     OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY: "minioadmin"
+     OPENPROJECT_FOG_CREDENTIALS_PATH__STYLE: "true"
+     OPENPROJECT_FOG_CREDENTIALS_REGION: "us-east-1"
+     OPENPROJECT_DEV_EXTRA_HOSTS: "${OPENPROJECT_DEV_HOST},http://127.0.0.1:9000"

--- a/docker/dev/minio/docker-compose.yml
+++ b/docker/dev/minio/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  # local S3 storage for development
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"  # API port
+      - "9001:9001"  # Admin Console (Management UI) port
+    volumes:
+      - minio_data:/data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    entrypoint: sh
+    # minio automatically maps folders to buckets, so we create the bucket here before starting the server
+    command: -c 'mkdir -p /data/openproject-uploads && /usr/bin/minio server --console-address ":9001" /data'
+    networks:
+      - external
+    labels:
+      - "traefik.enable=true"
+      # MinIO API
+      - "traefik.http.routers.minio.entrypoints=websecure"
+      - "traefik.http.routers.minio.rule=Host(`minio.local`)"
+      - "traefik.http.routers.minio.service=minio"
+      - "traefik.http.routers.minio.tls.certresolver=step"
+      - "traefik.http.services.minio.loadbalancer.server.port=9000"
+      # MinIO Admin Console (Management UI)
+      - "traefik.http.routers.minioadmin.entrypoints=websecure"
+      - "traefik.http.routers.minioadmin.rule=Host(`minioadmin.local`)"
+      - "traefik.http.routers.minioadmin.service=minioadmin"
+      - "traefik.http.routers.minioadmin.tls.certresolver=step"
+      - "traefik.http.services.minioadmin.loadbalancer.server.port=9001"
+    healthcheck:
+      test: [ "CMD", "mc", "ready", "local" ]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+volumes:
+  minio_data:
+
+networks:
+  external:
+    name: gateway
+    external: true

--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -14,6 +14,16 @@ x-op-env-override: &environment
   # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_TOKEN__ENDPOINT: /realms/<REALM>/protocol/openid-connect/token
   # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_USERINFO__ENDPOINT: /realms/<REALM>/protocol/openid-connect/userinfo
   # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_END__SESSION__ENDPOINT: https://keycloak.local/realms/<REALM>/protocol/openid-connect/logout
+  # uncomment the following for using minio (local S3) as file storage with TLS support:
+  # OPENPROJECT_ATTACHMENTS__STORAGE: "fog"
+  # OPENPROJECT_FOG_DIRECTORY: "openproject-uploads"
+  # OPENPROJECT_FOG_CREDENTIALS_PROVIDER: "AWS" # Minio is S3 compliant, so we can use the AWS provider
+  # OPENPROJECT_FOG_CREDENTIALS_ENDPOINT: "https://minio.local"
+  # OPENPROJECT_FOG_CREDENTIALS_AWS__ACCESS__KEY__ID: "minioadmin"
+  # OPENPROJECT_FOG_CREDENTIALS_AWS__SECRET__ACCESS__KEY: "minioadmin"
+  # OPENPROJECT_FOG_CREDENTIALS_PATH__STYLE: "true"
+  # OPENPROJECT_FOG_CREDENTIALS_REGION: "us-east-1"
+  # OPENPROJECT_DEV_EXTRA_HOSTS: "${OPENPROJECT_DEV_HOST},minio.local"
 
 services:
   backend:

--- a/docker/dev/tls/docker-compose.override.example.yml
+++ b/docker/dev/tls/docker-compose.override.example.yml
@@ -13,3 +13,5 @@ services:
           - gitlab.local
           - keycloak.local
           - hocuspocus.local
+          - minio.local
+          - minioadmin.local

--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -539,6 +539,35 @@ docker compose up -d frontend
 
 Upon setting up all the things correctly, we can see a login with `keycloak` option in login page of `OpenProject`.
 
+
+## MinIO Service (local S3 storage backend)
+
+Within `docker/dev/minio` a compose file is provided for running a local MinIO instance with TLS support which can be used as a S3 storage for uploading files. 
+When running with TLS support, the MinIO instance will be accessible on `https://minio.local` and a management UI (MinIO Console) will be available on `https://minioadmin.local/`.
+
+### Running the MinIO Instance
+
+MinIO is a S3 compatible data store which can be used for simulating uploads of files to S3.
+
+Start up the docker compose service for MinIO:
+
+```shell
+docker compose --project-directory docker/dev/minio up -d
+```
+This will automatically create a bucket named `openproject-uploads` which is used to store uploaded files.
+
+If you want to use TLS support, make sure to copy and uncomment the MinIO configuration environment variables in `docker/dev/tls/docker-compose.core.override.example.yml` to your `docker-compose.override.yml` file in the project root directory. If you want to use MinIO without TLS support, make sure to copy the environment variables from `docker/dev/minio/docker-compose.core-override.example.yml` to your `docker-compose.override.yml` file (in the project root directory). 
+After that, hard restart the `backend` service to apply the changes: 
+
+```
+docker compose down backend
+docker compose up backend
+```
+
+Another option is to use the MinIO service running in docker with OpenProject running locally. To do this, adapt the environment variables in `docker/dev/minio/docker-compose.core.override.example.yml` to your `.env` file and restart the OpenProject after that.
+
+After uploading a file, by e.g. adding an image to a work package, you should be able to see the file in the MinIO Console (a graphical Management UI accessible in the browser). With the TLS setup you can access the MinIO Console on `https://minioadmin.local/`, without TLS it is available on `http://localhost:9001`. For login credentials see `docker/dev/minio/docker-compose.yml`.
+
 ## Local files
 
 Running the docker images will change some of your local files in the mounted code directory. The


### PR DESCRIPTION
# Ticket
preparation for https://community.openproject.org/wp/67403

# What are you trying to accomplish?

This should make it easy for people to spin up a "local S3" so they can develop the API flow for uploading files to S3. Since this flow is more complex than the upload to a local storage, it should be easy to try it out locally.
