### PR TITLE
[DREAM-514] Yet another Angular-Turbo integration rework

### DIFF
--- a/app/views/activities/_filters_menu.html.erb
+++ b/app/views/activities/_filters_menu.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "activity_menu",
                     src: url_for(controller: "/activities", action: :menu, project_id: @project),
-                    data: { turbo: false },
                     loading: :lazy do %>
 <% end %>

--- a/app/views/layouts/angular/angular.html.erb
+++ b/app/views/layouts/angular/angular.html.erb
@@ -33,6 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
   <%= call_hook :view_work_package_overview_attributes %>
   <%# Disable caching for now %>
   <meta name="turbo-cache-control" content="no-cache">
+  <meta name="turbo-visit-control" content="reload">
 <% end -%>
 
 <%= content_for :content_body do %>

--- a/app/views/layouts/angular/angular.html.erb
+++ b/app/views/layouts/angular/angular.html.erb
@@ -31,6 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
   <% html_title(*local_assigns[:page_title]) if local_assigns[:page_title].present? %>
   <!-- plug-in specific tags -->
   <%= call_hook :view_work_package_overview_attributes %>
+  <%# Disable caching for now %>
+  <meta name="turbo-cache-control" content="no-cache">
 <% end -%>
 
 <%= content_for :content_body do %>

--- a/app/views/members/menus/_menu.html.erb
+++ b/app/views/members/menus/_menu.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "members_menu",
                     src: project_members_menu_path(@project, params.permit(*Members::UserFilterComponent.filter_param_keys)),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/app/views/notifications/menus/_menu.html.erb
+++ b/app/views/notifications/menus/_menu.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "notifications_sidemenu",
                     src: notifications_menu_path(**params.slice(:filter, :name).permit!),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/app/views/projects/menus/_menu.html.erb
+++ b/app/views/projects/menus/_menu.html.erb
@@ -4,5 +4,4 @@
                       **params.permit(:filters, :columns, :sortBy, :id, :query_id)
                     ),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/app/views/wiki/_menu_pages_tree.html.erb
+++ b/app/views/wiki/_menu_pages_tree.html.erb
@@ -1,6 +1,5 @@
 <%= turbo_frame_tag "wiki_main_menu",
                     src: url_for({ controller: "/wiki", action: :menu, project_id: @project.id, id: @page&.id }),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy do %>
 <% end %>

--- a/app/views/work_packages/menus/_menu.html.erb
+++ b/app/views/work_packages/menus/_menu.html.erb
@@ -10,5 +10,4 @@
 <%= turbo_frame_tag "work_packages_sidemenu",
                     src: path,
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -197,7 +197,6 @@ import {
 import { appBaseSelector, ApplicationBaseComponent } from 'core-app/core/routing/base/application-base.component';
 import { SpotSwitchComponent } from 'core-app/spot/components/switch/switch.component';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import {
   TimeEntriesWorkPackageAutocompleterComponent,
 } from 'core-app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter.component';
@@ -208,32 +207,23 @@ import { OpInviteUserModalAugmentService } from 'core-app/features/invite-user-m
 import { TimeEntryTimerService } from 'core-app/shared/components/time_entries/services/time-entry-timer.service';
 import { MyPageComponent } from './features/my-page/my-page.component';
 import { DashboardComponent } from './features/overview/dashboard.component';
+import { DisableTurboDirective } from 'core-app/shared/directives/disable-turbo.directive';
 
 export function initializeServices(injector:Injector) {
   return () => {
     const topMenuService = injector.get(TopMenuService);
     const keyboardShortcuts = injector.get(KeyboardShortcutService);
     const contextMenu = injector.get(OPContextMenuService);
-    const currentProject = injector.get(CurrentProjectService);
     const inviteUserAugmentService = injector.get(OpInviteUserModalAugmentService);
     const timeEntryTimerService = injector.get(TimeEntryTimerService);
 
     // Conditionally add the Revit Add-In settings button
     injector.get(RevitAddInSettingsButtonService);
 
-    const runOnRenderAndLoad = () => {
-      topMenuService.register();
-      contextMenu.register();
-      inviteUserAugmentService.setupListener();
-      timeEntryTimerService.initialize();
-      currentProject.detect();
-    };
-    runOnRenderAndLoad();
-
-    // Register on turbo:render, turbo:load
-    document.addEventListener('turbo:render', runOnRenderAndLoad);
-    document.addEventListener('turbo:load', runOnRenderAndLoad);
-
+    topMenuService.register();
+    contextMenu.register();
+    inviteUserAugmentService.setupListener();
+    timeEntryTimerService.initialize();
     keyboardShortcuts.register();
 
     return injector.get(ConfigurationService).initialize();
@@ -343,6 +333,8 @@ export function runBootstrap(appRef:ApplicationRef) {
 
     // My account
     OpenProjectMyAccountModule,
+
+    DisableTurboDirective
   ],
   providers: [
     { provide: States, useValue: new States() },

--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -252,6 +252,7 @@ export function initializeUiRouterListeners(injector:Injector) {
     // but for pages without any angular routes, this will stay empty.
     // So we also allow routes to happen after some delay
     if (openprojectBaseApp === null) {
+      console.error("NO OPENPROJECT BASEAPP - this shouldn't be displayed!!!");
       // Get the current path and compare
       const path = window.location.pathname;
       const pathWithSearch = path + window.location.search;

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -161,8 +161,8 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
     );
     this.calendar.resize$
       .pipe(
-        this.untilDestroyed(),
         debounceTime(50),
+        this.untilDestroyed(),
       )
       .subscribe(() => {
         this.ucCalendar.getApi().updateSize();

--- a/frontend/src/app/shared/directives/disable-turbo.directive.ts
+++ b/frontend/src/app/shared/directives/disable-turbo.directive.ts
@@ -1,0 +1,40 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Directive, ElementRef, Renderer2, AfterViewInit, inject, RendererStyleFlags2 } from '@angular/core';
+
+@Directive({ selector: 'a[uiSref]' })
+export class DisableTurboDirective implements AfterViewInit {
+  private readonly el:ElementRef<HTMLLinkElement> = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+
+  ngAfterViewInit() {
+    this.renderer.setStyle(this.el.nativeElement, 'color', 'red', RendererStyleFlags2.Important);
+    this.renderer.setAttribute(this.el.nativeElement, 'data-turbo', 'false');
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,7 +3,7 @@ import { enableProdMode } from '@angular/core';
 
 import 'core-app/core/setup/init-jquery';
 
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { platformBrowser } from '@angular/platform-browser';
 import { initializeLocale } from 'core-app/core/setup/init-locale';
 import { environment } from './environments/environment';
 import { configureErrorReporter } from 'core-app/core/errors/configure-reporter';
@@ -45,7 +45,6 @@ void initializeLocale()
       // Now that DOM is loaded, also run the global listeners
       initializeGlobalListeners();
 
-      // Due to the behaviour of the Edge browser we need to wait for 'DOM ready'
-      void platformBrowserDynamic().bootstrapModule(OpenProjectModule);
+      void platformBrowser().bootstrapModule(OpenProjectModule);
     });
   });

--- a/frontend/src/turbo/turbo-angular-wrapper.ts
+++ b/frontend/src/turbo/turbo-angular-wrapper.ts
@@ -1,31 +1,31 @@
-import { skip } from 'rxjs/operators';
-import { fromEvent } from 'rxjs';
-import { runBootstrap } from 'core-app/app.module';
-import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
+import { initializeServices, runBootstrap } from 'core-app/app.module';
+import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
 export function addTurboAngularWrapper() {
-  // When turbo:load fires, the angular application needs to be rebootstrapped.
-  // However, we don't want this to happen on the initial page load
-  fromEvent(document, 'turbo:load')
-    .pipe(
-      skip(1), // Skip the first turbo:load event
-    )
-    .subscribe(() => {
-      void window
-        .OpenProject
-        .getPluginContext()
-        .then((pluginContext:OpenProjectPluginContext) => {
-          const appRef = pluginContext.appRef;
-
-          // Remove all previous references to components
-          // This is mainly the base component
-          appRef.components.slice().forEach((component) => {
-            appRef.detachView(component.hostView);
-            component.destroy();
-          });
-
-          // Run bootstrap again to initialize the new application
-          runBootstrap(appRef);
-        });
+  // When turbo:render fires, the Angular application needs to be rebootstrapped.
+  // However, we first need to clean up components that are already initialized.
+  document.addEventListener('turbo:before-render', () => {
+    void window.OpenProject.getPluginContext().then(({ appRef }) => {
+      // Remove all previous references to components
+      // This is mainly the base component
+      appRef.components.slice().forEach((component) => {
+        appRef.detachView(component.hostView);
+        component.destroy();
+      });
     });
+  });
+
+  document.addEventListener('turbo:render', () => {
+    void window.OpenProject.getPluginContext().then(({ appRef }) => {
+      runBootstrap(appRef);
+      initializeServices(appRef.injector)();
+    });
+  });
+
+  document.addEventListener('turbo:load', () => {
+    void window.OpenProject.getPluginContext().then(({ appRef:{ injector } }) => {
+      const currentProject = injector.get(CurrentProjectService);
+      currentProject.detect();
+    });
+  });
 }

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -34,6 +34,12 @@ export function addTurboEventListeners() {
     headers['X-Authentication-Scheme'] = 'Session';
   });
 
+  document.addEventListener('turbo:before-cache', () => {
+    document.querySelectorAll<HTMLDialogElement>('dialog[open]').forEach((openDialog) => {
+      openDialog.close();
+    });
+  });
+
   // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces
   // https://github.com/hotwired/turbo/issues/294#issuecomment-2633216052
   // We remove them manually as a workaround

--- a/frontend/src/turbo/turbo-global-listeners.ts
+++ b/frontend/src/turbo/turbo-global-listeners.ts
@@ -15,7 +15,7 @@ import {
 } from 'core-app/core/setup/globals/global-listeners/setup-server-response';
 
 export function addTurboGlobalListeners() {
-  const runOnRenderAndLoad = () => {
+  const runOnLoad = () => {
     // Add to content if warnings displayed
     if (document.querySelector('.warning-bar--item')) {
       const content = document.querySelector('#content') as HTMLElement;
@@ -64,8 +64,7 @@ export function addTurboGlobalListeners() {
     activateFlashNotice();
     activateFlashError();
   };
-  document.addEventListener('turbo:render', runOnRenderAndLoad);
-  document.addEventListener('turbo:load', runOnRenderAndLoad);
+  document.addEventListener('turbo:load', runOnLoad);
 
   document.addEventListener('turbo:before-morph-element', (event) => {
     const element = event.target as HTMLElement;

--- a/modules/bim/app/views/bim/menus/_menu.html.erb
+++ b/modules/bim/app/views/bim/menus/_menu.html.erb
@@ -1,7 +1,6 @@
   <%= turbo_frame_tag "bim_sidemenu",
                       src: bcf_project_bcf_menu_path(@project, **params.permit(:query_props, :query_id, :name)),
                       target: "_top",
-                      data: { turbo: false },
                       loading: :lazy %>
 
   <hr>

--- a/modules/boards/app/views/boards/menus/_menu.html.erb
+++ b/modules/boards/app/views/boards/menus/_menu.html.erb
@@ -1,5 +1,4 @@
   <%= turbo_frame_tag "boards_sidemenu",
                       src: menu_project_work_package_boards_path(@project, **params.permit(:id)),
                       target: "_top",
-                      data: { turbo: false },
                       loading: :lazy %>

--- a/modules/calendar/app/views/calendar/menus/_menu.html.erb
+++ b/modules/calendar/app/views/calendar/menus/_menu.html.erb
@@ -1,5 +1,4 @@
   <%= turbo_frame_tag "calendar_sidemenu",
                       src: menu_project_calendars_path(@project, **params.permit(:id)),
                       target: "_top",
-                      data: { turbo: false },
                       loading: :lazy %>

--- a/modules/gantt/app/views/gantt/menus/_menu.html.erb
+++ b/modules/gantt/app/views/gantt/menus/_menu.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "gantt_menu",
                     src: @project ? menu_project_gantt_index_path(@project, params.permit(:query_props, :query_id, :name)) : gantt_menu_path(params.permit(:query_props, :query_id, :name)),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/modules/meeting/app/views/meetings/menus/_menu.html.erb
+++ b/modules/meeting/app/views/meetings/menus/_menu.html.erb
@@ -4,5 +4,4 @@
 <%= turbo_frame_tag "meeting_sidemenu",
                     src: @project.present? ? menu_project_meetings_path(@project, **request_params) : menu_meetings_path(**request_params),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/modules/reporting/app/views/cost_reports/menus/_menu.html.erb
+++ b/modules/reporting/app/views/cost_reports/menus/_menu.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "cost_reports_sidemenu",
                     src: @project ? menu_project_cost_reports_path(@project, **params.permit(:id)) : cost_reports_menu_path(**params.permit(:id)),
                     target: "_top",
-                    data: { turbo: false },
                     loading: :lazy %>

--- a/modules/team_planner/app/views/team_planner/menus/_menu.html.erb
+++ b/modules/team_planner/app/views/team_planner/menus/_menu.html.erb
@@ -1,5 +1,4 @@
   <%= turbo_frame_tag "team_planner_sidemenu",
                       src: menu_project_team_planners_path(@project, **params.permit(:id)),
                       target: "_top",
-                      data: { turbo: false },
                       loading: :lazy %>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-514

# What are you trying to accomplish?

`turbo-angular-wrapper.ts` destroys and re-bootstraps the whole Angular root on every `turbo:load`, with no tests before OP-19617. This branch is an early exploration of removing that re-bootstrap surface altogether, from before its 6-area coupling map (re-bootstrap, plugin-context seam, `opce-*` custom elements, morph guards, Rails `op_turbo`, the existing nav spec) was fully understood.

# What approach did you choose and why?

Exploratory, currently on hold. Splits the wrapper's single `turbo:load` handler into `turbo:before-render` / `turbo:render` / `turbo:load` phases, adds a `DisableTurboDirective` to force full navigations on `uiSref` links, and drops `data-turbo: false` from sidebar menu frames project-wide.

Parked in favour of landing OP-19617's test coverage first (`turbo-angular-wrapper.ts` deliberately left uncovered there for this ticket), and splitting the two independent consolidations this investigation turned up into their own tickets: OP-19618 (CSP nonce) and OP-19666 (custom-element morph policy). Still has debug leftovers (a `console.error`, a red `!important` marker style) — needs a rebase and cleanup pass before this resumes, not a merge as-is.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
