### PR TITLE
[68341] Padding before and behind macros, e.g. user avatar

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-custom-options-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-custom-options-display-field.module.ts
@@ -34,6 +34,7 @@ export class MultipleLinesCustomOptionsDisplayField extends ResourcesDisplayFiel
     const values = this.stringValue;
     element.setAttribute('title', displayText);
     element.textContent = displayText;
+    element.classList.add('-multiline');
 
     element.innerHTML = '';
 

--- a/frontend/src/app/shared/components/principal/principal-renderer.service.ts
+++ b/frontend/src/app/shared/components/principal/principal-renderer.service.ts
@@ -78,6 +78,7 @@ export class PrincipalRendererService {
     for (let i = 0; i < users.length; i++) {
       const userElement = document.createElement('span');
       if (multiLine) {
+        container.classList.add('-multiline');
         userElement.classList.add('op-principal--multi-line');
       }
 

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -257,10 +257,13 @@ $scrollbar-size: 10px
 
 @mixin macro--text-style
   @media screen
-    display: inline-block
+    display: inline
     background: rgba(218,223,225,0.19)
     border: 1px solid transparent
     padding: 2px
+
+    &:has(.-multiline)
+      display: inline-flex
 
     &:hover
       cursor: default


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68341

# What are you trying to accomplish?
Show only multi-line macros as "inline-flex"

## Screenshots
<img width="953" height="1006" alt="Bildschirmfoto 2025-10-22 um 11 29 15" src="https://github.com/user-attachments/assets/0c4b2949-7152-494a-9e16-293ac00f30c2" />
