### PR TITLE
Do not generate oauth token when the user is not allowed to edit documents

### DIFF
--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -121,6 +121,11 @@ class DocumentsController < ApplicationController
   end
 
   def generate_oauth_token
+    # do not generate a token if the user is not allowed to manage documents
+    if !current_user.allowed_in_project?(:manage_documents, @project)
+      return
+    end
+
     result = Documents::OAuth::GenerateTokenService
       .new(user: current_user)
       .call

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -163,6 +163,46 @@ RSpec.describe DocumentsController do
     end
   end
 
+  describe "generate_oauth_token" do
+    let(:manage_role) { create(:project_role, permissions: [:manage_documents]) }
+    let(:view_only_role) { create(:project_role, permissions: [:view_documents]) }
+    let(:user_with_manage) { create(:user) }
+    let(:user_without_manage) { create(:user) }
+
+    before do
+      create(:member, project:, user: user_with_manage, roles: [manage_role])
+      create(:member, project:, user: user_without_manage, roles: [view_only_role])
+    end
+
+    context "when user has manage_documents permission" do
+      current_user { user_with_manage }
+
+      it "generates an OAuth token for new action" do
+        get :new, params: { project_id: project.id }
+        expect(assigns(:oauth_token)).to be_present
+      end
+
+      it "generates an OAuth token for edit action" do
+        get :edit, params: { id: document.id }
+        expect(assigns(:oauth_token)).to be_present
+      end
+    end
+
+    context "when user does not have manage_documents permission" do
+      current_user { user_without_manage }
+
+      it "does not generate an OAuth token for new action" do
+        get :new, params: { project_id: project.id }
+        expect(assigns(:oauth_token)).to be_nil
+      end
+
+      it "does not generate an OAuth token for edit action" do
+        get :edit, params: { id: document.id }
+        expect(assigns(:oauth_token)).to be_nil
+      end
+    end
+  end
+
   def file_attachment
     test_document = "#{OpenProject::Documents::Engine.root}/spec/assets/attachments/testfile.txt"
     Rack::Test::UploadedFile.new(test_document, "text/plain")


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/68503/activity

# What are you trying to accomplish?

Avoid that users without manage permissions get access to editting documents. This is more like an extra check because the edit page does not even render if the user does not have access to editting documents.

# Merge checklist

- [x] Added/updated tests
