### PR TITLE
API: Do not issue SQL count for number of elements on current page

### DIFF
--- a/lib/api/decorators/collection.rb
+++ b/lib/api/decorators/collection.rb
@@ -66,7 +66,7 @@ module API
       end
 
       property :total, getter: ->(*) { @total }, exec_context: :decorator
-      property :count, getter: ->(*) { count }
+      property :count, getter: ->(*) { represented.to_a.size }, exec_context: :decorator
 
       property :groups,
                exec_context: :decorator,


### PR DESCRIPTION
We will be rendering the elements on the current page anyways, so it's unavoidable that we load them. By forcing us through to_a.size, we make sure that the elements are loaded first and then only count how many elements have been loaded. Since AR caches the result, the relation will not be loaded twice.

Previously we had a useless SQL count query, which can be tremendously slower than the actual loading of elements. In the case of time entries for a larger database, the COUNT took ~1.5 seconds, when the loading of those same elements only took ~20ms. I don't hope that this ratio is generalizable to all collection API endpoints, but it's definitely a nice speed boost.

# Ticket
https://community.openproject.org/wp/68455

Fixed while investigating https://community.openproject.org/wp/68390

# Log comparison

Comparing relevant queries before:

```
TimeEntry Count (2384.8ms)  SELECT COUNT(DISTINCT "time_entries"."id") FROM "time_entries" LEFT OUTER JOIN "users" ON "users"."status" != $1 AND "users"."id" = "time_entries"."user_id" AND "users"."type" IN ($2, $3, $4, $5, $6) LEFT OUTER JOIN "enumerations" ON "enumerations"."id" = "time_entries"."activity_id" AND "enumerations"."type" = $7 LEFT OUTER JOIN "projects" ON "projects"."id" = "time_entries"."project_id" LEFT OUTER JOIN "enabled_modules" ON "enabled_modules"."project_id" = "projects"."id" WHERE "time_entries"."ongoing" = $8 AND ("time_entries"."project_id" IN (SELECT "projects"."id" FROM "projects" WHERE "projects"."id" IN (SELECT "projects"."id" FROM "projects" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) OR "time_entries"."entity_type" = 'WorkPackage' AND "time_entries"."entity_id" IN (SELECT "work_packages"."id" FROM "work_packages" WHERE "work_packages"."id" IN (SELECT "work_packages"."id" FROM "work_packages" INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) AND "time_entries"."user_id" = 14859)  [["status", 5], ["type", "User"], ["type", "DeletedUser"], ["type", "ServiceAccount"], ["type", "AnonymousUser"], ["type", "SystemUser"], ["type", "TimeEntryActivity"], ["ongoing", false]]
TimeEntry Count (1851.1ms)  SELECT COUNT(*) FROM (SELECT 1 AS one FROM "time_entries" WHERE "time_entries"."ongoing" = $1 AND ("time_entries"."project_id" IN (SELECT "projects"."id" FROM "projects" WHERE "projects"."id" IN (SELECT "projects"."id" FROM "projects" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) OR "time_entries"."entity_type" = 'WorkPackage' AND "time_entries"."entity_id" IN (SELECT "work_packages"."id" FROM "work_packages" WHERE "work_packages"."id" IN (SELECT "work_packages"."id" FROM "work_packages" INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) AND "time_entries"."user_id" = 14859) LIMIT $2 OFFSET $3) subquery_for_count  [["ongoing", false], ["LIMIT", 50], ["OFFSET", 0]]
TimeEntry Load (19.9ms)  SELECT "time_entries"."id", "time_entries"."project_id", "time_entries"."user_id", "time_entries"."hours", "time_entries"."comments", "time_entries"."activity_id", "time_entries"."spent_on", "time_entries"."tyear", "time_entries"."tmonth", "time_entries"."tweek", "time_entries"."created_at", "time_entries"."updated_at", "time_entries"."overridden_costs", "time_entries"."costs", "time_entries"."rate_id", "time_entries"."logged_by_id", "time_entries"."ongoing", "time_entries"."start_time", "time_entries"."time_zone", "time_entries"."entity_type", "time_entries"."entity_id" FROM "time_entries" WHERE "time_entries"."ongoing" = $1 AND ("time_entries"."project_id" IN (SELECT "projects"."id" FROM "projects" WHERE "projects"."id" IN (SELECT "projects"."id" FROM "projects" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) OR "time_entries"."entity_type" = 'WorkPackage' AND "time_entries"."entity_id" IN (SELECT "work_packages"."id" FROM "work_packages" WHERE "work_packages"."id" IN (SELECT "work_packages"."id" FROM "work_packages" INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) AND "time_entries"."user_id" = 14859) ORDER BY "time_entries"."id" DESC LIMIT $2 OFFSET $3  [["ongoing", false], ["LIMIT", 50], ["OFFSET", 0]]
```

and after:

```
TimeEntry Count (2658.2ms)  SELECT COUNT(DISTINCT "time_entries"."id") FROM "time_entries" LEFT OUTER JOIN "users" ON "users"."status" != $1 AND "users"."id" = "time_entries"."user_id" AND "users"."type" IN ($2, $3, $4, $5, $6) LEFT OUTER JOIN "enumerations" ON "enumerations"."id" = "time_entries"."activity_id" AND "enumerations"."type" = $7 LEFT OUTER JOIN "projects" ON "projects"."id" = "time_entries"."project_id" LEFT OUTER JOIN "enabled_modules" ON "enabled_modules"."project_id" = "projects"."id" WHERE "time_entries"."ongoing" = $8 AND ("time_entries"."project_id" IN (SELECT "projects"."id" FROM "projects" WHERE "projects"."id" IN (SELECT "projects"."id" FROM "projects" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) OR "time_entries"."entity_type" = 'WorkPackage' AND "time_entries"."entity_id" IN (SELECT "work_packages"."id" FROM "work_packages" WHERE "work_packages"."id" IN (SELECT "work_packages"."id" FROM "work_packages" INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) AND "time_entries"."user_id" = 14859)  [["status", 5], ["type", "User"], ["type", "DeletedUser"], ["type", "ServiceAccount"], ["type", "AnonymousUser"], ["type", "SystemUser"], ["type", "TimeEntryActivity"], ["ongoing", false]]
TimeEntry Load (27.7ms)  SELECT "time_entries"."id", "time_entries"."project_id", "time_entries"."user_id", "time_entries"."hours", "time_entries"."comments", "time_entries"."activity_id", "time_entries"."spent_on", "time_entries"."tyear", "time_entries"."tmonth", "time_entries"."tweek", "time_entries"."created_at", "time_entries"."updated_at", "time_entries"."overridden_costs", "time_entries"."costs", "time_entries"."rate_id", "time_entries"."logged_by_id", "time_entries"."ongoing", "time_entries"."start_time", "time_entries"."time_zone", "time_entries"."entity_type", "time_entries"."entity_id" FROM "time_entries" WHERE "time_entries"."ongoing" = $1 AND ("time_entries"."project_id" IN (SELECT "projects"."id" FROM "projects" WHERE "projects"."id" IN (SELECT "projects"."id" FROM "projects" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) OR "time_entries"."entity_type" = 'WorkPackage' AND "time_entries"."entity_id" IN (SELECT "work_packages"."id" FROM "work_packages" WHERE "work_packages"."id" IN (SELECT "work_packages"."id" FROM "work_packages" INNER JOIN "projects" ON "projects"."id" = "work_packages"."project_id" INNER JOIN "enabled_modules" ON "projects"."id" = "enabled_modules"."project_id" AND "enabled_modules"."name" IN ('costs') AND "projects"."active" = TRUE WHERE "projects"."active" = TRUE)) AND "time_entries"."user_id" = 14859) ORDER BY "time_entries"."id" DESC LIMIT $2 OFFSET $3  [["ongoing", false], ["LIMIT", 50], ["OFFSET", 0]
```