### PR TITLE
[OP-18075] Migrate ReportingWidgets to ViewComponent

### DIFF
--- a/frontend/src/global_styles/content/reporting/_index.sass
+++ b/frontend/src/global_styles/content/reporting/_index.sass
@@ -40,28 +40,6 @@
 #query_form fieldset.header_collapsible.collapsible
   padding-bottom: 10px
 
-
-// -------------------------- Save and Delete Reports --------------------------
-#save_as_form, #delete_form
-  z-index: 999
-
-// -------------------------- Buttons --------------------------
-.form--buttons.-with-button-form
-  position: relative
-
-.form--buttons.-with-button-form .button
-  margin-bottom: 0
-
-div.button_form
-  background-color: var(--body-background)
-  border: 1px solid var(--borderColor-default)
-  -moz-border-radius: 3px
-  border-radius: 3px
-  left: 100px
-  position: absolute
-  padding: 1.0rem
-  width: 400px
-
 // -------------------------- Filter --------------------------
 .filter
   -webkit-border-radius: 5px

--- a/frontend/src/stimulus/controllers/dynamic/reporting/page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/reporting/page.controller.ts
@@ -86,6 +86,9 @@ export default class PageController extends Controller {
   private controls!:IControls;
   private restoreQueryModule!:IRestoreQuery;
 
+  static targets = ['table'];
+  declare readonly tableTarget:HTMLTableElement;
+
   connect() {
     this.initializeReportingEngine();
     this.initializeFilters();
@@ -97,6 +100,24 @@ export default class PageController extends Controller {
 
   disconnect() {
     // Clean up event handlers if needed
+  }
+
+  tableTargetConnected(table:HTMLTableElement) {
+    jQuery(table)
+      .tablesorter({
+        sortList: [[0, 0]],
+        widgets: ['saveSort'],
+        widgetOptions: {
+          storage_storageType: 's',
+        },
+        textExtraction(node:HTMLElement) {
+          return node.getAttribute('raw-data');
+        },
+      });
+  }
+
+  tableTargetDisconnected(table:HTMLTableElement) {
+    jQuery(table).trigger('destroy', [false]);
   }
 
   // Called from data-action
@@ -202,20 +223,6 @@ export default class PageController extends Controller {
       nextDesc: I18n.t('js.sort.activate_dsc'),
       nextNone: I18n.t('js.sort.activate_no'),
     };
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    jQuery('#sortable-table')
-      .not('.tablesorter')
-      .tablesorter({
-        sortList: [[0, 0]],
-        widgets: ['saveSort'],
-        widgetOptions: {
-          storage_storageType: 's',
-        },
-        textExtraction(node:HTMLElement) {
-          return node.getAttribute('raw-data');
-        },
-      });
   }
 
   private fireEvent(element:HTMLElement, event:string) {

--- a/frontend/src/stimulus/controllers/dynamic/reporting/page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/reporting/page.controller.ts
@@ -72,12 +72,7 @@ interface IGroupBys {
 }
 
 interface IControls {
-  attach_settings_callback:(element:JQuery, callback:(response:string) => void) => void;
   clear_query:(e:Event) => void;
-  observe_click:(elementId:string, callback:(e:Event) => void) => void;
-  update_result_table:(response:string) => void;
-  toggle_delete_form:(e:Event) => void;
-  toggle_save_as_form:(e:Event) => void;
 }
 
 interface IRestoreQuery {
@@ -221,28 +216,6 @@ export default class PageController extends Controller {
           return node.getAttribute('raw-data');
         },
       });
-  }
-
-  private flash(string:string, type = 'error') {
-    const options = type === 'error'
-      ? { id: 'errorExplanation', class: 'errorExplanation' }
-      : { id: `flash_${type}`, class: `flash ${type}` };
-
-    jQuery(`#${options.id}`).remove();
-
-    const flashElement = jQuery('<div></div>')
-      .attr('id', options.id)
-      .attr('class', options.class)
-      .attr('tabindex', '0')
-      .attr('role', 'alert')
-      .html(string);
-
-    jQuery('#content').prepend(flashElement);
-    jQuery(`#${options.id}`).focus();
-  }
-
-  private clearFlash() {
-    jQuery('div[id^=flash]').remove();
   }
 
   private fireEvent(element:HTMLElement, event:string) {
@@ -491,7 +464,7 @@ export default class PageController extends Controller {
   }
 
   private setActiveState(selector:string, active:boolean) {
-    const input = document.querySelector(selector) as HTMLElement;
+    const input = document.querySelector<HTMLElement>(selector);
 
     if (!input) {
       return;
@@ -658,127 +631,26 @@ export default class PageController extends Controller {
 
   private initializeControls() {
     this.controls = {
-      attach_settings_callback: (element:JQuery, callback:(response:string) => void) => {
-        this.attachSettingsCallback(element, callback);
-      },
-
-      clear_query: (e:Event) => {
-        e.preventDefault();
+      clear_query: (_e) => {
         this.filters.clear();
         this.groupBys.clear();
       },
-
-      observe_click: (elementId:string, callback:(e:Event) => void) => {
-        const target = document.getElementById(elementId)!;
-        target?.addEventListener('click', callback);
-      },
-
-      update_result_table: (response:string) => {
-        jQuery('#result-table').html(response);
-        this.initTableSorter();
-      },
-
-      toggle_delete_form: (e:Event) => {
-        e.preventDefault();
-        const offset = jQuery('#query-icon-delete').offset()?.left || 0;
-        jQuery('#delete_form').css('left', `${offset}px`).toggle();
-      },
-
-      toggle_save_as_form: (e:Event) => {
-        e.preventDefault();
-        const offset = jQuery('#query-icon-save-as').offset()?.left || 0;
-        jQuery('#save_as_form').css('left', `${offset}px`).toggle();
-      },
     };
 
-    // Bind control events
-    if (jQuery('#query_saved_name').length) {
-      if (jQuery('#query_saved_name').attr('data-is_new')) {
-        if (jQuery('#query-icon-delete').length) {
-          this.controls.observe_click('query-icon-delete', this.controls.toggle_delete_form);
-          this.controls.observe_click('query-icon-delete-cancel', this.controls.toggle_delete_form);
-          jQuery('#delete_form').hide();
-        }
-
-        if (jQuery('#query-breadcrumb-save').length) {
-          this.controls.attach_settings_callback(jQuery('#query-breadcrumb-save'), this.controls.update_result_table);
-        }
-      }
-    }
-
-    this.controls.observe_click('query-icon-save-as', this.controls.toggle_save_as_form);
-    this.controls.observe_click('query-icon-save-as-cancel', this.controls.toggle_save_as_form);
-
-    jQuery('#save_as_form').hide();
-
-    this.controls.attach_settings_callback(jQuery('#query-icon-save-button'), (newLocation:string) => {
-      document.location.href = newLocation;
-    });
-
-    this.controls.attach_settings_callback(jQuery('#query-icon-apply-button'), this.controls.update_result_table);
-
-    this.controls.observe_click('query-link-clear', this.controls.clear_query);
-  }
-
-  private attachSettingsCallback(element:JQuery, callback:(response:string) => void) {
-    if (!element?.length) {
-      return;
-    }
-
-    const failureCallback = (error:unknown) => {
-      jQuery('#result-table').html('');
-      this.defaultFailureCallback(error);
-    };
-
-    element[0].addEventListener('click', (e:Event) => {
-      e.preventDefault();
-      const target = jQuery(e.target as HTMLElement).closest('[data-target]').attr('data-target');
-      this.sendSettingsData(target || '', callback, failureCallback);
-    });
-  }
-
-  private sendSettingsData(targetUrl:string, callback:(_result:string) => void, failureCallback?:(_error:unknown) => void) {
-    const errorCallback = failureCallback || this.defaultFailureCallback;
-    this.clearFlash();
-
-    void post(targetUrl, { body: this.serializeSettingsForm() })
-      .then((response) => {
-        if (response.unprocessableEntity) {
-          return response.text.then((errorText) => { throw new ValidationError(errorText); });
-        }
-        if (!response.ok) {
-          throw new FetchRequestError(response.statusCode);
-        }
-
-        return response.text;
-      })
-      .then(callback)
-      .catch(errorCallback);
-  }
-
-  private serializeSettingsForm() {
     const queryForm = document.querySelector<HTMLFormElement>('#query_form')!;
-    const formData = new FormData(queryForm);
-
-    ['rows', 'columns'].forEach((type) => {
-      Array.from(document.querySelectorAll<HTMLElement>(`#group-by--${type} .group-by--selected-element`))
-        .map((el) => el.dataset.groupBy)
-        .filter((value) => value !== undefined)
-        .forEach((value) => {
-          formData.append(`groups[${type}][]`, value);
-        });
+    queryForm.addEventListener('reset', this.controls.clear_query);
+    queryForm.addEventListener('formdata', ({ formData }) => {
+      // perform custom serialization of our "quirky" group widget
+      ['rows', 'columns'].forEach((type) => {
+        Array.from(queryForm.querySelectorAll<HTMLElement>(`#group-by--${type} .group-by--selected-element`))
+          .map((el) => el.dataset.groupBy)
+          .filter((value) => value !== undefined)
+          .forEach((value) => {
+            formData.append(`groups[${type}][]`, value);
+          });
+      });
     });
-
-    return formData;
   }
-
-  private defaultFailureCallback = (error:unknown) => {
-    if (error instanceof ValidationError) {
-      this.flash(error.message);
-    } else {
-      this.flash(window.I18n.t('js.reporting_engine.label_response_error'));
-    }
-  };
 
   private restoreQuery() {
     this.restoreQueryModule = {

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.html.erb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { render_widget Widget::Controls::QueryName, @query }
+    header.with_title { render Widget::Controls::QueryName.new(@query) }
     header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: :normal)
 
     if show_export_button?

--- a/modules/reporting/app/components/cost_reports/index_page_header_component.rb
+++ b/modules/reporting/app/components/cost_reports/index_page_header_component.rb
@@ -31,7 +31,6 @@
 module CostReports
   class IndexPageHeaderComponent < ApplicationComponent
     include ApplicationHelper
-    include Widget::ReportingWidget::RenderWidgetInstanceMethods
 
     def initialize(query:, project: nil)
       super

--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -40,6 +40,8 @@ class CostReportsController < ApplicationController
 
   Widget::Base.dont_cache!
 
+  include OpTurbo::ComponentStream
+
   before_action :check_cache
   before_action :load_all
   before_action :load_and_authorize_in_optional_project
@@ -76,11 +78,12 @@ class CostReportsController < ApplicationController
   end
 
   def index
-    table
-    return if performed?
-
     respond_to do |format|
       format.html { render_html }
+      format.turbo_stream do
+        update_via_turbo_stream(component: Widget::Table.new(@query))
+        render turbo_stream: turbo_streams
+      end
       format.xls { export(:xls) }
       format.pdf { export(:pdf) }
     end
@@ -112,14 +115,6 @@ class CostReportsController < ApplicationController
     end
   end
 
-  ##
-  # Render the report. Renders either the complete index or the table only
-  def table
-    if set_filter? && request.xhr?
-      self.response_body = render_widget(Widget::Table, @query)
-    end
-  end
-
   current_menu_item [:index, :show] do |controller|
     controller.menu_item_to_highlight_on_index
   end
@@ -134,8 +129,12 @@ class CostReportsController < ApplicationController
   def show
     if @query
       store_query
-      table
-      render action: "index", locals: { menu_name: project_or_global_menu } unless performed?
+
+      respond_to do |format|
+        format.html do
+          render action: "index", locals: { menu_name: project_or_global_menu }
+        end
+      end
     else
       raise ActiveRecord::RecordNotFound
     end
@@ -144,7 +143,8 @@ class CostReportsController < ApplicationController
   ##
   # Create a new saved query. Returns the redirect url to an XHR or redirects directly
   def create
-    @query.name = params[:query_name].presence || ::I18n.t(:label_default)
+    expected_params = params.expect(query: %i[name is_public])
+    @query.name = expected_params[:name] || ::I18n.t(:label_default)
     @query.public! if make_query_public?
     @query.send(:"#{user_key}=", current_user.id)
     @query.save!
@@ -152,11 +152,8 @@ class CostReportsController < ApplicationController
     redirect_params = { action: "show", id: @query.id }
     redirect_params[:project_id] = @project.identifier if @project
 
-    if request.xhr? # Update via AJAX - return url for redirect
-      render plain: url_for(**redirect_params)
-    else # Redirect to the new record
-      redirect_to **redirect_params
-    end
+    # Redirect to the new record
+    redirect_to(**redirect_params, status: :see_other)
   end
 
   ##
@@ -174,10 +171,16 @@ class CostReportsController < ApplicationController
     elsif set_filter? # apply
       prepare_query
     end
-    if request.xhr?
-      table
-    else
-      redirect_to action: "show", id: @query.id
+
+    respond_to do |format|
+      format.turbo_stream do
+        update_via_turbo_stream(component: Widget::Table.new(@query))
+        render turbo_stream: turbo_streams
+      end
+
+      format.html do
+        redirect_to action: "show", id: @query.id
+      end
     end
   end
 
@@ -197,14 +200,20 @@ class CostReportsController < ApplicationController
   # Rename a record and update its publicity. Redirects to the updated record or
   # renders the updated name on XHR
   def rename
-    @query.name = params[:query_name]
+    expected_params = params.expect(query: %i[name is_public])
+    @query.name = expected_params[:name]
     @query.public! if make_query_public?
     @query.save!
     store_query
-    if request.xhr?
-      render plain: @query.name
-    else
-      redirect_to action: "show", id: @query.id
+
+    respond_to do |format|
+      format.turbo_stream do
+        render plain: @query.name
+      end
+
+      format.html do
+        redirect_to action: "show", id: @query.id
+      end
     end
   end
 
@@ -222,9 +231,8 @@ class CostReportsController < ApplicationController
     filter = f_cls.new.tap do |f|
       f.values = JSON.parse(params[:values].tr("'", '"')) if params[:values].present? && params[:values]
     end
-    render_widget Widget::Filters::Option, filter, to: canvas = +"".html_safe
 
-    render html: canvas, layout: !request.xhr?
+    render Widget::Filters::Option.new(filter), layout: !request.xhr?
   end
 
   ##
@@ -586,7 +594,7 @@ class CostReportsController < ApplicationController
   end
 
   def make_query_public?
-    !!params[:query_is_public]
+    params.dig(:query, :is_public).to_i == 1
   end
 
   ##

--- a/modules/reporting/lib/widget/base.rb
+++ b/modules/reporting/lib/widget/base.rb
@@ -32,8 +32,7 @@ require "digest/sha1"
 
 module ::Widget
   class Base < Widget::ReportingWidget
-    attr_reader :engine, :output
-    attr_accessor :request
+    option :current_user, default: -> { User.current }
 
     ##
     # Deactivate caching for certain widgets. If called on Widget::Base,
@@ -48,37 +47,6 @@ module ::Widget
       @dont_cache or (self != Widget::Base && Widget::Base.dont_cache?)
     end
 
-    def initialize(query)
-      @subject = query
-      @engine = query.class
-      @options = {}
-    end
-
-    ##
-    # Write a string to the canvas.
-    def write(str)
-      @output ||= (+"").html_safe
-      @output << str
-      str
-    end
-
-    ##
-    # Render this widget. Abstract method. Needs to call #write at least once
-    def render
-      raise NotImplementedError, "#render is missing in my subclass #{self.class}"
-    end
-
-    ##
-    # Render this widget, passing options.
-    # Available options:
-    #   :to => canvas - The canvas (streaming or otherwise) to render to. Has to respond to #write
-    def render_with_options(options = {}, &)
-      set_canvas(options.delete(:to)) if options.has_key? :to
-      @options = options
-      render_with_cache(options, &)
-      @output
-    end
-
     def cache_key
       @cache_key ||= Digest::SHA1::hexdigest begin
         if subject.respond_to? :cache_key
@@ -91,12 +59,6 @@ module ::Widget
 
     def cached?
       cache? && Rails.cache.exist?(cache_key)
-    end
-
-    protected
-
-    def render_view_component(component, &)
-      component.render_in(controller.view_context, &)
     end
 
     private
@@ -114,12 +76,6 @@ module ::Widget
         render(&)
         Rails.cache.write(cache_key, @output) if cache?
       end
-    end
-
-    ##
-    # Set the canvas.
-    def set_canvas(canvas)
-      @output = canvas
     end
   end
 end

--- a/modules/reporting/lib/widget/controls.rb
+++ b/modules/reporting/lib/widget/controls.rb
@@ -27,7 +27,22 @@
 #++
 
 class Widget::Controls < Widget::Base
-  def cache_key
-    "#{super}#{@subject.new_record? ? 1 : 0}"
+  include Primer::AttributesHelper
+
+  param :subject
+  param :form, optional: true
+
+  def call
+    render(Primer::Alpha::StackItem.new) do
+      render_control
+    end
+  end
+
+  def render_control
+    raise NotImplementedError, "Control subclasses must implement this method."
+  end
+
+  def render_button(**, &)
+    render(Primer::Beta::Button.new(**), &)
   end
 end

--- a/modules/reporting/lib/widget/controls/apply.rb
+++ b/modules/reporting/lib/widget/controls/apply.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,11 +29,13 @@
 #++
 
 class Widget::Controls::Apply < Widget::Controls
-  def render
-    write link_to(I18n.t(:button_apply),
-                  "#",
-                  id: "query-icon-apply-button",
-                  class: "button -primary",
-                  "data-target": url_for(action: "index", set_filter: "1"))
+  def render_control
+    render_button(
+      scheme: :primary,
+      type: :submit,
+      id: "query-icon-apply-button"
+    ) do
+      I18n.t(:button_apply)
+    end
   end
 end

--- a/modules/reporting/lib/widget/controls/clear.rb
+++ b/modules/reporting/lib/widget/controls/clear.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,10 +29,15 @@
 #++
 
 class Widget::Controls::Clear < Widget::Controls
-  def render
-    write link_to(I18n.t(:button_clear),
-                  "#",
-                  id: "query-link-clear",
-                  class: "button icon-context icon-undo")
+  def render_control
+    render_button(
+      scheme: :invisible,
+      type: :reset,
+      id: "query-link-clear"
+    ) do |button|
+      button.with_leading_visual_icon(icon: :undo)
+
+      I18n.t(:button_clear)
+    end
   end
 end

--- a/modules/reporting/lib/widget/controls/delete.rb
+++ b/modules/reporting/lib/widget/controls/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,30 +29,68 @@
 #++
 
 class Widget::Controls::Delete < Widget::Controls
-  def render # rubocop:disable Metrics/AbcSize
-    return "" if @subject.new_record? or !@options[:can_delete]
+  DIALOG_ID = "delete_form"
+  private_constant :DIALOG_ID
 
-    button = link_to(I18n.t(:button_delete),
-                     "#",
-                     id: "query-icon-delete",
-                     class: "button icon-context icon-delete")
-    popup = content_tag :div, id: "delete_form", style: "display:none", class: "button_form" do
-      question = content_tag :p, I18n.t(:label_really_delete_question)
+  option :can_delete, default: -> { false }
 
-      url_opts = { id: @subject.id }
-      url_opts[request_forgery_protection_token] = form_authenticity_token # if protect_against_forgery?
-      opt1 = link_to I18n.t(:button_delete),
-                     url_for(url_opts),
-                     data: { turbo_method: :delete },
-                     class: "button -danger icon-context icon-delete"
-      opt2 = link_to I18n.t(:button_cancel),
-                     "#",
-                     id: "query-icon-delete-cancel",
-                     class: "button icon-context icon-cancel"
-      opt1 + opt2
+  def render_control
+    render_popup
+  end
 
-      question + opt1 + opt2
+  def render?
+    @subject.persisted? && can_delete
+  end
+
+  private
+
+  def render_popup
+    render(
+      Primer::Alpha::Dialog.new(
+        id: DIALOG_ID,
+        title: t(:label_really_delete_question),
+        subtitle: nil,
+        visually_hide_title: true,
+        classes: "DangerDialog",
+        role: "alertdialog"
+      )
+    ) do |dialog|
+      dialog.with_show_button(scheme: :invisible) do |button|
+        button.with_leading_visual_icon(icon: :trash)
+
+        I18n.t(:button_delete)
+      end
+
+      dialog.with_body do
+        render Primer::OpenProject::FeedbackMessage.new(
+          icon_arguments: { icon: :alert, color: :danger },
+          border: false
+        ) do |message|
+          message.with_heading(tag: :h2) { I18n.t(:label_really_delete_question) }
+        end
+      end
+
+      dialog.with_footer(show_divider: true) do
+        render_popup_buttons
+      end
     end
-    write(button + popup)
+  end
+
+  def render_popup_buttons
+    delete_button = render_button(
+      scheme: :danger,
+      type: :submit,
+      formaction: url_for(action: :destroy, id: @subject.id),
+      formmethod: :delete,
+      data: { submit_dialog_id: DIALOG_ID }
+    ) do
+      I18n.t(:button_delete)
+    end
+
+    cancel_button = render_button(data: { close_dialog_id: DIALOG_ID }) do
+      I18n.t(:button_cancel)
+    end
+
+    safe_join([cancel_button, delete_button])
   end
 end

--- a/modules/reporting/lib/widget/controls/query_name.rb
+++ b/modules/reporting/lib/widget/controls/query_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,19 +29,24 @@
 #++
 
 class Widget::Controls::QueryName < Widget::Controls
-  dont_cache! # The name might change, but the query stays the same...
+  def initialize(...)
+    super
 
-  def render
-    options = { id: "query_saved_name", "data-translations" => translations }
-    if @subject.new_record?
-      name = I18n.t(:label_new_report)
-      icon = ""
-    else
-      name = @subject.name
-      options["data-is_public"] = @subject.public?
-      options["data-is_new"] = @subject.new_record?
-    end
-    write(content_tag(:span, h(name), options) + icon.to_s)
+    @system_arguments = { id: "query_saved_name", data: { translations: } }
+    @name = if @subject.new_record?
+              I18n.t(:label_new_report)
+            else
+              @subject.name
+            end
+    @system_arguments[:data] = merge_data(
+      @system_arguments, {
+        data: { is_new: @subject.new_record? }
+      }
+    )
+  end
+
+  def call
+    render Primer::Beta::Text.new(**@system_arguments).with_content(@name)
   end
 
   def translations

--- a/modules/reporting/lib/widget/controls/save.rb
+++ b/modules/reporting/lib/widget/controls/save.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,13 +29,21 @@
 #++
 
 class Widget::Controls::Save < Widget::Controls
-  def render
-    return "" if @subject.new_record? or !@options[:can_save]
+  option :can_save, default: -> { false }
 
-    write link_to(I18n.t(:button_save),
-                  "#",
-                  id: "query-breadcrumb-save",
-                  class: "button icon-context icon-save",
-                  "data-target": url_for(action: :update, id: @subject.id, set_filter: "1", save_query: "1"))
+  def render_control
+    render_button(
+      type: :submit,
+      id: "query-breadcrumb-save",
+      formaction: url_for(action: :update, id: @subject.id, set_filter: "1", save_query: "1")
+    ) do |button|
+      button.with_leading_visual_icon(icon: :"op-save")
+
+      I18n.t(:button_save)
+    end
+  end
+
+  def render?
+    @subject.persisted? && can_save
   end
 end

--- a/modules/reporting/lib/widget/controls/save_as.rb
+++ b/modules/reporting/lib/widget/controls/save_as.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,82 +29,87 @@
 #++
 
 class Widget::Controls::SaveAs < Widget::Controls
-  def render
-    link_name =
-      if @subject.new_record?
-        I18n.t(:button_save)
-      else
-        I18n.t(:button_save_report_as)
+  DIALOG_ID = "save_as_form"
+  private_constant :DIALOG_ID
+
+  option :can_save_as, default: -> { false }
+  option :can_save_as_public, default: -> { false }
+
+  def render_control
+    concat(
+      render_button(
+        id: "query-icon-save-as",
+        data: { show_dialog_id: DIALOG_ID }
+      ) do |button|
+        button.with_leading_visual_icon(icon: :"op-save")
+
+        button_text
       end
-    button = link_to(link_name, "#", id: "query-icon-save-as", class: "button icon-context icon-save")
-    write(button + render_popup)
+    )
+
+    concat render_popup
   end
 
-  def cache_key
-    "#{super}#{@subject.name}"
+  def render?
+    can_save_as
   end
 
-  # rubocop:disable Metrics/AbcSize
+  private
+
+  def render_popup
+    render(Primer::Alpha::Dialog.new(id: DIALOG_ID, title: button_text)) do |dialog|
+      dialog.with_header(variant: :large)
+
+      dialog.with_body do
+        render_popup_form
+      end
+
+      dialog.with_footer(show_divider: true) do
+        render_popup_buttons
+      end
+    end
+  end
+
   def render_popup_form
-    name = content_tag :p,
-                       class: "form--field -required -wide-label" do
-      label_tag(:query_name,
-                class: "form--label -transparent") do
-        Query.human_attribute_name(:name)
-      end +
-        content_tag(:span,
-                    class: "form--field-container") do
-          content_tag(:span,
-                      class: "form--text-field-container") do
-            text_field_tag(:query_name,
-                           @subject.name,
-                           required: true)
-          end
-        end
-    end
-    if @options[:can_save_as_public]
-      box = content_tag :p, class: "form--field -wide-label" do
-        label_tag(:query_is_public,
-                  Query.human_attribute_name(:public),
-                  class: "form--label -transparent") +
-          content_tag(:span,
-                      class: "form--field-container") do
-            content_tag(:span,
-                        class: "form--check-box-container") do
-              check_box_tag(:query_is_public,
-                            1,
-                            false,
-                            class: "form--check-box")
-            end
-          end
+    can_save_as_public = self.can_save_as_public
+
+    render_inline_form(form) do |form|
+      form.text_field name: :name, label: Query.human_attribute_name(:name), required: true
+
+      if can_save_as_public
+        form.check_box name: :is_public, label: Query.human_attribute_name(:public)
       end
-      name + box
-    else
-      name
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def render_popup_buttons
     save_url_params = { action: "create", set_filter: "1" }
     save_url_params[:project_id] = @subject.project.id if @subject.project
 
-    save = link_to(I18n.t(:button_save),
-                   "#",
-                   id: "query-icon-save-button",
-                   class: "button -primary icon-context icon-save",
-                   "data-target": url_for(**save_url_params))
+    save_button = render_button(
+      scheme: :primary,
+      type: :submit,
+      id: "query-icon-save-button",
+      formaction: url_for(**save_url_params),
+      data: { submit_dialog_id: DIALOG_ID }
+    ) do |button|
+      button.with_leading_visual_icon(icon: :check)
 
-    cancel = link_to(I18n.t(:button_cancel),
-                     "#",
-                     id: "query-icon-save-as-cancel",
-                     class: "button icon-context icon-cancel")
-    save + cancel
+      I18n.t(:button_save)
+    end
+
+    cancel_button = render_button(data: { close_dialog_id: DIALOG_ID }) do
+      I18n.t(:button_cancel)
+    end
+
+    safe_join([cancel_button, save_button])
   end
 
-  def render_popup
-    content_tag :div, id: "save_as_form", class: "button_form", style: "display:none" do
-      render_popup_form + render_popup_buttons
+  def button_text
+    if @subject.new_record?
+      I18n.t(:button_save)
+    else
+      I18n.t(:button_save_report_as)
     end
   end
 end

--- a/modules/reporting/lib/widget/cost_types.rb
+++ b/modules/reporting/lib/widget/cost_types.rb
@@ -27,31 +27,23 @@
 #++
 
 class Widget::CostTypes < Widget::Base
-  def render_with_options(options, &)
-    @cost_types = options.delete(:cost_types)
-    @selected_type_id = options.delete(:selected_type_id)
+  param :subject, reader: false
 
-    super
-  end
+  option :selected_type_id, optional: true
 
-  def render
-    write contents
+  def call
+    contents
   end
 
   def contents
     content_tag :div do
-      tabs = available_cost_type_tabs(@subject).sort_by { |id, _| id }.map do |id, label|
-        content_tag :div, class: "form--field -trailing-label" do
-          types = label_tag "unit_#{id}", h(label), class: "form--label"
-          types += content_tag :span, class: "form--field-container" do
-            content_tag :span, class: "form--radio-button-container" do
-              radio_button_tag("unit", id, id == @selected_type_id, class: "form--radio-button")
-            end
-          end
+      render(Primer::Alpha::RadioButtonGroup.new(name: "unit")) do |component|
+        available_cost_type_tabs(@subject)
+          .sort_by { |id, _| id }
+          .map do |id, label|
+          component.radio_button(label:, value: id, checked: id == @selected_type_id)
         end
       end
-
-      safe_join(tabs)
     end
   end
 end

--- a/modules/reporting/lib/widget/filters.rb
+++ b/modules/reporting/lib/widget/filters.rb
@@ -28,7 +28,17 @@
 
 # rubocop:disable Metrics/AbcSize
 class Widget::Filters < Widget::Base
-  def render
+  param :subject, reader: false
+
+  attr_reader :engine
+
+  def initialize(...)
+    super
+
+    @engine = @subject.class
+  end
+
+  def call
     spacer = content_tag :li, "", class: "advanced-filters--spacer hide-when-print"
 
     add_filter = content_tag :li, id: "add_filter_block", class: "advanced-filters--add-filter hide-when-print" do
@@ -60,7 +70,7 @@ class Widget::Filters < Widget::Base
       render_filters + spacer + add_filter
     end
 
-    write content_tag(:div, list)
+    content_tag(:div, list)
   end
 
   def selectables

--- a/modules/reporting/lib/widget/filters/base.rb
+++ b/modules/reporting/lib/widget/filters/base.rb
@@ -29,7 +29,7 @@
 class Widget::Filters::Base < Widget::Base
   attr_reader :filter, :filter_class
 
-  def initialize(filter)
+  def initialize(filter, **)
     if filter.instance_of?(Class)
       @filter_class = filter
       @filter = filter.new
@@ -38,6 +38,16 @@ class Widget::Filters::Base < Widget::Base
       @filter_class = filter.class
     end
     @engine = filter.engine
+
+    super
+  end
+
+  def call
+    render_filter
+  end
+
+  def render_filter
+    raise NotImplementedError, "Filter subclasses must implement this method."
   end
 
   def expand_comma_separated_values!

--- a/modules/reporting/lib/widget/filters/date.rb
+++ b/modules/reporting/lib/widget/filters/date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,11 +31,11 @@
 class Widget::Filters::Date < Widget::Filters::Base
   include AngularHelper
 
-  def render # rubocop:disable Metrics/AbcSize
+  def render_filter # rubocop:disable Metrics/AbcSize
     name = "values[#{filter_class.underscore_name}][]"
     id_prefix = "#{filter_class.underscore_name}_"
 
-    write(content_tag(:span, class: "advanced-filters--filter-value -binary") do
+    content_tag(:span, class: "advanced-filters--filter-value -binary") do
       label1 = label_tag "#{id_prefix}arg_1_val",
                          value_label,
                          class: "sr-only"
@@ -78,7 +80,7 @@ class Widget::Filters::Date < Widget::Filters::Base
       end
 
       arg1 + arg2 + arg3
-    end)
+    end
   end
 
   def value_label

--- a/modules/reporting/lib/widget/filters/heavy.rb
+++ b/modules/reporting/lib/widget/filters/heavy.rb
@@ -34,7 +34,7 @@
 #        But well this is again one of those temporary solutions.
 class Widget::Filters::Heavy < Widget::Filters::Base
   # rubocop:disable Metrics/AbcSize
-  def render
+  def render_filter
     # TODO: sometimes filter.values is of the form [["3"]] and sometimes ["3"].
     #       (using cost reporting)
     #       this might be a bug - further research would be fine
@@ -57,7 +57,7 @@ class Widget::Filters::Heavy < Widget::Filters::Base
       box
     end
     alternate_text = safe_join(opts.map(&:first), ", ")
-    write(div + content_tag(:label, alternate_text))
+    div + content_tag(:label, alternate_text)
   end
 
   # rubocop:enable Metrics/AbcSize

--- a/modules/reporting/lib/widget/filters/multi_choice.rb
+++ b/modules/reporting/lib/widget/filters/multi_choice.rb
@@ -28,9 +28,9 @@
 
 class Widget::Filters::MultiChoice < Widget::Filters::Base
   # rubocop:disable Metrics/AbcSize
-  def render
+  def render_filter
     filter_name = filter_class.underscore_name
-    result = content_tag :div, id: "#{filter_name}_arg_1", class: "advanced-filters--filter-value" do
+    content_tag :div, id: "#{filter_name}_arg_1", class: "advanced-filters--filter-value" do
       choices = filter_class.available_values.each_with_index.map do |(label, value), i|
         opts = {
           type: "radio",
@@ -48,7 +48,6 @@ class Widget::Filters::MultiChoice < Widget::Filters::Base
       content_tag :div, safe_join(choices),
                   id: "#{filter_class.underscore_name}_arg_1_val"
     end
-    write result
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/modules/reporting/lib/widget/filters/multi_values.rb
+++ b/modules/reporting/lib/widget/filters/multi_values.rb
@@ -29,14 +29,16 @@
 #++
 
 class Widget::Filters::MultiValues < Widget::Filters::Base
-  def render # rubocop:disable Metrics/AbcSize
-    write(content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
+  option :lazy, optional: true
+
+  def render_filter # rubocop:disable Metrics/AbcSize
+    content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
       select_options = {
         "data-remote-url": url_for(action: "available_values"),
         "data-initially-selected": JSON::dump(Array(filter.values).flatten),
         style: "vertical-align: top;", # FIXME: Do CSS
         name: "values[#{filter_class.underscore_name}][]",
-        "data-loading": @options[:lazy] ? "ajax" : "",
+        "data-loading": @lazy ? "ajax" : "",
         id: "#{filter_class.underscore_name}_arg_1_val",
         class: "form--select filter-value",
         "data-filter-name": filter_class.underscore_name,
@@ -48,7 +50,7 @@ class Widget::Filters::MultiValues < Widget::Filters::Base
                         class: "sr-only"
 
       box = content_tag :select, select_options, id: "#{filter_class.underscore_name}_select_1" do
-        render_widget Widget::Filters::Option, filter, to: box_content unless @options[:lazy]
+        render_widget Widget::Filters::Option, filter, to: box_content unless @lazy
       end
       plus = content_tag :a,
                          href: "#",
@@ -67,6 +69,6 @@ class Widget::Filters::MultiValues < Widget::Filters::Base
       content_tag(:span, class: "inline-label") do
         label + box + plus
       end
-    end)
+    end
   end
 end

--- a/modules/reporting/lib/widget/filters/operators.rb
+++ b/modules/reporting/lib/widget/filters/operators.rb
@@ -28,8 +28,8 @@
 
 class Widget::Filters::Operators < Widget::Filters::Base
   # rubocop:disable Metrics/AbcSize
-  def render
-    write(content_tag(:div, class: "advanced-filters--filter-operator") do
+  def render_filter
+    content_tag(:div, class: "advanced-filters--filter-operator") do
       hide_select_box = filter_class.available_operators.count == 1 || filter_class.heavy?
       options = { class: "advanced-filters--select filters-select filter_operator",
                   id: "operators[#{filter_class.underscore_name}]",
@@ -40,10 +40,10 @@ class Widget::Filters::Operators < Widget::Filters::Base
 
       select_box = content_tag :select, options do
         operators = filter_class.available_operators.map do |o|
-          opts = { value: h(o.to_s), "data-arity": o.arity }
+          opts = { value: o.to_s, "data-arity": o.arity }
           opts.reverse_merge! "data-forced": o.forced if o.forced?
           opts[:selected] = "selected" if filter.operator.to_s == o.to_s
-          content_tag(:option, opts) { h(I18n.t(o.label)) }
+          content_tag(:option, opts) { I18n.t(o.label) }
         end
         safe_join(operators)
       end
@@ -57,7 +57,7 @@ class Widget::Filters::Operators < Widget::Filters::Base
         end
       end
       hide_select_box ? label1 + select_box + label : label1 + select_box
-    end)
+    end
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/modules/reporting/lib/widget/filters/option.rb
+++ b/modules/reporting/lib/widget/filters/option.rb
@@ -31,9 +31,11 @@
 # as it would appear in a filters available values. If given, it renders the
 # option-tags from the content array instead of the filters available values.
 class Widget::Filters::Option < Widget::Filters::Base
-  def render
-    options = content(@options[:content] || filter_class.available_values)
-    write safe_join(options)
+  option :content, optional: true
+
+  def render_filter
+    options = content(@content || filter_class.available_values)
+    safe_join(options)
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity

--- a/modules/reporting/lib/widget/filters/project.rb
+++ b/modules/reporting/lib/widget/filters/project.rb
@@ -29,8 +29,8 @@
 class Widget::Filters::Project < Widget::Filters::Base
   include AngularHelper
 
-  def render
-    write(content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
+  def render_filter
+    content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
       label = html_label
 
       selected_values = map_filter_values
@@ -49,7 +49,7 @@ class Widget::Filters::Project < Widget::Filters::Base
       content_tag(:span, class: "inline-label") do
         label + box
       end
-    end)
+    end
   end
 
   private

--- a/modules/reporting/lib/widget/filters/remove_button.rb
+++ b/modules/reporting/lib/widget/filters/remove_button.rb
@@ -29,7 +29,7 @@
 #++
 
 class Widget::Filters::RemoveButton < Widget::Filters::Base
-  def render
+  def render_filter
     hidden_field = tag :input,
                        id: "rm_#{filter_class.underscore_name}",
                        name: "fields[]", type: "hidden", value: ""
@@ -44,8 +44,8 @@ class Widget::Filters::RemoveButton < Widget::Filters::Base
       icon_wrapper("icon-close advanced-filters--remove-filter-icon", I18n.t(:description_remove_filter))
     end
 
-    write(content_tag(:div, hidden_field + button,
-                      id: "rm_box_#{filter_class.underscore_name}",
-                      class: "advanced-filters--remove-filter"))
+    content_tag(:div, hidden_field + button,
+                id: "rm_box_#{filter_class.underscore_name}",
+                class: "advanced-filters--remove-filter")
   end
 end

--- a/modules/reporting/lib/widget/filters/text_box.rb
+++ b/modules/reporting/lib/widget/filters/text_box.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,18 +29,18 @@
 #++
 
 class Widget::Filters::TextBox < Widget::Filters::Base
-  def render
+  def render_filter # rubocop:disable Metrics/AbcSize
     label = content_tag :label,
                         "#{h(filter_class.label)} #{I18n.t(:label_filter_value)}",
                         for: "#{filter_class.underscore_name}_arg_1_val",
                         class: "sr-only"
 
-    write(content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
+    content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
       label + text_field_tag("values[#{filter_class.underscore_name}]", "",
                              size: "6",
                              class: "advanced-filters--text-field",
                              id: "#{filter_class.underscore_name}_arg_1_val",
                              "data-filter-name": filter_class.underscore_name)
-    end)
+    end
   end
 end

--- a/modules/reporting/lib/widget/filters/user.rb
+++ b/modules/reporting/lib/widget/filters/user.rb
@@ -31,8 +31,8 @@
 class Widget::Filters::User < Widget::Filters::Base
   include AngularHelper
 
-  def render # rubocop:disable Metrics/AbcSize
-    write(content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
+  def render_filter # rubocop:disable Metrics/AbcSize
+    content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
       label = html_label
 
       selected_values = map_filter_values
@@ -60,7 +60,7 @@ class Widget::Filters::User < Widget::Filters::Base
       content_tag(:span, class: "inline-label") do
         label + box
       end
-    end)
+    end
   end
 
   private

--- a/modules/reporting/lib/widget/filters/work_package.rb
+++ b/modules/reporting/lib/widget/filters/work_package.rb
@@ -31,8 +31,8 @@
 class Widget::Filters::WorkPackage < Widget::Filters::Base
   include AngularHelper
 
-  def render
-    write(content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
+  def render_filter
+    content_tag(:div, id: "#{filter_class.underscore_name}_arg_1", class: "advanced-filters--filter-value") do
       label = html_label
 
       selected_values = map_filter_values
@@ -55,7 +55,7 @@ class Widget::Filters::WorkPackage < Widget::Filters::Base
       content_tag(:span, class: "inline-label") do
         label + box
       end
-    end)
+    end
   end
 
   private

--- a/modules/reporting/lib/widget/group_bys.rb
+++ b/modules/reporting/lib/widget/group_bys.rb
@@ -27,16 +27,35 @@
 #++
 
 class Widget::GroupBys < Widget::Base
+  param :subject, reader: false
+
+  attr_reader :engine
+
+  def initialize(...)
+    super
+
+    @engine = @subject.class
+  end
+
+  def call
+    content_tag(:div, id: "group-by--area", class: "autoscroll") do
+      out = "".html_safe
+      out << render_group("columns", @subject.group_bys(:column))
+      out << render_group("rows", @subject.group_bys(:row))
+      out
+    end
+  end
+
   # rubocop:disable Metrics/AbcSize
   def render_options(group_by_ary)
     options = group_by_ary.sort_by(&:label).map do |group_by|
       next unless group_by.selectable?
 
-      label_text = CGI::escapeHTML(h(group_by.label)).to_s
+      label_text = group_by.label
       option_tags = { value: group_by.underscore_name, "data-label": label_text }
-      option_tags[:title] = label_text if group_by.label.length > 40
+      option_tags[:title] = label_text if label_text.length > 40
       content_tag :option, option_tags do
-        h(truncate_single_line(group_by.label, length: 40))
+        truncate_single_line(label_text, length: 40)
       end
     end
 
@@ -45,7 +64,7 @@ class Widget::GroupBys < Widget::Base
 
   def render_group(type, initially_selected)
     initially_selected = initially_selected.map do |group_by|
-      [group_by.class.underscore_name, h(group_by.class.label)]
+      [group_by.class.underscore_name, group_by.class.label]
     end
 
     content_tag :fieldset do
@@ -82,7 +101,7 @@ class Widget::GroupBys < Widget::Base
             sort_by_options = engine::GroupBy.all_grouped.sort_by do |i18n_key, _group_by_ary|
               I18n.t(i18n_key)
             end.map do |i18n_key, group_by_ary| # rubocop:disable Style/MultilineBlockChain
-              content_tag :optgroup, label: h(I18n.t(i18n_key)) do
+              content_tag :optgroup, label: I18n.t(i18n_key) do
                 render_options group_by_ary
               end
             end
@@ -99,15 +118,5 @@ class Widget::GroupBys < Widget::Base
       legend + container
     end
   end
-
   # rubocop:enable Metrics/AbcSize
-
-  def render
-    write(content_tag(:div, id: "group-by--area", class: "autoscroll") do
-      out = "".html_safe
-      out << render_group("columns", @subject.group_bys(:column))
-      out << render_group("rows", @subject.group_bys(:row))
-      out
-    end)
-  end
 end

--- a/modules/reporting/lib/widget/reporting_widget.rb
+++ b/modules/reporting/lib/widget/reporting_widget.rb
@@ -26,49 +26,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::ReportingWidget < ActionView::Base
-  include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::AssetTagHelper
-  include ActionView::Helpers::FormTagHelper
-  include ActionView::Helpers::JavaScriptHelper
-  include ActionView::Helpers::OutputSafetyHelper
+class Widget::ReportingWidget < ViewComponent::Base
+  extend Dry::Initializer[undefined: false]
   include Rails.application.routes.url_helpers
   include ApplicationHelper
-  include AngularHelper
   include ReportingHelper
   include Redmine::I18n
 
-  attr_accessor :output_buffer, :controller, :config, :_content_for, :_routes, :subject
+  def render_widget(widget, *, to: nil, **, &)
+    instance = widget.new(*, **)
+    rendered = instance.render_in(self, &)
+    return rendered unless to
 
-  def self.new(subject)
-    super.tap do |o|
-      o.subject = subject
-    end
-  end
-
-  def current_language
-    ::I18n.locale
-  end
-
-  def protect_against_forgery?
-    false
-  end
-
-  def method_missing(name, *, &)
-    controller.send(name, *, &)
-  rescue NoMethodError
-    raise NoMethodError, "undefined method `#{name}' for #<#{self.class}:0x#{object_id}>"
+    to << rendered
+    to
   end
 
   module RenderWidgetInstanceMethods
-    def render_widget(widget, subject, options = {}, &)
-      i = widget.new(subject)
-      i.config = config
-      i._routes = _routes
-      i._content_for = @_content_for
-      i.controller = respond_to?(:controller) ? controller : self
-      i.request = request
-      i.render_with_options(options, &)
+    def render_widget(widget, *, **, &)
+      widget.new(*, **).render_in(self, &)
     end
   end
 end

--- a/modules/reporting/lib/widget/settings.rb
+++ b/modules/reporting/lib/widget/settings.rb
@@ -27,70 +27,80 @@
 #++
 
 class Widget::Settings < Widget::Base
-  dont_cache! # Settings may change due to permissions
+  param :subject, reader: false
+  option :cost_types, optional: true
+  option :selected_type_id, optional: true
+
+  delegate :allowed_in_report?, to: :controller
+
+  def call
+    primer_form_with(
+      model: @subject,
+      scope: :query,
+      id: "query_form",
+      url: url_for(action: "index", set_filter: "1"),
+      method: :post
+    ) do |f|
+      content_tag :div, id: "query_form_content" do
+        concat render_filter_settings
+        concat render_group_by_settings
+        concat render_cost_types_settings
+        concat render_controls_settings(f)
+      end
+    end
+  end
+
+  private
 
   def render_filter_settings
-    render_widget Widget::Settings::Fieldset, @subject,
-                  type: "filters" do
-      render_widget Widget::Filters, @subject
+    render Widget::Settings::Fieldset.new(@subject, type: "filters") do
+      render Widget::Filters.new(@subject)
     end
   end
 
   def render_group_by_settings
-    render_widget Widget::Settings::Fieldset, @subject,
-                  type: "group_by" do
-      render_widget Widget::GroupBys, @subject
+    render Widget::Settings::Fieldset.new(@subject, type: "group_by") do
+      render Widget::GroupBys.new(@subject)
     end
   end
 
   def render_cost_types_settings
-    render_widget Widget::Settings::Fieldset, @subject, type: "units" do
-      render_widget Widget::CostTypes,
-                    @cost_types,
-                    selected_type_id: @selected_type_id
+    render Widget::Settings::Fieldset.new(@subject, type: "units") do
+      render Widget::CostTypes.new(@cost_types, selected_type_id: @selected_type_id)
     end
   end
 
-  def render_controls_settings
-    content_tag :div, class: "form--buttons -with-button-form hide-when-print" do
-      widgets = "".html_safe
-      render_widget(Widget::Controls::Apply, @subject, to: widgets)
-      render_widget(Widget::Controls::Save, @subject, to: widgets,
-                                                      can_save: allowed_in_report?(:save, @subject, current_user))
-      if allowed_in_report?(:create, @subject, current_user)
-        render_widget(Widget::Controls::SaveAs, @subject, to: widgets,
-                                                          can_save_as_public: allowed_in_report?(:save_as_public, @subject, current_user))
-      end
-      render_widget(Widget::Controls::Clear, @subject, to: widgets)
-      render_widget(Widget::Controls::Delete, @subject, to: widgets,
-                                                        can_delete: allowed_in_report?(:destroy, @subject, current_user))
+  def render_controls_settings(form) # rubocop:disable Metrics/AbcSize
+    render(
+      Primer::Alpha::Stack.new(
+        gap: :condensed,
+        direction: :horizontal,
+        align: :start,
+        wrap: :wrap,
+        role: "toolbar",
+        style: "gap: 0.5rem" # override gap: :condensed
+      )
+    ) do
+      concat render(
+        Widget::Controls::Apply.new(@subject, form)
+      )
+      concat render(
+        Widget::Controls::Save.new(@subject, form, can_save: allowed_in_report?(:save, @subject, current_user))
+      )
+      concat render(
+        Widget::Controls::SaveAs.new(
+          @subject,
+          form,
+          can_save_as: allowed_in_report?(:create, @subject, current_user),
+          can_save_as_public: allowed_in_report?(:save_as_public, @subject, current_user)
+        )
+      )
+      concat render(
+        Widget::Controls::Clear.new(@subject, form)
+      )
+      concat render(
+        Widget::Controls::Delete.new(@subject, form, can_delete: allowed_in_report?(:destroy, @subject, current_user))
+      )
     end
-  end
-
-  def render
-    write(form_tag("#", id: "query_form", method: :post) do
-      content_tag :div, id: "query_form_content" do
-        # will render a setting menu for every setting.
-        # To add new settings, write a new instance method render_<a name>_setting
-        # and add <a name> to the @@settings_to_render list.
-        content = "".html_safe
-        settings_to_render.each do |setting_name|
-          render_method_name = "render_#{setting_name}_settings"
-          content << send(render_method_name) if respond_to? render_method_name
-        end
-        content
-      end
-    end)
-  end
-
-  def render_with_options(options, &)
-    @cost_types = options.delete(:cost_types)
-    @selected_type_id = options.delete(:selected_type_id)
-
-    super
-  end
-
-  def settings_to_render
-    @settings_to_render ||= %i[filter group_by cost_types controls]
   end
 end

--- a/modules/reporting/lib/widget/settings/fieldset.rb
+++ b/modules/reporting/lib/widget/settings/fieldset.rb
@@ -27,21 +27,19 @@
 #++
 
 class Widget::Settings::Fieldset < Widget::Base
-  dont_cache!
+  option :type, default: -> { "filter" }
 
-  def render_with_options(options, &)
-    @type = options.delete(:type) || "filter"
+  def initialize(...)
+    super
+
     @id = @type.to_s
     @label = :"label_#{@type}"
-    super
   end
 
-  def render(&)
-    write(
-      render_view_component Primer::OpenProject::CollapsibleSection.new(id: @id, display: :block, mb: 3) do |section|
-        section.with_title(tag: :h3) { I18n.t(@label) }
-        section.with_collapsible_content(&)
-      end
-    )
+  def call
+    render Primer::OpenProject::CollapsibleSection.new(id: @id, display: :block, mb: 3) do |section|
+      section.with_title(tag: :h3) { I18n.t(@label) }
+      section.with_collapsible_content { content }
+    end
   end
 end

--- a/modules/reporting/lib/widget/table.rb
+++ b/modules/reporting/lib/widget/table.rb
@@ -28,12 +28,18 @@
 
 class Widget::Table < Widget::Base
   extend Report::InheritedAttribute
+  include OpTurbo::Streamable
   include ReportingHelper
+
+  delegate :cost_type, :unit_id, to: :controller
 
   attr_accessor :fields, :mapping
 
-  def initialize(query)
-    raise ArgumentError, "Tables only work on CostQuery!" unless query.is_a? CostQuery
+  def initialize(subject, **options)
+    raise ArgumentError, "Tables only work on CostQuery!" unless subject.is_a? CostQuery
+
+    @subject = subject
+    @options = options
 
     super
   end
@@ -46,15 +52,17 @@ class Widget::Table < Widget::Base
     end
   end
 
-  def render
-    write("<!-- table start -->".html_safe)
-    if @subject.result.count <= 0
-      write(content_tag(:div, "", class: "generic-table--no-results-container") do
-        content_tag(:i, "", class: "icon-info1") +
-          content_tag(:span, I18n.t(:no_results_title_text), class: "generic-table--no-results-title")
-      end)
-    else
-      render_widget(resolve_table, @subject, @options.reverse_merge(to: @output))
+  def call
+    component_wrapper(tag: "turbo-frame") do
+      # concat("<!-- table start -->".html_safe)
+      if @subject.result.count <= 0
+        content_tag(:div, "", class: "generic-table--no-results-container") do
+          content_tag(:i, "", class: "icon-info1") +
+            content_tag(:span, I18n.t(:no_results_title_text), class: "generic-table--no-results-title")
+        end
+      else
+        render_widget(resolve_table, @subject, **@options)
+      end
     end
   end
 end

--- a/modules/reporting/lib/widget/table/entry_table.rb
+++ b/modules/reporting/lib/widget/table/entry_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,12 +29,12 @@
 #++
 
 class Widget::Table::EntryTable < Widget::Table
-  include ReportingHelper
+  include AngularHelper
 
   FIELDS = %i[user_id activity_id entity_gid comments logged_by_id project_id].freeze
 
-  def render
-    content = content_tag :div, class: "generic-table--container -with-footer" do
+  def call
+    content_tag :div, class: "generic-table--container -with-footer" do
       content_tag :div, class: "generic-table--results-container" do
         table = content_tag :table, class: "generic-table",
                                     id: "sortable-table" do
@@ -44,7 +46,6 @@ class Widget::Table::EntryTable < Widget::Table
         table
       end
     end
-    write content
   end
 
   def colgroup

--- a/modules/reporting/lib/widget/table/entry_table.rb
+++ b/modules/reporting/lib/widget/table/entry_table.rb
@@ -37,7 +37,8 @@ class Widget::Table::EntryTable < Widget::Table
     content_tag :div, class: "generic-table--container -with-footer" do
       content_tag :div, class: "generic-table--results-container" do
         table = content_tag :table, class: "generic-table",
-                                    id: "sortable-table" do
+                                    id: "sortable-table",
+                                    data: { reporting__page_target: "table" } do
           concat colgroup
           concat head
           concat foot

--- a/modules/reporting/lib/widget/table/report_table.rb
+++ b/modules/reporting/lib/widget/table/report_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -71,18 +73,18 @@ class Widget::Table::ReportTable < Widget::Table
   end
   # rubocop:enable Metrics/AbcSize
 
-  def render
+  def call
     configure_query
     configure_walker
-    write "<table class='report'>".html_safe
+    concat "<table class='report'>".html_safe
     render_thead
     render_tfoot
     render_tbody
-    write "</table>".html_safe
+    concat "</table>".html_safe
   end
 
   def render_tbody
-    write "<tbody>".html_safe
+    concat "<tbody>".html_safe
     first = true
     odd = true
     walker.body do |line|
@@ -91,10 +93,10 @@ class Widget::Table::ReportTable < Widget::Table
         first = false
       end
       line = mark_penultimate_column(line)
-      write content_tag(:tr, line, class: odd ? "odd" : "even")
+      concat content_tag(:tr, line, class: odd ? "odd" : "even")
       odd = !odd
     end
-    write "</tbody>".html_safe
+    concat "</tbody>".html_safe
   end
 
   def mark_penultimate_column(line)
@@ -108,57 +110,59 @@ class Widget::Table::ReportTable < Widget::Table
     walker.headers
     return if walker.headers_empty?
 
-    write "<thead>".html_safe
+    concat "<thead>".html_safe
     walker.headers do |list, first, first_in_col, last_in_col|
-      write "<tr>".html_safe if first_in_col
+      concat "<tr>".html_safe if first_in_col
       if first
-        write(content_tag(:th, "", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)))
+        concat(content_tag(:th, "", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)))
       end
       list.each do |column|
         opts = { colspan: column.final_number(:column) }
         opts[:class] = "inner" if column.final?(:column)
-        write(content_tag(:th, opts) do
+        concat(content_tag(:th, opts) do
           show_row column
         end)
       end
       if first
-        write(content_tag(:th, "", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)))
+        concat(content_tag(:th, "", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row)))
       end
-      write "</tr>".html_safe if last_in_col
+      concat "</tr>".html_safe if last_in_col
     end
-    write "</thead>".html_safe
+    concat "</thead>".html_safe
   end
 
   def render_tfoot
     return if walker.headers_empty?
 
-    write "<tfoot>".html_safe
+    concat "<tfoot>".html_safe
     walker.reverse_headers do |list, first, first_in_col, last_in_col|
       if first_in_col
-        write "<tr>".html_safe
+        concat "<tr>".html_safe
         if first
-          write(content_tag(:th, " ", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row), class: "top"))
+          concat(content_tag(:th, " ", rowspan: @subject.depth_of(:column), colspan: @subject.depth_of(:row), class: "top"))
         end
       end
 
       list.each do |column|
         opts = { colspan: column.final_number(:column) }
         opts[:class] = "inner" if first
-        write(content_tag(:th, show_result(column), opts))
+        concat(content_tag(:th, show_result(column), opts))
       end
       if last_in_col
         if first
-          write(content_tag(:th,
-                            rowspan: @subject.depth_of(:column),
-                            colspan: @subject.depth_of(:row),
-                            class: "top result") do
-                  show_result @subject
-                end)
+          concat(
+            content_tag(:th,
+                        rowspan: @subject.depth_of(:column),
+                        colspan: @subject.depth_of(:row),
+                        class: "top result") do
+              show_result @subject
+            end
+          )
         end
-        write "</tr>".html_safe
+        concat "</tr>".html_safe
       end
     end
-    write "</tfoot>".html_safe
+    concat "</tfoot>".html_safe
   end
   # rubocop:enable Metrics/AbcSize
 end

--- a/modules/reporting/spec/features/custom_fields_spec.rb
+++ b/modules/reporting/spec/features/custom_fields_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Custom fields reporting", :js do
       expect(select).to have_css("option", text: "Second option")
       select.find("option", text: "Second option").select_option
 
-      click_link "Apply"
+      click_on "Apply"
 
       # Expect empty result table
       within("#result-table") do
@@ -127,7 +127,7 @@ RSpec.describe "Custom fields reporting", :js do
       select "List CF", from: "group-by--add-columns"
       select "Work package", from: "group-by--add-rows"
 
-      click_link "Apply"
+      click_on "Apply"
 
       # Expect row of work package
       within("#result-table") do
@@ -190,7 +190,7 @@ RSpec.describe "Custom fields reporting", :js do
         select "Work package", from: "group-by--add-rows"
 
         sleep(0.1)
-        click_link "Apply"
+        click_on "Apply"
 
         # Expect row of work package
         within("#result-table") do
@@ -223,7 +223,7 @@ RSpec.describe "Custom fields reporting", :js do
       select "Text CF", from: "group-by--add-columns"
       select "Work package", from: "group-by--add-rows"
 
-      click_link "Apply"
+      click_on "Apply"
 
       # Expect row of work package
       within("#result-table") do

--- a/modules/reporting/spec/features/date_filter_spec.rb
+++ b/modules/reporting/spec/features/date_filter_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Cost report date filter", :js do
 
     # 'Date (spent on)' filter is also selected by default
     select "today", from: "operators[spent_on]"
-    click_link "Apply"
+    click_on "Apply"
 
     expect(page).to have_content(today_time_entry.hours)
     expect(page).to have_content(today_time_entry.entity.subject)
@@ -64,7 +64,7 @@ RSpec.describe "Cost report date filter", :js do
 
     select "<=", from: "operators[spent_on]"
     fill_in "spent_on_arg_1_val", with: 4.days.ago.iso8601
-    click_link "Apply"
+    click_on "Apply"
 
     expect(page).to have_content(five_days_ago_time_entry.hours)
     expect(page).to have_content(five_days_ago_time_entry.entity.subject)
@@ -73,7 +73,7 @@ RSpec.describe "Cost report date filter", :js do
 
     select "during the last days", from: "operators[spent_on]"
     fill_in "spent_on_arg_1_integers_val", with: "5"
-    click_link "Apply"
+    click_on "Apply"
 
     expect(page).to have_content(five_days_ago_time_entry.hours)
     expect(page).to have_content(five_days_ago_time_entry.entity.subject)
@@ -83,7 +83,7 @@ RSpec.describe "Cost report date filter", :js do
 
     select ">=", from: "operators[spent_on]"
     fill_in "spent_on_arg_1_val", with: 4.days.from_now.iso8601
-    click_link "Apply"
+    click_on "Apply"
 
     expect(page).to have_content(five_days_from_now_time_entry.hours)
     expect(page).to have_content(five_days_from_now_time_entry.entity.subject)
@@ -93,7 +93,7 @@ RSpec.describe "Cost report date filter", :js do
     select "between", from: "operators[spent_on]"
     fill_in "spent_on_arg_1_val", with: 4.days.ago.iso8601
     fill_in "spent_on_arg_2_val", with: 4.days.from_now.iso8601
-    click_link "Apply"
+    click_on "Apply"
 
     expect(page).to have_content(today_time_entry.hours)
     expect(page).to have_content(today_time_entry.entity.subject)

--- a/modules/reporting/spec/lib/widget/controls/apply_spec.rb
+++ b/modules/reporting/spec/lib/widget/controls/apply_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Controls::Apply, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query)
+      end
     end
+  end
+
+  it "renders a button" do
+    expect(rendered_component).to have_button text: "Apply", type: "submit"
   end
 end

--- a/modules/reporting/spec/lib/widget/controls/clear_spec.rb
+++ b/modules/reporting/spec/lib/widget/controls/clear_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Controls::Clear, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query)
+      end
     end
+  end
+
+  it "renders a button" do
+    expect(rendered_component).to have_button text: "Clear", type: "reset"
   end
 end

--- a/modules/reporting/spec/lib/widget/controls/delete_spec.rb
+++ b/modules/reporting/spec/lib/widget/controls/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,35 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Controls::Delete, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query, **options)
+      end
+    end
+  end
+
+  context "when :can_delete is false (default)" do
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
+  end
+
+  context "when :can_delete is true" do
+    let(:options) { { can_delete: true } }
+
+    it "renders a button" do
+      expect(rendered_component).to have_button text: "Delete", type: "button"
     end
   end
 end

--- a/modules/reporting/spec/lib/widget/controls/query_name_spec.rb
+++ b/modules/reporting/spec/lib/widget/controls/query_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,34 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Controls::QueryName, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query)
+      end
+    end
+  end
+
+  context "when query is unsaved" do
+    let(:cost_query) { build(:public_cost_query, name: "My special report") }
+
+    it "renders text" do
+      expect(rendered_component).to have_primer_text "New cost report"
+    end
+  end
+
+  context "when query is saved" do
+    let(:cost_query) { build_stubbed(:public_cost_query, name: "My special report") }
+
+    it "renders text" do
+      expect(rendered_component).to have_primer_text "My special report"
     end
   end
 end

--- a/modules/reporting/spec/lib/widget/controls/save_as_spec.rb
+++ b/modules/reporting/spec/lib/widget/controls/save_as_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,41 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Controls::SaveAs, type: :component do
+  include ViewComponent::TestHelpers
+
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_in_view_context(described_class, cost_query, self) do |described_class, model, spec_context|
+          primer_form_with(model:, url: "") do |f|
+            render(described_class.new(model, f, **spec_context.options))
+          end
+        end
+      end
+    end
+  end
+
+  context "when :can_save_as is false (default)" do
+    it "does not render a button" do
+      expect(rendered_component).to have_no_button text: "Save"
+    end
+  end
+
+  context "when :can_save_as is true" do
+    let(:options) { { can_save_as: true } }
+
+    it "renders a button" do
+      expect(rendered_component).to have_button text: "Save", type: "button"
     end
   end
 end

--- a/modules/reporting/spec/lib/widget/controls/save_spec.rb
+++ b/modules/reporting/spec/lib/widget/controls/save_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,35 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Controls::Save, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query, **options)
+      end
+    end
+  end
+
+  context "when :can_save is false (default)" do
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
+  end
+
+  context "when :can_save is true" do
+    let(:options) { { can_save: true } }
+
+    it "renders a button" do
+      expect(rendered_component).to have_button text: "Save", type: "submit"
     end
   end
 end

--- a/modules/reporting/spec/lib/widget/cost_types_spec.rb
+++ b/modules/reporting/spec/lib/widget/cost_types_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::CostTypes, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_types) { create_list(:cost_type, 2).pluck(:id) }
+  let(:options) { { selected_type_id: cost_types.last } }
+
+  subject(:rendered_component) do
+    render_component(cost_types, **options)
+  end
+
+  it "renders radio group" do
+    expect(rendered_component).to have_element :fieldset, role: "radiogroup"
+  end
+
+  it "renders 1 checked radio button" do
+    expect(rendered_component).to have_checked_field count: 1
+  end
+
+  it "renders 2 unchecked radio buttons" do
+    expect(rendered_component).to have_unchecked_field count: 2
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/date_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::Date, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::DueDate.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "Finish date Value", class: "sr-only"
+  end
+
+  it "renders date picker" do
+    expect(rendered_component).to have_element "opce-basic-single-date-picker"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/heavy_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/heavy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Filters::Heavy, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::Tyear.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(filter, **options)
+      end
     end
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders empty select" do
+    expect(rendered_component).to have_select options: []
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/label_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/label_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::Label, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::Subject.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders label" do
+    expect(rendered_component).to have_element :label, text: "Subject", class: "advanced-filters--filter-name"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/multi_choice_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/multi_choice_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::MultiChoice, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::MultiChoice.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/multi_values_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/multi_values_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,33 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Filters::MultiValues, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::Tyear.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(filter, **options)
+      end
     end
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "Year (Spent) Value", class: "sr-only"
+  end
+
+  it "renders select" do
+    expect(rendered_component).to have_select "Year (Spent) Value", selected: [Time.zone.now.year.to_s]
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/operators_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/operators_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,39 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Filters::Operators, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::Subject.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-operator"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "Subject Operator", class: "sr-only"
+  end
+
+  context "with a string operators filter" do
+    it "renders select" do
+      expect(rendered_component).to have_select options: ["doesn't contain", "contains", "is", "is not"]
+    end
+  end
+
+  context "with a multi-choice filter" do
+    let(:filter) { CostQuery::Filter::MultiChoice.new }
+
+    it "renders hidden select" do
+      expect(rendered_component).to have_select options: ["is"], visible: :hidden
     end
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/option_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/option_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::Option, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::Tyear.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders options" do
+    expect(rendered_component).to have_element :option
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/project_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::Project, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::ProjectId.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "Project Value", class: "sr-only"
+  end
+
+  it "renders autocompleter" do
+    expect(rendered_component).to have_element "opce-project-autocompleter"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/remove_button_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/remove_button_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::RemoveButton, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::DueDate.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--remove-filter"
+  end
+
+  it "renders link" do
+    expect(rendered_component).to have_link "Remove filter"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/text_box_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/text_box_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::TextBox, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::Subject.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "Subject Value", class: "sr-only"
+  end
+
+  it "renders text input" do
+    expect(rendered_component).to have_field "Subject Value", class: "advanced-filters--text-field"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/user_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::User, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::UserId.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "User Value", class: "sr-only"
+  end
+
+  it "renders autocompleter" do
+    expect(rendered_component).to have_element "opce-user-autocompleter"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters/work_package_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters/work_package_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
-    end
+require "rails_helper"
+
+RSpec.describe Widget::Filters::WorkPackage, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:filter) { CostQuery::Filter::WorkPackageId.new }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(filter, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_css ".advanced-filters--filter-value"
+  end
+
+  it "renders label for accessibility" do
+    expect(rendered_component).to have_element :label, text: "Work package Value", class: "sr-only"
+  end
+
+  it "renders autocompleter" do
+    expect(rendered_component).to have_element "opce-autocompleter", class: "advanced-filters--ng-select"
   end
 end

--- a/modules/reporting/spec/lib/widget/filters_spec.rb
+++ b/modules/reporting/spec/lib/widget/filters_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Widget::Filters, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query, **options)
+      end
+    end
+  end
+
+  context "with no filters applied" do
+    it "renders no filters" do
+      expect(rendered_component).to have_list id: "filter_table" do |list|
+        expect(list).to have_list_item class: "advanced-filters--filter", count: 0
+        expect(list).to have_list_item class: "advanced-filters--spacer"
+        expect(list).to have_list_item class: "advanced-filters--add-filter"
+      end
+    end
+
+    it "renders select with available filters" do
+      expect(rendered_component).to have_select "add_filter_select", with_options: ["Status", "Created on"]
+    end
+  end
+
+  context "with some filters applied" do
+    before do
+      cost_query.filter :status_id, operator: "o"
+      cost_query.filter :created_on, operator: "t"
+    end
+
+    it "renders filters" do
+      expect(rendered_component).to have_list id: "filter_table" do |list|
+        expect(list).to have_list_item class: "advanced-filters--filter", count: 2
+        expect(list).to have_list_item class: "advanced-filters--spacer"
+        expect(list).to have_list_item class: "advanced-filters--add-filter"
+      end
+    end
+  end
+end

--- a/modules/reporting/spec/lib/widget/group_bys_spec.rb
+++ b/modules/reporting/spec/lib/widget/group_bys_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Widget::GroupBys, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    render_component(cost_query, **options)
+  end
+
+  it "renders component" do
+    expect(rendered_component).to have_element id: "group-by--area"
+  end
+
+  it "renders 'selected columns' fieldset" do
+    expect(rendered_component).to have_selector :fieldset, "Selected columns"
+  end
+
+  it "renders 'selected rows' fieldset" do
+    expect(rendered_component).to have_selector :fieldset, "Selected rows"
+  end
+
+  it "renders 'add group by' selects" do
+    expect(rendered_component).to have_select "Add Group-by Attribute", count: 2
+    expect(rendered_component).to have_select "Add Group-by Attribute", fieldset: "Selected columns"
+    expect(rendered_component).to have_select "Add Group-by Attribute", fieldset: "Selected rows"
+  end
+
+  context "with no groupings applied" do
+    it "renders empty columns data" do
+      expect(rendered_component).to have_element id: "group-by--columns" do |div|
+        expect(div["data-initially-selected"]).to eql "[]"
+      end
+    end
+
+    it "renders empty rows data" do
+      expect(rendered_component).to have_element id: "group-by--rows" do |div|
+        expect(div["data-initially-selected"]).to eql "[]"
+      end
+    end
+  end
+
+  context "with some groupings applied" do
+    before do
+      cost_query.group_by :spent_on
+      cost_query.group_by :project_id
+      cost_query.row :user_id
+    end
+
+    it "renders columns data" do
+      expect(rendered_component).to have_element id: "group-by--columns" do |div|
+        expect(div["data-initially-selected"]).to eql "[['project_id','Project'],['spent_on','Date (Spent)']]"
+      end
+    end
+
+    it "renders rows data" do
+      expect(rendered_component).to have_element id: "group-by--rows" do |div|
+        expect(div["data-initially-selected"]).to eql "[['user_id','User']]"
+      end
+    end
+  end
+end

--- a/modules/reporting/spec/lib/widget/settings_spec.rb
+++ b/modules/reporting/spec/lib/widget/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,37 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Settings, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query, **options)
+      end
     end
+  end
+
+  it "renders form" do
+    expect(rendered_component).to have_element :form, id: "query_form"
+  end
+
+  it "renders regions", :aggregate_failures do
+    expect(rendered_component).to have_region count: 3
+    expect(rendered_component).to have_region "Filter"
+    expect(rendered_component).to have_region "Group by"
+    expect(rendered_component).to have_region "Units"
+  end
+
+  it "renders buttons", :aggregate_failures do
+    expect(rendered_component).to have_button "Apply"
+    expect(rendered_component).to have_button "Clear"
   end
 end

--- a/modules/reporting/spec/lib/widget/table_spec.rb
+++ b/modules/reporting/spec/lib/widget/table_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,15 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Widget::Filters::Label < Widget::Filters::Base
-  def render_filter
-    options = {
-      id: filter_class.underscore_name,
-      class: "advanced-filters--filter-name",
-      title: filter_class.label
-    }
-    content_tag(:label, options) do
-      filter_class.label
+require "rails_helper"
+
+RSpec.describe Widget::Table, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  let(:cost_query) { build_stubbed(:public_cost_query) }
+  let(:options) { {} }
+
+  subject(:rendered_component) do
+    with_controller_class(CostReportsController) do
+      with_request_url("/cost_reports") do
+        render_component(cost_query, **options)
+      end
+    end
+  end
+
+  context "when there are no items" do
+    it "renders nothing" do
+      expect(rendered_component).to have_css ".generic-table--no-results-title", text: "There is currently nothing to display."
     end
   end
 end


### PR DESCRIPTION
⚠️ **~~This PR is based off #20562. Please review/merge that first.~~**

# Ticket

https://community.openproject.org/wp/OP-18075

# What are you trying to accomplish?

* Replaces custom widget implementation with standard ViewComponents.
* Begins Primerization / style refresh:
  - cost type radios
  - buttons
  - dialogs
* Begins migration of jQuery-implemented behavior to Turbo.

## Screenshots

<img width="1223" height="739" alt="Screenshot 2025-10-20 at 15 29 39" src="https://github.com/user-attachments/assets/325e69ea-9774-4271-bcaa-681df48515af" />

<img width="1230" height="645" alt="Screenshot 2025-10-20 at 15 29 06" src="https://github.com/user-attachments/assets/55a75858-7930-4545-b700-501acf9a64e1" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
