### PR TITLE
[#68476] Graphs in widgets/dashboard only have black color in dark theme

### DIFF
--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -61,18 +61,20 @@ function getCSSVariable(variable:string) {
   return getComputedStyle(document.body).getPropertyValue(variable).trim();
 }
 
-const EMPHASIS_COLORS = PRIMER_COLORS
-  .map((color) => getCSSVariable(`--display-${color}-scale-6`));
+function getEmphasisColors() {
+  return PRIMER_COLORS.map((color) => getCSSVariable(`--display-${color}-scale-6`));
+}
 
-const MUTED_COLORS = PRIMER_COLORS
-  .map((color) => getCSSVariable(`--display-${color}-scale-2`));
+function getMutedColors() {
+  return PRIMER_COLORS.map((color) => getCSSVariable(`--display-${color}-scale-2`));
+}
 
 function getEmphasisColor(i:number) {
-  return EMPHASIS_COLORS[i % EMPHASIS_COLORS.length];
+  return getEmphasisColors()[i % PRIMER_COLORS.length];
 }
 
 function getMutedColor(i:number) {
-  return MUTED_COLORS[i % MUTED_COLORS.length];
+  return getMutedColors()[i % PRIMER_COLORS.length];
 }
 
 function colorizeDefaultDataset(dataset:ChartDataset, i:number) {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68476

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Moving the variable lookup into functions called at runtime, we ensure that the correct colors are picked after the OS theme has been applied.

## Screenshots
Before:
<img width="1054" height="444" alt="Screenshot 2025-10-21 at 12 42 56" src="https://github.com/user-attachments/assets/232652d9-f042-48f0-8a01-172f6a153f0a" />

After:
<img width="1097" height="499" alt="Screenshot 2025-10-21 at 12 42 35" src="https://github.com/user-attachments/assets/33ca886f-83a0-4d33-a674-720a2776a2d6" />
