### PR TITLE
[67530] Icons are misaligned on WP list baseline view

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
@@ -34,7 +34,7 @@
       display: flex
       // Firefox applies additional baseline spacing to inline SVG
       // It removes unwanted space
-      @supports (-moz-appearance: none)
+      .-browser-firefox &
         display: inline-block
         vertical-align: middle
         line-height: 0

--- a/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
@@ -31,9 +31,13 @@
     padding-right: 0
 
     i
-      display: inline-block
-      vertical-align: middle
-      line-height: 0
+      display: flex
+      // Firefox applies additional baseline spacing to inline SVG
+      // It removes unwanted space
+      @supports (-moz-appearance: none)
+        display: inline-block
+        vertical-align: middle
+        line-height: 0
 
   &--icon-added
     color: #5F42E0

--- a/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table_baseline.sass
@@ -31,7 +31,9 @@
     padding-right: 0
 
     i
-      display: flex
+      display: inline-block
+      vertical-align: middle
+      line-height: 0
 
   &--icon-added
     color: #5F42E0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67530

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Firefox applies additional baseline spacing to inline SVG elements, which causes them to render higher or lower than expected when used within text or table cells.

To address this, the SVG container is adjusted to remove the unwanted baseline gap and ensure consistent alignment across browsers.

## Screenshots
Before:
Windows Firefox:
![WhatsApp Image 2025-10-06 at 11 59 43](https://github.com/user-attachments/assets/0593c5fe-30bd-4624-99b2-4ff626179372)

After:
Windows Firefox:
![WhatsApp Image 2025-10-06 at 11 59 02](https://github.com/user-attachments/assets/434e5402-6666-4cf7-89cd-3170566aaa67)

Mac Chrome:
<img width="185" height="125" alt="Screenshot 2025-10-06 at 11 57 34" src="https://github.com/user-attachments/assets/99eab3c4-117e-4c6d-8ee7-b47919296de8" />

Mac Firefox:
<img width="198" height="127" alt="Screenshot 2025-10-06 at 12 14 09" src="https://github.com/user-attachments/assets/1dabffde-fe76-4bd8-b261-c2c14a1ffc6e" />

