### PR TITLE
Fix redirect after logo delete

### DIFF
--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -254,6 +254,6 @@ class CustomStylesController < ApplicationController
     end
 
     @custom_style.send(remove_method)
-    redirect_to custom_style_path
+    redirect_to custom_style_path, status: :see_other
   end
 end

--- a/app/views/custom_styles/uploads/_font.html.erb
+++ b/app/views/custom_styles/uploads/_font.html.erb
@@ -58,7 +58,7 @@ See COPYRIGHT and LICENSE files for more details.
         <%= render(Primer::Beta::Button.new(
           tag: :a,
           href: font[:delete_path],
-          data: { method: :delete }
+          data: { turbo_method: :delete }
         )) do |button|
           button.with_leading_visual_icon(icon: :trash)
           t(:button_delete)

--- a/spec/controllers/custom_styles_controller_spec.rb
+++ b/spec/controllers/custom_styles_controller_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe CustomStylesController do
 
         it "removes the logo from custom_style" do
           expect(response).to redirect_to(action: :show)
-          expect(response).to have_http_status(:found)
+          expect(response).to have_http_status(:see_other)
         end
       end
 
@@ -710,6 +710,7 @@ RSpec.describe CustomStylesController do
           allow(CustomStyle).to receive(:current).and_return(style)
           delete :export_font_regular_delete
           expect(response).to redirect_to(action: :show)
+          expect(response).to have_http_status(:see_other)
           expect(style.reload.export_font_regular).not_to be_present
         end
 
@@ -718,6 +719,7 @@ RSpec.describe CustomStylesController do
           allow(CustomStyle).to receive(:current).and_return(style)
           delete :export_font_bold_delete
           expect(response).to redirect_to(action: :show)
+          expect(response).to have_http_status(:see_other)
           expect(style.reload.export_font_bold).not_to be_present
         end
 
@@ -726,6 +728,7 @@ RSpec.describe CustomStylesController do
           allow(CustomStyle).to receive(:current).and_return(style)
           delete :export_font_italic_delete
           expect(response).to redirect_to(action: :show)
+          expect(response).to have_http_status(:see_other)
           expect(style.reload.export_font_italic).not_to be_present
         end
 
@@ -734,6 +737,7 @@ RSpec.describe CustomStylesController do
           allow(CustomStyle).to receive(:current).and_return(style)
           delete :export_font_bold_italic_delete
           expect(response).to redirect_to(action: :show)
+          expect(response).to have_http_status(:see_other)
           expect(style.reload.export_font_bold_italic).not_to be_present
         end
       end


### PR DESCRIPTION
After now using a  `turbo_method: :delete`, a redirect needs to use 303 status to not use the HTTP delete method for the redirect