### PR TITLE
[66444] Activity Module delivers error 404 in newly set up instances

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -45,7 +45,9 @@ Redmine::MenuManager.map :top_menu do |menu|
   menu.push :activity,
             { controller: "/activities", action: "index" },
             context: :modules,
-            if: Proc.new { User.current.logged? || !Setting.login_required? },
+            if: Proc.new {
+              Project.visible.active.has_module(:activity).present? && (User.current.logged? || !Setting.login_required?)
+            },
             icon: "history"
 
   menu.push :work_packages,
@@ -55,7 +57,8 @@ Redmine::MenuManager.map :top_menu do |menu|
             icon: "op-view-list",
             if: ->(_) {
               (User.current.logged? || !Setting.login_required?) &&
-                User.current.allowed_in_any_work_package?(:view_work_packages)
+                User.current.allowed_in_any_work_package?(:view_work_packages) &&
+                Project.visible.active.has_module(:work_package_tracking).present?
             }
   menu.push :news,
             { controller: "/news", project_id: nil, action: "index" },
@@ -64,7 +67,8 @@ Redmine::MenuManager.map :top_menu do |menu|
             icon: "megaphone",
             if: ->(_) {
               (User.current.logged? || !Setting.login_required?) &&
-                User.current.allowed_in_any_project?(:view_news)
+                User.current.allowed_in_any_project?(:view_news) &&
+                Project.visible.active.has_module(:news).present?
             }
 
   menu.push :help,
@@ -186,6 +190,9 @@ Redmine::MenuManager.map :global_menu do |menu|
   # Activity
   menu.push :activity,
             { controller: "/activities", action: "index" },
+            if: Proc.new {
+              Project.visible.active.has_module(:activity).present? && (User.current.logged? || !Setting.login_required?)
+            },
             icon: "history",
             after: :projects
 
@@ -214,7 +221,8 @@ Redmine::MenuManager.map :global_menu do |menu|
             after: :boards,
             if: ->(_) {
               (User.current.logged? || !Setting.login_required?) &&
-                User.current.allowed_in_any_project?(:view_news)
+                User.current.allowed_in_any_project?(:view_news) &&
+                Project.visible.active.has_module(:news).present?
             }
 end
 

--- a/spec/features/activities/global_menu_item_spec.rb
+++ b/spec/features/activities/global_menu_item_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+#
+
+require "spec_helper"
+
+RSpec.describe "Activities global menu item spec", :js do
+  shared_let(:admin) { create(:admin) }
+
+  before do
+    project
+    login_as admin
+    visit root_path
+  end
+
+  context "when activity module is active" do
+    let(:project) { create(:project, enabled_module_names: %w[activity]) }
+
+    it "does show the menu item" do
+      within "#main-menu" do
+        click_link "Activity"
+      end
+
+      expect(page).to have_current_path(activity_index_path)
+    end
+  end
+
+  context "when activity module is nowhere active" do
+    let(:project) { create(:project, enabled_module_names: %w[]) }
+
+    it "doesn't render the menu item" do
+      within "#main-menu" do
+        expect(page).to have_no_link "Activity"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66444

# What are you trying to accomplish?
Hide the module globally if no project has it activated


