### PR TITLE
Bug/68589 enabling calculated value by adding project to through custom field admin doesn t trigger calculation

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -228,10 +228,12 @@ class CustomField < ApplicationRecord
       ActiveRecord::Type::Boolean.new.cast(value)
     when "int"
       value.to_i
-    when "float"
+    when "float", "calculated_value"
       value.to_f
     when "user", "version"
       field_format.classify.constantize.find_by(id: value.to_i)
+    when "hierarchy", "scored_list"
+      CustomField::Hierarchy::Item.find_by(id: value.to_i)
     end
   end
 

--- a/app/services/project_custom_field_project_mappings/bulk_create_service.rb
+++ b/app/services/project_custom_field_project_mappings/bulk_create_service.rb
@@ -41,6 +41,28 @@ module ProjectCustomFieldProjectMappings
       super(user:, mapping_context:)
     end
 
+    protected
+
+    def after_perform(service_result, _params)
+      super.tap do
+        recalculate_values(service_result)
+      end
+    end
+
+    def recalculate_values(service_result)
+      mappings = service_result.result
+
+      mappings.each do |mapping|
+        project = mapping.project
+
+        affected_cfs = project.available_custom_fields.affected_calculated_fields([mapping.custom_field_id])
+
+        project.calculate_custom_fields(affected_cfs)
+
+        project.save if project.changed_for_autosave?
+      end
+    end
+
     private
 
     def permission = :select_project_custom_fields

--- a/app/services/project_custom_field_project_mappings/delete_service.rb
+++ b/app/services/project_custom_field_project_mappings/delete_service.rb
@@ -30,6 +30,25 @@
 
 module ProjectCustomFieldProjectMappings
   class DeleteService < ::BaseServices::Delete
+    protected
+
+    def after_perform(service_result)
+      super.tap do
+        recalculate_values(service_result)
+      end
+    end
+
+    def recalculate_values(service_result)
+      mapping = service_result.result
+      project = mapping.project
+
+      affected_cfs = project.all_available_custom_fields.affected_calculated_fields([mapping.custom_field_id])
+
+      project.calculate_custom_fields(affected_cfs)
+
+      project.save if project.changed_for_autosave?
+    end
+
     # Mappings have custom deletion rules that are similar to the update rules all derived from the base contract
     # Reuse the update contract to ensure that the deletion rules are consistent with the update rules
     def default_contract_class

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -597,4 +597,28 @@ RSpec.describe CustomField do
       expect(described_class.where(id: field.id)).not_to exist
     end
   end
+
+  describe "#cast_value" do
+    describe "handling all registered formats" do
+      before do
+        allow(User).to receive(:find_by).with(id: 1).and_return(build(:user))
+        allow(Version).to receive(:find_by).with(id: 1).and_return(build(:version))
+        allow(CustomField::Hierarchy::Item).to receive(:find_by).with(id: 1).and_return(build(:hierarchy_item))
+      end
+
+      OpenProject::CustomFieldFormat.registered.map(&:name).each do |field_format|
+        it "handles custom field with format #{field_format}" do
+          field = build(:custom_field, field_format:)
+
+          input = field_format == "date" ? "2025.10.27" : "1"
+
+          if field_format == "empty"
+            expect(field.cast_value(input)).to be_nil
+          else
+            expect(field.cast_value(input)).not_to be_nil
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/services/custom_fields/update_service_spec.rb
+++ b/spec/services/custom_fields/update_service_spec.rb
@@ -121,9 +121,10 @@ RSpec.describe CustomFields::UpdateService, type: :model do
 
         before do
           projects.each.with_index(1) do |project, i|
-            create(:custom_value, customized: project, custom_field: static, value: i)
-            create(:custom_value, customized: project, custom_field: custom_field, value: 0)
-            create(:custom_value, customized: project, custom_field: custom_field2, value: 0)
+            # using update_columns to prevent auto enabling for the project
+            create(:custom_value, customized: project, custom_field: static).update_columns(value: i)
+            create(:custom_value, customized: project, custom_field: custom_field).update_columns(value: 0)
+            create(:custom_value, customized: project, custom_field: custom_field2).update_columns(value: 0)
           end
         end
 

--- a/spec/services/project_custom_field_project_mappings/bulk_create_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/bulk_create_service_spec.rb
@@ -32,12 +32,122 @@ require "spec_helper"
 require_relative "../bulk_services/project_mappings/behaves_like_bulk_project_mapping_create_service"
 
 RSpec.describe ProjectCustomFieldProjectMappings::BulkCreateService do
-  shared_let(:project_custom_field) { create(:project_custom_field) }
-
   it_behaves_like "BulkServices project mappings create service" do
+    shared_let(:project_custom_field) { create(:project_custom_field) }
+
     let(:model) { project_custom_field }
     let(:model_mapping_class) { ProjectCustomFieldProjectMapping }
     let(:model_foreign_key_id) { :custom_field_id }
     let(:required_permission) { :select_project_custom_fields }
+  end
+
+  describe "calculated values", with_flag: { calculated_value_project_attribute: true } do
+    using CustomFieldFormulaReferencing
+
+    shared_let(:user) { create(:admin) }
+
+    shared_let(:project_a) { create(:project) }
+    shared_let(:project_b) { create(:project) }
+    shared_let(:project_bb) { create(:project, parent: project_b) }
+    shared_let(:project_c) { create(:project) }
+    shared_let(:all_projects) { [project_a, project_b, project_bb, project_c] }
+
+    shared_let(:project_custom_field_section) { create(:project_custom_field_section) }
+    shared_let(:static) { create(:integer_project_custom_field, project_custom_field_section:) }
+    shared_let(:calculated) do
+      create(:calculated_value_project_custom_field, :skip_validations, formula: "#{static} * 7", project_custom_field_section:)
+    end
+    shared_let(:enabled) do
+      create(:calculated_value_project_custom_field, :skip_validations, formula: "11", project_custom_field_section:)
+    end
+    shared_let(:disabled) do
+      create(:calculated_value_project_custom_field, :skip_validations, formula: "13", project_custom_field_section:)
+    end
+
+    let(:projects) { [project_a, project_b] }
+    let(:instance) { described_class.new(user:, model: custom_field, projects:, include_sub_projects:) }
+
+    before do
+      User.current = user
+
+      all_projects.each do |project|
+        create(:custom_value, custom_field: enabled, value: "11", customized: project)
+      end
+    end
+
+    context "when enabling referenced static field" do
+      let(:custom_field) { static }
+
+      before do
+        all_projects.each.with_index(1) do |project, i|
+          # create first with blank value to skip auto enabling it
+          create(:custom_value, custom_field: static, value: nil, customized: project).update_columns(value: i)
+
+          create(:project_custom_field_project_mapping, project:, project_custom_field: calculated)
+        end
+      end
+
+      context "when enabling including sub projects" do
+        let(:include_sub_projects) { true }
+
+        it "recalculates the value for enabled projects including sub projects" do
+          expect(instance.call).to be_success
+
+          expect(project_a.custom_value_attributes).to eq(static.id => "1", calculated.id => "7", enabled.id => "11")
+          expect(project_b.custom_value_attributes).to eq(static.id => "2", calculated.id => "14", enabled.id => "11")
+          expect(project_bb.custom_value_attributes).to eq(static.id => "3", calculated.id => "21", enabled.id => "11")
+          expect(project_c.custom_value_attributes).to eq(calculated.id => nil, enabled.id => "11")
+        end
+      end
+
+      context "when enabling not including sub projects" do
+        let(:include_sub_projects) { false }
+
+        it "recalculates the value for enabled projects including sub projects" do
+          expect(instance.call).to be_success
+
+          expect(project_a.custom_value_attributes).to eq(static.id => "1", calculated.id => "7", enabled.id => "11")
+          expect(project_b.custom_value_attributes).to eq(static.id => "2", calculated.id => "14", enabled.id => "11")
+          expect(project_bb.custom_value_attributes).to eq(calculated.id => nil, enabled.id => "11")
+          expect(project_c.custom_value_attributes).to eq(calculated.id => nil, enabled.id => "11")
+        end
+      end
+    end
+
+    context "when enabling calculated field" do
+      let(:custom_field) { calculated }
+
+      before do
+        all_projects.each.with_index(1) do |project, i|
+          create(:custom_value, custom_field: static, value: i, customized: project)
+        end
+      end
+
+      context "when enabling including sub projects" do
+        let(:include_sub_projects) { true }
+
+        it "recalculates the value for enabled projects including sub projects" do
+          expect(instance.call).to be_success
+
+          expect(project_a.custom_value_attributes).to eq(static.id => "1", calculated.id => "7", enabled.id => "11")
+          expect(project_b.custom_value_attributes).to eq(static.id => "2", calculated.id => "14", enabled.id => "11")
+          expect(project_bb.custom_value_attributes).to eq(static.id => "3", calculated.id => "21", enabled.id => "11")
+          expect(project_c.custom_value_attributes).to eq(static.id => "4", enabled.id => "11")
+        end
+      end
+
+      context "when enabling not including sub projects" do
+        let(:include_sub_projects) { false }
+
+        it "recalculates the value for enabled projects including sub projects" do
+          expect(instance.call).to be_success
+
+          expect(project_a.custom_value_attributes).to eq(static.id => "1", calculated.id => "7", enabled.id => "11")
+          expect(project_b.custom_value_attributes).to eq(static.id => "2", calculated.id => "14", enabled.id => "11")
+          expect(project_bb.custom_value_attributes).to eq(static.id => "3", enabled.id => "11")
+          expect(project_c.custom_value_attributes).to eq(static.id => "4", enabled.id => "11")
+        end
+      end
+    end
   end
 end

--- a/spec/services/project_custom_field_project_mappings/delete_service_spec.rb
+++ b/spec/services/project_custom_field_project_mappings/delete_service_spec.rb
@@ -38,4 +38,63 @@ RSpec.describe ProjectCustomFieldProjectMappings::DeleteService do
       "#{namespace}::UpdateContract".constantize
     end
   end
+
+  describe "calculated values", with_flag: { calculated_value_project_attribute: true } do
+    using CustomFieldFormulaReferencing
+
+    shared_let(:user) { create(:admin) }
+
+    shared_let(:project) { create(:project) }
+    shared_let(:project_custom_field_section) { create(:project_custom_field_section) }
+    shared_let(:static) { create(:integer_project_custom_field, project_custom_field_section:) }
+    shared_let(:calculated) do
+      create(:calculated_value_project_custom_field, :skip_validations, formula: "#{static} * 7", project_custom_field_section:)
+    end
+    shared_let(:enabled) do
+      create(:calculated_value_project_custom_field, :skip_validations, formula: "11", project_custom_field_section:)
+    end
+    shared_let(:disabled) do
+      create(:calculated_value_project_custom_field, :skip_validations, formula: "13", project_custom_field_section:)
+    end
+
+    shared_let(:static_mapping) { create(:project_custom_field_project_mapping, project:, project_custom_field: static) }
+    shared_let(:calculated_mapping) { create(:project_custom_field_project_mapping, project:, project_custom_field: calculated) }
+    shared_let(:enabled_mapping) { create(:project_custom_field_project_mapping, project:, project_custom_field: enabled) }
+
+    let(:instance) { described_class.new(user:, model:) }
+
+    let(:without_calculated) { { static.id => "2", calculated.id => nil, enabled.id => "11", disabled.id => nil } }
+
+    before do
+      {
+        static => 2,
+        calculated => 14,
+        enabled => 11
+      }.each { |custom_field, value| create(:custom_value, custom_field:, value:, customized: project) }
+    end
+
+    context "when removing referenced static field" do
+      let(:model) { static_mapping }
+
+      it "recalculates the value" do
+        expect(instance.call).to be_success
+
+        project.reload
+        expect(project.project_custom_fields).to contain_exactly(calculated, enabled)
+        expect(project.custom_value_attributes(all: true)).to eq(without_calculated)
+      end
+    end
+
+    context "when removing calculated field" do
+      let(:model) { calculated_mapping }
+
+      it "recalculates the value" do
+        expect(instance.call).to be_success
+
+        project.reload
+        expect(project.project_custom_fields).to contain_exactly(static, enabled)
+        expect(project.custom_value_attributes(all: true)).to eq(without_calculated)
+      end
+    end
+  end
 end

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -495,10 +495,10 @@ RSpec.describe Projects::SetAttributesService, type: :model do
           end
 
           before do
-            create(:custom_value, customized: project, custom_field: cf_static, value: -5)
-            create(:custom_value, customized: project, custom_field: cf_calculated1, value: -6)
-            create(:custom_value, customized: project, custom_field: cf_calculated2, value: -6)
-            create(:custom_value, customized: project, custom_field: cf_calculated3, value: -6)
+            create(:custom_value, customized: project, custom_field: cf_static).update_columns(value: -5)
+            [cf_calculated1, cf_calculated2, cf_calculated3].each do |custom_field|
+              create(:custom_value, customized: project, custom_field:).update_columns(value: -6)
+            end
           end
 
           it "calculates only accessible values" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68589

# What are you trying to accomplish?
Recalculate value when project attribute is added/removed to project through projects tab of a calculated value project attribute or attribute that is used in one

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
