### PR TITLE
bug/68252 Reduce the intersection threshold to 5% to account for small screens

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
@@ -120,7 +120,7 @@ export default class LazyPageController extends BaseController {
 
     const [_observe, unobserve] = useIntersection(this, {
       root,
-      threshold: 0.25,
+      threshold: 0.05,
       dispatchEvent: false
     });
 


### PR DESCRIPTION
https://community.openproject.org/wp/68252

Addresses https://github.com/opf/openproject/pull/20365#discussion_r2417401325

- [x] On small screens the lazy page might never load: [Reduce the intersection threshold to 5% to account for small screens](https://github.com/opf/openproject/commit/42d75bb777cafd23d2eddd96a76b326c024ca0c6)