### PR TITLE
Group react updates on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
       appsignal:
         patterns:
           - '@appsignal/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Ticket
No ticket, this is a follow up of an error happening on https://github.com/opf/openproject/pull/20531

# What are you trying to accomplish?
Group updates to react and react-dom as they should always be on the same version
