### PR TITLE
[#67844] Clearing backlog doesn't remove the items  

### DIFF
--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -182,7 +182,6 @@ class MeetingSectionsController < ApplicationController
 
   def clear_backlog
     errors = []
-    meeting_section = @meeting.backlog
     @meeting.backlog.agenda_items.each do |item|
       call = ::MeetingAgendaItems::DeleteService
         .new(user: current_user, model: item)
@@ -191,7 +190,7 @@ class MeetingSectionsController < ApplicationController
       errors << call.errors unless call.success?
     end
 
-    update_section_via_turbo_stream(collapsed: true, meeting_section:, current_occurrence: @current_occurrence)
+    update_backlog_via_turbo_stream(meeting: @current_occurrence, collapsed: true)
     render_error_flash_message_via_turbo_stream(message: t("text_backlog_clear_error")) if errors.any?
 
     respond_with_turbo_streams

--- a/modules/meeting/spec/features/meeting_backlogs_spec.rb
+++ b/modules/meeting/spec/features/meeting_backlogs_spec.rb
@@ -199,6 +199,10 @@ RSpec.describe "Meeting Backlogs", :js do
         show_page.select_action(agenda_item, I18n.t(:label_agenda_item_move_to_backlog))
         show_page.clear_backlog
         show_page.expect_backlog collapsed: true
+
+        # expect all agenda items to be removed (Bug #67844)
+        show_page.click_on_backlog
+        show_page.expect_empty_backlog
       end
     end
   end
@@ -344,6 +348,10 @@ RSpec.describe "Meeting Backlogs", :js do
         first_occurrence_page.select_action(agenda_item, I18n.t(:label_agenda_item_move_to_backlog))
         first_occurrence_page.clear_backlog
         first_occurrence_page.expect_series_backlog collapsed: true
+
+        # expect all agenda items to be removed (Bug #67844)
+        first_occurrence_page.click_on_backlog
+        first_occurrence_page.expect_empty_backlog
       end
 
       it "allow items to be moved from multiple occurrences to the series backlog and vice versa" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67844

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
I'm not sure why it works when the backlog is updated directly instead of as a section, but since that workaround isn't needed anymore because of access to the current occurrence, I think this makes more sense anyway. 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
