### PR TITLE
[68352] Version overview widgets don't have enough space

### DIFF
--- a/app/components/projects/settings/versions/overview_widget_component.rb
+++ b/app/components/projects/settings/versions/overview_widget_component.rb
@@ -45,10 +45,6 @@ module Projects
             end
           end
         end
-
-        def wrapper_arguments
-          { classes: "-thin" }
-        end
       end
     end
   end

--- a/app/components/projects/settings/versions/overview_widget_component.rb
+++ b/app/components/projects/settings/versions/overview_widget_component.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects
+  module Settings
+    module Versions
+      class OverviewWidgetComponent < Grids::WidgetComponent
+        option :version
+
+        def title
+          I18n.t(:label_overview)
+        end
+
+        def call
+          widget_wrapper do |widget|
+            widget.with_body(padding: :default) do
+              render partial: "versions/overview", locals: { version: }
+            end
+          end
+        end
+
+        def wrapper_arguments
+          { classes: "-thin" }
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/versions/progress_widget_component.html.erb
+++ b/app/components/projects/settings/versions/progress_widget_component.html.erb
@@ -1,0 +1,19 @@
+<%# Only render the widget if visible %>
+<% if visible? %>
+  <%= widget_wrapper do |widget| %>
+    <%= widget.with_body(padding: :default) do %>
+      <table>
+        <tr>
+          <td style="width: 130px; align: right;"><%= Version.human_attribute_name(:estimated_hours) %></td>
+          <td style="width: 240px; align: right;" class="total-hours"><%= helpers.l_hours(version.estimated_hours) %></td>
+        </tr>
+        <% if User.current.allowed_in_project?(:view_time_entries, project) %>
+          <tr>
+            <td style="width: 130px; align: right;"><%= t(:label_spent_time) %></td>
+            <td style="width: 240px; align: right;" class="total-hours"><%= helpers.l_hours(version.spent_hours) %></td>
+          </tr>
+        <% end %>
+      </table>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/projects/settings/versions/progress_widget_component.html.erb
+++ b/app/components/projects/settings/versions/progress_widget_component.html.erb
@@ -1,5 +1,5 @@
 <%= widget_wrapper do |widget| %>
-  <%= widget.with_body(padding: :default) do %>
+  <%= widget.with_body do %>
     <table>
       <tr>
         <td style="width: 130px; align: right;"><%= Version.human_attribute_name(:estimated_hours) %></td>

--- a/app/components/projects/settings/versions/progress_widget_component.html.erb
+++ b/app/components/projects/settings/versions/progress_widget_component.html.erb
@@ -1,19 +1,16 @@
-<%# Only render the widget if visible %>
-<% if visible? %>
-  <%= widget_wrapper do |widget| %>
-    <%= widget.with_body(padding: :default) do %>
-      <table>
+<%= widget_wrapper do |widget| %>
+  <%= widget.with_body(padding: :default) do %>
+    <table>
+      <tr>
+        <td style="width: 130px; align: right;"><%= Version.human_attribute_name(:estimated_hours) %></td>
+        <td style="width: 240px; align: right;" class="total-hours"><%= helpers.l_hours(version.estimated_hours) %></td>
+      </tr>
+      <% if User.current.allowed_in_project?(:view_time_entries, project) %>
         <tr>
-          <td style="width: 130px; align: right;"><%= Version.human_attribute_name(:estimated_hours) %></td>
-          <td style="width: 240px; align: right;" class="total-hours"><%= helpers.l_hours(version.estimated_hours) %></td>
+          <td style="width: 130px; align: right;"><%= t(:label_spent_time) %></td>
+          <td style="width: 240px; align: right;" class="total-hours"><%= helpers.l_hours(version.spent_hours) %></td>
         </tr>
-        <% if User.current.allowed_in_project?(:view_time_entries, project) %>
-          <tr>
-            <td style="width: 130px; align: right;"><%= t(:label_spent_time) %></td>
-            <td style="width: 240px; align: right;" class="total-hours"><%= helpers.l_hours(version.spent_hours) %></td>
-          </tr>
-        <% end %>
-      </table>
-    <% end %>
+      <% end %>
+    </table>
   <% end %>
 <% end %>

--- a/app/components/projects/settings/versions/progress_widget_component.rb
+++ b/app/components/projects/settings/versions/progress_widget_component.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects
+  module Settings
+    module Versions
+      class ProgressWidgetComponent < Grids::WidgetComponent
+        option :version
+        option :project
+
+        def title
+          I18n.t(:label_estimates_and_progress)
+        end
+
+        def visible?
+          version.estimated_hours.positive? || current_user.allowed_in_project?(:view_time_entries, project)
+        end
+
+        def wrapper_arguments
+          { classes: "-thin" }
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/versions/progress_widget_component.rb
+++ b/app/components/projects/settings/versions/progress_widget_component.rb
@@ -39,12 +39,8 @@ module Projects
           I18n.t(:label_estimates_and_progress)
         end
 
-        def visible?
+        def render?
           version.estimated_hours.positive? || current_user.allowed_in_project?(:view_time_entries, project)
-        end
-
-        def wrapper_arguments
-          { classes: "-thin" }
         end
       end
     end

--- a/app/components/projects/settings/versions/related_issues_widget_component.rb
+++ b/app/components/projects/settings/versions/related_issues_widget_component.rb
@@ -45,26 +45,30 @@ module Projects
           return if issues.blank?
 
           widget_wrapper do |widget|
-            issues.first(MAX_DISPLAYED_ISSUES).each do |issue|
-              widget.with_row do
-                helpers.flex_layout(flex_wrap: :nowrap, align_items: :center) do |flex|
-                  flex.with_column(mr: 2) do
-                    render(::WorkPackages::InfoLineComponent.new(work_package: issue, font_size: :small))
-                  end
-                  flex.with_column do
-                    issue.subject
-                  end
-                end
+            render_issues(widget)
+            render_view_all_link(widget) if issues.size > MAX_DISPLAYED_ISSUES
+          end
+        end
+
+        private
+
+        def render_issues(widget)
+          issues.first(MAX_DISPLAYED_ISSUES).each do |issue|
+            widget.with_row do
+              helpers.flex_layout(flex_wrap: :nowrap, align_items: :center) do |flex|
+                flex.with_column(mr: 2) { issue.subject }
+                flex.with_column { render(::WorkPackages::InfoLineComponent.new(work_package: issue, font_size: :small)) }
               end
             end
-            if issues.size > MAX_DISPLAYED_ISSUES
-              widget.with_row do
-                helpers.link_to(
-                  I18n.t("projects.settings.versions.show_work_packages"),
-                  helpers.project_work_packages_version_path(version)
-                )
-              end
-            end
+          end
+        end
+
+        def render_view_all_link(widget)
+          widget.with_row do
+            helpers.link_to(
+              I18n.t("projects.settings.versions.show_work_packages"),
+              helpers.project_work_packages_version_path(version)
+            )
           end
         end
       end

--- a/app/components/projects/settings/versions/related_issues_widget_component.rb
+++ b/app/components/projects/settings/versions/related_issues_widget_component.rb
@@ -56,8 +56,10 @@ module Projects
           issues.first(MAX_DISPLAYED_ISSUES).each do |issue|
             widget.with_row do
               helpers.flex_layout(flex_wrap: :nowrap, align_items: :center) do |flex|
-                flex.with_column(mr: 2) { issue.subject }
-                flex.with_column { render(::WorkPackages::InfoLineComponent.new(work_package: issue, font_size: :small)) }
+                flex.with_column(mr: 2) do
+                  render(::WorkPackages::InfoLineComponent.new(work_package: issue, font_size: :small))
+                end
+                flex.with_column(classes: "ellipsis", flex: 1) { issue.subject }
               end
             end
           end

--- a/app/components/projects/settings/versions/related_issues_widget_component.rb
+++ b/app/components/projects/settings/versions/related_issues_widget_component.rb
@@ -35,6 +35,8 @@ module Projects
         option :version
         option :issues, default: -> { [] }
 
+        MAX_DISPLAYED_ISSUES = 10
+
         def title
           I18n.t(:label_related_work_packages)
         end
@@ -43,9 +45,24 @@ module Projects
           return if issues.blank?
 
           widget_wrapper do |widget|
-            issues.each do |issue|
+            issues.first(MAX_DISPLAYED_ISSUES).each do |issue|
               widget.with_row do
-                helpers.link_to_work_package(issue, project: issue.project != version.project)
+                helpers.flex_layout(flex_wrap: :nowrap, align_items: :center) do |flex|
+                  flex.with_column(mr: 2) do
+                    render(::WorkPackages::InfoLineComponent.new(work_package: issue, font_size: :small))
+                  end
+                  flex.with_column do
+                    issue.subject
+                  end
+                end
+              end
+            end
+            if issues.size > MAX_DISPLAYED_ISSUES
+              widget.with_row do
+                helpers.link_to(
+                  I18n.t("projects.settings.versions.show_work_packages"),
+                  helpers.project_work_packages_version_path(version)
+                )
               end
             end
           end

--- a/app/components/projects/settings/versions/related_issues_widget_component.rb
+++ b/app/components/projects/settings/versions/related_issues_widget_component.rb
@@ -50,10 +50,6 @@ module Projects
             end
           end
         end
-
-        def wrapper_arguments
-          { classes: "-thin -wider" }
-        end
       end
     end
   end

--- a/app/components/projects/settings/versions/related_issues_widget_component.rb
+++ b/app/components/projects/settings/versions/related_issues_widget_component.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects
+  module Settings
+    module Versions
+      class RelatedIssuesWidgetComponent < Grids::WidgetComponent
+        option :version
+        option :issues, default: -> { [] }
+
+        def title
+          I18n.t(:label_related_work_packages)
+        end
+
+        def call
+          return if issues.blank?
+
+          widget_wrapper do |widget|
+            issues.each do |issue|
+              widget.with_row do
+                helpers.link_to_work_package(issue, project: issue.project != version.project)
+              end
+            end
+          end
+        end
+
+        def wrapper_arguments
+          { classes: "-thin -wider" }
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/versions/wiki_widget_component.rb
+++ b/app/components/projects/settings/versions/wiki_widget_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects
+  module Settings
+    module Versions
+      class WikiWidgetComponent < Grids::WidgetComponent
+        option :version
+
+        def title
+          version.wiki_page_title.presence || I18n.t(:label_wiki_page)
+        end
+
+        def call
+          return unless version.wiki_page
+
+          widget_wrapper do |widget|
+            widget.with_body(padding: :default) do
+              render partial: "wiki/text", locals: { page: version.wiki_page }
+            end
+          end
+        end
+
+        def wrapper_arguments
+          { classes: "-thin -wider" }
+        end
+      end
+    end
+  end
+end

--- a/app/components/projects/settings/versions/wiki_widget_component.rb
+++ b/app/components/projects/settings/versions/wiki_widget_component.rb
@@ -47,10 +47,6 @@ module Projects
             end
           end
         end
-
-        def wrapper_arguments
-          { classes: "-thin -wider" }
-        end
       end
     end
   end

--- a/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
+++ b/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
@@ -35,7 +35,7 @@ module Projects
         option :version
 
         def title
-          I18n.t(:label_work_package_tracking)
+          I18n.t("projects.settings.versions.work_packages_graph")
         end
 
         def call

--- a/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
+++ b/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
@@ -42,17 +42,16 @@ module Projects
           return unless version.work_packages.any?
 
           widget_wrapper do |widget|
-            widget.with_body(padding: :none) do
-              tag.opce_wp_overview_graph(
-                "global-scope": version.systemwide?,
-                "initial-filters": helpers.version_wp_overview_graph_initial_filters(version)
+            widget.with_body do
+              helpers.angular_component_tag(
+                "opce-wp-overview-graph",
+                inputs: {
+                  "global-scope": version.systemwide?,
+                  "initial-filters": helpers.version_wp_overview_graph_initial_filters(version)
+                }
               )
             end
           end
-        end
-
-        def wrapper_arguments
-          { classes: "-thin -wider" }
         end
       end
     end

--- a/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
+++ b/app/components/projects/settings/versions/work_packages_graph_widget_component.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2010-2024 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Projects
+  module Settings
+    module Versions
+      class WorkPackagesGraphWidgetComponent < Grids::WidgetComponent
+        option :version
+
+        def title
+          I18n.t(:label_work_package_tracking)
+        end
+
+        def call
+          return unless version.work_packages.any?
+
+          widget_wrapper do |widget|
+            widget.with_body(padding: :none) do
+              tag.opce_wp_overview_graph(
+                "global-scope": version.systemwide?,
+                "initial-filters": helpers.version_wp_overview_graph_initial_filters(version)
+              )
+            end
+          end
+        end
+
+        def wrapper_arguments
+          { classes: "-thin -wider" }
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -98,6 +98,6 @@ module VersionsHelper
     end
     filters << { version: { operator: "=", values: [version.id] } }
 
-    JSON.dump(filters)
+    filters # return as an array, not JSON string
   end
 end

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -54,11 +54,13 @@ module WorkPackagesFilterHelper
     filters = [
       filter_object("version_id", "=", version.id)
     ]
-    if version.systemwide? || %w[hierarchy tree].include?(version.sharing)
+
+    unless version.sharing == "none"
       # include all projects that share this version
       project_ids = version.projects.visible.ids
       filters << filter_object("project_id", "=", project_ids) unless project_ids.empty?
     end
+
     query = { f: filters }
     project_work_packages_with_query_path(version.project, query, options)
   end

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -51,11 +51,15 @@ module WorkPackagesFilterHelper
   end
 
   def project_work_packages_version_path(version, options = {})
-    query = {
-      f: [
-        filter_object("version_id", "=", version.id)
-      ]
-    }
+    filters = [
+      filter_object("version_id", "=", version.id)
+    ]
+    if version.systemwide? || %w[hierarchy tree].include?(version.sharing)
+      # include all projects that share this version
+      project_ids = version.projects.visible.ids
+      filters << filter_object("project_id", "=", project_ids) unless project_ids.empty?
+    end
+    query = { f: filters }
     project_work_packages_with_query_path(version.project, query, options)
   end
 

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -50,6 +50,15 @@ module WorkPackagesFilterHelper
     project_work_packages_with_query_path(version.project, query, options)
   end
 
+  def project_work_packages_version_path(version, options = {})
+    query = {
+      f: [
+        filter_object("version_id", "=", version.id)
+      ]
+    }
+    project_work_packages_with_query_path(version.project, query, options)
+  end
+
   def project_work_packages_shared_with_path(principal, project, options = {})
     query = {
       f: [

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -88,61 +88,16 @@ See COPYRIGHT and LICENSE files for more details.
   end
 %>
 
-<div class="widget-boxes -grid">
-  <div class="widget-box -thin">
-    <%= render partial: "versions/overview", locals: { version: @version } %>
-  </div>
-
-  <% if @version.estimated_hours > 0 || User.current.allowed_in_project?(:view_time_entries, @project) %>
-    <div class="widget-box -thin">
-      <fieldset class="form--fieldset">
-        <legend class="form--fieldset-legend"><%= t(:label_estimates_and_progress) %></legend>
-        <table>
-          <tr>
-            <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
-            <td width="240px" class="total-hours" align="right"><%= l_hours(@version.estimated_hours) %></td>
-          </tr>
-          <% if User.current.allowed_in_project?(:view_time_entries, @project) %>
-            <tr>
-              <td width="130px" align="right"><%= t(:label_spent_time) %></td>
-              <td width="240px" class="total-hours" align="right"><%= l_hours(@version.spent_hours) %></td>
-            </tr>
-          <% end %>
-        </table>
-      </fieldset>
-    </div>
-  <% end %>
-
+<%= render(Grids::WidgetGridComponent.new) do |grid| %>
+  <% grid.with_widget(Projects::Settings::Versions::OverviewWidgetComponent, version: @version) %>
+  <% grid.with_widget(Projects::Settings::Versions::ProgressWidgetComponent, version: @version, project: @project) %>
   <% if @version.wiki_page %>
-    <div class="widget-box -thin -wider">
-      <%= render(partial: "wiki/text", locals: { page: @version.wiki_page }) if @version.wiki_page %>
-    </div>
+    <% grid.with_widget(Projects::Settings::Versions::WikiWidgetComponent, version: @version) %>
   <% end %>
-
   <% if @issues.present? %>
-    <div class="widget-box -thin -wider">
-      <% if @issues.present? %>
-        <fieldset class="form--fieldset related_issues">
-          <legend class="form--fieldset-legend"><%= t(:label_related_work_packages) %></legend>
-          <ul>
-            <% @issues.each do |issue| -%>
-              <li><%= link_to_work_package(issue, project: issue.project != @version.project) %></li>
-            <% end -%>
-          </ul>
-        </fieldset>
-      <% end %>
-    </div>
+    <% grid.with_widget(Projects::Settings::Versions::RelatedIssuesWidgetComponent, version: @version, issues: @issues) %>
   <% end %>
-
-  <% if @version.work_packages.count > 0 %>
-    <div class="widget-box -thin -wider">
-      <opce-wp-overview-graph
-        global-scope='<%= @version.systemwide? %>'
-        initial-filters='<%= version_wp_overview_graph_initial_filters(@version) %>'>
-      </opce-wp-overview-graph>
-    </div>
-  <% end %>
-</div>
+<% end %>
 <%= call_hook :view_versions_show_bottom, version: @version %>
 
 <% html_title h(@version.name) %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -97,6 +97,9 @@ See COPYRIGHT and LICENSE files for more details.
   <% if @issues.present? %>
     <% grid.with_widget(Projects::Settings::Versions::RelatedIssuesWidgetComponent, version: @version, issues: @issues) %>
   <% end %>
+  <% if @version.work_packages.any? %>
+    <% grid.with_widget(Projects::Settings::Versions::WorkPackagesGraphWidgetComponent, version: @version) %>
+  <% end %>
 <% end %>
 <%= call_hook :view_versions_show_bottom, version: @version %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -566,6 +566,7 @@ en:
         no_results_title_text: There are currently no versions for the project.
         no_results_content_text: Create a new version
         work_packages_graph: Work packages graph
+        show_work_packages: Show work packages
       storage:
         no_results_title_text: There is no additional recorded disk space consumed by this project.
       work_package_priorities:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -565,6 +565,7 @@ en:
       versions:
         no_results_title_text: There are currently no versions for the project.
         no_results_content_text: Create a new version
+        work_packages_graph: Work packages graph
       storage:
         no_results_title_text: There is no additional recorded disk space consumed by this project.
       work_package_priorities:

--- a/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.component.ts
@@ -69,9 +69,20 @@ export class WorkPackageOverviewGraphComponent implements OnInit {
 
   ngOnInit() {
     const element = this.elementRef.nativeElement;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this.initialFilters = JSON.parse(element.getAttribute('initial-filters') || 'null');
-    this.globalScope = element.getAttribute('global-scope') === 'true';
+
+    const initialFiltersAttr =
+      element.getAttribute('initial-filters') ??
+      element.getAttribute('data-initial-filters');
+
+    this.initialFilters = initialFiltersAttr
+      ? (JSON.parse(initialFiltersAttr) as [])
+      : null;
+
+    const globalScopeAttr =
+      element.getAttribute('global-scope') ??
+      element.getAttribute('data-global-scope');
+
+    this.globalScope = globalScopeAttr === 'true';
 
     this.setQueryProps();
   }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68352

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Use widget component for showing components
