### PR TITLE
[68380] Save 'Working days only' value upon work package creation

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -148,7 +148,7 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
       this.resource.startDate = startDate;
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    this.resource.includeNonWorkingDays = includeNonWorkingDays;
+    this.resource.ignoreNonWorkingDays = includeNonWorkingDays;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     this.resource.scheduleManually = scheduleManually;
 

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -385,6 +385,21 @@ RSpec.describe "new work package", :js do
       date_field.expect_value "no start date - no finish date"
     end
 
+    it "Keeps 'Working days only' value upon saving (Bug #68380)" do
+      create_work_package_globally(type_task, project.name)
+      expect(page).to have_selector(safeguard_selector, wait: 10)
+
+      datepicker = wp_page.edit_field(:combinedDate).click_to_open_datepicker
+
+      datepicker.uncheck_working_days_only
+      datepicker.save!
+
+      wp_page.save!
+      wp_page.expect_and_dismiss_toaster(message: "Successful creation.")
+
+      expect(WorkPackage.last).to have_attributes(ignore_non_working_days: true)
+    end
+
     context "with a project without type_bug" do
       let!(:project_without_bug) do
         create(:project, name: "Unrelated project", types: [type_task])

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -96,6 +96,7 @@ class DateEditField < EditField
 
   def click_to_open_datepicker
     input_element.click
+    datepicker
   end
 
   def active?


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68380

# What are you trying to accomplish?

Fix weird behavior happening when creating a work package with dates being on 2 non-working days. Error "Duration is larger than the interval between the start and the finish date." is displayed and prevents the creation.

This happens because the "Working days only" checkbox in the work package creation form is ignored.

## Screenshots

See ticket

# What approach did you choose and why?

This bug happened because we have to many different names for the same property:
- "Working days only" (UI)
- `ignoreNonWorkingDays` (frontend)
- `includeNonWorkingDays` (frontend)
- `ignore_non_working_days` (backend and database)

We used the wrong name at the wrong place, the `resource.ignoreNonWorkingDays` was never set, so it use the default value (`false`).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
