### PR TITLE
[#64524] Recalculate when a score of a scored list is changed within the administration

### DIFF
--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -83,7 +83,13 @@ module CustomFields
       def delete_branch(item:)
         return Failure(:item_is_root) if item.root?
 
-        item.destroy ? Success() : Failure(item.errors)
+        root_item = item.root
+        if item.destroy
+          update_calculated_values_using_hierarchy(root_item)
+          Success()
+        else
+          Failure(item.errors)
+        end
       end
 
       # Gets all nodes in a tree from the item/node back to the root.

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -178,9 +178,24 @@ module CustomFields
 
       def update_item_attributes(item:, attributes:)
         if item.update(label: attributes[:label], short: attributes[:short], score: attributes[:score])
+          update_calculated_values_using_hierarchy(item.root)
           Success(item)
         else
           Failure(item.errors)
+        end
+      end
+
+      # Recalculates Calculated Values in all projects that use the hierarchy's custom field
+      def update_calculated_values_using_hierarchy(hierarchy)
+        custom_field = hierarchy.custom_field
+
+        return unless custom_field.field_format_scored_list?
+
+        custom_field.projects.each do |project|
+          affected_cfs = project.available_custom_fields.affected_calculated_fields([custom_field.id])
+
+          project.calculate_custom_fields(affected_cfs)
+          project.save if project.changed_for_autosave?
         end
       end
 

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -83,9 +83,14 @@ module CustomFields
       def delete_branch(item:)
         return Failure(:item_is_root) if item.root?
 
-        root_item = item.root
+        # We need to remember item_ids and custom_field and pass them separately
+        # to update_calculated_values_for_hierarchy, as after destroying the
+        # item, the methods will not return expected value (will return empty
+        # list and nil)
+        item_ids = item.self_and_descendant_ids
+        custom_field = item.root&.custom_field
         if item.destroy
-          update_calculated_values_using_hierarchy(root_item)
+          update_calculated_values_for_hierarchy(item_ids:, custom_field:)
           Success()
         else
           Failure(item.errors)
@@ -184,7 +189,10 @@ module CustomFields
 
       def update_item_attributes(item:, attributes:)
         if item.update(label: attributes[:label], short: attributes[:short], score: attributes[:score])
-          update_calculated_values_using_hierarchy(item.root)
+          if item.score_previously_changed?
+            # Only changes to item are of interest, so no need to pass descendant ids
+            update_calculated_values_for_hierarchy(item_ids: item.id, custom_field: item.root&.custom_field)
+          end
           Success(item)
         else
           Failure(item.errors)
@@ -192,17 +200,17 @@ module CustomFields
       end
 
       # Recalculates Calculated Values in all projects that use the hierarchy's custom field
-      def update_calculated_values_using_hierarchy(hierarchy)
-        custom_field = hierarchy.custom_field
+      def update_calculated_values_for_hierarchy(item_ids:, custom_field:)
+        return unless custom_field&.field_format_scored_list?
 
-        return unless custom_field.field_format_scored_list?
+        custom_field.class.customized_class
+          .where(custom_values: custom_field.custom_values.where(value: item_ids))
+          .find_each do |customized|
+            affected_cfs = customized.available_custom_fields.affected_calculated_fields([custom_field.id])
 
-        custom_field.projects.each do |project|
-          affected_cfs = project.available_custom_fields.affected_calculated_fields([custom_field.id])
-
-          project.calculate_custom_fields(affected_cfs)
-          project.save if project.changed_for_autosave?
-        end
+            customized.calculate_custom_fields(affected_cfs)
+            customized.save if customized.changed_for_autosave?
+          end
       end
 
       def update_item_order(item:, new_sort_order:)

--- a/modules/overviews/app/components/overviews/project_custom_fields/item_component.rb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/item_component.rb
@@ -47,7 +47,7 @@ module Overviews
       private
 
       def not_set?
-        @project_custom_field_values.empty? || @project_custom_field_values.all? { |cf_value| cf_value.value.blank? }
+        @project_custom_field_values.none?(&:value?)
       end
 
       def calculation_error?

--- a/spec/features/admin/custom_fields/projects/scored_lists_and_calculated_values_spec.rb
+++ b/spec/features/admin/custom_fields/projects/scored_lists_and_calculated_values_spec.rb
@@ -68,19 +68,23 @@ RSpec.describe "Scored Lists and Calculated Values", :js, with_ee: %i[calculated
       end
     end
 
-    describe "editing scored lists triggers calculated value recalculation" do
-      before do
-        project.custom_values.create!(custom_field: scored_list, value: one.id)
-      end
-
-      it "recalculates dependent calculated values" do
-        click_on "Items"
-
-        within("#admin-custom-fields-hierarchy-item-component-#{one.id}") do
+    describe "editing scored lists triggers Calculate Value recalculation" do
+      def click_edit_button(hierarchy_item)
+        within("#admin-custom-fields-hierarchy-item-component-#{hierarchy_item.id}") do
           edit_button = page.find_test_selector("op-hierarchy-item--action-menu")
           expect(edit_button).to be_present
           edit_button.click
         end
+      end
+
+      before do
+        project.custom_values.create!(custom_field: scored_list, value: one.id)
+      end
+
+      it "when updating a score" do
+        click_on "Items"
+
+        click_edit_button(one)
 
         click_on "Edit"
         expect(page).to have_field("score", with: "1.0")
@@ -88,6 +92,18 @@ RSpec.describe "Scored Lists and Calculated Values", :js, with_ee: %i[calculated
         click_on "Save"
 
         expect(project.reload.custom_value_for(calculated_value).value).to eq("4.0")
+      end
+
+      it "when deleting an item" do
+        click_on "Items"
+
+        click_edit_button(one)
+
+        click_on "Delete"
+        page.find_field("confirm_dangerous_action").click
+        click_on "Delete permanently"
+
+        expect(project.reload.custom_value_for(calculated_value).value).to be_nil
       end
     end
   end

--- a/spec/features/admin/custom_fields/projects/scored_lists_and_calculated_values_spec.rb
+++ b/spec/features/admin/custom_fields/projects/scored_lists_and_calculated_values_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "shared_context"
+
+RSpec.describe "Scored Lists and Calculated Values", :js, with_ee: %i[calculated_values],
+                                                          with_flag: { scored_list_custom_fields: true,
+                                                                       calculated_value_project_attribute: true } do
+  current_user { create(:admin) }
+
+  let!(:project) { create(:project) }
+  let!(:scored_list) { create(:scored_list_project_custom_field, projects: [project]) }
+  let!(:one) { create(:hierarchy_item, parent: scored_list.hierarchy_root, label: "One", score: 1) }
+  let!(:two) { create(:hierarchy_item, parent: scored_list.hierarchy_root, label: "Two", score: 2) }
+  let!(:calculated_value) do
+    create(:calculated_value_project_custom_field,
+           :skip_validations,
+           projects: [project],
+           formula: "{{cf_#{scored_list.id}}} * 2")
+  end
+
+  context "with sufficient permissions" do
+    before do
+      visit edit_admin_settings_project_custom_field_path(scored_list)
+    end
+
+    it "shows a correct breadcrumb menu" do
+      within ".PageHeader-breadcrumbs" do
+        expect(page).to have_link("Administration")
+        expect(page).to have_link("Projects")
+        expect(page).to have_link("Project attributes")
+        expect(page).to have_text(scored_list.name)
+      end
+    end
+
+    it "shows tab navigation" do
+      within_test_selector("project_attribute_detail_header") do
+        expect(page).to have_link("Details")
+        expect(page).to have_link("Projects")
+      end
+    end
+
+    describe "editing scored lists triggers calculated value recalculation" do
+      before do
+        project.custom_values.create!(custom_field: scored_list, value: one.id)
+      end
+
+      it "recalculates dependent calculated values" do
+        click_on "Items"
+
+        within("#admin-custom-fields-hierarchy-item-component-#{one.id}") do
+          edit_button = page.find_test_selector("op-hierarchy-item--action-menu")
+          expect(edit_button).to be_present
+          edit_button.click
+        end
+
+        click_on "Edit"
+        expect(page).to have_field("score", with: "1.0")
+        fill_in("score", with: "2.0")
+        click_on "Save"
+
+        expect(project.reload.custom_value_for(calculated_value).value).to eq("4.0")
+      end
+    end
+  end
+end

--- a/spec/features/admin/custom_fields/projects/scored_lists_and_calculated_values_spec.rb
+++ b/spec/features/admin/custom_fields/projects/scored_lists_and_calculated_values_spec.rb
@@ -69,27 +69,33 @@ RSpec.describe "Scored Lists and Calculated Values", :js, with_ee: %i[calculated
     end
 
     describe "editing scored lists triggers Calculate Value recalculation" do
-      def click_edit_button(hierarchy_item)
-        within("#admin-custom-fields-hierarchy-item-component-#{hierarchy_item.id}") do
-          edit_button = page.find_test_selector("op-hierarchy-item--action-menu")
-          expect(edit_button).to be_present
-          edit_button.click
+      def row_selector(hierarchy_item)
+        "#admin-custom-fields-hierarchy-item-component-#{hierarchy_item.id}"
+      end
+
+      def open_action_menu(hierarchy_item)
+        within(row_selector(hierarchy_item)) do
+          find_test_selector("op-hierarchy-item--action-menu").click
         end
       end
 
       before do
         project.custom_values.create!(custom_field: scored_list, value: one.id)
+        project.custom_values.create!(custom_field: calculated_value, value: "2.0")
       end
 
       it "when updating a score" do
         click_on "Items"
 
-        click_edit_button(one)
-
+        open_action_menu(one)
         click_on "Edit"
+
         expect(page).to have_field("score", with: "1.0")
         fill_in("score", with: "2.0")
         click_on "Save"
+
+        # ensure thet processing finished
+        expect(find(row_selector(one))).to have_text("2.0")
 
         expect(project.reload.custom_value_for(calculated_value).value).to eq("4.0")
       end
@@ -97,11 +103,14 @@ RSpec.describe "Scored Lists and Calculated Values", :js, with_ee: %i[calculated
       it "when deleting an item" do
         click_on "Items"
 
-        click_edit_button(one)
-
+        open_action_menu(one)
         click_on "Delete"
+
         page.find_field("confirm_dangerous_action").click
         click_on "Delete permanently"
+
+        # ensure thet processing finished
+        expect(page).to have_no_selector(row_selector(one))
 
         expect(project.reload.custom_value_for(calculated_value).value).to be_nil
       end

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -335,7 +335,6 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:cust
                                                                  scored_list_custom_fields: true } do
     current_user { create(:admin) }
 
-    let!(:contract_class) { CustomFields::Hierarchy::UpdateScoredItemContract }
     let!(:project) { create(:project) }
     let!(:custom_field) { create(:scored_list_project_custom_field, projects: [project]) }
     let!(:one) { create(:hierarchy_item, parent: custom_field.hierarchy_root, label: "One", score: 1) }
@@ -351,11 +350,24 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:cust
       project.custom_values.create!(custom_field: custom_field, value: one.id)
     end
 
-    it "updates calculated values affected by the change" do
-      result = service.update_item(contract_class:, item: one, score: 42)
-      expect(result).to be_success
+    describe "updating the score of an item" do
+      let!(:contract_class) { CustomFields::Hierarchy::UpdateScoredItemContract }
 
-      expect(project.custom_value_for(calculated_value).value).to eq("84.0")
+      it "updates calculated values affected by the change" do
+        result = service.update_item(contract_class:, item: one, score: 42)
+        expect(result).to be_success
+
+        expect(project.custom_value_for(calculated_value).value).to eq("84.0")
+      end
+    end
+
+    describe "deleting an item" do
+      it "updates calculated values affected by the change" do
+        result = service.delete_branch(item: one)
+        expect(result).to be_success
+
+        expect(project.custom_value_for(calculated_value).value).to be_nil
+      end
     end
   end
 end

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -31,301 +31,331 @@
 require "spec_helper"
 
 RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:custom_field_hierarchies] do
-  let!(:custom_field) { create(:custom_field, field_format: "hierarchy", hierarchy_root: nil) }
-  let!(:invalid_custom_field) { create(:custom_field, field_format: "text", hierarchy_root: nil) }
-  let!(:contract_class) { CustomFields::Hierarchy::InsertListItemContract }
-
-  let!(:root) { service.generate_root(custom_field).value! }
-  let!(:luke) { service.insert_item(contract_class:, parent: root, label: "luke", short: "LS").value! }
-  let!(:mara) { service.insert_item(contract_class:, parent: luke, label: "mara").value! }
-
   subject(:service) { described_class.new }
 
-  describe "#generate_root" do
-    context "with valid hierarchy root" do
-      it "creates a root item successfully" do
-        expect(service.generate_root(custom_field)).to be_success
+  context "with ListItemContract" do
+    let!(:custom_field) { create(:custom_field, field_format: "hierarchy", hierarchy_root: nil) }
+    let!(:invalid_custom_field) { create(:custom_field, field_format: "text", hierarchy_root: nil) }
+    let!(:contract_class) { CustomFields::Hierarchy::InsertListItemContract }
+
+    let!(:root) { service.generate_root(custom_field).value! }
+    let!(:luke) { service.insert_item(contract_class:, parent: root, label: "luke", short: "LS").value! }
+    let!(:mara) { service.insert_item(contract_class:, parent: luke, label: "mara").value! }
+
+    describe "#generate_root" do
+      context "with valid hierarchy root" do
+        it "creates a root item successfully" do
+          expect(service.generate_root(custom_field)).to be_success
+        end
+      end
+
+      it "requires a custom field of type hierarchy" do
+        result = service.generate_root(invalid_custom_field).failure
+
+        expect(result.errors[:custom_field]).to eq(["format 'text' is unsupported."])
+      end
+
+      context "with persistence of hierarchy root fails" do
+        it "fails to create a root item" do
+          allow(CustomField::Hierarchy::Item)
+            .to receive(:create)
+                  .and_return(instance_double(CustomField::Hierarchy::Item, new_record?: true, errors: "some errors"))
+
+          result = service.generate_root(custom_field)
+          expect(result).to be_failure
+        end
       end
     end
 
-    it "requires a custom field of type hierarchy" do
-      result = service.generate_root(invalid_custom_field).failure
+    describe "#insert_item" do
+      let(:label) { "Child Item" }
+      let(:short) { "Short Description" }
 
-      expect(result.errors[:custom_field]).to eq(["format 'text' is unsupported."])
-    end
+      context "with valid parameters" do
+        it "inserts an item successfully without short" do
+          result = service.insert_item(contract_class:, parent: luke, label:)
 
-    context "with persistence of hierarchy root fails" do
-      it "fails to create a root item" do
-        allow(CustomField::Hierarchy::Item)
-          .to receive(:create)
-                .and_return(instance_double(CustomField::Hierarchy::Item, new_record?: true, errors: "some errors"))
+          expect(result).to be_success
+          expect(luke.reload.children.count).to eq(2)
+        end
 
-        result = service.generate_root(custom_field)
-        expect(result).to be_failure
+        it "inserts an item successfully with short" do
+          result = service.insert_item(contract_class:, parent: root, label:, short:)
+          expect(result).to be_success
+        end
+
+        it "insert an item into a specific sort_order" do
+          leia = service.insert_item(contract_class:, parent: root, label: "leia").value!
+          expect(root.reload.children).to contain_exactly(luke, leia)
+
+          bob = service.insert_item(contract_class:, parent: root, label: "Bob", sort_order: 1).value!
+          expect(root.reload.children).to contain_exactly(luke, bob, leia)
+        end
+
+        it "updates the position_cache" do
+          leia = service.insert_item(contract_class:, parent: root, label: "leia").value!
+          expect(root.reload.position_cache).to eq(64)
+
+          service.insert_item(contract_class:, parent: root, label: "Bob", sort_order: 1).value!
+          expect(leia.reload.position_cache).to eq(200)
+        end
+      end
+
+      context "with invalid item" do
+        it "fails to insert an item" do
+          child = instance_double(CustomField::Hierarchy::Item, new_record?: true, errors: "some errors")
+          allow(root.children).to receive(:create).and_return(child)
+
+          result = service.insert_item(contract_class:, parent: root, label:, short:)
+          expect(result).to be_failure
+        end
       end
     end
-  end
 
-  describe "#insert_item" do
-    let(:label) { "Child Item" }
-    let(:short) { "Short Description" }
-
-    context "with valid parameters" do
-      it "inserts an item successfully without short" do
-        result = service.insert_item(contract_class:, parent: luke, label:)
-
-        expect(result).to be_success
-        expect(luke.reload.children.count).to eq(2)
+    describe "#update_item" do
+      context "with valid parameters" do
+        it "updates the item with new attributes" do
+          update_contract = CustomFields::Hierarchy::UpdateListItemContract
+          result = service.update_item(contract_class: update_contract, item: luke, label: "Luke Skywalker", short: "LS")
+          expect(result).to be_success
+        end
       end
 
-      it "inserts an item successfully with short" do
-        result = service.insert_item(contract_class:, parent: root, label:, short:)
-        expect(result).to be_success
+      context "with invalid parameters" do
+        let!(:leia) { service.insert_item(contract_class:, parent: root, label: "leia").value! }
+
+        it "refuses to update the item with new attributes" do
+          update_contract = CustomFields::Hierarchy::UpdateListItemContract
+          result = service.update_item(contract_class: update_contract, item: leia, label: "luke", short: "LS")
+          expect(result).to be_failure
+
+          errors = result.failure.errors
+          expect(errors[:label]).to eq(["must be unique within the same hierarchy level."])
+          expect(errors[:short]).to eq(["must be unique within the same hierarchy level."])
+        end
+      end
+    end
+
+    describe "#delete_branch" do
+      context "with valid item to destroy" do
+        it "deletes the entire branch" do
+          result = service.delete_branch(item: luke)
+          expect(result).to be_success
+          expect(luke).to be_frozen
+          expect(CustomField::Hierarchy::Item.count).to eq(1)
+          expect(root.reload.children).to be_empty
+        end
+
+        it "updates the position_cache" do
+          result = service.delete_branch(item: luke)
+
+          expect(result).to be_success
+          expect(root.reload.position_cache).to eq(27)
+        end
       end
 
-      it "insert an item into a specific sort_order" do
-        leia = service.insert_item(contract_class:, parent: root, label: "leia").value!
-        expect(root.reload.children).to contain_exactly(luke, leia)
+      context "with root item" do
+        it "refuses to delete the item" do
+          result = service.delete_branch(item: root)
+          expect(result).to be_failure
+        end
+      end
+    end
 
-        bob = service.insert_item(contract_class:, parent: root, label: "Bob", sort_order: 1).value!
-        expect(root.reload.children).to contain_exactly(luke, bob, leia)
+    describe "#get_branch" do
+      context "with a non-root node" do
+        it "returns all the ancestors to that item" do
+          result = service.get_branch(item: mara)
+          expect(result).to be_success
+
+          ancestors = result.value!
+          expect(ancestors.size).to eq(3)
+          expect(ancestors).to contain_exactly(root, luke, mara)
+          expect(ancestors.last).to eq(mara)
+        end
+      end
+
+      context "with a root node" do
+        it "returns a empty list" do
+          result = service.get_branch(item: root)
+          expect(result).to be_success
+          expect(result.value!).to match_array(root)
+        end
+      end
+    end
+
+    describe "#get_descendants" do
+      let!(:subitem) { service.insert_item(contract_class:, parent: mara, label: "Sub1").value! }
+      let!(:subitem2) { service.insert_item(contract_class:, parent: mara, label: "sub two").value! }
+      let!(:unrelated_subitem) { service.insert_item(contract_class:, parent: luke, label: "not related").value! }
+
+      context "with a non-root node" do
+        it "returns all the descendants to that item" do
+          result = service.get_descendants(item: mara)
+          expect(result).to be_success
+
+          descendants = result.value!
+          expect(descendants).to contain_exactly(mara, subitem, subitem2)
+        end
+      end
+
+      context "with a leaf node" do
+        it "returns just the leaf node" do
+          result = service.get_descendants(item: subitem2)
+          expect(result).to be_success
+          expect(result.value!).to match_array(subitem2)
+        end
+      end
+
+      context "when does not include self" do
+        it "returns all descendants not including the item passed" do
+          result = service.get_descendants(item: mara, include_self: false)
+          expect(result).to be_success
+
+          descendants = result.value!
+          expect(descendants).to contain_exactly(subitem, subitem2)
+        end
+      end
+    end
+
+    describe "#move_item" do
+      let(:lando) { service.insert_item(contract_class:, parent: root, label: "lando").value! }
+
+      it "move the node to the new parent" do
+        expect { service.move_item(item: mara, new_parent: lando) }.to change { mara.reload.ancestors.first }.to(lando)
+      end
+
+      it "all child nodes follow" do
+        service.move_item(item: luke, new_parent: lando)
+
+        expect(luke.reload.ancestors).to contain_exactly(root, lando)
+        expect(mara.reload.ancestors).to contain_exactly(root, lando, luke)
       end
 
       it "updates the position_cache" do
-        leia = service.insert_item(contract_class:, parent: root, label: "leia").value!
-        expect(root.reload.position_cache).to eq(64)
+        service.move_item(item: luke, new_parent: lando)
 
-        service.insert_item(contract_class:, parent: root, label: "Bob", sort_order: 1).value!
-        expect(leia.reload.position_cache).to eq(200)
+        preordered_descendants = root.reload.self_and_descendants_preordered.pluck(:label)
+        expect(root.self_and_descendants.reorder(:position_cache).pluck(:label)).to eq(preordered_descendants)
       end
     end
 
-    context "with invalid item" do
-      it "fails to insert an item" do
-        child = instance_double(CustomField::Hierarchy::Item, new_record?: true, errors: "some errors")
-        allow(root.children).to receive(:create).and_return(child)
+    describe "#reorder_item" do
+      let!(:lando) { service.insert_item(contract_class:, parent: root, label: "lando").value! }
+      let!(:chewbacca) { service.insert_item(contract_class:, parent: root, label: "AWOOO").value! }
 
-        result = service.insert_item(contract_class:, parent: root, label:, short:)
-        expect(result).to be_failure
+      it "reorders the item to the target position" do
+        service.reorder_item(item: chewbacca, new_sort_order: 1)
+
+        expect(luke.reload.sort_order).to eq(0)
+        expect(chewbacca.reload.sort_order).to eq(1)
+        expect(lando.reload.sort_order).to eq(2)
       end
-    end
-  end
 
-  describe "#update_item" do
-    context "with valid parameters" do
-      it "updates the item with new attributes" do
-        update_contract = CustomFields::Hierarchy::UpdateListItemContract
-        result = service.update_item(contract_class: update_contract, item: luke, label: "Luke Skywalker", short: "LS")
-        expect(result).to be_success
+      it "reorders the item even if sort order is a string" do
+        service.reorder_item(item: chewbacca, new_sort_order: "1")
+
+        expect(luke.reload.sort_order).to eq(0)
+        expect(chewbacca.reload.sort_order).to eq(1)
+        expect(lando.reload.sort_order).to eq(2)
       end
-    end
 
-    context "with invalid parameters" do
-      let!(:leia) { service.insert_item(contract_class:, parent: root, label: "leia").value! }
+      it "reorders the item to the last position" do
+        service.reorder_item(item: lando, new_sort_order: root.children.length)
 
-      it "refuses to update the item with new attributes" do
-        update_contract = CustomFields::Hierarchy::UpdateListItemContract
-        result = service.update_item(contract_class: update_contract, item: leia, label: "luke", short: "LS")
-        expect(result).to be_failure
-
-        errors = result.failure.errors
-        expect(errors[:label]).to eq(["must be unique within the same hierarchy level."])
-        expect(errors[:short]).to eq(["must be unique within the same hierarchy level."])
+        expect(luke.reload.sort_order).to eq(0)
+        expect(chewbacca.reload.sort_order).to eq(1)
+        expect(lando.reload.sort_order).to eq(2)
       end
-    end
-  end
 
-  describe "#delete_branch" do
-    context "with valid item to destroy" do
-      it "deletes the entire branch" do
-        result = service.delete_branch(item: luke)
-        expect(result).to be_success
-        expect(luke).to be_frozen
-        expect(CustomField::Hierarchy::Item.count).to eq(1)
-        expect(root.reload.children).to be_empty
+      it "reorders the item to the first position" do
+        service.reorder_item(item: chewbacca, new_sort_order: 0)
+
+        expect(chewbacca.reload.sort_order).to eq(0)
+        expect(luke.reload.sort_order).to eq(1)
+        expect(lando.reload.sort_order).to eq(2)
+      end
+
+      it "does not reorder before first" do
+        service.reorder_item(item: lando, new_sort_order: -10)
+
+        expect(lando.reload.sort_order).to eq(0)
+        expect(luke.reload.sort_order).to eq(1)
+        expect(chewbacca.reload.sort_order).to eq(2)
+      end
+
+      it "does not reorder after last" do
+        service.reorder_item(item: chewbacca, new_sort_order: 99)
+
+        expect(luke.reload.sort_order).to eq(0)
+        expect(lando.reload.sort_order).to eq(1)
+        expect(chewbacca.reload.sort_order).to eq(2)
+      end
+
+      it "does not reorder when changing self" do
+        service.reorder_item(item: lando, new_sort_order: lando.sort_order)
+
+        expect(luke.reload.sort_order).to eq(0)
+        expect(lando.reload.sort_order).to eq(1)
+        expect(chewbacca.reload.sort_order).to eq(2)
       end
 
       it "updates the position_cache" do
-        result = service.delete_branch(item: luke)
+        service.reorder_item(item: chewbacca, new_sort_order: 0)
 
-        expect(result).to be_success
-        expect(root.reload.position_cache).to eq(27)
+        preordered_descendants = root.reload.self_and_descendants_preordered.pluck(:label)
+        expect(root.self_and_descendants.reorder(:position_cache).pluck(:label)).to eq(preordered_descendants)
       end
     end
 
-    context "with root item" do
-      it "refuses to delete the item" do
-        result = service.delete_branch(item: root)
-        expect(result).to be_failure
+    describe "#hashed_subtree" do
+      let!(:lando) { service.insert_item(contract_class:, parent: root, label: "lando").value! }
+      let!(:chewbacca) { service.insert_item(contract_class:, parent: root, label: "AWOOO").value! }
+      let!(:lowbacca) { service.insert_item(contract_class:, parent: chewbacca, label: "ARWWWW").value! }
+
+      it "produces a hash version of the tree" do
+        subtree = service.hashed_subtree(item: root, depth: -1)
+
+        expect(subtree.value!).to be_a(Hash)
+        expect(subtree.value![root].size).to eq(3)
+        expect(subtree.value![root][lando]).to be_empty
+        expect(subtree.value![root][chewbacca][lowbacca]).to be_empty
       end
-    end
-  end
 
-  describe "#get_branch" do
-    context "with a non-root node" do
-      it "returns all the ancestors to that item" do
-        result = service.get_branch(item: mara)
-        expect(result).to be_success
+      it "produces a hash version of a sub tree with limited depth" do
+        subtree = service.hashed_subtree(item: chewbacca, depth: 0)
 
-        ancestors = result.value!
-        expect(ancestors.size).to eq(3)
-        expect(ancestors).to contain_exactly(root, luke, mara)
-        expect(ancestors.last).to eq(mara)
-      end
-    end
-
-    context "with a root node" do
-      it "returns a empty list" do
-        result = service.get_branch(item: root)
-        expect(result).to be_success
-        expect(result.value!).to match_array(root)
+        expect(subtree.value!).to be_a(Hash)
+        expect(subtree.value![chewbacca]).to be_empty
       end
     end
   end
 
-  describe "#get_descendants" do
-    let!(:subitem) { service.insert_item(contract_class:, parent: mara, label: "Sub1").value! }
-    let!(:subitem2) { service.insert_item(contract_class:, parent: mara, label: "sub two").value! }
-    let!(:unrelated_subitem) { service.insert_item(contract_class:, parent: luke, label: "not related").value! }
+  context "with scored list and calculated values", with_flag: { calculated_value_project_attribute: true,
+                                                                 scored_list_custom_fields: true } do
+    current_user { create(:admin) }
 
-    context "with a non-root node" do
-      it "returns all the descendants to that item" do
-        result = service.get_descendants(item: mara)
-        expect(result).to be_success
-
-        descendants = result.value!
-        expect(descendants).to contain_exactly(mara, subitem, subitem2)
-      end
+    let!(:contract_class) { CustomFields::Hierarchy::UpdateScoredItemContract }
+    let!(:project) { create(:project) }
+    let!(:custom_field) { create(:scored_list_project_custom_field, projects: [project]) }
+    let!(:one) { create(:hierarchy_item, parent: custom_field.hierarchy_root, label: "One", score: 1) }
+    let!(:two) { create(:hierarchy_item, parent: custom_field.hierarchy_root, label: "Two", score: 2) }
+    let!(:calculated_value) do
+      create(:calculated_value_project_custom_field,
+             :skip_validations,
+             projects: [project],
+             formula: "{{cf_#{custom_field.id}}} * 2")
     end
 
-    context "with a leaf node" do
-      it "returns just the leaf node" do
-        result = service.get_descendants(item: subitem2)
-        expect(result).to be_success
-        expect(result.value!).to match_array(subitem2)
-      end
+    before do
+      project.custom_values.create!(custom_field: custom_field, value: one.id)
     end
 
-    context "when does not include self" do
-      it "returns all descendants not including the item passed" do
-        result = service.get_descendants(item: mara, include_self: false)
-        expect(result).to be_success
+    it "updates calculated values affected by the change" do
+      result = service.update_item(contract_class:, item: one, score: 42)
+      expect(result).to be_success
 
-        descendants = result.value!
-        expect(descendants).to contain_exactly(subitem, subitem2)
-      end
-    end
-  end
-
-  describe "#move_item" do
-    let(:lando) { service.insert_item(contract_class:, parent: root, label: "lando").value! }
-
-    it "move the node to the new parent" do
-      expect { service.move_item(item: mara, new_parent: lando) }.to change { mara.reload.ancestors.first }.to(lando)
-    end
-
-    it "all child nodes follow" do
-      service.move_item(item: luke, new_parent: lando)
-
-      expect(luke.reload.ancestors).to contain_exactly(root, lando)
-      expect(mara.reload.ancestors).to contain_exactly(root, lando, luke)
-    end
-
-    it "updates the position_cache" do
-      service.move_item(item: luke, new_parent: lando)
-
-      preordered_descendants = root.reload.self_and_descendants_preordered.pluck(:label)
-      expect(root.self_and_descendants.reorder(:position_cache).pluck(:label)).to eq(preordered_descendants)
-    end
-  end
-
-  describe "#reorder_item" do
-    let!(:lando) { service.insert_item(contract_class:, parent: root, label: "lando").value! }
-    let!(:chewbacca) { service.insert_item(contract_class:, parent: root, label: "AWOOO").value! }
-
-    it "reorders the item to the target position" do
-      service.reorder_item(item: chewbacca, new_sort_order: 1)
-
-      expect(luke.reload.sort_order).to eq(0)
-      expect(chewbacca.reload.sort_order).to eq(1)
-      expect(lando.reload.sort_order).to eq(2)
-    end
-
-    it "reorders the item even if sort order is a string" do
-      service.reorder_item(item: chewbacca, new_sort_order: "1")
-
-      expect(luke.reload.sort_order).to eq(0)
-      expect(chewbacca.reload.sort_order).to eq(1)
-      expect(lando.reload.sort_order).to eq(2)
-    end
-
-    it "reorders the item to the last position" do
-      service.reorder_item(item: lando, new_sort_order: root.children.length)
-
-      expect(luke.reload.sort_order).to eq(0)
-      expect(chewbacca.reload.sort_order).to eq(1)
-      expect(lando.reload.sort_order).to eq(2)
-    end
-
-    it "reorders the item to the first position" do
-      service.reorder_item(item: chewbacca, new_sort_order: 0)
-
-      expect(chewbacca.reload.sort_order).to eq(0)
-      expect(luke.reload.sort_order).to eq(1)
-      expect(lando.reload.sort_order).to eq(2)
-    end
-
-    it "does not reorder before first" do
-      service.reorder_item(item: lando, new_sort_order: -10)
-
-      expect(lando.reload.sort_order).to eq(0)
-      expect(luke.reload.sort_order).to eq(1)
-      expect(chewbacca.reload.sort_order).to eq(2)
-    end
-
-    it "does not reorder after last" do
-      service.reorder_item(item: chewbacca, new_sort_order: 99)
-
-      expect(luke.reload.sort_order).to eq(0)
-      expect(lando.reload.sort_order).to eq(1)
-      expect(chewbacca.reload.sort_order).to eq(2)
-    end
-
-    it "does not reorder when changing self" do
-      service.reorder_item(item: lando, new_sort_order: lando.sort_order)
-
-      expect(luke.reload.sort_order).to eq(0)
-      expect(lando.reload.sort_order).to eq(1)
-      expect(chewbacca.reload.sort_order).to eq(2)
-    end
-
-    it "updates the position_cache" do
-      service.reorder_item(item: chewbacca, new_sort_order: 0)
-
-      preordered_descendants = root.reload.self_and_descendants_preordered.pluck(:label)
-      expect(root.self_and_descendants.reorder(:position_cache).pluck(:label)).to eq(preordered_descendants)
-    end
-  end
-
-  describe "#hashed_subtree" do
-    let!(:lando) { service.insert_item(contract_class:, parent: root, label: "lando").value! }
-    let!(:chewbacca) { service.insert_item(contract_class:, parent: root, label: "AWOOO").value! }
-    let!(:lowbacca) { service.insert_item(contract_class:, parent: chewbacca, label: "ARWWWW").value! }
-
-    it "produces a hash version of the tree" do
-      subtree = service.hashed_subtree(item: root, depth: -1)
-
-      expect(subtree.value!).to be_a(Hash)
-      expect(subtree.value![root].size).to eq(3)
-      expect(subtree.value![root][lando]).to be_empty
-      expect(subtree.value![root][chewbacca][lowbacca]).to be_empty
-    end
-
-    it "produces a hash version of a sub tree with limited depth" do
-      subtree = service.hashed_subtree(item: chewbacca, depth: 0)
-
-      expect(subtree.value!).to be_a(Hash)
-      expect(subtree.value![chewbacca]).to be_empty
+      expect(project.custom_value_for(calculated_value).value).to eq("84.0")
     end
   end
 end

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -335,38 +335,64 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:cust
                                                                  scored_list_custom_fields: true } do
     current_user { create(:admin) }
 
-    let!(:project) { create(:project) }
-    let!(:custom_field) { create(:scored_list_project_custom_field, projects: [project]) }
+    let!(:project_using_one) { create(:project) }
+    let!(:project_using_two) { create(:project) }
+    let!(:project_having_fields_enabled) { create(:project) }
+    let!(:project_not_having_fields_enabled) { create(:project) }
+    let!(:projects) { [project_using_one, project_using_two, project_having_fields_enabled] }
+    let!(:custom_field) { create(:scored_list_project_custom_field, projects:) }
     let!(:one) { create(:hierarchy_item, parent: custom_field.hierarchy_root, label: "One", score: 1) }
     let!(:two) { create(:hierarchy_item, parent: custom_field.hierarchy_root, label: "Two", score: 2) }
     let!(:calculated_value) do
       create(:calculated_value_project_custom_field,
              :skip_validations,
-             projects: [project],
+             projects:,
              formula: "{{cf_#{custom_field.id}}} * 2")
     end
 
     before do
-      project.custom_values.create!(custom_field: custom_field, value: one.id)
+      project_using_one.custom_values.create!(custom_field: custom_field, value: one.id)
+      project_using_one.custom_values.create!(custom_field: calculated_value, value: "123")
+
+      project_using_two.custom_values.create!(custom_field: custom_field, value: two.id)
+      project_using_two.custom_values.create!(custom_field: calculated_value, value: "123")
     end
 
     describe "updating the score of an item" do
       let!(:contract_class) { CustomFields::Hierarchy::UpdateScoredItemContract }
 
+      subject(:result) { service.update_item(contract_class:, item: one, label: one.label, score: 42) }
+
       it "updates calculated values affected by the change" do
-        result = service.update_item(contract_class:, item: one, score: 42)
         expect(result).to be_success
 
-        expect(project.custom_value_for(calculated_value).value).to eq("84.0")
+        expect(project_using_one.custom_value_for(calculated_value)).to have_attributes(value: "84.0")
+      end
+
+      it "doesn't update calculated values unaffected by the change" do
+        expect(result).to be_success
+
+        expect(project_using_two.custom_value_for(calculated_value)).to have_attributes(value: "123")
+        expect(project_having_fields_enabled.custom_values).to be_empty
+        expect(project_having_fields_enabled.custom_values).to be_empty
       end
     end
 
     describe "deleting an item" do
+      subject(:result) { service.delete_branch(item: one) }
+
       it "updates calculated values affected by the change" do
-        result = service.delete_branch(item: one)
         expect(result).to be_success
 
-        expect(project.custom_value_for(calculated_value).value).to be_nil
+        expect(project_using_one.custom_value_for(calculated_value)).to have_attributes(value: nil)
+      end
+
+      it "doesn't update calculated values unaffected by the change" do
+        expect(result).to be_success
+
+        expect(project_using_two.custom_value_for(calculated_value)).to have_attributes(value: "123")
+        expect(project_having_fields_enabled.custom_values).to be_empty
+        expect(project_having_fields_enabled.custom_values).to be_empty
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64524

# Important
This branch is based on #20454. Either merge that one first - or merge this branch into it instead of `dev`.

# What are you trying to accomplish?
When the score of a scored list is changed within the administration, all Calculated Values that are using the scored list should be recalculated.

- [x] Recalculate when item score is updated in the administration
- [x] Recalculate when an hierarchy item is deleted in the administration

## Notes

In case I have to take my parental leave in the near future, here are some notes on the current state of this PR:

* The general workflow of updating a score and seeing the recalculation happening works.
* The same goes for deleting an item from a scored list.
  * There was a "visual bug" here where we would render a "not found" message that did not make much sense on the project overview. So I removed that (see `hierarchy_strategy.rb`). But I did not yet double check if that broke the UI somewhere else. Please be aware that the strategy is not only used by Scored Lists, but also by Hierarchies. If Hierarchies need the error string, we could simply include a type check and render a different formatted value.
* I have provided a handful of "functional" specs (see `hierarchical_item_service_spec.rb`) - but I am not happy with them. They utilize the database quite a lot. I feel like it should be possible without doing so - but then, I had to mock too much for my taste. Maybe you have a better idea of how to do this.
* I have also provided a small amount of feature specs that update a scored list or delete an item from it while inspecting what happens with Calculated Values in that case. See: `scored_lists_and_calculated_values_spec.rb`
* Lastly, I might have missed some cases in which we have to recalculate, please double check.

**TL;DR**: Everything should work. Specs ugly. Please double-check if there are other cases in which recalculation might be needed for Scored Lists. Thank you!

## Screenshots
https://github.com/user-attachments/assets/ca65692a-028a-49fe-870e-f8ba125b6da7

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
