### PR TITLE
Remove unnecessary query for avatar urls

### DIFF
--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -34,7 +34,6 @@ module Primer
       # :nodoc:
       class BlockNoteEditor < Primer::Forms::BaseComponent
         include ::OpenProject::StaticRouting::UrlHelpers
-        include ::AvatarHelper
 
         attr_reader :input,
                     :value,
@@ -51,17 +50,15 @@ module Primer
           super()
           @input = input
           @value = value
-          @users = User.active.preload(:attachments).map do |user|
+          @users = User.active.map do |user|
             {
               id: user.id,
-              username: user.name,
-              avatarUrl: avatar_url(user)
+              username: user.name
             }
           end
           @active_user = {
             id: User.current.id,
-            username: User.current.name,
-            avatarUrl: avatar_url(User.current)
+            username: User.current.name
           }
           @document_id = document_id
           @hocuspocus_url = Setting.collaborative_editing_hocuspocus_url


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/68234/activity

# What are you trying to accomplish?
We are not using avatarUrls, so we can remove this query. It is causing an N+1.

# What approach did you choose and why?
Looking into [BlockNote js collaboration docs](https://www.blocknotejs.org/docs/features/collaboration) they don't mention avatarUrls, unless we're using [collaborative comments](https://www.blocknotejs.org/docs/features/collaboration/comments). We don't use that feature yet so we don't need avatarUrls, and we can remove them.