### PR TITLE
[#63550] Add validateCustomFields api flag documentation

### DIFF
--- a/docs/api/apiv3/components/examples/work_package_with_meta_validation.yml
+++ b/docs/api/apiv3/components/examples/work_package_with_meta_validation.yml
@@ -1,0 +1,6 @@
+description: |-
+  A request body to edit a work package with custom field validation enabled via the _meta object.
+value:
+  subject: Replace GNK power droids
+  _meta:
+    validateCustomFields: true

--- a/docs/api/apiv3/components/schemas/work_package_write_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_write_model.yml
@@ -119,3 +119,15 @@ properties:
               Parent work package
 
               **Resource**: WorkPackage
+  _meta:
+    type: object
+    description: Meta information for the work package request
+    properties:
+      validateCustomFields:
+        type: boolean
+        description: |-
+          When set to true, explicitly validates all required custom fields on the work package, regardless of whether
+          they are provided in the request body. This overrides the default behavior where only custom fields included
+          in the request are validated. Use this parameter when you need to ensure all required custom fields have
+          valid values before allowing the update to proceed.
+        default: false

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -617,6 +617,8 @@ components:
       $ref: "./components/examples/work_package_create_valid.yml"
     WorkPackageEditSubject:
       $ref: "./components/examples/work_package_edit_subject.yml"
+    WorkPackageWithMetaValidation:
+      $ref: "./components/examples/work_package_with_meta_validation.yml"
 
   responses:
     InvalidQuery:

--- a/docs/api/apiv3/paths/work_package.yml
+++ b/docs/api/apiv3/paths/work_package.yml
@@ -133,7 +133,7 @@ patch:
     specific attributes independently without having to provide values for all required custom fields.
 
     To override this behavior and validate all required custom fields regardless of whether they are included in the
-    request, set the `validateCustomFields` query parameter to `true`.
+    request, set `validateCustomFields` to `true` in the `_meta` object of the request body.
   parameters:
     - name: id
       description: Work package id
@@ -152,29 +152,20 @@ patch:
         type: boolean
         default: true
       example: false
-    - name: validateCustomFields
-      description: |-
-        When set to true, explicitly validates all required custom fields on the work package, regardless of whether
-        they are provided in the request body. This overrides the default behavior where only custom fields included
-        in the request are validated. Use this parameter when you need to ensure all required custom fields have
-        valid values before allowing the update to proceed.
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: false
-      example: true
   requestBody:
     content:
       application/json:
         schema:
-          $ref: '../components/schemas/work_package_model.yml'
+          $ref: '../components/schemas/work_package_patch_model.yml'
+        examples:
+          'With custom field validation':
+            $ref: '../components/examples/work_package_with_meta_validation.yml'
   responses:
     '200':
       content:
         application/hal+json:
           schema:
-            '$ref': '../components/schemas/work_package_patch_model.yml'
+            '$ref': '../components/schemas/work_package_model.yml'
       description: OK
     '400':
       $ref: '../components/responses/invalid_request_body.yml'

--- a/docs/api/apiv3/paths/work_package_form.yml
+++ b/docs/api/apiv3/paths/work_package_form.yml
@@ -23,6 +23,9 @@ post:
     Required custom fields are only validated when they are explicitly provided in the request body. If a custom field
     is not included in the form request, it will not be validated, allowing clients to validate partial updates
     without triggering validation errors for unrelated required custom fields.
+
+    To override this behavior and validate all required custom fields regardless of whether they are included in the
+    request, set `validateCustomFields` to `true` in the `_meta` object of the request body.
   requestBody:
     content:
       application/json:
@@ -31,6 +34,8 @@ post:
         examples:
           'Changing subject':
             $ref: '../components/examples/work_package_edit_subject.yml'
+          'With custom field validation':
+            $ref: '../components/examples/work_package_with_meta_validation.yml'
   parameters:
     - name: id
       description: ID of the work package being modified


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/63550

# What are you trying to accomplish?
Add documentation for the new validateCustomFields meta parameter in Work Package API endpoints. 

# What approach did you choose and why?

Updated work package update and update form endpoints to document the new `_meta.validateCustomFields` parameter:
- Updated `PATCH /work_packages/{id}` endpoint documentation
- Updated `POST /work_packages/{id}/form`  endpoints documentation
- Added example showing meta parameter usage

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
