### PR TITLE
[65896] Left side menu icon overlaps with header on Log unit costs page

### DIFF
--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -28,7 +28,17 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% html_title t(:label_log_costs) %>
-<h2><%= t(:label_log_costs) %></h2>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { I18n.t(:label_log_costs) }
+    header.with_breadcrumbs(
+      [({ href: project_overview_path(@project.id), text: @project.name }),
+       ({ href: project_work_packages_path(@project), text: t(:label_work_package_plural) }),
+       I18n.t(:label_log_costs)]
+    )
+  end
+%>
 
 <% url = if @cost_entry.new_record?
            { action: "create", project_id: @project.id }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65896

# What are you trying to accomplish?
Use Primer PageHeader instead of simple h2 tag. The PageHeader correctly reacts to the collapsed menu.

## Screenshots

<img width="641" height="237" alt="Bildschirmfoto 2025-10-02 um 15 02 00" src="https://github.com/user-attachments/assets/cf1aa25b-9a71-4719-b72b-6c26f71d300d" />
