### PR TITLE
fix has_image? check by using assets manifest

### DIFF
--- a/app/components/homescreen/blocks/new_features.rb
+++ b/app/components/homescreen/blocks/new_features.rb
@@ -65,7 +65,7 @@ module Homescreen
       end
 
       def has_image?
-        Rails.application.assets.find_asset(feature_teaser_image) != nil
+        Rails.application.assets_manifest.assets.has_key?(feature_teaser_image)
       end
 
       private


### PR DESCRIPTION
Fixes the broken [stage deployments](https://github.com/opf/openproject-flavours/actions/workflows/ci-stage.yml) which fail during the build test stage with:

```
app-1  | E, [2025-10-24T12:53:33.981140 #50] ERROR -- : [5198ba55-06b3-419f-8e4b-7e581f52cbbf] [public] user=1 domain= namespace=public shard= undefined method 'find_asset' for nil: undefined method 'find_asset' for nil
app-1  | I, [2025-10-24T12:53:34.320549 #50]  INFO -- : [5198ba55-06b3-419f-8e4b-7e581f52cbbf] [public] method=GET path=/ format=*/* controller=HomescreenController action=index status=500 allocations=110963 duration=715.17 view=304.80 db=46.20 user=1 domain= namespace=public shard=
```