### PR TITLE
[68357] Derive ignore_non_working_days when switching to automatic scheduling

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -68,6 +68,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
       unify_milestone_dates
     else
       update_dates
+      update_ignore_non_working_days
     end
     shift_dates_to_soonest_working_days
     update_duration_to_one_day_for_milestones
@@ -300,6 +301,12 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
 
     work_package.due_date = new_due_date(min_start)
     work_package.start_date = min_start
+  end
+
+  def update_ignore_non_working_days
+    if work_package.schedule_automatically? && work_package.children.any?
+      work_package.ignore_non_working_days = work_package.children.any?(&:ignore_non_working_days)
+    end
   end
 
   def unify_milestone_dates

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -494,6 +494,7 @@ RSpec.describe "date inplace editor", :js, :selenium, with_settings: { date_form
           datepicker.expect_working_days_only true
 
           datepicker.toggle_working_days_only
+          datepicker.wait_for_preview_update
           datepicker.expect_working_days_only false
 
           # Reset "working days only" when switching back to automatic scheduling

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -468,8 +468,7 @@ RSpec.describe "date inplace editor", :js, :selenium, with_settings: { date_form
         wp_timeline.expect_timeline!
       end
 
-      context "when parent is not manually scheduled, child has workdays only set" do
-        let(:schedule_manually) { false }
+      context "and child has working days only set" do
         let!(:child) do
           create(:work_package,
                  project:,
@@ -486,17 +485,19 @@ RSpec.describe "date inplace editor", :js, :selenium, with_settings: { date_form
           datepicker.expect_working_days_only_disabled
           datepicker.expect_working_days_only true
 
-          # When toggling manually scheduled
-          start_date.toggle_scheduling_mode
-          datepicker.expect_working_days_only_enabled
-          datepicker.toggle_working_days_only
-          datepicker.expect_working_days_only false
-
+          # When switching to manually scheduled, "working days only" can be changed
+          datepicker.click_manual_scheduling_mode
           expect(page).to have_css(test_selector("op-modal-banner-warning").to_s,
                                    text: "Manually scheduled. Dates not affected by relations.\nThis has child work packages but their start dates are ignored.")
 
-          # Reset when disabled
-          start_date.toggle_scheduling_mode
+          datepicker.expect_working_days_only_enabled
+          datepicker.expect_working_days_only true
+
+          datepicker.toggle_working_days_only
+          datepicker.expect_working_days_only false
+
+          # Reset "working days only" when switching back to automatic scheduling
+          datepicker.click_automatic_scheduling_mode
           datepicker.expect_working_days_only_disabled
           datepicker.expect_working_days_only true
 

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -2164,7 +2164,6 @@ RSpec.describe WorkPackages::SetAttributesService,
              due_date: child_due_date)
     end
     let(:call_attributes) { { schedule_manually: false } }
-    let(:expected_attributes) { {} }
 
     context "when the child has dates" do
       let(:child_start_date) { Time.zone.today + 2.days }
@@ -2175,6 +2174,108 @@ RSpec.describe WorkPackages::SetAttributesService,
           {
             start_date: child_start_date,
             due_date: child_due_date
+          }
+        end
+      end
+    end
+  end
+
+  describe "ignore_non_working_days when switching back to automatic scheduling" do
+    shared_let(:project) { create(:project) }
+    let!(:work_package) do
+      create(:work_package,
+             subject: "work_package",
+             project:,
+             ignore_non_working_days:,
+             schedule_manually: true)
+    end
+    let(:call_attributes) { { schedule_manually: false } }
+
+    context "without any children" do
+      context "when ignoring non working days" do
+        let(:ignore_non_working_days) { true }
+
+        include_examples "service call", description: "keeps its ignore non-working days value" do
+          let(:expected_attributes) do
+            {
+              ignore_non_working_days: true
+            }
+          end
+        end
+      end
+
+      context "when not ignoring non working days" do
+        let(:ignore_non_working_days) { false }
+
+        include_examples "service call", description: "keeps its ignore non-working days value" do
+          let(:expected_attributes) do
+            {
+              ignore_non_working_days: false
+            }
+          end
+        end
+      end
+    end
+
+    context "with one child ignoring non working days" do
+      let(:ignore_non_working_days) { false }
+      let!(:child) do
+        create(:work_package,
+               subject: "child",
+               project:,
+               parent: work_package,
+               ignore_non_working_days: true)
+      end
+
+      include_examples "service call", description: "sets the parent to ignore non-working days" do
+        let(:expected_attributes) do
+          {
+            ignore_non_working_days: true
+          }
+        end
+      end
+    end
+
+    context "with one child not ignoring non working days" do
+      let(:ignore_non_working_days) { true }
+      let!(:child) do
+        create(:work_package,
+               subject: "child",
+               project:,
+               parent: work_package,
+               ignore_non_working_days: false)
+      end
+
+      include_examples "service call", description: "sets the parent to not ignore non-working days" do
+        let(:expected_attributes) do
+          {
+            ignore_non_working_days: false
+          }
+        end
+      end
+    end
+
+    context "with two children: one ignoring and the other not ignoring non working days" do
+      let(:ignore_non_working_days) { false }
+      let!(:child1) do
+        create(:work_package,
+               subject: "child",
+               project:,
+               parent: work_package,
+               ignore_non_working_days: false)
+      end
+      let!(:child2) do
+        create(:work_package,
+               subject: "child",
+               project:,
+               parent: work_package,
+               ignore_non_working_days: true)
+      end
+
+      include_examples "service call", description: "sets the parent to ignore non-working days" do
+        let(:expected_attributes) do
+          {
+            ignore_non_working_days: true
           }
         end
       end

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1387,6 +1387,65 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
         TABLE
       end
     end
+
+    context "when the work package has working days only and the child has not" do
+      let_work_packages(<<~TABLE)
+        | hierarchy    | scheduling mode | days counting
+        | work_package | manual          | working days only
+        |   child      | manual          | all days
+      TABLE
+
+      it "unsets working days only for the parent" do
+        expect(subject).to be_success
+        expect(subject.all_results.pluck(:subject)).to contain_exactly("work_package")
+
+        expect_work_packages_after_reload([work_package, child], <<~TABLE)
+          | hierarchy    | scheduling mode | days counting
+          | work_package | automatic       | all days
+          |   child      | manual          | all days
+        TABLE
+      end
+    end
+
+    context "when the work package has not working days only and the child has" do
+      let_work_packages(<<~TABLE)
+        | hierarchy    | scheduling mode | days counting
+        | work_package | manual          | all days
+        |   child      | manual          | working days only
+      TABLE
+
+      it "sets working days only for the parent" do
+        expect(subject).to be_success
+        expect(subject.all_results.pluck(:subject)).to contain_exactly("work_package")
+
+        expect_work_packages_after_reload([work_package, child], <<~TABLE)
+          | hierarchy    | scheduling mode | days counting
+          | work_package | automatic       | working days only
+          |   child      | manual          | working days only
+        TABLE
+      end
+    end
+
+    context "when the work package has working days only and one of the children has not" do
+      let_work_packages(<<~TABLE)
+        | hierarchy    | scheduling mode | days counting
+        | work_package | manual          | working days only
+        |   child1     | manual          | working days only
+        |   child2     | manual          | all days
+      TABLE
+
+      it "unsets working days only for the parent" do
+        expect(subject).to be_success
+        expect(subject.all_results.pluck(:subject)).to contain_exactly("work_package")
+
+        expect_work_packages_after_reload([work_package, child1, child2], <<~TABLE)
+          | hierarchy    | scheduling mode | days counting
+          | work_package | automatic       | all days
+          |   child1     | manual          | working days only
+          |   child2     | manual          | all days
+        TABLE
+      end
+    end
   end
 
   context "when setting dates" do

--- a/spec/support/components/datepicker/work_package_datepicker.rb
+++ b/spec/support/components/datepicker/work_package_datepicker.rb
@@ -230,6 +230,19 @@ module Components
       set_duration("")
     end
 
+    def wait_for_preview_update
+      # we no visual clue that informs that the preview is in progress. With
+      # cuprite we can wait for the network idle, but otherwise we need to sleep
+      # an arbitrary amount of time.
+      if using_cuprite?
+        wait_for_network_idle
+      else
+        # TODO: find a better mechanism to wait for the preview to finish and
+        # update the datepicker values.
+        sleep 0.350
+      end
+    end
+
     private
 
     def save_button_label


### PR DESCRIPTION

# Ticket

https://community.openproject.org/wp/68357

# What are you trying to accomplish?

Initially, I wanted to fix a flaky spec, then I noticed that the behavior was incorrect: when a work package switches to automatic mode, the "Working days only" checkbox (the `ignore_non_working_days` value) was not updated at all. It was updated only when the children's value was changed.

## Screenshots

none

# What approach did you choose and why?

Implement the logic in `WorkPackages::SetAttributesService`: when a work package in automatic scheduling mode has children, its `ignore_non_working_days` value is set by the children's values:
- if at least one child has `ignore_non_working_days` `true`, then the parent has it `true`.
- if all children have `ignore_non_working_days` `false`, then the parent has it `false`.

And then finally fix that flaky spec

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
