### PR TITLE
[68459] When logging out, display shortly defaults to light mode before detecting OS display mode

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -455,7 +455,7 @@ module ApplicationHelper
   # To avoid the menu flickering, disable it
   # by default unless we're in test mode
   def initial_menu_styles(side_displayed)
-    Rails.env.test? || !side_displayed ? "" : "display:none"
+    Rails.env.test? || "display:none"
   end
 
   def initial_menu_classes(side_displayed, show_decoration)

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -40,8 +40,6 @@ See COPYRIGHT and LICENSE files for more details.
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
   <%# Disable prefetching for now %>
   <meta name="turbo-prefetch" content="false">
-  <%# Apply system theme immediately to prevent flickering %>
-
 </head>
 <%= content_tag :body,
                 class: "#{body_css_classes}  __overflowing_element_container __overflowing_body",

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -200,10 +200,6 @@ See COPYRIGHT and LICENSE files for more details.
   if (savedMainMenuWidth >= 0) {
     document.documentElement.style.setProperty('--main-menu-width', savedMainMenuWidth + 'px');
   }
-
-  //window.OpenProject.theme.applySystemThemeImmediately();
-
-  //wrapper.style.display = '';
 <% end %>
 
 <%= nonced_javascript_tag do %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -40,9 +40,31 @@ See COPYRIGHT and LICENSE files for more details.
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>
   <%# Disable prefetching for now %>
   <meta name="turbo-prefetch" content="false">
+  <%# Apply system theme immediately to prevent flickering %>
+  <% if User.current.pref.sync_with_os_theme? %>
+    <%= nonced_javascript_tag do %>
+      (function waitForBody() {
+      if (!document.body) {
+      return requestAnimationFrame(waitForBody);
+      }
+
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
+      const colorMode = prefersDark ? 'dark' : 'light';
+      const increaseContrast = prefersHighContrast;
+
+      const body = document.body;
+      const otherColorMode = colorMode === 'light' ? 'dark' : 'light';
+
+      body.setAttribute('data-color-mode', colorMode);
+      body.setAttribute(`data-${colorMode}-theme`, increaseContrast ? `${colorMode}_high_contrast` : colorMode);
+      body.removeAttribute(`data-${otherColorMode}-theme`);
+      })();
+    <% end %>
+  <% end %>
 </head>
 <%= content_tag :body,
-                class: "#{body_css_classes}  __overflowing_element_container __overflowing_body",
+                class: "#{body_css_classes} __overflowing_element_container __overflowing_body",
                 data: body_data_attributes(local_assigns) do %>
 <%= render partial: "warning_bar/warning_bar" %>
 <noscript>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -64,7 +64,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 </head>
 <%= content_tag :body,
-                class: "#{body_css_classes} __overflowing_element_container __overflowing_body",
+                class: "#{body_css_classes}  __overflowing_element_container __overflowing_body",
                 data: body_data_attributes(local_assigns) do %>
 <%= render partial: "warning_bar/warning_bar" %>
 <noscript>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,27 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
   <%# Disable prefetching for now %>
   <meta name="turbo-prefetch" content="false">
   <%# Apply system theme immediately to prevent flickering %>
-  <% if User.current.pref.sync_with_os_theme? %>
-    <%= nonced_javascript_tag do %>
-      (function waitForBody() {
-      if (!document.body) {
-      return requestAnimationFrame(waitForBody);
-      }
 
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const prefersHighContrast = window.matchMedia('(prefers-contrast: more)').matches;
-      const colorMode = prefersDark ? 'dark' : 'light';
-      const increaseContrast = prefersHighContrast;
-
-      const body = document.body;
-      const otherColorMode = colorMode === 'light' ? 'dark' : 'light';
-
-      body.setAttribute('data-color-mode', colorMode);
-      body.setAttribute(`data-${colorMode}-theme`, increaseContrast ? `${colorMode}_high_contrast` : colorMode);
-      body.removeAttribute(`data-${otherColorMode}-theme`);
-      })();
-    <% end %>
-  <% end %>
 </head>
 <%= content_tag :body,
                 class: "#{body_css_classes}  __overflowing_element_container __overflowing_body",
@@ -221,7 +201,9 @@ See COPYRIGHT and LICENSE files for more details.
     document.documentElement.style.setProperty('--main-menu-width', savedMainMenuWidth + 'px');
   }
 
-  wrapper.style.display = '';
+  //window.OpenProject.theme.applySystemThemeImmediately();
+
+  //wrapper.style.display = '';
 <% end %>
 
 <%= nonced_javascript_tag do %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -200,6 +200,7 @@ See COPYRIGHT and LICENSE files for more details.
   if (savedMainMenuWidth >= 0) {
     document.documentElement.style.setProperty('--main-menu-width', savedMainMenuWidth + 'px');
   }
+    window.OpenProject.wrapper.removeFocusWrapper();
 <% end %>
 
 <%= nonced_javascript_tag do %>

--- a/frontend/src/app/core/setup/globals/openproject.ts
+++ b/frontend/src/app/core/setup/globals/openproject.ts
@@ -31,6 +31,7 @@ import { input, InputState } from '@openproject/reactivestates';
 import { getMetaElement, GlobalHelpers } from 'core-app/core/setup/globals/global-helpers';
 import { firstValueFrom } from 'rxjs';
 import { ThemeUtils } from './theme-utils';
+import { WrapperUtils } from './wrapper-utils';
 
 export type OpenProjectPageState = 'pristine'|'edited'|'submitted';
 
@@ -46,6 +47,7 @@ export class OpenProject {
    * Theme utilities for system theme detection and application
    */
   public theme = new ThemeUtils();
+  public wrapper = new WrapperUtils();
 
   /** Globally setable variable whether the page was edited or submitted */
   pageState:OpenProjectPageState = 'pristine';

--- a/frontend/src/app/core/setup/globals/wrapper-utils.ts
+++ b/frontend/src/app/core/setup/globals/wrapper-utils.ts
@@ -1,0 +1,36 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+export class WrapperUtils {
+  public removeFocusWrapper() {
+    const wrapper = document.getElementById('wrapper')!;
+    wrapper.style.display = '';
+  }
+}

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -61,8 +61,6 @@ export default class AutoThemeSwitcher extends Controller {
     } else {
       this.applyTheme(this.themeValue, this.increaseContrastValue);
     }
-
-    window.OpenProject.wrapper.removeFocusWrapper();
   }
 
   syncWithOS():void {

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -61,6 +61,9 @@ export default class AutoThemeSwitcher extends Controller {
     } else {
       this.applyTheme(this.themeValue, this.increaseContrastValue);
     }
+
+    const wrapper = document.getElementById('wrapper')!;
+    wrapper.style.display = '';
   }
 
   syncWithOS():void {

--- a/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
+++ b/frontend/src/stimulus/controllers/auto-theme-switcher.controller.ts
@@ -62,8 +62,7 @@ export default class AutoThemeSwitcher extends Controller {
       this.applyTheme(this.themeValue, this.increaseContrastValue);
     }
 
-    const wrapper = document.getElementById('wrapper')!;
-    wrapper.style.display = '';
+    window.OpenProject.wrapper.removeFocusWrapper();
   }
 
   syncWithOS():void {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68459

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
- Use a `requestAnimationFrame` loop to wait for `document.body` to exist.
- Detect the user's OS theme via `window.matchMedia`.
When loading the page `window.OpenProject.theme` is not yet defined, so we can't use `window.OpenProject.theme.applyThemeToBody(theme, increaseContrast);` 
- Apply the theme directly to the body with `data-color-mode` and `data-${colorMode}-theme`.
- Restrict this logic to the anonymous user

This ensures the login page respects the OS theme from the start, avoiding the light-mode flash and the JS errors.

