### PR TITLE
code maintenance/68252 use journal sorting inquiry methods and remove unnecessary `repository.project` call

### DIFF
--- a/app/components/work_packages/activities_tab/journals/filter_and_sorting_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/filter_and_sorting_component.html.erb
@@ -58,7 +58,7 @@
             content_arguments: {
               data: { turbo_stream: true, test_selector: "op-wp-journals-sorting-desc" }
             },
-            active: desc_sorting?
+            active: journal_sorting.desc?
           )
           menu.with_item(
             label: t("activities.work_packages.activity_tab.label_sort_asc"),
@@ -67,7 +67,7 @@
             content_arguments: {
               data: { turbo_stream: true, test_selector: "op-wp-journals-sorting-asc" }
             },
-            active: asc_sorting?
+            active: journal_sorting.asc?
           )
         end
       end

--- a/app/components/work_packages/activities_tab/journals/filter_and_sorting_component.rb
+++ b/app/components/work_packages/activities_tab/journals/filter_and_sorting_component.rb
@@ -59,14 +59,6 @@ module WorkPackages
         def show_only_changes?
           filter == :only_changes
         end
-
-        def desc_sorting?
-          journal_sorting == "desc"
-        end
-
-        def asc_sorting?
-          journal_sorting == "asc"
-        end
       end
     end
   end

--- a/app/components/work_packages/activities_tab/journals/index_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/index_component.html.erb
@@ -37,7 +37,7 @@
               end
             end
 
-            if !journal_sorting_desc? && journals.count > MAX_RECENT_JOURNALS
+            if !journal_sorting.desc? && journals.count > MAX_RECENT_JOURNALS
               journals_index_container.with_row do
                 helpers.turbo_frame_tag("work-package-activities-tab-content-older-journals", src: work_package_activities_path(work_package, filter:, deferred: true))
               end
@@ -58,7 +58,7 @@
               end
             end
 
-            if journal_sorting_desc? && journals.count > MAX_RECENT_JOURNALS
+            if journal_sorting.desc? && journals.count > MAX_RECENT_JOURNALS
               journals_index_container.with_row do
                 helpers.turbo_frame_tag("work-package-activities-tab-content-older-journals", src: work_package_activities_path(work_package, filter:, deferred: true))
               end

--- a/app/components/work_packages/activities_tab/journals/index_component.rb
+++ b/app/components/work_packages/activities_tab/journals/index_component.rb
@@ -59,10 +59,6 @@ module WorkPackages
           "work-package-journal-days"
         end
 
-        def journal_sorting_desc?
-          journal_sorting == "desc"
-        end
-
         def base_journals
           combine_and_sort_records(fetch_journals, fetch_revisions)
         end
@@ -85,7 +81,7 @@ module WorkPackages
         def combine_and_sort_records(journals, revisions)
           (journals + revisions).sort_by do |record|
             timestamp = record_timestamp(record)
-            journal_sorting_desc? ? [-timestamp, -record.id] : [timestamp, record.id]
+            journal_sorting.desc? ? [-timestamp, -record.id] : [timestamp, record.id]
           end
         end
 
@@ -102,7 +98,7 @@ module WorkPackages
         end
 
         def recent_journals
-          if journal_sorting_desc?
+          if journal_sorting.desc?
             base_journals.first(MAX_RECENT_JOURNALS)
           else
             base_journals.last(MAX_RECENT_JOURNALS)
@@ -110,7 +106,7 @@ module WorkPackages
         end
 
         def older_journals
-          if journal_sorting_desc?
+          if journal_sorting.desc?
             base_journals.drop(MAX_RECENT_JOURNALS)
           else
             base_journals.take(base_journals.size - MAX_RECENT_JOURNALS)
@@ -133,7 +129,7 @@ module WorkPackages
         end
 
         def inner_container_margin_bottom
-          if journal_sorting_desc?
+          if journal_sorting.desc?
             3
           else
             0

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -213,7 +213,7 @@ module WorkPackages
         end
 
         def skip_rendering_details?
-          journal.initial? && journal_sorting == "desc"
+          journal.initial? && journal_sorting.desc?
         end
 
         def render_journal_details(details_container_inner)

--- a/app/components/work_packages/activities_tab/journals/revision_component.rb
+++ b/app/components/work_packages/activities_tab/journals/revision_component.rb
@@ -81,9 +81,8 @@ module WorkPackages
 
         def revision_url
           repository = changeset.repository
-          project = repository.project
 
-          show_revision_project_repository_path(project_id: project.id, rev: changeset.revision)
+          show_revision_project_repository_path(project_id: repository.project_id, rev: changeset.revision)
         end
 
         def short_revision


### PR DESCRIPTION
https://community.openproject.org/wp/68252

Addresses https://github.com/opf/openproject/pull/20365#pullrequestreview-3319684018

- [x] [Use journal_sorting.{asc?,desc?} inquiries](https://github.com/opf/openproject/pull/20607/commits/992588e308c94309316e9f0b99e74550281fd3cc)
- [x] [Remove unnecessary repository.project call, just access project_id](https://github.com/opf/openproject/pull/20607/commits/3b9f3b00d1f58a41f6d3a57cbc1f2705c3ea3c6e)