### PR TITLE
Preload entities when rendering time entries

### DIFF
--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -65,7 +65,14 @@ module API
                render_nil: false,
                writable: false
 
+      # List of associations that shall be eager_load'ed when rendering entities represented by this decorator.
+      # This is a hint for renderers of this representer.
       class_attribute :to_eager_load
+
+      # List of associations that shall be preload'ed when rendering entities represented by this decorator.
+      # This is a hint for renderers of this representer.
+      class_attribute :to_preload
+
       class_attribute :checked_permissions
 
       # Override in subclasses to specify the JSON indicated "_type" of this representer

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -162,9 +162,7 @@ module API
             if constraint.is_a?(Class)
               result_scope
             else
-              result_scope
-                .includes(constraint.includes_values)
-                .merge constraint
+              result_scope.merge(constraint)
             end
           end
         end

--- a/modules/costs/lib/api/v3/time_entries/time_entries_api.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entries_api.rb
@@ -34,7 +34,10 @@ module API
 
         resources :time_entries do
           get &::API::V3::Utilities::Endpoints::Index.new(model: TimeEntry,
-                                                          scope: -> { TimeEntry.includes(TimeEntryRepresenter.to_eager_load) })
+                                                          scope: lambda do
+                                                            TimeEntry.eager_load(TimeEntryRepresenter.to_eager_load)
+                                                                     .preload(TimeEntryRepresenter.to_preload)
+                                                          end)
                                                      .mount
           post &::API::V3::Utilities::Endpoints::Create.new(model: TimeEntry).mount
 

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -181,6 +181,9 @@ module API
         end
 
         self.to_eager_load = [:user, :activity, { project: :enabled_modules }]
+
+        # entity is a polymorphic association and thus can't be eager-loaded, but it can be preloaded
+        self.to_preload = [:entity]
       end
     end
   end


### PR DESCRIPTION
We were previously eager-loading work packages, but when time entries were refactored to have a polymorphic association to "entities", eager loading was not possible anymore and the eagerload was removed without replacement (see eb4a1d7138).

However, preloading is a viable alternative for polymorphic associations, so we use that now instead. Docs around the "to_eager_load" and the newly added "to_preload" method have been added to clarify the purpose of these two methods.

# Ticket
https://community.openproject.org/wp/68513