### PR TITLE
[64158] Fix adding work packages in backlog module on firefox

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs/model.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/model.ts
@@ -60,7 +60,9 @@ RB.Model = (function ($) {
       this.refresh(result);
 
       if (isNew) {
-        this.$.attr('id', result.$.attr('id'));
+        const id = result.$.filter('.model').attr('id');
+        this.$.attr('id', id);
+
         this.afterCreate(data, response);
       } else {
         this.afterUpdate(data, response);
@@ -382,7 +384,7 @@ RB.Model = (function ($) {
     },
 
     refresh(obj:any) {
-      this.$.html(obj.$.html());
+      this.$.html($(obj.el).filter('.model').html());
 
       if (obj.$.length > 1) {
         // execute script tags, that were attached to the sources
@@ -420,18 +422,22 @@ RB.Model = (function ($) {
       editors.each(function (this:any, index:any) {
         const editor = $(this).find('input,select,textarea').addBack('input,select,textarea');
         const fieldName = editor.attr('name');
-        const type = editor.attr('type');
-        if (type?.match(/select/)) {
+        const tagName = editor.prop('tagName');
+        if (tagName === 'SELECT') {
           // if the user changes the type and that type does not offer the status
           // of the current story, the status field is set to blank
           // if the user saves this edit we will receive a validation error
           // the following 3 lines will prevent the override of the status id
           // otherwise we would loose the status id of the current ticket
-          if (!(editor.val() === '' && fieldName === 'status_id')) {
+          if (!(fieldName === 'status_id' && editor.val() === '')) {
             j.children(`div.${fieldName}`).children('.v').text(editor.val());
           }
+          let text = editor.children(':selected').text().trim();
+          if (fieldName === 'type_id') {
+            text += ':';
+          }
 
-          j.children(`div.${fieldName}`).children('.t').text(editor.children(':selected').text());
+          j.children(`div.${fieldName}`).children('.t').text(text);
         } else {
           j.children(`div.${fieldName}`).text(editor.val());
         }

--- a/modules/backlogs/app/views/layouts/backlogs.html.erb
+++ b/modules/backlogs/app/views/layouts/backlogs.html.erb
@@ -28,10 +28,11 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% content_for :header_tags do %>
-  <%= nonced_javascript_tag do %>
-    <%= render(partial: "shared/server_variables", formats: [:js]) %>
-  <% end %>
   <%= frontend_stylesheet_link_tag "backlogs.css" %>
+<% end %>
+
+<% content_for :additional_js_dom_ready do %>
+  <%= render(partial: "shared/server_variables", formats: [:js]) %>
 <% end %>
 
 <% content_controller "backlogs" %>

--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -28,7 +28,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Backlogs", :js do
+RSpec.describe "Backlogs", :js, :selenium, driver: :firefox_de do # using FF due to regression #64158
   let(:story_type) do
     create(:type_feature)
   end

--- a/spec/features/users/my/access_tokens_spec.rb
+++ b/spec/features/users/my/access_tokens_spec.rb
@@ -363,6 +363,7 @@ RSpec.describe "my access tokens", :js do
                 find_test_selector("oauth-token-row-#{app.id}-revoke").click
               end
             end
+            expect_and_dismiss_flash message: "Revocation of application #{app.name} successful."
           end
 
           User.current.reload


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/64158

# What are you trying to accomplish?

Due to CSP issues, it was not possible to add new stories in backlog module when using Firefox.

In addition, the rendering was weird in dev mode after adding a story, regardless of the browser

# Screenshot

Before, after adding a work package in dev mode the added line looks weird:

<img width="658" height="408" alt="image" src="https://github.com/user-attachments/assets/bc789c0c-dcde-413c-8726-8db1e43a3c97" />

# What approach did you choose and why?

For the bug, the issue lies in inline javascript inside the html `<head>`: it does not work when loaded after a
turbo visit because the nonce is removed by turbo. Then the browser CSP blocks the inline javascript from the header
because the nonce is missing. This happens on Firefox.

Fix is to use the `content_for :additional_js_dom_ready` hook to load the javascript instead of the `content_for :header_tags`.

For the second issue, visible only in development, it's because there are some comments added around the html returned by the server. This makes functions like `result.$.attr('id')` not work as expected: they'll try to work on the
first child which is a comment, and so will return empty string or `undefined`.

Fix it by explicitly filter out the comments with `.filter('.model')`. Also use`$(obj.el)` instead of `obj.$` because it's more reliable. `obj.$.html()` was returning empty string. Not sure why.

This last change can't be tested as it happens only in development mode. It looked fine in test.

# Merge checklist

- [ ] Added/updated tests
  - I wanted to use Firefox for running `modules/backlogs/spec/features/backlogs/create_story_spec.rb` by adding `:selenium, driver: :firefox_de` to the test, but it hangs on my machine. Not sure if that's the right thing to do.
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
