### PR TITLE
Bug/68440 custom fields in project settings not ordered

### DIFF
--- a/app/views/projects/settings/work_packages/custom_fields/_form.html.erb
+++ b/app/views/projects/settings/work_packages/custom_fields/_form.html.erb
@@ -68,7 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
         </thead>
         <tbody>
           <% all_custom_fields = @project.all_work_package_custom_fields.pluck(:id) %>
-          <% work_package_custom_fields.includes(:types).find_each do |custom_field| %>
+          <% work_package_custom_fields.includes(:types).each do |custom_field| # rubocop:disable Rails/FindEach %>
           <%
             options = {
               lang: custom_field.name_locale,

--- a/app/views/projects/settings/work_packages/types/_form.html.erb
+++ b/app/views/projects/settings/work_packages/types/_form.html.erb
@@ -79,7 +79,7 @@ See COPYRIGHT and LICENSE files for more details.
       </thead>
       <tbody>
         <% projects_types_id = project.types.pluck(:id) %>
-        <% Type.includes(:color).find_each do |type| %>
+        <% Type.includes(:color).reorder('lower(name)').each do |type| # rubocop:disable Rails/FindEach %>
           <tr>
             <td>
               <%= icon_for_type(type) %>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68440

# What are you trying to accomplish?

Have the list of work packages in the project settings be ordered by name (ignoring the case).

The order was already defined to be `lower(name)` but the `find_each` lead to that being ignored. `find_each` should not be necessary in this case at all.

The type list used to be ordered by position before the change to `find_each`. I personally find that a questionable sort order since when having many types, it becomes harder to find a particular one. Therefore, the PR changes this as well. 

This was changed in c5a5d526 because of the linter complaining about the `find_each` presumably 
