### PR TITLE
Fix flaky spec structured_meeting_crud_spec.rb

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1781,6 +1781,7 @@ en:
       issue_priority:
         one: "Priority"
         other: "Priorities"
+      meeting_participant: "Meeting participant"
       member: "Member"
       news: "News"
       notification:

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -84,11 +84,10 @@ RSpec.describe "Meetings CRUD",
     end
 
     meetings_page.click_create
+    expect_and_dismiss_flash(type: :success, message: I18n.t(:notice_successful_create))
   end
 
   it "can create a meeting and add agenda items" do
-    expect_and_dismiss_flash(type: :success, message: "Successful creation")
-
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
@@ -262,8 +261,6 @@ RSpec.describe "Meetings CRUD",
   end
 
   it "shows an error toast trying to update an outdated item" do
-    expect_flash(type: :success, message: "Successful creation")
-
     # Can add and edit a single item
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
@@ -285,8 +282,6 @@ RSpec.describe "Meetings CRUD",
   end
 
   it "can copy the meeting via the dialog form" do
-    expect_flash(type: :success, message: "Successful creation")
-
     show_page.add_agenda_item do
       fill_in "Title", with: "My agenda item"
       fill_in "Duration", with: "25"
@@ -312,7 +307,7 @@ RSpec.describe "Meetings CRUD",
       click_on("op-meetings-header-action-trigger")
       click_on "Copy"
       # dynamically wait for the modal to be loaded
-      expect(page).to have_text("Copy meeting")
+      show_page.expect_modal("Copy meeting")
     end
 
     fill_in "Title", with: ""
@@ -322,6 +317,7 @@ RSpec.describe "Meetings CRUD",
     expect(page).to have_content "Title can't be blank."
     fill_in "Title", with: "Some title"
     click_on "Create meeting"
+    expect_and_dismiss_flash(type: :success, message: I18n.t(:notice_successful_create))
 
     new_meeting = Meeting.last
     copied_meeting_page = Pages::Meetings::Show.new(new_meeting)
@@ -372,8 +368,6 @@ RSpec.describe "Meetings CRUD",
 
     context "when starting with empty sections" do
       it "can add, edit and delete sections" do
-        expect_flash(type: :success, message: "Successful creation")
-
         # create the first section
         show_page.add_section do
           fill_in "Title", with: "First section"

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -127,6 +127,8 @@ module Pages::Meetings
 
     def expect_modal(...)
       expect(page).to have_modal(...)
+      modal = find(:modal, ...)
+      wait_for_size_animation_completion(modal)
     end
 
     def expect_no_add_form
@@ -568,6 +570,7 @@ module Pages::Meetings
     def start_meeting
       page.within("#meetings-side-panel-state-component") do
         click_on("Start meeting")
+        expect(page).to have_link("Close meeting")
       end
     end
 

--- a/spec/support/capybara/wait_helpers.rb
+++ b/spec/support/capybara/wait_helpers.rb
@@ -34,11 +34,19 @@ module WaitHelpers
   # Useful to wait for a primer dialog to finish opening, as they have an
   # opening animation.
   #
-  # @param selector [String] CSS selector for the element to wait for
+  # @param selector_or_element [String or Capybara::Node::Element] CSS selector or element to wait for
   # @param wait [Integer] Optional maximum time to wait in seconds, defaults to
   #   Capybara's default wait time
-  def wait_for_size_animation_completion(selector, wait: Capybara.default_max_wait_time)
-    element = page.find(selector, wait:)
+  def wait_for_size_animation_completion(selector_or_element, wait: Capybara.default_max_wait_time)
+    element =
+      case selector_or_element
+      when String
+        page.find(selector_or_element, wait:)
+      when Capybara::Node::Element
+        selector_or_element
+      else
+        raise ArgumentError, "Invalid selector or element"
+      end
     page.document.synchronize do
       initial_position = page.evaluate_script("arguments[0].getBoundingClientRect()", element)
       sleep 0.1 # Small delay to allow for animation


### PR DESCRIPTION
failing spec: modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb:287
failing run: https://github.com/opf/openproject/actions/runs/18215876372/job/51864889174

There were multiple failures locally, and multiple causes:

First one, the dialog "Meeting participant" was doing `MeetingParticipant.model_name.human`, but no translation existed for :en, so it tried the fallback locales, which means all supported locales. The i18n translations are lazily loaded in tests for performance reasons, so initialization has to be done. It can take more than 3 seconds on a loaded system, which means that the expectation fails because the backend has not rendered the modal yet as it is still busy loading the translations for _all_ languages.

Fix was to add a translation for `activerecord.models.meeting_participant` key.

Second is that the interaction with some modals is done too early: the modal has still not finished its appearing animation (it zooms in), so some capybara actions do not quite work: for instance when capybara tries to click in a field, it capture the position of the element, locate the center, and clicks on that point. But as the animation is in progress, the element being clicked has already moved and Capybara clicks on the wrong place.

Fix was to modify `expect_modal` helper to always wait for this animation to complete using `wait_for_size_animation_completion` helper.

Third one was a race condition when opening the meeting participant list after copying and starting a meeting. When checking if all participants are listed as expected, it also checks for the presence of the "Mark as attended" button for each participant if the meeting is in progress. Problem is: after clicking "Start meeting", the test opens the "manage participants" modal immediately. If the meeting status has not finished updating yet, the "manage participants" modal will be rendered without the "Mark as attended" buttons, and when the participant presence is checked, the meeting status has been updated in the meantime. So it checks for the buttons presence, but they are not => failure.

Fix was to wait for the meeting status to be updated after starting the meeting.
