### PR TITLE
[#67827] Hide new Project Overview behind feature flag

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -75,3 +75,6 @@ OpenProject::FeatureDecisions.add :portfolio_models,
 OpenProject::FeatureDecisions.add :change_hierarchy_item_parent,
                                   description: "Enables a functionality to change the parent of a hierarchy item of " \
                                                "custom fields of type hierarchy and scored list."
+
+OpenProject::FeatureDecisions.add :new_project_overview,
+                                  description: "Enables the new project overview experience."

--- a/lib/constraints/feature_decision.rb
+++ b/lib/constraints/feature_decision.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Constraints
+  class FeatureDecision
+    def initialize(flag_name)
+      @flag_name = flag_name
+    end
+
+    def matches?(...)
+      OpenProject::FeatureDecisions.public_send(:"#{@flag_name}_active?")
+    end
+  end
+end

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 require_relative "../../../overviews/spec/support/pages/dashboard"
 require_relative "../support/pages/calendar"
 
-RSpec.describe "Calendar Widget", :js, with_settings: { start_of_week: 1 } do
+RSpec.describe "Calendar Widget", :js, with_flag: { new_project_overview: true }, with_settings: { start_of_week: 1 } do
   shared_let(:project) do
     create(:project, enabled_module_names: %w[work_package_tracking calendar_view meetings])
   end

--- a/modules/overviews/app/components/overviews/page_header_component.html.erb
+++ b/modules/overviews/app/components/overviews/page_header_component.html.erb
@@ -43,23 +43,25 @@
       end
     end
 
-    header.with_tab_nav(label: nil, test_selector: "overview-tabs") do |tab_nav|
-      tab_nav.with_tab(
-        test_selector: "project-overview-tab",
-        selected: current_page?(project_overview_path),
-        href: helpers.project_overview_path,
-      ) do |t|
-        t.with_icon(icon: :"op-view-split")
-        t.with_text { I18n.t("overviews.label_overview") }
-      end
+    if OpenProject::FeatureDecisions.new_project_overview_active?
+      header.with_tab_nav(label: nil, test_selector: "overview-tabs") do |tab_nav|
+        tab_nav.with_tab(
+          test_selector: "project-overview-tab",
+          selected: current_page?(project_overview_path),
+          href: helpers.project_overview_path,
+        ) do |t|
+          t.with_icon(icon: :"op-view-split")
+          t.with_text { I18n.t("overviews.label_overview") }
+        end
 
-      tab_nav.with_tab(
-        test_selector: "project-dashboard-tab",
-        selected: current_page?(dashboard_project_overview_path),
-        href: helpers.dashboard_project_overview_path,
-      ) do |t|
-        t.with_icon(icon: :"op-view-list")
-        t.with_text { I18n.t("overviews.label_dashboard") }
+        tab_nav.with_tab(
+          test_selector: "project-dashboard-tab",
+          selected: current_page?(dashboard_project_overview_path),
+          href: helpers.dashboard_project_overview_path,
+        ) do |t|
+          t.with_icon(icon: :"op-view-list")
+          t.with_text { I18n.t("overviews.label_dashboard") }
+        end
       end
     end
   end

--- a/modules/overviews/app/components/overviews/page_header_component.rb
+++ b/modules/overviews/app/components/overviews/page_header_component.rb
@@ -48,7 +48,11 @@ module Overviews
     end
 
     def page_title
-      I18n.t("overviews.label_home", workspace_type: project.workspace_label)
+      if OpenProject::FeatureDecisions.new_project_overview_active?
+        I18n.t("overviews.label_home", workspace_type: project.workspace_label)
+      else
+        I18n.t("overviews.label_overview")
+      end
     end
 
     def favorited?

--- a/modules/overviews/app/components/overviews/show_component.html.erb
+++ b/modules/overviews/app/components/overviews/show_component.html.erb
@@ -54,6 +54,10 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    render Overviews::OverviewGridComponent.new(project:)
+    if OpenProject::FeatureDecisions.new_project_overview_active?
+      render Overviews::OverviewGridComponent.new(project:)
+    else
+      render Overviews::DashboardComponent.new(project:, current_user:)
+    end
   end
 %>

--- a/modules/overviews/config/routes.rb
+++ b/modules/overviews/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
     scope "projects/:project_id", as: "project" do
       scope module: "overviews" do
         resource :overview, path: "/", only: [:show] do
-          get :dashboard, on: :member
+          constraints(Constraints::FeatureDecision.new(:new_project_overview)) do
+            get :dashboard, on: :member
+          end
         end
 
         controller :overviews do

--- a/modules/overviews/lib/overviews/engine.rb
+++ b/modules/overviews/lib/overviews/engine.rb
@@ -36,7 +36,13 @@ module Overviews
       ::Redmine::MenuManager.map(:project_menu) do |menu|
         menu.push(:overview,
                   { controller: "/overviews/overviews", action: "show" },
-                  caption: ->(project) { I18n.t("overviews.label_home", workspace_type: project.workspace_label) },
+                  caption: ->(project) {
+                    if OpenProject::FeatureDecisions.new_project_overview_active?
+                      I18n.t("overviews.label_home", workspace_type: project.workspace_label)
+                    else
+                      I18n.t("overviews.label_overview")
+                    end
+                  },
                   first: true,
                   icon: "info")
       end

--- a/modules/overviews/spec/components/overviews/page_header_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/page_header_component_spec.rb
@@ -65,41 +65,59 @@ RSpec.describe Overviews::PageHeaderComponent, type: :component do
       expect(rendered_component).to have_css ".PageHeader-contextBar"
     end
 
-    it "renders current page" do
+    it "renders current page", with_flag: { new_project_overview: true } do
       expect(rendered_component).to have_link "Project home", current: "page"
     end
+
+    it "renders current page", with_flag: { new_project_overview: false } do
+      expect(rendered_component).to have_link "Overview", current: "page"
+    end
   end
 
-  it "renders a Page Header (with tab nav)" do
-    expect(rendered_component).to have_element "page-header", class: "PageHeader--withTabNav"
-  end
-
-  context "with Project" do
-    it "renders title" do
-      expect(rendered_component).to have_heading "Project home", class: "PageHeader-title"
+  context "with the feature flag enabled", with_flag: { new_project_overview: true } do
+    it "renders a Page Header (with tab nav)" do
+      expect(rendered_component).to have_element "page-header", class: "PageHeader--withTabNav"
     end
 
-    it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Project home"]
-  end
+    context "with Project" do
+      it "renders title" do
+        expect(rendered_component).to have_heading "Project home", class: "PageHeader-title"
+      end
 
-  context "with Portfolio" do
-    let(:workspace_type) { :portfolio }
-
-    it "renders title" do
-      expect(rendered_component).to have_heading "Portfolio home", class: "PageHeader-title"
+      it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Project home"]
     end
 
-    it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Portfolio home"]
-  end
+    context "with Portfolio" do
+      let(:workspace_type) { :portfolio }
 
-  context "with Program" do
-    let(:workspace_type) { :program }
+      it "renders title" do
+        expect(rendered_component).to have_heading "Portfolio home", class: "PageHeader-title"
+      end
 
-    it "renders title" do
-      expect(rendered_component).to have_heading "Program home", class: "PageHeader-title"
+      it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Portfolio home"]
     end
 
-    it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Program home"]
+    context "with Program" do
+      let(:workspace_type) { :program }
+
+      it "renders title" do
+        expect(rendered_component).to have_heading "Program home", class: "PageHeader-title"
+      end
+
+      it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Program home"]
+    end
+  end
+
+  context "with the feature flag disabled", with_flag: { new_project_overview: false } do
+    it "renders a Page Header" do
+      expect(rendered_component).to have_element "page-header"
+    end
+
+    it "renders title" do
+      expect(rendered_component).to have_heading "Overview", class: "PageHeader-title"
+    end
+
+    it_behaves_like "rendering breadcrumbs", ["OpenProject", "Too big to fail", "Overview"]
   end
 
   describe "actions" do
@@ -140,7 +158,7 @@ RSpec.describe Overviews::PageHeaderComponent, type: :component do
     end
   end
 
-  describe "tab bar" do
+  describe "tab bar", with_flag: { new_project_overview: true } do
     it "renders a tab bar" do
       expect(rendered_component).to have_css ".PageHeader-tabNavBar"
     end

--- a/modules/overviews/spec/components/overviews/show_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/show_component_spec.rb
@@ -74,8 +74,24 @@ RSpec.describe Overviews::ShowComponent, type: :component do
     end
   end
 
-  it "renders overview grid" do
-    expect(rendered_component).to have_css ".widget-boxes"
+  context "with the feature flag enabled", with_flag: { new_project_overview: true } do
+    it "renders overview grid" do
+      expect(rendered_component).to have_css ".widget-boxes"
+    end
+
+    it "does not render widgets" do
+      expect(rendered_component).to have_no_element "opce-dashboard"
+    end
+  end
+
+  context "with the feature flag disabled", with_flag: { new_project_overview: false } do
+    it "does not render overview grid" do
+      expect(rendered_component).to have_no_css ".widget-boxes"
+    end
+
+    it "renders widgets" do
+      expect(rendered_component).to have_element "opce-dashboard"
+    end
   end
 
   context "when project has neither project attributes or life cycle" do

--- a/modules/overviews/spec/controllers/overviews/overviews_controller_spec.rb
+++ b/modules/overviews/spec/controllers/overviews/overviews_controller_spec.rb
@@ -78,4 +78,12 @@ RSpec.describe Overviews::OverviewsController do
       end
     end
   end
+
+  describe "#dashboard", with_flag: { new_project_overview: true } do
+    it "renders 'dashboard'" do
+      get :dashboard, params: { project_id: project.id }
+
+      expect(response).to be_successful
+    end
+  end
 end

--- a/modules/overviews/spec/features/low_permissions_page_creation_spec.rb
+++ b/modules/overviews/spec/features/low_permissions_page_creation_spec.rb
@@ -30,7 +30,9 @@ require "spec_helper"
 
 require_relative "../support/pages/dashboard"
 
-RSpec.describe "Dashboard page on the fly creation if user lacks :manage_dashboards permission", :js do
+RSpec.describe "Dashboard page on the fly creation if user lacks :manage_dashboards permission",
+               :js,
+               with_flag: { new_project_overview: true } do
   let!(:type) { create(:type) }
   let!(:project) { create(:project, types: [type]) }
   let!(:open_status) { create(:default_status) }

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,9 +30,9 @@
 
 require "spec_helper"
 
-require_relative "../support/pages/dashboard"
+require_relative "../support/pages/overview"
 
-RSpec.describe "Dashboard page managing", :js, with_flag: { new_project_overview: true } do
+RSpec.describe "Overview page managing", :js, with_flag: { new_project_overview: false } do
   let!(:type) { create(:type) }
   let!(:project) { create(:project, types: [type], description: "My **custom** description") }
   let!(:open_status) { create(:default_status) }
@@ -74,15 +76,15 @@ RSpec.describe "Dashboard page managing", :js, with_flag: { new_project_overview
            })
   end
 
-  let(:dashboard_page) do
-    Pages::Dashboard.new(project)
+  let(:overview_page) do
+    Pages::Overview.new(project)
   end
 
   context "as a user with permission" do
     before do
       login_as user
 
-      dashboard_page.visit!
+      overview_page.visit!
     end
 
     it "renders the default view, allows altering and saving" do
@@ -107,17 +109,17 @@ RSpec.describe "Dashboard page managing", :js, with_flag: { new_project_overview
       end
 
       # within top-left area, add an additional widget
-      dashboard_page.add_widget(1, 1, :row, "Work packages table")
+      overview_page.add_widget(1, 1, :row, "Work packages table")
       # Actually there are two success messages displayed currently. One for the grid getting updated and one
       # for the query assigned to the new widget being created. A user will not notice it but the automated
       # browser can get confused. Therefore we dismiss it twice.
-      dashboard_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+      overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
 
       # Fixing flaky spec: for some reason, the second request to load the table is not executed until
       # some activity happens on the page. Sending an enter key to trigger the second request.
       page.find("body").send_keys(:enter)
 
-      dashboard_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+      overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
 
       table_area = Components::Grids::GridArea.new(".grid--area.-widgeted:nth-of-type(5)")
       table_area.expect_to_span(1, 1, 2, 2)
@@ -125,13 +127,13 @@ RSpec.describe "Dashboard page managing", :js, with_flag: { new_project_overview
       # A useless resizing shows no message and does not alter the size
       table_area.resize_to(1, 1)
 
-      dashboard_page.expect_no_toaster message: I18n.t("js.notice_successful_update")
+      overview_page.expect_no_toaster message: I18n.t("js.notice_successful_update")
 
       table_area.expect_to_span(1, 1, 2, 2)
 
       table_area.resize_to(1, 2)
 
-      dashboard_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+      overview_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
 
       # Resizing leads to the table area now spanning a larger area
       table_area.expect_to_span(1, 1, 2, 3)
@@ -147,7 +149,7 @@ RSpec.describe "Dashboard page managing", :js, with_flag: { new_project_overview
 
       # Reloading kept the user's values
       visit home_path
-      dashboard_page.visit!
+      overview_page.visit!
 
       ## Because of the added column and the resizing the other widgets have moved down
       # For unknown, undesired reasons, the project description no longer spans two rows.
@@ -199,13 +201,13 @@ RSpec.describe "Dashboard page managing", :js, with_flag: { new_project_overview
     before do
       login_as user_without_permission
 
-      dashboard_page.visit!
+      overview_page.visit!
     end
 
     it "does not show the option to add widgets" do
       # Neither hover effects
-      dashboard_page.expect_unable_to_add_widget(1, 1, :column, nil)
-      dashboard_page.expect_unable_to_add_widget(1, 1, :row, nil)
+      overview_page.expect_unable_to_add_widget(1, 1, :column, nil)
+      overview_page.expect_unable_to_add_widget(1, 1, :row, nil)
 
       # nor a create button are shown
       expect(page).to have_no_test_selector("overview--add-widgets-button")

--- a/modules/overviews/spec/features/navigation_spec.rb
+++ b/modules/overviews/spec/features/navigation_spec.rb
@@ -42,64 +42,128 @@ RSpec.describe "Navigate to overview", :js do
     login_as user
   end
 
-  it "can visit the overview page" do
-    visit project_path(project)
+  context "with the feature flag enabled", with_flag: { new_project_overview: true } do
+    it "can visit the overview page" do
+      visit project_path(project)
 
-    within "#menu-sidebar" do
-      click_link "Project home"
+      within "#menu-sidebar" do
+        click_link "Project home"
+      end
+
+      within "#content" do
+        expect(page).to have_heading "Project home"
+      end
     end
 
-    within "#content" do
-      expect(page)
-        .to have_content("Overview")
+    context "as user with permissions" do
+      let(:project) { create(:project, enabled_module_names: %i[work_package_tracking]) }
+      let(:user) { create(:admin) }
+      let(:query) do
+        create(:query_with_view_work_packages_table,
+               project:,
+               user:,
+               name: "My important Query")
+      end
+
+      before do
+        query
+        login_as user
+      end
+
+      it "can navigate to other modules (regression #55024)" do
+        visit project_overview_path(project.id)
+
+        # Expect page to be loaded
+        within "#content" do
+          expect(page).to have_heading "Project home"
+        end
+
+        # Navigate to the WP module
+        page.find_test_selector("main-menu-toggler--work_packages").click
+
+        # Click on a saved query
+        query_menu.click_item "My important Query"
+
+        loading_indicator_saveguard
+
+        within "#content" do
+          # Expect the query content to be shown
+          expect(page).to have_field("editable-toolbar-title", with: query.name)
+
+          # Expect no page header of the Overview to be shown any more
+          expect(page).to have_no_heading "Project home"
+        end
+
+        # Navigate back to the Overview page
+        page.execute_script("window.history.back()")
+
+        # Expect page to be loaded
+        within "#content" do
+          expect(page).to have_heading "Project home"
+        end
+      end
     end
   end
 
-  context "as user with permissions" do
-    let(:project) { create(:project, enabled_module_names: %i[work_package_tracking]) }
-    let(:user) { create(:admin) }
-    let(:query) do
-      create(:query_with_view_work_packages_table,
-             project:,
-             user:,
-             name: "My important Query")
-    end
+  context "with the feature flag disabled", with_flag: { new_project_overview: false } do
+    it "can visit the overview page" do
+      visit project_path(project)
 
-    before do
-      query
-      login_as user
-    end
-
-    it "can navigate to other modules (regression #55024)" do
-      visit project_overview_path(project.id)
-
-      # Expect page to be loaded
-      within "#content" do
-        expect(page).to have_content("Overview")
+      within "#menu-sidebar" do
+        click_link "Overview"
       end
 
-      # Navigate to the WP module
-      page.find_test_selector("main-menu-toggler--work_packages").click
-
-      # Click on a saved query
-      query_menu.click_item "My important Query"
-
-      loading_indicator_saveguard
-
       within "#content" do
-        # Expect the query content to be shown
-        expect(page).to have_field("editable-toolbar-title", with: query.name)
+        expect(page).to have_heading "Overview"
+      end
+    end
 
-        # Expect no page header of the Overview to be shown any more
-        expect(page).to have_no_content("Overview")
+    context "as user with permissions" do
+      let(:project) { create(:project, enabled_module_names: %i[work_package_tracking]) }
+      let(:user) { create(:admin) }
+      let(:query) do
+        create(:query_with_view_work_packages_table,
+               project:,
+               user:,
+               name: "My important Query")
       end
 
-      # Navigate back to the Overview page
-      page.execute_script("window.history.back()")
+      before do
+        query
+        login_as user
+      end
 
-      # Expect page to be loaded
-      within "#content" do
-        expect(page).to have_content("Overview")
+      it "can navigate to other modules (regression #55024)" do
+        visit project_overview_path(project.id)
+
+        # Expect page to be loaded
+        within "#content" do
+          expect(page).to have_heading "Overview"
+        end
+
+        # Navigate to the WP module
+        page.find_test_selector("main-menu-toggler--work_packages").click
+
+        # Click on a saved query
+        query_menu.click_item "My important Query"
+
+        loading_indicator_saveguard
+
+        within "#content" do
+          # Expect the query content to be shown
+          expect(page).to have_field("editable-toolbar-title", with: query.name)
+
+          # Expect no page header of the Overview to be shown any more
+          expect(page).to have_no_heading "Overview"
+        end
+
+        # Navigate back to the Overview page
+        page.execute_script("window.history.back()")
+
+        # Expect page to be loaded
+        within "#content" do
+          expect(page).to have_heading "Overview"
+        end
       end
     end
   end

--- a/modules/overviews/spec/routing/overviews_routing_spec.rb
+++ b/modules/overviews/spec/routing/overviews_routing_spec.rb
@@ -39,11 +39,19 @@ RSpec.describe Overviews::OverviewsController do
         )
     end
 
-    it do
-      expect(get("/projects/my-project/dashboard"))
-        .to route_to(
-          controller: "overviews/overviews", action: "dashboard", project_id: "my-project"
-        )
+    context "with the feature flag enabled", with_flag: { new_project_overview: true } do
+      it do
+        expect(get("/projects/my-project/dashboard"))
+          .to route_to(
+            controller: "overviews/overviews", action: "dashboard", project_id: "my-project"
+          )
+      end
+    end
+
+    context "with the feature flag disabled", with_flag: { new_project_overview: false } do
+      it do
+        expect(get("/projects/my-project/dashboard")).not_to be_routable
+      end
     end
 
     it do
@@ -71,11 +79,19 @@ RSpec.describe Overviews::OverviewsController do
         )
     end
 
-    it do
-      expect(get(dashboard_project_overview_path("my-project")))
-        .to route_to(
-          controller: "overviews/overviews", action: "dashboard", project_id: "my-project"
-        )
+    context "with the feature flag enabled", with_flag: { new_project_overview: true } do
+      it do
+        expect(get(dashboard_project_overview_path("my-project")))
+          .to route_to(
+            controller: "overviews/overviews", action: "dashboard", project_id: "my-project"
+          )
+      end
+    end
+
+    context "with the feature flag disabled", with_flag: { new_project_overview: false } do
+      it do
+        expect(get(dashboard_project_overview_path("my-project"))).not_to be_routable
+      end
     end
 
     it do

--- a/modules/overviews/spec/support/pages/overview.rb
+++ b/modules/overviews/spec/support/pages/overview.rb
@@ -33,6 +33,7 @@ require "support/pages/page"
 require_relative "../../../../grids/spec/support/pages/grid"
 
 module Pages
+  # TODO: inherit from `::Pages::Page` when `new_project_overview` feature flag is removed.
   class Overview < ::Pages::Grid
     attr_accessor :project
 

--- a/modules/overviews/spec/support/pages/overview.rb
+++ b/modules/overviews/spec/support/pages/overview.rb
@@ -30,8 +30,10 @@
 
 require "support/pages/page"
 
+require_relative "../../../../grids/spec/support/pages/grid"
+
 module Pages
-  class Overview < ::Pages::Page
+  class Overview < ::Pages::Grid
     attr_accessor :project
 
     def initialize(project)

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Project attribute help texts", :js do
+RSpec.describe "Project attribute help texts", :js, with_flag: { new_project_overview: true } do
   let!(:project) { create(:project) }
 
   let!(:name_help_text) do

--- a/spec/features/work_packages/work_package_index_spec.rb
+++ b/spec/features/work_packages/work_package_index_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe "Work Packages", "index view", :js do
       visit project_path(project)
 
       within("#content") do
+        # TODO: change to `have_heading "Project home"` when `new_project_overview` feature flag is removed.
         expect(page).to have_heading "Overview"
       end
 

--- a/spec/features/work_packages/work_package_index_spec.rb
+++ b/spec/features/work_packages/work_package_index_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Work Packages", "index view", :js do
       visit project_path(project)
 
       within("#content") do
-        expect(page).to have_content("Overview")
+        expect(page).to have_heading "Overview"
       end
 
       within("#main-menu") do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/67827

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots

**Feature Flag in Administration > System Settings > Experimental**

<img width="736" height="218" alt="image" src="https://github.com/user-attachments/assets/d4a1d398-10b4-4da6-8c4d-3cc300e29977" />

**Project Overview**

| with Feature Flag disabled | with Feature Flag enabled: Overview tab | with Feature Flag enabled: Dashboard tab |
|--------|--------|--------|
| <img width="1500" height="782" alt="Screenshot 2025-10-06 at 11 51 18" src="https://github.com/user-attachments/assets/f83a734c-bbe1-43d3-b1b3-5a2264c89557" /> | <img width="1502" height="776" alt="Screenshot 2025-10-06 at 11 51 47" src="https://github.com/user-attachments/assets/4e8a48d4-c0af-45f8-9284-0e4bc07a726c" /> | <img width="1506" height="790" alt="Screenshot 2025-10-06 at 11 52 01" src="https://github.com/user-attachments/assets/0c64e8f5-e827-4151-bfa2-bd4eb03082f3" /> | 


# What approach did you choose and why?

Adds conditionals/branch logic in at least four places:

- `Overviews::PageHeaderComponent`
- `Overviews::ShowComponent`
- `Overviews::Engine` (menu)
- and `modules/overviews/config/routes.rb`

Another approach might have been to create separate `PageHeader` and `ShowComponent` for the two variants - the disadvantage would be that it's less DRY. the advantage would be that, when it comes time to remove the feature flag and make the new Overview page available to everyone, we would only need to delete branch logic in one place and files. This might also be more consistent with was I advocating for in another PR https://github.com/opf/openproject/pull/20490#pullrequestreview-3291002777.

## Tests

I've updated routing, component and feature specs - testing both with the feature flag enabled and disabled, when I feel that is relevant.

## Permissions

This PR **does not undo** the [`manage_overview` to `manage_dashboards` permission rename](https://github.com/opf/openproject/pull/20045/files) introduced previously in #20045 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
