### PR TITLE
Automatically pre- and eager-load collections

### DIFF
--- a/lib/api/decorators/collection.rb
+++ b/lib/api/decorators/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -39,26 +41,36 @@ module API
         super(models, current_user:)
       end
 
-      class_attribute :element_decorator_class
+      class << self
+        attr_writer :element_decorator_class
 
-      def self.element_decorator(klass)
-        self.element_decorator_class = klass
+        def element_decorator_class
+          @element_decorator_class ||= begin
+            unless name.end_with?("CollectionRepresenter")
+              raise ArgumentError,
+                    "Can't deduce representer name from #{name}, please specify it with `element_decorator ClassName`"
+            end
+
+            name.gsub("CollectionRepresenter", "Representer")
+                .constantize
+          end
+        end
+
+        def element_decorator(klass)
+          self.element_decorator_class = klass
+        end
+
+        def to_eager_load
+          super || element_decorator_class.to_eager_load
+        end
+
+        def to_preload
+          super || element_decorator_class.to_preload
+        end
       end
 
       def element_decorator
-        self.class.element_decorator_class || deduce_element_decorator
-      end
-
-      def deduce_element_decorator
-        name = self.class.name
-
-        unless name.end_with?("CollectionRepresenter")
-          raise ArgumentError, "Can't deduce representer name from #{name}, please specify it with `element_decorator ClassName`"
-        end
-
-        name
-          .gsub("CollectionRepresenter", "Representer")
-          .constantize
+        self.class.element_decorator_class
       end
 
       link :self do

--- a/lib/api/decorators/sql_collection_representer.rb
+++ b/lib/api/decorators/sql_collection_representer.rb
@@ -34,6 +34,11 @@ module API
       include API::Decorators::Sql::Hal
 
       class << self
+        # Implementing same interface as API::Decorators::Single, but not asking for any external eagerloading,
+        # since this class generates its own SQL.
+        def to_eager_load = []
+        def to_preload = []
+
         def ctes(walker_result)
           cte = {
             projection: walker_result.projection_scope

--- a/lib/api/v3/activities/activity_collection_representer.rb
+++ b/lib/api/v3/activities/activity_collection_representer.rb
@@ -30,6 +30,9 @@ module API
   module V3
     module Activities
       class ActivityCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+        self.to_eager_load = []
+        self.to_preload = []
+
         def initialize(models, self_link:, current_user:)
           super
 

--- a/lib/api/v3/notifications/notification_collection_representer.rb
+++ b/lib/api/v3/notifications/notification_collection_representer.rb
@@ -30,6 +30,9 @@ module API
   module V3
     module Notifications
       class NotificationCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        self.to_eager_load = []
+        self.to_preload = []
+
         property :detailsSchemas,
                  getter: ->(*) { details_schemas },
                  exec_context: :decorator,

--- a/lib/api/v3/principals/not_builtin_elements.rb
+++ b/lib/api/v3/principals/not_builtin_elements.rb
@@ -33,6 +33,11 @@ module API
         extend ::ActiveSupport::Concern
 
         included do
+          # There is no common representer class for all elements, we thus override the default behaviour
+          # of forwarding eager_loading preferences to the element representer
+          self.to_eager_load = []
+          self.to_preload = []
+
           collection :elements,
                      getter: ->(*) {
                        represented.map do |model|

--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -35,7 +35,6 @@ module API
   module V3
     module Projects
       class ProjectCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
-        self.to_eager_load = ::API::V3::Projects::ProjectRepresenter.to_eager_load
         self.checked_permissions = ::API::V3::Projects::ProjectRepresenter.checked_permissions
 
         links :representations do

--- a/lib/api/v3/relations/relation_collection_representer.rb
+++ b/lib/api/v3/relations/relation_collection_representer.rb
@@ -32,7 +32,6 @@ module API
       # TODO: Usage of this is to be replaced by its paginated equivalent once the front end
       # handles paginated responses.
       class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        self.to_eager_load = ::API::V3::Relations::RelationRepresenter.to_eager_load
       end
     end
   end

--- a/lib/api/v3/relations/relation_paginated_collection_representer.rb
+++ b/lib/api/v3/relations/relation_paginated_collection_representer.rb
@@ -30,8 +30,6 @@ module API
   module V3
     module Relations
       class RelationPaginatedCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
-        self.to_eager_load = ::API::V3::Relations::RelationRepresenter.to_eager_load
-
         element_decorator RelationRepresenter
       end
     end

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -32,10 +32,6 @@ module API
       class RelationsAPI < ::API::OpenProjectAPI
         resources :relations do
           get &::API::V3::Utilities::Endpoints::Index.new(model: Relation,
-                                                          scope: -> {
-                                                            Relation
-                                                              .includes(::API::V3::Relations::RelationRepresenter.to_eager_load)
-                                                          },
                                                           render_representer: RelationPaginatedCollectionRepresenter)
                                                      .mount
 

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -159,6 +159,8 @@ module API
           end
 
           def apply_scope_constraint(constraint, result_scope)
+            result_scope = result_scope.eager_load(render_representer.to_eager_load)
+                                       .preload(render_representer.to_preload)
             if constraint.is_a?(Class)
               result_scope
             else

--- a/lib/api/v3/versions/available_projects_api.rb
+++ b/lib/api/v3/versions/available_projects_api.rb
@@ -39,7 +39,6 @@ module API
                                                           scope: -> {
                                                             Project
                                                               .allowed_to(User.current, :manage_versions)
-                                                              .includes(::API::V3::Projects::ProjectRepresenter.to_eager_load)
                                                           })
                                                      .mount
         end

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -30,6 +30,9 @@ module API
   module V3
     module WorkPackages
       class WorkPackageCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        self.to_eager_load = []
+        self.to_preload = []
+
         attr_accessor :timestamps, :query
 
         def initialize(models,

--- a/modules/costs/lib/api/v3/time_entries/time_entries_api.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entries_api.rb
@@ -33,12 +33,7 @@ module API
         helpers ::API::Utilities::UrlPropsParsingHelper
 
         resources :time_entries do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: TimeEntry,
-                                                          scope: lambda do
-                                                            TimeEntry.eager_load(TimeEntryRepresenter.to_eager_load)
-                                                                     .preload(TimeEntryRepresenter.to_preload)
-                                                          end)
-                                                     .mount
+          get &::API::V3::Utilities::Endpoints::Index.new(model: TimeEntry).mount
           post &::API::V3::Utilities::Endpoints::Create.new(model: TimeEntry).mount
 
           mount ::API::V3::TimeEntries::CreateFormAPI

--- a/modules/github_integration/lib/api/v3/github_pull_requests/github_pull_request_collection_representer.rb
+++ b/modules/github_integration/lib/api/v3/github_pull_requests/github_pull_request_collection_representer.rb
@@ -30,7 +30,6 @@ module API
   module V3
     module GithubPullRequests
       class GithubPullRequestCollectionRepresenter < ::API::Decorators::Collection
-        self.to_eager_load = ::API::V3::GithubPullRequests::GithubPullRequestRepresenter.to_eager_load
       end
     end
   end

--- a/modules/gitlab_integration/lib/api/v3/gitlab_issues/gitlab_issue_collection_representer.rb
+++ b/modules/gitlab_integration/lib/api/v3/gitlab_issues/gitlab_issue_collection_representer.rb
@@ -33,7 +33,6 @@ module API
   module V3
     module GitlabIssues
       class GitlabIssueCollectionRepresenter < ::API::Decorators::Collection
-        self.to_eager_load = ::API::V3::GitlabIssues::GitlabIssueRepresenter.to_eager_load
       end
     end
   end

--- a/modules/gitlab_integration/lib/api/v3/gitlab_merge_requests/gitlab_merge_request_collection_representer.rb
+++ b/modules/gitlab_integration/lib/api/v3/gitlab_merge_requests/gitlab_merge_request_collection_representer.rb
@@ -33,7 +33,6 @@ module API
   module V3
     module GitlabMergeRequests
       class GitlabMergeRequestCollectionRepresenter < ::API::Decorators::Collection
-        self.to_eager_load = ::API::V3::GitlabMergeRequests::GitlabMergeRequestRepresenter.to_eager_load
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -36,6 +36,8 @@ module API
         include API::V3::Attachments::AttachableRepresenterMixin
         include API::Decorators::DateProperty
 
+        self.to_eager_load = [:author, { project: :enabled_modules }]
+
         self_link title_getter: ->(*) { represented.title }
 
         property :id


### PR DESCRIPTION
Index endpoints will automatically discover and use the `to_eager_load` and `to_preload` declarations of their representers. This takes away the possibility of forgetting to add those to the scope.

I found a few endpoint that didn't use them, when other endpoints rendering the same collection did.

Interestingly the SCM integration modules consistently declared those methods but never used them.

# Ticket
https://community.openproject.org/wp/68559