### PR TITLE
fix enterprise banner for calculated_values form

### DIFF
--- a/app/components/admin/custom_fields/calculated_values/details_component.html.erb
+++ b/app/components/admin/custom_fields/calculated_values/details_component.html.erb
@@ -28,8 +28,8 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  component_wrapper do
-    with_enterprise_banner_guard(:calculated_values, variant: :large, image: "enterprise/calculated-values.png") do
+  with_enterprise_banner_guard(:calculated_values, variant: :large, image: "enterprise/calculated-values.png") do
+    component_wrapper do
       settings_primer_form_with(
         model:,
         scope: :custom_field,


### PR DESCRIPTION
Before the fix if feature is in trial, then dismissible enterprise banner will be displayed alone and the form will be displayed only after reloading the page