### PR TITLE
[68275] Project attributes are not showing as required on Project overview page

### DIFF
--- a/app/components/open_project/common/attribute_label_component.html.erb
+++ b/app/components/open_project/common/attribute_label_component.html.erb
@@ -1,4 +1,7 @@
 <%= render Primer::ConditionalWrapper.new(condition: !@tag.nil?, trim: true, **@system_arguments) do %>
   <%= content %>
+  <% if @required %>
+    <%= render Primer::BaseComponent.new(tag: :span, ml: 1, aria: { hidden: true }).with_content("*") %>
+  <% end %>
   <%= render OpenProject::Common::AttributeHelpTextComponent.new(help_text: @help_text) if @help_text.present? %>
 <% end %>

--- a/app/components/open_project/common/attribute_label_component.rb
+++ b/app/components/open_project/common/attribute_label_component.rb
@@ -36,6 +36,7 @@ module OpenProject
         model:,
         tag: :span,
         current_user: User.current,
+        required: false,
         **system_arguments
       )
         super()
@@ -47,6 +48,8 @@ module OpenProject
           @system_arguments[:classes],
           "op-attribute-label"
         )
+
+        @required = required
 
         @help_text = ::AttributeHelpText.for(model)
           &.cached(current_user)

--- a/modules/overviews/app/components/overviews/project_custom_fields/item_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/item_component.html.erb
@@ -11,7 +11,8 @@
     custom_field_value_container.with_row(mb: 1) do
       render OpenProject::Common::AttributeLabelComponent.new(
         attribute: @project_custom_field.attribute_name,
-        model: @project
+        model: @project,
+        required: @project_custom_field.required?
       ) do
         render(Primer::Beta::Text.new(font_weight: :bold)) { @project_custom_field.name }
       end

--- a/spec/components/open_project/common/attribute_label_component_spec.rb
+++ b/spec/components/open_project/common/attribute_label_component_spec.rb
@@ -35,12 +35,13 @@ RSpec.describe OpenProject::Common::AttributeLabelComponent, type: :component do
 
   let(:attribute) { "name" }
   let(:model) { create(:project) }
+  let(:required) { false }
   let(:tag) { :span }
   let(:current_user) { create(:user) }
   let(:content) { "Name" }
 
   subject do
-    render_inline(described_class.new(attribute:, model:, tag:, current_user:)) do
+    render_inline(described_class.new(attribute:, model:, tag:, current_user:, required:)) do
       content
     end
 
@@ -66,6 +67,14 @@ RSpec.describe OpenProject::Common::AttributeLabelComponent, type: :component do
 
     it "renders content" do
       expect(subject).to have_text "Name"
+    end
+
+    context "with a required field" do
+      let(:required) { true }
+
+      it "renders a required star" do
+        expect(subject).to have_text "*"
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68275

# What are you trying to accomplish?
Allow required star to be shown for AttributeLabelComponent

## Screenshots
<img width="322" height="336" alt="Bildschirmfoto 2025-10-17 um 11 05 47" src="https://github.com/user-attachments/assets/c623ad2c-da74-4191-8a09-0983110642b5" />

