### PR TITLE
[42064] Inconsistent position of search icon in search box

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -22,7 +22,7 @@ $search-input-height: 30px
   &--button
     @include unset-button-styles
     position: absolute
-    right: 2px
+    left: 2px
     font-size: var(--header-item-font-size)
     color: var(--header-item-font-color)
     z-index: 1
@@ -63,6 +63,9 @@ $search-input-height: 30px
       &:focus-within
         @include spot-focus
 
+    .ng-value-container
+      padding-left: 35px !important
+
     .ng-arrow-wrapper
       display: none
 
@@ -70,7 +73,7 @@ $search-input-height: 30px
       color: var(--header-item-font-color)
       top: 1px
       width: 30px
-      right: 25px
+      right: 10px
       text-align: center
 
     .ng-input
@@ -139,4 +142,4 @@ $search-input-height: 30px
     // Fix position of the spinner
     .ng-spinner-loader
       position: relative
-      right: 24px
+      right: 14px

--- a/frontend/src/app/core/global_search/input/global-search.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search.component.sass
@@ -9,6 +9,10 @@
   &--input[type="text"]
     // Uppercase letters with accents like Ü and Â would get cut off
     line-height: 20px
+    padding-left: 25px !important
+
+    @media screen and (max-width: $breakpoint-md)
+      padding-left: 0 !important
 
   &--option,
   &--option:hover


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/42064

# What are you trying to accomplish?
Move search icon to the left in the global search for a more consistent UI

## Screenshots
<img width="522" height="62" alt="Bildschirmfoto 2025-10-17 um 09 15 50" src="https://github.com/user-attachments/assets/b314b537-fa54-4d76-9da5-1474e3ac0c0b" />

<img width="595" height="219" alt="Bildschirmfoto 2025-10-17 um 09 16 03" src="https://github.com/user-attachments/assets/5540da7a-bccc-4d3d-beb9-ed63d9a455e2" />
