### PR TITLE
Translate "total" in widgets

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.html
@@ -14,7 +14,7 @@
 
   <ng-container>
     <div class="total-hours">
-      <p>Total: <span [textContent]="total"></span></p>
+      <p><span [textContent]="total"></span></p>
     </div>
   </ng-container>
 </div>

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
@@ -43,7 +43,7 @@ export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetCompone
       .reduce((current, entry) => current + this.timezone.toHours(entry.hours), 0);
 
     if (duration > 0) {
-      const amount = this.i18n.t('js.units.hour', { count: duration });
+      const amount = this.i18n.t('js.units.hour_string', { hours: duration.toFixed(2)});
       return this.i18n.t('js.label_total_amount', { amount });
     }
     return this.i18n.t('js.placeholders.default');

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
@@ -43,7 +43,8 @@ export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetCompone
       .reduce((current, entry) => current + this.timezone.toHours(entry.hours), 0);
 
     if (duration > 0) {
-      return this.i18n.t('js.units.hour_string', { hours: duration.toFixed(2)});
+      const amount = this.i18n.t('js.units.hour', { count: duration });
+      return this.i18n.t('js.label_total_amount', { amount });
     }
     return this.i18n.t('js.placeholders.default');
   }

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -13,7 +13,7 @@
 
   @if (!noEntries) {
     <div class="total-hours">
-      <p>Total: <span [textContent]="total"></span></p>
+      <p><span [textContent]="total"></span></p>
     </div>
     @if (entriesLoaded && anyEntries) {
       <div class="generic-table--results-container">

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -95,8 +95,8 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
 
   public get total():string {
     const duration = this.entries.reduce((current, entry) => current + this.timezone.toHours(entry.hours), 0);
-
-    return this.i18n.t('js.units.hour', { count: duration });
+    const amount = this.i18n.t('js.units.hour', { count: duration });
+    return this.i18n.t('js.label_total_amount', { amount });
   }
 
   public get anyEntries():boolean {


### PR DESCRIPTION
# Ticket 
TBD

# What are you trying to accomplish?
Fix Totals translation at time entries widget.

## Screenshots
<img width="421" height="257" alt="Screenshot_20251021_132801" src="https://github.com/user-attachments/assets/50ba15b2-2fa8-450c-b210-ecaa6490fa1b" />

# What approach did you choose and why?
Just use existing translation.
