### PR TITLE
[67893] Hide legal notice link when no impressum is set

### DIFF
--- a/app/components/homescreen/link_component.rb
+++ b/app/components/homescreen/link_component.rb
@@ -42,7 +42,7 @@ module Homescreen
     end
 
     def render?
-      link.present?
+      link.present? && url.present?
     end
 
     private

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -74,6 +74,12 @@ module OpenProject
           links[:website][:href]
         end
 
+        def reset_cache
+          @cache_key = nil
+          @links = nil
+          @static_links = nil
+        end
+
         private
 
         def links

--- a/spec/components/homescreen/link_component_spec.rb
+++ b/spec/components/homescreen/link_component_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Homescreen::LinkComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  subject(:rendered_component) do
+    render_component(link:)
+  end
+
+  context "with a blank link" do
+    it "does not render" do
+      expect(render_component(link: nil).to_s).to be_empty
+      expect(render_component(link: {}).to_s).to be_empty
+    end
+  end
+
+  context "with a link with :url being blank" do
+    it "does not render" do
+      expect(render_component(link: { url: nil }).to_s).to be_empty
+      expect(render_component(link: { url: "" }).to_s).to be_empty
+    end
+  end
+
+  context "with a link with :url being set" do
+    let(:link) { { url: "https://www.openproject.org/docs/", label: :user_guides, icon: "milestone" } }
+
+    it "renders the link using :url" do
+      render_component(link:)
+      expect(page).to have_link "User guides", href: "https://www.openproject.org/docs/"
+    end
+  end
+
+  context "with a link with :url_key being set" do
+    let(:link) { { url_key: :user_guides, label: :user_guides, icon: "milestone" } }
+
+    it "renders the link using the url from static links" do
+      render_component(link:)
+      expect(page).to have_link "User guides", href: OpenProject::Static::Links.url_for(link[:url_key])
+    end
+  end
+
+  context "with a link with :url_key being set to a key not referenced in static links" do
+    let(:link) { { url_key: :non_existent_key } }
+
+    it "does not render" do
+      expect(render_component(link:).to_s).to be_empty
+    end
+  end
+
+  context "with both :url and :url_key being set" do
+    let(:link) do
+      { url: "https://www.openproject.org/i_am_the_url/",
+        url_key: :user_guides,
+        label: :user_guides,
+        icon: "milestone" }
+    end
+
+    it "renders the link using :url" do
+      render_component(link:)
+      expect(page).to have_link "User guides", href: link[:url]
+    end
+  end
+end

--- a/spec/features/homescreen/index_spec.rb
+++ b/spec/features/homescreen/index_spec.rb
@@ -114,4 +114,35 @@ RSpec.describe "Homescreen", "index" do
       end
     end
   end
+
+  describe "Impressum (legal notice) link" do
+    before do
+      OpenProject::Static::Links.reset_cache
+      login_as user
+      visit root_url
+    end
+
+    after do
+      OpenProject::Static::Links.reset_cache
+    end
+
+    context "when impressum_link is set",
+            with_config: { impressum_link: "https://example.com/impressum/" } do
+      it "renders the correct link" do
+        expect(page).to have_link(I18n.t("homescreen.links.impressum"),
+                                  href: OpenProject::Static::Links.url_for(:impressum))
+      end
+    end
+
+    context "when impressum_link is not set",
+            with_config: { impressum_link: nil } do
+      it "does not render the 'Legal notice' link" do
+        # Wait for page load before checking absence of impressum link
+        expect(page).to have_link(I18n.t("homescreen.links.blog"),
+                                  href: OpenProject::Static::Links.url_for(:blog))
+
+        expect(page).to have_no_link(I18n.t("homescreen.links.impressum"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/67893

# What are you trying to accomplish?

Hide the "Legal notice" link when no impressum is set (and show it when [the impressum link is set](https://www.openproject.org/docs/installation-and-operations/configuration/#impressum-link))

## Screenshots

Before:

<img width="1395" height="570" alt="image" src="https://github.com/user-attachments/assets/e89eae40-60b8-4372-8727-8ab1b037bab1" />

After:

<img width="1397" height="562" alt="image" src="https://github.com/user-attachments/assets/9fb04226-b7ee-4cc5-bdff-4b08897bf096" />

# What approach did you choose and why?

Render only if url is present, like before 82a8c3de81a. And add tests hoping that won't surface again.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
