### PR TITLE
Only load EXDATEs for cancelled events, not all

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -173,11 +173,11 @@ module Meetings
 
     def preload_for_recurring_meetings(recurring_meetings:)
       @excluded_dates_cache = ScheduledMeeting
+        .cancelled
         .where(recurring_meeting: recurring_meetings)
         .group(:recurring_meeting_id)
         .pluck(:recurring_meeting_id, "array_agg(start_time)")
         .to_h
-        .transform_values { |dates| dates.map { |date| ical_datetime(date) } }
 
       @instantiated_occurrences_cache = ScheduledMeeting
         .where(recurring_meeting: recurring_meetings)
@@ -297,8 +297,7 @@ module Meetings
                          .scheduled_meetings
                          .cancelled
                          .pluck(:start_time)
-                         .map { ical_datetime(it, timezone: recurring_meeting.time_zone) }
-                     end
+                     end.map { ical_datetime(it, timezone: recurring_meeting.time_zone) }
     end
 
     def upcoming_instantiated_schedules(recurring_meeting)

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -252,6 +252,39 @@ RSpec.describe Meetings::IcalendarBuilder,
       meeting.scheduled_meeting
     end
 
+    context "when using the cache" do
+      subject(:builder) { described_class.new(timezone:) }
+
+      before do
+        builder.preload_for_recurring_meetings(recurring_meetings: [recurring_meeting])
+      end
+
+      it "preloads the correct caches" do
+        builder.add_series_event(recurring_meeting:)
+
+        expect(builder.instance_variable_get(:@excluded_dates_cache)).to eq(
+          recurring_meeting.id => [second_occurrence.start_time]
+        )
+
+        expect(builder.instance_variable_get(:@instantiated_occurrences_cache)).to eq(
+          recurring_meeting.id => [third_occurence]
+        )
+
+        expect(builder.instance_variable_get(:@series_cache_loaded)).to be true
+      end
+
+      it "puts the correct EXDATEs in the generated event (REGRESSION: #68068)" do
+        builder.add_series_event(recurring_meeting:)
+
+        parsed_calendar = Icalendar::Calendar.parse(builder.to_ical).first
+        event = parsed_calendar.events.find { |e| e.uid == recurring_meeting.uid }
+
+        expect(event.exdate).not_to be_empty
+        exdate_values = event.exdate.map(&:value)
+        expect(exdate_values).to include(second_occurrence.start_time)
+      end
+    end
+
     context "when current user needs to take action" do
       subject(:builder) { described_class.new(timezone:, user: user1) }
 

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Meetings::IcalendarBuilder,
 
         expect(event.exdate).not_to be_empty
         exdate_values = event.exdate.map(&:value)
-        expect(exdate_values).to include(second_occurrence.start_time)
+        expect(exdate_values).to contain_exactly(second_occurrence.start_time)
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/68068/

# What are you trying to accomplish?
- Currently when using the cache (which we do for building the AllMeetings feed) we wrongly load all occurence dates that were instantiated and just stupidly all dates. This fixes this.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
