### PR TITLE
[67561] More information link in enterprise banner opens in a new tab but doesn't have a blank target

### DIFF
--- a/app/components/enterprise_edition/upsell_buttons_component.rb
+++ b/app/components/enterprise_edition/upsell_buttons_component.rb
@@ -103,7 +103,7 @@ module EnterpriseEdition
     def more_info_button
       return if @feature_key == :teaser
 
-      render(Primer::Beta::Link.new(href: enterprise_link)) do |link|
+      render(Primer::Beta::Link.new(href: enterprise_link, target: "_blank")) do |link|
         link.with_trailing_visual_icon(icon: "link-external")
         link_title
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67561

# What are you trying to accomplish?
Add target "blank" to link

