### PR TITLE
Allow connect-src to CDN For source maps

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -62,6 +62,9 @@ Rails.application.config.after_initialize do
       # Allow requests to CLI in dev mode
       connect_src = default_src + [OpenProject::Configuration.enterprise_trial_creation_host]
 
+      # Allow connections to asset host for source maps
+      connect_src << asset_host if asset_host.present?
+
       # Rules for media (e.g. video sources)
       media_src = default_src
       media_src << asset_host if asset_host.present?


### PR DESCRIPTION
Should fix source map CSP errors of the kind:

```
Refused to connect to 'https://cdn.aws-de-trials2.openproject.com/assets/frontend/polyfills-2A2EJ5YK.js.map' because it violates the following Content Security Policy directive: "connect-src 'self' saas-openproject-aws-de-trials2-20241119125120412800000002.s3.amazonaws.com saas-openproject-aws-de-trials2-20241119125120412800000002.s3.eu-central-1.amazonaws.com https://*.chargebee.com https://start.openproject.com saas-openproject-aws-de-trials2-20241119125120412800000002.s3-eu-central-1.amazonaws.com".
```