### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -167,6 +167,13 @@ module OpenProject
     # Include tstzrange columns in the list of time zone aware types
     ActiveRecord::Base.time_zone_aware_types += [:tstzrange]
 
+    # Specifies whether `to_time` methods preserve the UTC offset of their receivers
+    # or preserves the timezone. Rails 8.0+ default is `:zone`.
+    # If set to `:zone`, `to_time` methods will use the timezone of their receivers.
+    # If set to `:offset`, `to_time` methods will use the UTC offset.
+    # If `false`, `to_time` methods will convert to the local system UTC offset instead.
+    config.active_support.to_time_preserves_timezone = :zone
+
     # Activate being able to specify the format in which full_message works.
     # Doing this, it is e.g. possible to avoid having the format of '%{attribute} %{message}' which
     # will always prepend the attribute name to the error message.

--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -40,33 +40,6 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
-# Controls whether Active Job's `#perform_later` and similar methods automatically defer
-# the job queuing to after the current Active Record transaction is committed.
-#
-# Example:
-#   Topic.transaction do
-#     topic = Topic.create(...)
-#     NewTopicNotificationJob.perform_later(topic)
-#   end
-#
-# In this example, if the configuration is set to `:never`, the job will
-# be enqueued immediately, even though the `Topic` hasn't been committed yet.
-# Because of this, if the job is picked up almost immediately, or if the
-# transaction doesn't succeed for some reason, the job will fail to find this
-# topic in the database.
-#
-# If `enqueue_after_transaction_commit` is set to `:default`, the queue adapter
-# will define the behaviour.
-#
-# Note: Active Job backends can disable this feature. This is generally done by
-# backends that use the same database as Active Record as a queue, hence they
-# don't need this feature.
-#++
-
-# OP does use the same database as the queue. So writing to GoodJob is already transactional.
-Rails.application.config.active_job.enqueue_after_transaction_commit = :never
-
-###
 # Adds image/webp to the list of content types Active Storage considers as an image
 # Prevents automatic conversion to a fallback PNG, and assumes clients support WebP, as they support gif, jpeg, and png.
 # This is possible due to broad browser support for WebP, but older browsers and email clients may still not support

--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -40,14 +40,6 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
-# Specifies whether `to_time` methods preserve the UTC offset of their receivers or preserves the timezone.
-# If set to `:zone`, `to_time` methods will use the timezone of their receivers.
-# If set to `:offset`, `to_time` methods will use the UTC offset.
-# If `false`, `to_time` methods will convert to the local system UTC offset instead.
-#++
-Rails.application.config.active_support.to_time_preserves_timezone = :zone
-
-###
 # When both `If-Modified-Since` and `If-None-Match` are provided by the client
 # only consider `If-None-Match` as specified by RFC 7232 Section 6.
 # If set to `false` both conditions need to be satisfied.

--- a/modules/bim/app/controllers/bim/bcf/api/root.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/root.rb
@@ -39,7 +39,7 @@ module Bim::Bcf
       default_format :json
 
       error_representer ::Bim::Bcf::API::V2_1::Errors::ErrorRepresenter, "application/json; charset=utf-8"
-      error_formatter :json, ::Bim::Bcf::API::ErrorFormatter::Json
+      error_formatter :json, ::Bim::Bcf::API::ErrorFormatter::BcfJson
 
       authentication_scope OpenProject::Authentication::Scope::BCF_V2_1
 

--- a/modules/bim/app/formatters/bim/bcf/api/error_formatter/bcf_json.rb
+++ b/modules/bim/app/formatters/bim/bcf/api/error_formatter/bcf_json.rb
@@ -29,7 +29,7 @@
 module Bim::Bcf
   module API
     module ErrorFormatter
-      class Json < Grape::ErrorFormatter::Base
+      class BcfJson < Grape::ErrorFormatter::Base
         class << self
           def call(message, _backtrace, _options = {}, env = nil, _original_exception = nil)
             present(message, env)


### PR DESCRIPTION
# Ticket

* https://community.openproject.org/wp/63574 (one part of the PR)

# What are you trying to accomplish?

Fix some annoying deprecation warnings visible when running tests:

```
DEPRECATION WARNING: `to_time` will always preserve the full timezone rather than offset of the receiver in Rails 8.1. To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`. (called from <top (required)> at /Users/cbliard/code/opf/openproject/dev/config/environment.rb:35)
DEPRECATION WARNING: `config.active_job.enqueue_after_transaction_commit` is deprecated and will be removed in Rails 8.1. This configuration can still be set on individual jobs using `self.enqueue_after_transaction_commit=`, but due the nature of this behavior, it is not recommended to be set globally. (called from <top (required)> at /Users/cbliard/code/opf/openproject/dev/app/mailers/application_mailer.rb:31)
/Users/cbliard/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/grape-2.4.0/lib/grape/util/registry.rb:10:in 'Grape::Util::Registry#register': json is already registered with class Bim::Bcf::API::ErrorFormatter::Json (StructuredWarnings::StandardWarning)
```

I was not able to remove the one from Grape.

# What approach did you choose and why?

Actually we were already using the recommended defaults:
- for `config.active_job.enqueue_after_transaction_commit`, default is `false` and we were using `:never` which is equivalent to `false`
- for `config.active_support.to_time_preserves_timezone` we were using `:zone` but too late in the loading process. Moving it to `config/application.rb` fixed the warning.
- for grape, the error formatter for json gets registered automatically when it inherits `Grape::ErrorFormatter::Base`. So the default formatter `Grape::ErrorFormatter::Json` is registered, and then when we define ours, `Bim::Bcf::API::ErrorFormatter::Json`, it registers it and it overrides the default one. That outputs a warning by default (with a wrong message by the way). Not sure if we can avoid it...

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
