### PR TITLE
[68483] Missing space when renaming project attribute section

### DIFF
--- a/app/components/settings/project_custom_field_sections/dialog_body_form_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/dialog_body_form_component.html.erb
@@ -2,12 +2,8 @@
   component_wrapper do
     primer_form_with(**form_config) do |f|
       component_collection do |collection|
-        collection.with_component(Primer::BaseComponent.new(tag: :div)) do
-          flex_layout(mb: 3) do |modal_body|
-            modal_body.with_row do
-              render(ProjectCustomFieldSections::NameForm.new(f))
-            end
-          end
+        collection.with_component(Primer::Alpha::Dialog::Body.new) do
+          render(ProjectCustomFieldSections::NameForm.new(f))
         end
 
         collection.with_component(Primer::Alpha::Dialog::Footer.new) do

--- a/app/components/settings/project_custom_field_sections/new_section_dialog_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/new_section_dialog_component.html.erb
@@ -4,8 +4,6 @@
         size: :medium_portrait,
         id: MODAL_ID
       )
-    ) do |d| %>
-  <% d.with_body do %>
+    ) do %>
     <%= render(Settings::ProjectCustomFieldSections::DialogBodyFormComponent.new) %>
-  <% end %>
 <% end %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68483

# What are you trying to accomplish?
Render Footer outside the Body for correct spacings

## Screenshots

<img width="500" height="212" alt="Bildschirmfoto 2025-10-22 um 08 11 11" src="https://github.com/user-attachments/assets/50ae655a-86f9-472c-9ca8-155df34f58dc" />
<img width="500" height="208" alt="Bildschirmfoto 2025-10-22 um 08 11 25" src="https://github.com/user-attachments/assets/42549105-cd40-4c91-a647-bcc8c1e468f8" />

