### PR TITLE
[#68558] Blocknote: Show error when uploading non-whitelisted file

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -139,11 +139,18 @@ export default function OpBlockNoteContainer({ inputField,
 
   async function uploadFile(file:File) {
     const pluginContext = await window.OpenProject.getPluginContext();
-    const service = pluginContext.services.attachmentsResourceService;
-    const iUploadFile = fileToIUploadFile(file);
-    const result = await service.addAttachments('documents', attachmentsUploadUrl, [iUploadFile]).toPromise();
+    try {
+      const service = pluginContext.services.attachmentsResourceService;
+      const iUploadFile = fileToIUploadFile(file);
+      const result = await service.addAttachments('documents', attachmentsUploadUrl, [iUploadFile]).toPromise();
 
-    return result?.[0]._links.downloadLocation.href ?? '';
+      return result?.[0]._links.downloadLocation.href ?? '';
+    } catch(error:any) {
+      const toastService = pluginContext.services.notifications;
+      toastService.addError(error);
+
+      return '';
+    }
   }
 
   const getCustomSlashMenuItems = (editor:EditorType) => {

--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -152,11 +152,7 @@ RSpec.describe "Upload attachment to documents",
 
   shared_examples "can upload an image in BlockNote" do
     it "is possible to upload attachments from the editor" do
-      visit edit_document_path(document)
-      expect(page).to have_css(".document-form--long-description")
-      expect(page).not_to have_element("opce-ckeditor-augmented-textarea")
       expect(page).to have_no_css("img[alt='image.png']")
-
       editor.open_add_image_dialog
       expect do
         attach_file(image_fixture.path, make_visible: true) do
@@ -173,17 +169,42 @@ RSpec.describe "Upload attachment to documents",
     end
   end
 
+  shared_examples "with non-whitelisted file types" do
+    context "with an incompatible attachment allowlist",
+            with_settings: { attachment_whitelist: %w[image/jpg] } do
+      it "shows a nice error" do
+        editor.open_add_image_dialog
+        expect do
+          attach_file(image_fixture.path, make_visible: true) do
+            find(:button, text: "Upload image").click
+          end
+          expect(page).to have_content I18n.t("activerecord.errors.models.attachment.attributes.content_type.not_allowlisted",
+                                              value: "image/png")
+          expect(page).to have_no_css("img[alt='image.png']")
+        end.not_to change { document.attachments.count }
+      end
+    end
+  end
+
   context "for collaborative documents", with_flag: { block_note_editor: true } do
     let(:experimental_category) { create(:document_category, name: "Experimental", project:) }
     let(:document) { create(:document, category: experimental_category, project:) }
     let(:editor) { FormFields::Primerized::BlockNoteEditorInput.new }
 
+    before do
+      visit edit_document_path(document)
+      expect(page).to have_css(".document-form--long-description") # rubocop:disable RSpec/ExpectInHook
+      expect(page).not_to have_element("opce-ckeditor-augmented-textarea") # rubocop:disable RSpec/ExpectInHook
+    end
+
     context "with internal uploads" do
       it_behaves_like "can upload an image in BlockNote"
+      it_behaves_like "with non-whitelisted file types"
     end
 
     context "with uploads to an external storage", :with_direct_uploads do
       it_behaves_like "can upload an image in BlockNote"
+      it_behaves_like "with non-whitelisted file types"
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/68558

# What are you trying to accomplish?

When a user tries to upload a file in blocknote (the new editor for documents) of a type that is not whitelisted in the file settings, a nice error message should be shown.

# What approach did you choose and why?

Since blocknote itself offers no way to show error messages, this uses the toast service. It would have been nice not to have to use an angular service, however, there is no alternative yet.

## Screenshots
<img width="1754" height="664" alt="image" src="https://github.com/user-attachments/assets/34ef6f84-3038-46f7-a51f-74549f2d6b93" />

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox)
