### PR TITLE
Add participation status to Participant model

### DIFF
--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -120,7 +120,9 @@ class Meeting < ApplicationRecord
 
   before_save :add_new_participants_as_watcher
 
-  after_update :send_updated_mail, if: -> { saved_change_to_start_time? || saved_change_to_duration? || saved_change_to_location? }
+  after_update :send_updated_mail, if: -> {
+    saved_change_to_start_time? || saved_change_to_duration? || saved_change_to_location?
+  }
 
   enum :state, {
     open: 0, # 0 -> default, leave values for future states between open and closed

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -29,7 +29,7 @@
 #++
 
 class MeetingParticipant < ApplicationRecord
-  belongs_to :meeting
+  belongs_to :meeting, inverse_of: :participants
   belongs_to :user
 
   validates :user, :meeting, presence: true

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -43,8 +43,8 @@ class MeetingParticipant < ApplicationRecord
     declined: "declined",
     tentative: "tentative",
     delegated: "delegated",
-    unknown: "unknown" # this is the default in the DB for all old entries
-  }, default: :needs_action
+    unknown: "unknown" # this status is used for existing participants when introducing the field
+  }
 
   def name
     user.present? ? user.name : I18n.t("user.deleted")

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -29,7 +29,7 @@
 #++
 
 class MeetingParticipant < ApplicationRecord
-  belongs_to :meeting, inverse_of: :participants
+  belongs_to :meeting
   belongs_to :user
 
   validates :user, :meeting, presence: true

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -41,9 +41,10 @@ class MeetingParticipant < ApplicationRecord
     needs_action: "needs-action",
     accepted: "accepted",
     declined: "declined",
-    tentative: "tentativ",
-    delegated: "delegated"
-  }, default: :needs_action, validate: { allow_nil: true }
+    tentative: "tentative",
+    delegated: "delegated",
+    unknown: "unknown" # this is the default in the DB for all old entries
+  }, default: :needs_action
 
   def name
     user.present? ? user.name : I18n.t("user.deleted")

--- a/modules/meeting/app/models/meeting_participant.rb
+++ b/modules/meeting/app/models/meeting_participant.rb
@@ -37,6 +37,14 @@ class MeetingParticipant < ApplicationRecord
   scope :invited, -> { where(invited: true) }
   scope :attended, -> { where(attended: true) }
 
+  enum :participation_status, {
+    needs_action: "needs-action",
+    accepted: "accepted",
+    declined: "declined",
+    tentative: "tentativ",
+    delegated: "delegated"
+  }, default: :needs_action, validate: { allow_nil: true }
+
   def name
     user.present? ? user.name : I18n.t("user.deleted")
   end
@@ -53,6 +61,6 @@ class MeetingParticipant < ApplicationRecord
 
   def copy_attributes
     # create a clean attribute set allowing to attach participants to different meetings
-    attributes.reject { |k, _v| ["id", "meeting_id", "attended", "created_at", "updated_at"].include?(k) }
+    attributes.except("id", "meeting_id", "attended", "created_at", "updated_at")
   end
 end

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -46,7 +46,6 @@ module AllMeetings
         end
 
         calendar.preload_for_recurring_meetings(recurring_meetings: recurring_meetings)
-        calendar.treat_participations_from_user_as_accepted!
         calendar.calendar_title = "#{Setting.app_title} - #{I18n.t('label_my_meetings')}"
 
         recurring_meetings.each do |recurring_meeting|

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -42,11 +42,6 @@ module Meetings
       @excluded_dates_cache = {}
       @instantiated_occurrences_cache = {}
       @series_cache_loaded = false
-      @action_needed_from_user_as_attendee = true
-    end
-
-    def treat_participations_from_user_as_accepted!
-      @action_needed_from_user_as_attendee = false
     end
 
     def calendar_title=(title)
@@ -212,27 +207,37 @@ module Meetings
           {
             "CN" => user.name,
             "EMAIL" => user.mail,
-            "PARTSTAT" => attendee_participation_status(user),
-            "RSVP" => attendee_rsvp_needed?(user) ? "TRUE" : "FALSE",
+            "PARTSTAT" => attendee_participation_status(participant),
+            "RSVP" => attendee_rsvp_needed?(participant) ? "TRUE" : nil,
             "CUTYPE" => "INDIVIDUAL",
             "ROLE" => "REQ-PARTICIPANT"
-          }
+          }.compact
         )
 
         event.append_attendee(address)
       end
     end
 
-    def attendee_participation_status(user)
-      if calendar_generated_for_user == user && @action_needed_from_user_as_attendee
+    def attendee_participation_status(participant) # rubocop:disable Metrics/PerceivedComplexity
+      return nil if participant.participation_status.nil?
+
+      if participant.needs_action?
         "NEEDS-ACTION"
-      else
-        "ACCEPTED" # until we handle RSVPs properly, we assume participants have accepted
+      elsif participant.accepted?
+        "ACCEPTED"
+      elsif participant.declined?
+        "DECLINED"
+      elsif participant.tentative?
+        "TENTATIVE"
+      elsif participant.delegated?
+        "DELEGATED"
+      elsif participant.unknown?
+        nil
       end
     end
 
-    def attendee_rsvp_needed?(user)
-      calendar_generated_for_user == user && @action_needed_from_user_as_attendee
+    def attendee_rsvp_needed?(participant)
+      calendar_generated_for_user == participant.user && participant.needs_action?
     end
 
     def ical_datetime(time, timezone: builder_internal_timezone)

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
       meeting_participant:
         invited: "Invited"
         attended: "Attended"
+        participation_status: "Participation status"
     errors:
       models:
         meeting_participant:

--- a/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
+++ b/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
@@ -2,6 +2,13 @@
 
 class AddParticipationStatusForMeetingParticipant < ActiveRecord::Migration[8.0]
   def change
-    add_column :meeting_participants, :participation_status, :string, null: false, default: "unknown"
+    add_column :meeting_participants, :participation_status, :string, null: true
+    execute <<-SQL.squish
+      UPDATE meeting_participants
+      SET participation_status = 'unknown'
+      WHERE participation_status IS NULL
+    SQL
+    change_column_default :meeting_participants, :participation_status, "needs-action"
+    change_column_null :meeting_participants, :participation_status, false
   end
 end

--- a/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
+++ b/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
@@ -11,7 +11,7 @@ class AddParticipationStatusForMeetingParticipant < ActiveRecord::Migration[8.0]
           WHERE participation_status IS NULL
         SQL
       end
-    end    
+    end
     change_column_default :meeting_participants, :participation_status, "needs-action"
     change_column_null :meeting_participants, :participation_status, false
   end

--- a/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
+++ b/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
@@ -2,6 +2,6 @@
 
 class AddParticipationStatusForMeetingParticipant < ActiveRecord::Migration[8.0]
   def change
-    add_column :meeting_participants, :participation_status, :string, null: true
+    add_column :meeting_participants, :participation_status, :string, null: false, default: "unknown"
   end
 end

--- a/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
+++ b/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddParticipationStatusForMeetingParticipant < ActiveRecord::Migration[8.0]
+  def change
+    add_column :meeting_participants, :participation_status, :string, null: true
+  end
+end

--- a/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
+++ b/modules/meeting/db/migrate/20251022114752_add_participation_status_for_meeting_participant.rb
@@ -3,11 +3,15 @@
 class AddParticipationStatusForMeetingParticipant < ActiveRecord::Migration[8.0]
   def change
     add_column :meeting_participants, :participation_status, :string, null: true
-    execute <<-SQL.squish
-      UPDATE meeting_participants
-      SET participation_status = 'unknown'
-      WHERE participation_status IS NULL
-    SQL
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL.squish
+          UPDATE meeting_participants
+          SET participation_status = 'unknown'
+          WHERE participation_status IS NULL
+        SQL
+      end
+    end    
     change_column_default :meeting_participants, :participation_status, "needs-action"
     change_column_null :meeting_participants, :participation_status, false
   end

--- a/modules/meeting/spec/contracts/meeting_participants/create_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_participants/create_contract_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe MeetingParticipants::CreateContract do
   shared_let(:user_without_meeting_permissions) { create(:user, member_with_permissions: { project => %i[view_project] }) }
   shared_let(:user_not_in_project) { create(:user) }
 
-  let(:participant) { build(:meeting_participant, meeting:, user:) }
+  let(:participant) { build(:meeting_participant, :needs_action, meeting:, user:) }
   let(:contract) { described_class.new(participant, user) }
 
   describe "validation" do

--- a/modules/meeting/spec/factories/meeting_factory.rb
+++ b/modules/meeting/spec/factories/meeting_factory.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
 
     trait :author_participates do
       after(:build) do |meeting|
-        meeting.participants.build(user: meeting.author, invited: true)
+        build(:meeting_participant, meeting: meeting, user: meeting.author, invited: true)
       end
     end
 

--- a/modules/meeting/spec/factories/meeting_factory.rb
+++ b/modules/meeting/spec/factories/meeting_factory.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
 
     trait :author_participates do
       after(:build) do |meeting|
-        build(:meeting_participant, meeting: meeting, user: meeting.author, invited: true)
+        meeting.participants << build(:meeting_participant, meeting: meeting, user: meeting.author, invited: true)
       end
     end
 

--- a/modules/meeting/spec/factories/meeting_participant_factory.rb
+++ b/modules/meeting/spec/factories/meeting_participant_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
   factory :meeting_participant do |_mp|
     user
     meeting
+    participation_status { "unknown" }
 
     trait :invitee do
       invited { true }

--- a/modules/meeting/spec/factories/meeting_participant_factory.rb
+++ b/modules/meeting/spec/factories/meeting_participant_factory.rb
@@ -40,5 +40,7 @@ FactoryBot.define do
     trait :attendee do
       attended { true }
     end
+
+    traits_for_enum(:participation_status)
   end
 end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -57,10 +57,40 @@ RSpec.describe Meetings::IcalendarBuilder,
   context "with a single meeting" do
     let(:meeting) { create(:meeting, :author_participates, start_time: Time.zone.parse("2025-08-30 10:00")) }
 
+    context "when meeting has been created before we added RSVP support" do
+      subject(:builder) { described_class.new(timezone:, user: meeting.author) }
+
+      let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+      before do
+        meeting.participants.first.update(participation_status: "unknown")
+      end
+
+      it "does not set PARTSTAT and RSVP for current user" do
+        builder.add_single_meeting_event(meeting:)
+        builder.update_calendar_status(cancelled: false)
+
+        event = parsed_calendar.events.first
+        expect(event.attendee).not_to be_empty
+
+        # Find the current user's attendee entry
+        current_user_attendee = event.attendee.find { |a| a.to_s.include?(meeting.author.mail) }
+        expect(current_user_attendee).to be_present
+        expect(current_user_attendee.ical_params).not_to have_key("partstat")
+        expect(current_user_attendee.ical_params["rsvp"]).to be_nil
+        expect(current_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
+        expect(current_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
+      end
+    end
+
     context "when current user needs to take action" do
       subject(:builder) { described_class.new(timezone:, user: meeting.author) }
 
       let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
+
+      before do
+        meeting.participants.first.update(participation_status: :needs_action)
+      end
 
       it "sets PARTSTAT to NEEDS-ACTION and RSVP to TRUE for current user" do
         builder.add_single_meeting_event(meeting:)
@@ -90,7 +120,11 @@ RSpec.describe Meetings::IcalendarBuilder,
 
     context "when current user has accepted all invitations" do
       subject(:builder) do
-        described_class.new(timezone:, user: meeting.author).tap(&:treat_participations_from_user_as_accepted!)
+        described_class.new(timezone:, user: meeting.author)
+      end
+
+      before do
+        meeting.participants.first.update(participation_status: :accepted)
       end
 
       let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
@@ -104,7 +138,7 @@ RSpec.describe Meetings::IcalendarBuilder,
 
         event.attendee.each do |attendee|
           expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(attendee.ical_params["rsvp"]).to be_nil
           expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
           expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
         end
@@ -117,7 +151,7 @@ RSpec.describe Meetings::IcalendarBuilder,
 
       subject(:builder) { described_class.new(timezone:, user: other_user) }
 
-      it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all attendees" do
+      it "does not set PARTSTAT and RSVP for any attendees" do
         builder.add_single_meeting_event(meeting:)
         builder.update_calendar_status(cancelled: false)
 
@@ -125,8 +159,8 @@ RSpec.describe Meetings::IcalendarBuilder,
         expect(event.attendee).not_to be_empty
 
         event.attendee.each do |attendee|
-          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(attendee.ical_params["partstat"]).to be_nil
+          expect(attendee.ical_params["rsvp"]).to be_nil
           expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
           expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
         end
@@ -138,8 +172,8 @@ RSpec.describe Meetings::IcalendarBuilder,
       let(:user2) { create(:user, firstname: "Jane", lastname: "Smith", mail: "jane@example.com") }
       let(:meeting_with_participants) do
         meeting = create(:meeting, start_time: Time.zone.parse("2025-08-30 10:00"))
-        create(:meeting_participant, meeting:, user: user1)
-        create(:meeting_participant, meeting:, user: user2)
+        create(:meeting_participant, :needs_action, meeting:, user: user1)
+        create(:meeting_participant, :accepted, meeting:, user: user2)
         meeting
       end
 
@@ -170,39 +204,9 @@ RSpec.describe Meetings::IcalendarBuilder,
 
           # Jane is not the current user, so she should have ACCEPTED and RSVP=FALSE
           expect(jane_attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(jane_attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(jane_attendee.ical_params["rsvp"]).to be_nil
           expect(jane_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
           expect(jane_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
-        end
-      end
-
-      context "when current user has accepted all invitations" do
-        subject(:builder) do
-          described_class.new(timezone:, user: user1).tap(&:treat_participations_from_user_as_accepted!)
-        end
-
-        let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
-
-        it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all multiple attendees" do
-          builder.add_single_meeting_event(meeting: meeting_with_participants)
-          builder.update_calendar_status(cancelled: false)
-
-          event = parsed_calendar.events.first
-          expect(event.attendee.count).to eq(2)
-
-          # Find attendees by email
-          john_attendee = event.attendee.find { |a| a.to_s.include?("john@example.com") }
-          jane_attendee = event.attendee.find { |a| a.to_s.include?("jane@example.com") }
-
-          expect(john_attendee).to be_present
-          expect(jane_attendee).to be_present
-
-          [john_attendee, jane_attendee].each do |attendee|
-            expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-            expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
-            expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
-            expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
-          end
         end
       end
     end
@@ -288,6 +292,14 @@ RSpec.describe Meetings::IcalendarBuilder,
     context "when current user needs to take action" do
       subject(:builder) { described_class.new(timezone:, user: user1) }
 
+      before do
+        recurring_meeting.template.participants.find_by(user: user1).update(participation_status: :needs_action)
+        recurring_meeting.meetings.each do |meeting|
+          meeting.participants.find_by(user: user1).update(participation_status: :needs_action)
+        end
+        recurring_meeting.template.participants.find_by(user: user2).update(participation_status: :declined)
+      end
+
       let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
 
       it "sets PARTSTAT to NEEDS-ACTION and RSVP to TRUE for current user in recurring meeting series" do
@@ -307,9 +319,9 @@ RSpec.describe Meetings::IcalendarBuilder,
         expect(current_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
         expect(current_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
 
-        # Other user should have ACCEPTED and RSVP=FALSE
-        expect(other_user_attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-        expect(other_user_attendee.ical_params["rsvp"]).to eq(["FALSE"])
+        # Other user should have DECLINED
+        expect(other_user_attendee.ical_params["partstat"]).to eq(["DECLINED"])
+        expect(other_user_attendee.ical_params["rsvp"]).to be_nil
         expect(other_user_attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
         expect(other_user_attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
 
@@ -321,8 +333,8 @@ RSpec.describe Meetings::IcalendarBuilder,
 
           expect(current_user_override.ical_params["partstat"]).to eq(["NEEDS-ACTION"])
           expect(current_user_override.ical_params["rsvp"]).to eq(["TRUE"])
-          expect(other_user_override.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(other_user_override.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(other_user_override.ical_params["partstat"]).to be_nil
+          expect(other_user_override.ical_params["rsvp"]).to be_nil
         end
       end
 
@@ -353,12 +365,12 @@ RSpec.describe Meetings::IcalendarBuilder,
 
     context "when current user has accepted all invitations" do
       subject(:builder) do
-        described_class.new(timezone:, user: user1).tap(&:treat_participations_from_user_as_accepted!)
+        described_class.new(timezone:, user: user1)
       end
 
       let(:parsed_calendar) { Icalendar::Calendar.parse(builder.to_ical).first }
 
-      it "sets PARTSTAT to ACCEPTED and RSVP to FALSE for all attendees in recurring meeting series" do
+      it "does not set PARTSTAT and RSVP for all attendees in recurring meeting series" do
         builder.add_series_event(recurring_meeting:)
 
         master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
@@ -367,8 +379,8 @@ RSpec.describe Meetings::IcalendarBuilder,
         # Check master event attendees
         expect(master.attendee).not_to be_empty
         master.attendee.each do |attendee|
-          expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-          expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+          expect(attendee.ical_params["partstat"]).to be_nil
+          expect(attendee.ical_params["rsvp"]).to be_nil
           expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
           expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
         end
@@ -377,8 +389,8 @@ RSpec.describe Meetings::IcalendarBuilder,
         overrides.each do |override_event|
           expect(override_event.attendee).not_to be_empty
           override_event.attendee.each do |attendee|
-            expect(attendee.ical_params["partstat"]).to eq(["ACCEPTED"])
-            expect(attendee.ical_params["rsvp"]).to eq(["FALSE"])
+            expect(attendee.ical_params["partstat"]).to be_nil
+            expect(attendee.ical_params["rsvp"]).to be_nil
             expect(attendee.ical_params["cutype"]).to eq(["INDIVIDUAL"])
             expect(attendee.ical_params["role"]).to eq(["REQ-PARTICIPANT"])
           end

--- a/modules/meeting/spec/services/recurring_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/ical_service_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe RecurringMeetings::ICalService, type: :model do # rubocop:disable
       expect(series_ical).to include("LOCATION:https://example.com/meet/important-meeting")
       expect(series_ical).to include("SUMMARY:Weekly")
       expect(series_ical).to include("CN=OpenProject:mailto:openproject@example.net")
-      expect(series_ical).to include("ATTENDEE;CN=Bob Barker;EMAIL=bob@example.com;PARTSTAT=NEEDS-ACTION;RSVP=TRU")
-      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com;PARTSTAT=ACCEPTED;RSVP=FALSE")
+      expect(series_ical).to include("ATTENDEE;CN=Bob Barker;EMAIL=bob@example.com")
+      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com")
       expect(series_ical).to include("RRULE:FREQ=WEEKLY;UNTIL=20251202T000000Z")
     end
   end
@@ -100,8 +100,8 @@ RSpec.describe RecurringMeetings::ICalService, type: :model do # rubocop:disable
       expect(parsed_events.count).to eq(1)
       expect(series_ical).to include("LOCATION:https://example.com/meet/important-meeting")
       expect(series_ical).to include("SUMMARY:Weekly")
-      expect(series_ical).to include("ATTENDEE;CN=Bob Barker;EMAIL=bob@example.com;PARTSTAT=NEEDS-ACTION;RSVP=TRU")
-      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com;PARTSTAT=ACCEPTED;RSVP=FALSE")
+      expect(series_ical).to include("ATTENDEE;CN=Bob Barker;EMAIL=bob@example.com")
+      expect(series_ical).to include("ATTENDEE;CN=Foo Fooer;EMAIL=foo@example.com")
       expect(series_ical).to include("RRULE:FREQ=WEEKLY")
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/68451

# What are you trying to accomplish?
- Add participation status "unknown" for all exisitng db entries
- Status "needs-action" is default for all new entries
- Change the iCal builder to take the new field into account

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
