### PR TITLE
[66753] Removing widgets from Projects Overview page is very slow/unresponsive

### DIFF
--- a/frontend/src/app/features/overview/overview.component.ts
+++ b/frontend/src/app/features/overview/overview.component.ts
@@ -26,13 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, OnInit } from '@angular/core';
+import { Component, ElementRef, inject, Input, OnInit } from '@angular/core';
 import { GridPageComponent } from 'core-app/shared/components/grids/grid/page/grid-page.component';
 import { GRID_PROVIDERS } from 'core-app/shared/components/grids/grid/grid.component';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 
+// The OnPush change detection strategy makes the page very slow, especially removing widgets. See #66753
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: '../../shared/components/grids/grid/page/grid-page.component.html',
   styleUrls: ['../../shared/components/grids/grid/page/grid-page.component.sass'],
   providers: GRID_PROVIDERS,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66753

# What are you trying to accomplish?
Kudos to @myabc who found that fix orginally. Due to time pressure, we will for now go with the Default ChangeDetectionStrategy instead of fixing the performance with `OnPush` (see https://github.com/opf/openproject/pull/20039)
