### PR TITLE
[68402] Correctly recompute duration for automatic work packages with children

### DIFF
--- a/app/controllers/work_packages/date_picker_controller.rb
+++ b/app/controllers/work_packages/date_picker_controller.rb
@@ -293,8 +293,8 @@ class WorkPackages::DatePickerController < ApplicationController
   def manage_params_for_automatic_mode(wp_params)
     return wp_params if wp_params["schedule_manually"] != "false"
 
-    # For WP with children the dates are always fixed
-    return wp_params.without("start_date", "due_date") if work_package.children.any?
+    # For WP with children the dates and duration are always fixed
+    return wp_params.without("start_date", "due_date", "duration") if work_package.children.any?
 
     # the start should be preserved and will thus be send as a parameter
     wp_params["start_date"] = work_package.start_date.to_s

--- a/spec/controllers/work_packages/date_picker_controller_spec.rb
+++ b/spec/controllers/work_packages/date_picker_controller_spec.rb
@@ -258,6 +258,62 @@ RSpec.describe WorkPackages::DatePickerController do
     end
   end
 
+  describe "GET /work_packages/:id/date_picker/preview" do
+    context "when the work package is an automatically scheduled parent with dates inherited from child" do
+      shared_let(:child) do
+        create(:work_package,
+               parent: work_package,
+               subject: "child",
+               start_date: work_package.start_date,
+               due_date: work_package.due_date,
+               duration: work_package.duration)
+      end
+
+      before do
+        work_package.update(schedule_manually: false)
+      end
+
+      context "when the user clears the duration" do
+        let(:params) do
+          {
+            "field" => "work_package[duration]",
+            "date_mode" => "range",
+            "triggering_field" => "combined_date",
+            "work_package" => {
+              "start_date" => "2025-04-01",
+              "due_date" => "2025-04-07",
+              "duration" => "", # <= here is the change: clear the duration
+              "ignore_non_working_days" => "0",
+              "schedule_manually" => "false",
+              "initial" => {
+                "start_date" => "2025-04-01",
+                "due_date" => "2025-04-07",
+                "duration" => "5",
+                "ignore_non_working_days" => "false",
+                "schedule_manually" => "false"
+              },
+              "start_date_touched" => "false",
+              "due_date_touched" => "false",
+              "duration_touched" => "true", # <= here is the change: clear the duration
+              "ignore_non_working_days_touched" => "false",
+              "schedule_manually_touched" => "false"
+            }
+          }
+        end
+
+        it "keeps the dates and duration from the child (Bug #68402)" do
+          get("preview", params: params.merge("work_package_id" => work_package.id))
+
+          expect(assigns(:work_package)).to have_attributes(
+            start_date: child.start_date,
+            due_date: child.due_date,
+            duration: child.duration
+          )
+        end
+      end
+    end
+  end
+
   describe "GET /work_packages/:id/progress" do
     let(:params_from_first_display_of_date_picker) do
       {

--- a/spec/features/work_packages/datepicker/datepicker_parent_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_parent_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe "Datepicker logic on parents", :js, with_settings: { date_format:
       {
         start_date: "2021-02-01",
         due_date: "2021-02-02",
+        duration: 2,
         ignore_non_working_days: true
       }
     end
@@ -115,6 +116,35 @@ RSpec.describe "Datepicker logic on parents", :js, with_settings: { date_format:
         # Therefore, the calendar sheets also show the start_date of the child first
         first_monday = Time.zone.parse(child_attributes[:start_date]).beginning_of_month.next_occurring(:monday)
         datepicker.expect_disabled(first_monday)
+      end
+    end
+
+    context "when the parent is switched to manual, and dates are cleared, " \
+            "and scheduling mode is switched back to automatic" do
+      let(:parent_attributes) do
+        # parent inherits from child attributes
+        child_attributes.merge(schedule_manually: false)
+      end
+
+      it "shows the inherited dates and duration of the child in the date picker" do
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date child_attributes[:start_date], disabled: true
+        datepicker.expect_due_date child_attributes[:due_date], disabled: true
+        datepicker.expect_duration child_attributes[:duration], disabled: true
+
+        datepicker.toggle_scheduling_mode
+        datepicker.wait_for_preview_update
+        datepicker.expect_manual_scheduling_mode
+        datepicker.set_start_date ""
+        datepicker.set_due_date ""
+        datepicker.expect_duration ""
+
+        datepicker.toggle_scheduling_mode
+        datepicker.wait_for_preview_update
+        datepicker.expect_automatic_scheduling_mode
+        datepicker.expect_start_date child_attributes[:start_date], disabled: true
+        datepicker.expect_due_date child_attributes[:due_date], disabled: true
+        datepicker.expect_duration child_attributes[:duration], disabled: true
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68402

# What are you trying to accomplish?

Fix bad values being displayed for a parent automatically scheduled having dates inherited from its children: when switching to manual mode, clearing dates, and switching back to automatic, the wrong values would be displayed in the date picker for finish date and duration

## Screenshots

Before fix:

<img width="601" height="611" alt="image" src="https://github.com/user-attachments/assets/768dfb0c-adbc-4018-ac9f-d262146c1ea2" />

After fix:

<img width="599" height="611" alt="image" src="https://github.com/user-attachments/assets/7f9358ac-92a8-4a11-b6d7-381823fda1b7" />

There is a full screen recording attached to the bug in OpenProject.

# What approach did you choose and why?

There was a bug where when switching to manual mode and clearing the dates, the controller would also clear the duration and consider it as being done by the user (touched field). Then when switching to automatic mode, before calling the SetAttributesService, start date and finish date would be discarded because the work package is in automatic mode.

The SetAttributesService would then think that the duration being empty was done by the user, and would then also unset the finish date. That lead to the incorrect display of the dates and duration in the date picker: they would appear as empty instead of having the dates inherited from the child.

Fix is to also discard the duration if the work package is automatically scheduled and has children.


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
