### PR TITLE
[42064] Colorize octicons within spot text fields

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/text-field.sass
+++ b/frontend/src/app/spot/styles/sass/components/text-field.sass
@@ -52,6 +52,9 @@
     &:focus-visible
       outline: none
 
+  .octicon
+    fill: var(--body-font-color)
+
   &--clear-button
     border: 0
     background: transparent


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/42064/activity#comment-1466822

# What are you trying to accomplish?
Set color of octicons within spot text fields

## Screenshots
<img width="277" height="80" alt="Bildschirmfoto 2025-10-20 um 08 03 35" src="https://github.com/user-attachments/assets/2effc0c1-96ec-4399-9d0c-f54441282e14" />
