### PR TITLE
[#66623] Harmonise input data of download link query and open file link query

### DIFF
--- a/modules/storages/app/common/storages/adapters/input/download_link.rb
+++ b/modules/storages/app/common/storages/adapters/input/download_link.rb
@@ -35,7 +35,7 @@ module Storages
         private_class_method :new
 
         def self.build(file_id:, origin_name: nil, contract: DownloadLinkContract.new)
-          contract.call(file_id:).to_monad.fmap { |it| new(file_id: it[:file_id], origin_name:) }
+          contract.call(file_id:).to_monad.fmap { |file| new(file_id: file[:file_id], origin_name:) }
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/input/download_link.rb
+++ b/modules/storages/app/common/storages/adapters/input/download_link.rb
@@ -31,11 +31,11 @@
 module Storages
   module Adapters
     module Input
-      DownloadLink = Data.define(:file_id, :origin_name) do
+      DownloadLink = Data.define(:file_id) do
         private_class_method :new
 
-        def self.build(file_id:, origin_name: nil, contract: DownloadLinkContract.new)
-          contract.call(file_id:).to_monad.fmap { |file| new(file_id: file[:file_id], origin_name:) }
+        def self.build(file_id:, contract: DownloadLinkContract.new)
+          contract.call(file_id:).to_monad.fmap { |file| new(file_id: file[:file_id]) }
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/input/download_link.rb
+++ b/modules/storages/app/common/storages/adapters/input/download_link.rb
@@ -31,11 +31,11 @@
 module Storages
   module Adapters
     module Input
-      DownloadLink = Data.define(:file_link) do
+      DownloadLink = Data.define(:file_id, :origin_name) do
         private_class_method :new
 
-        def self.build(file_link:, contract: DownloadLinkContract.new)
-          contract.call(file_link:).to_monad.fmap { |it| new(**it.to_h) }
+        def self.build(file_id:, origin_name: nil, contract: DownloadLinkContract.new)
+          contract.call(file_id:).to_monad.fmap { |it| new(file_id: it[:file_id], origin_name:) }
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/input/download_link_contract.rb
+++ b/modules/storages/app/common/storages/adapters/input/download_link_contract.rb
@@ -33,7 +33,7 @@ module Storages
     module Input
       class DownloadLinkContract < DryApplicationContract
         params do
-          required(:file_link).filled(type?: FileLink)
+          required(:file_id).filled(:string)
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -76,7 +76,7 @@ module Storages
                   return Success(file_name) if file_name.present?
 
                   error = Results::Error.new(source: self.class, payload: file_info)
-                  Failure(error.with(code: :invalid_file_name))
+                  Failure(error.with(code: :not_found))
                 end
             end
 

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -70,16 +70,14 @@ module Storages
             end
 
             def fetch_origin_name(input_data, auth_strategy)
-              file_info_result = FileInfoQuery.call(storage: @storage, auth_strategy:, input_data:)
-              return file_info_result unless file_info_result.success?
+              FileInfoQuery.call(storage: @storage, auth_strategy:, input_data:)
+                .bind do |file_info|
+                  file_name = file_info.name
+                  return Success(file_name) if file_name.present?
 
-              name = file_info_result.value!.name
-              if name.blank?
-                error = Results::Error.new(source: self.class, payload: file_info_result.value!)
-                Failure(error.with(code: :invalid_file_name))
-              else
-                Success(name)
-              end
+                  error = Results::Error.new(source: self.class, payload: file_info)
+                  Failure(error.with(code: :invalid_file_name))
+                end
             end
 
             def fetch_download_token(auth_strategy, file_id)

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -35,7 +35,6 @@ module Storages
         module Queries
           class DownloadLinkQuery < Base
             def call(auth_strategy:, input_data:)
-              binding.pry
               Authentication[auth_strategy].call(storage: @storage, http_options:) do |http|
                 handle_response(http.post(request_url, json: { fileId: input_data.file_id })).fmap do |token|
                   URI(download_link(token, input_data.origin_name))

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -40,10 +40,6 @@ module Storages
                   URI(download_link(token, input_data.origin_name))
                 end
               end
-
-              # direct_download_request(auth_strategy:, file_link: input_data.file_link)
-              #   .bind { |response_body| direct_download_token(body: response_body) }
-              #   .map { |download_token| download_link(download_token, file_link.origin_name) }
             end
 
             private

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -35,9 +35,10 @@ module Storages
         module Queries
           class DownloadLinkQuery < Base
             def call(auth_strategy:, input_data:)
+              binding.pry
               Authentication[auth_strategy].call(storage: @storage, http_options:) do |http|
-                handle_response(http.post(request_url, json: { fileId: input_data.file_link.origin_id })).fmap do |token|
-                  URI(download_link(token, input_data.file_link.origin_name))
+                handle_response(http.post(request_url, json: { fileId: input_data.file_id })).fmap do |token|
+                  URI(download_link(token, input_data.origin_name))
                 end
               end
 

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/download_link_query.rb
@@ -36,8 +36,10 @@ module Storages
           class DownloadLinkQuery < Base
             def call(auth_strategy:, input_data:)
               Authentication[auth_strategy].call(storage: @storage, http_options:) do |http|
-                handle_response(http.post(request_url, json: { fileId: input_data.file_id })).fmap do |token|
-                  URI(download_link(token, input_data.origin_name))
+                fetch_origin_name(input_data, auth_strategy).bind do |origin_name|
+                  fetch_download_token(auth_strategy, input_data.file_id).fmap do |token|
+                    URI(download_link(token, origin_name))
+                  end
                 end
               end
             end
@@ -64,6 +66,25 @@ module Storages
                 Failure(error.with(code: :unauthorized))
               else
                 Failure(error.with(code: error))
+              end
+            end
+
+            def fetch_origin_name(input_data, auth_strategy)
+              file_info_result = FileInfoQuery.call(storage: @storage, auth_strategy:, input_data:)
+              return file_info_result unless file_info_result.success?
+
+              name = file_info_result.value!.name
+              if name.blank?
+                error = Results::Error.new(source: self.class, payload: file_info_result.value!)
+                Failure(error.with(code: :invalid_file_name))
+              else
+                Success(name)
+              end
+            end
+
+            def fetch_download_token(auth_strategy, file_id)
+              Authentication[auth_strategy].call(storage: @storage, http_options:) do |http|
+                handle_response(http.post(request_url, json: { fileId: file_id }))
               end
             end
 

--- a/modules/storages/app/common/storages/adapters/providers/one_drive/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/one_drive/queries/download_link_query.rb
@@ -36,7 +36,7 @@ module Storages
           class DownloadLinkQuery < Base
             def call(auth_strategy:, input_data:)
               Authentication[auth_strategy].call(storage: @storage) do |http|
-                handle_errors http.get(url_for(input_data.file_link.origin_id))
+                handle_errors http.get(url_for(input_data.file_id))
               end
             end
 

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/queries/download_link_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/queries/download_link_query.rb
@@ -37,7 +37,7 @@ module Storages
             def call(auth_strategy:, input_data:)
               with_tagged_logger do
                 Authentication[auth_strategy].call(storage: @storage) do |http|
-                  split_identifier(input_data.file_link.origin_id) => { drive_id:, location: }
+                  split_identifier(input_data.file_id) => { drive_id:, location: }
                   info "Fetching download link for drive item #{location} on drive #{drive_id}."
                   handle_errors http.get(request_uri(drive_id:, location:))
                 end

--- a/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
@@ -41,7 +41,8 @@ class API::V3::FileLinks::FileLinksDownloadAPI < API::OpenProjectAPI
 
   resources :download do
     get do
-      Storages::Adapters::Input::DownloadLink.build(file_id: @file_link.origin_id).bind do |input_data|
+      Storages::Adapters::Input::DownloadLink.build(file_id: @file_link.origin_id,
+                                                    origin_name: @file_link.origin_name).bind do |input_data|
         Storages::Adapters::Registry.resolve("#{@file_link.storage}.queries.download_link")
           .call(storage: @file_link.storage, auth_strategy:, input_data:)
           .either(

--- a/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
@@ -41,7 +41,7 @@ class API::V3::FileLinks::FileLinksDownloadAPI < API::OpenProjectAPI
 
   resources :download do
     get do
-      Storages::Adapters::Input::DownloadLink.build(file_link: @file_link).bind do |input_data|
+      Storages::Adapters::Input::DownloadLink.build(file_id: @file_link.origin_id).bind do |input_data|
         Storages::Adapters::Registry.resolve("#{@file_link.storage}.queries.download_link")
           .call(storage: @file_link.storage, auth_strategy:, input_data:)
           .either(

--- a/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
+++ b/modules/storages/lib/api/v3/file_links/file_links_download_api.rb
@@ -41,8 +41,7 @@ class API::V3::FileLinks::FileLinksDownloadAPI < API::OpenProjectAPI
 
   resources :download do
     get do
-      Storages::Adapters::Input::DownloadLink.build(file_id: @file_link.origin_id,
-                                                    origin_name: @file_link.origin_name).bind do |input_data|
+      Storages::Adapters::Input::DownloadLink.build(file_id: @file_link.origin_id).bind do |input_data|
         Storages::Adapters::Registry.resolve("#{@file_link.storage}.queries.download_link")
           .call(storage: @file_link.storage, auth_strategy:, input_data:)
           .either(

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -43,7 +43,7 @@ module Storages
             end
             let(:auth_strategy) { Registry["nextcloud.authentication.user_bound"].call(user, storage) }
 
-            let(:file_link) { create(:file_link, origin_id: "182") }
+            let(:file_link) { create(:file_link, origin_id: "182", origin_name: "file_name_1") }
             let(:not_existent_file_link) { create(:file_link, origin_id: "DeathStarNumberThree") }
             let(:input_data) { Input::DownloadLink.build(file_id: file_link.origin_id).value! }
 

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -57,7 +57,7 @@ module Storages
                 expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq auth_strategy], %i[keyreq input_data])
               end
 
-              context "with file_id string with invalid file id", vcr: "nextcloud/download_link_query_success" do
+              context "with file_id string with invalid file id", vcr: "nextcloud/download_link_query_not_found" do
                 let(:input_data) { Input::DownloadLink.build(file_id: "rubbish!@#", origin_name: "rubbish.txt").value! }
 
                 it "returns an error for invalid file_id" do
@@ -66,7 +66,7 @@ module Storages
 
                   error = download_link.failure
                   expect(error.source).to eq(described_class)
-                  expect(error.code).to eq(:invalid_file_id)
+                  expect(error.code).to eq(:not_found)
                 end
               end
 

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -57,6 +57,19 @@ module Storages
                 expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq auth_strategy], %i[keyreq input_data])
               end
 
+              context "with file_id string with invalid file id", vcr: "nextcloud/download_link_query_success" do
+                let(:input_data) { Input::DownloadLink.build(file_id: "rubbish!@#", origin_name: "rubbish.txt").value! }
+
+                it "returns an error for invalid file_id" do
+                  download_link = subject.call(auth_strategy:, input_data:)
+                  expect(download_link).to be_failure
+
+                  error = download_link.failure
+                  expect(error.source).to eq(described_class)
+                  expect(error.code).to eq(:invalid_file_id)
+                end
+              end
+
               context "with outbound request successful" do
                 it "returns a result with a download url", vcr: "nextcloud/download_link_query_success" do
                   download_link = subject.call(auth_strategy:, input_data:)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -45,7 +45,7 @@ module Storages
 
             let(:file_link) { create(:file_link, origin_id: "182") }
             let(:not_existent_file_link) { create(:file_link, origin_id: "DeathStarNumberThree") }
-            let(:input_data) { Input::DownloadLink.build(file_id: file_link.origin_id, origin_name: file_link.origin_name).value! }
+            let(:input_data) { Input::DownloadLink.build(file_id: file_link.origin_id).value! }
 
             subject { described_class.new(storage) }
 
@@ -70,14 +70,13 @@ module Storages
                 end
 
                 it "returns an error if the file is not found", vcr: "nextcloud/download_link_query_not_found" do
-                  input_data = Input::DownloadLink.build(file_id: not_existent_file_link.origin_id,
-                                                         origin_name: not_existent_file_link.origin_name).value!
+                  input_data = Input::DownloadLink.build(file_id: not_existent_file_link.origin_id).value!
                   download_link = subject.call(auth_strategy:, input_data:)
 
                   expect(download_link).to be_failure
 
                   error = download_link.failure
-                  expect(error.source).to eq(described_class)
+                  expect(error.source).to eq(FileInfoQuery)
                   expect(error.code).to eq(:not_found)
                 end
               end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -45,7 +45,7 @@ module Storages
 
             let(:file_link) { create(:file_link, origin_id: "182") }
             let(:not_existent_file_link) { create(:file_link, origin_id: "DeathStarNumberThree") }
-            let(:input_data) { Input::DownloadLink.build(file_link:).value! }
+            let(:input_data) { Input::DownloadLink.build(file_id: file_link.origin_id, origin_name: file_link.origin_name).value! }
 
             subject { described_class.new(storage) }
 
@@ -60,7 +60,6 @@ module Storages
               context "with outbound request successful" do
                 it "returns a result with a download url", vcr: "nextcloud/download_link_query_success" do
                   download_link = subject.call(auth_strategy:, input_data:)
-
                   expect(download_link).to be_success
 
                   uri = download_link.value!
@@ -70,7 +69,8 @@ module Storages
                 end
 
                 it "returns an error if the file is not found", vcr: "nextcloud/download_link_query_not_found" do
-                  input_data = Input::DownloadLink.build(file_link: not_existent_file_link).value!
+                  input_data = Input::DownloadLink.build(file_id: not_existent_file_link.origin_id,
+                                                         origin_name: not_existent_file_link.origin_name).value!
                   download_link = subject.call(auth_strategy:, input_data:)
 
                   expect(download_link).to be_failure

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -57,19 +57,6 @@ module Storages
                 expect(method.parameters).to contain_exactly(%i[keyreq storage], %i[keyreq auth_strategy], %i[keyreq input_data])
               end
 
-              context "with file_id string with invalid file id", vcr: "nextcloud/download_link_query_not_found" do
-                let(:input_data) { Input::DownloadLink.build(file_id: "rubbish!@#", origin_name: "rubbish.txt").value! }
-
-                it "returns an error for invalid file_id" do
-                  download_link = subject.call(auth_strategy:, input_data:)
-                  expect(download_link).to be_failure
-
-                  error = download_link.failure
-                  expect(error.source).to eq(described_class)
-                  expect(error.code).to eq(:not_found)
-                end
-              end
-
               context "with outbound request successful" do
                 it "returns a result with a download url", vcr: "nextcloud/download_link_query_success" do
                   download_link = subject.call(auth_strategy:, input_data:)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -60,6 +60,7 @@ module Storages
               context "with outbound request successful" do
                 it "returns a result with a download url", vcr: "nextcloud/download_link_query_success" do
                   download_link = subject.call(auth_strategy:, input_data:)
+
                   expect(download_link).to be_success
 
                   uri = download_link.value!

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/download_link_query_spec.rb
@@ -44,7 +44,7 @@ module Storages
             let(:file_link) { create(:file_link, origin_id: "01AZJL5PNDURPQGKUSGFCJQJMNNWXKTHSE") }
             let(:not_existent_file_link) { create(:file_link, origin_id: "DeathStarNumberThree") }
 
-            let(:input_data) { Input::DownloadLink.build(file_link:).value! }
+            let(:input_data) { Input::DownloadLink.build(file_id: file_link.origin_id).value! }
 
             subject { described_class.new(storage) }
 
@@ -68,7 +68,7 @@ module Storages
                 end
 
                 it "returns an error if the file is not found", vcr: "one_drive/download_link_query_not_found" do
-                  input_data = Input::DownloadLink.build(file_link: not_existent_file_link).value!
+                  input_data = Input::DownloadLink.build(file_id: not_existent_file_link.origin_id).value!
 
                   download_link = subject.call(auth_strategy:, input_data:)
                   expect(download_link).to be_failure

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/download_link_query_spec.rb
@@ -46,7 +46,7 @@ module Storages
             let(:not_existent_file_link) { create(:file_link, origin_id: "#{drive_id}:IHaveTheHighGround") }
             let(:folder_file_link) { create(:file_link, origin_id: "#{drive_id}:01ANJ53W4MWZNYS4FOTNDI3UVTLEXUZ5TQ") }
 
-            let(:input_data) { Input::DownloadLink.build(file_link:).value! }
+            let(:input_data) { Input::DownloadLink.build(file_id: file_link.origin_id).value! }
 
             subject { described_class.new(storage) }
 
@@ -70,7 +70,7 @@ module Storages
                 end
 
                 it "returns an error on folders", vcr: "sharepoint/download_link_query_folder" do
-                  input_data = Input::DownloadLink.build(file_link: folder_file_link).value!
+                  input_data = Input::DownloadLink.build(file_id: folder_file_link.origin_id).value!
 
                   download_link = subject.call(auth_strategy:, input_data:)
 
@@ -82,7 +82,7 @@ module Storages
                 end
 
                 it "returns an error if the file is not found", vcr: "sharepoint/download_link_query_not_found" do
-                  input_data = Input::DownloadLink.build(file_link: not_existent_file_link).value!
+                  input_data = Input::DownloadLink.build(file_id: not_existent_file_link.origin_id).value!
 
                   download_link = subject.call(auth_strategy:, input_data:)
                   expect(download_link).to be_failure

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_not_found.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_not_found.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://nextcloud.local/ocs/v2.php/apps/dav/api/v1/direct
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/DeathStarNumberThree
     body:
-      encoding: UTF-8
-      string: '{"fileId":"DeathStarNumberThree"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Ocs-Apirequest:
       - 'true'
@@ -14,26 +14,24 @@ http_interactions:
       Authorization:
       - Bearer <BEARER TOKEN>
       User-Agent:
-      - httpx.rb/1.2.3
+      - httpx.rb/1.2.5
       Accept-Encoding:
       - gzip, deflate
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '33'
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
       Content-Security-Policy:
       - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 08 Apr 2024 11:45:08 GMT
+      - Mon, 17 Jun 2024 11:39:18 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Feature-Policy:
@@ -44,21 +42,21 @@ http_interactions:
       Referrer-Policy:
       - no-referrer
       Server:
-      - Apache/2.4.57 (Debian)
+      - Apache/2.4.59 (Debian)
       Set-Cookie:
-      - ocirabgzify6=a2f996f3ca668255552213b8f9f091a2; path=/; secure; HttpOnly; SameSite=Lax,
-        oc_sessionPassphrase=aIbW5xgiklv%2Fcfy4ntVIlzu3JMbuSiRJiXSk8ppLfI2gFKnJYXdBBVkte0boPAZC1p58VWSVgWFrZpFn8JNXGvMmRARg4nkegifImFgoO3njSdxgOPyt2MmBRp%2BNBTkp;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
+      - oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=rCjW7PVMs0Wm7Cw%2FcEI51lR1%2FV%2Bx%2BWCIx8VrzECdrUbW53QVoxVHHN4nK4fbwOe9vyJEehUu8U5sdNoLYL%2FbIcRTh9H29kT8XzeNQ8yDIV9S7AtMuL%2B3kTDCUTSlhQwS;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
         path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
         path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
         __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
-        31-Dec-2100 23:59:59 GMT; SameSite=strict, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
-        path=/; secure; HttpOnly; SameSite=Lax, ocirabgzify6=a2f996f3ca668255552213b8f9f091a2;
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=e1159d217b1a2c60643d94b7d7a82944;
         path=/; secure; HttpOnly; SameSite=Lax
       X-Content-Type-Options:
       - nosniff
@@ -67,17 +65,18 @@ http_interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Powered-By:
-      - PHP/8.2.16
+      - PHP/8.2.18
       X-Request-Id:
-      - pmHzKTYbkUkfiUSko8Er
+      - im6fmMY2IdNhzoANEckx
       X-Robots-Tag:
       - noindex, nofollow
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '77'
+      - '115'
     body:
       encoding: UTF-8
-      string: '{"ocs":{"meta":{"status":"failure","statuscode":404,"message":""},"data":[]}}'
+      string: '{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"","totalitems":"","itemsperpage":""},"data":{"status":"Not
+        Found","statuscode":404}}}'
   recorded_at: Mon, 08 Apr 2024 11:45:08 GMT
 recorded_with: VCR 6.2.0

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_success.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_success.yml
@@ -1,6 +1,85 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/182
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 19 Jul 2024 09:06:54 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=0UfgvCBTXJ6J2s0wDA51RRyFzBpgnBCHD1QZy152qDxKWlHITzPGJHaFgi%2BNP8MCls0tcR1NCLHmgsq29y3hW418N6kD0Grt08syWSRMuural3JnsPmCJ5JLW%2FcXCMHF;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - cYTJzrAbVbXP6RvUzrxi
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '265'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":182,"name":"file_name_1.txt","mtime":1669880616,"ctime":0,"mimetype":"application\/gzip","size":982713473,"owner_name":"admin","owner_id":"admin","modifier_name":null,"modifier_id":null,"dav_permissions":"RGDNVW","path":"files\/My
+        files\/file_name_1.txt"}}}'
+  recorded_at: Mon, 08 Apr 2024 11:34:13 GMT
+- request:
     method: post
     uri: https://nextcloud.local/ocs/v2.php/apps/dav/api/v1/direct
     body:

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_unauthorized.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_unauthorized.yml
@@ -76,7 +76,7 @@ http_interactions:
       - '265'
     body:
       encoding: UTF-8
-      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":182,"name":"file_name_3.txt","mtime":1669880616,"ctime":0,"mimetype":"application\/gzip","size":982713473,"owner_name":"admin","owner_id":"admin","modifier_name":null,"modifier_id":null,"dav_permissions":"RGDNVW","path":"files\/My
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":182,"name":"file_name_1.txt","mtime":1669880616,"ctime":0,"mimetype":"application\/gzip","size":982713473,"owner_name":"admin","owner_id":"admin","modifier_name":null,"modifier_id":null,"dav_permissions":"RGDNVW","path":"files\/My
         files\/file_name_1.txt"}}}'
   recorded_at: Mon, 08 Apr 2024 11:34:13 GMT
 - request:

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_unauthorized.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/download_link_query_unauthorized.yml
@@ -1,6 +1,85 @@
 ---
 http_interactions:
 - request:
+    method: get
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/182
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Ocs-Apirequest:
+      - 'true'
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.3.0
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 19 Jul 2024 09:06:54 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Feature-Policy:
+      - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
+        'none';payment 'none'
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Server:
+      - Apache/2.4.59 (Debian)
+      Set-Cookie:
+      - oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=0UfgvCBTXJ6J2s0wDA51RRyFzBpgnBCHD1QZy152qDxKWlHITzPGJHaFgi%2BNP8MCls0tcR1NCLHmgsq29y3hW418N6kD0Grt08syWSRMuural3JnsPmCJ5JLW%2FcXCMHF;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
+        path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
+        __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax, oc07ul6b4oaw=4f7d12e13c12c5157b6c4a62d4472371;
+        path=/; secure; HttpOnly; SameSite=Lax
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - PHP/8.2.21
+      X-Request-Id:
+      - cYTJzrAbVbXP6RvUzrxi
+      X-Robots-Tag:
+      - noindex, nofollow
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '265'
+    body:
+      encoding: UTF-8
+      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":182,"name":"file_name_3.txt","mtime":1669880616,"ctime":0,"mimetype":"application\/gzip","size":982713473,"owner_name":"admin","owner_id":"admin","modifier_name":null,"modifier_id":null,"dav_permissions":"RGDNVW","path":"files\/My
+        files\/file_name_1.txt"}}}'
+  recorded_at: Mon, 08 Apr 2024 11:34:13 GMT
+- request:
     method: post
     uri: https://nextcloud.local/ocs/v2.php/apps/dav/api/v1/direct
     body:


### PR DESCRIPTION
# Ticket
[[#66623]](https://community.openproject.org/work_packages/66623)

# What are you trying to accomplish?
Change DownloadLink input to accept file_id instead of file_link object. Update contract and all usages in API, providers, and specs. Add optional origin_name for Nextcloud compatibility. Improves consistency between download and open link APIs.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
