### PR TITLE
[67572] Wrong hover icon when hovering over active timer in right side bar

### DIFF
--- a/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.html
+++ b/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.html
@@ -6,7 +6,7 @@
       (click)="stopTimer()"
       >
       <svg op-stopwatch-stop-icon size="small" />
-      {{text.stop}}
+      <span>{{text.stop}}</span>
     </a>
   </span>
   <a

--- a/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.sass
+++ b/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.sass
@@ -11,8 +11,13 @@
     @include spot-body-small (bold)
     line-height: $spot-spacing-2
 
-    &-icon
-      margin-left: auto
+  &--timer-icon
+    margin-left: auto
+    cursor: pointer
+
+    .octicon
+      margin-right: var(--base-size-4)
+
   &--wp-details
     padding: 0 10px
     display: inline-block


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67572

# What are you trying to accomplish?
Show currect cursor


