### PR TITLE
[#67644] set autofocus on label only if form is empty

### DIFF
--- a/app/forms/custom_fields/hierarchy/item_form.rb
+++ b/app/forms/custom_fields/hierarchy/item_form.rb
@@ -41,7 +41,7 @@ module CustomFields
             value: @target_item.label,
             visually_hide_label: true,
             required: true,
-            autofocus: true,
+            autofocus: @target_item.errors.empty?,
             placeholder: I18n.t("custom_fields.admin.items.placeholder.label"),
             validation_message: validation_message_for(:label)
           )


### PR DESCRIPTION
# Ticket
[#67644](https://community.openproject.org/work_packages/67644)

# What are you trying to accomplish?
- set autofocus on label only if form is empty