### PR TITLE
Fix running Cuprite specs in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
       DATABASE_URL: postgresql://openproject:openproject@db-test/openproject
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SELENIUM_GRID_URL: http://selenium-hub:4444/wd/hub
-      CHROME_URL: http://cuprite-chrome:3333
+      CHROME_WS_URL: ws://cuprite-chrome:3000/chrome
       CAPYBARA_SERVER_PORT: 3000
       CAPYBARA_DYNAMIC_BIND_IP: 1
       CAPYBARA_APP_HOSTNAME: backend-test
@@ -232,12 +232,11 @@ services:
   cuprite-chrome:
     # Currently, Apple M1 is only supported in unnumbered "latest" versions.
     # See https://github.com/browserless/chrome/issues/1393
-    image: browserless/chrome:latest
+    image: ghcr.io/browserless/chrome:latest
     networks:
       - testing
     environment:
-      # By default, it uses 3000, which is typically used by Rails.
-      PORT: 3333
+      HOST: cuprite-chrome
       # Set connection timeout to avoid timeout exception during debugging
       # https://docs.browserless.io/docs/docker.html#connection-timeout
       CONNECTION_TIMEOUT: 600000

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -63,7 +63,10 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       inspector: true,
       headless: headless_mode?,
       save_path: DownloadList::SHARED_PATH.to_s,
-      window_size: [1920, 1080]
+      window_size: [1920, 1080],
+      # workaround for compatibility issues with browserless docker image and ferrum
+      # see https://github.com/rubycdp/ferrum/issues/540
+      flatten: false
     }
 
     if headful_mode? && ENV["CAPYBARA_WINDOW_RESOLUTION"]
@@ -75,15 +78,7 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       options = options.merge(slowmo: ENV["OPENPROJECT_TESTING_SLOWDOWN_FACTOR"])
     end
 
-    if ENV["CHROME_URL"].present? && ENV["CHROME_WS_URL"].present?
-      raise "Both CHROME_URL and CHROME_WS_URL were passed. Only one can be accepted at a time."
-    end
-
-    if ENV["CHROME_URL"].present?
-      options = options.merge(url: ENV["CHROME_URL"])
-    elsif ENV["CHROME_WS_URL"].present?
-      options = options.merge(ws_url: ENV["CHROME_WS_URL"])
-    end
+    options = configure_remote_chrome(options)
 
     browser_options = {
       "disable-dev-shm-usage": nil,
@@ -117,6 +112,17 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
   Capybara::Screenshot.register_driver(name) do |driver, path|
     driver.save_screenshot(path)
   end
+end
+
+def configure_remote_chrome(options)
+  if ENV["CHROME_URL"].present? && ENV["CHROME_WS_URL"].present?
+    raise "Both CHROME_URL and CHROME_WS_URL were passed. Only one can be accepted at a time."
+  end
+
+  return options.merge(url: ENV["CHROME_URL"]) if ENV["CHROME_URL"].present?
+  return options.merge(ws_url: ENV["CHROME_WS_URL"]) if ENV["CHROME_WS_URL"].present?
+
+  options
 end
 
 register_better_cuprite "en"

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -75,8 +75,14 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       options = options.merge(slowmo: ENV["OPENPROJECT_TESTING_SLOWDOWN_FACTOR"])
     end
 
+    if ENV["CHROME_URL"].present? && ENV["CHROME_WS_URL"].present?
+      raise "Both CHROME_URL and CHROME_WS_URL were passed. Only one can be accepted at a time."
+    end
+
     if ENV["CHROME_URL"].present?
       options = options.merge(url: ENV["CHROME_URL"])
+    elsif ENV["CHROME_WS_URL"].present?
+      options = options.merge(ws_url: ENV["CHROME_WS_URL"])
     end
 
     browser_options = {


### PR DESCRIPTION
This ultimatively seems to be a bug in Ferrum or an incompatibility between Ferrum and browserless. I understand that the setting defines whether a single or multiple web socket connections are used to communicate with the browser, but apart from that I don't understand well what the actual issue is.

### References

* https://github.com/rubycdp/ferrum/issues/540