### PR TITLE
Let projects eager load their parent in APIv3

### DIFF
--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -235,7 +235,7 @@ module API
           "Project"
         end
 
-        self.to_eager_load = [:enabled_modules]
+        self.to_eager_load = %i[enabled_modules parent]
 
         self.checked_permissions = %i[add_work_packages view_project]
       end


### PR DESCRIPTION
I noticed during investigation of a reported performance issue with large page sizes, that there is an N+1 query happening when listing projects. I don't see any downside from eager-loading this relation.

# Ticket
https://community.openproject.org/wp/68496