### PR TITLE
Chore/limit usage of i18n fallbacks and lazy loading

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,7 +152,6 @@ class ApplicationController < ActionController::Base
                 :tag_request,
                 :check_if_login_required,
                 :log_requesting_user,
-                :reset_i18n_fallbacks,
                 :check_session_lifetime,
                 :stop_if_feeds_disabled,
                 :set_cache_buster,
@@ -222,14 +221,6 @@ class ApplicationController < ActionController::Base
   def escape_for_logging(string)
     # only allow numbers, ASCII letters, space and the following characters: @.-"'!?=/
     string.gsub(/[^0-9a-zA-Z@._\-"'!?=\/ ]{1}/, "#")
-  end
-
-  def reset_i18n_fallbacks
-    fallbacks = [I18n.default_locale] + Redmine::I18n.valid_languages.map(&:to_sym)
-    return if I18n.fallbacks.defaults == fallbacks
-
-    I18n.fallbacks = nil
-    I18n.fallbacks.defaults = fallbacks
   end
 
   def set_localization

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -33,15 +33,13 @@
 require "open_project/translations/pluralization_backend"
 I18n::Backend::Simple.include OpenProject::Translations::PluralizationBackend
 
-# Adds fallback to default locale for untranslated strings
+# Adds fallback to default locale for untranslated strings. Useful for instance
+# during development when adding new strings and using another locale than
+# English. For production, that's less useful as files downloaded from Crowdin
+# already contain fallback English translations.
+#
+# Also we can't completly remove the fallback mechanism: we still need the it to
+# get translated versions of email header and footer as they are supplied by the
+# admins and may not be provided for all configured languages. (See
+# `Setting#localized_emails_header` and `Setting#localized_emails_footer`.)
 I18n::Backend::Simple.include I18n::Backend::Fallbacks
-
-Rails.application.reloader.to_prepare do
-  # As we enabled +config.i18n.fallbacks+, Rails will fall back
-  # to the default locale.
-  # When other locales are available, fall back to them.
-  if Setting.table_exists? # don't want to prevent migrations
-    defaults = Set.new(I18n.fallbacks.defaults + Redmine::I18n.valid_languages.map(&:to_sym))
-    I18n.fallbacks.defaults = defaults
-  end
-end

--- a/spec/support/i18n_lazy_loading.rb
+++ b/spec/support/i18n_lazy_loading.rb
@@ -28,12 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Lazy loads translations based on the current locale.
-# It avoids a 2 to 4 seconds penalty when all locales are loaded.
-# Need to make LocaleExtractor recognize our js-<locale>.yaml file format
+# Enable translations lazy loading by default, except on CI where we want to
+# have all translations loaded during application eager loading to be closer to
+# production configuration.
+return if ENV["CI"]
 
+# Lazy loading translations avoids a 2 to 4 seconds penalty on first call to
+# `I18n.translate` by loading only the translations for the current locale
+# instead of loading them for all locales.
 require "i18n/backend/lazy_loadable"
 
+# Need to make LocaleExtractor recognize our js-<locale>.yaml file format
 class I18n::Backend::LocaleExtractor
   def self.locale_from_path(path)
     name = File.basename(path, ".*")


### PR DESCRIPTION
# Ticket

None

# What are you trying to accomplish?

2 things:
- Fallback to English when a translation is not available in current locale (instead of falling back to all languages).
- Disable lazy loading of translations on CI

# Why?

In a flaky spec, the failure was due to `MeetingParticipant.model_name.human` triggering the initialization of translations for all locales, and that took more than 3 seconds. 3 seconds is longer than the wait time for an `expect(page).to have_text("foo")`, so it failed.

It initialized all locales because as translation was missing for `activerecord.models.meeting_participant`, it looked into the fallback locales. [Fallback locales were set to all known locales](https://github.com/opf/openproject/blob/dev/app/controllers/application_controller.rb#L227-L233) for some reason. But that's a non sense:
- If a translation is not available in your language, having the translation from another random language would not help much.
- Files downloaded from Crowdin are always complete, and already fall back to english in the YML, so this fallback mechanism feels a bit useless (but it still needed).

So 2 actions to prevent similar failure in the future (in addition to fixing the test by adding a proper translation):
- restrict fallback locales to English, so only English would be loaded and it's fast enough to prevent the test from failing.
- disable lazy loading on CI, so translations are loaded during initialization and the test would not fail.

# What approach did you choose and why?

**Fallback to English when a translation is not available in current locale** (instead of falling back to all languages)

Do not ever set `I18n.fallbacks.defaults` and rely on `i18n` default fallback mechanism: it will fall back to our default locale (English) when a translation isn't available in current locale.

We still need the fallback mechanism for at least 2 use cases:
  - useful during development when we are adding strings to the translation files and we are not using the English locale. (Only after crowdin took its turn, does a locale key exist everywhere)
  - useful also in production for `Settings::Email#localized_emails_header` and `Settings::Email#localized_emails_footer`: translations are set by the admins and some languages do not have a localized version. We use the fallback mechanism to get translations from other locales if there is none for the current locale.

**Disable lazy loading of translations on CI**

Easy: do it only when `ENV["CI"]` is not set

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
