### PR TITLE
[68341] Padding before and behind macros, e.g. user avatar

### DIFF
--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -257,7 +257,7 @@ $scrollbar-size: 10px
 
 @mixin macro--text-style
   @media screen
-    display: inline
+    display: inline-block
     background: rgba(218,223,225,0.19)
     border: 1px solid transparent
     padding: 2px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68341

# What are you trying to accomplish?
Avoid that the containing border is shown in a different line than the value of the macro

## Screenshots

###After

**No hover**
<img width="238" height="196" alt="Bildschirmfoto 2025-10-16 um 12 32 11" src="https://github.com/user-attachments/assets/7f5577fa-bb69-41c7-aeaa-ef78fa17708d" />

**Hover**
<img width="178" height="134" alt="Bildschirmfoto 2025-10-16 um 12 32 19" src="https://github.com/user-attachments/assets/83586a1a-cb4f-4015-898a-0f20c3a441e2" />

### Before
**No hover**
<img width="211" height="212" alt="Bildschirmfoto 2025-10-16 um 12 35 16" src="https://github.com/user-attachments/assets/4c8bab65-bd40-4ff1-9675-7bb233b8b8f4" />

**Hover**
<img width="176" height="155" alt="Bildschirmfoto 2025-10-16 um 12 35 32" src="https://github.com/user-attachments/assets/ecc1f893-86c5-43ec-bd98-83db16a5bb01" />
