### PR TITLE
[#68045] switch to single select variant for change parent

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/change_item_parent_dialog_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/change_item_parent_dialog_component.rb
@@ -86,12 +86,18 @@ module Admin
           {
             label: item.label,
             current: current?(item),
-            value: item.id
+            value: item.id,
+            select_variant: :single,
+            disabled: disabled?(item)
           }
         end
 
         def current?(item)
           item.id == @hierarchy_item.id
+        end
+
+        def disabled?(item)
+          item.id == @hierarchy_item.id || item.id == @hierarchy_item.parent.id
         end
       end
     end

--- a/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
@@ -97,24 +97,20 @@ module Admin
         end
 
         def change_parent
-          result = parse_parent_input(new_parent_params).bind do |new_parent|
-            validate_new_parent(new_parent).bind do
-              item_service.move_item(item: @active_item, new_parent:)
-            end
-          end
-
-          result.either(
-            ->(result) do
-              redirect_to action: :show,
-                          id: result.parent,
-                          status: :see_other,
-                          notice: I18n.t(:notice_successful_update)
-            end,
-            ->(error) do
-              render_error_flash_message_via_turbo_stream(message: error)
-              respond_with_turbo_streams(&:html)
-            end
-          )
+          parse_parent_input(new_parent_params)
+            .bind { item_service.move_item(item: @active_item, new_parent: it) }
+            .either(
+              ->(result) do
+                redirect_to action: :show,
+                            id: result.parent,
+                            status: :see_other,
+                            notice: I18n.t(:notice_successful_update)
+              end,
+              ->(error) do
+                render_error_flash_message_via_turbo_stream(message: error)
+                respond_with_turbo_streams(&:html)
+              end
+            )
         end
 
         def destroy
@@ -209,13 +205,6 @@ module Admin
           else
             Failure("Invalid input: #{new_parent_input}")
           end
-        end
-
-        def validate_new_parent(new_parent)
-          return Failure("Parent must not be the same as before.") if @active_item.parent.id == new_parent.id
-          return Failure("Parent must not be the current item.") if @active_item.id == new_parent.id
-
-          Success()
         end
 
         def find_model_object

--- a/modules/webhooks/spec/features/manage_webhooks_spec.rb
+++ b/modules/webhooks/spec/features/manage_webhooks_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Manage webhooks through UI", :js, :selenium do
     let(:user) { create(:admin) }
     let!(:project) { create(:project) }
 
-    it "allows the management flow" do
+    it "allows the management flow", skip: "flickering spec (#68224)" do
       visit admin_outgoing_webhooks_path
       expect(page).to have_css(".generic-table--empty-row")
 


### PR DESCRIPTION
# Ticket
[#68045](https://community.openproject.org/work_packages/68045)

# What are you trying to accomplish?
- change parent selection dialog uses an appropriate selection method

# What approach did you choose and why?
- use new select_variant :single
- disable current item and current parent for selection
- remove custom error messages

