### PR TITLE
bug/68404 On Work Package Side View (via "info" ℹ️ icon) the lazy pages never load, only the first page is loaded

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
@@ -82,8 +82,6 @@ export default class LazyPageController extends BaseController {
   }
 
   private startObserving(root = this.scrollableContainer) {
-    if (!root) return;
-
     const [_observe, unobserve] = useIntersection(this, {
       root,
       threshold: 0.05,


### PR DESCRIPTION
https://community.openproject.org/work_packages/68404

When the root (scrollableContainer) is undefined, fall back to the document viewport. Do not return early or abort the observer setup.

> [!NOTE]
> Specifying the root is generally a good idea for scoping down the observable area. When the root is null, Stimulus-Use will fallback to the document viewport. 📖  https://stimulus-use.github.io/stimulus-use/#/use-intersection?id=reference
> 
> The "root" is different based on the context the activity tab is rendered- we maintain [a list of variants](https://github.com/opf/openproject/blob/dev/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/view-port-service.ts#L85-L96), but I don't particularly like adding to that list. Rather falling back.


https://github.com/user-attachments/assets/e5f8ca8e-c06d-4da6-9d12-d33f09dc3bdc
