### PR TITLE
Allow to seed supported grant types from environment variables

### DIFF
--- a/docs/system-admin-guide/authentication/openid-providers/README.md
+++ b/docs/system-admin-guide/authentication/openid-providers/README.md
@@ -444,6 +444,9 @@ OPENPROJECT_OPENID__CONNECT_KEYCLOAK_USERINFO__ENDPOINT="/realms/<REALM>/protoco
 # Optional: endpoint to redirect users for logout
 OPENPROJECT_OPENID__CONNECT_KEYCLOAK_END__SESSION__ENDPOINT="http://keycloak.example.com/realms/<REALM>/protocol/openid-connect/logout"
 
+# Optional: space separated list of grant types supported by the provider
+OPENPROJECT_OPENID__CONNECT_KEYCLOAK_GRANT_TYPES_SUPPORTED="authorization_code urn:ietf:params:oauth:grant-type:token-exchange"
+
 # Host name of Keycloak, required if endpoint information are not absolute URLs
 OPENPROJECT_OPENID__CONNECT_KEYCLOAK_HOST="<Hostname of the keycloak server>"
 
@@ -464,6 +467,12 @@ OPENPROJECT_OPENID__CONNECT_KEYCLOAK_ACR__VALUES="phr phrh Multi_Factor"
 
 # Optional: Claim mapping using JSON, see Step 7 above for more information on syntax
 OPENPROJECT_OPENID__CONNECT_KEYCLOAK_CLAIMS="{\"id_token\":{\"acr\":{\"essential\":true,\"values\":[\"phr\",\"phrh\",\"Multi_Factor\"]}}}"
+
+# Optional: Whether group synchronization should be enabled (default: false)
+OPENPROJECT_OPENID__CONNECT_KEYCLOAK_SYNC__GROUPS="true"
+
+# Optional: The name of the claim in the ID token that contains the group memberships
+OPENPROJECT_OPENID__CONNECT_KEYCLOAK_GROUPS__CLAIM="groups"
 ```
 
 

--- a/modules/openid_connect/app/services/openid_connect/configuration_mapper.rb
+++ b/modules/openid_connect/app/services/openid_connect/configuration_mapper.rb
@@ -61,6 +61,7 @@ module OpenIDConnect
         "userinfo_endpoint" => extract_url(options, "userinfo_endpoint"),
         "end_session_endpoint" => extract_url(options, "end_session_endpoint"),
         "jwks_uri" => extract_url(options, "jwks_uri"),
+        "grant_types_supported" => options["grant_types_supported"],
         "mapping_login" => options.dig("attribute_map", "login"),
         "mapping_email" => options.dig("attribute_map", "email"),
         "mapping_first_name" => options.dig("attribute_map", "first_name"),

--- a/modules/openid_connect/spec/services/openid_connect/configuration_mapper_spec.rb
+++ b/modules/openid_connect/spec/services/openid_connect/configuration_mapper_spec.rb
@@ -213,6 +213,22 @@ RSpec.describe OpenIDConnect::ConfigurationMapper, type: :model do
     end
   end
 
+  describe "grant_types_supported" do
+    subject { result }
+
+    context "when provided" do
+      let(:configuration) { { grant_types_supported: "a b" } }
+
+      it { is_expected.to include("grant_types_supported" => "a b") }
+    end
+
+    context "when not provided" do
+      let(:configuration) { { foo: "bar" } }
+
+      it { is_expected.not_to have_key("grant_types_supported") }
+    end
+  end
+
   %w[authorization_endpoint token_endpoint userinfo_endpoint end_session_endpoint jwks_uri].each do |key|
     describe "setting #{key}" do
       subject { result }


### PR DESCRIPTION
This wasn't possible before, making it impossible to seed a provider with complete metadata, thus preventing to use token exchange.

# Ticket
https://community.openproject.org/wp/68601