### PR TITLE
Allow dynamic CSP to define addresses without standard ports

### DIFF
--- a/app/controllers/concerns/dynamic_content_security_policy.rb
+++ b/app/controllers/concerns/dynamic_content_security_policy.rb
@@ -68,8 +68,14 @@ module DynamicContentSecurityPolicy
         nil
       end
       if uri.present?
-        append_content_security_policy_directives(connect_src: ["#{uri.scheme}://#{uri.host}"])
+        append_content_security_policy_directives(connect_src: ["#{uri.scheme}://#{host_with_port(uri)}"])
       end
     end
+  end
+
+  def host_with_port(uri)
+    # Include port if it's not the default port for the scheme (necessary for local dev support)
+    default_port = ["wss", "https"].include?(uri.scheme) ? 443 : 80
+    uri.port && uri.port != default_port ? "#{uri.host}:#{uri.port}" : uri.host
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/68580/activity

# What are you trying to accomplish?

When defining dynamically the CSP addresses we don't take into account addresses that might be used in local development like `ws://127.0.0.1:1234`. The port number was not being taken into account.
