### PR TITLE
[#67907] Wrong cell format in XLS export do not allow for calculations

### DIFF
--- a/app/models/exports/formatters/default.rb
+++ b/app/models/exports/formatters/default.rb
@@ -79,6 +79,14 @@ module Exports
         {}
       end
 
+      def currency_format
+        "#,##0.00 [$#{Setting.costs_currency}]"
+      end
+
+      def number_format
+        "0.00"
+      end
+
       protected
 
       # By default, use try as a non-destructive accessor

--- a/app/models/work_package/exports/formatters/work_hours.rb
+++ b/app/models/work_package/exports/formatters/work_hours.rb
@@ -28,32 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects::Exports::Formatters
-  class BudgetCurrencyAttribute < ::Exports::Formatters::Default
-    def self.apply?(attribute, _export_format)
-      budget_mapping.key? attribute.to_sym
-    end
+module WorkPackage::Exports
+  module Formatters
+    class WorkHours < ::Exports::Formatters::Default
+      def self.apply?(name, export_format)
+        %i[estimated_hours remaining_hours].include?(name.to_sym) && export_format == :csv
+      end
 
-    def self.budget_mapping
-      {
-        budget_available: :total_available,
-        budget_spent: :total_spent,
-        budget_planned: :total_planned
-      }
-    end
-
-    def format(project, **)
-      return unless project.module_enabled?("budgets") && User.current.allowed_in_project?(:view_budgets, project)
-
-      project_budgets = ::Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets.new(project)
-      budgets_attribute = BudgetCurrencyAttribute.budget_mapping.fetch(attribute.to_sym)
-      return unless project_budgets && budgets_attribute
-
-      project_budgets.public_send(budgets_attribute)
-    end
-
-    def format_options
-      { number_format: currency_format }
+      def format_options
+        { number_format: }
+      end
     end
   end
 end

--- a/config/initializers/export_formats.rb
+++ b/config/initializers/export_formats.rb
@@ -48,6 +48,7 @@ Rails.application.configure do |application|
       formatter WorkPackage, WorkPackage::Exports::Formatters::Hours
       formatter WorkPackage, WorkPackage::Exports::Formatters::ProjectPhase
       formatter WorkPackage, WorkPackage::Exports::Formatters::SpentUnits
+      formatter WorkPackage, WorkPackage::Exports::Formatters::WorkHours
 
       list Project, Projects::Exports::CSV
       list Project, Projects::Exports::PDF

--- a/modules/budgets/spec/models/projects/exports/formatters/budget_currency_attribute_spec.rb
+++ b/modules/budgets/spec/models/projects/exports/formatters/budget_currency_attribute_spec.rb
@@ -89,25 +89,43 @@ RSpec.describe Projects::Exports::Formatters::BudgetCurrencyAttribute do
         User.current = user_with_permission
       end
 
-      it "formats the budget available" do
+      it "returns the raw budget available value" do
         allow(project_budgets_double).to receive(:total_available).and_return(42.7)
         instance = described_class.new(:budget_available)
 
-        expect(instance.format(project)).to eq("43 EUR")
+        expect(instance.format(project)).to eq(42.7)
       end
 
-      it "formats the budget spent" do
+      it "returns the raw budget spent value" do
         allow(project_budgets_double).to receive(:total_spent).and_return(42.7)
         instance = described_class.new(:budget_spent)
 
-        expect(instance.format(project)).to eq("43 EUR")
+        expect(instance.format(project)).to eq(42.7)
       end
 
-      it "formats the budget planned" do
+      it "returns the raw budget planned value" do
         allow(project_budgets_double).to receive(:total_planned).and_return(42.7)
         instance = described_class.new(:budget_planned)
 
-        expect(instance.format(project)).to eq("43 EUR")
+        expect(instance.format(project)).to eq(42.7)
+      end
+    end
+  end
+
+  describe "#format_options" do
+    let(:instance) { described_class.new(:budget_available) }
+
+    it "returns currency format options" do
+      with_settings(costs_currency: "USD", costs_currency_format: "%n %u") do
+        expected_format = "#,##0.00 [$USD]"
+        expect(instance.format_options).to eq({ number_format: expected_format })
+      end
+    end
+
+    it "handles different currency settings" do
+      with_settings(costs_currency: "EUR", costs_currency_format: "%u %n") do
+        expected_format = "[$EUR] #,##0.00"
+        expect(instance.format_options).to eq({ number_format: expected_format })
       end
     end
   end

--- a/spec/models/work_package/exports/formatters/work_hours_spec.rb
+++ b/spec/models/work_package/exports/formatters/work_hours_spec.rb
@@ -28,32 +28,36 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects::Exports::Formatters
-  class BudgetCurrencyAttribute < ::Exports::Formatters::Default
-    def self.apply?(attribute, _export_format)
-      budget_mapping.key? attribute.to_sym
+require "spec_helper"
+
+RSpec.describe WorkPackage::Exports::Formatters::WorkHours do
+  let(:formatter_instance) { described_class.new(:estimated_hours) }
+
+  describe ".apply?" do
+    it "returns true for estimated_hours and csv format" do
+      expect(described_class.apply?(:estimated_hours, :csv)).to be true
     end
 
-    def self.budget_mapping
-      {
-        budget_available: :total_available,
-        budget_spent: :total_spent,
-        budget_planned: :total_planned
-      }
+    it "returns true for remaining_hours and csv format" do
+      expect(described_class.apply?(:remaining_hours, :csv)).to be true
     end
 
-    def format(project, **)
-      return unless project.module_enabled?("budgets") && User.current.allowed_in_project?(:view_budgets, project)
-
-      project_budgets = ::Budgets::Patches::Projects::RowComponentPatch::ProjectBudgets.new(project)
-      budgets_attribute = BudgetCurrencyAttribute.budget_mapping.fetch(attribute.to_sym)
-      return unless project_budgets && budgets_attribute
-
-      project_budgets.public_send(budgets_attribute)
+    it "returns false for spent_hours and csv format" do
+      expect(described_class.apply?(:spent_hours, :csv)).to be false
     end
 
-    def format_options
-      { number_format: currency_format }
+    it "returns false for estimated_hours and pdf format" do
+      expect(described_class.apply?(:estimated_hours, :pdf)).to be false
+    end
+
+    it "returns false for other attributes" do
+      expect(described_class.apply?(:other_attribute, :csv)).to be false
+    end
+  end
+
+  describe "#format_options" do
+    it "returns number format for hours" do
+      expect(formatter_instance.format_options).to eq({ number_format: "0.00" })
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/67907

# What are you trying to accomplish?
- Add number format for work columns on the work package exporter.
- Fix currency format to the Project budget attribute.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
- Create a WorkPackage::Exports::Formatters::WorkHours formatter to format estimated_hours and remaining_hours columns.
- Update the existing Projects::Exports::Formatters::BudgetCurrencyAttribute with the right currency column format. 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
