### PR TITLE
bug/66552 Add filter support to activities tab paginator for better page distribution

### DIFF
--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -212,7 +212,8 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   private
 
   def initialize_pagination
-    @paginator, @paginated_journals = WorkPackages::ActivitiesTab::Paginator.paginate(@work_package, params)
+    @paginator, @paginated_journals = WorkPackages::ActivitiesTab::Paginator
+      .paginate(@work_package, params.merge(filter: @filter))
   end
 
   def respond_with_error(error_message)

--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -28,6 +28,26 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+# Paginates work package activities (journals and changesets) with support for filtering and anchor navigation.
+#
+# Filter modes:
+# - :all - Shows all activities (default)
+# - :only_comments - Shows only journals with notes
+# - :only_changes - Shows only journals with detected changes using SQL heuristics
+#
+# Anchor format (filter is reset to :all when using anchors):
+# - "comment-{journal_id}" - Navigate to specific journal by ID
+# - "activity-{sequence_version}" - Navigate to journal by sequence version
+#
+# @param work_package [WorkPackage] The work package to paginate activities for
+# @param params [Hash] Pagination and filtering parameters
+#
+# @option params [Integer] :page Page number (default: 1)
+# @option params [Integer] :limit Records per page (default: Pagy::DEFAULT[:limit])
+# @option params [Symbol] :filter Filter mode (:all, :only_comments, :only_changes)
+# @option params [String] :anchor Anchor to navigate to specific journal
+#
+# @return [Array<Pagy, Array>] Pagy pagination object and array of activity records
 class WorkPackages::ActivitiesTab::Paginator
   include Pagy::Backend
   include WorkPackages::ActivitiesTab::JournalSortingInquirable
@@ -36,9 +56,12 @@ class WorkPackages::ActivitiesTab::Paginator
     new(work_package, params).call
   end
 
+  attr_reader :work_package, :params, :filter
+
   def initialize(work_package, params = {})
     @work_package = work_package
     @params = params
+    @filter = params[:filter]&.to_sym || :all
   end
 
   def call
@@ -46,6 +69,7 @@ class WorkPackages::ActivitiesTab::Paginator
 
     pagy, records =
       if anchor_type && target_record_id
+        @filter = :all # Ignore filter when jumping to specific journal
         pagy_array_for_target_journal(anchor_type, target_record_id)
       else
         pagy_array(base_journals, **pagy_options)
@@ -58,8 +82,6 @@ class WorkPackages::ActivitiesTab::Paginator
   end
 
   private
-
-  attr_reader :work_package, :params
 
   def pagy_options
     { page: params[:page] || 1, limit: params[:limit] || Pagy::DEFAULT[:limit], max_pages: 100 }.compact
@@ -105,15 +127,28 @@ class WorkPackages::ActivitiesTab::Paginator
   end
 
   def fetch_ar_journals
-    work_package
+    journals = work_package
       .journals
       .internal_visible
-      .includes(:user, :customizable_journals, :attachable_journals, :storable_journals, :notifications)
+      .includes(
+        :user,
+        :customizable_journals,
+        :attachable_journals,
+        :storable_journals,
+        :notifications
+      )
       .reorder(version: :desc) # Always fetch newest first for pagination
       .with_sequence_version
+
+    journals = journals.where.not(notes: [nil, ""]) if filter == :only_comments
+    journals = apply_only_changes_filter_heuristic(journals) if filter == :only_changes
+
+    journals
   end
 
   def fetch_revisions
+    return Changeset.none if filter == :only_comments
+
     work_package.changesets.includes(:user, :repository)
   end
 
@@ -130,5 +165,66 @@ class WorkPackages::ActivitiesTab::Paginator
     elsif record.is_a?(Changeset)
       record.committed_on.to_i
     end
+  end
+
+  # SQL-based heuristic to filter journals with changes.
+  #
+  # Includes journals that have:
+  #   * Initial journal (version = 1) - always included
+  #   * Attachment changes (attachable_journals association)
+  #   * Custom field changes (customizable_journals association)
+  #   * File link changes (storages_file_links_journals association)
+  #   * Cause metadata (system-triggered changes)
+  #   * Attribute/data changes (compares work_package_journals columns with immediate predecessor)
+  #
+  # Note: This heuristic may include false positives (journals without actual changes)
+  # for performance reasons, as it uses EXISTS subqueries and cannot guarantee perfect accuracy.
+  def apply_only_changes_filter_heuristic(journals)
+    sql = <<~SQL.squish
+      version = 1
+      OR EXISTS (SELECT 1 FROM attachable_journals WHERE attachable_journals.journal_id = journals.id)
+      OR EXISTS (SELECT 1 FROM customizable_journals WHERE customizable_journals.journal_id = journals.id)
+      OR EXISTS (SELECT 1 FROM storages_file_links_journals WHERE storages_file_links_journals.journal_id = journals.id)
+      OR (cause IS NOT NULL AND cause != '{}')
+      OR EXISTS (#{attribute_data_changes_condition_sql})
+    SQL
+
+    journals.where(OpenProject::SqlSanitization.sanitize(sql))
+  end
+
+  def attribute_data_changes_condition_sql
+    <<~SQL.squish
+      SELECT 1
+        FROM journals predecessor
+        INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
+        INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
+        WHERE predecessor.journable_id = journals.journable_id
+          AND predecessor.journable_type = journals.journable_type
+          AND predecessor.version = (#{max_predecessor_version_sql})
+          AND (#{data_changes_condition_sql})
+    SQL
+  end
+
+  # Identify the immediate predecessor journal for comparison.
+  # NB: Journal versions are incremental but not guaranteed to be sequential.
+  def max_predecessor_version_sql
+    <<~SQL.squish
+      SELECT MAX(version)
+      FROM journals p2
+      WHERE p2.journable_id = journals.journable_id
+        AND p2.journable_type = journals.journable_type
+        AND p2.version < journals.version
+    SQL
+  end
+
+  # Detect changes in work_package_journals columns.
+  def data_changes_condition_sql
+    data_change_columns.map do |column_name|
+      "pred_data.#{column_name} IS DISTINCT FROM curr_data.#{column_name}"
+    end.join(" OR ")
+  end
+
+  def data_change_columns
+    Journal::WorkPackageJournal.column_names - ["id", "project_phase_definition_id"]
   end
 end

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -255,5 +255,256 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator do
         end
       end
     end
+
+    context "with :only_comments filter" do
+      let!(:journal_with_notes) do
+        create(:work_package_journal,
+               user:,
+               notes: "This is a comment",
+               journable: work_package,
+               version: 2)
+      end
+      let!(:journal_without_notes) do
+        create(:work_package_journal,
+               user:,
+               notes: "",
+               journable: work_package,
+               version: 3)
+      end
+
+      before do
+        params[:filter] = :only_comments
+      end
+
+      it "includes journals with notes" do
+        _pagy, records = paginator.call
+
+        journal_notes = records.map(&:notes)
+        expect(journal_notes).to include("This is a comment")
+      end
+
+      it "excludes journals without notes" do
+        _pagy, records = paginator.call
+
+        expect(records.map(&:id)).not_to include(journal_without_notes.id)
+      end
+
+      context "with changesets" do
+        let(:repository) { create(:repository_subversion, project:) }
+        let!(:changeset) do
+          create(:changeset,
+                 repository:,
+                 committed_on: 1.day.ago,
+                 revision: "rev1")
+        end
+
+        before do
+          work_package.changesets << changeset
+        end
+
+        it "excludes changesets (code commits are not comments)" do
+          _pagy, records = paginator.call
+
+          expect(records).not_to include(changeset)
+        end
+      end
+
+      context "with pagination" do
+        let(:test_limit) { 2 }
+
+        before do
+          # Create journals with notes by updating work package
+          work_package.subject = "Updated 1"
+          work_package.save!
+          work_package.journals.last.update_column(:notes, "Comment 1")
+
+          work_package.subject = "Updated 2"
+          work_package.save!
+          work_package.journals.last.update_column(:notes, "Comment 2")
+
+          params[:limit] = test_limit
+        end
+
+        it "paginates filtered results correctly" do
+          pagy, records = paginator.call
+
+          expect(pagy.count).to be >= 2
+          expect(records.size).to eq(test_limit)
+        end
+      end
+    end
+
+    context "with :only_changes filter" do
+      let(:initial_journal) { work_package.journals.find_by(version: 1) }
+
+      before do
+        params[:filter] = :only_changes
+      end
+
+      it "includes the initial journal (version = 1)" do
+        _pagy, records = paginator.call
+
+        expect(records.map(&:id)).to include(initial_journal.id)
+      end
+
+      context "with attribute changes" do
+        before do
+          # Create journal with attribute change
+          work_package.subject = "Updated subject"
+          work_package.save!
+        end
+
+        it "includes journals with attribute changes" do
+          _pagy, records = paginator.call
+
+          changed_journal = work_package.journals.order(:version).last
+          expect(records.map(&:id)).to include(changed_journal.id)
+        end
+      end
+
+      context "with only notes (no attribute changes)" do
+        let!(:notes_only_journal) do
+          journal = work_package.journals.last
+          journal.update_column(:notes, "Just a comment")
+          journal
+        end
+
+        it "may include journals with only notes (acceptable false positive)" do
+          _pagy, records = paginator.call
+
+          expect(records).not_to be_empty
+        end
+      end
+
+      context "with attachment changes" do
+        before do
+          work_package.attachments << create(:attachment)
+          work_package.save!
+        end
+
+        it "includes journals with attachment changes" do
+          _pagy, records = paginator.call
+
+          attachment_journal = work_package.journals.order(:version).last
+          expect(records.map(&:id)).to include(attachment_journal.id)
+        end
+      end
+
+      context "with cause attribute" do
+        let!(:journal_with_cause) do
+          work_package.subject = "Changed by system"
+          work_package.save!
+          journal = work_package.journals.last
+          journal.update_column(:cause, { type: "system_update" })
+          journal
+        end
+
+        it "includes journals with cause" do
+          _pagy, records = paginator.call
+
+          expect(records.map(&:id)).to include(journal_with_cause.id)
+        end
+      end
+
+      context "with custom field changes" do
+        let!(:custom_field) { create(:work_package_custom_field, field_format: "string") }
+
+        before do
+          project.work_package_custom_fields << custom_field
+          work_package.type.custom_fields << custom_field
+          work_package.custom_field_values = { custom_field.id => "Custom value" }
+          work_package.save!
+        end
+
+        it "includes journals with custom field changes" do
+          _pagy, records = paginator.call
+
+          cf_journal = work_package.journals.order(:version).last
+          expect(records.map(&:id)).to include(cf_journal.id)
+        end
+      end
+
+      context "with file link changes" do
+        let(:storage) { create(:nextcloud_storage) }
+        let(:file_link) { create(:file_link, container: work_package, storage:) }
+
+        before do
+          create(:project_storage, project:, storage:)
+          file_link # Trigger file link creation which creates a journal
+        end
+
+        it "includes journals with file link changes" do
+          _pagy, records = paginator.call
+
+          file_link_journal = work_package.journals.order(:version).last
+          expect(records.map(&:id)).to include(file_link_journal.id)
+        end
+      end
+    end
+
+    context "with filter and deep linking" do
+      let!(:journal_with_notes) do
+        create(:work_package_journal,
+               user:,
+               notes: "Comment 1",
+               journable: work_package,
+               version: 2)
+      end
+      let!(:journal_without_notes) do
+        create(:work_package_journal,
+               user:,
+               notes: "",
+               journable: work_package,
+               version: 3)
+      end
+
+      before do
+        params[:filter] = :only_comments
+      end
+
+      context "when anchoring to a journal that matches the filter" do
+        it "returns the page containing the target journal" do
+          params[:anchor] = "comment-#{journal_with_notes.id}"
+          _pagy, records = paginator.call
+
+          expect(paginator.filter).to eq(:all) # resets to :all when anchoring
+          expect(records.map(&:id)).to include(journal_with_notes.id)
+        end
+      end
+
+      context "when anchoring to a journal that doesn't match the filter" do
+        it "ignores the filter and shows all journals (fallback behavior)" do
+          params[:anchor] = "comment-#{journal_without_notes.id}"
+          _pagy, records = paginator.call
+
+          expect(paginator.filter).to eq(:all) # resets to :all when anchoring
+          expect(records.map(&:id)).to include(journal_without_notes.id)
+          expect(records.map(&:id)).to include(journal_with_notes.id)
+        end
+      end
+    end
+
+    context "with all journals filtered out" do
+      let(:work_package) { create(:work_package, project:, author: user) }
+
+      before do
+        # Create only journals without notes
+        3.times do |i|
+          create(:work_package_journal,
+                 user:,
+                 notes: "",
+                 journable: work_package,
+                 version: i + 2)
+        end
+        params[:filter] = :only_comments
+      end
+
+      it "returns empty results" do
+        pagy, records = paginator.call
+
+        expect(pagy.count).to eq(0)
+        expect(records).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/66552

Implements `:only_comments` and `:only_changes` filters to prevent paginating journals that don't match the active filter, reducing unnecessary HTTP requests during lazy loading.

Use SQL-based heuristic to filter journals with changes at database level

  * Include journals with: initial version, attachments, custom fields, file links, cause metadata, or attribute changes
  * Compare work_package_journals columns with immediate predecessor to detect data changes _(handles non-sequential journal versions)_

Test WP: https://qa.openproject-stage.com/projects/cecile-demo-project/work_packages/3647/activity

<details> <summary> <em>The red borders demarcate page nodes. (Click to see code change)</em> </summary>

```ruby
diff --git a/app/components/work_packages/activities_tab/journals/page_component.html.erb b/app/components/work_packages/activities_tab/journals/page_component.html.erb
index cc02170f5fc..621bc2eca2f 100644
--- a/app/components/work_packages/activities_tab/journals/page_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/page_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   component_wrapper do
-    flex_layout do |flex_container|
+    flex_layout(style: "border: 2px dashed red;") do |flex_container|
       journals.each do |record|
         flex_container.with_row do
           if record.is_a?(Changeset)
```

</details>

**_Before:_**

<img width="1958" height="1251" alt="Screenshot 2025-10-23 at 9 32 40 AM" src="https://github.com/user-attachments/assets/09a64631-d318-449d-af2c-1424c8eea2e4" />

**_After:_**

<img width="3007" height="1565" alt="Screenshot 2025-10-23 at 2 02 45 PM" src="https://github.com/user-attachments/assets/608774ab-3884-4a0e-9eaf-33ff99ad5e9e" />

----

<details> <summary> Sample resulting query </summary>

```sql
SELECT * 
FROM "journals" 
JOIN LATERAL (
    SELECT 
        journals_rank.id, 
        ROW_NUMBER() OVER (ORDER BY version ASC) AS sequence_version
    FROM journals journals_rank 
    WHERE journals_rank.journable_id = journals.journable_id 
      AND journals_rank.journable_type = journals.journable_type
) ranked ON ranked.id = journals.id 

WHERE "journals"."journable_id" = 3647 
  AND "journals"."journable_type" = 'WorkPackage' 
  AND "journals"."restricted" = FALSE 
  AND (
    version = 1 
    OR EXISTS (
        SELECT 1 FROM attachable_journals 
        WHERE attachable_journals.journal_id = journals.id
    )
    OR EXISTS (
        SELECT 1 FROM customizable_journals 
        WHERE customizable_journals.journal_id = journals.id
    )
    OR EXISTS (
        SELECT 1 FROM storages_file_links_journals 
        WHERE storages_file_links_journals.journal_id = journals.id
    )
    OR (cause IS NOT NULL AND cause != '{}')
    OR EXISTS (
        SELECT 1 
        FROM journals predecessor 
        INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
        INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
        WHERE predecessor.journable_id = journals.journable_id 
          AND predecessor.journable_type = journals.journable_type 
          AND predecessor.version = (
              SELECT MAX(version) 
              FROM journals p2 
              WHERE p2.journable_id = journals.journable_id 
                AND p2.journable_type = journals.journable_type 
                AND p2.version < journals.version
          )
          AND (
              pred_data.type_id IS DISTINCT FROM curr_data.type_id 
              OR pred_data.project_id IS DISTINCT FROM curr_data.project_id 
              OR pred_data.subject IS DISTINCT FROM curr_data.subject 
              OR pred_data.description IS DISTINCT FROM curr_data.description 
              OR pred_data.due_date IS DISTINCT FROM curr_data.due_date 
              OR pred_data.category_id IS DISTINCT FROM curr_data.category_id 
              OR pred_data.status_id IS DISTINCT FROM curr_data.status_id 
              OR pred_data.assigned_to_id IS DISTINCT FROM curr_data.assigned_to_id 
              OR pred_data.priority_id IS DISTINCT FROM curr_data.priority_id 
              OR pred_data.version_id IS DISTINCT FROM curr_data.version_id 
              OR pred_data.author_id IS DISTINCT FROM curr_data.author_id 
              OR pred_data.done_ratio IS DISTINCT FROM curr_data.done_ratio 
              OR pred_data.estimated_hours IS DISTINCT FROM curr_data.estimated_hours 
              OR pred_data.start_date IS DISTINCT FROM curr_data.start_date 
              OR pred_data.parent_id IS DISTINCT FROM curr_data.parent_id 
              OR pred_data.responsible_id IS DISTINCT FROM curr_data.responsible_id 
              OR pred_data.derived_estimated_hours IS DISTINCT FROM curr_data.derived_estimated_hours 
              OR pred_data.schedule_manually IS DISTINCT FROM curr_data.schedule_manually 
              OR pred_data.duration IS DISTINCT FROM curr_data.duration 
              OR pred_data.ignore_non_working_days IS DISTINCT FROM curr_data.ignore_non_working_days 
              OR pred_data.derived_remaining_hours IS DISTINCT FROM curr_data.derived_remaining_hours 
              OR pred_data.derived_done_ratio IS DISTINCT FROM curr_data.derived_done_ratio 
              OR pred_data.story_points IS DISTINCT FROM curr_data.story_points 
              OR pred_data.remaining_hours IS DISTINCT FROM curr_data.remaining_hours 
              OR pred_data.budget_id IS DISTINCT FROM curr_data.budget_id
          )
    )
  )
ORDER BY "journals"."version" DESC
```

</details>