### PR TITLE
Fix flaky create user spec

### DIFF
--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -2,3 +2,6 @@ inherit_from: ../.rubocop.yml
 
 Style/RescueModifier:
   Enabled: false
+
+Rails/FindEach:
+  Enabled: false

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -48,8 +48,6 @@ RSpec.describe "create users" do
 
   shared_examples_for "successful user creation" do |redirect_to_edit_page: true|
     it "creates the user" do
-      expect_flash(message: "Successful creation.")
-
       new_user = User.order(Arel.sql("id DESC")).first
 
       expect(page).to have_current_path redirect_to_edit_page ? edit_user_path(new_user) : user_path(new_user)
@@ -71,6 +69,7 @@ RSpec.describe "create users" do
 
       perform_enqueued_jobs do
         new_user_page.submit!
+        expect_flash(message: "Successful creation.")
       end
     end
 
@@ -100,29 +99,39 @@ RSpec.describe "create users" do
     end
   end
 
-  context "with external authentication", :js do
+  context "with external authentication" do
     before do
-      new_user_page.visit!
+      visit new_user_page.path
 
+      # Normally, the username field would appear on the page once
+      # ldap_auth_source is set, but as we are acting without javascript, we
+      # first create the user and then update it to set the username.
+      #
+      # We can't use the browser because it makes the spec flaky, and we were
+      # unable to find why.
       new_user_page.fill_in! first_name: "bobfirst",
                              last_name: "boblast",
                              email: "bob@mail.com",
-                             login: "bob",
                              ldap_auth_source: auth_source.name
 
       perform_enqueued_jobs do
         new_user_page.submit!
-        wait_for_network_idle
+        expect_flash(message: "Successful creation.")
+
+        # Fill both "Username" fields on the edit user page: as they have the
+        # same name, if only the first one is filled, then second one would
+        # overwrite the value of the first one.
+        page.all(:field, "Username", visible: :all).each do |field|
+          field.fill_in with: "bob"
+        end
+
+        page.click_button "Save"
+        expect_flash(message: "Successful update.")
       end
     end
 
-    after do
-      # Clear session to avoid that the onboarding tour starts
-      page.execute_script("window.sessionStorage.clear();")
-    end
-
     it_behaves_like "successful user creation" do
-      describe "activation", :js do
+      describe "activation" do
         before do
           # Ensure we clear any flashes
           visit "/logout"
@@ -150,9 +159,10 @@ RSpec.describe "create users" do
             .to(receive(:authenticate).with("bob", "dummy"))
             .and_return({ dn: "cn=bob,ou=users,dc=example,dc=com" })
 
-          fill_in "password", with: "dummy" # accepted by DummyAuthSource
-          click_button "Sign in", type: "submit"
-          wait_for_network_idle
+          within "#content-body" do
+            fill_in "password", with: "dummy" # accepted by DummyAuthSource
+            click_button "Sign in", type: "submit"
+          end
 
           # landed on the 'my page'
           expect(page).to have_text "Welcome to OpenProject, bobfirst boblast"
@@ -177,6 +187,7 @@ RSpec.describe "create users" do
 
         perform_enqueued_jobs do
           new_user_page.submit!
+          expect_flash(message: "Successful creation.")
         end
       end
 
@@ -221,6 +232,7 @@ RSpec.describe "create users" do
 
         perform_enqueued_jobs do
           new_user_page.submit!
+          expect_flash(message: "Successful creation.")
         end
       end
 

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -73,28 +73,28 @@ RSpec.describe "create users" do
       end
     end
 
-    it_behaves_like "successful user creation" do
-      describe "activation" do
-        before do
-          allow(User).to receive(:current).and_call_original
+    it_behaves_like "successful user creation"
 
-          visit "/account/activate?token=#{token}"
-        end
+    describe "activation" do
+      before do
+        allow(User).to receive(:current).and_call_original
 
-        it "shows the registration form" do
-          expect(page).to have_text "Create a new account"
-        end
+        visit "/account/activate?token=#{token}"
+      end
 
-        it "registers the user upon submission" do
-          fill_in "user_password", with: "foobarbaz1"
-          fill_in "user_password_confirmation", with: "foobarbaz1"
+      it "shows the registration form" do
+        expect(page).to have_text "Create a new account"
+      end
 
-          click_button "Create"
+      it "registers the user upon submission" do
+        fill_in "user_password", with: "foobarbaz1"
+        fill_in "user_password_confirmation", with: "foobarbaz1"
 
-          # landed on the 'my page'
-          expect(page).to have_text "Welcome, your account has been activated. You are logged in now."
-          user_menu.expect_user_shown "bobfirst boblast"
-        end
+        click_button "Create"
+
+        # landed on the 'my page'
+        expect(page).to have_text "Welcome, your account has been activated. You are logged in now."
+        user_menu.expect_user_shown "bobfirst boblast"
       end
     end
   end
@@ -130,45 +130,45 @@ RSpec.describe "create users" do
       end
     end
 
-    it_behaves_like "successful user creation" do
-      describe "activation" do
-        before do
-          # Ensure we clear any flashes
-          visit "/logout"
+    it_behaves_like "successful user creation"
 
-          allow(User).to receive(:current).and_call_original
+    describe "activation" do
+      before do
+        # Ensure we clear any flashes
+        visit "/logout"
 
-          visit "/account/activate?token=#{token}"
+        allow(User).to receive(:current).and_call_original
+
+        visit "/account/activate?token=#{token}"
+      end
+
+      it "shows the login form prompting the user to login" do
+        expect(page).to have_text "Please login as bob to activate your account."
+      end
+
+      it "registers the user upon submission" do
+        user = User.find_by login: "bob"
+
+        allow(User)
+          .to(receive(:find_by_login))
+          .with("bob")
+          .and_return(user)
+
+        allow(user).to receive(:ldap_auth_source).and_return(auth_source)
+
+        allow(auth_source)
+          .to(receive(:authenticate).with("bob", "dummy"))
+          .and_return({ dn: "cn=bob,ou=users,dc=example,dc=com" })
+
+        within "#content-body" do
+          fill_in "password", with: "dummy" # accepted by DummyAuthSource
+          click_button "Sign in", type: "submit"
         end
 
-        it "shows the login form prompting the user to login" do
-          expect(page).to have_text "Please login as bob to activate your account."
-        end
-
-        it "registers the user upon submission" do
-          user = User.find_by login: "bob"
-
-          allow(User)
-            .to(receive(:find_by_login))
-            .with("bob")
-            .and_return(user)
-
-          allow(user).to receive(:ldap_auth_source).and_return(auth_source)
-
-          allow(auth_source)
-            .to(receive(:authenticate).with("bob", "dummy"))
-            .and_return({ dn: "cn=bob,ou=users,dc=example,dc=com" })
-
-          within "#content-body" do
-            fill_in "password", with: "dummy" # accepted by DummyAuthSource
-            click_button "Sign in", type: "submit"
-          end
-
-          # landed on the 'my page'
-          expect(page).to have_text "Welcome to OpenProject, bobfirst boblast"
-          expect(page).to have_current_path "/", ignore_query: true
-          user_menu.expect_user_shown "bobfirst boblast"
-        end
+        # landed on the 'my page'
+        expect(page).to have_text "Welcome to OpenProject, bobfirst boblast"
+        expect(page).to have_current_path "/", ignore_query: true
+        user_menu.expect_user_shown "bobfirst boblast"
       end
     end
   end
@@ -191,28 +191,28 @@ RSpec.describe "create users" do
         end
       end
 
-      it_behaves_like "successful user creation", redirect_to_edit_page: false do
-        describe "activation" do
-          before do
-            allow(User).to receive(:current).and_call_original
+      it_behaves_like "successful user creation", redirect_to_edit_page: false
 
-            visit "/account/activate?token=#{token}"
-          end
+      describe "activation" do
+        before do
+          allow(User).to receive(:current).and_call_original
 
-          it "shows the registration form" do
-            expect(page).to have_text "Create a new account"
-          end
+          visit "/account/activate?token=#{token}"
+        end
 
-          it "registers the user upon submission" do
-            fill_in "user_password", with: "foobarbaz1"
-            fill_in "user_password_confirmation", with: "foobarbaz1"
+        it "shows the registration form" do
+          expect(page).to have_text "Create a new account"
+        end
 
-            click_button "Create"
+        it "registers the user upon submission" do
+          fill_in "user_password", with: "foobarbaz1"
+          fill_in "user_password_confirmation", with: "foobarbaz1"
 
-            # landed on the 'my page'
-            expect(page).to have_text "Welcome, your account has been activated. You are logged in now."
-            user_menu.expect_user_shown "bobfirst boblast"
-          end
+          click_button "Create"
+
+          # landed on the 'my page'
+          expect(page).to have_text "Welcome, your account has been activated. You are logged in now."
+          user_menu.expect_user_shown "bobfirst boblast"
         end
       end
     end


### PR DESCRIPTION
# Ticket

None

# What are you trying to accomplish?

Fix flaky spec `spec/features/users/create_spec.rb:146`, failing on many PRs.
Failing run: https://github.com/opf/openproject/actions/runs/18487329720/job/52673204968

# What approach did you choose and why?

Despite many efforts, I was not able to reproduce the flaky test locally. I still don't know why it was often failing in CI and never locally.

But I noticed that in the same spec, the one in context "as global user" had a similar setup and never failed. Probably because it was not using any browser but the default Capybara driver `Capybara::RackTest::Driver`.

So the flaky test was changed to not rely on browser-based drivers anymore. The test setup had to be adapated: as javascript is not available, the username field is not shown when `ldap_auth_source` is set, so we create the user first and then update it to set the username. That's a bit hacky but that works.

This should fix the flakiness of the test.

As a bonus, the test is executed faster now (8 seconds instead of 17).

I also disabled the `Rails/FindEach` rubocop rule in `spec/` because it's annoying and can't differentiate capybara calls from activerecord calls.
 
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
