### PR TITLE
Fix running feature specs in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
   frontend-test:
     build:
       <<: *frontend-build
-    command: "npm run serve:test"
+    command: "npm run serve"
     volumes:
       - ".:/home/dev/openproject"
       - "fedata-test:/home/dev/openproject/public/assets/frontend"
@@ -138,6 +138,8 @@ services:
       FE_HOST: frontend-test
     networks:
       - testing
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://frontend-test:4200/"]
 
   backend-test:
     build:
@@ -148,10 +150,14 @@ services:
     networks:
       - testing
     depends_on:
-      - db-test
-      - selenium-hub
-      - frontend-test
-      - cuprite-chrome
+      db-test:
+        condition: service_started
+      selenium-hub:
+        condition: service_started
+      frontend-test:
+        condition: service_healthy
+      cuprite-chrome:
+        condition: service_started
     environment:
       RAILS_ENV: test
       OPENPROJECT_RAILS__RELATIVE__URL__ROOT: "${OPENPROJECT_RAILS__RELATIVE__URL__ROOT:-}"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -186,7 +186,6 @@
     "ci:plugins:register_frontend": "node ci-plugins-generator.js",
     "tokens:generate": "theo src/app/spot/styles/tokens/tokens.yml --transform web --format sass,json --dest src/app/spot/styles/tokens/dist",
     "serve": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng serve --host ${FE_HOST:-localhost} --port ${FE_PORT:-4200}",
-    "serve:test": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng serve --host ${FE_HOST:-localhost} --port ${FE_PORT:-4200} --disable-host-check",
     "test": "ng test --watch=false",
     "test:watch": "ng test --watch=true",
     "lint": "ng lint",


### PR DESCRIPTION
The serve:test command was broken, because it used an unsupported command-line option. Thus the frontend container would not start at all, thus breaking asset delivery during tests.

A healthcheck was introduced as well, so that a non starting frontend container is easier to spot going forward.