### PR TITLE
work around poor PgSQL query planning

### DIFF
--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -127,14 +127,28 @@ module WorkPackages::Scopes
         # 	)
         # ```
         # Postgresql however sometimes turns to a sequential scan with the query above.
+        #
+        # Index scans can still happen in the combination of the CTE with the check outside of the
+        # CTEs for the existence of any record.
+        # This is particularly likely in case AR.exists? is used which adds a LIMIT 1
+        # to the query. In this case, there is a known shortcoming that PostgreSQL's query planner
+        # will make poor choices
+        # (https://www.postgresql.org/message-id/flat/CA%2BU5nMLbXfUT9cWDHJ3tpxjC3bTWqizBKqTwDgzebCB5bAGCgg%40mail.gmail.com).
+        #
+        # Once AR supports adding materialization hints (https://github.com/rails/rails/pull/54322), the inner
+        # `allowed` CTE can be abandoned as it is only used for being able to provide such a hint.
         allowed_by_projects_and_work_packages = Arel.sql(<<~SQL.squish)
-          SELECT id from work_packages
-          WHERE project_id in (SELECT id FROM member_projects)
-          AND NOT EXISTS (
-            SELECT 1 FROM entity_member_projects_without_duplicates
-            WHERE entity_member_projects_without_duplicates.id = work_packages.project_id
-            AND entity_member_projects_without_duplicates.entity_id != work_packages.id
+          WITH allowed AS MATERIALIZED (
+            SELECT id from work_packages
+            WHERE project_id in (SELECT id FROM member_projects)
+            AND NOT EXISTS (
+              SELECT 1 FROM entity_member_projects_without_duplicates
+              WHERE entity_member_projects_without_duplicates.id = work_packages.project_id
+              AND entity_member_projects_without_duplicates.entity_id != work_packages.id
+            )
           )
+
+          SELECT * from allowed
         SQL
 
         with(member_projects: Arel.sql(allowed_via_project_or_work_package_membership.to_sql),


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68593

# What are you trying to accomplish?

Force the query planner to use the probably way smaller set of results returned from a CTE on projects and work packages allowed to the user rather than doing a full index scan over the work packages first. 

Applying `MATERIALIZED` to the CTE will force a boundary for the query planner. This is only beneficial as long as the set of allowed entities is way smaller than the whole entries in `work_packages` which should be rather safe to assume.
