### PR TITLE
[68067] Screen reader hint is not localized

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -372,6 +372,10 @@ en:
   concatenation:
     single: "or"
 
+  danger_dialog:
+    confirmation_live_message_checked: "The button to proceed is now active."
+    confirmation_live_message_unchecked: "The button to proceed is now inactive. You need to tick the checkbox to continue."  
+
   op_dry_validation:
     or: "or"
     errors:


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68067

# What are you trying to accomplish?
Add missing locals for danger dialog
