### PR TITLE
[#67268] Meeting draft mode

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.html.erb
@@ -1,21 +1,9 @@
 <%=
   component_wrapper do
     flex_layout(mb: 3) do |flex|
-      if @meeting.template?
+      if @meeting.template? || @meeting.draft?
         flex.with_row(mb: 3) do
-          render Primer::Alpha::Banner.new(
-            scheme: :default,
-            icon: :info,
-            dismiss_scheme: :none
-          ) do
-            t(
-              "recurring_meeting.template.banner_html",
-              link: link_to(
-                @meeting.recurring_meeting.title,
-                project_recurring_meeting_path(@meeting.project, @meeting.recurring_meeting)
-              )
-            )
-          end
+          banner
         end
       end
       flex.with_row(id: insert_target_modifier_id, data: { "allowed-drop-type": "section" }.merge(drop_target_config)) do

--- a/modules/meeting/app/components/meeting_agenda_items/list_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.rb
@@ -74,8 +74,9 @@ module MeetingAgendaItems
         dismiss_scheme: :none
       ) do
         if @meeting.template?
+          draft = @meeting.draft? ? "draft_" : ""
           t(
-            "recurring_meeting.template.banner_html",
+            "recurring_meeting.template.#{draft}banner_html",
             link: link_to(
               @meeting.recurring_meeting.title,
               project_recurring_meeting_path(@meeting.project, @meeting.recurring_meeting)

--- a/modules/meeting/app/components/meeting_agenda_items/list_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.rb
@@ -66,5 +66,25 @@ module MeetingAgendaItems
     def sections_except_backlog
       @meeting.sections.reject { |s| s.backlog? || !s.persisted? }
     end
+
+    def banner
+      render Primer::Alpha::Banner.new(
+        scheme: :default,
+        icon: :info,
+        dismiss_scheme: :none
+      ) do
+        if @meeting.template?
+          t(
+            "recurring_meeting.template.banner_html",
+            link: link_to(
+              @meeting.recurring_meeting.title,
+              project_recurring_meeting_path(@meeting.project, @meeting.recurring_meeting)
+            )
+          )
+        elsif @meeting.draft?
+          t("text_meeting_draft_banner")
+        end
+      end
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.html.erb
@@ -1,0 +1,78 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(
+    Primer::Alpha::Dialog.new(
+      id:,
+      title: "Open meeting",
+      size: :medium_portrait
+    )
+  ) do |dialog|
+    dialog.with_header(
+      show_divider: false,
+      visually_hide_title: true
+    )
+    dialog.with_body do
+      flex_layout(align_items: :center, justify_content: :space_between) do |flex|
+        flex.with_row do
+          render(Primer::Beta::Text.new(font_weight: :bold)) { "Open this meeting and send invites?" }
+        end
+        flex.with_row do
+          render(Primer::Beta::Text.new) { "You cannot return to draft mode once you schedule a meeting." }
+        end
+        flex.with_row do
+          render(Meetings::ExitDraftModeFormComponent.new(meeting: @meeting))
+        end
+      end
+    end
+    dialog.with_footer do
+      component_collection do |footer|
+        footer.with_component(
+          Primer::Beta::Button.new(
+            data: { "close-dialog-id": "exit-draft-mode-dialog" }
+          )
+        ) do
+          I18n.t(:button_cancel)
+        end
+
+        footer.with_component(
+          Primer::Beta::Button.new(
+            scheme: :primary,
+            form: "exit-draft-mode-form",
+            data: { turbo: true },
+            type: :submit
+          )
+        ) do
+          I18n.t("label_meeting_open_action")
+        end
+      end
+    end
+  end
+%>

--- a/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     Primer::Alpha::Dialog.new(
       id:,
-      title: "Open meeting",
+      title:,
       size: :medium_portrait
     )
   ) do |dialog|
@@ -42,10 +42,10 @@ See COPYRIGHT and LICENSE files for more details.
     dialog.with_body do
       flex_layout(align_items: :center, justify_content: :space_between) do |flex|
         flex.with_row do
-          render(Primer::Beta::Text.new(font_weight: :bold)) { "Open this meeting and send invites?" }
+          render(Primer::Beta::Text.new(font_weight: :bold)) { title }
         end
         flex.with_row do
-          render(Primer::Beta::Text.new) { "You cannot return to draft mode once you schedule a meeting." }
+          render(Primer::Beta::Text.new) { subtitle }
         end
         flex.with_row do
           render(Meetings::ExitDraftModeFormComponent.new(meeting: @meeting))

--- a/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.rb
@@ -44,7 +44,21 @@ module Meetings
     private
 
     def id = "exit-draft-mode-dialog"
-    def title = I18n.t("text_exit_draft_mode_dialog_title")
-    def subtitle = I18n.t("text_exit_draft_mode_dialog_subtitle")
+
+    def title
+      if @meeting.recurring?
+        I18n.t("text_exit_draft_mode_dialog_template_title")
+      else
+        I18n.t("text_exit_draft_mode_dialog_title")
+      end
+    end
+
+    def subtitle
+      if @meeting.recurring?
+        I18n.t("text_exit_draft_mode_dialog_template_subtitle")
+      else
+        I18n.t("text_exit_draft_mode_dialog_subtitle")
+      end
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.rb
@@ -44,45 +44,7 @@ module Meetings
     private
 
     def id = "exit-draft-mode-dialog"
-
-    # def title
-    #   if recurring_meeting.present?
-    #     I18n.t("meeting.delete_dialog.occurrence.title")
-    #   else
-    #     I18n.t("meeting.delete_dialog.one_time.title")
-    #   end
-    # end
-    #
-    # def heading
-    #   if recurring_meeting.present?
-    #     I18n.t("meeting.delete_dialog.occurrence.heading")
-    #   else
-    #     I18n.t("meeting.delete_dialog.one_time.heading")
-    #   end
-    # end
-    #
-    # def confirmation_message
-    #   if recurring_meeting.present?
-    #     t("meeting.delete_dialog.occurrence.confirmation_message_html")
-    #   else
-    #     t("meeting.delete_dialog.one_time.confirmation_message_html")
-    #   end
-    # end
-    #
-    # def confirm_button_text
-    #   if recurring_meeting.present?
-    #     I18n.t("meeting.delete_dialog.occurrence.confirm_button")
-    #   else
-    #     I18n.t("button_delete")
-    #   end
-    # end
-    #
-    # def cancel_button_text
-    #   if recurring_meeting.present?
-    #     I18n.t("button_close")
-    #   else
-    #     I18n.t("button_cancel")
-    #   end
-    # end
+    def title = I18n.t("text_exit_draft_mode_dialog_title")
+    def subtitle = I18n.t("text_exit_draft_mode_dialog_subtitle")
   end
 end

--- a/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_dialog_component.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Meetings
+  class ExitDraftModeDialogComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    def initialize(meeting:)
+      super
+
+      @meeting = meeting
+      @project = meeting.project
+    end
+
+    private
+
+    def id = "exit-draft-mode-dialog"
+
+    # def title
+    #   if recurring_meeting.present?
+    #     I18n.t("meeting.delete_dialog.occurrence.title")
+    #   else
+    #     I18n.t("meeting.delete_dialog.one_time.title")
+    #   end
+    # end
+    #
+    # def heading
+    #   if recurring_meeting.present?
+    #     I18n.t("meeting.delete_dialog.occurrence.heading")
+    #   else
+    #     I18n.t("meeting.delete_dialog.one_time.heading")
+    #   end
+    # end
+    #
+    # def confirmation_message
+    #   if recurring_meeting.present?
+    #     t("meeting.delete_dialog.occurrence.confirmation_message_html")
+    #   else
+    #     t("meeting.delete_dialog.one_time.confirmation_message_html")
+    #   end
+    # end
+    #
+    # def confirm_button_text
+    #   if recurring_meeting.present?
+    #     I18n.t("meeting.delete_dialog.occurrence.confirm_button")
+    #   else
+    #     I18n.t("button_delete")
+    #   end
+    # end
+    #
+    # def cancel_button_text
+    #   if recurring_meeting.present?
+    #     I18n.t("button_close")
+    #   else
+    #     I18n.t("button_cancel")
+    #   end
+    # end
+  end
+end

--- a/modules/meeting/app/components/meetings/exit_draft_mode_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_form_component.html.erb
@@ -1,0 +1,50 @@
+<%=
+  component_wrapper do
+    primer_form_with(
+      model: @meeting,
+      method: :post,
+      url: exit_draft_mode_project_meeting_path(@project, @meeting),
+      data: {
+        controller: "show-when-checked"
+      },
+      html: {
+        id: "exit-draft-mode-form"
+      }
+    ) do |f|
+      flex_layout do |body|
+        body.with_row do
+          render(OpPrimer::InsetBoxComponent.new(mt: 3)) do
+            flex_layout do |box|
+              box.with_row do
+                render(Meeting::SendEmailUpdates.new(f, meeting: @meeting))
+              end
+            end
+          end
+        end
+        body.with_row(
+          mt: 3,
+          data: {
+            "target-name": "notification-banner",
+            "show-when-checked-target": "effect",
+            "show-when": "checked",
+            visibility_class: "d-none"
+          }
+        ) do
+          render(Meetings::EmailUpdatesBannerComponent.new(@meeting, override: :enabled))
+        end
+        body.with_row(
+          mt: 3,
+          classes: "d-none",
+          data: {
+            "target-name": "notification-banner",
+            "show-when-checked-target": "effect",
+            "show-when": "unchecked",
+            visibility_class: "d-none"
+          }
+        ) do
+          render(Meetings::EmailUpdatesBannerComponent.new(@meeting, override: :disabled))
+        end
+      end
+    end
+  end
+%>

--- a/modules/meeting/app/components/meetings/exit_draft_mode_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_form_component.html.erb
@@ -3,7 +3,7 @@
     primer_form_with(
       model: @meeting,
       method: :post,
-      url: exit_draft_mode_project_meeting_path(@project, @meeting),
+      url:,
       data: {
         controller: "show-when-checked"
       },

--- a/modules/meeting/app/components/meetings/exit_draft_mode_form_component.rb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_form_component.rb
@@ -40,5 +40,15 @@ module Meetings
       @meeting = meeting
       @project = meeting.project
     end
+
+    private
+
+    def url
+      if @meeting.recurring?
+        template_completed_project_recurring_meeting_path(@project, @meeting.recurring_meeting)
+      else
+        exit_draft_mode_project_meeting_path(@project, @meeting)
+      end
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/exit_draft_mode_form_component.rb
+++ b/modules/meeting/app/components/meetings/exit_draft_mode_form_component.rb
@@ -28,23 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Meeting::SendEmailUpdates < ApplicationForm
-  form do |meeting_form|
-    meeting_form.check_box(
-      name: "notify",
-      label: I18n.t("label_meeting_send_updates"),
-      caption: "All participants will receive updated calendar invites via email informing them of changes.",
-      checked: true,
-      data: {
-        "show-when-checked-target": "cause",
-        "target-name": "notification-banner"
-      }
-    )
-  end
+module Meetings
+  class ExitDraftModeFormComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
 
-  def initialize(meeting:)
-    super()
+    def initialize(meeting:)
+      super
 
-    @meeting = meeting
+      @meeting = meeting
+      @project = meeting.project
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -35,17 +35,9 @@
       header.with_breadcrumbs(breadcrumb_items)
       header.with_description(underlined_links: false) { render(Meetings::HeaderInfolineComponent.new(@meeting)) }
       if finish_setup_enabled?
-        header.with_action_button(
-          tag: :a,
-          scheme: :primary,
-          mobile_label: I18n.t("recurring_meeting.template.button_finalize"),
-          mobile_icon: :check,
-          size: :medium,
-          data: { "turbo-method": :post },
-          href: template_completed_project_recurring_meeting_path(@project, @meeting.recurring_meeting)
-        ) do |button|
+        header.with_action_button(**action_button_params) do |button|
           button.with_leading_visual_icon(icon: :check)
-          I18n.t("recurring_meeting.template.button_finalize")
+          action_button_label
         end
       end
 

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -80,6 +80,7 @@ module Meetings
         mobile_label: action_button_label,
         mobile_icon: :check,
         size: :medium,
+        id: "open-meeting-button",
         data: {
           action: "click->meetings--submit#intercept",
           href: action_button_href,

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -69,9 +69,8 @@ module Meetings
     end
 
     def finish_setup_enabled?
-      (@meeting.template? &&
-        User.current.allowed_in_project?(:create_meetings, @meeting.project) &&
-        @series.scheduled_meetings.none?) || @meeting.draft?
+      @meeting.draft? &&
+        User.current.allowed_in_project?(:create_meetings, @meeting.project)
     end
 
     def action_button_params
@@ -84,7 +83,7 @@ module Meetings
         data: {
           action: "click->meetings--submit#intercept",
           href: action_button_href,
-          method: @meeting.recurring? ? "POST" : "GET"
+          method: "GET"
         }
       }
     end
@@ -94,12 +93,7 @@ module Meetings
     end
 
     def action_button_href
-      if @meeting.recurring?
-        template_completed_project_recurring_meeting_path(@project,
-                                                          @meeting.recurring_meeting)
-      else
-        exit_draft_mode_dialog_project_meeting_path(@project, @meeting)
-      end
+      exit_draft_mode_dialog_project_meeting_path(@project, @meeting)
     end
 
     def send_emails?

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -68,9 +69,39 @@ module Meetings
     end
 
     def finish_setup_enabled?
-      @meeting.template? &&
+      (@meeting.template? &&
         User.current.allowed_in_project?(:create_meetings, @meeting.project) &&
-        @series.scheduled_meetings.none?
+        @series.scheduled_meetings.none?) || @meeting.draft?
+    end
+
+    def action_button_params
+      {
+        tag: :button,
+        scheme: :primary,
+        mobile_label: action_button_label,
+        mobile_icon: :check,
+        size: :medium,
+        data: {
+          action: "click->meetings--submit#intercept",
+          href: action_button_href,
+          method: @meeting.recurring? ? "POST" : "PUT"
+        }
+      }
+    end
+
+    def action_button_label
+      @meeting.recurring? ? I18n.t("recurring_meeting.template.button_finalize") : I18n.t("label_meeting_open_action")
+    end
+
+    def action_button_href
+      if @meeting.recurring?
+        template_completed_project_recurring_meeting_path(@project,
+                                                          @meeting.recurring_meeting)
+      else
+        change_state_project_meeting_path(
+          @project, @meeting, state: "open"
+        )
+      end
     end
 
     def send_emails?

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -84,7 +84,7 @@ module Meetings
         data: {
           action: "click->meetings--submit#intercept",
           href: action_button_href,
-          method: @meeting.recurring? ? "POST" : "PUT"
+          method: @meeting.recurring? ? "POST" : "GET"
         }
       }
     end
@@ -98,9 +98,7 @@ module Meetings
         template_completed_project_recurring_meeting_path(@project,
                                                           @meeting.recurring_meeting)
       else
-        change_state_project_meeting_path(
-          @project, @meeting, state: "open"
-        )
+        exit_draft_mode_dialog_project_meeting_path(@project, @meeting)
       end
     end
 

--- a/modules/meeting/app/components/meetings/header_infoline_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_infoline_component.html.erb
@@ -1,5 +1,17 @@
 <%= render(Primer::BaseComponent.new(tag: :div, classes: "meeting-infoline")) do %>
-  <% if @series && !@meeting.template? %>
+  <% if @series && @meeting.template? %>
+    <% if @meeting.draft? %>
+      <%= render(Primer::BaseComponent.new(tag: :div, classes: "hidden-for-mobile", mr: 2)) do %>
+        <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
+      <% end %>
+    <% end %>
+    <%=
+      render(Primer::Beta::Text.new(mr: 1)) do
+        t(:label_meeting_created_by)
+      end
+    %>
+    <%= helpers.primer_link_to_user(@meeting.author, underline: true) %>.
+  <% elsif @series %>
     <%= render(Primer::BaseComponent.new(tag: :div, classes: "hidden-for-mobile", mr: 2)) do %>
       <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
     <% end %>
@@ -8,17 +20,10 @@
         t("recurring_meeting.occurrence.infoline", title: @series.title)
       end
     %>
-  <% elsif !@meeting.template? %>
+  <% else %>
     <%= render(Primer::BaseComponent.new(tag: :span, classes: "hidden-for-mobile", mr: 2)) do %>
       <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
     <% end %>
-    <%=
-      render(Primer::Beta::Text.new(mr: 1)) do
-        t(:label_meeting_created_by)
-      end
-    %>
-    <%= helpers.primer_link_to_user(@meeting.author, underline: true) %>.
-  <% else %>
     <%=
       render(Primer::Beta::Text.new(mr: 1)) do
         t(:label_meeting_created_by)

--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -140,37 +140,6 @@
             render(Meetings::EmailUpdatesBannerComponent.new(@meeting))
           end
         end
-
-        if (@meeting.is_a?(RecurringMeeting) && !@meeting.persisted?) || @meeting.is_a?(Meeting)
-          modal_body.with_row(mt: 3) do
-            render(Meeting::SendEmailUpdates.new(f, meeting: @meeting, copy_from: @copy_from))
-          end
-
-          modal_body.with_row(
-            mt: 3,
-            data: {
-              "target-name": "notification-banner",
-              "show-when-checked-target": "effect",
-              "show-when": "checked",
-              visibility_class: "d-none"
-            }
-          ) do
-            render(Meetings::EmailUpdatesBannerComponent.new(@meeting, override: :enabled))
-          end
-
-          modal_body.with_row(
-            mt: 3,
-            classes: "d-none",
-            data: {
-              "target-name": "notification-banner",
-              "show-when-checked-target": "effect",
-              "show-when": "unchecked",
-              visibility_class: "d-none"
-            }
-          ) do
-            render(Meetings::EmailUpdatesBannerComponent.new(@meeting, override: :disabled))
-          end
-        end
       end
     end
   end

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -22,7 +22,7 @@
               classes: "hide-when-print",
               data: button_data_attributes(href("open"))
             ) do |button|
-              button.with_leading_visual_icon(icon: :play)
+              button.with_leading_visual_icon(icon: :"issue-opened")
               t("label_meeting_open_action")
             end
           end

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -17,10 +17,13 @@
           if edit_enabled?
             section.with_footer_button(
               color: :accent,
-              tag: :a,
-              href: href("open"),
+              tag: :button,
               classes: "hide-when-print",
-              data: button_data_attributes(href("open"))
+              data: {
+                action: "click->meetings--submit#intercept",
+                href: exit_draft_mode_dialog_project_meeting_path(@project, @meeting),
+                method: "GET"
+              }
             ) do |button|
               button.with_leading_visual_icon(icon: :"issue-opened")
               t("label_meeting_open_action")

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -4,6 +4,30 @@
       section.with_title { t(:label_meeting_state) }
 
       case @meeting.state
+      when "draft"
+        flex_layout(classes: "op-meeting-sidebar-state") do |draft_state|
+          draft_state.with_row do
+            status_button
+          end
+
+          draft_state.with_row(mt: 3, classes: "hidden-for-mobile") do
+            render(Primer::Beta::Text.new(color: :subtle)) { t("text_meeting_draft_description") }
+          end
+
+          if edit_enabled?
+            section.with_footer_button(
+              color: :accent,
+              tag: :a,
+              href: href("open"),
+              classes: "hide-when-print",
+              data: button_data_attributes(href("open"))
+            ) do |button|
+              button.with_leading_visual_icon(icon: :play)
+              t("label_meeting_open_action")
+            end
+          end
+        end
+
       when "open"
         flex_layout(classes: "op-meeting-sidebar-state") do |open_state|
           open_state.with_row do

--- a/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/state_component.html.erb
@@ -26,7 +26,7 @@
               }
             ) do |button|
               button.with_leading_visual_icon(icon: :"issue-opened")
-              t("label_meeting_open_action")
+              @meeting.recurring? ? t("recurring_meeting.template.button_finalize") : t("label_meeting_open_action")
             end
           end
         end

--- a/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
@@ -47,8 +47,8 @@ module Meetings
         OpPrimer::StatusButtonComponent.new(
           current_status: current_status,
           items: [open_status, in_progress_status, closed_status],
-          readonly: !edit_enabled?,
-          disabled: !edit_enabled?,
+          readonly: !edit_enabled? || @meeting.state == "draft",
+          disabled: !edit_enabled? || @meeting.state == "draft",
           button_arguments: {
             title: t("label_meeting_state"),
             size: @size
@@ -67,6 +67,8 @@ module Meetings
 
     def current_status
       case @meeting.state
+      when "draft"
+        draft_status
       when "open"
         open_status
       when "in_progress"
@@ -74,6 +76,19 @@ module Meetings
       when "closed"
         closed_status
       end
+    end
+
+    def draft_status
+      OpPrimer::StatusButtonOption.new(name: t("label_meeting_state_draft"),
+                                       color_ref: Meetings::Statuses::DRAFT.id,
+                                       color_namespace: :meeting_status,
+                                       icon: :"issue-draft",
+                                       tag: :a,
+                                       href: "fdfdf",
+                                       description: "fsdfds",
+                                       content_arguments: {
+                                         data: data_attributes("fdfds")
+                                       })
     end
 
     def open_status

--- a/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel/status_button_component.rb
@@ -47,8 +47,8 @@ module Meetings
         OpPrimer::StatusButtonComponent.new(
           current_status: current_status,
           items: [open_status, in_progress_status, closed_status],
-          readonly: !edit_enabled? || @meeting.state == "draft",
-          disabled: !edit_enabled? || @meeting.state == "draft",
+          readonly: !edit_enabled? || @meeting.draft?,
+          disabled: !edit_enabled? || @meeting.draft?,
           button_arguments: {
             title: t("label_meeting_state"),
             size: @size
@@ -83,12 +83,7 @@ module Meetings
                                        color_ref: Meetings::Statuses::DRAFT.id,
                                        color_namespace: :meeting_status,
                                        icon: :"issue-draft",
-                                       tag: :a,
-                                       href: "fdfdf",
-                                       description: "fsdfds",
-                                       content_arguments: {
-                                         data: data_attributes("fdfds")
-                                       })
+                                       tag: :a)
     end
 
     def open_status

--- a/modules/meeting/app/components/meetings/side_panel_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel_component.html.erb
@@ -7,7 +7,7 @@
         panel.with_section(email_updates_mode_selector)
       end
 
-      unless @meeting.template?
+      unless @meeting.template? && !@meeting.draft?
         panel.with_section(Meetings::SidePanel::StateComponent.new(meeting: @meeting))
       end
 

--- a/modules/meeting/app/components/meetings/side_panel_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel_component.html.erb
@@ -3,7 +3,7 @@
     render(Primer::OpenProject::SidePanel.new) do |panel|
       panel.with_section(Meetings::SidePanel::DetailsComponent.new(meeting: @meeting))
 
-      if @meeting.editable?
+      if @meeting.editable? && !@meeting.draft?
         panel.with_section(email_updates_mode_selector)
       end
 

--- a/modules/meeting/app/constants/meetings/statuses.rb
+++ b/modules/meeting/app/constants/meetings/statuses.rb
@@ -32,11 +32,13 @@ module Meetings
   module Statuses
     RECORD = Struct.new(:id, :color, keyword_init: true)
 
+    DRAFT = RECORD.new(id: "draft", color: Color.new(hexcode: "#BF3989"))
     OPEN = RECORD.new(id: "open", color: Color.new(hexcode: "#006edb"))
     IN_PROGRESS = RECORD.new(id: "in_progress", color: Color.new(hexcode: "#894ceb"))
     CLOSED = RECORD.new(id: "closed", color: Color.new(hexcode: "#25292e"))
 
     AVAILABLE = [
+      DRAFT,
       OPEN,
       IN_PROGRESS,
       CLOSED

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -345,6 +345,26 @@ class MeetingsController < ApplicationController
     respond_with_turbo_streams
   end
 
+  def exit_draft_mode_dialog
+    respond_with_dialog Meetings::ExitDraftModeDialogComponent.new(meeting: @meeting)
+  end
+
+  def exit_draft_mode
+    call = ::Meetings::UpdateService
+             .new(user: current_user, model: @meeting)
+             .call({ state: "open", notify: meeting_params[:notify] == "1" })
+
+    if call.success?
+      update_all_via_turbo_stream
+      update_backlog_via_turbo_stream(collapsed: nil)
+
+      respond_with_turbo_streams
+    else
+      @meeting = call.result
+      render action: :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def load_query

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -167,9 +167,9 @@ class RecurringMeetingsController < ApplicationController
   end
 
   def template_completed # rubocop:disable Metrics/AbcSize
-    call = ::RecurringMeetings::InitOccurrenceService
+    call = ::RecurringMeetings::TemplateCompletedService
       .new(user: current_user, recurring_meeting: @recurring_meeting)
-      .call(start_time: @first_occurrence)
+      .call(notify: params[:meeting][:notify] == "1", first_occurrence: @first_occurrence)
 
     if call.success?
       init_next_occurrence_job(@first_occurrence)

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -35,22 +35,26 @@ class RecurringMeetingsController < ApplicationController
     end
   end
 
-  def new
-    @recurring_meeting = RecurringMeeting.new(project: @project)
-  end
-
   def show
-    if @direction == "past"
-      @meetings = @recurring_meeting.scheduled_instances(upcoming: false).limit(@count)
+    if @recurring_meeting.template.draft?
+      redirect_to meeting_path(@recurring_meeting.template)
     else
-      @meetings, @planned_meetings = upcoming_meetings(count: @count)
-    end
+      if @direction == "past"
+        @meetings = @recurring_meeting.scheduled_instances(upcoming: false).limit(@count)
+      else
+        @meetings, @planned_meetings = upcoming_meetings(count: @count)
+      end
 
-    respond_to do |format|
-      format.html do
-        render :show, locals: { menu_name: project_or_global_menu }
+      respond_to do |format|
+        format.html do
+          render :show, locals: { menu_name: project_or_global_menu }
+        end
       end
     end
+  end
+
+  def new
+    @recurring_meeting = RecurringMeeting.new(project: @project)
   end
 
   def init

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -166,7 +166,7 @@ class RecurringMeetingsController < ApplicationController
     end
   end
 
-  def template_completed
+  def template_completed # rubocop:disable Metrics/AbcSize
     call = ::RecurringMeetings::InitOccurrenceService
       .new(user: current_user, recurring_meeting: @recurring_meeting)
       .call(start_time: @first_occurrence)
@@ -180,7 +180,11 @@ class RecurringMeetingsController < ApplicationController
       flash[:error] = call.message
     end
 
-    redirect_to action: :show, id: @recurring_meeting, status: :see_other
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.redirect_to(project_recurring_meeting_path(@project, @recurring_meeting))
+      end
+    end
   end
 
   def delete_scheduled_dialog

--- a/modules/meeting/app/forms/meeting/send_email_updates.rb
+++ b/modules/meeting/app/forms/meeting/send_email_updates.rb
@@ -33,7 +33,7 @@ class Meeting::SendEmailUpdates < ApplicationForm
     meeting_form.check_box(
       name: "notify",
       label: I18n.t("label_meeting_send_updates"),
-      caption: "All participants will receive updated calendar invites via email informing them of changes.",
+      caption: I18n.t("label_meeting_send_updates_caption"),
       checked: true,
       data: {
         "show-when-checked-target": "cause",

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -120,7 +120,7 @@ class Meeting < ApplicationRecord
 
   enum :state, {
     open: 0, # 0 -> default, leave values for future states between open and closed
-    planned: 1,
+    draft: 1,
     in_progress: 3,
     cancelled: 4,
     closed: 5

--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -45,7 +45,7 @@ module Meetings
       model.change_by_system do
         model.author = user
         model.duration ||= 1
-        model.state = "draft" unless model.recurring?
+        model.state = "draft" if !model.recurring? || model.template?
         model.notify = false
       end
     end

--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -45,6 +45,7 @@ module Meetings
       model.change_by_system do
         model.author = user
         model.duration ||= 1
+        model.state = "draft"
       end
     end
 

--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -46,6 +46,7 @@ module Meetings
         model.author = user
         model.duration ||= 1
         model.state = "draft" unless model.recurring?
+        model.notify = false
       end
     end
 

--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -45,7 +45,7 @@ module Meetings
       model.change_by_system do
         model.author = user
         model.duration ||= 1
-        model.state = "draft"
+        model.state = "draft" unless model.recurring?
       end
     end
 

--- a/modules/meeting/app/services/recurring_meetings/template_completed_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/template_completed_service.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module RecurringMeetings
+  class TemplateCompletedService < ::BaseServices::BaseCallable
+    def initialize(user:, recurring_meeting:)
+      super()
+
+      @user = user
+      @recurring_meeting = recurring_meeting
+    end
+
+    protected
+
+    def perform
+      notify = params.fetch(:notify)
+      first_occurrence = params.fetch(:first_occurrence)
+
+      call = update_template(notify)
+      init_first_occurrence(call, first_occurrence) if call.success?
+
+      call
+    end
+
+    def update_template(notify)
+      ::Meetings::UpdateService
+        .new(user: @user, model: @recurring_meeting.template)
+        .call({ state: "open", notify: })
+    end
+
+    def init_first_occurrence(call, first_occurrence)
+      init_call = ::RecurringMeetings::InitOccurrenceService
+                    .new(user: @user, recurring_meeting: @recurring_meeting)
+                    .call(start_time: first_occurrence)
+
+      call.merge!(init_call)
+    end
+  end
+end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -413,6 +413,10 @@ en:
         You are currently editing a template of a meeting series: %{link}.
         Every new occurrence of a meeting in the series will use this template.
         Changes will not affect past or already-created meetings.
+      draft_banner_html: >
+        You are currently editing a template of a meeting series: %{link}.
+        Every new occurrence of a meeting in the series will use this template.
+        Changes will not affect past or already-created meetings.
         No email invites will be sent in this current draft mode until you open the first meeting.
     frequency:
       x_daily:

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -613,6 +613,8 @@ en:
   text_meeting_in_progress_dropdown_description: "Document outcomes like information needs or decisions taken during the meeting."
   text_meeting_closed_dropdown_description: "This meeting is closed. You cannot modify agenda items or outcomes anymore."
 
+  text_meeting_draft_banner: "You are currently in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
+
   text_meeting_not_editable_anymore: "This meeting is not editable anymore."
   text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."
 

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -144,7 +144,8 @@ en:
   label_meeting_date_time: "Date/Time"
   label_meeting_date_and_time: "Date and time"
   label_meeting_diff: "Diff"
-  label_meeting_send_updates: "Send email calendar updates"
+  label_meeting_send_updates: "Send email calendar invite and updates"
+  label_meeting_send_updates_caption: "Send out email invites to all participants of this meeting"
   label_recurring_meeting: "Recurring meeting"
   label_recurring_meeting_part_of: "Part of a meeting series"
   label_recurring_meeting_new: "New recurring meeting"
@@ -356,9 +357,9 @@ en:
             Email calendar updates are disabled. Participants will not receive an email informing them when you add or remove participants.
         onetime:
           enabled: >
-            All participants will receive updated calendar invites via email informing them of your changes.
+            All participants will receive updated calendar invites via email when you add or remove participants.
           disabled: >
-            Email calendar updates are disabled. Participants will not receive an email informing them of your changes.
+            Participants will not receive an email informing them of changes to meeting date, time or participants.
         occurrence:
           enabled: >
             Email calendar updates are enabled for the meeting series.
@@ -614,6 +615,9 @@ en:
   text_meeting_closed_dropdown_description: "This meeting is closed. You cannot modify agenda items or outcomes anymore."
 
   text_meeting_draft_banner: "You are currently in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
+  text_exit_draft_mode_dialog_title: "Open this meeting and send invites?"
+  text_exit_draft_mode_dialog_subtitle: "You cannot return to draft mode once you schedule a meeting."
+
 
   text_meeting_not_editable_anymore: "This meeting is not editable anymore."
   text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -412,7 +412,8 @@ en:
       banner_html: >
         You are currently editing a template of a meeting series: %{link}.
         Every new occurrence of a meeting in the series will use this template.
-        Changes will not affect past or already created meetings.
+        Changes will not affect past or already-created meetings.
+        No email invites will be sent in this current draft mode until you open the first meeting.
     frequency:
       x_daily:
         one: "Every day"
@@ -617,7 +618,8 @@ en:
   text_meeting_draft_banner: "You are currently in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
   text_exit_draft_mode_dialog_title: "Open this meeting and send invites?"
   text_exit_draft_mode_dialog_subtitle: "You cannot return to draft mode once you schedule a meeting."
-
+  text_exit_draft_mode_dialog_template_title: "Open the first occurrence of this meeting series?"
+  text_exit_draft_mode_dialog_template_subtitle: "You cannot return to draft mode after this."
 
   text_meeting_not_editable_anymore: "This meeting is not editable anymore."
   text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -593,6 +593,7 @@ en:
   label_meeting_details_edit: "Edit meeting details"
 
   label_meeting_state: "Meeting status"
+  label_meeting_state_draft: "Draft"
   label_meeting_state_open: "Open"
   label_meeting_state_closed: "Closed"
   label_meeting_state_agenda_created: "Agenda created"
@@ -603,6 +604,8 @@ en:
   label_meeting_reopen_action: "Reopen meeting"
   label_meeting_close_action: "Close meeting"
   label_meeting_in_progress_action: "Start meeting"
+  label_meeting_open_action: "Open meeting"
+  text_meeting_draft_description: "Prepare your agenda in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
   text_meeting_open_description: "You can add/remove agenda items and participants. Once the agenda is ready, mark it as in progress to document outcomes."
   text_meeting_closed_description: "This meeting is closed. You cannot add/remove agenda items anymore."
   text_meeting_in_progress_description: "You can modify the agenda, document outcomes for each item and track attendance for participants. Once the meeting is complete, you can mark it as closed to lock it."

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
         get :generate_pdf_dialog
         get :toggle_notifications_dialog
         post :toggle_notifications
+        get :exit_draft_mode_dialog
+        post :exit_draft_mode
       end
     end
 

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -88,7 +88,7 @@ module OpenProject::Meeting
                    require: :member
         permission :manage_agendas,
                    {
-                     meetings: %i[change_state],
+                     meetings: %i[change_state exit_draft_mode_dialog exit_draft_mode],
                      meeting_agenda_items: %i[new cancel_new create edit cancel_edit update destroy drop move
                                               move_to_next_meeting move_to_next_meeting_dialog
                                               move_to_section move_to_section_dialog],

--- a/modules/meeting/spec/features/meeting_notifications_spec.rb
+++ b/modules/meeting/spec/features/meeting_notifications_spec.rb
@@ -48,15 +48,17 @@ RSpec.describe "Meeting notifications", :js do
 
   shared_examples "notification checkbox behaviour" do
     it "shows checkbox checked initially" do
-      pending "needs spec"
-      within "#meeting-form" do
+      page.find_by_id("open-meeting-button").click
+
+      within "#exit-draft-mode-dialog" do
         expect(page).to have_field(I18n.t("label_meeting_send_updates"), type: "checkbox", checked: true)
       end
     end
 
     it "toggles banner on checkbox change" do
-      pending "needs spec"
-      within "#meeting-form" do
+      page.find_by_id("open-meeting-button").click
+
+      within "#exit-draft-mode-dialog" do
         # toggle between checkbox states
         checkbox = find_field(I18n.t("label_meeting_send_updates"))
         expect(page).to have_css(".Banner", text: enabled_text.strip)
@@ -83,14 +85,13 @@ RSpec.describe "Meeting notifications", :js do
       meetings_page.visit!
       meetings_page.click_on "add-meeting-button"
       meetings_page.click_on "One-time"
+      meetings_page.set_title "Some title"
+      meetings_page.click_create
     end
 
     include_examples "notification checkbox behaviour"
 
     it "sets and toggles the calendar updates state" do
-      meetings_page.set_title "Some title"
-      meetings_page.click_create
-
       # check if the default is set correctly
       expect(meeting.notify).to be false
 
@@ -221,6 +222,8 @@ RSpec.describe "Meeting notifications", :js do
       page.within(".Overlay") do
         meetings_page.click_on "Recurring"
       end
+      meetings_page.set_title "Some title"
+      meetings_page.click_create
     end
 
     include_examples "notification checkbox behaviour"
@@ -228,28 +231,27 @@ RSpec.describe "Meeting notifications", :js do
 
   context "for a recurring meeting" do
     let(:current_user) { user }
-    let(:meeting) do
-      create :recurring_meeting,
-             :skip_validations,
-             project:,
-             start_time: 1.day.from_now.to_date,
-             duration: 1.5,
-             frequency: "weekly",
-             end_after: "specific_date",
-             end_date: 1.year.from_now.to_date,
-             author: current_user
-    end
+    let(:meetings_page) { Pages::Meetings::Index.new(project:) }
+    let(:meeting) { RecurringMeeting.last }
     let(:show_page) { Pages::RecurringMeeting::Show.new(meeting) }
     let(:template_page) { Pages::Meetings::Show.new(meeting.template) }
     let(:occurrence_page) { Pages::Meetings::Show.new(meeting.meetings.where(template: false).first) }
 
+    before do
+      meetings_page.visit!
+      meetings_page.click_on "add-meeting-button"
+      page.within(".Overlay") do
+        meetings_page.click_on "Recurring"
+      end
+      meetings_page.set_title "Some title"
+      meetings_page.click_create
+    end
+
     it "can set and toggle the calendar updates state for the template and occurrences" do
       template_page.visit!
 
-      expect(meeting.template.notify).to be true
-      page.within("#meetings-header-component") do
-        click_on "Open first meeting"
-      end
+      expect(meeting.template.notify).to be false
+      template_page.open_first_meeting
 
       wait_for_network_idle
 
@@ -368,6 +370,18 @@ RSpec.describe "Meeting notifications", :js do
   context "when a meeting is closed" do
     let(:current_user) { user }
     let(:meeting) { create(:meeting, project:, author: current_user, notify: true, state: :closed) }
+    let(:show_page) { Pages::Meetings::Show.new(meeting) }
+
+    it "does not show the sidebar component" do
+      show_page.visit!
+
+      expect(page).to have_no_css("[data-test-selector='email-updates-mode-selector']")
+    end
+  end
+
+  context "when a meeting is in draft state" do
+    let(:current_user) { user }
+    let(:meeting) { create(:meeting, project:, author: current_user, notify: true, state: :draft) }
     let(:show_page) { Pages::Meetings::Show.new(meeting) }
 
     it "does not show the sidebar component" do

--- a/modules/meeting/spec/features/meeting_notifications_spec.rb
+++ b/modules/meeting/spec/features/meeting_notifications_spec.rb
@@ -48,12 +48,14 @@ RSpec.describe "Meeting notifications", :js do
 
   shared_examples "notification checkbox behaviour" do
     it "shows checkbox checked initially" do
+      pending "needs spec"
       within "#meeting-form" do
         expect(page).to have_field(I18n.t("label_meeting_send_updates"), type: "checkbox", checked: true)
       end
     end
 
     it "toggles banner on checkbox change" do
+      pending "needs spec"
       within "#meeting-form" do
         # toggle between checkbox states
         checkbox = find_field(I18n.t("label_meeting_send_updates"))
@@ -85,19 +87,18 @@ RSpec.describe "Meeting notifications", :js do
 
     include_examples "notification checkbox behaviour"
 
-    it "sets and toggle the calendar updates state" do
+    it "sets and toggles the calendar updates state" do
       meetings_page.set_title "Some title"
       meetings_page.click_create
 
-      # check if notify is set correct
-      expect(meeting.notify).to be true
-
-      # send initial mail to meeting creator
-      perform_enqueued_jobs
-      expect(ActionMailer::Base.deliveries.size).to eq 1
-      ActionMailer::Base.deliveries.clear
+      # check if the default is set correctly
+      expect(meeting.notify).to be false
 
       show_page.visit!
+
+      # check if notify is set to true when opening a meeting without unchecking
+      show_page.open_meeting
+      expect(meeting.reload.notify).to be true
 
       # check calendar updates sidepanel component
       page.within("[data-test-selector='email-updates-mode-selector']") do

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe "Recurring meetings creation",
   shared_let(:user) do
     create(:user,
            lastname: "First",
-           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings] }).tap do |u|
+           member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings
+                                                    manage_agendas] }).tap do |u|
       u.pref[:time_zone] = "Etc/UTC"
 
       u.save!
@@ -75,7 +76,6 @@ RSpec.describe "Recurring meetings creation",
 
   context "with a user with permissions" do
     it "can create a recurring meeting" do
-      pending "needs specification"
       login_as current_user
       meetings_page.visit!
       expect(page).to have_current_path(meetings_page.path)
@@ -95,14 +95,14 @@ RSpec.describe "Recurring meetings creation",
       meetings_page.set_end_after "a specific date"
       meetings_page.set_end_date "2025-01-15"
 
-      sleep 0.5 # quick fix as wait_for_network_idle isn't working all the time
-      expect(page).to have_text "Every week on Tuesday at 01:30 PM"
+      # quick fix as wait_for_network_idle isn't working all the time
+      expect(page).to have_text("Every week on Tuesday at 01:30 PM", wait: 2)
 
       click_on "Create meeting"
       wait_for_network_idle
       expect_and_dismiss_flash(type: :success, message: "Successful creation.")
 
-      # Use is redirected to the template
+      # User is redirected to the template
       expect(page).to have_current_path(project_meeting_path(project, meeting.template))
       expect(page).to have_content(I18n.t("recurring_meeting.template.description"))
 
@@ -125,10 +125,17 @@ RSpec.describe "Recurring meetings creation",
       perform_enqueued_jobs
       expect(ActionMailer::Base.deliveries.size).to eq 0
 
-      expect(page).to have_link("Open first meeting")
+      # Before exiting draft mode, user is always redirected to the template
+      show_page.visit!
+      expect(page).to have_current_path(project_meeting_path(project, meeting.template))
 
-      click_link_or_button "Open first meeting"
+      expect(page).to have_css("#meetings-side-panel-state-component")
+
+      template_page.open_first_meeting
       wait_for_network_idle
+
+      # State component is only visible for draft mode in a template
+      expect(page).to have_no_selector("#meetings-side-panel-state-component")
 
       # Sends out an invitation to the series
       show_page.visit!

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "Recurring meetings creation",
 
   context "with a user with permissions" do
     it "can create a recurring meeting" do
+      pending "needs specification"
       login_as current_user
       meetings_page.visit!
       expect(page).to have_current_path(meetings_page.path)

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -302,10 +302,9 @@ RSpec.describe "Meetings CRUD",
 
     wait_for_network_idle
 
-    # check for email notifications for creator & added participant
+    # check that no emails are sent out in draft mode
     perform_enqueued_jobs
-    expect(ActionMailer::Base.deliveries.size).to eq 2
-    ActionMailer::Base.deliveries.clear
+    expect(ActionMailer::Base.deliveries.size).to eq 0
 
     retry_block do
       click_on("op-meetings-header-action-trigger")
@@ -330,7 +329,7 @@ RSpec.describe "Meetings CRUD",
     # check for copied agenda items
     copied_meeting_page.expect_agenda_item title: "My agenda item"
 
-    copied_meeting_page.start_meeting
+    new_meeting.update!(state: "in_progress")
 
     # check for copied participants with attended status reset
     copied_meeting_page.open_participant_form
@@ -339,9 +338,9 @@ RSpec.describe "Meetings CRUD",
       copied_meeting_page.expect_participant(other_user)
     end
 
-    # check for email notifications for both participants
+    # check that no emails are sent out as the copied meeting is in draft mode
     perform_enqueued_jobs
-    expect(ActionMailer::Base.deliveries.size).to eq 2
+    expect(ActionMailer::Base.deliveries.size).to eq 0
   end
 
   context "with a work package reference to another" do

--- a/modules/meeting/spec/requests/meetings_spec.rb
+++ b/modules/meeting/spec/requests/meetings_spec.rb
@@ -83,31 +83,17 @@ RSpec.describe "Meeting requests",
       end
     end
 
-    describe "send_notifications" do
-      let(:params) { { notify: } }
+    describe "does not send notifications" do
+      before do
+        post meetings_path(project),
+             params: base_params
 
-      context "when enabled" do
-        let(:notify) { "1" }
-
-        before do
-          post meetings_path(project),
-               params: base_params.deep_merge(meeting: params)
-
-          Meeting.find_by(title: "Copied meeting")
-          perform_enqueued_jobs
-        end
-
-        it "sends out emails" do
-          expect(ActionMailer::Base.deliveries.size).to eq 1
-        end
+        Meeting.find_by(title: "Copied meeting")
+        perform_enqueued_jobs
       end
 
-      context "when disabled" do
-        let(:notify) { "0" }
-
-        it "sends out no emails" do
-          expect(ActionMailer::Base.deliveries).to be_empty
-        end
+      it do
+        expect(ActionMailer::Base.deliveries.size).to eq 0
       end
     end
 

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "Recurring meetings complete template",
   let(:current_user) { user }
   let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting).with_capybara_page(page) }
   let(:request) do
-    post template_completed_project_recurring_meeting_path(project, recurring_meeting), as: :turbo_stream
+    post template_completed_project_recurring_meeting_path(project, recurring_meeting), as: :turbo_stream,
+                                                                                        params: { meeting: { notify: "1" } }
   end
 
   subject do

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_template_completed_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Recurring meetings complete template",
   let(:current_user) { user }
   let(:show_page) { Pages::RecurringMeeting::Show.new(recurring_meeting).with_capybara_page(page) }
   let(:request) do
-    post template_completed_project_recurring_meeting_path(project, recurring_meeting)
+    post template_completed_project_recurring_meeting_path(project, recurring_meeting), as: :turbo_stream
   end
 
   subject do
@@ -64,7 +64,10 @@ RSpec.describe "Recurring meetings complete template",
   context "when first occurrence is not existing" do
     it "instantiates the first occurrence from template and schedules the init job" do
       expect { subject }.to change(recurring_meeting.scheduled_meetings, :count).by(1)
-      expect(response).to be_redirect
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('action="redirect_to"')
+      expect(response.body).to include(project_recurring_meeting_path(project, recurring_meeting))
 
       expect(recurring_meeting.scheduled_meetings.count).to eq(1)
       first = recurring_meeting.scheduled_meetings.first
@@ -92,7 +95,7 @@ RSpec.describe "Recurring meetings complete template",
 
     it "does not create a new meeting" do
       expect { subject }.not_to change(recurring_meeting.scheduled_meetings, :count)
-      expect(response).to be_redirect
+      expect(response).to redirect_to(project_recurring_meeting_path(project, recurring_meeting))
 
       expect(recurring_meeting.scheduled_meetings.count).to eq(1)
       first = recurring_meeting.scheduled_meetings.first.meeting
@@ -110,7 +113,10 @@ RSpec.describe "Recurring meetings complete template",
 
     it "takes over that occurrence" do
       expect { subject }.to change(recurring_meeting.meetings, :count).by(1)
-      expect(response).to be_redirect
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('action="redirect_to"')
+      expect(response.body).to include(project_recurring_meeting_path(project, recurring_meeting))
 
       expect(recurring_meeting.scheduled_meetings.count).to eq(1)
       first = recurring_meeting.scheduled_meetings.first

--- a/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
+++ b/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe Meetings::CopyService, "integration", type: :model do
   end
 
   context "when the meeting is closed" do
-    it "reopens the meeting" do
+    it "creates the copy in draft mode" do
       meeting.update! state: "closed"
       expect(service_result).to be_success
-      expect(copy.state).to eq("open")
+      expect(copy.state).to eq("draft")
     end
   end
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -597,6 +597,17 @@ module Pages::Meetings
       end
     end
 
+    def open_first_meeting
+      page.within("#meetings-side-panel-state-component") do
+        click_on("Open first meeting")
+      end
+
+      expect(page).to have_dialog(I18n.t("text_exit_draft_mode_dialog_template_title"))
+      page.within_dialog(I18n.t("text_exit_draft_mode_dialog_template_title")) do
+        click_on "Open meeting"
+      end
+    end
+
     def start_meeting
       page.within("#meetings-side-panel-state-component") do
         click_on("Start meeting")

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -502,7 +502,9 @@ module Pages::Meetings
 
     def open_participant_form
       page.find_test_selector("manage-participants-button").click
-      expect_modal("Manage participants")
+      retry_block do
+        expect_modal("Manage participants")
+      end
     end
 
     def in_participant_form(&)
@@ -577,6 +579,21 @@ module Pages::Meetings
     def close_meeting_from_in_progress
       page.within("#meetings-side-panel-state-component") do
         click_on("Close meeting")
+      end
+    end
+
+    def open_meeting
+      page.within("#meetings-side-panel-state-component") do
+        click_on("Open meeting")
+      end
+
+      expect(page).to have_dialog(I18n.t("text_exit_draft_mode_dialog_title"))
+      page.within_dialog(I18n.t("text_exit_draft_mode_dialog_title")) do
+        click_on "Open meeting"
+      end
+
+      page.within("#meetings-side-panel-state-component") do
+        expect(page).to have_link("Start meeting")
       end
     end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67268

# Changes
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add a draft state to meetings. This is the creation state for one-time meetings and series templates. Series occurrences skip this and continue to be created in the open state
- The sidepanel state component has been added to series templates, but only when in draft mode
- Email notification status checkboxes and banners have been removed from the one-time and series create/copy forms. Instead, that is decided when moving out of draft mode through a dedicated dialog component
- A series is always redirected to the template if still in draft mode

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
