### PR TITLE
[68217] Misaligned date picker on mobile web

### DIFF
--- a/app/components/work_packages/date_picker/date_form_component.sass
+++ b/app/components/work_packages/date_picker/date_form_component.sass
@@ -22,8 +22,3 @@
         display: none
       ~ .wp-datepicker-dialog-set-today-link
         display: none
-
-@media screen and (max-width: $breakpoint-sm)
-  .wp-datepicker-dialog-date-form
-    &--add-button
-      margin-top: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68217

# What are you trying to accomplish?
Correctly align Datepicker buttons on mobile

## Screenshots
<img width="348" height="70" alt="Bildschirmfoto 2025-10-13 um 15 05 03" src="https://github.com/user-attachments/assets/8b3660c1-8940-4507-a53e-9841f9c582cc" />
<img width="389" height="101" alt="Bildschirmfoto 2025-10-13 um 15 05 10" src="https://github.com/user-attachments/assets/32f6fcb5-028b-4f4b-852b-6016dc5ec924" />

