### PR TITLE
[68014] Fix setting milestone date on creation

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/combined-date-edit-field.component.ts
@@ -108,9 +108,7 @@ export class CombinedDateEditFieldComponent extends DatePickerEditFieldComponent
   }
 
   protected current(dateAttribute:'startDate' | 'dueDate' | 'date'):string {
-    // Since the rework of the datepicker, the milestone date field has the name 'start_date' to match the database
-    const valueReference = dateAttribute === 'date' ? 'startDate' : dateAttribute;
-    const value = (this.resource && (this.resource as WorkPackageResource)[valueReference]) as string|null;
-    return (value || this.text.placeholder[dateAttribute]);
+    const value = (this.resource && (this.resource as WorkPackageResource)[dateAttribute]) as string|null;
+    return (value ?? this.text.placeholder[dateAttribute]);
   }
 }

--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -135,15 +135,21 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
       includeNonWorkingDays,
       scheduleManually } } = event as { detail:{ duration:number, startDate:Date, dueDate:Date, includeNonWorkingDays:boolean, scheduleManually:boolean } };
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     this.resource.duration = duration ? this.timezoneService.toISODuration(duration, 'days') : null;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.dueDate = dueDate;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
-    this.resource.startDate = startDate;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
+    // debugger;
+    if (this.isMilestone()) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      this.resource.date = startDate;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      this.resource.dueDate = dueDate;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      this.resource.startDate = startDate;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     this.resource.includeNonWorkingDays = includeNonWorkingDays;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     this.resource.scheduleManually = scheduleManually;
 
     this.onModalClosed();
@@ -162,4 +168,8 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
   }
 
   public cancel():void {}
+
+  private isMilestone():boolean {
+    return !!this.change.schema.isMilestone;
+  }
 }

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -290,12 +290,23 @@ RSpec.describe "new work package", :js do
 
       # Set date
       date_field.click_to_open_datepicker
-      date = Time.zone.today.iso8601
+      date = Date.current.iso8601
       date_field.set_milestone_date date
       date_field.save!
 
       # Expect date to be displayed
       date_field.expect_value date
+
+      # Save work package
+      wp_page.subject_field.set(subject)
+      wp_page.save!
+      wp_page.expect_and_dismiss_toaster(message: "Successful creation.")
+
+      # Expect date to be saved
+      expect(WorkPackage.last).to have_attributes(
+        start_date: Date.current,
+        is_milestone?: true
+      )
     end
 
     it_behaves_like "work package creation workflow" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68014

# What are you trying to accomplish?

Fix creation of a milestone with a date: the date is not saved. It should be saved

## Screenshots

Not applicable.

# What approach did you choose and why?

When frontend sends the date(s) to the backend, it needs to send `date` for milestone type instead of `start_date` because the backend would ignore `startDate` and `dueDate` for milestone type.

Date picker deals with `startDate` and `dueDate` fields only internally, so on save, when `handleSuccessfulCreate` is called, the field `date` is set instead of `startDate` and `dueDate` if the work package is a milestone.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
