### PR TITLE
Use syntax available in blocks to splat arguments

### DIFF
--- a/modules/costs/lib/api/v3/cost_entries/work_package_costs_by_type_representer.rb
+++ b/modules/costs/lib/api/v3/cost_entries/work_package_costs_by_type_representer.rb
@@ -46,9 +46,7 @@ module API
 
         collection :elements,
                    getter: ->(*) {
-                     cost_helper.summarized_cost_entries.map do |kvp|
-                       type = kvp[0]
-                       units = kvp[1]
+                     cost_helper.summarized_cost_entries.map do |type, units|
                        ::API::V3::CostEntries::AggregatedCostEntryRepresenter.new(type, units)
                      end
                    },


### PR DESCRIPTION
I found this while looking for something else in the API. Not the most important fix, but feels good to fix some 10 year old code from myself xD

# Ticket
none