### PR TITLE
[68465] Keep parent in manual mode after deleting its children

### DIFF
--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -168,10 +168,13 @@ class WorkPackages::UpdateAncestorsService < BaseServices::BaseCallable
   #
   # This method is called only when parent or parent_id attribute of the
   # initiator work package has been changed
-  def switch_to_automatic_mode(work_package, loader)
+  def switch_to_automatic_mode(work_package, loader) # rubocop:disable Metrics/AbcSize
     # it only applies to the initiator's direct parent
     return if initiator_work_package.parent_id.nil?
     return if initiator_work_package.parent_id != work_package.id
+
+    # it does not apply if the child was deleted
+    return if initiator_work_package.destroyed?
 
     # it only applies if there is no bulk duplicate in progress: if it's a copy, the copy must stay exact
     return if state.bulk_duplicate_in_progress

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -1191,6 +1191,25 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
         expect(future_parent.reload.schedule_manually).to be(true)
       end
     end
+
+    context "when a manually scheduled parent with two children has one child deleted" do
+      let_work_packages(<<~TABLE)
+        hierarchy | scheduling mode
+        parent    | manual
+          child1  | manual
+          child2  | manual
+      TABLE
+      let(:initiator_work_package) { child1 }
+
+      before do
+        child1.destroy
+      end
+
+      it "keeps the scheduling mode to manual (Bug #68465)" do
+        expect(call_result).to be_success
+        expect(parent.reload).to have_attributes(schedule_manually: true)
+      end
+    end
   end
 
   describe "ignore_non_working_days propagation" do


### PR DESCRIPTION
Switching to automatic mode is only when having the first child.

# Ticket

https://community.openproject.org/wp/68465

# What are you trying to accomplish?

When a parent is manually scheduled and the children are removed one by one, it should remain in manual mode.

The bug was that when only one child remained, it switched to automatic mode, like if the child was just added. That's wrong.

# What approach did you choose and why?

In the code responsible for switching to automatic mode, return if the child was destroyed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
