### PR TITLE
[68364] WP graph legend does not match the actual graph 

### DIFF
--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -96,6 +96,25 @@ function assignColorsForDataset(dataset:ChartDataset, i:number):number {
   return i;
 }
 
+function colorizeMultiDataset(dataset:ChartDataset, i:number) {
+  const backgroundColors:string[] = [];
+  const borderColors:string[] = [];
+
+  // Instead of directly counting the index up, all elements of that dataset will get the same colour
+  // Only at the end, we increase so that the next dataset is in a different colour
+  // See https://community.openproject.org/wp/68364
+  for (const _ of dataset.data) {
+    backgroundColors.push(getMutedColor(i));
+    borderColors.push(getEmphasisColor(i));
+  }
+
+  dataset.backgroundColor = backgroundColors;
+  dataset.borderColor = borderColors;
+  dataset.borderWidth = 1;
+
+  return i+1;
+}
+
 function getColorizer() {
   let i = 0;
 
@@ -114,9 +133,14 @@ const plugin:Plugin<ChartType, PrimerColorsPluginOptions> = {
     }
 
     const { data: { datasets } } = chart.config;
-    const colorizer = getColorizer();
-
-    datasets.forEach(colorizer);
+    if (datasets.length === 1) {
+      const colorizer = getColorizer();
+      datasets.forEach(colorizer);
+    } else {
+      datasets.forEach((dataset:ChartDataset, index = 0) => {
+        colorizeMultiDataset(dataset, index);
+      });
+    }
   },
 };
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68364

# What are you trying to accomplish?
Make sure that multi data sets that show the data for example split between "Open" and "closed" have the correct colour palette

## Screenshots
**Before**
<img width="1339" height="628" alt="Bildschirmfoto 2025-10-16 um 15 34 04" src="https://github.com/user-attachments/assets/5e6e4e4d-bf0e-4429-b3d8-a75efebdc0fc" />

**After**
<img width="1337" height="622" alt="Bildschirmfoto 2025-10-16 um 15 35 55" src="https://github.com/user-attachments/assets/7b26332a-b97e-41c8-9003-3a75daaa276d" />

