### PR TITLE
Add rake db:seed:performance

### DIFF
--- a/app/seeders/composite_seeder.rb
+++ b/app/seeders/composite_seeder.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 class CompositeSeeder < Seeder
   def seed_data!
-    ActiveRecord::Base.transaction do
+    maybe_transactional do
       seed_with(data_seeders)
 
       if discovered_seeders.any?
@@ -72,6 +72,16 @@ class CompositeSeeder < Seeder
 
   def namespace
     raise NotImplementedError, "has to be implemented by subclasses"
+  end
+
+  def maybe_transactional(&block)
+    return block.call unless run_in_transaction?
+
+    ActiveRecord::Base.transaction(&block)
+  end
+
+  def run_in_transaction?
+    true
   end
 
   ##

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -109,7 +109,7 @@ module DemoData
         author: admin_user,
         assigned_to: find_principal(attributes["assigned_to"]),
         subject: attributes["subject"],
-        description: attributes["description"],
+        description: attributes["description"] || "",
         status: find_status(attributes),
         type: find_type(attributes),
         priority: IssuePriority.default,

--- a/app/seeders/performance_data/projects_seeder.rb
+++ b/app/seeders/performance_data/projects_seeder.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+module PerformanceData
+  class ProjectsSeeder < Seeder
+    TARGET_PROJECT_COUNT = 2_000
+    MEMBERS_PER_PROJECT = 20
+
+    # How many times the work packages configured via YAML are going to be seeded into each project
+    WORK_PACKAGE_MULTIPLIER = 10
+
+    def seed_data!
+      print_status " ↳ Creating performance projects..."
+      create_projects
+    end
+
+    def applicable?
+      Project.count < TARGET_PROJECT_COUNT
+    end
+
+    def create_projects
+      project_indexes.each do |index|
+        ActiveRecord::Base.transaction do
+          project = Project.new(project_data(index))
+
+          project.save!
+
+          seed_members(project)
+          seed_versions(project)
+          seed_work_packages(project)
+        end
+      end
+    end
+
+    def project_indexes
+      (Project.count + 1)..TARGET_PROJECT_COUNT
+    end
+
+    def project_data(index)
+      create_progress = index.to_f / TARGET_PROJECT_COUNT
+      active_chance = create_progress < 0.5 ? 0 : 100 * (create_progress**2)
+
+      {
+        active: chance?(active_chance),
+        name: "[perf] Project ##{index}",
+        identifier: "mass-project-#{index}",
+        enabled_module_names: project_modules,
+        types: Type.all,
+        workspace_type: Project.workspace_types[:project],
+        work_package_custom_field_ids: custom_field_ids
+      }
+    end
+
+    def seed_members(project)
+      @user_ids ||= User.not_builtin.pluck(:id)
+
+      admin_seeded = false
+      @user_ids.sample(MEMBERS_PER_PROJECT).each do |id|
+        role_name = if !admin_seeded || chance?(10)
+                      admin_seeded = true
+                      :default_role_project_admin
+                    elsif chance?(70)
+                      :default_role_member
+                    else
+                      :default_role_reader
+                    end
+
+        role = seed_data.find_reference(role_name)
+
+        Member.create! project:, user_id: id, roles: [role]
+      end
+    end
+
+    def seed_versions(project)
+      version_data = seed_data.lookup("projects.scrum-project.versions")
+      return unless version_data.is_a? Array
+
+      version_data.each do |attributes|
+        project.versions.create!(
+          name: attributes["name"],
+          status: attributes["status"],
+          sharing: attributes["sharing"]
+        )
+      end
+    end
+
+    def seed_work_packages(project)
+      seeder = DemoData::WorkPackageSeeder.new(project, seed_data.lookup("performance_projects"))
+      WORK_PACKAGE_MULTIPLIER.times { seeder.seed! }
+    end
+
+    def custom_field_ids
+      @custom_field_ids ||= CustomField.where("name like 'CF DEV%'").pluck(:id)
+    end
+
+    def project_modules
+      Setting.default_projects_modules - %w(news wiki meetings calendar)
+    end
+
+    def chance?(percent)
+      rand < percent / 100.0
+    end
+  end
+end

--- a/app/seeders/performance_data/users_seeder.rb
+++ b/app/seeders/performance_data/users_seeder.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module PerformanceData
+  class UsersSeeder < Seeder
+    TARGET_USER_COUNT = 1000
+
+    def seed_data!
+      print_status "Seeding performance users ..."
+      user_names.each do |login|
+        user = new_user(login)
+        ActiveRecord::Base.transaction do
+          user.save!(validate: false)
+        end
+      end
+    end
+
+    def applicable?
+      !seed_users_disabled? && User.count < TARGET_USER_COUNT
+    end
+
+    def seed_users_disabled?
+      off_values = %w[off false no 0]
+
+      off_values.include? ENV.fetch("OP_DEV_USER_SEEDER_ENABLED", nil)
+    end
+
+    def user_names
+      ((User.count + 1)..TARGET_USER_COUNT).map { |i| "mass-user-#{i}" }
+    end
+
+    def not_applicable_message
+      msg = "Not seeding development users."
+      msg = "#{msg} seed users disabled through ENV" if seed_users_disabled?
+
+      msg
+    end
+
+    def new_user(login)
+      User.new.tap do |user|
+        user.login = login
+        user.password = login
+        user.firstname = login.humanize
+        user.lastname = "Performance user"
+        user.mail = "#{login}@example.net"
+        user.status = chance?(90) ? User.statuses[:active] : User.statuses[:locked]
+        user.language = chance?(50) ? "de" : "en"
+        user.force_password_change = false
+        user.notification_settings.build(assignee: true, responsible: true, mentioned: true, watched: true)
+      end
+    end
+
+    def chance?(percent)
+      rand < percent / 100.0
+    end
+  end
+end

--- a/app/seeders/performance_data_seeder.rb
+++ b/app/seeders/performance_data_seeder.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+class PerformanceDataSeeder < CompositeSeeder
+  def data_seeder_classes
+    [
+      PerformanceData::UsersSeeder,
+      PerformanceData::ProjectsSeeder
+    ]
+  end
+
+  def applicable?
+    PerformanceData::ProjectsSeeder.new.applicable?
+  end
+
+  def namespace
+    "PerformanceData"
+  end
+
+  # PerformanceData seeders take care of transactions themselves to allow for interrupts and restarts during seeding
+  def run_in_transaction?
+    false
+  end
+end

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -819,6 +819,51 @@ projects:
       * After Sprint Review, will be moderated by Scrum Master.
       * The team discusses the sprint: what went well, what needs to be improved to be more productive for the next sprint or even have more fun.
 
+performance_projects:
+  work_packages:
+  - t_subject: "Project kick-off"
+    status: :default_status_closed
+    type: :default_type_summary_task
+    children:
+    - t_subject: Staff project with members
+      type: :default_type_task
+      status: :default_status_closed
+    - t_subject: Define project scope
+      type: :default_type_task
+      status: :default_status_closed
+    - t_subject: Talk to relevant stakeholders
+      type: :default_type_task
+      status: :default_status_closed
+    - t_subject: Decide for a management method
+      type: :default_type_task
+      status: :default_status_closed
+    - t_subject: Have a kick-off meeting
+      type: :default_type_task
+      status: :default_status_closed
+  - t_subject: Organize awesome open source conference
+    status: :default_status_in_progress
+    type: :default_type_summary_task
+    duration: 15
+    schedule_manually: false
+    children:
+    - t_subject: Set date and location of conference
+      status: :default_status_in_progress
+      type: :default_type_task
+      duration: 4
+      schedule_manually: false
+      children:
+      - t_subject: Send invitation to speakers
+        status: :default_status_in_progress
+        type: :default_type_task
+      - t_subject: Contact sponsoring partners
+        status: :default_status_new
+        type: :default_type_task
+        duration: 2
+      - t_subject: Create sponsorship brochure and hand-outs
+        status: :default_status_new
+        type: :default_type_task
+        duration: 4
+
 statuses:
   - reference: :default_status_new
     t_name: New

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -50,5 +50,19 @@ namespace :db do
         raise ArgumentError, "No seeder with class name #{seeder_class_name}"
       end
     end
+
+    desc "Run performance data seeder. Long executions can be interrupted and still generate partial data."
+    task performance: :environment do
+      root_seeder = RootSeeder.new
+      root_seeder.seed!
+
+      # Running outside the root seeder context, so that it can take care of transactions on its own
+      # (thus allowing interrupts and restarts of the seeding)
+      begin
+        PerformanceDataSeeder.new(root_seeder.seed_data).seed!
+      rescue Interrupt
+        puts "Seeding interrupted. You can continue at a later point."
+      end
+    end
   end
 end


### PR DESCRIPTION
This is an extended seed task that seeds
many users, projects and work packages at the
end of the regular seeding.

Due to the extensive runtime of the seeder, it has been designed to be interruptible. This means it will commit changes more often to the database and every fully seeded project will be immediately available.

# Ticket
https://community.openproject.org/wp/68370