### PR TITLE
[68297] Move to section modal doesn't use all the available whitespace

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -360,8 +360,12 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
       }
 
       if (this.openDirectly) {
-        this.ngSelectInstance.open();
-        this.ngSelectInstance.focus();
+        // Autocompleters within dialogs need longer to be visible, which is why we have to delay the opening further
+        const timeout = this.ngSelectInstance.element.closest('dialog') ? 200 : 0;
+        setTimeout(() => {
+          this.ngSelectInstance.open();
+          this.ngSelectInstance.focus();
+        }, timeout);
       } else if (this.focusDirectly) {
         this.ngSelectInstance.focus();
       }

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
           end
         end
         flex.with_row(mb: 3) do
-          render(Meeting::AddToSection.new(f, wrapper_id: "move-to-section-dialog", occurrence: @meeting, item: @agenda_item))
+          render(Meeting::AddToSection.new(f, wrapper_id: "move-to-section-dialog", occurrence: @meeting, item: @agenda_item, open_directly: true))
         end
       end
     end

--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -39,10 +39,10 @@ class Meeting::AddToSection < ApplicationForm
         decorated: true,
         defaultData: false,
         multiple: false,
-        focus_directly: false,
         disabled: meeting.blank?,
         placeholder: placeholder_text,
-        append_to: append_to_container
+        append_to: append_to_container,
+        openDirectly: @open_directly
       }
     ) do |select|
       items.each do |item|
@@ -55,12 +55,13 @@ class Meeting::AddToSection < ApplicationForm
     end
   end
 
-  def initialize(wrapper_id: nil, occurrence: nil, item: nil)
+  def initialize(wrapper_id: nil, occurrence: nil, item: nil, open_directly: false)
     super()
 
     @wrapper_id = wrapper_id
     @occurrence = occurrence
     @selected_section = item&.meeting_section
+    @open_directly = open_directly
   end
 
   private

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -612,7 +612,7 @@ en:
   text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."
 
   label_add_work_package_to_meeting_dialog_title: "Select meeting"
-  label_add_work_package_to_meeting_section_label: "Add to section"
+  label_add_work_package_to_meeting_section_label: "Section"
   label_add_work_package_to_meeting_dialog_button: "Add to meeting"
   label_meeting_selection_caption: "It is only possible to add this work package to an upcoming or an ongoing meeting."
   label_section_selection_caption: "Choose a particular section of the agenda or add it to the backlog."


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68297

# What are you trying to accomplish?
Automatically open the autocompleter in the "Add to section" dialog to make better use of the available space

