### PR TITLE
[67693] On mobile, list of names for mentions spills out of screen if some names are long

### DIFF
--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -129,10 +129,10 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
   path
     fill: var(--body-font-color) !important
 
-.ck-balloon-panel.ck-balloon-panel_visible
-  @media (max-width: $breakpoint-sm)
+@media (max-width: $breakpoint-sm)
+  .ck-balloon-panel.ck-balloon-panel_visible
     left: 5vw !important
     right: 5vw !important
 
-.ck-list__item .mention-list-item
-  max-width: none !important
+  .ck-list__item .mention-list-item
+    max-width: none !important

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -128,3 +128,11 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
 .ck-icon_inherit-color
   path
     fill: var(--body-font-color) !important
+
+.ck-balloon-panel.ck-balloon-panel_visible
+  @media (max-width: $breakpoint-sm)
+    left: 5vw !important
+    right: 5vw !important
+
+.ck-list__item .mention-list-item
+  max-width: none !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67693

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add some space to the left and right of the dropdown list

## Screenshots
Before:
<img width="503" height="606" alt="Screenshot 2025-10-13 at 15 20 23" src="https://github.com/user-attachments/assets/1c462d5e-ee36-4095-9cc1-c124a5799809" />

After:
<img width="472" height="702" alt="Screenshot 2025-10-13 at 15 17 25" src="https://github.com/user-attachments/assets/1ad44e07-e5a4-4b99-949f-9226675c3dd5" />
