### PR TITLE
[68600] Carry over user filter when applying type filters in activity

### DIFF
--- a/app/views/activities/_filters_menu.html.erb
+++ b/app/views/activities/_filters_menu.html.erb
@@ -1,5 +1,11 @@
 <%= turbo_frame_tag "activity_menu",
-                    src: url_for(controller: "/activities", action: :menu, project_id: @project),
+                    src: url_for(
+                      controller: "/activities",
+                      action: :menu,
+                      project_id: @project,
+                      user_id: params[:user_id],
+                      from: params[:from]
+                    ),
                     data: { turbo: false },
                     loading: :lazy do %>
 <% end %>

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -142,6 +142,19 @@ RSpec.describe "Activity page navigation", :js do
       expect(page).to have_heading("#{user.name}'s activity")
       expect(page).to have_link(user.name)
       expect(page).to have_no_link(another_user.name)
+
+      # Applying filters should keep the user filter applied
+      click_button "Apply"
+
+      expect(page).to have_link(user.name)
+      expect(page).to have_no_link(another_user.name)
+
+      # Navigating to the previous/next pages should keep the user filter applied
+      click_link("Previous")
+      click_link("Next")
+
+      expect(page).to have_link(user.name)
+      expect(page).to have_no_link(another_user.name)
     end
   end
 

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -307,13 +307,6 @@ RSpec.describe "Activity page navigation", :js do
           assert_navigating_to_diff_page_and_back_comes_back_to_the_same_page(activity_page)
         end
       end
-
-      # work package activity page is rendered by Angular, so it needs js: true
-      it "Back button navigates to the previously seen work package page", :js do
-        pending "The back button is not rendered on the work package activity page anymore for some reason -> relevant?"
-        activity_page = work_package_path(project_work_package)
-        assert_navigating_to_diff_page_and_back_comes_back_to_the_same_page(activity_page, is_work_package: true)
-      end
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68600

# What are you trying to accomplish?

Keep user filter in activity page when applying type filters.
This user filter is active when coming to all projects "Activity" page via "My activity" page.

# What approach did you choose and why?

carry over `:from` and `:user_id` params as query params when querying the controller menu rendering.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
