### PR TITLE
Add "opened" to triggers for version check

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -2,7 +2,11 @@ name: Check work package version
 
 on:
   pull_request:
-    types: [labeled, synchronize, ready_for_review]
+    types:
+      - opened
+      - labeled
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
We've had a few instances, where the PR target branch mismatched the WP version, but it was only noticed after a second push to the pull request (presumably that's the "synchronize" type).

This change intends to ensure that the version check is already performed, when the PR is opened.