### PR TITLE
[68371] Safari date picker opens on calendar, hiding the top banner

### DIFF
--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.html
@@ -1,5 +1,5 @@
 <div
-  class="spot-modal spot-modal_auto-size loading-indicator--location"
+  class="spot-modal spot-modal_full-screen-when-narrow loading-indicator--location"
   data-indicator-name="modal"
   tabindex="0"
   >

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -30,10 +30,13 @@
     width: 60rem
     min-height: 40vh
 
-  &_auto-size
-    @media #{$spot-mq-desktop}
-      width: auto
-      min-height: auto
+  &_full-screen-when-narrow
+    @media #{$spot-mq-mobile}
+      width: 100dvw
+      height: 100dvh
+      max-height: unset
+      max-width: unset
+      border-radius: 0
 
   &--header
     @include spot-subheader-big


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68371

# What are you trying to accomplish?
Let datepicker modal go full screen on mobile

## Screenshots
<img width="461" height="904" alt="Bildschirmfoto 2025-10-20 um 08 32 25" src="https://github.com/user-attachments/assets/f8168561-7cc6-47b3-acc4-098c3f7287e9" />

