### PR TITLE
Select columns specifically needed for WP autocompletion

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
@@ -63,6 +63,8 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
   protected createParams(resource:TOpAutocompleterResource):{ [p:string]:string } {
     if (resource === 'work_packages') {
       return {
+        // see op-autocompleter/op-autocompleter.component.html for required attributes
+        select: 'elements/id,elements/subject,elements/author,elements/type,elements/project,elements/status',
         sortBy: '[["updatedAt","desc"]]',
       };
     }

--- a/lib/api/v3/work_packages/work_package_sql_representer.rb
+++ b/lib/api/v3/work_packages/work_package_sql_representer.rb
@@ -44,6 +44,26 @@ module API
                      condition: "projects.id = work_packages.project_id",
                      select: ["projects.name project_name"] }
 
+        link :status,
+             path: { api: :status, params: %w(id) },
+             column: -> { :status_id },
+             title: -> { "status_name" },
+             join: {
+               table: :statuses,
+               condition: "statuses.id = work_packages.status_id",
+               select: ["statuses.name status_name"]
+             }
+
+        link :type,
+             path: { api: :type, params: %w(id) },
+             column: -> { :type_id },
+             title: -> { "type_name" },
+             join: {
+               table: :types,
+               condition: "types.id = work_packages.type_id",
+               select: ["types.name type_name"]
+             }
+
         associated_user_link :author
 
         associated_user_link :assignee,

--- a/spec/lib/api/v3/work_packages/work_package_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sql_representer_rendering_spec.rb
@@ -48,11 +48,13 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSqlRepresenter, "rendering" do
   let(:rendered_work_package) do
     create(:work_package,
            project:,
+           type:,
            assigned_to: assignee,
            author:,
            responsible:)
   end
-  let(:project) { create(:project, types: [create(:type, is_milestone:)]) }
+  let(:project) { create(:project, types: [type]) }
+  let(:type) { create(:type, is_milestone:) }
   let(:is_milestone) { false }
   let(:assignee) { nil }
   let(:author) { create(:user) }
@@ -91,6 +93,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSqlRepresenter, "rendering" do
             author: {
               href: api_v3_paths.user(author.id),
               title: author.name
+            },
+            status: {
+              href: api_v3_paths.status(rendered_work_package.status.id),
+              title: rendered_work_package.status.name
+            },
+            type: {
+              href: api_v3_paths.type(type.id),
+              title: type.name
             }
           }
         }
@@ -128,6 +138,14 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSqlRepresenter, "rendering" do
             author: {
               href: api_v3_paths.user(author.id),
               title: author.name
+            },
+            status: {
+              href: api_v3_paths.status(rendered_work_package.status.id),
+              title: rendered_work_package.status.name
+            },
+            type: {
+              href: api_v3_paths.type(type.id),
+              title: type.name
             }
           }
         }


### PR DESCRIPTION
This allows to make more efficient database queries in the API and reduces overhead by too large JSON responses.

Assuming we fix [#68457](https://community.openproject.org/wp/68458), additional improvements in response time can be expected, because we do not need to perform a count for all matching work packages anymore (because we do not select "total").

# Ticket
https://community.openproject.org/wp/68458