### PR TITLE
[64485] CreateFolderService for SharePoint

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/commands/set_permissions_command.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/commands/set_permissions_command.rb
@@ -36,11 +36,7 @@ module Storages
           class SetPermissionsCommand < Base
             include Dry::Monads::Do.for(:call)
 
-            PermissionUpdateData = ::Data.define(:role,
-                                                 :permission_ids,
-                                                 :user_ids,
-                                                 :drive_id,
-                                                 :item_id) do
+            PermissionUpdateData = ::Data.define(:role, :permission_ids, :user_ids, :drive_id, :item_id) do
               def create? = permission_ids.empty? && user_ids.any?
 
               def delete? = permission_ids.any? && user_ids.empty?
@@ -99,8 +95,7 @@ module Storages
             end
 
             def role_to_user_map(input_data)
-              input_data.user_permissions
-                        .each_with_object({ read: [], write: [] }) do |user_permission_set, map|
+              input_data.user_permissions.each_with_object({ read: [], write: [] }) do |user_permission_set, map|
                 if user_permission_set[:permissions].include?(:write_files)
                   map[:write] << user_permission_set[:user_id]
                 elsif user_permission_set[:permissions].include?(:read_files)

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/managed_folder_identifier.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/managed_folder_identifier.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages
+  module Adapters
+    module Providers
+      module Sharepoint
+        class ManagedFolderIdentifier
+          CHARACTER_BLOCKLIST = /[\\<>+?:"|\/]/
+
+          def initialize(project_storage)
+            @project_storage = project_storage
+          end
+
+          def name
+            "#{project.name.gsub(CHARACTER_BLOCKLIST, '_')} (#{project.id})"
+          end
+
+          def path
+            "#{storage.managed_drive_name}/#{name}"
+          end
+
+          def location
+            @project_storage.project_folder_id
+          end
+
+          private
+
+          def project = @project_storage.project
+          def storage = @project_storage.storage
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/queries/file_path_to_id_map_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/queries/file_path_to_id_map_query.rb
@@ -34,13 +34,7 @@ module Storages
       module Sharepoint
         module Queries
           class FilePathToIdMapQuery < Base
-            FOLDER_FIELDS = %w[id
-                               name
-                               parentReference
-                               webUrl
-                               fileSystemInfo
-                               createdBy
-                               lastModifiedBy].freeze
+            FOLDER_FIELDS = %w[id name parentReference webUrl fileSystemInfo createdBy lastModifiedBy].freeze
 
             def initialize(*)
               super

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Storages
+  module Adapters
+    module Providers
+      module Sharepoint
+        module Services
+          class CreateManagedFoldersService < BaseService
+            using Peripherals::ServiceResultRefinements
+
+            def self.i18n_key = "sharepoint_sync_service"
+
+            class << self
+              def call(storage:, project_storages_scope: nil)
+                new(storage:, project_storages_scope:).call
+              end
+            end
+
+            def initialize(storage:, project_storages_scope:, hide_missing_folders: project_storages_scope.nil?)
+              super()
+              @storage = storage
+              @hide_missing_folders = hide_missing_folders
+              @project_storages = (project_storages_scope || @storage.project_storages).active.automatic
+            end
+
+            def call
+              with_tagged_logger([self.class.name, "storage-#{@storage.id}"]) do
+                remote_folders_map.bind do |existing_remote_folders|
+                  ensure_folders_exist(existing_remote_folders).bind do
+                    hide_inactive_folders(existing_remote_folders) if @hide_missing_folders
+                  end
+                end
+
+                @result
+              end
+            end
+
+            private
+
+            def ensure_folders_exist(folder_map)
+              info "Ensuring that automatically managed project folders exist and are correctly named."
+              @project_storages.includes(:project).find_each do |project_storage|
+                unless folder_map.key?(project_storage.project_folder_id)
+                  info "#{project_storage.managed_project_folder_path} does not exist. Creating..."
+                  next create_remote_folder(project_storage.managed_project_folder_name, project_storage)
+                end
+
+                rename_project_folder(folder_map[project_storage.project_folder_id], project_storage)
+              end
+
+              Success(:folder_maintenance_done)
+            end
+
+            def hide_inactive_folders(folder_map)
+              info "Hiding folders related to inactive projects"
+
+              inactive_folder_ids(folder_map).each { |item_id| hide_folder(item_id, folder_map) }
+            end
+
+            def hide_folder(file_id, folder_map)
+              info "Hiding folder with ID #{file_id} as it does not belong to any active project"
+
+              input_data = Adapters::Input::SetPermissions.build(file_id:, user_permissions: []).value_or do |failure|
+                log_validation_error(failure, file_id:, context: "hide_folder")
+              end
+
+              set_permissions.call(auth_strategy:, input_data:).or do |error|
+                add_error(:hide_inactive_folders, error, options: { context: "hide folders", path: folder_map[item_id] })
+              end
+            end
+
+            def inactive_folder_ids(folder_map)
+              folder_map.keys - @project_storages.pluck(:project_folder_id).compact
+            end
+
+            def rename_project_folder(current_folder_name, project_storage)
+              actual_name = project_storage.managed_project_folder_name
+              return if current_folder_name == actual_name
+
+              info "#{current_folder_name} is misnamed. Renaming to #{actual_name}"
+              folder_id = project_storage.project_folder_id
+
+              Adapters::Input::RenameFile.build(location: folder_id, new_name: actual_name).bind do |input_data|
+                rename_file.call(auth_strategy:, input_data:).or do |error|
+                  add_error(
+                    :rename_project_folder, error,
+                    options: { current_path: current_folder_name, project_folder_name: actual_name, project_folder_id: folder_id }
+                  )
+                end
+              end
+            end
+
+            def create_remote_folder(folder_name, project_storage)
+              input_data = Adapters::Input::CreateFolder
+                .build(folder_name:, parent_location: drive_id)
+                .value_or { return Failure(log_validation_error(it, folder_name: folder_name, parent_location: drive_id)) }
+
+              folder_info = create_folder.call(auth_strategy:, input_data:).value_or do |error|
+                add_error(:create_folder, error, options: { folder_name:, parent_location: drive_name })
+                return Failure()
+              end
+
+              project_storage.update(project_folder_id: folder_info.id)
+            end
+
+            def remote_folders_map
+              info "Retrieving already existing folders under #{drive_id}"
+
+              input_data = Adapters::Input::Files.build(folder: "/#{drive_name}").value_or do |error|
+                log_validation_error(error, context: "remote_folders")
+                return Failure()
+              end
+
+              file_list = files.call(auth_strategy:, input_data:).value_or do |error|
+                add_error(:remote_folders, error, options: { drive_name: })
+                return Failure()
+              end
+
+              filter_folders_from(file_list)
+            end
+
+            def filter_folders_from(files)
+              folder_map = files.all_folders.to_h { [it.id, it.name] }
+              info "Found #{folder_map.size} folders. Map: #{folder_map}"
+              Success(folder_map)
+            end
+
+            def drive_id = @storage.managed_drive_id
+            def drive_name = @storage.managed_drive_name
+
+            def create_folder = Adapters::Registry.resolve("sharepoint.commands.create_folder").new(@storage)
+
+            def rename_file = Adapters::Registry.resolve("sharepoint.commands.rename_file").new(@storage)
+
+            def set_permissions = Adapters::Registry.resolve("sharepoint.commands.set_permissions").new(@storage)
+
+            def files = Adapters::Registry.resolve("sharepoint.queries.files").new(@storage)
+
+            def auth_strategy
+              @auth_strategy ||= Adapters::Registry["one_drive.authentication.userless"].call
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service.rb
@@ -90,6 +90,7 @@ module Storages
 
               input_data = Adapters::Input::SetPermissions.build(file_id:, user_permissions: []).value_or do |failure|
                 log_validation_error(failure, file_id:, context: "hide_folder")
+                return Failure(:hide_inactive_folders)
               end
 
               set_permissions.call(auth_strategy:, input_data:).or do |error|

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/sharepoint_registry.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/sharepoint_registry.rb
@@ -68,6 +68,10 @@ module Storages
             register(:general_information, SharepointContract)
           end
 
+          namespace("models") do
+            register(:managed_folder_identifier, ManagedFolderIdentifier)
+          end
+
           namespace("validators") do
             register(:connection, Validators::ConnectionValidator)
           end

--- a/modules/storages/app/models/storages/sharepoint_storage.rb
+++ b/modules/storages/app/models/storages/sharepoint_storage.rb
@@ -34,11 +34,13 @@ module Storages
 
     PROVIDER_FIELDS_DEFAULTS = {
       automatically_managed: false,
-      automatic_management_enabled: false
+      automatic_management_enabled: false,
+      managed_drive_name: "OpenProject"
     }.freeze
 
     store_attribute :provider_fields, :tenant_id, :string
     store_attribute :provider_fields, :managed_drive_id, :string
+    store_attribute :provider_fields, :managed_drive_name, :string
 
     # For now SharePoint is visible only in tests.
     # This is to prevent it from being shown in the UI, as it is not ready yet.

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -120,6 +120,12 @@ en:
         hide_inactive_folders: 'Hide Inactive Folders Step:'
         remote_folders: 'Read contents of the group folder:'
         rename_project_folder: 'Rename managed project Folder:'
+      sharepoint_sync_service:
+        create_folder: 'Managed Project Folder Creation:'
+        ensure_root_folder_permissions: 'Set Base Folder Permissions:'
+        hide_inactive_folders: 'Hide Inactive Folders Step:'
+        remote_folders: 'Read contents of the group folder:'
+        rename_project_folder: 'Rename managed project Folder:'
     errors:
       messages:
         error: An unexpected error occurred. Please check OpenProject logs for more information or contact an administrator
@@ -179,6 +185,24 @@ en:
               permission_not_set: could not set permissions on %{path}.
           error: An unexpected error occurred. Please ensure that OneDrive is reachable and check OpenProject worker logs for more information
           not_allowed: OpenProject wasn't allowed to access your OneDrive drive. Please check the permissions set on the Azure Application.
+          unauthorized: OpenProject could not sync with OneDrive. Please check your storage and Azure Application configuration.
+          user_does_not_exist: "%{user} does not exist in Nextcloud."
+        sharepoint_sync_service:
+          attributes:
+            create_folder:
+              conflict: The %{folder_name} already exists on %{parent_location}.
+              not_found: "%{parent_location} wasn't found."
+            hide_inactive_folders:
+              permission_not_set: could not set permissions on %{path}.
+            rename_project_folder:
+              conflict: OpenProject could not rename the folder %{current_path} to %{project_folder_name} as a folder with the same name already exists
+              forbidden: OpenProject does not have access to %{current_path} in order to rename it.
+              not_found: "%{current_path} wasn't found."
+            set_folders_permissions:
+              permission_not_set: could not set permissions on %{path}.
+          error: An unexpected error occurred. Please ensure that OneDrive is reachable and check OpenProject worker logs for more information
+          not_allowed: OpenProject wasn't allowed to access your OneDrive drive. Please check the permissions set on the Azure Application.
+          not_found: OpenProject could not access your library %{drive_name}. Please check you Sharepoint site document libraries.
           unauthorized: OpenProject could not sync with OneDrive. Please check your storage and Azure Application configuration.
           user_does_not_exist: "%{user} does not exist in Nextcloud."
         upload_link_service:

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -178,12 +178,12 @@ en:
             remote_folders:
               request_error: OpenProject could not access your drive %{drive_id}. Please check if your storage configuration is correct.
             rename_project_folder:
-              conflict: OpenProject could not rename the folder %{current_path} to %{project_folder_name} as a folder with the same name already exists
+              conflict: OpenProject could not rename the folder %{current_path} to %{project_folder_name} as a folder with the same name already exists.
               forbidden: OpenProject does not have access to %{current_path} in order to rename it.
               not_found: "%{current_path} wasn't found."
             set_folders_permissions:
               permission_not_set: could not set permissions on %{path}.
-          error: An unexpected error occurred. Please ensure that OneDrive is reachable and check OpenProject worker logs for more information
+          error: An unexpected error occurred. Please ensure that OneDrive is reachable and check OpenProject worker logs for more information.
           not_allowed: OpenProject wasn't allowed to access your OneDrive drive. Please check the permissions set on the Azure Application.
           unauthorized: OpenProject could not sync with OneDrive. Please check your storage and Azure Application configuration.
           user_does_not_exist: "%{user} does not exist in Nextcloud."

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service_spec.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
+module Storages
+  module Adapters
+    module Providers
+      module Sharepoint
+        module Services
+          RSpec.describe CreateManagedFoldersService, :webmock do
+            shared_let(:admin) { create(:admin) }
+            shared_let(:storage) do
+              create(:sharepoint_storage, :sandbox,
+                     oauth_client_token_user: admin,
+                     managed_drive_id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v",
+                     managed_drive_name: "AMPF VCR")
+            end
+
+            shared_let(:admin_remote_identity) do
+              create(:remote_identity,
+                     auth_source: storage.oauth_client,
+                     user: admin,
+                     integration: storage,
+                     origin_user_id: "f220e557-9477-47d5-94a7-672843be6b0a") # Megan
+            end
+
+            shared_let(:oidc_provider) { create(:oidc_provider) }
+
+            # USER FACTORIES
+            shared_let(:oidc_user) { create(:user, authentication_provider: oidc_provider) }
+            shared_let(:single_project_user) { oidc_user }
+            shared_let(:single_project_user_remote_identity) do
+              create(:remote_identity,
+                     user: single_project_user,
+                     auth_source: oidc_user.authentication_provider,
+                     integration: storage,
+                     origin_user_id: "a9023fd0-c421-4695-b83c-bb3ba67708d6") # OP Member
+            end
+
+            shared_let(:multiple_projects_user) { create(:user) }
+            shared_let(:multiple_project_user_remote_identity) do
+              create(:remote_identity,
+                     user: multiple_projects_user,
+                     auth_source: storage.oauth_client,
+                     integration: storage,
+                     origin_user_id: "49abf87c-31df-47ef-858d-fbc801b0985a") # Henrietta
+            end
+
+            # ROLE FACTORIES
+            shared_let(:ordinary_role) { create(:project_role, permissions: %w[read_files write_files]) }
+            shared_let(:read_only_role) { create(:project_role, permissions: %w[read_files]) }
+            shared_let(:non_member_role) { create(:non_member, permissions: %w[read_files]) }
+
+            # PROJECT FACTORIES
+            shared_let(:project) do
+              create(:project,
+                     name: "[Sample] Project Name / Ehuu",
+                     members: { multiple_projects_user => ordinary_role,
+                                oidc_user => ordinary_role,
+                                single_project_user => ordinary_role })
+            end
+            shared_let(:project_storage) do
+              create(:project_storage, :with_historical_data, project_folder_mode: "automatic", storage:, project:)
+            end
+
+            shared_let(:disallowed_chars_project) do
+              create(:project, name: '<=o=> | "Jedi" Project Folder ///', members: { multiple_projects_user => ordinary_role })
+            end
+            shared_let(:disallowed_chars_project_storage) do
+              create(:project_storage, :with_historical_data, project_folder_mode: "automatic", project: disallowed_chars_project,
+                                                              storage:)
+            end
+
+            shared_let(:inactive_project) do
+              create(:project, name: "INACTIVE PROJECT! f0r r34lz", active: false,
+                               members: { multiple_projects_user => ordinary_role })
+            end
+            shared_let(:inactive_project_storage) do
+              create(:project_storage, :with_historical_data, project_folder_mode: "automatic", project: inactive_project,
+                                                              storage:)
+            end
+
+            shared_let(:public_project) { create(:public_project, name: "PUBLIC PROJECT", active: true) }
+            shared_let(:public_project_storage) do
+              create(:project_storage, :with_historical_data, project_folder_mode: "automatic", project: public_project, storage:)
+            end
+
+            shared_let(:unmanaged_project) do
+              create(:project, name: "Non Managed Project", active: true, members: { multiple_projects_user => ordinary_role })
+            end
+            shared_let(:unmanaged_project_storage) do
+              create(:project_storage, :with_historical_data, project_folder_mode: "manual", project: unmanaged_project, storage:)
+            end
+
+            # This is a remote service call. We need to enable WebMock and VCR in order to record it,
+            # otherwise it will run the request every test suite run.
+            # Then we disable both VCR and WebMock to return to the usual state
+            shared_let(:original_folder_ids) do
+              use_storages_vcr_cassette("sharepoint/sync_service_original_folders") { original_folders }
+            end
+
+            subject(:service) do
+              described_class.new(storage:, project_storages_scope: storage.reload.project_storages, hide_missing_folders: true)
+            end
+
+            describe "#call" do
+              before { storage.update(automatically_managed: true) }
+              after { delete_created_folders }
+
+              describe "Remote Folder Creation", vcr: "sharepoint/sync_service_create_folder" do
+                let(:single_project_user_origin_user_id) { single_project_user_remote_identity.origin_user_id }
+                let(:multiple_project_user_origin_user_id) { multiple_project_user_remote_identity.origin_user_id }
+                let(:admin_origin_user_id) { admin_remote_identity.origin_user_id }
+
+                it "updates the project folder id for all active automatically managed projects" do
+                  expect { service.call }.to change { disallowed_chars_project_storage.reload.project_folder_id }
+                                               .from(nil).to(String)
+                                               .and(change { project_storage.reload.project_folder_id }.from(nil).to(String))
+                                               .and(change {
+                                                      public_project_storage.reload.project_folder_id
+                                                    }.from(nil).to(String))
+                                               .and(not_change { inactive_project_storage.reload.project_folder_id })
+                                               .and(not_change { unmanaged_project_storage.reload.project_folder_id })
+                end
+
+                it "adds a record to the LastProjectFolder for each new folder" do
+                  skip "This introduces a bug on certain scenarios that lead to unrecoverable errors with a Sharepoint Storage"
+                  scope = ->(project_storage) { LastProjectFolder.where(project_storage:).last }
+
+                  expect { service.call }.to not_change { scope[unmanaged_project_storage].reload.origin_folder_id }
+                                               .and(not_change { scope[inactive_project_storage].reload.origin_folder_id })
+
+                  expect(scope[project_storage].origin_folder_id).to eq(project_storage.reload.project_folder_id)
+                  expect(scope[public_project_storage].origin_folder_id).to eq(public_project_storage.reload.project_folder_id)
+                  expect(scope[disallowed_chars_project_storage].origin_folder_id)
+                    .to eq(disallowed_chars_project_storage.reload.project_folder_id)
+                end
+
+                it "creates the remote folders for all projects with automatically managed folders enabled" do
+                  service.call
+
+                  [project_storage, disallowed_chars_project_storage, public_project_storage].each do |proj_storage|
+                    expect(project_folder_info(proj_storage)).to be_success
+                  end
+                end
+
+                it "makes sure that the last_project_folder.origin_folder_id match the current project_folder_id" do
+                  skip "This introduces a bug on certain scenarios that lead to unrecoverable errors with a Sharepoint Storage"
+
+                  service.call
+
+                  [project_storage, disallowed_chars_project_storage, public_project_storage].each do |proj_storage|
+                    proj_storage.reload
+                    the_real_last_project_folder = proj_storage.last_project_folders.last
+
+                    expect(proj_storage.project_folder_id).to eq(the_real_last_project_folder.origin_folder_id)
+                  end
+                end
+              end
+
+              it "renames an already existing project folder", vcr: "sharepoint/sync_service_rename_folder" do
+                original_folder = create_folder_for(disallowed_chars_project_storage, "Old Jedi Project")
+                disallowed_chars_project_storage.update(project_folder_id: original_folder.id)
+
+                service_result = service.call
+                expect(service_result).to be_success
+                expect(service_result.errors).to be_empty
+
+                result = project_folder_info(disallowed_chars_project_storage).value!
+                expect(result.name).to match(/_=o=_ _ _Jedi_ Project Folder ___ \(\d+\)/)
+              end
+
+              it "hides (removes all permissions) from inactive project folders", vcr: "sharepoint/sync_service_hide_inactive" do
+                original_folder = create_folder_for(inactive_project_storage)
+                inactive_project_storage.update(project_folder_id: original_folder.id)
+
+                set_permissions_on(original_folder.id,
+                                   [{ user_id: "f220e557-9477-47d5-94a7-672843be6b0a", permissions: [:read_files] },
+                                    { user_id: "49abf87c-31df-47ef-858d-fbc801b0985a", permissions: [:write_files] },
+                                    { user_id: "a9023fd0-c421-4695-b83c-bb3ba67708d6", permissions: [:write_files] }])
+
+                expect(remote_permissions_for(inactive_project_storage))
+                  .to eq({ read: ["f220e557-9477-47d5-94a7-672843be6b0a"],
+                           write: %w[a9023fd0-c421-4695-b83c-bb3ba67708d6 49abf87c-31df-47ef-858d-fbc801b0985a] })
+
+                result = service.call
+
+                expect(result).to be_success
+                expect(result.errors).to be_empty
+                expect(remote_permissions_for(inactive_project_storage)).to be_empty
+              end
+
+              describe "error handling" do
+                let(:error_key_prefix) { "services.errors.models.sharepoint_sync_service" }
+
+                before { allow(Rails.logger).to receive_messages(%i[error warn]) }
+
+                context "when reading the root folder fails" do
+                  before { storage.update(managed_drive_id: "THIS-IS-NOT-A-DRIVE-ID", managed_drive_name: "Bob") }
+
+                  it "returns a failure in case retrieving the root list fails",
+                     vcr: "sharepoint/sync_service_root_read_failure" do
+                    result = service.call
+
+                    expect(result).to be_failure
+
+                    expect(result.errors[:base])
+                      .to match_array(I18n.t("#{error_key_prefix}.not_found", drive_name: storage.managed_drive_name))
+                  end
+
+                  it "logs the occurrence", vcr: "sharepoint/sync_service_root_read_failure" do
+                    service.call
+                    expect(Rails.logger)
+                      .to have_received(:error)
+                            .with(error_code: :not_found, drive_name: storage.managed_drive_name, data: String)
+                  end
+                end
+
+                it "does not break in case of timeout", vcr: "sharepoint/sync_service_timeout" do
+                  skip "The timeout setting isn't working as expected"
+                  stub_request_with_timeout(:get, /\/root\/children$/)
+                  service.call
+
+                  expect(Rails.logger)
+                    .to have_received(:error)
+                          .with(command: described_class,
+                                message: nil,
+                                data: { body: /timed out while waiting on select/, status: nil })
+                end
+
+                context "when folder creation fails" do
+                  it "doesn't update the project_storage", vcr: "sharepoint/sync_service_creation_fail" do
+                    already_existing_folder = create_folder_for(project_storage)
+                    result = nil
+
+                    expect { result = service.call }.not_to change(project_storage, :project_folder_id)
+
+                    expect(result).to be_failure
+                    expect(result.errors[:create_folder])
+                      .to match_array(I18n.t("#{error_key_prefix}.attributes.create_folder.conflict",
+                                             folder_name: project_storage.managed_project_folder_name,
+                                             parent_location: storage.managed_drive_name))
+                  ensure
+                    delete_folder(already_existing_folder.id)
+                  end
+
+                  it "logs the occurrence", vcr: "sharepoint/sync_service_creation_fail" do
+                    already_existing_folder = create_folder_for(project_storage)
+                    service.call
+
+                    expect(Rails.logger)
+                      .to have_received(:error)
+                            .with(folder_name: "[Sample] Project Name _ Ehuu (#{project.id})",
+                                  parent_location: storage.managed_drive_name,
+                                  error_code: :conflict,
+                                  data: { body: /nameAlreadyExists/, status: Integer })
+                  ensure
+                    delete_folder(already_existing_folder.id)
+                  end
+                end
+
+                context "when folder renaming fails" do
+                  it "adds an error and logs the occurrence", vcr: "sharepoint/sync_service_rename_failed" do
+                    already_existing_folder = create_folder_for(project_storage)
+                    original_folder = create_folder_for(project_storage, "Flawless Death Star Blueprints")
+                    project_storage.update(project_folder_id: original_folder.id)
+
+                    result = service.call
+
+                    expect(result.errors[:rename_project_folder])
+                      .to match_array(I18n.t("#{error_key_prefix}.attributes.rename_project_folder.conflict",
+                                             current_path: original_folder.name,
+                                             project_folder_name: project_storage.managed_project_folder_name))
+
+                    expect(Rails.logger)
+                      .to have_received(:error).with(current_path: original_folder.name,
+                                                     project_folder_id: project_storage.project_folder_id,
+                                                     project_folder_name: "[Sample] Project Name _ Ehuu (#{project.id})",
+                                                     error_code: :conflict,
+                                                     data: { body: /nameAlreadyExists/, status: Integer })
+                  ensure
+                    delete_folder(already_existing_folder.id)
+                  end
+                end
+              end
+            end
+
+            private
+
+            def remote_permissions_for(project_storage)
+              return if project_folder_info(project_storage).failure?
+
+              Adapters::Authentication[auth_strategy].call(storage:) do |http|
+                response = http.get(UrlBuilder.url(storage.uri,
+                                                   "/v1.0/drives",
+                                                   storage.managed_drive_id,
+                                                   "/items",
+                                                   project_storage.project_folder_id.split(":").last,
+                                                   "/permissions"))
+                response.json(symbolize_keys: true).fetch(:value, []).each_with_object({}) do |grant, hash|
+                  next if grant[:roles].member?("owner")
+
+                  hash[grant[:roles].first.to_sym] ||= []
+                  hash[grant[:roles].first.to_sym] << grant.dig(:grantedToV2, :user, :id)
+                end
+              end
+            end
+
+            def original_folders
+              root_folder_contents.bind { return it.all_folders.map(&:id) }
+            end
+
+            def project_folder_info(project_storage)
+              root_folder_contents.fmap do |storage_files|
+                storage_files.files.find { |file| file.id == project_storage.project_folder_id }
+              end
+            end
+
+            def root_folder_contents
+              Adapters::Input::Files.build(folder: "/#{storage.managed_drive_name}").bind do |input_data|
+                Adapters::Registry.resolve("sharepoint.queries.files").call(storage:, auth_strategy:, input_data:)
+              end
+            end
+
+            def create_folder_for(project_storage, folder_override = nil)
+              folder_name = folder_override || project_storage.managed_project_folder_name
+
+              Adapters::Input::CreateFolder.build(folder_name:, parent_location: storage.managed_drive_id)
+                                           .bind do |input_data|
+                Adapters::Registry.resolve("sharepoint.commands.create_folder")
+                                  .call(storage: project_storage.storage, auth_strategy:, input_data:)
+                                  .value_or { fail "Folder creation failed" }
+              end
+            end
+
+            def set_permissions_on(file_id, user_permissions)
+              Adapters::Input::SetPermissions.build(file_id:, user_permissions:).bind do |input_data|
+                Adapters::Registry.resolve("sharepoint.commands.set_permissions").call(storage:, auth_strategy:, input_data:)
+              end
+            end
+
+            def delete_created_folders
+              storage.project_storages.automatic.where(storage:)
+                     .with_project_folder.find_each { |project_storage| delete_folder(project_storage.project_folder_id) }
+            end
+
+            def delete_folder(item_id)
+              Adapters::Input::DeleteFolder.build(location: item_id).bind do |input_data|
+                Adapters::Registry.resolve("sharepoint.commands.delete_folder").call(storage:, auth_strategy:, input_data:)
+              end
+            end
+
+            def auth_strategy = Adapters::Registry.resolve("sharepoint.authentication.userless").call
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_create_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_create_folder.yml
@@ -1,0 +1,942 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 4223d09a-c019-4416-8d67-647638191f00
+      X-Ms-Ests-Server:
+      - 2.1.22170.4 - SEC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-wVNEoF6PHLG6mN6GuGJFIQ'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop-endpoint"
+      Reporting-Endpoints:
+      - coop-endpoint="https://idux.azurewebsites.net/api/coopReport"
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AnV0_YyLjKFCkg7NbiEw6xJZ-dCOAQAAAKlniOAOAAAA; expires=Wed, 19-Nov-2025
+        17:26:02 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 20 Oct 2025 17:26:01 GMT
+      Content-Length:
+      - '2033'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 20 Oct 2025 17:26:02 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 8a85198e-68d1-4c8c-9147-e6b602cd8f2d
+      Client-Request-Id:
+      - 8a85198e-68d1-4c8c-9147-e6b602cd8f2d
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000538"}}'
+      Splogid:
+      - 4f4dd1a1-1036-0000-8a5a-6ff91af3655c
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:02 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:22:48Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:03 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - c7115f43-e374-40fd-94ed-594dc4414cfd
+      Client-Request-Id:
+      - c7115f43-e374-40fd-94ed-594dc4414cfd
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000538"}}'
+      Splogid:
+      - 4f4dd1a1-504e-0000-83a4-a670405f54b7
+      Date:
+      - Mon, 20 Oct 2025 17:26:02 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:03 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 5423d3b1-1026-4ea3-bc3f-3a18c8ee7b15
+      Client-Request-Id:
+      - 5423d3b1-1026-4ea3-bc3f-3a18c8ee7b15
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000538"}}'
+      Splogid:
+      - 4f4dd1a1-5056-0000-8a5a-6e7e5f80c06a
+      Date:
+      - Mon, 20 Oct 2025 17:26:02 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"root","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","fileSystemInfo":{"createdDateTime":"2025-10-20T08:57:53Z","lastModifiedDateTime":"2025-10-20T17:22:48Z"},"folder":{"childCount":0},"size":0}'
+  recorded_at: Mon, 20 Oct 2025 17:26:03 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (256)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '100'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W45XWHMUUOJ6NBITE6F5RVHO7Q6')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 70be2f3f-cf48-4c1f-bfba-36b5f1b14728
+      Client-Request-Id:
+      - 70be2f3f-cf48-4c1f-bfba-36b5f1b14728
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002C3"}}'
+      Splogid:
+      - 4f4dd1a1-906c-0000-83a4-a87c7cf43e41
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:03 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},1\"","eTag":"\"{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},1\"","lastModifiedDateTime":"2025-10-20T17:26:04Z","createdDateTime":"2025-10-20T17:26:04Z","id":"01ANJ53W45XWHMUUOJ6NBITE6F5RVHO7Q6","name":"[Sample]
+        Project Name _ Ehuu (256)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(256)","cTag":"\"c:{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:03 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"_=o=_ _ _Jedi_ Project Folder ___ (257)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '105'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{28433460-3605-4DF8-9676-946DB9294EDA},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W3AGRBSQBJW7BGZM5UUNW4SSTW2')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - ab2ff92c-a671-488b-aee5-0d27d91d3700
+      Client-Request-Id:
+      - ab2ff92c-a671-488b-aee5-0d27d91d3700
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000356"}}'
+      Splogid:
+      - 4f4dd1a1-e08a-0000-8a23-6c13a85657e5
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:03 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{28433460-3605-4DF8-9676-946DB9294EDA},1\"","eTag":"\"{28433460-3605-4DF8-9676-946DB9294EDA},1\"","lastModifiedDateTime":"2025-10-20T17:26:04Z","createdDateTime":"2025-10-20T17:26:04Z","id":"01ANJ53W3AGRBSQBJW7BGZM5UUNW4SSTW2","name":"_=o=_
+        _ _Jedi_ Project Folder ___ (257)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(257)","cTag":"\"c:{28433460-3605-4DF8-9676-946DB9294EDA},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:04 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"PUBLIC PROJECT (259)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '86'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W5FNNVUP3MWOZGLOKMYB7L7PX5D')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 3098139a-2bdf-420c-a6a8-12cb6cc24e70
+      Client-Request-Id:
+      - 3098139a-2bdf-420c-a6a8-12cb6cc24e70
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002C3"}}'
+      Splogid:
+      - 4f4dd1a1-40a7-0000-83a4-a02f6acc6fa6
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},1\"","eTag":"\"{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},1\"","lastModifiedDateTime":"2025-10-20T17:26:05Z","createdDateTime":"2025-10-20T17:26:05Z","id":"01ANJ53W5FNNVUP3MWOZGLOKMYB7L7PX5D","name":"PUBLIC
+        PROJECT (259)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(259)","cTag":"\"c:{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:05Z","lastModifiedDateTime":"2025-10-20T17:26:05Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:04 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 4ebfc141-5a3d-4dbe-9526-75e88811e1e3
+      Client-Request-Id:
+      - 4ebfc141-5a3d-4dbe-9526-75e88811e1e3
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000D05"}}'
+      Splogid:
+      - 4f4dd1a1-60be-0000-90c2-c140e10efb27
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:05Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:05 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - ab64e95d-f5d4-4bac-952c-bd6e0c1d213d
+      Client-Request-Id:
+      - ab64e95d-f5d4-4bac-952c-bd6e0c1d213d
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000D05"}}'
+      Splogid:
+      - 4f4dd1a1-50cf-0000-8a23-6c4294f27f43
+      Date:
+      - Mon, 20 Oct 2025 17:26:04 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W45XWHMUUOJ6NBITE6F5RVHO7Q6","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (256)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(256)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{28433460-3605-4DF8-9676-946DB9294EDA},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W3AGRBSQBJW7BGZM5UUNW4SSTW2","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"_=o=_ _ _Jedi_
+        Project Folder ___ (257)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(257)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W5FNNVUP3MWOZGLOKMYB7L7PX5D","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"PUBLIC PROJECT
+        (259)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(259)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:05Z","lastModifiedDateTime":"2025-10-20T17:26:05Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:05 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - de934131-fef6-44a8-9feb-c0b350c87a7a
+      Client-Request-Id:
+      - de934131-fef6-44a8-9feb-c0b350c87a7a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002DF"}}'
+      Splogid:
+      - 4f4dd1a1-e0e8-0000-8a5a-689e126c4ff4
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:05 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:05Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:05 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 13e45390-b1bd-4c79-95f6-f6f1bf618fdd
+      Client-Request-Id:
+      - 13e45390-b1bd-4c79-95f6-f6f1bf618fdd
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002DF"}}'
+      Splogid:
+      - 4f4dd1a1-90fb-0000-8a5a-646fe4e59006
+      Date:
+      - Mon, 20 Oct 2025 17:26:06 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W45XWHMUUOJ6NBITE6F5RVHO7Q6","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (256)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(256)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{28433460-3605-4DF8-9676-946DB9294EDA},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W3AGRBSQBJW7BGZM5UUNW4SSTW2","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"_=o=_ _ _Jedi_
+        Project Folder ___ (257)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(257)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W5FNNVUP3MWOZGLOKMYB7L7PX5D","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"PUBLIC PROJECT
+        (259)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(259)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:05Z","lastModifiedDateTime":"2025-10-20T17:26:05Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:06 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 60fdc05f-0380-4c49-8379-8fe6b2997c0e
+      Client-Request-Id:
+      - 60fdc05f-0380-4c49-8379-8fe6b2997c0e
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002E7"}}'
+      Splogid:
+      - 504dd1a1-c00f-0000-8a5a-6c33ddbd2056
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:06 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:05Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5249457,"remaining":27487613329592,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:06 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e8b5af1f-1c07-4e2f-8433-6f06655c59d6
+      Client-Request-Id:
+      - e8b5af1f-1c07-4e2f-8433-6f06655c59d6
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF000002E7"}}'
+      Splogid:
+      - 504dd1a1-a020-0000-8a5a-6bf0486b0429
+      Date:
+      - Mon, 20 Oct 2025 17:26:06 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{CA8EBD9D-C951-42F3-8993-C5EC6A777E1E},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W45XWHMUUOJ6NBITE6F5RVHO7Q6","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (256)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(256)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{28433460-3605-4DF8-9676-946DB9294EDA},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W3AGRBSQBJW7BGZM5UUNW4SSTW2","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"_=o=_ _ _Jedi_
+        Project Folder ___ (257)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(257)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:04Z","lastModifiedDateTime":"2025-10-20T17:26:04Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{476B6BA5-96ED-4C76-B729-980FD7F7DFA3},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W5FNNVUP3MWOZGLOKMYB7L7PX5D","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"PUBLIC PROJECT
+        (259)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(259)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:05Z","lastModifiedDateTime":"2025-10-20T17:26:05Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:06 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W45XWHMUUOJ6NBITE6F5RVHO7Q6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 1cfa33b3-4a9a-40b8-aa35-384c939b6381
+      Client-Request-Id:
+      - 1cfa33b3-4a9a-40b8-aa35-384c939b6381
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000318"}}'
+      Splogid:
+      - 504dd1a1-a036-0000-83a4-ad1a30669169
+      Date:
+      - Mon, 20 Oct 2025 17:26:06 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:07 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W3AGRBSQBJW7BGZM5UUNW4SSTW2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - b14a0baa-dc51-4dc4-b21f-cf1417eea039
+      Client-Request-Id:
+      - b14a0baa-dc51-4dc4-b21f-cf1417eea039
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000449"}}'
+      Splogid:
+      - 504dd1a1-704d-0000-8a5a-6f5fc893ff7c
+      Date:
+      - Mon, 20 Oct 2025 17:26:07 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:07 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W5FNNVUP3MWOZGLOKMYB7L7PX5D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - d03ae542-7c32-4f7a-8cdf-b29e16d7a447
+      Client-Request-Id:
+      - d03ae542-7c32-4f7a-8cdf-b29e16d7a447
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"005","RoleInstance":"FR3PEPF00000315"}}'
+      Splogid:
+      - 504dd1a1-405f-0000-83a4-ac7873825320
+      Date:
+      - Mon, 20 Oct 2025 17:26:07 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:07 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_creation_fail.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_creation_fail.yml
@@ -1,0 +1,636 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 5a529830-5f15-416e-a3a0-e492431f0b00
+      X-Ms-Ests-Server:
+      - 2.1.22276.5 - SEC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-34Xq56o80gqL5ivvR_t8Lg'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AseF3yIOXS5NhHikC-C2oN5Z-dCOAQAAANTciuAOAAAA; expires=Fri, 21-Nov-2025
+        14:10:28 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Wed, 22 Oct 2025 14:10:28 GMT
+      Content-Length:
+      - '2035'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Wed, 22 Oct 2025 14:10:28 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (96)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '99'
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{7AA93F2E-C961-4861-81F1-94531CEB4C0F},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - c910a313-5132-45b5-9b08-c400fd034c20
+      Client-Request-Id:
+      - c910a313-5132-45b5-9b08-c400fd034c20
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000351"}}'
+      Splogid:
+      - e9e6d1a1-10ea-0000-8a23-6ed0f4487f35
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 22 Oct 2025 14:10:28 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{7AA93F2E-C961-4861-81F1-94531CEB4C0F},1\"","eTag":"\"{7AA93F2E-C961-4861-81F1-94531CEB4C0F},1\"","lastModifiedDateTime":"2025-10-22T14:10:29Z","createdDateTime":"2025-10-22T14:10:29Z","id":"01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP","name":"[Sample]
+        Project Name _ Ehuu (96)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(96)","cTag":"\"c:{7AA93F2E-C961-4861-81F1-94531CEB4C0F},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-22T14:10:29Z","lastModifiedDateTime":"2025-10-22T14:10:29Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Wed, 22 Oct 2025 14:10:29 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 65d5ddc5-b9e9-4a60-aaff-8b151155e454
+      Client-Request-Id:
+      - 65d5ddc5-b9e9-4a60-aaff-8b151155e454
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000160"}}'
+      Splogid:
+      - eae6d1a1-500e-0000-8a5a-6512e78dd2bd
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 22 Oct 2025 14:10:29 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-22T14:10:29Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5254087,"remaining":27487613324962,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Wed, 22 Oct 2025 14:10:29 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 50d0c90d-44d1-4586-9324-5b8a13d5edfb
+      Client-Request-Id:
+      - 50d0c90d-44d1-4586-9324-5b8a13d5edfb
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000160"}}'
+      Splogid:
+      - eae6d1a1-6027-0000-8a23-688c4d2d2e87
+      Date:
+      - Wed, 22 Oct 2025 14:10:29 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{7AA93F2E-C961-4861-81F1-94531CEB4C0F},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (96)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(96)","fileSystemInfo":{"createdDateTime":"2025-10-22T14:10:29Z","lastModifiedDateTime":"2025-10-22T14:10:29Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Wed, 22 Oct 2025 14:10:29 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (96)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '99'
+  response:
+    status:
+      code: 409
+      message: Conflict
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 7718c416-0443-4d94-bbd9-139ddb41dcbd
+      Client-Request-Id:
+      - 7718c416-0443-4d94-bbd9-139ddb41dcbd
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000F1D"}}'
+      Splogid:
+      - eae6d1a1-1041-0000-8a23-64fcc9991d43
+      Date:
+      - Wed, 22 Oct 2025 14:10:30 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"nameAlreadyExists","message":"Name already exists","innerError":{"date":"2025-10-22T14:10:30","request-id":"7718c416-0443-4d94-bbd9-139ddb41dcbd","client-request-id":"7718c416-0443-4d94-bbd9-139ddb41dcbd"}}}'
+  recorded_at: Wed, 22 Oct 2025 14:10:30 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"_=o=_ _ _Jedi_ Project Folder ___ (97)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '104'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{D99BFE2C-367F-45AD-854C-164EAD257973},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53WZM72N5S7ZWVVCYKTAWJ2WSK6LT')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e1888e92-7115-4512-af5e-b64f23a10c81
+      Client-Request-Id:
+      - e1888e92-7115-4512-af5e-b64f23a10c81
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000F42"}}'
+      Splogid:
+      - eae6d1a1-1050-0000-8a23-6758ceb3209e
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 22 Oct 2025 14:10:29 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{D99BFE2C-367F-45AD-854C-164EAD257973},1\"","eTag":"\"{D99BFE2C-367F-45AD-854C-164EAD257973},1\"","lastModifiedDateTime":"2025-10-22T14:10:30Z","createdDateTime":"2025-10-22T14:10:30Z","id":"01ANJ53WZM72N5S7ZWVVCYKTAWJ2WSK6LT","name":"_=o=_
+        _ _Jedi_ Project Folder ___ (97)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(97)","cTag":"\"c:{D99BFE2C-367F-45AD-854C-164EAD257973},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-22T14:10:30Z","lastModifiedDateTime":"2025-10-22T14:10:30Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Wed, 22 Oct 2025 14:10:30 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"PUBLIC PROJECT (99)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{E1A701BF-AE57-484E-845B-50954AA5F5C7},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W57AGT6CV5OJZEIIW2QSVFKL5OH')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 43da8960-7bef-4ad5-83bb-9eaca4d6b919
+      Client-Request-Id:
+      - 43da8960-7bef-4ad5-83bb-9eaca4d6b919
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF0000054B"}}'
+      Splogid:
+      - eae6d1a1-206c-0000-8a2e-02721bea9467
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 22 Oct 2025 14:10:30 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{E1A701BF-AE57-484E-845B-50954AA5F5C7},1\"","eTag":"\"{E1A701BF-AE57-484E-845B-50954AA5F5C7},1\"","lastModifiedDateTime":"2025-10-22T14:10:31Z","createdDateTime":"2025-10-22T14:10:31Z","id":"01ANJ53W57AGT6CV5OJZEIIW2QSVFKL5OH","name":"PUBLIC
+        PROJECT (99)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(99)","cTag":"\"c:{E1A701BF-AE57-484E-845B-50954AA5F5C7},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-22T14:10:31Z","lastModifiedDateTime":"2025-10-22T14:10:31Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Wed, 22 Oct 2025 14:10:31 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 6782f90d-7a32-43b8-9fe1-4bf4d07a95b6
+      Client-Request-Id:
+      - 6782f90d-7a32-43b8-9fe1-4bf4d07a95b6
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000ECB"}}'
+      Splogid:
+      - eae6d1a1-b091-0000-90c2-c5b33a95436e
+      Date:
+      - Wed, 22 Oct 2025 14:10:31 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"createdDateTime":"2025-10-22T14:10:29Z","eTag":"\"{7AA93F2E-C961-4861-81F1-94531CEB4C0F},2\"","id":"01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"lastModifiedDateTime":"2025-10-22T14:10:29Z","name":"[Sample]
+        Project Name _ Ehuu (96)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(96)","cTag":"\"c:{7AA93F2E-C961-4861-81F1-94531CEB4C0F},0\"","fileSystemInfo":{"createdDateTime":"2025-10-22T14:10:29Z","lastModifiedDateTime":"2025-10-22T14:10:29Z"},"folder":{"childCount":0},"shared":{"scope":"users"},"size":0}'
+  recorded_at: Wed, 22 Oct 2025 14:10:31 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP/permissions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 745233d2-0942-4059-b716-793791020e22
+      Client-Request-Id:
+      - 745233d2-0942-4059-b716-793791020e22
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000ECB"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - eae6d1a1-20a9-0000-8a2e-092c9b537287
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 22 Oct 2025 14:10:31 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items(''01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP'')/permissions","value":[{"id":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","roles":["owner"],"shareId":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","grantedToV2":{"group":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"},"siteUser":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"6","loginName":"c:0o.c|federateddirectoryclaimprovider|5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb_o"}},"grantedTo":{"user":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"}},"inheritedFrom":{}}]}'
+  recorded_at: Wed, 22 Oct 2025 14:10:32 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZOH6UXUYOJMFEID4MUKMOOWTAP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 1f5ad2aa-ccfd-4308-b252-8ebfd8b8c47b
+      Client-Request-Id:
+      - 1f5ad2aa-ccfd-4308-b252-8ebfd8b8c47b
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000364"}}'
+      Splogid:
+      - eae6d1a1-00e0-0000-8a2e-0bb7e7f8b1f7
+      Date:
+      - Wed, 22 Oct 2025 14:10:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 22 Oct 2025 14:10:32 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZM72N5S7ZWVVCYKTAWJ2WSK6LT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 896011bf-951d-4629-9083-ecdf18ae23f8
+      Client-Request-Id:
+      - 896011bf-951d-4629-9083-ecdf18ae23f8
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000351"}}'
+      Splogid:
+      - eae6d1a1-70f6-0000-83a4-a1d4d5708c49
+      Date:
+      - Wed, 22 Oct 2025 14:10:32 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 22 Oct 2025 14:10:33 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W57AGT6CV5OJZEIIW2QSVFKL5OH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - daa72997-e5d8-4ba1-b66b-d076da18a89c
+      Client-Request-Id:
+      - daa72997-e5d8-4ba1-b66b-d076da18a89c
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000F1F"}}'
+      Splogid:
+      - ebe6d1a1-000c-0000-8a23-6544e0e2844b
+      Date:
+      - Wed, 22 Oct 2025 14:10:33 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 22 Oct 2025 14:10:33 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_hide_inactive.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_hide_inactive.yml
@@ -1,0 +1,1452 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - d977b974-2106-47c6-8c44-b03bc5d31b00
+      X-Ms-Ests-Server:
+      - 2.1.22170.4 - WEULR1 ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-beeAZH8UDawx_8pCh-9tWg'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop-endpoint"
+      Reporting-Endpoints:
+      - coop-endpoint="https://idux.azurewebsites.net/api/coopReport"
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AnaPD3RLKXhNkliA6eBrUr1Z-dCOAQAAANdniOAOAAAA; expires=Wed, 19-Nov-2025
+        17:26:47 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 20 Oct 2025 17:26:46 GMT
+      Content-Length:
+      - '2041'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 20 Oct 2025 17:26:47 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"INACTIVE PROJECT! f0r r34lz (268)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '99'
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 14a19f3a-751e-4f56-a61a-e1a47c89520f
+      Client-Request-Id:
+      - 14a19f3a-751e-4f56-a61a-e1a47c89520f
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001E1"}}'
+      Splogid:
+      - 5a4dd1a1-b030-0000-8a23-6c82768ac6aa
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:47 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},1\"","eTag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},1\"","lastModifiedDateTime":"2025-10-20T17:26:48Z","createdDateTime":"2025-10-20T17:26:48Z","id":"01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7","name":"INACTIVE
+        PROJECT! f0r r34lz (268)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/INACTIVE%20PROJECT!%20f0r%20r34lz%20(268)","cTag":"\"c:{497A2FFA-4551-4DB8-9A7E-EC689C62905F},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:48Z","lastModifiedDateTime":"2025-10-20T17:26:48Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:48 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 5fcd0bc6-928d-4be9-8829-b6acb98358f4
+      Client-Request-Id:
+      - 5fcd0bc6-928d-4be9-8829-b6acb98358f4
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000400"}}'
+      Splogid:
+      - 5a4dd1a1-004f-0000-83a4-a5ced54645d1
+      Date:
+      - Mon, 20 Oct 2025 17:26:48 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"createdDateTime":"2025-10-20T17:26:48Z","eTag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},2\"","id":"01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"lastModifiedDateTime":"2025-10-20T17:26:48Z","name":"INACTIVE
+        PROJECT! f0r r34lz (268)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/INACTIVE%20PROJECT!%20f0r%20r34lz%20(268)","cTag":"\"c:{497A2FFA-4551-4DB8-9A7E-EC689C62905F},0\"","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:48Z","lastModifiedDateTime":"2025-10-20T17:26:48Z"},"folder":{"childCount":0},"shared":{"scope":"users"},"size":0}'
+  recorded_at: Mon, 20 Oct 2025 17:26:48 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e7a8db05-ae8e-49e6-9dbc-bd3013e63694
+      Client-Request-Id:
+      - e7a8db05-ae8e-49e6-9dbc-bd3013e63694
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000400"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5a4dd1a1-505a-0000-8a5a-6f877ce99e69
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:48 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items(''01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7'')/permissions","value":[{"id":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","roles":["owner"],"shareId":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","grantedToV2":{"group":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"},"siteUser":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"6","loginName":"c:0o.c|federateddirectoryclaimprovider|5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb_o"}},"grantedTo":{"user":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"}},"inheritedFrom":{}}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:48 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/invite
+    body:
+      encoding: UTF-8
+      string: '{"requireSignIn":true,"sendInvitation":false,"roles":["read"],"recipients":[{"objectId":"f220e557-9477-47d5-94a7-672843be6b0a"}]}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '129'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Location:
+      - https://graph.microsoft.com
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e7333392-5fbc-4285-b5da-956ae914d78a
+      Client-Request-Id:
+      - e7333392-5fbc-4285-b5da-956ae914d78a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000400"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5a4dd1a1-7066-0000-83a4-a0f8b34067b2
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:48 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.permission)","value":[{"id":"aTowIy5mfG1lbWJlcnNoaXB8bWVnYW5iQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","roles":["read"],"grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"f220e557-9477-47d5-94a7-672843be6b0a"}},"grantedTo":{"user":{"displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"f220e557-9477-47d5-94a7-672843be6b0a"}}}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:48 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/invite
+    body:
+      encoding: UTF-8
+      string: '{"requireSignIn":true,"sendInvitation":false,"roles":["write"],"recipients":[{"objectId":"49abf87c-31df-47ef-858d-fbc801b0985a"},{"objectId":"a9023fd0-c421-4695-b83c-bb3ba67708d6"}]}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '182'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Location:
+      - https://graph.microsoft.com
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - c8f817f1-2574-42e3-8c43-fc5706433419
+      Client-Request-Id:
+      - c8f817f1-2574-42e3-8c43-fc5706433419
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000400"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5a4dd1a1-a076-0000-8a5a-6c83f7a1c43f
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:48 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.permission)","value":[{"id":"aTowIy5mfG1lbWJlcnNoaXB8aGVucmlldHRhbUB5bXQ2ZC5vbm1pY3Jvc29mdC5jb20","roles":["write"],"grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"49abf87c-31df-47ef-858d-fbc801b0985a"}},"grantedTo":{"user":{"displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"49abf87c-31df-47ef-858d-fbc801b0985a"}}},{"id":"aTowIy5mfG1lbWJlcnNoaXB8b3AubWVtYmVyQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","roles":["write"],"grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6"}},"grantedTo":{"user":{"displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6"}}}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:49 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - d97c0dbf-3659-48c4-b722-40d801381d1a
+      Client-Request-Id:
+      - d97c0dbf-3659-48c4-b722-40d801381d1a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001EE"}}'
+      Splogid:
+      - 5a4dd1a1-0095-0000-8a5a-6f8fb5572447
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:49 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:48Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:49 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e48a739c-de71-47d6-888d-970e3dc810db
+      Client-Request-Id:
+      - e48a739c-de71-47d6-888d-970e3dc810db
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001EE"}}'
+      Splogid:
+      - 5a4dd1a1-10a9-0000-8a2e-0d6cd35c27f3
+      Date:
+      - Mon, 20 Oct 2025 17:26:49 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"INACTIVE PROJECT!
+        f0r r34lz (268)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/INACTIVE%20PROJECT!%20f0r%20r34lz%20(268)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:48Z","lastModifiedDateTime":"2025-10-20T17:26:48Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:50 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 15cdcc71-2089-4574-ab64-fafc9fe85cb9
+      Client-Request-Id:
+      - 15cdcc71-2089-4574-ab64-fafc9fe85cb9
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001DD"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5a4dd1a1-70c5-0000-8a23-6c01eb6b7fc7
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:49 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items(''01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7'')/permissions","value":[{"id":"aTowIy5mfG1lbWJlcnNoaXB8bWVnYW5iQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","roles":["read"],"shareId":"aTowIy5mfG1lbWJlcnNoaXB8bWVnYW5iQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"f220e557-9477-47d5-94a7-672843be6b0a"},"siteUser":{"displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"12","loginName":"i:0#.f|membership|meganb@ymt6d.onmicrosoft.com"}},"grantedTo":{"user":{"displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"f220e557-9477-47d5-94a7-672843be6b0a"}}},{"id":"aTowIy5mfG1lbWJlcnNoaXB8b3AubWVtYmVyQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","roles":["write"],"shareId":"aTowIy5mfG1lbWJlcnNoaXB8b3AubWVtYmVyQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6"},"siteUser":{"displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"15","loginName":"i:0#.f|membership|op.member@ymt6d.onmicrosoft.com"}},"grantedTo":{"user":{"displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6"}}},{"id":"aTowIy5mfG1lbWJlcnNoaXB8aGVucmlldHRhbUB5bXQ2ZC5vbm1pY3Jvc29mdC5jb20","roles":["write"],"shareId":"aTowIy5mfG1lbWJlcnNoaXB8aGVucmlldHRhbUB5bXQ2ZC5vbm1pY3Jvc29mdC5jb20","grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"49abf87c-31df-47ef-858d-fbc801b0985a"},"siteUser":{"displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"25","loginName":"i:0#.f|membership|henriettam@ymt6d.onmicrosoft.com"}},"grantedTo":{"user":{"displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"49abf87c-31df-47ef-858d-fbc801b0985a"}}},{"id":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","roles":["owner"],"shareId":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","grantedToV2":{"group":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"},"siteUser":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"6","loginName":"c:0o.c|federateddirectoryclaimprovider|5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb_o"}},"grantedTo":{"user":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"}}}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:50 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 27bab254-7a67-4eab-8c8c-26b7e7529ac2
+      Client-Request-Id:
+      - 27bab254-7a67-4eab-8c8c-26b7e7529ac2
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000E02"}}'
+      Splogid:
+      - 5a4dd1a1-50df-0000-8a5a-653847e36834
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:50 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:48Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:50 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 800f326c-2541-40a3-abb0-766e252e5cca
+      Client-Request-Id:
+      - 800f326c-2541-40a3-abb0-766e252e5cca
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000E02"}}'
+      Splogid:
+      - 5a4dd1a1-50f1-0000-83a4-a645cd3f89f2
+      Date:
+      - Mon, 20 Oct 2025 17:26:50 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"INACTIVE PROJECT!
+        f0r r34lz (268)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/INACTIVE%20PROJECT!%20f0r%20r34lz%20(268)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:48Z","lastModifiedDateTime":"2025-10-20T17:26:48Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:51 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (266)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '100'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{F76C98BC-63F1-47FE-B462-97D687975C91},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W54TBWPP4LD7ZD3IYUX22DZOXER')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 37f4c7da-6e79-4664-aed8-6f4c0b25efdd
+      Client-Request-Id:
+      - 37f4c7da-6e79-4664-aed8-6f4c0b25efdd
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Splogid:
+      - 5b4dd1a1-800a-0000-8a23-64db333edef2
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:50 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{F76C98BC-63F1-47FE-B462-97D687975C91},1\"","eTag":"\"{F76C98BC-63F1-47FE-B462-97D687975C91},1\"","lastModifiedDateTime":"2025-10-20T17:26:51Z","createdDateTime":"2025-10-20T17:26:51Z","id":"01ANJ53W54TBWPP4LD7ZD3IYUX22DZOXER","name":"[Sample]
+        Project Name _ Ehuu (266)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(266)","cTag":"\"c:{F76C98BC-63F1-47FE-B462-97D687975C91},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:51Z","lastModifiedDateTime":"2025-10-20T17:26:51Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:51 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"_=o=_ _ _Jedi_ Project Folder ___ (267)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '105'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{2B863FD2-C2AD-4BF7-88FC-6A28A5C44E76},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W6SH6DCXLOC65FYR7DKFCS4ITTW')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - b90e3e41-e42b-4ebc-8189-b60595c842b5
+      Client-Request-Id:
+      - b90e3e41-e42b-4ebc-8189-b60595c842b5
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000E74"}}'
+      Splogid:
+      - 5b4dd1a1-3029-0000-90c2-ca2274e10cef
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:51 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{2B863FD2-C2AD-4BF7-88FC-6A28A5C44E76},1\"","eTag":"\"{2B863FD2-C2AD-4BF7-88FC-6A28A5C44E76},1\"","lastModifiedDateTime":"2025-10-20T17:26:52Z","createdDateTime":"2025-10-20T17:26:52Z","id":"01ANJ53W6SH6DCXLOC65FYR7DKFCS4ITTW","name":"_=o=_
+        _ _Jedi_ Project Folder ___ (267)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(267)","cTag":"\"c:{2B863FD2-C2AD-4BF7-88FC-6A28A5C44E76},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:52Z","lastModifiedDateTime":"2025-10-20T17:26:52Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:52 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"PUBLIC PROJECT (269)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '86'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{43E9D695-1127-4B4E-A3EE-F5AF6E687EC3},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W4V23UUGJYRJZF2H3XVV5XGQ7WD')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 5a4a0972-8c21-4c09-bd65-9707b924a977
+      Client-Request-Id:
+      - 5a4a0972-8c21-4c09-bd65-9707b924a977
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF0000054D"}}'
+      Splogid:
+      - 5b4dd1a1-5045-0000-8a23-6ab6b180695a
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:52 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{43E9D695-1127-4B4E-A3EE-F5AF6E687EC3},1\"","eTag":"\"{43E9D695-1127-4B4E-A3EE-F5AF6E687EC3},1\"","lastModifiedDateTime":"2025-10-20T17:26:52Z","createdDateTime":"2025-10-20T17:26:52Z","id":"01ANJ53W4V23UUGJYRJZF2H3XVV5XGQ7WD","name":"PUBLIC
+        PROJECT (269)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(269)","cTag":"\"c:{43E9D695-1127-4B4E-A3EE-F5AF6E687EC3},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:52Z","lastModifiedDateTime":"2025-10-20T17:26:52Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:52 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 8c77e0bd-fa6c-4f54-a716-f7c72fb75aa5
+      Client-Request-Id:
+      - 8c77e0bd-fa6c-4f54-a716-f7c72fb75aa5
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Splogid:
+      - 5b4dd1a1-005f-0000-83a4-a366f9f58a05
+      Date:
+      - Mon, 20 Oct 2025 17:26:51 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"createdDateTime":"2025-10-20T17:26:48Z","eTag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},2\"","id":"01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"lastModifiedDateTime":"2025-10-20T17:26:48Z","name":"INACTIVE
+        PROJECT! f0r r34lz (268)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/INACTIVE%20PROJECT!%20f0r%20r34lz%20(268)","cTag":"\"c:{497A2FFA-4551-4DB8-9A7E-EC689C62905F},0\"","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:48Z","lastModifiedDateTime":"2025-10-20T17:26:48Z"},"folder":{"childCount":0},"shared":{"scope":"users"},"size":0}'
+  recorded_at: Mon, 20 Oct 2025 17:26:52 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 27dfc64d-07da-48ad-91fd-3c71944a127f
+      Client-Request-Id:
+      - 27dfc64d-07da-48ad-91fd-3c71944a127f
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5b4dd1a1-3069-0000-8a23-60fbcad3f5b2
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:52 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items(''01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7'')/permissions","value":[{"id":"aTowIy5mfG1lbWJlcnNoaXB8bWVnYW5iQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","roles":["read"],"shareId":"aTowIy5mfG1lbWJlcnNoaXB8bWVnYW5iQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"f220e557-9477-47d5-94a7-672843be6b0a"},"siteUser":{"displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"12","loginName":"i:0#.f|membership|meganb@ymt6d.onmicrosoft.com"}},"grantedTo":{"user":{"displayName":"Megan
+        Bowen","email":"MeganB@ymt6d.onmicrosoft.com","id":"f220e557-9477-47d5-94a7-672843be6b0a"}}},{"id":"aTowIy5mfG1lbWJlcnNoaXB8b3AubWVtYmVyQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","roles":["write"],"shareId":"aTowIy5mfG1lbWJlcnNoaXB8b3AubWVtYmVyQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ","grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6"},"siteUser":{"displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"15","loginName":"i:0#.f|membership|op.member@ymt6d.onmicrosoft.com"}},"grantedTo":{"user":{"displayName":"OP
+        Member","email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6"}}},{"id":"aTowIy5mfG1lbWJlcnNoaXB8aGVucmlldHRhbUB5bXQ2ZC5vbm1pY3Jvc29mdC5jb20","roles":["write"],"shareId":"aTowIy5mfG1lbWJlcnNoaXB8aGVucmlldHRhbUB5bXQ2ZC5vbm1pY3Jvc29mdC5jb20","grantedToV2":{"user":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"49abf87c-31df-47ef-858d-fbc801b0985a"},"siteUser":{"displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"25","loginName":"i:0#.f|membership|henriettam@ymt6d.onmicrosoft.com"}},"grantedTo":{"user":{"displayName":"Henrietta
+        Mueller","email":"HenriettaM@ymt6d.onmicrosoft.com","id":"49abf87c-31df-47ef-858d-fbc801b0985a"}}},{"id":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","roles":["owner"],"shareId":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","grantedToV2":{"group":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"},"siteUser":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"6","loginName":"c:0o.c|federateddirectoryclaimprovider|5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb_o"}},"grantedTo":{"user":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"}}}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:52 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions/aTowIy5mfG1lbWJlcnNoaXB8bWVnYW5iQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 5d0a7a87-5497-446f-8292-4ddadcd65376
+      Client-Request-Id:
+      - 5d0a7a87-5497-446f-8292-4ddadcd65376
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5b4dd1a1-8075-0000-83a4-aed65dc09aa4
+      Date:
+      - Mon, 20 Oct 2025 17:26:52 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:53 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions/aTowIy5mfG1lbWJlcnNoaXB8b3AubWVtYmVyQHltdDZkLm9ubWljcm9zb2Z0LmNvbQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - c19dd4ef-2947-4db6-b18f-6240c235bcec
+      Client-Request-Id:
+      - c19dd4ef-2947-4db6-b18f-6240c235bcec
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5b4dd1a1-9083-0000-8a23-64be63fdfdaf
+      Date:
+      - Mon, 20 Oct 2025 17:26:52 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:53 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions/aTowIy5mfG1lbWJlcnNoaXB8aGVucmlldHRhbUB5bXQ2ZC5vbm1pY3Jvc29mdC5jb20
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 3f595738-32c6-44d9-ad94-904bb9777bbb
+      Client-Request-Id:
+      - 3f595738-32c6-44d9-ad94-904bb9777bbb
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5b4dd1a1-c093-0000-83a4-ac12902d8a24
+      Date:
+      - Mon, 20 Oct 2025 17:26:52 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:53 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 214e45fa-5ed7-4a41-b017-044d1fbe261f
+      Client-Request-Id:
+      - 214e45fa-5ed7-4a41-b017-044d1fbe261f
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF0000054D"}}'
+      Splogid:
+      - 5b4dd1a1-80af-0000-83a4-aafe571b7b6c
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:53 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:52Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5252235,"remaining":27487613326814,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:54 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - f9c30bb6-2447-453f-a6e8-81a84f81cc8d
+      Client-Request-Id:
+      - f9c30bb6-2447-453f-a6e8-81a84f81cc8d
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF0000054D"}}'
+      Splogid:
+      - 5b4dd1a1-60be-0000-8a23-6174336f2609
+      Date:
+      - Mon, 20 Oct 2025 17:26:54 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{F76C98BC-63F1-47FE-B462-97D687975C91},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W54TBWPP4LD7ZD3IYUX22DZOXER","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (266)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(266)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:51Z","lastModifiedDateTime":"2025-10-20T17:26:51Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{2B863FD2-C2AD-4BF7-88FC-6A28A5C44E76},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W6SH6DCXLOC65FYR7DKFCS4ITTW","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"_=o=_ _ _Jedi_
+        Project Folder ___ (267)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(267)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:52Z","lastModifiedDateTime":"2025-10-20T17:26:52Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{497A2FFA-4551-4DB8-9A7E-EC689C62905F},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"INACTIVE PROJECT!
+        f0r r34lz (268)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/INACTIVE%20PROJECT!%20f0r%20r34lz%20(268)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:48Z","lastModifiedDateTime":"2025-10-20T17:26:48Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{43E9D695-1127-4B4E-A3EE-F5AF6E687EC3},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W4V23UUGJYRJZF2H3XVV5XGQ7WD","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"PUBLIC PROJECT
+        (269)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(269)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:52Z","lastModifiedDateTime":"2025-10-20T17:26:52Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:54 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7/permissions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 39ffcadf-383f-4a05-a8d4-2780b65f50df
+      Client-Request-Id:
+      - 39ffcadf-383f-4a05-a8d4-2780b65f50df
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000003EA"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 5b4dd1a1-c0cf-0000-8a23-6aaaa1c0f8da
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:53 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items(''01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7'')/permissions","value":[{"id":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","roles":["owner"],"shareId":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","grantedToV2":{"group":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"},"siteUser":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"6","loginName":"c:0o.c|federateddirectoryclaimprovider|5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb_o"}},"grantedTo":{"user":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"}}}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:54 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W54TBWPP4LD7ZD3IYUX22DZOXER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - f657e30c-a674-4d1c-8c94-10538aab69c6
+      Client-Request-Id:
+      - f657e30c-a674-4d1c-8c94-10538aab69c6
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000E74"}}'
+      Splogid:
+      - 5b4dd1a1-80e2-0000-8a23-63da1bc12e72
+      Date:
+      - Mon, 20 Oct 2025 17:26:54 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:54 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W6SH6DCXLOC65FYR7DKFCS4ITTW
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - ffb4c19b-c2be-4583-b06f-b9c1a585add1
+      Client-Request-Id:
+      - ffb4c19b-c2be-4583-b06f-b9c1a585add1
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001E9"}}'
+      Splogid:
+      - 5b4dd1a1-20f6-0000-8a23-6d6b95db93f2
+      Date:
+      - Mon, 20 Oct 2025 17:26:54 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:55 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W72F55ESUKFXBGZU7XMNCOGFEC7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - d14ff278-a854-4309-b136-b526fd8cb599
+      Client-Request-Id:
+      - d14ff278-a854-4309-b136-b526fd8cb599
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF000001E5"}}'
+      Splogid:
+      - 5c4dd1a1-100d-0000-8a23-6de0a3b5fa27
+      Date:
+      - Mon, 20 Oct 2025 17:26:54 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:55 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W4V23UUGJYRJZF2H3XVV5XGQ7WD
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 68e95d42-2089-4fba-ad6d-4e2718a28260
+      Client-Request-Id:
+      - 68e95d42-2089-4fba-ad6d-4e2718a28260
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"001","RoleInstance":"FR2PEPF00000E74"}}'
+      Splogid:
+      - 5c4dd1a1-401f-0000-90c2-c8ffdaa7a707
+      Date:
+      - Mon, 20 Oct 2025 17:26:55 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:55 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_original_folders.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_original_folders.yml
@@ -1,0 +1,240 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - c9fde238-2ec2-4833-8f6e-5e8acb179300
+      X-Ms-Ests-Server:
+      - 2.1.22170.4 - NEULR1 ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce--Pz4-sOCtr6y4VOZpLLLUQ'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop-endpoint"
+      Reporting-Endpoints:
+      - coop-endpoint="https://idux.azurewebsites.net/api/coopReport"
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AkbCfd-ollJAquMgrSZUROpZ-dCOAQAAACVDiOAOAAAA; expires=Wed, 19-Nov-2025
+        14:50:14 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 20 Oct 2025 14:50:13 GMT
+      Content-Length:
+      - '2043'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 20 Oct 2025 14:50:14 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e59e3cc0-0025-478d-a9b2-67aa7c5ec9ad
+      Client-Request-Id:
+      - e59e3cc0-0025-478d-a9b2-67aa7c5ec9ad
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000313"}}'
+      Splogid:
+      - 6444d1a1-a0da-0000-8a23-66a802c49a09
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 14:50:13 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T14:24:24Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5237401,"remaining":27487613343582,"state":"normal","total":27487790694400,"used":172113417}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,8\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 14:50:14 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 52bba17a-75b6-447e-bb87-98467b7e279b
+      Client-Request-Id:
+      - 52bba17a-75b6-447e-bb87-98467b7e279b
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000313"}}'
+      Splogid:
+      - 6444d1a1-60ee-0000-8a23-6d201e436d70
+      Date:
+      - Mon, 20 Oct 2025 14:50:14 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[]}'
+  recorded_at: Mon, 20 Oct 2025 14:50:14 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 4d742de6-de36-468f-829b-63a395b8c92f
+      Client-Request-Id:
+      - 4d742de6-de36-468f-829b-63a395b8c92f
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"002","RoleInstance":"FR3PEPF00000313"}}'
+      Splogid:
+      - 6444d1a1-f0f4-0000-8a23-646b565e6ac0
+      Date:
+      - Mon, 20 Oct 2025 14:50:14 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"root","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","fileSystemInfo":{"createdDateTime":"2025-10-20T08:57:53Z","lastModifiedDateTime":"2025-10-20T14:24:24Z"},"folder":{"childCount":0},"size":0}'
+  recorded_at: Mon, 20 Oct 2025 14:50:14 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_rename_failed.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_rename_failed.yml
@@ -1,0 +1,736 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 6fde0edd-62e9-45ce-92e8-d2ac16932800
+      X-Ms-Ests-Server:
+      - 2.1.22276.5 - NEULR1 ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce--_YnUAT0REotmgrQgyCSVQ'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AlCZ6GyrLCpAk1vxjFFhBKhZ-dCOAQAAAELgi-AOAAAA; expires=Sat, 22-Nov-2025
+        08:37:22 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Thu, 23 Oct 2025 08:37:22 GMT
+      Content-Length:
+      - '2044'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Thu, 23 Oct 2025 08:37:22 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (131)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '100'
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{68451435-0028-483C-BE60-D33A1AD1FC73},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 3b59ba72-c435-4e00-8994-3d08ca164577
+      Client-Request-Id:
+      - 3b59ba72-c435-4e00-8994-3d08ca164577
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF000041E6"}}'
+      Splogid:
+      - 4026d2a1-1062-0000-8a23-6d9871ea21e7
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:37:22 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{68451435-0028-483C-BE60-D33A1AD1FC73},1\"","eTag":"\"{68451435-0028-483C-BE60-D33A1AD1FC73},1\"","lastModifiedDateTime":"2025-10-23T08:37:23Z","createdDateTime":"2025-10-23T08:37:23Z","id":"01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT","name":"[Sample]
+        Project Name _ Ehuu (131)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(131)","cTag":"\"c:{68451435-0028-483C-BE60-D33A1AD1FC73},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:23Z","lastModifiedDateTime":"2025-10-23T08:37:23Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Thu, 23 Oct 2025 08:37:22 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"Flawless Death Star Blueprints","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '96'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{AC752417-34EE-41BC-8EA4-162C1DA701B1},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53WYXER22Z3RUXRAY5JAWFQO2OANR')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 2dbeed4a-a857-402a-a5bd-5ea975eb9112
+      Client-Request-Id:
+      - 2dbeed4a-a857-402a-a5bd-5ea975eb9112
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC2"}}'
+      Splogid:
+      - 4026d2a1-4084-0000-8a2e-045fde9b81d1
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:37:23 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{AC752417-34EE-41BC-8EA4-162C1DA701B1},1\"","eTag":"\"{AC752417-34EE-41BC-8EA4-162C1DA701B1},1\"","lastModifiedDateTime":"2025-10-23T08:37:24Z","createdDateTime":"2025-10-23T08:37:24Z","id":"01ANJ53WYXER22Z3RUXRAY5JAWFQO2OANR","name":"Flawless
+        Death Star Blueprints","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/Flawless%20Death%20Star%20Blueprints","cTag":"\"c:{AC752417-34EE-41BC-8EA4-162C1DA701B1},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:24Z","lastModifiedDateTime":"2025-10-23T08:37:24Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Thu, 23 Oct 2025 08:37:23 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 45527010-803c-4f67-aec3-fecccb2e48a4
+      Client-Request-Id:
+      - 45527010-803c-4f67-aec3-fecccb2e48a4
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC3"}}'
+      Splogid:
+      - 4026d2a1-e09d-0000-8a2e-0a4913f30797
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:37:23 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-23T08:37:24Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5255478,"remaining":27487613323571,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Thu, 23 Oct 2025 08:37:23 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - e375e4b6-fb38-4bc0-b1f3-a6286ec0d755
+      Client-Request-Id:
+      - e375e4b6-fb38-4bc0-b1f3-a6286ec0d755
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC3"}}'
+      Splogid:
+      - 4026d2a1-20bd-0000-8a5a-6b13aef2ad3f
+      Date:
+      - Thu, 23 Oct 2025 08:37:24 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{68451435-0028-483C-BE60-D33A1AD1FC73},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (131)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(131)","fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:23Z","lastModifiedDateTime":"2025-10-23T08:37:23Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{AC752417-34EE-41BC-8EA4-162C1DA701B1},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53WYXER22Z3RUXRAY5JAWFQO2OANR","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"Flawless Death
+        Star Blueprints","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/Flawless%20Death%20Star%20Blueprints","fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:24Z","lastModifiedDateTime":"2025-10-23T08:37:24Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Thu, 23 Oct 2025 08:37:24 GMT
+- request:
+    method: patch
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WYXER22Z3RUXRAY5JAWFQO2OANR
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (131)"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '45'
+  response:
+    status:
+      code: 409
+      message: Conflict
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 18668bbe-623c-47f4-8b5a-f4a0fdb2bfe6
+      Client-Request-Id:
+      - 18668bbe-623c-47f4-8b5a-f4a0fdb2bfe6
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FCF"}}'
+      Splogid:
+      - 4026d2a1-20dc-0000-8a23-635bbea77b44
+      Date:
+      - Thu, 23 Oct 2025 08:37:24 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"nameAlreadyExists","message":"Name already exists","innerError":{"date":"2025-10-23T08:37:25","request-id":"18668bbe-623c-47f4-8b5a-f4a0fdb2bfe6","client-request-id":"18668bbe-623c-47f4-8b5a-f4a0fdb2bfe6"}}}'
+  recorded_at: Thu, 23 Oct 2025 08:37:24 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"_=o=_ _ _Jedi_ Project Folder ___ (132)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '105'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{0D5D1123-A174-41C3-837F-F188DE03B313},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53WZDCFOQ25FBYNAYG77RRDPAHMYT')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 16cf5948-4614-4270-b0e5-e12d3059a513
+      Client-Request-Id:
+      - 16cf5948-4614-4270-b0e5-e12d3059a513
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF000041E5"}}'
+      Splogid:
+      - 4026d2a1-b0f7-0000-8a2e-049e0345998a
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:37:25 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{0D5D1123-A174-41C3-837F-F188DE03B313},1\"","eTag":"\"{0D5D1123-A174-41C3-837F-F188DE03B313},1\"","lastModifiedDateTime":"2025-10-23T08:37:26Z","createdDateTime":"2025-10-23T08:37:26Z","id":"01ANJ53WZDCFOQ25FBYNAYG77RRDPAHMYT","name":"_=o=_
+        _ _Jedi_ Project Folder ___ (132)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(132)","cTag":"\"c:{0D5D1123-A174-41C3-837F-F188DE03B313},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:26Z","lastModifiedDateTime":"2025-10-23T08:37:26Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Thu, 23 Oct 2025 08:37:25 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"PUBLIC PROJECT (134)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '86'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{CA91E0C9-E672-42D0-B4E0-483AAE1D02EB},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W6J4CI4U4XG2BBLJYCIHKXB2AXL')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 7214d5dc-e8e3-46e8-8805-963d7acf5bbd
+      Client-Request-Id:
+      - 7214d5dc-e8e3-46e8-8805-963d7acf5bbd
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC8"}}'
+      Splogid:
+      - 4126d2a1-0020-0000-8a23-6e4212e47719
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:37:25 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{CA91E0C9-E672-42D0-B4E0-483AAE1D02EB},1\"","eTag":"\"{CA91E0C9-E672-42D0-B4E0-483AAE1D02EB},1\"","lastModifiedDateTime":"2025-10-23T08:37:26Z","createdDateTime":"2025-10-23T08:37:26Z","id":"01ANJ53W6J4CI4U4XG2BBLJYCIHKXB2AXL","name":"PUBLIC
+        PROJECT (134)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(134)","cTag":"\"c:{CA91E0C9-E672-42D0-B4E0-483AAE1D02EB},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:26Z","lastModifiedDateTime":"2025-10-23T08:37:26Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Thu, 23 Oct 2025 08:37:25 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - b4dfdf86-b182-4d7f-b36b-cc329d41d7a4
+      Client-Request-Id:
+      - b4dfdf86-b182-4d7f-b36b-cc329d41d7a4
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00005340"}}'
+      Splogid:
+      - 4126d2a1-3046-0000-8a23-6d67db9a2c9a
+      Date:
+      - Thu, 23 Oct 2025 08:37:27 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"createdDateTime":"2025-10-23T08:37:23Z","eTag":"\"{68451435-0028-483C-BE60-D33A1AD1FC73},2\"","id":"01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"lastModifiedDateTime":"2025-10-23T08:37:23Z","name":"[Sample]
+        Project Name _ Ehuu (131)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(131)","cTag":"\"c:{68451435-0028-483C-BE60-D33A1AD1FC73},0\"","fileSystemInfo":{"createdDateTime":"2025-10-23T08:37:23Z","lastModifiedDateTime":"2025-10-23T08:37:23Z"},"folder":{"childCount":0},"shared":{"scope":"users"},"size":0}'
+  recorded_at: Thu, 23 Oct 2025 08:37:26 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT/permissions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 4cd4c7c7-b88f-4584-8fdd-07e4137565a2
+      Client-Request-Id:
+      - 4cd4c7c7-b88f-4584-8fdd-07e4137565a2
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00005340"}}'
+      Link:
+      - <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html",
+        <https://developer.microsoft-tst.com/en-us/graph/changes?$filterby=v1.0,Removal&from=2021-09-01&to=2021-10-01>;rel="deprecation";type="text/html"
+      Deprecation:
+      - Fri, 03 Sep 2021 23:59:59 GMT
+      Sunset:
+      - Sun, 01 Oct 2023 23:59:59 GMT
+      Splogid:
+      - 4126d2a1-c060-0000-8a23-6866b73b74f6
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:37:27 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items(''01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT'')/permissions","value":[{"id":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","roles":["owner"],"shareId":"Yzowby5jfGZlZGVyYXRlZGRpcmVjdG9yeWNsYWltcHJvdmlkZXJ8NWRmYjQyNjktZDNlMy00YzcwLTgzZjUtYzQ5MzdmZjZkY2RiX28","grantedToV2":{"group":{"@odata.type":"#microsoft.graph.sharePointIdentity","displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"},"siteUser":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"6","loginName":"c:0o.c|federateddirectoryclaimprovider|5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb_o"}},"grantedTo":{"user":{"displayName":"OP
+        Test Owners","email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb"}},"inheritedFrom":{}}]}'
+  recorded_at: Thu, 23 Oct 2025 08:37:26 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZVCRCWQKAAHREL4YGTHINND7DT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - cf060e2b-d72f-48ff-b716-76b8ed76b491
+      Client-Request-Id:
+      - cf060e2b-d72f-48ff-b716-76b8ed76b491
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FD1"}}'
+      Splogid:
+      - 4126d2a1-507c-0000-8a2e-0e6aef4175b3
+      Date:
+      - Thu, 23 Oct 2025 08:37:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 23 Oct 2025 08:37:27 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WYXER22Z3RUXRAY5JAWFQO2OANR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 9e831268-43ef-4d83-917a-8d783e297f75
+      Client-Request-Id:
+      - 9e831268-43ef-4d83-917a-8d783e297f75
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF000041E3"}}'
+      Splogid:
+      - 4126d2a1-e09a-0000-8a2e-0964c29800a7
+      Date:
+      - Thu, 23 Oct 2025 08:37:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 23 Oct 2025 08:37:27 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53WZDCFOQ25FBYNAYG77RRDPAHMYT
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - cccc63e1-a7e5-4b08-ad11-6a45f22b74e3
+      Client-Request-Id:
+      - cccc63e1-a7e5-4b08-ad11-6a45f22b74e3
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF000041E4"}}'
+      Splogid:
+      - 4126d2a1-a0b8-0000-8a2e-07893497d4d1
+      Date:
+      - Thu, 23 Oct 2025 08:37:28 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 23 Oct 2025 08:37:27 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W6J4CI4U4XG2BBLJYCIHKXB2AXL
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 3ee9243d-a35a-4dec-a251-8c77a39e2d52
+      Client-Request-Id:
+      - 3ee9243d-a35a-4dec-a251-8c77a39e2d52
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF000044A0"}}'
+      Splogid:
+      - 4126d2a1-00cd-0000-8a23-6bf3fdf995f9
+      Date:
+      - Thu, 23 Oct 2025 08:37:28 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 23 Oct 2025 08:37:28 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_rename_folder.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_rename_folder.yml
@@ -1,0 +1,680 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 2216b7ed-a9e6-4209-a00a-7551b6ae1400
+      X-Ms-Ests-Server:
+      - 2.1.22170.4 - FRC ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-2FzWjwOfsXrDS5gCCjY9Uw'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop-endpoint"
+      Reporting-Endpoints:
+      - coop-endpoint="https://idux.azurewebsites.net/api/coopReport"
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=As0HxI3CMv9PqZijQGgtMDNZ-dCOAQAAAL1niOAOAAAA; expires=Wed, 19-Nov-2025
+        17:26:21 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Mon, 20 Oct 2025 17:26:20 GMT
+      Content-Length:
+      - '2040'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Mon, 20 Oct 2025 17:26:21 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"Old Jedi Project","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '82'
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - de22a0d1-5c57-4a7b-9da8-3f6299163c76
+      Client-Request-Id:
+      - de22a0d1-5c57-4a7b-9da8-3f6299163c76
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FD1"}}'
+      Splogid:
+      - 534dd1a1-80d1-0000-83a4-a2c70ac92c48
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:20 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},1\"","eTag":"\"{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},1\"","lastModifiedDateTime":"2025-10-20T17:26:22Z","createdDateTime":"2025-10-20T17:26:22Z","id":"01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ","name":"Old
+        Jedi Project","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/Old%20Jedi%20Project","cTag":"\"c:{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:22Z","lastModifiedDateTime":"2025-10-20T17:26:22Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:21 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 79e9337b-7184-417f-979d-87cd0dcab5d6
+      Client-Request-Id:
+      - 79e9337b-7184-417f-979d-87cd0dcab5d6
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC9"}}'
+      Splogid:
+      - 534dd1a1-d0ee-0000-8a23-65caf5708609
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:21 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:22Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:22 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - bdfdb438-175a-4378-8aeb-c8c8d55bb110
+      Client-Request-Id:
+      - bdfdb438-175a-4378-8aeb-c8c8d55bb110
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC9"}}'
+      Splogid:
+      - 544dd1a1-e000-0000-8a23-626ec859fca7
+      Date:
+      - Mon, 20 Oct 2025 17:26:21 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"Old Jedi Project","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/Old%20Jedi%20Project","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:22Z","lastModifiedDateTime":"2025-10-20T17:26:22Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:22 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"[Sample] Project Name _ Ehuu (261)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '100'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{212AECAC-4C32-4903-A3FC-44911D919373},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W5M5QVCCMSMANE2H7CESEOZDE3T')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - a09c6b7c-2b4c-472b-83d2-09955f8be184
+      Client-Request-Id:
+      - a09c6b7c-2b4c-472b-83d2-09955f8be184
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC2"}}'
+      Splogid:
+      - 544dd1a1-a013-0000-83a4-a042c6c6bc52
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:22 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{212AECAC-4C32-4903-A3FC-44911D919373},1\"","eTag":"\"{212AECAC-4C32-4903-A3FC-44911D919373},1\"","lastModifiedDateTime":"2025-10-20T17:26:23Z","createdDateTime":"2025-10-20T17:26:23Z","id":"01ANJ53W5M5QVCCMSMANE2H7CESEOZDE3T","name":"[Sample]
+        Project Name _ Ehuu (261)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(261)","cTag":"\"c:{212AECAC-4C32-4903-A3FC-44911D919373},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:23Z","lastModifiedDateTime":"2025-10-20T17:26:23Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:23 GMT
+- request:
+    method: patch
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ
+    body:
+      encoding: UTF-8
+      string: '{"name":"_=o=_ _ _Jedi_ Project Folder ___ (262)"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '50'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 19a8eda5-86da-4d07-9a00-cb11027e0bf3
+      Client-Request-Id:
+      - 19a8eda5-86da-4d07-9a00-cb11027e0bf3
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FD1"}}'
+      Splogid:
+      - 544dd1a1-f02c-0000-83a4-a9c327a47b13
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:22 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/items/$entity","createdDateTime":"2025-10-20T17:26:22Z","eTag":"\"{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},3\"","id":"01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ","lastModifiedDateTime":"2025-10-20T17:26:23Z","name":"_=o=_
+        _ _Jedi_ Project Folder ___ (262)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(262)","cTag":"\"c:{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},0\"","size":0,"createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:22Z","lastModifiedDateTime":"2025-10-20T17:26:23Z"},"folder":{"childCount":0},"shared":{"scope":"users"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:23 GMT
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children
+    body:
+      encoding: UTF-8
+      string: '{"name":"PUBLIC PROJECT (264)","folder":{},"@microsoft.graph.conflictBehavior":"fail"}'
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '86'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Etag:
+      - '"{3A5884BD-D93C-4EF8-8C9B-BFEECC6A5998},1"'
+      Location:
+      - https://ymt6d.sharepoint.com/_api/v2.0/drives('b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v')/items('root')/children('01ANJ53W55QRMDUPGZ7BHIZG5753GGUWMY')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - b52aced2-a832-4ac6-bfe4-2fc182e0e65e
+      Client-Request-Id:
+      - b52aced2-a832-4ac6-bfe4-2fc182e0e65e
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FCC"}}'
+      Splogid:
+      - 544dd1a1-f05a-0000-83a4-a4a608e3e0df
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:23 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives(''b%21FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v'')/root/children/$entity","@odata.etag":"\"{3A5884BD-D93C-4EF8-8C9B-BFEECC6A5998},1\"","eTag":"\"{3A5884BD-D93C-4EF8-8C9B-BFEECC6A5998},1\"","lastModifiedDateTime":"2025-10-20T17:26:24Z","createdDateTime":"2025-10-20T17:26:24Z","id":"01ANJ53W55QRMDUPGZ7BHIZG5753GGUWMY","name":"PUBLIC
+        PROJECT (264)","size":0,"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(264)","cTag":"\"c:{3A5884BD-D93C-4EF8-8C9B-BFEECC6A5998},0\"","commentSettings":{"commentingDisabled":{"isDisabled":false}},"createdBy":{"application":{"displayName":"OP
+        Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"application":{"displayName":"OP Selected","id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9"},"user":{"displayName":"SharePoint
+        App"}},"parentReference":{"driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","driveType":"documentLibrary","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","sharepointIds":{"listId":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","listItemUniqueId":"b8815bb8-1f88-4adf-8998-4ae00259ff11","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff","siteUrl":"https://ymt6d.sharepoint.com/sites/OPTest","tenantId":"e36f1dbc-fdae-427e-b61b-0d96ddfb81a4","webId":"6af246f0-e3be-45ef-b91a-8eca4dcc5d8f"}},"fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:24Z","lastModifiedDateTime":"2025-10-20T17:26:24Z"},"folder":{"childCount":0},"shared":{"scope":"unknown"}}'
+  recorded_at: Mon, 20 Oct 2025 17:26:24 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 04a91d61-53dc-4a32-ae82-8aedbcf01895
+      Client-Request-Id:
+      - 04a91d61-53dc-4a32-ae82-8aedbcf01895
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC2"}}'
+      Splogid:
+      - 544dd1a1-6074-0000-83a4-a4f13997e998
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Mon, 20 Oct 2025 17:26:23 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-20T17:26:24Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5250846,"remaining":27487613328203,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:24 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root/children?$select=id,name,size,webUrl,lastModifiedBy,createdBy,fileSystemInfo,file,folder,parentReference
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - fce971a4-c1a3-4b44-8518-24c838be7e34
+      Client-Request-Id:
+      - fce971a4-c1a3-4b44-8518-24c838be7e34
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FC2"}}'
+      Splogid:
+      - 544dd1a1-b08e-0000-83a4-abf947ad37af
+      Date:
+      - Mon, 20 Oct 2025 17:26:23 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)","value":[{"@odata.etag":"\"{212AECAC-4C32-4903-A3FC-44911D919373},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W5M5QVCCMSMANE2H7CESEOZDE3T","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"[Sample] Project
+        Name _ Ehuu (261)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/%5BSample%5D%20Project%20Name%20_%20Ehuu%20(261)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:23Z","lastModifiedDateTime":"2025-10-20T17:26:23Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{DB1A4458-239B-44E5-932F-ECCFAF1E8D19},3\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"_=o=_ _ _Jedi_
+        Project Folder ___ (262)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/_=o=_%20_%20_Jedi_%20Project%20Folder%20___%20(262)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:22Z","lastModifiedDateTime":"2025-10-20T17:26:23Z"},"folder":{"childCount":0},"size":0},{"@odata.etag":"\"{3A5884BD-D93C-4EF8-8C9B-BFEECC6A5998},2\"","createdBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"id":"01ANJ53W55QRMDUPGZ7BHIZG5753GGUWMY","lastModifiedBy":{"application":{"id":"404e0567-19a1-4a64-b2d1-d3b0c99f2ed9","displayName":"OP
+        Selected"},"user":{"displayName":"SharePoint App"}},"name":"PUBLIC PROJECT
+        (264)","parentReference":{"driveType":"documentLibrary","driveId":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","id":"01ANJ53W56Y2GOVW7725BZO354PWSELRRZ","name":"AMPF
+        VCR","path":"/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/root:","siteId":"1099e315-d0c7-47c7-8640-aa9504b70fff"},"webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR/PUBLIC%20PROJECT%20(264)","fileSystemInfo":{"createdDateTime":"2025-10-20T17:26:24Z","lastModifiedDateTime":"2025-10-20T17:26:25Z"},"folder":{"childCount":0},"size":0}]}'
+  recorded_at: Mon, 20 Oct 2025 17:26:24 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W5M5QVCCMSMANE2H7CESEOZDE3T
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - f4278fe7-46e3-4c29-a382-be37b4c5644a
+      Client-Request-Id:
+      - f4278fe7-46e3-4c29-a382-be37b4c5644a
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF000041E0"}}'
+      Splogid:
+      - 544dd1a1-50a5-0000-8a5a-645da19d3ebc
+      Date:
+      - Mon, 20 Oct 2025 17:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:25 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W2YIQNNXGZD4VCJGL7MZ6XR5DIZ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 36142af7-9bf3-4967-b632-ec36acca66c8
+      Client-Request-Id:
+      - 36142af7-9bf3-4967-b632-ec36acca66c8
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00001FCB"}}'
+      Splogid:
+      - 544dd1a1-a0be-0000-90c2-cd3b22a4b6e7
+      Date:
+      - Mon, 20 Oct 2025 17:26:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:25 GMT
+- request:
+    method: delete
+    uri: https://graph.microsoft.com/v1.0/drives/b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v/items/01ANJ53W55QRMDUPGZ7BHIZG5753GGUWMY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <BEARER TOKEN>
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - d9fae2bf-6f0c-4eeb-81d0-40cfafe9c26f
+      Client-Request-Id:
+      - d9fae2bf-6f0c-4eeb-81d0-40cfafe9c26f
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"006","RoleInstance":"FR1PEPF00003A0A"}}'
+      Splogid:
+      - 544dd1a1-b0d2-0000-8a5a-6eba69f1c1e0
+      Date:
+      - Mon, 20 Oct 2025 17:26:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 20 Oct 2025 17:26:25 GMT
+recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_root_read_failure.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/sharepoint/sync_service_root_read_failure.yml
@@ -1,0 +1,150 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/e36f1dbc-fdae-427e-b61b-0d96ddfb81a4/oauth2/v2.0/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials&scope=https%3A%2F%2Fgraph.microsoft.com%2F.default+offline_access&client_id=404e0567-19a1-4a64-b2d1-d3b0c99f2ed9&client_secret=QRB8Q%7Ei.1rID_.MC9FTfRGq-FTE5SgWYsoeLacWf
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      X-Ms-Request-Id:
+      - 4faead77-8cd3-44d9-87ca-514c5ec45b00
+      X-Ms-Ests-Server:
+      - 2.1.22276.5 - WEULR1 ProdSlices
+      X-Ms-Srs:
+      - 1.P
+      Content-Security-Policy-Report-Only:
+      - object-src 'none'; base-uri 'self'; script-src 'self' 'nonce-x2CuIQUFAV6tb0NoguK-RQ'
+        'unsafe-inline' 'unsafe-eval' https://*.msauth.net https://*.msftauth.net
+        https://*.msftauthimages.net https://*.msauthimages.net https://*.msidentity.com
+        https://*.microsoftonline-p.com https://*.microsoftazuread-sso.com https://*.azureedge.net
+        https://*.outlook.com https://*.office.com https://*.office365.com https://*.microsoft.com
+        https://*.bing.com 'report-sample'; report-uri https://csp.microsoft.com/report/ESTS-UX-All
+      X-Xss-Protection:
+      - '0'
+      Set-Cookie:
+      - fpc=AonNU9XwPbFKrdRQq15PSW9Z-dCOAQAAAHPli-AOAAAA; expires=Sat, 22-Nov-2025
+        08:59:32 GMT; path=/; secure; HttpOnly; SameSite=None, x-ms-gateway-slice=estsfd;
+        path=/; secure; samesite=none; httponly, stsservicecookie=estsfd; path=/;
+        secure; samesite=none; httponly
+      Date:
+      - Thu, 23 Oct 2025 08:59:31 GMT
+      Content-Length:
+      - '2041'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"<ACCESS_TOKEN>"}'
+  recorded_at: Thu, 23 Oct 2025 08:59:32 GMT
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/sites/ymt6d.sharepoint.com:/sites/OPTest:/lists?$expand=drive&$select=id,name,drive
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - httpx.rb/1.6.2
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer <BEARER TOKEN>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, no-cache
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 9f21b0af-63ee-444d-adde-78203dbfe17e
+      Client-Request-Id:
+      - 9f21b0af-63ee-444d-adde-78203dbfe17e
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Germany West Central","Slice":"E","Ring":"4","ScaleUnit":"004","RoleInstance":"FR2PEPF00000E07"}}'
+      Splogid:
+      - 8427d2a1-10f0-0000-8a2e-0cbb73d4104c
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Thu, 23 Oct 2025 08:59:31 GMT
+    body:
+      encoding: UTF-8
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(id,name,drive,drive())","value":[{"@odata.etag":"\"df897210-689b-48ba-a128-0a6b8662a40a,26\"","id":"df897210-689b-48ba-a128-0a6b8662a40a","name":"OpenProject","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''df897210-689b-48ba-a128-0a6b8662a40a'')/drive/$entity","drive":{"createdDateTime":"2024-02-02T13:53:33Z","description":"Enabled
+        for automatic management","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK","lastModifiedDateTime":"2025-10-14T07:40:08Z","name":"OpenProject","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/OpenProject","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"7a76be3b-077e-41ef-a9d9-1d7f97080cb0,22\"","id":"7a76be3b-077e-41ef-a9d9-1d7f97080cb0","name":"Shared
+        Documents","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''7a76be3b-077e-41ef-a9d9-1d7f97080cb0'')/drive/$entity","drive":{"createdDateTime":"2023-12-10T00:27:16Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw","lastModifiedDateTime":"2025-09-23T11:10:46Z","name":"Documents","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Shared%20Documents","driveType":"documentLibrary","createdBy":{"user":{"displayName":"System
+        Account"}},"lastModifiedBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5cda990f-64f2-4035-9932-21b6d6409a25,20\"","id":"5cda990f-64f2-4035-9932-21b6d6409a25","name":"Selected
+        Permissions","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5cda990f-64f2-4035-9932-21b6d6409a25'')/drive/$entity","drive":{"createdDateTime":"2024-08-12T13:14:43Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Pmdpc8mQ1QJkyIbbWQJol","lastModifiedDateTime":"2025-09-19T02:10:34Z","name":"Selected
+        Permissions","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Selected%20Permissions","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f,22\"","id":"f5a7a0d8-fb24-48d8-9785-46ccb1e3317f","name":"Chris
+        document library","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''f5a7a0d8-fb24-48d8-9785-46ccb1e3317f'')/drive/$entity","drive":{"createdDateTime":"2024-02-13T15:38:57Z","description":"For
+        testing","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY_YoKf1JPvYSJeFRsyx4zF_","lastModifiedDateTime":"2024-05-21T12:58:12Z","name":"Chris
+        document library","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Chris%20document%20library","driveType":"documentLibrary","createdBy":{"user":{"email":"cbliard@ymt6d.onmicrosoft.com","id":"5bbaa900-f913-41c9-9593-c3d03a14684b","displayName":"Christophe
+        Bliard"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"87d67c02-fdaf-4504-8b39-920984585ad7,20\"","id":"87d67c02-fdaf-4504-8b39-920984585ad7","name":"Marcello
+        AMPF","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''87d67c02-fdaf-4504-8b39-920984585ad7'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:03:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8CfNaHr_0ERYs5kgmEWFrX","lastModifiedDateTime":"2025-09-29T13:42:11Z","name":"Marcello
+        (AMPF)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20AMPF","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"displayName":"SharePoint App"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"587ba428-c078-4d0d-a857-952e781601e7,6\"","id":"587ba428-c078-4d0d-a857-952e781601e7","name":"Dominic","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''587ba428-c078-4d0d-a857-952e781601e7'')/drive/$entity","drive":{"createdDateTime":"2024-07-05T09:54:25Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8opHtYeMANTahXlS54FgHn","lastModifiedDateTime":"2024-07-19T07:48:01Z","name":"Dominic","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Dominic","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"6b0e0177-f280-47a8-bb4c-c29b29823f79,25\"","id":"6b0e0177-f280-47a8-bb4c-c29b29823f79","name":"Markus","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''6b0e0177-f280-47a8-bb4c-c29b29823f79'')/drive/$entity","drive":{"createdDateTime":"2024-05-13T14:53:56Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY93AQ5rgPKoR7tMwpspgj95","lastModifiedDateTime":"2025-05-19T13:28:22Z","name":"Markus","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Markus","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"5ea9a363-3a24-4fab-b9ae-cef9a25a3156,20\"","id":"5ea9a363-3a24-4fab-b9ae-cef9a25a3156","name":"Marcello
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''5ea9a363-3a24-4fab-b9ae-cef9a25a3156'')/drive/$entity","drive":{"createdDateTime":"2025-04-07T12:02:17Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW","lastModifiedDateTime":"2025-10-06T14:57:47Z","name":"Marcello
+        (VCR)","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/Marcello%20VCR","driveType":"documentLibrary","createdBy":{"user":{"email":"op.admin@ymt6d.onmicrosoft.com","id":"5b5a7dc4-4539-41ba-9fa9-100f0a26acb7","displayName":"Eric
+        Schubert"}},"lastModifiedBy":{"user":{"email":"op.member@ymt6d.onmicrosoft.com","id":"a9023fd0-c421-4695-b83c-bb3ba67708d6","displayName":"OP
+        Member"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f,3\"","id":"03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f","name":"AMPF
+        VCR","drive@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.list)(''03b7a8ae-9cc8-46b9-9d63-d25b83d1bd6f'')/drive/$entity","drive":{"createdDateTime":"2025-10-20T08:57:53Z","description":"","id":"b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v","lastModifiedDateTime":"2025-10-23T08:37:29Z","name":"AMPF
+        VCR","webUrl":"https://ymt6d.sharepoint.com/sites/OPTest/AMPF%20VCR","driveType":"documentLibrary","createdBy":{"user":{"displayName":"SharePoint
+        App"}},"lastModifiedBy":{"user":{"email":"op.owner@ymt6d.onmicrosoft.com","id":"ddbce65c-65fd-42a9-be30-253e244c3f36","displayName":"OP
+        Owner"}},"owner":{"group":{"email":"OPTest@ymt6d.onmicrosoft.com","id":"5dfb4269-d3e3-4c70-83f5-c4937ff6dcdb","displayName":"OP
+        Test Owners"}},"quota":{"deleted":5257327,"remaining":27487613321722,"state":"normal","total":27487790694400,"used":172115351}}},{"@odata.etag":"\"da53472d-ec9c-4fb1-b021-d89d3748c8a1,0\"","id":"da53472d-ec9c-4fb1-b021-d89d3748c8a1","name":"wte"},{"@odata.etag":"\"834449c8-dc24-44e0-a59a-e94f9128801c,11\"","id":"834449c8-dc24-44e0-a59a-e94f9128801c","name":"Access
+        Requests"}]}'
+  recorded_at: Thu, 23 Oct 2025 08:59:32 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
### Related Work Package: [OP#64485](https://community.openproject.org/projects/document-workflows-stream/work_packages/64485/activity)

# What?

This PR introduces the first service needed to support the background job related to AMPF support: creating the folder under the managed Document Library.

# How?

The process is almost identical to the OneDrive one with some subtle differences mostly relating to how we deal with the "drives".

I also introduced the "managed_drive_name" field to the SharePoint storage in order to facilitate tests but this can be leveraged to allow a user to configure the name of their managed document library.

One thing that was done was the removal of the LastProjectFolder interaction, that can lead to unrecoverable statuses under MS infrastructure